### PR TITLE
[4.0] Fix clear button for search tools for views without fullordering select list

### DIFF
--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -439,7 +439,7 @@ Joomla = window.Joomla || {};
         this.orderField.setAttribute('name', self.options.orderFieldName);
         this.orderField.setAttribute('value', `${self.activeOrder} ${this.activeDirection}`);
 
-        this.theForm.innerHTML += this.orderField.outerHTML;
+        this.theForm.append(this.orderField);
       }
 
       // Add missing columns to the order select


### PR DESCRIPTION
Pull Request for Issue #32329 .

### Summary of Changes

Use `this.theForm.append(this.orderField);` instead of `this.theForm.innerHTML += this.orderField.outerHTML;` to append the order field.

Thanks @skurvish for reporting the issue and suggesting the right fix.

### Testing Instructions

Have an admin list view that does not have fullordering select list in it's search tools form, or remove that field from that form for some component.

E.g. for com_contacts, remove the following lines of code:

https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_contact/forms/filter_contacts.xml#L95-L125

In the list view of that component, try to apply some filter with search tools and try to use the clear button.

Enter some text into the text search box and then use the "Clear" button to clear the text search box.

Apply the patch of this pull request and then test again.

Note: It needs npm to compile the js after you have applied the patch, or you use the package built by drone for this PR.

### Actual result BEFORE applying this Pull Request

Search tools "Filter Options" drop down doesn't work.

Filters or text searches are not cleared when using the "Clear" button.

### Expected result AFTER applying this Pull Request

Everything works.

### Documentation Changes Required

None.