### PR TITLE
[4.0] Fire the change event on both the custom element and the input

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -153,6 +153,8 @@
       this.inputElement.value = value;
       this.updatePreview();
 
+      // trigger change event both on the input and on the custom element
+      this.inputElement.dispatchEvent(new Event('change'));
       this.dispatchEvent(new CustomEvent('change', {
         detail: { value },
         bubbles: true,

--- a/build/media_source/system/js/fields/joomla-field-simple-color.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-simple-color.w-c.es6.js
@@ -365,6 +365,8 @@
       this.icon.setAttribute('class', clss);
       this.icon.style.backgroundColor = bgcolor;
 
+      // trigger change event both on the select and on the custom element
+      this.select.dispatchEvent(new Event('change'));
       this.dispatchEvent(new CustomEvent('change', {
         detail: { value: color },
         bubbles: true,

--- a/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
@@ -139,7 +139,8 @@
     setValue(value, name) {
       this.input.setAttribute('value', value);
       this.inputName.setAttribute('value', name || value);
-      // trigger change event
+      // trigger change event both on the input and on the custom element
+      this.input.dispatchEvent(new Event('change'));
       this.dispatchEvent(new CustomEvent('change', {
         detail: { value, name },
         bubbles: true,


### PR DESCRIPTION
Pull Request supplementary to https://github.com/joomla/joomla-cms/pull/32379 .

Add missing change events for the fields media, user and simple color

Testing Instructions

in your browser console (assuming Chrome) Selecet the HTML element for the field (eg joomla-field-simple-color) and in the console copy paste $0.addEventListener('change', (ev) => console.log(ev)); Then select a color. Observe the console. Repeat for the other 2 fields


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

