### PR TITLE
Search by ldap_uid when binding as user (#32399)

### DIFF
--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -122,11 +122,8 @@ class PlgAuthenticationLdap extends JPlugin
 				if ($success)
 				{
 					$userdetails = $this->searchByString(
-						str_replace(
-							'[search]',
-							str_replace(';', '\3b', $ldap->escape($credentials['username'], null, LDAP_ESCAPE_FILTER)),
-							$this->params->get('search_string')
-						),
+						$ldap_uid .'='.
+						str_replace(';', '\3b', $ldap->escape($credentials['username'], null, LDAP_ESCAPE_FILTER)),
 						$ldap
 					);
 				}

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -122,7 +122,7 @@ class PlgAuthenticationLdap extends JPlugin
 				if ($success)
 				{
 					$userdetails = $this->searchByString(
-						$ldap_uid .'='.
+						$ldap_uid . '=' .
 						str_replace(';', '\3b', $ldap->escape($credentials['username'], null, LDAP_ESCAPE_FILTER)),
 						$ldap
 					);


### PR DESCRIPTION
Pull Request for Issue #32399.

### Summary of Changes

Switch from searching by `search_string`, which is described as not required for bind-as-user, to building a filter based on the `ldap_uid` attribute laid out in settings.

### Testing Instructions

1. Enable LDAP plugin
2. Set to bind directly as the user, and fill out required configuration, leaving `search_string` blank.
2. set `display_errors` to `On`
3. Go to administrative login
4. Attempt to log in as a user who is valid in LDAP, but is not authorized to access Joomla!

### Actual result BEFORE applying this Pull Request

Along with the authentication failure message, a php error message is displayed indicating an invalid LDAP filter.

### Expected result AFTER applying this Pull Request

Only the intended authentication failure message is displayed.

### Documentation Changes Required

None, to my knowledge.