### PR TITLE
[4.0] RTL: Correcting skipto separators alignment

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -126,7 +126,7 @@ ul {
 
 // skipto
 .skip-to [role="separator"] {
-    text-align: right !important;
+  text-align: right !important;
 }
 
 // SearchTools rounded corners

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -124,6 +124,11 @@ ul {
   direction: ltr;
 }
 
+// skipto
+.skip-to [role="separator"] {
+    text-align: right !important;
+}
+
 // SearchTools rounded corners
 .input-group > .input-group-prepend > .btn,
 .input-group > .input-group-prepend > .input-group-text,

--- a/templates/cassiopeia/scss/template-rtl.scss
+++ b/templates/cassiopeia/scss/template-rtl.scss
@@ -58,6 +58,11 @@ body,
   }
 }
 
+// skipto
+.skip-to [role="separator"] {
+    text-align: right !important;
+}
+
 // SearchTools rounded corners
 .awesomplete {
   input {

--- a/templates/cassiopeia/scss/template-rtl.scss
+++ b/templates/cassiopeia/scss/template-rtl.scss
@@ -60,7 +60,7 @@ body,
 
 // skipto
 .skip-to [role="separator"] {
-    text-align: right !important;
+  text-align: right !important;
 }
 
 // SearchTools rounded corners


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/32395

### Summary of Changes
Added rtl override in template-rtl.scss in both Atum and Cassiopea


### Testing Instructions
Install Persian language.
Add to the admin persian language folder this file
[plg_system_skipto.txt](https://github.com/joomla/joomla-cms/files/5971356/plg_system_skipto.txt)

Note: some strings are not translated (Aside, Header, Form)

(Change .txt to .ini)

Make sure skipto system plugin is set to be used on site (or both).

Load site with Persian as default language. Click on Tab and then Enter

Patch, run npm and test again
### Actual result BEFORE applying this Pull Request

<img width="337" alt="Screen Shot 2021-02-12 at 12 22 37" src="https://user-images.githubusercontent.com/869724/107762258-06cd3600-6d2d-11eb-94a9-558d91dd4139.png">

### Expected result AFTER applying this Pull Request

<img width="378" alt="Screen Shot 2021-02-13 at 08 00 52" src="https://user-images.githubusercontent.com/869724/107844234-020e8d80-6dd2-11eb-90e1-0cbd8ef19ac6.png">
