### PR TITLE
Add styling to article index (toc)

### DIFF
--- a/plugins/content/pagebreak/tmpl/toc.php
+++ b/plugins/content/pagebreak/tmpl/toc.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Router\Route;
 
 ?>
-<div class="card float-end article-index">
+<div class="card float-end article-index ms-3 mb-3">
 	<div class="card-body">
 
 		<?php if ($headingtext) : ?>

--- a/plugins/content/pagebreak/tmpl/toc.php
+++ b/plugins/content/pagebreak/tmpl/toc.php
@@ -22,7 +22,7 @@ use Joomla\CMS\Router\Route;
 		<ul class="nav flex-column">
 		<?php foreach ($list as $listItem) : ?>
 			<?php $class = $listItem->active ? ' active' : ''; ?>
-			<li>
+			<li class="py-1">
 				<a href="<?php echo Route::_($listItem->link); ?>" class="toclink<?php echo $class; ?>">
 					<?php echo $listItem->title; ?>
 				</a>

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -218,6 +218,12 @@ meter {
   border-bottom-left-radius: 0;
 }
 
+.article-index {
+  .toclink.active {
+    color: currentColor;
+  }
+}
+
 // Bootstrap 4 b/c
 .sr-only {
   @extend .visually-hidden;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Added BS5 classes for margin and padding to article index (toc)
Added color to active link
Run npm (scss changes)


### Testing Instructions
Create an article with page breaks and article index (table of content)


### Actual result BEFORE applying this Pull Request
The article index has no margin to the article text, the links have no adding and the active link is not discernible:

![Screenshot_2021-02-14 Article with index](https://user-images.githubusercontent.com/9153168/107874001-d74a3500-6eb6-11eb-837c-091d8deb7ade.png)


### Expected result AFTER applying this Pull Request
The article index has a margin (works in lrt too), the links have some padding and the active link is visually discernible:

![grafik](https://user-images.githubusercontent.com/9153168/107874800-60b03600-6ebc-11eb-8b78-0326fb96ac9a.png)



### Documentation Changes Required

