### PR TITLE
Style article pagination (page break)

### DIFF
--- a/plugins/content/pagebreak/tmpl/navigation.php
+++ b/plugins/content/pagebreak/tmpl/navigation.php
@@ -20,25 +20,25 @@ use Joomla\CMS\Router\Route;
 
 $lang = Factory::getLanguage();
 ?>
-<ul>
-	<li>
+<ul class="pagination">
+	<li class="previous page-item">
 		<?php if ($links['previous']) :
 		$direction = $lang->isRtl() ? 'right' : 'left';
 		$title = htmlspecialchars($this->list[$page]->title, ENT_QUOTES, 'UTF-8');
 		$ariaLabel = Text::_('JPREVIOUS') . ': ' . $title . ' (' . Text::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', $page, $n) . ')';
 		?>
-		<a href="<?php echo Route::_($links['previous']); ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="prev">
+		<a class="page-link" href="<?php echo Route::_($links['previous']); ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="prev">
 			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span> ' . Text::_('JPREV'); ?>
 		</a>
 		<?php endif; ?>
 	</li>
-	<li>
+	<li class="next page-item">
 		<?php if ($links['next']) :
 		$direction = $lang->isRtl() ? 'left' : 'right';
 		$title = htmlspecialchars($this->list[$page + 2]->title, ENT_QUOTES, 'UTF-8');
 		$ariaLabel = Text::_('JNEXT') . ': ' . $title . ' (' . Text::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', ($page + 2), $n) . ')';
 		?>
-		<a href="<?php echo Route::_($links['next']); ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="next">
+		<a class="page-link" href="<?php echo Route::_($links['next']); ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="next">
 			<?php echo Text::_('JNEXT') . ' <span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
 		</a>
 		<?php endif; ?>

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -179,7 +179,8 @@ meter {
   width: 100%;
 }
 
-.pagenavigation {
+.pagenavigation,
+.pager {
   clear: both;
   .pagination {
     justify-content: space-between;
@@ -201,6 +202,12 @@ meter {
   color: var(--cassiopeia-color-link);
   &:hover {
     color: var(--cassiopeia-color-link);
+  }
+}
+
+.pager {
+  .pagination {
+    justify-content: center;
   }
 }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Styling for the article pagination (page breaks)


### Testing Instructions
Create an article with page breaks.
Run npm (scss changes).


### Actual result BEFORE applying this Pull Request
The buttons prev and next are not styled:

![Screenshot_2021-02-14 Article with index-nav](https://user-images.githubusercontent.com/9153168/107874565-c56a9100-6eba-11eb-8a43-3cdca4aa9230.png)




### Expected result AFTER applying this Pull Request
![grafik](https://user-images.githubusercontent.com/9153168/107874559-bd125600-6eba-11eb-9406-866db92174fd.png)



### Documentation Changes Required

