### PR TITLE
Remove nav class on links in contacts

### DIFF
--- a/components/com_contact/tmpl/contact/default_links.php
+++ b/components/com_contact/tmpl/contact/default_links.php
@@ -33,7 +33,7 @@ use Joomla\CMS\Language\Text;
 			$label = $label ?: $link;
 			?>
 			<li>
-				<a href="<?php echo $link; ?>" itemprop="url" rel="nofollow">
+				<a href="<?php echo $link; ?>" itemprop="url" rel="noopener noreferrer">
 					<?php echo $label; ?>
 				</a>
 			</li>

--- a/components/com_contact/tmpl/contact/default_links.php
+++ b/components/com_contact/tmpl/contact/default_links.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Language\Text;
 <?php echo '<h3>' . Text::_('COM_CONTACT_LINKS') . '</h3>'; ?>
 
 <div class="com-contact__links contact-links">
-	<ul class="nav flex-column">
+	<ul class="list-unstyled">
 		<?php
 		// Letters 'a' to 'e'
 		foreach (range('a', 'e') as $char) :
@@ -32,8 +32,8 @@ use Joomla\CMS\Language\Text;
 			// If no label is present, take the link
 			$label = $label ?: $link;
 			?>
-			<li class="nav-item">
-				<a class="nav-link" href="<?php echo $link; ?>" itemprop="url">
+			<li>
+				<a href="<?php echo $link; ?>" itemprop="url" rel="nofollow">
 					<?php echo $label; ?>
 				</a>
 			</li>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Removed class nav flex-column in the list of links in contacts. Added rel="noopener noreferrer" on links.
Other links lists in J4 are "normal" lists and not nav lists (blog_links.php in blog layout, default_links.php on articles). We should stay consistent.


### Testing Instructions
Create a contact, add some links.


### Actual result BEFORE applying this Pull Request
![grafik](https://user-images.githubusercontent.com/9153168/107886256-f7054b80-6efe-11eb-8181-95b791331942.png)



### Expected result AFTER applying this Pull Request
![grafik](https://user-images.githubusercontent.com/9153168/107886229-d4733280-6efe-11eb-80fe-606456ab4ad0.png)



### Documentation Changes Required

