### PR TITLE
[4.0] Correct btn-group radius in atum subhead

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -125,13 +125,11 @@
     margin-inline-start: -$border-radius;
 
     [dir="ltr"] & {
-      border-top-right-radius: $border-radius;
-      border-bottom-right-radius: $border-radius;
+      border-radius: 0 $border-radius $border-radius 0;
     }
 
     [dir="rtl"] & {
-      border-top-left-radius: $border-radius;
-      border-bottom-left-radius: $border-radius;
+      border-radius: $border-radius 0 0 $border-radius;
     }
   }
 

--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -122,6 +122,7 @@
   }
 
   .btn-group:not(:last-child) > .dropdown-toggle-split {
+    order: 1;
     margin-inline-start: -$border-radius;
 
     [dir="ltr"] & {

--- a/layouts/joomla/toolbar/dropdown.php
+++ b/layouts/joomla/toolbar/dropdown.php
@@ -42,7 +42,7 @@ $direction = Factory::getLanguage()->isRtl() ? 'dropdown-menu-end' : '';
 		<?php HTMLHelper::_('bootstrap.dropdown', '.dropdown'); ?>
 		<?php // @todo use a class instead of the inline style.
 			 //  Reverse order solves a console err for dropdown ?>
-		<div id="<?php echo $id; ?>" class="btn-group dropdown-<?php echo $name ?? ''; ?>" role="group" style="flex-direction: row-reverse;">
+		<div id="<?php echo $id; ?>" class="btn-group dropdown-<?php echo $name ?? ''; ?>" role="group">
 			<button type="button" class="<?php echo $caretClass ?? ''; ?> dropdown-toggle-split"
 				data-bs-toggle="dropdown" data-bs-target=".dropdown-menu" data-bs-display="static" aria-haspopup="true" aria-expanded="false">
 				<span class="visually-hidden"><?php echo Text::_('JGLOBAL_TOGGLE_DROPDOWN'); ?></span>


### PR DESCRIPTION
Pull Request for Issue #32433.

### Summary of Changes
Correct border-radius in subhead buttons (Artticle Edit)..


### Testing Instructions



### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/2803503/108122233-dde5d180-709b-11eb-8414-a0c0a55b1f11.png)


### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/2803503/108122206-d45c6980-709b-11eb-9127-abf22a548ada.png)




### Documentation Changes Required

