### PR TITLE
[4.0] Fix blog masonry class breaking inside item

### DIFF
--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -223,6 +223,7 @@
     column-gap: $cassiopeia-grid-gutter;
 
     .blog-item {
+      display: inline-flex;
       margin-bottom: $cassiopeia-grid-gutter;
       page-break-inside: avoid;
       break-inside: avoid;


### PR DESCRIPTION
Pull Request for Issue #32439 .

### Summary of Changes
Stops the blog masonry class breaking inside a blog item


### Testing Instructions
Create a blog menu item with a **BLog Class** of **masonry-3**. Test in Firefox and ensure items dont split across columns.

@Magnytu2


### Documentation Changes Required

