### PR TITLE
Make BS5 breakpoint xxl available in Cassiopeia

### DIFF
--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -14,7 +14,7 @@
       ". bot-b bot-b bot-b bot-b ."
       ". footer footer footer footer ."
       ". debug debug debug debug .";
-    grid-template-columns: [full-start] minmax(0, 1fr) [main-start] repeat(4, minmax(0, 16.875rem)) [main-end] minmax(0, 1fr) [full-end];
+    grid-template-columns: [full-start] minmax(0, 1fr) [main-start] repeat(4, minmax(0, 19.875rem)) [main-end] minmax(0, 1fr) [full-end];
     grid-gap: 0 $cassiopeia-grid-gutter;
 
     > [class^="container-"],

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -3,7 +3,7 @@
 .grid-child {
   display: flex;
   width: 100%;
-  max-width: max-width(xl);
+  max-width: max-width(xxl);
   margin-right: auto;
   margin-left: auto;
 }

--- a/templates/cassiopeia/scss/tools/variables/_variables.scss
+++ b/templates/cassiopeia/scss/tools/variables/_variables.scss
@@ -106,7 +106,8 @@ $grid-breakpoints: (
   sm:                                 36em,
   md:                                 48em,
   lg:                                 62em,
-  xl:                                 75em
+  xl:                                 75em,
+  xxl:                                87.5em
 );
 
 // Grid containers
@@ -114,7 +115,8 @@ $container-max-widths: (
   sm:                                 33.75em,
   md:                                 45em,
   lg:                                 60em,
-  xl:                                 71.25em
+  xl:                                 71.25em,
+  xxl:                                82.5em
 );
 
 // Grid columns


### PR DESCRIPTION
Pull Request for Issue #32443  .

### Summary of Changes
Added xxl as breakpoint in the variables of Cassiopeia.
Changed the max-width of grid-child to xxl
Increased the width of main content column.


### Testing Instructions
Run npm
Check the website in displays > 1400px


### Actual result BEFORE applying this Pull Request
No xxl breakpoint in Cassiopeia (inspect the template.css file)


### Expected result AFTER applying this Pull Request
xxl breakpoint available in Cassiopeia 
In displays > 1400px you will notice, that the whole width of the content has increased a bit.


### Documentation Changes Required

