### PR TITLE
[4.0] Shouldn't Article Title be H1?

### DIFF
--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -26,6 +26,7 @@ $urls    = json_decode($this->item->urls);
 $canEdit = $params->get('access-edit');
 $user    = Factory::getUser();
 $info    = $params->get('info_block_position', 0);
+$htag    = $this->params->get('show_page_heading') ? 'h2' : 'h1';
 
 // Check if associations are implemented. If they are, define the parameter.
 $assocParam        = (Associations::isEnabled() && $params->get('show_associations'));
@@ -52,9 +53,9 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 
 	<?php if ($params->get('show_title')) : ?>
 	<div class="page-header">
-		<<?php echo $tag = $this->params->get('show_page_heading') ? 'h2' : 'h1'; ?> itemprop="headline">
+		<<?php echo $htag; ?> itemprop="headline">
 			<?php echo $this->escape($this->item->title); ?>
-		</<?php echo $tag; ?>>
+		</<?php echo $htag; ?>>
 		<?php if ($this->item->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
 			<span class="badge bg-warning text-dark"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -52,9 +52,9 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 
 	<?php if ($params->get('show_title')) : ?>
 	<div class="page-header">
-		<h2 itemprop="headline">
+		<h1 itemprop="headline">
 			<?php echo $this->escape($this->item->title); ?>
-		</h2>
+		</h1>
 		<?php if ($this->item->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
 			<span class="badge bg-warning text-dark"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -52,11 +52,9 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 
 	<?php if ($params->get('show_title')) : ?>
 	<div class="page-header">
-		<?php if ($this->params->get('show_page_heading')) : ?>
-			<h2 itemprop="headline"><?php echo $this->escape($this->item->title); ?></h2>
-		<?php else : ?>
-			<h1 itemprop="headline"><?php echo $this->escape($this->item->title); ?></h1>
-		<?php endif; ?>
+		<<?php echo $tag = $this->params->get('show_page_heading') ? 'h2' : 'h1' ?> itemprop="headline">
+			<?php echo $this->escape($this->item->title); ?>
+		</<?php echo $tag ?>>
 		<?php if ($this->item->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
 			<span class="badge bg-warning text-dark"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -52,9 +52,11 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 
 	<?php if ($params->get('show_title')) : ?>
 	<div class="page-header">
-		<h1 itemprop="headline">
-			<?php echo $this->escape($this->item->title); ?>
-		</h1>
+		<?php if ($this->params->get('show_page_heading')) : ?>
+			<h2 itemprop="headline"><?php echo $this->escape($this->item->title); ?></h2>
+		<?php else : ?>
+			<h1 itemprop="headline"><?php echo $this->escape($this->item->title); ?></h1>
+		<?php endif; ?>
 		<?php if ($this->item->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
 			<span class="badge bg-warning text-dark"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -54,7 +54,7 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 	<div class="page-header">
 		<<?php echo $tag = $this->params->get('show_page_heading') ? 'h2' : 'h1' ?> itemprop="headline">
 			<?php echo $this->escape($this->item->title); ?>
-		</<?php echo $tag ?>>
+		</<?php echo $tag; ?>>
 		<?php if ($this->item->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
 			<span class="badge bg-warning text-dark"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -52,7 +52,7 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 
 	<?php if ($params->get('show_title')) : ?>
 	<div class="page-header">
-		<<?php echo $tag = $this->params->get('show_page_heading') ? 'h2' : 'h1' ?> itemprop="headline">
+		<<?php echo $tag = $this->params->get('show_page_heading') ? 'h2' : 'h1'; ?> itemprop="headline">
 			<?php echo $this->escape($this->item->title); ?>
 		</<?php echo $tag; ?>>
 		<?php if ($this->item->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>


### PR DESCRIPTION
### Summary of Changes

Currently in Joomla, the Title of the article is rendered as a H2 instead of a H1.

I get that H1 can also be the "Page Heading" aka Menu Title.

But in an article view, you're most likely not gonna wanna have the Menu Title as an H1.

I personally don't care as I fix it in template overrides anyway. But as a standard, common practice, my two cents is that Article title should be H1 by default.

### Actual result BEFORE applying this Pull Request

Article title is H2.

### Expected result AFTER applying this Pull Request

Article title is H1 if Menu Title is hidden.
