### PR TITLE
Escape the private message to protect against xss

### DIFF
--- a/administrator/components/com_messages/views/message/tmpl/default.php
+++ b/administrator/components/com_messages/views/message/tmpl/default.php
@@ -43,7 +43,7 @@ JHtml::_('formbehavior.chosen', 'select');
 				<?php echo JText::_('COM_MESSAGES_FIELD_MESSAGE_LABEL'); ?>
 			</div>
 			<div class="controls">
-				<?php echo $this->item->message; ?>
+				<?php echo $this->escape($this->item->message); ?>
 			</div>
 		</div>
 		<input type="hidden" name="task" value="" />


### PR DESCRIPTION
Pull Request for an issue reported to the JSST by DangKhai from Viettel Cyber Security

### Summary of Changes

Escape the private message to protect against xss. We do not apply any script filters to messages written by superadministartors. So a super admin could send a message with a script tag to an non super-admin.

### Testing Instructions

set the editor plugin to "none" 
Send (as super user) a message with a script tag in the body to another backend user
login as that other user
notice that the script tag is triggered
apply the patch
notice that the script tag is now escaped

### Actual result BEFORE applying this Pull Request

the script tag is executed

### Expected result AFTER applying this Pull Request

the script tag is escaped  

### Documentation Changes Required

None