### PR TITLE
Make sure we don't allow IP overrides within the com_content vote feature

### DIFF
--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -269,6 +269,9 @@ class ContentModelArticle extends JModelItem
 	{
 		if ($rate >= 1 && $rate <= 5 && $pk > 0)
 		{
+			// Meke sure we don't allow IP overrides
+			IpHelper::setAllowIpOverrides(false);
+
 			$userIP = IpHelper::getIp();
 
 			// Initialize variables.

--- a/components/com_content/models/article.php
+++ b/components/com_content/models/article.php
@@ -269,7 +269,7 @@ class ContentModelArticle extends JModelItem
 	{
 		if ($rate >= 1 && $rate <= 5 && $pk > 0)
 		{
-			// Meke sure we don't allow IP overrides
+			// Make sure we don't allow IP overrides
 			IpHelper::setAllowIpOverrides(false);
 
 			$userIP = IpHelper::getIp();


### PR DESCRIPTION
Pull Request for an issue reported to the JSST by DangKhai from Viettel Cyber Security

### Summary of Changes

Make sure we dont allow IP overrides by the X-Forwarded-For or Client-Ip HTTP headers for the com_content vote feature.

### Testing Instructions

Setup voting for an article
make sure voting works
apply the patch
make sure voting still works

### Actual result BEFORE applying this Pull Request

It was possible to override the ip using the X-Forwarded-For or Client-Ip HTTP headers

### Expected result AFTER applying this Pull Request

that behavior is disabled now

### Documentation Changes Required

None