### PR TITLE
Fix Save as Copy tag

### DIFF
--- a/administrator/components/com_tags/models/tag.php
+++ b/administrator/components/com_tags/models/tag.php
@@ -272,9 +272,24 @@ class TagsModelTag extends JModelAdmin
 		// Alter the title for save as copy
 		if ($input->get('task') == 'save2copy')
 		{
-			list($title, $alias) = $this->generateNewTitle($data['parent_id'], $data['alias'], $data['title']);
-			$data['title']       = $title;
-			$data['alias']       = $alias;
+			$origTable = $this->getTable();
+			$origTable->load($input->getInt('id'));
+
+			if ($data['title'] == $origTable->title)
+			{
+				list($title, $alias) = $this->generateNewTitle($data['parent_id'], $data['alias'], $data['title']);
+				$data['title'] = $title;
+				$data['alias'] = $alias;
+			}
+			else
+			{
+				if ($data['alias'] == $origTable->alias)
+				{
+					$data['alias'] = '';
+				}
+			}
+
+			$data['published'] = 0;
 		}
 
 		// Bind the data.

--- a/administrator/components/com_tags/models/tag.php
+++ b/administrator/components/com_tags/models/tag.php
@@ -281,12 +281,9 @@ class TagsModelTag extends JModelAdmin
 				$data['title'] = $title;
 				$data['alias'] = $alias;
 			}
-			else
+			elseif ($data['alias'] == $origTable->alias)
 			{
-				if ($data['alias'] == $origTable->alias)
-				{
-					$data['alias'] = '';
-				}
+				$data['alias'] = '';
 			}
 
 			$data['published'] = 0;


### PR DESCRIPTION
Pull Request for Issue #32407 and #32406.

### Summary of Changes
This PR fixes 2 issues as described in #32407 and #32406 :

- Tag created by Save as Copy should be unpublished
- When Save as Copy, if Admin changes Title of the tag before saving, Alias of the created tag should be created base on the new title

### Testing Instructions
- Test #1:
1. Click on a tag to edit
2. Press Save as Copy button in the toolbar
3. Before patch: Tag is published. After patch, tag is unpublished

- Test #2:

1. Click on a tag to edit
2. Change title of the Tag, press Save as Copy button in the toolbar.
3. Before patch: Alias is not generated base on the new Title. After patch, alias is generated base on Title.

