### PR TITLE
[4.0] Fix cassiopeia scss dependencies

### DIFF
--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -245,6 +245,10 @@
           "public/assets/styles/choices.css": "css/choices.css",
           "public/assets/styles/choices.min.css": "css/choices.min.css"
         },
+        "filesExtra": {
+          "src/styles/base.scss": "scss/base.scss",
+          "src/styles/choices.scss": "scss/choices.scss"
+        },
         "provideAssets": [
           {
             "name": "choicesjs",

--- a/templates/cassiopeia/scss/template.scss
+++ b/templates/cassiopeia/scss/template.scss
@@ -9,7 +9,7 @@
 @import "../../../media/vendor/bootstrap/scss/bootstrap";
 
 // jQuery Minicolors
-@import "../../../build/media_source/system/scss/jquery-minicolors";
+@import "../../../media/system/scss/jquery-minicolors";
 
 // Blocks
 @import "blocks/global"; // Leave this first

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -3,7 +3,7 @@
 @import "../../../../../media/vendor/bootstrap/scss/mixins";
 
 // choices.js
-@import "../../../../../node_modules/choices.js/src/styles/choices";
+@import "../../../../../media/vendor/choicesjs/scss/choices";
 
 // Cassiopea Variables, Functions and Mixins
 @import "../../tools/tools";

--- a/templates/cassiopeia/scss/vendor/fontawesome-free/fontawesome.scss
+++ b/templates/cassiopeia/scss/vendor/fontawesome-free/fontawesome.scss
@@ -10,4 +10,4 @@ $fa-font-path: "../../../../../media/vendor/fontawesome-free/webfonts" !default;
 @import "../../../../../media/vendor/fontawesome-free/scss/brands";
 
 // B/C for Icomoon
-@import "../../../../../build/media_source/system/scss/icomoon";
+@import "../../../../../media/system/scss/icomoon";

--- a/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/templates/cassiopeia/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -1,5 +1,5 @@
 @import "../../tools/tools";
-@import "../../../../../node_modules/joomla-ui-custom-elements/dist/css/joomla-alert";
+@import "../../../../../media/vendor/joomla-custom-elements/css/joomla-alert.css";
 
 // The following is a restyle for the system alerts
 #system-message-container {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/32457 .

### Summary of Changes
Allow the delivered SCSS files to be compiled without the need for the build folder


### Testing Instructions
Check that Cassiopeia is still propely rendering


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required


@thednp