### PR TITLE
[4.0] Multilingual: Create Article using specific category improvement

### DIFF
--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -631,7 +631,12 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 					)
 				);
 				$data->set('catid', $app->input->getInt('catid', (!empty($filters['category_id']) ? $filters['category_id'] : null)));
-				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+
+				if ($app->isClient('administrator'))
+				{
+					$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+				}
+
 				$data->set('access',
 					$app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
 				);

--- a/components/com_content/src/Model/FormModel.php
+++ b/components/com_content/src/Model/FormModel.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 
@@ -223,11 +224,14 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
 
 			if (Multilanguage::isEnabled())
 			{
+				$categoryId = (int) $params->get('catid');
+
 				$db    = $this->getDbo();
 				$query = $db->getQuery(true)
 					->select($db->quoteName('language'))
 					->from($db->quoteName('#__categories'))
-					->where($db->quoteName('id') . ' = ' . $db->quote($params->get('catid')));
+					->where($db->quoteName('id') . ' = :categoryId')
+					->bind(':categoryId', $categoryId, ParameterType::INTEGER);
 				$db->setQuery($query);
 
 				$result = $db->loadResult();

--- a/components/com_content/src/Model/FormModel.php
+++ b/components/com_content/src/Model/FormModel.php
@@ -220,6 +220,24 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
 		{
 			$form->setFieldAttribute('catid', 'default', $params->get('catid'));
 			$form->setFieldAttribute('catid', 'readonly', 'true');
+
+			if (Multilanguage::isEnabled())
+			{
+				$db    = $this->getDbo();
+				$query = $db->getQuery(true)
+					->select($db->quoteName('language'))
+					->from($db->quoteName('#__categories'))
+					->where($db->quoteName('id') . ' = ' . $db->quote($params->get('catid')));
+				$db->setQuery($query);
+
+				$result = $db->loadResult();
+
+				if ($result != '*')
+				{
+					$form->setFieldAttribute('language', 'readonly', 'true');
+					$form->setFieldAttribute('language', 'default', $result);
+				}
+			}
 		}
 
 		if (!Multilanguage::isEnabled())

--- a/components/com_content/src/View/Form/HtmlView.php
+++ b/components/com_content/src/View/Form/HtmlView.php
@@ -164,7 +164,7 @@ class HtmlView extends BaseHtmlView
 		$this->user   = $user;
 
 		// Propose current language as default when creating new article
-		if (empty($this->item->id) && Multilanguage::isEnabled())
+		if (empty($this->item->id) && Multilanguage::isEnabled() && $params->get('enable_category') != 1)
 		{
 			$lang = Factory::getLanguage()->getTag();
 			$this->form->setFieldAttribute('language', 'default', $lang);


### PR DESCRIPTION
### Summary of Changes
Multilingual site
When using a Create Article menu item using a specific category, whatever the language set for that category, the default language field is always set to the site language and can also be modified, which can cause unwanted errors. 
In a multilingual site, an article tagged to a specific language should only be in a category tagged to the same language or All languages.

1. The first correction comes from https://github.com/joomla/joomla-cms/pull/6966 where the intention was, when creating an article in **backend** to propose in the create article form by default the same language as the language filter articles manager was set to . Thanks to @Bakual for helping me finding this :)
As this was not limited to Administration, it was forcing as default the site default language when creating an article in **frontend**.

https://github.com/joomla/joomla-cms/blob/52fc4b86a8cb83fdae095f52977de3139e115522/administrator/components/com_content/src/Model/ArticleModel.php#L634

This is now corrected here by limiting it to admin

We never remarked that overseen aspect because we had already a way in frontend to do that in the HtmlView.php

https://github.com/joomla/joomla-cms/blob/52fc4b86a8cb83fdae095f52977de3139e115522/components/com_content/src/View/Form/HtmlView.php#L166-L171

2. To prevent a user a to submit an article with the wrong language when a specific category is selected in the menu item, we then first have to check if this parameter is set in the view.
If it is, then we should not propose as default the site language (which can be modifed) but instead code the FormModel `preprocessForm()` method to check the language of the category and, if not set to All languages, force the article to be set to the same language and read-only.

Note: The patch not only prevents error when the Create Article menu item deals with a specific category set to the same language as the site language, but also, cherry on the cake, let's create such menu items with a category set to another language than the site language. Both read-only.

For example:
One can have a Create Article menu item tagged to French and thus displayed in French frontend, with an English tagged specific category. The language field will be rightfully set as English per default and read-only.
As when one can do the more, one can do the less, let's test it.


### Testing Instructions
Multilingual site with 2 languages.
Let's do the cherry on the cake :)
Create a Create Article menu item tagged to French with a specific category tagged to English in a French tagged menu.
Set access to Special.
Login frontend and click on the menu item.
Check the category and the language before submitting.
Check the Articles Manager for the new article.


### Expected result AFTER applying this Pull Request
**Creating the menu item**
<img width="1194" alt="Screen Shot 2021-02-19 at 09 58 48" src="https://user-images.githubusercontent.com/869724/108482674-14893b00-729a-11eb-974a-716c3439034f.png">

<img width="1193" alt="Screen Shot 2021-02-19 at 09 59 08" src="https://user-images.githubusercontent.com/869724/108482731-27037480-729a-11eb-95cb-3181d61c3828.png">

**Frontend menu item displayed**

<img width="943" alt="Screen Shot 2021-02-19 at 09 59 45" src="https://user-images.githubusercontent.com/869724/108482855-4ac6ba80-729a-11eb-8cb2-ee07a826e013.png">

**Article form showing category**

<img width="1005" alt="Screen Shot 2021-02-19 at 10 00 13" src="https://user-images.githubusercontent.com/869724/108482964-721d8780-729a-11eb-9d17-34fbb04bfbf2.png">

**Article form showing read-only language field**

<img width="956" alt="Screen Shot 2021-02-19 at 10 00 25" src="https://user-images.githubusercontent.com/869724/108483194-b6108c80-729a-11eb-98dd-db2781e85c14.png">

**Articles Manager showing newly created article**

<img width="938" alt="Screen Shot 2021-02-19 at 10 04 22" src="https://user-images.githubusercontent.com/869724/108483325-e3f5d100-729a-11eb-9ed5-7a7966c54c1b.png">


### Note
One can have multiple Create Article menu items set to use different specific category (See my screenshot above).
Beware: once there is (are) such Create Article menu item(s), there should never be also a Create Article menu item NOT set to use a specific category.

