### PR TITLE
[4.0] Skipto RTL

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -125,8 +125,18 @@ ul {
 }
 
 // skipto
-.skip-to [role="separator"] {
-  text-align: right !important;
+.skip-to {
+  &.popup {
+    left: 0 !important;
+    right: -3000em;
+    &.focus {
+      left: 0 !important;
+      right: 46%;
+    }
+  }
+  [role="separator"] {
+    text-align: right !important;
+  }
 }
 
 // SearchTools rounded corners

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -127,11 +127,11 @@ ul {
 // skipto
 .skip-to {
   &.popup {
-    left: 0 !important;
     right: -3000em;
+    left: 0 !important;
     &.focus {
-      left: 0 !important;
       right: 46%;
+      left: 0 !important;
     }
   }
   [role="separator"] {

--- a/templates/cassiopeia/scss/template-rtl.scss
+++ b/templates/cassiopeia/scss/template-rtl.scss
@@ -59,8 +59,18 @@ body,
 }
 
 // skipto
-.skip-to [role="separator"] {
-  text-align: right !important;
+.skip-to {
+  &.popup {
+    left: 0 !important;
+    right: -3000em;
+    &.focus {
+      left: 0 !important;
+      right: 46%;
+    }
+  }
+  [role="separator"] {
+    text-align: right !important;
+  }
 }
 
 // SearchTools rounded corners

--- a/templates/cassiopeia/scss/template-rtl.scss
+++ b/templates/cassiopeia/scss/template-rtl.scss
@@ -61,11 +61,11 @@ body,
 // skipto
 .skip-to {
   &.popup {
-    left: 0 !important;
     right: -3000em;
+    left: 0 !important;
     &.focus {
-      left: 0 !important;
       right: 46%;
+      left: 0 !important;
     }
   }
   [role="separator"] {


### PR DESCRIPTION
Updates the RTL override for the skipto plugin to prevent a bug where 3000em were added to the left of the template.

Hopefully this will be fixed upstream eventually and this can be removed then


@ceford I think you observed this bug before