### PR TITLE
[4.0] Improve/Restructure Article Model

### DIFF
--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -499,7 +499,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 		// For new articles we load the potential state + associations
 		if ($id == 0 && $formField = $form->getField('catid'))
 		{
-			$assignedCatids = (int) $data['catid'] ?? $form->getValue('catid');
+			$assignedCatids = $data['catid'] ?? $form->getValue('catid');
 
 			$assignedCatids = is_array($assignedCatids)
 				? (int) reset($assignedCatids)

--- a/components/com_content/src/Model/FormModel.php
+++ b/components/com_content/src/Model/FormModel.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Table\Table;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 
@@ -202,6 +203,55 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
 	}
 
 	/**
+	 * Method to get the record form.
+	 *
+	 * @param   array    $data      Data for the form.
+	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
+	 *
+	 * @return  Form|boolean  A Form object on success, false on failure
+	 *
+	 * @since   1.6
+	 */
+	public function getForm($data = [], $loadData = true)
+	{
+		$form = parent::getForm($data, $loadData);
+
+		if (empty($form))
+		{
+			return false;
+		}
+
+		$user = Factory::getApplication()->getIdentity();
+
+		$id = (int) $this->getState('article.id');
+
+		// Existing record. We can't edit the category in frontend if not edit.state.
+		if ($id > 0 && !$user->authorise('core.edit.state', 'com_content.article.' . $id))
+		{
+			$form->setFieldAttribute('catid', 'readonly', 'true');
+			$form->setFieldAttribute('catid', 'required', 'false');
+			$form->setFieldAttribute('catid', 'filter', 'unset');
+		}
+
+		// Prevent messing with article language and category when editing existing article with associations
+		if ($this->getState('article.id') && Associations::isEnabled())
+		{
+			$associations = Associations::getAssociations('com_content', '#__content', 'com_content.item', $id);
+
+			// Make fields read only
+			if (!empty($associations))
+			{
+				$form->setFieldAttribute('language', 'readonly', 'true');
+				$form->setFieldAttribute('catid', 'readonly', 'true');
+				$form->setFieldAttribute('language', 'filter', 'unset');
+				$form->setFieldAttribute('catid', 'filter', 'unset');
+			}
+		}
+
+		return $form;
+	}
+
+	/**
 	 * Allows preprocessing of the JForm object.
 	 *
 	 * @param   Form    $form   The form object
@@ -228,7 +278,7 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
 			$form->setFieldAttribute('language', 'default', '*');
 		}
 
-		return parent::preprocessForm($form, $data, $group);
+		parent::preprocessForm($form, $data, $group);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Currently, the method **getForm** of backend **ArticleModel** has code which handle form fields adjustment form both frontend and backend (thus in some places, it has to use $app->isClient to check to see if it is dealing with frontend or backend submit article, it even has to use application input to get article id..), so it is quite messy.

I re-arrange the code of that model. Instead of put everything into backend ArticleModel model, I move the code (which is related to frontend submit article only) to frontend **FormModel** to make it more clean and easier to maintain.

I also made some small adjustment:

- Fix the wrong type casting here https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_content/src/Model/ArticleModel.php#L529 (when $form->getValue return array, it is casted to int with wrong value)
- Remove un-used JLoader::register here https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_content/src/Model/ArticleModel.php#L167  because we are using namespace class already
- Made some code style fix.

### Testing Instructions
1. Apply patch
2. Create/edit article from backend, make sure it is working as expected
3. Create a menu item to link to Create Article menu option of com_content, submit an article, make sure it works.