### PR TITLE
[4.0] Remove eval from modal.js

### DIFF
--- a/build/media_source/vendor/bootstrap/js/modal.es6.js
+++ b/build/media_source/vendor/bootstrap/js/modal.es6.js
@@ -46,8 +46,9 @@ Joomla.initialiseModal = (modal, options) => {
         idFieldArr[0] = idFieldArr[0].replace(/&quot;/g, '"');
 
         if (!document.getElementById(idFieldArr[1])) {
-          // eslint-disable-next-line no-eval
-          el = eval(idFieldArr[0]); // This is UNSAFE!!!!
+          // eslint-disable-next-line no-new-func
+          const fn = new Function(`return ${idFieldArr[0]}`); // This is UNSAFE!!!!
+          el = fn.call(null);
         } else {
           el = document.getElementById(idFieldArr[1]).value;
         }


### PR DESCRIPTION
### Summary of Changes

Redo of #32271 but without `eval`


### Testing Instructions

Same as #32271 

ping @wilsonge @dgrammatiko 

