### PR TITLE
Fix frontend create article permission

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -414,10 +414,33 @@ class ContentModelArticle extends JModelAdmin
 			$form->setFieldAttribute('catid', 'action', 'core.create');
 		}
 
-		// Check for existing article.
+		// Object uses for checking edit state permission of article
+		$record = new stdClass;
+		$record->id = $id;
+
+		// Get the category which the article is being added to
+		if (!empty($data['catid']))
+		{
+			$catId = (int) $data['catid'];
+		}
+		else
+		{
+			$catIds  = $form->getValue('catid');
+
+			$catId = is_array($catIds)
+				? (int) reset($catIds)
+				: (int) $catIds;
+
+			if (!$catId)
+			{
+				$catId = (int) $form->getFieldAttribute('catid', 'default', 0);
+			}
+		}
+
+		$record->catid = $catId;
+
 		// Modify the form based on Edit State access controls.
-		if ($id != 0 && (!$user->authorise('core.edit.state', 'com_content.article.' . (int) $id))
-			|| ($id == 0 && !$user->authorise('core.edit.state', 'com_content')))
+		if (!$this->canEditState($record))
 		{
 			// Disable fields for display.
 			$form->setFieldAttribute('featured', 'disabled', 'true');

--- a/components/com_content/models/form.php
+++ b/components/com_content/models/form.php
@@ -42,18 +42,27 @@ class ContentModelForm extends ContentModelArticle
 	{
 		$app = JFactory::getApplication();
 
+		// Load the parameters.
+		$params = $app->getParams();
+		$this->setState('params', $params);
+
+		if ($params && $params->get('enable_category') == 1 && $params->get('catid'))
+		{
+			$catId = $params->get('catid');
+		}
+		else
+		{
+			$catId = 0;
+		}
+
 		// Load state from the request.
 		$pk = $app->input->getInt('a_id');
 		$this->setState('article.id', $pk);
 
-		$this->setState('article.catid', $app->input->getInt('catid'));
+		$this->setState('article.catid', $app->input->getInt('catid', $catId));
 
 		$return = $app->input->get('return', null, 'base64');
 		$this->setState('return_page', base64_decode($return));
-
-		// Load the parameters.
-		$params = $app->getParams();
-		$this->setState('params', $params);
 
 		$this->setState('layout', $app->input->getString('layout'));
 	}
@@ -212,6 +221,6 @@ class ContentModelForm extends ContentModelArticle
 			$form->setFieldAttribute('catid', 'readonly', 'true');
 		}
 
-		return parent::preprocessForm($form, $data, $group);
+		parent::preprocessForm($form, $data, $group);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #32117, #17812

### Summary of Changes
Similar PR to https://github.com/joomla/joomla-cms/pull/32468 but for staging.

This PR improves frontend article submission form so that the form will respect permission of the pre-selected category (which is selected in the menu item parameter). See https://github.com/joomla/joomla-cms/issues/32117 to understand the issue better

### Testing Instructions
1. Create a new user account, assign the account to **Author** user group.
2. Edit an existing article category (or create a new category), in the Permissions tab, make sure **Edit State** permission for **Author** user group is set to Allowed.
3. Create a menu item to link to **Create Article** menu option.
4. Login to frontend using the user account which belong to Author user group above, access to the menu item to try to submit article:
- Before patch: You do not have Edit State permission, so you cannot change settings such as Published, Start Publishing, Start Featured....
- After patch: You can select status for the article (for example Published), select date For Start Publishing, Start Featured.. (in Publish tab)