### PR TITLE
[4.0] Fix trash button

### DIFF
--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -210,7 +210,7 @@ class HtmlView extends BaseHtmlView
 
 				$childBar->checkin('articles.checkin')->listCheck(true);
 
-				if (!$this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED)
+				if ($this->state->get('filter.published') != ContentComponent::CONDITION_TRASHED)
 				{
 					$childBar->trash('articles.trash')->listCheck(true);
 				}


### PR DESCRIPTION
Pull Request for Issue #32472

### Summary of Changes
Just a small PR to fix issue #32472. Trash button should always be available unless status filter is trashed.


### Testing Instructions
1. See https://github.com/joomla/joomla-cms/issues/32472, confirm the issue
2. Apply patch, confirm the issue fixed.