### PR TITLE
[4.0] Ensure that an invalid status code is thrown in the generic JSON error hander

### DIFF
--- a/libraries/src/Error/Renderer/JsonRenderer.php
+++ b/libraries/src/Error/Renderer/JsonRenderer.php
@@ -10,7 +10,9 @@ namespace Joomla\CMS\Error\Renderer;
 
 \defined('JPATH_PLATFORM') or die;
 
+use Joomla\Application\WebApplicationInterface;
 use Joomla\CMS\Error\AbstractRenderer;
+use Joomla\CMS\Factory;
 
 /**
  * JSON error page renderer
@@ -49,6 +51,20 @@ class JsonRenderer extends AbstractRenderer
 		if (JDEBUG)
 		{
 			$data['trace'] = $error->getTraceAsString();
+		}
+
+		$app = Factory::getApplication();
+
+		if ($app instanceof WebApplicationInterface)
+		{
+			$errorCode = 500;
+
+			if ($error->getCode() > 0)
+			{
+				$errorCode = $error->getCode();
+			}
+
+			$app->setHeader('status', $errorCode);
 		}
 
 		// Push the data object into the document


### PR DESCRIPTION
Pull Request for Issue #32259 .

### Summary of Changes
Ensures that a non-200 status code is thrown when an invalid JSON response is thrown

### Testing Instructions
As a super admin create a menu link of type "Create Contact"
On the frontend login as an EDITOR and click menu item "Create Contact"
For the Image field click Select.

### Actual result BEFORE applying this Pull Request
No error message thrown. Timeout reached loading page and Javascript error in console

### Expected result AFTER applying this Pull Request
Error thrown in the UI showing no permissions

### Documentation Changes Required
None
