### PR TITLE
[4.0] Individual class for tags as additional class

### DIFF
--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -22,9 +22,9 @@ $authorised = Factory::getUser()->getAuthorisedViewLevels();
 		<?php foreach ($displayData as $i => $tag) : ?>
 			<?php if (in_array($tag->access, $authorised)) : ?>
 				<?php $tagParams = new Registry($tag->params); ?>
-				<?php $link_class = $tagParams->get('tag_link_class'); ?>
+				<?php $link_class = $tagParams->get('tag_link_class', 'btn-info'); ?>
 				<li class="list-inline-item tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i; ?>" itemprop="keywords">
-					<a href="<?php echo Route::_(RouteHelper::getTagRoute($tag->tag_id . ':' . $tag->alias)); ?>" class="btn btn-info btn-sm <?php echo $link_class; ?>">
+					<a href="<?php echo Route::_(RouteHelper::getTagRoute($tag->tag_id . ':' . $tag->alias)); ?>" class="btn btn-sm <?php echo $link_class; ?>">
 						<?php echo $this->escape($tag->title); ?>
 					</a>
 				</li>

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -22,9 +22,9 @@ $authorised = Factory::getUser()->getAuthorisedViewLevels();
 		<?php foreach ($displayData as $i => $tag) : ?>
 			<?php if (in_array($tag->access, $authorised)) : ?>
 				<?php $tagParams = new Registry($tag->params); ?>
-				<?php $link_class = $tagParams->get('tag_link_class', 'btn btn-info btn-sm'); ?>
+				<?php $link_class = $tagParams->get('tag_link_class'); ?>
 				<li class="list-inline-item tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i; ?>" itemprop="keywords">
-					<a href="<?php echo Route::_(RouteHelper::getTagRoute($tag->tag_id . ':' . $tag->alias)); ?>" class="<?php echo $link_class; ?>">
+					<a href="<?php echo Route::_(RouteHelper::getTagRoute($tag->tag_id . ':' . $tag->alias)); ?>" class="btn btn-info btn-sm <?php echo $link_class; ?>">
 						<?php echo $this->escape($tag->title); ?>
 					</a>
 				</li>


### PR DESCRIPTION
Pull Request for Issue #31025  .

### Summary of Changes
Changed the tag layout to use the tag class as additional class to the existent ones (btn btn-info btn-sm).


### Testing Instructions

-Create or edit a tag
-Set a CSS Class for tag link in the Options of the tag, for example btn-danger
-Set a Tag in an article
-Look at the tag in the article

![grafik](https://user-images.githubusercontent.com/9153168/108687710-5662ed00-74f7-11eb-9141-0ea2169c926c.png)


### Actual result BEFORE applying this Pull Request
The tag has no styling and looks as a normal link.


### Expected result AFTER applying this Pull Request
The tag is styled like the others, the additional class btn-danger override btn-info and the background is now red. 
![grafik](https://user-images.githubusercontent.com/9153168/108687744-5e229180-74f7-11eb-8445-be0072b03fbe.png)



