### PR TITLE
Revert white-space:nowrap for Tagline in Cassiopeia

### DIFF
--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -23,6 +23,7 @@
   .site-description {
     font-size: 1rem;
     color: $white;
+    white-space: normal;
   }
 
   .navbar-brand {


### PR DESCRIPTION
Pull Request for Issue #32507  .

### Summary of Changes
Added white-space:normal to site-description div.


### Testing Instructions
See issue


### Actual result BEFORE applying this Pull Request
Long tagline doesn't break on small devices.


### Expected result AFTER applying this Pull Request
Long tagline breaks in more lines.


