### PR TITLE
[4.0] Fix Frontend Editing Article Error

### DIFF
--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -498,7 +498,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 		// Get ID of the article from input, for frontend, we use a_id while backend uses id
 		$articleIdFromInput = $app->input->getInt('a_id') ?: $app->input->getInt('id', 0);
 
-		// On edit article, we get get ID of article from article.id state, but on save, we use data from input
+		// On edit article, we get ID of article from article.id state, but on save, we use data from input
 		$id = (int) $this->getState('article.id', $articleIdFromInput);
 
 		// For new articles we load the potential state + associations

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -484,7 +484,8 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 	 */
 	public function getForm($data = array(), $loadData = true)
 	{
-		$user = Factory::getApplication()->getIdentity();
+		$app  = Factory::getApplication();
+		$user = $app->getIdentity();
 
 		// Get the form.
 		$form = $this->loadForm('com_content.article', 'article', array('control' => 'jform', 'load_data' => $loadData));
@@ -494,7 +495,11 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 			return false;
 		}
 
-		$id = (int) $this->getState('article.id');
+		// Get ID of the article from input, for frontend, we use a_id while backend uses id
+		$articleIdFromInput = $app->input->getInt('a_id') ?: $app->input->getInt('id', 0);
+
+		// On edit article, we get get ID of article from article.id state, but on save, we use data from input
+		$id = (int) $this->getState('article.id', $articleIdFromInput);
 
 		// For new articles we load the potential state + associations
 		if ($id == 0 && $formField = $form->getField('catid'))

--- a/components/com_content/src/Model/FormModel.php
+++ b/components/com_content/src/Model/FormModel.php
@@ -225,7 +225,7 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
 		$app  = Factory::getApplication();
 		$user = $app->getIdentity();
 
-		// On edit article, we get get ID of article from article.id state, but on save, we use data from input
+		// On edit article, we get ID of article from article.id state, but on save, we use data from input
 		$id = (int) $this->getState('article.id', $app->input->getInt('a_id'));
 
 		// Existing record. We can't edit the category in frontend if not edit.state.

--- a/components/com_content/src/Model/FormModel.php
+++ b/components/com_content/src/Model/FormModel.php
@@ -222,9 +222,11 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
 			return false;
 		}
 
-		$user = Factory::getApplication()->getIdentity();
+		$app  = Factory::getApplication();
+		$user = $app->getIdentity();
 
-		$id = (int) $this->getState('article.id');
+		// On edit article, we get get ID of article from article.id state, but on save, we use data from input
+		$id = (int) $this->getState('article.id', $app->input->getInt('a_id'));
 
 		// Existing record. We can't edit the category in frontend if not edit.state.
 		if ($id > 0 && !$user->authorise('core.edit.state', 'com_content.article.' . $id))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR fixes issue with editing an existing article from frontend using an Author account (basically, an account with Edit State Permission enabled for the article being edited but without Edit State Permission in component level)

### Testing Instructions
1. Login to administrator area of your site using a super admin account, edit an article, look at Permission tab, Select Author user group, set Edit and Edit State Permission for that article to Allowed.
2. Login to frontend of of your site using an Author account, edit the above article
3. Before patch: You get **0 Invalid field: Start Featured** error
4. After patch, the article is being saved properly.