### PR TITLE
[4.0] Improve category breadcrumps code

### DIFF
--- a/components/com_content/src/View/Category/HtmlView.php
+++ b/components/com_content/src/View/Category/HtmlView.php
@@ -152,11 +152,7 @@ class HtmlView extends CategoryView
 		// we need to get it from the menu item itself
 		$active = $app->getMenu()->getActive();
 
-		if ($active
-			&& $active->component == 'com_content'
-			&& isset($active->query['view'], $active->query['id'])
-			&& $active->query['view'] == 'category'
-			&& $active->query['id'] == $this->category->id)
+		if ($this->menuItemMatchCategory)
 		{
 			$this->params->def('page_heading', $this->params->get('page_title', $active->title));
 			$title = $this->params->get('page_title', $active->title);
@@ -220,30 +216,42 @@ class HtmlView extends CategoryView
 	protected function prepareDocument()
 	{
 		parent::prepareDocument();
-		$menu = $this->menu;
-		$id = (int) @$menu->query['id'];
-
-		if ($menu && (!isset($menu->query['option']) || $menu->query['option'] !== 'com_content' || $menu->query['view'] === 'article'
-			|| $id != $this->category->id))
-		{
-			$path = array(array('title' => $this->category->title, 'link' => ''));
-			$category = $this->category->getParent();
-
-			while ((!isset($menu->query['option']) || $menu->query['option'] !== 'com_content' || $menu->query['view'] === 'article'
-				|| $id != $category->id) && $category->id > 1)
-			{
-				$path[] = array('title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id, $category->language));
-				$category = $category->getParent();
-			}
-
-			$path = array_reverse($path);
-
-			foreach ($path as $item)
-			{
-				$this->pathway->addItem($item['title'], $item['link']);
-			}
-		}
 
 		parent::addFeed();
+
+		if ($this->menuItemMatchCategory)
+		{
+			// If the active menu item is linked directly to the category being displayed, no further process is needed
+			return;
+		}
+
+		// Get ID of the category from active menu item
+		$menu = $this->menu;
+
+		if ($menu && $menu->component == 'com_content' && isset($menu->query['view'])
+			&& in_array($menu->query['view'], ['categories', 'category']))
+		{
+			$id = $menu->query['id'];
+		}
+		else
+		{
+			$id = 0;
+		}
+
+		$path     = [['title' => $this->category->title, 'link' => '']];
+		$category = $this->category->getParent();
+
+		while ($id != $category->id && $category->id > 1)
+		{
+			$path[]   = ['title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id, $category->language)];
+			$category = $category->getParent();
+		}
+
+		$path = array_reverse($path);
+
+		foreach ($path as $item)
+		{
+			$this->pathway->addItem($item['title'], $item['link']);
+		}
 	}
 }

--- a/components/com_content/src/View/Category/HtmlView.php
+++ b/components/com_content/src/View/Category/HtmlView.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Content\Site\View\Category;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\CategoryView;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Content\Site\Helper\RouteHelper;

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -106,6 +106,14 @@ class CategoryView extends HtmlView
 	protected $runPlugins = false;
 
 	/**
+	 * The flag to mark if the active menu item is linked to the category being displayed
+	 *
+	 * @var bool
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $menuItemMatchCategory = false;
+
+	/**
 	 * Method with common display elements used in category list displays
 	 *
 	 * @return  void
@@ -231,6 +239,8 @@ class CategoryView extends HtmlView
 			{
 				$this->setLayout($active->query['layout']);
 			}
+
+			$this->menuItemMatchCategory = true;
 		}
 		elseif ($layout = $category->params->get('category_layout'))
 		{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This is my attempt to improve the code add breadcrumbs in category view. Currently, the code is messy, hard to understand and could contains potential issue (wrong value for $id variable if you read the code - there is a reason we use @ in the code **$id = (int) @$menu->query['id'];**)


### Testing Instructions
1. Access to Content -> Categories, create several categories and sub-categories)
2. Apply patch
3. Test and make sure the breadcrumbs are still handled properly

#### Test 1:
- Create a menu item to link to **Categories List** menu option.
- Access to that menu item, see categories list. Access to parent category and child category, look at the breadcrumps module, make sure  breadcrump items are added properly (should have the format **Home -> Menu Item Title -> Parent Category -> Child Category**)

#### Test 2:
- Create a menu item to link to Category Blog menu option.
- Access to that menu item, look at look at the breadcrumps module, make sure  breadcrump items are added properly (should have the format **Home -> Menu Item Title)

If someone can review the code changes, that would be great.
