### PR TITLE
fix(mod_submenu): hide disabled components in mod_submenu

### DIFF
--- a/administrator/modules/mod_submenu/mod_submenu.php
+++ b/administrator/modules/mod_submenu/mod_submenu.php
@@ -36,7 +36,7 @@ if ($root && $root->hasChildren())
 		true
 	);
 
-	Menu::preprocess($root);
+	Menu::preprocess($root, Menu::disabledExtensions());
 
 	// Render the module layout
 	require ModuleHelper::getLayoutPath('mod_submenu', $params->get('layout', 'default'));

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -59,13 +59,14 @@ abstract class Menu
 	/**
 	 * Filter and perform other preparatory tasks for loaded menu items based on access rights and module configurations for display
 	 *
-	 * @param   MenuItem  $parent  A menu item to process
+	 * @param   MenuItem  $parent              A menu item to process
+	 * @param   array     $disabledExtensions  Names of disabled extensions, that shall be removed from the result
 	 *
 	 * @return  void
 	 *
 	 * @since   4.0.0
 	 */
-	public static function preprocess($parent, array $disabledExtensions)
+	public static function preprocess($parent, array $disabledExtensions = [])
 	{
 		$app      = Factory::getApplication();
 		$user     = $app->getIdentity();

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -41,19 +41,21 @@ abstract class Menu
 		$query = $db->getQuery(true);
 
 		// Prepare the query.
-		$query->select($db->quoteName('e.name'))
+		$query->select($db->quoteName('e.element'))
 			->from($db->quoteName('#__extensions', 'e'))
+			->where($db->quoteName('e.type') . ' = ' . $db->quote('component'))
+			->where($db->quoteName('e.client_id') . ' = 1')
 			->where($db->quoteName('e.enabled') . ' = 0');
 		$iterator = $db->setQuery($query)->getIterator();
 
-		$names = [];
+		$extensions = [];
 
 		foreach ($iterator as $item)
 		{
-			$names[] = $item->name;
+			$extensions[] = $item->element;
 		}
 
-		return $names;
+		return $extensions;
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #32456 .

### Summary of Changes

The changes introduced hide menu items for disabled components from the cpanel.

### Testing Instructions

1. Disable the CSP extension

### Actual result BEFORE applying this Pull Request

The menu item "Content Security Policy" is still available in the cpanel.

### Expected result AFTER applying this Pull Request

The menu item "Content Security Policy" is not available in the cpanel anymore.

### Documentation Changes Required

