### PR TITLE
[4.0] Fixed empty blog class on update

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7084,6 +7084,11 @@ class JoomlaInstallerScript
 				// Convert to the according CSS class depending on order = "down" or "across".
 				$layout = ($order === 0) ? 'masonry-' : 'columns-';
 
+				if (!isset($params['blog_class']))
+				{
+					$params['blog_class'] = '';
+				}
+
 				if (strpos($params['blog_class'], $layout) === false)
 				{
 					$params['blog_class'] .= ' ' . $layout . $nColumns;
@@ -7105,7 +7110,7 @@ class JoomlaInstallerScript
 		// Update global parameters for com_content.
 		$nColumns = $contentParams->get('num_columns');
 
-		if ($nColumns !== null || true)
+		if ($nColumns !== null)
 		{
 			$nColumns = (int) $nColumns;
 			$order  = (int) $contentParams->get('multi_column_order', '0');


### PR DESCRIPTION
Pull Request for Issue #32493 .

### Summary of Changes

This fixes two things:
1. A PHP notice that occurs under certain circumstances (see testing instructions).
2. A `|| true` that I used for debugging purposes in the making of #31570 and accidentally committed (can be merged on code review).

### Testing Instructions

1. Install a clean beta-7 or nightly version.
2. Set error reporting to development or maximum, don't make any other changes.
3. Immediately after installation, run an update using an update package.

To test the PR, please start again with a clean beta-7 or nightly and then use the update package from this PR. This PR has no effect when updating an already updated site.

### Actual result BEFORE applying this Pull Request

If you use an unpatched beta-7 update package, you will see notices like in #32493.

### Expected result AFTER applying this Pull Request

Using the update package from this PR (see at the bottom "Show all checks" - "Download"), the notices should no longer appear.

### Documentation Changes Required

none