### PR TITLE
[4.0] Frontend editing is not inline editing

### DIFF
--- a/administrator/language/en-GB/com_config.ini
+++ b/administrator/language/en-GB/com_config.ini
@@ -187,7 +187,7 @@ COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_METHODS_DESC="Specifies the Web service 
 COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_ORIGIN_DESC="Specifies the origin allowed to access Web services on this site, sent back in response to a preflight request. Default: * (=all)."
 COM_CONFIG_FIELDSET_TAGS_LABEL="Tags"
 COM_CONFIG_FILTER_OPTION_SELECT_EXTENSION="- Select Extension -"
-COM_CONFIG_FRONTEDITING_LABEL="Inline Editing"
+COM_CONFIG_FRONTEDITING_LABEL="Frontend Editing"
 COM_CONFIG_FRONTEDITING_MENUSANDMODULES="Modules & Menus"
 COM_CONFIG_FRONTEDITING_MODULES="Modules"
 COM_CONFIG_FTP_DETAILS="FTP Login Details"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The label inline editing is wrong. Inline editing is not having buttons to open an edit form.


### Testing Instructions
Code review, or see the label on Global cofniguration. 


