### PR TITLE
[4.0] Hide disabled components in mod_submenu

### DIFF
--- a/administrator/components/com_menus/presets/system.xml
+++ b/administrator/components/com_menus/presets/system.xml
@@ -127,25 +127,25 @@
 		<menuitem
 			title="MOD_MENU_MANAGE_LANGUAGES"
 			type="component"
-			element="com_language"
+			element="com_languages"
 			link="index.php?option=com_languages&amp;view=installed"
-			permission="core.manage;com_language"
+			permission="core.manage;com_languages"
 		/>
 
 		<menuitem
 			title="MOD_MENU_MANAGE_LANGUAGES_CONTENT"
 			type="component"
-			element="com_language"
+			element="com_languages"
 			link="index.php?option=com_languages&amp;view=languages"
-			permission="core.manage;com_language"
+			permission="core.manage;com_languages"
 		/>
 
 		<menuitem
 			title="MOD_MENU_MANAGE_LANGUAGES_OVERRIDES"
 			type="component"
-			element="com_language"
+			element="com_languages"
 			link="index.php?option=com_languages&amp;view=overrides"
-			permission="core.manage;com_language"
+			permission="core.manage;com_languages"
 		/>
 
 		<menuitem

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -51,7 +51,7 @@ abstract class Menu
 
 		foreach ($children as $item)
 		{
-			if (!ComponentHelper::isEnabled($item->element))
+			if (!empty($item->element) && (!ComponentHelper::isEnabled($item->element)))
 			{
 				$parent->removeChild($item);
 				continue;

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -51,6 +51,12 @@ abstract class Menu
 
 		foreach ($children as $item)
 		{
+			if (!ComponentHelper::isEnabled($item->element))
+			{
+				$parent->removeChild($item);
+				continue;
+			}
+
 			$itemParams = $item->getParams();
 
 			// Exclude item with menu item option set to exclude from menu modules

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -51,7 +51,7 @@ abstract class Menu
 
 		foreach ($children as $item)
 		{
-			if ($item->element && (!ComponentHelper::isEnabled($item->element)))
+			if ($item->element && !ComponentHelper::isEnabled($item->element))
 			{
 				$parent->removeChild($item);
 				continue;

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -51,7 +51,7 @@ abstract class Menu
 
 		foreach ($children as $item)
 		{
-			if (!empty($item->element) && (!ComponentHelper::isEnabled($item->element)))
+			if ($item->element && (!ComponentHelper::isEnabled($item->element)))
 			{
 				$parent->removeChild($item);
 				continue;


### PR DESCRIPTION
Pull Request for Issue #32456.

### Summary of Changes
don't show items from disabled component in mod_submenu


### Testing Instructions
see #32456.


### Actual result BEFORE applying this Pull Request
see #32456.


### Expected result AFTER applying this Pull Request
no items from disabled components are shown


### alterrnative to  #32539

let's see how many :-1:  i got :rofl: 