### PR TITLE
[4.0] Fix Batch Menu Items in 4.0 - Update default_batch_body.php

### DIFF
--- a/administrator/components/com_menus/tmpl/items/default_batch_body.php
+++ b/administrator/components/com_menus/tmpl/items/default_batch_body.php
@@ -56,7 +56,7 @@ if ($clientId == 1)
 						<option value=""><?php echo Text::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
 						<?php
 						$opts     = array(
-							'published' => $published,
+							'published' => $this->state->get('filter.published'),
 							'checkacl'  => (int) $this->state->get('menutypeid'),
 							'clientid'  => (int) $clientId,
 						);


### PR DESCRIPTION
Pull Request for Issue #32375, but for Joomla 4 instance.

### Summary of Changes
Issue resolved in "Fix batch menu items" #32380 was applied to staging, but also affects 4.0-dev, as mentioned by @infograf768 in [this comment](https://github.com/joomla/joomla-cms/pull/32380#issuecomment-777255090).

Changing the published option from $published to $this->state->get('filter.published') resolves it.

Problem identified during testing in Joomla 4 Beta 8 nightly build. Problem didn't appear to occur in Beta 6, but does occur in Beta 7 onwards.

### Testing Instructions
- Access to Menus -> Main Menu
- Select some menu items, then press Batch button in the toolbar
- The dropdown for the Copy/Move option to reassign the parent for the batch selection of menu items should show a list of published menu items, but currently does not without the patch applied.

### Actual result BEFORE applying this Pull Request
Before patch: On the popup you only see the Menu names, and no options to assign as parent.
![image](https://user-images.githubusercontent.com/5515866/109609465-780b4680-7b7f-11eb-8b87-f47c71810fd9.png)

### Expected result AFTER applying this Pull Request
After patch: Published menu items are displayed to assign as parent items
![image](https://user-images.githubusercontent.com/5515866/109609552-96714200-7b7f-11eb-9f70-c6e0764948f5.png)