### PR TITLE
Remove reference to joomlacode.org (2)

### DIFF
--- a/administrator/includes/framework.php
+++ b/administrator/includes/framework.php
@@ -43,7 +43,7 @@ if (!file_exists(JPATH_CONFIGURATION . '/configuration.php')
 	}
 }
 
-// Pre-Load configuration. Don't remove the Output Buffering due to BOM issues, see JCode 26026
+// Pre-Load configuration. Don't remove the Output Buffering due to BOM issues
 ob_start();
 require_once JPATH_CONFIGURATION . '/configuration.php';
 ob_end_clean();


### PR DESCRIPTION
Remove reference to joomlacode.org - as Joomla code is dead (soon) https://developer.joomla.org/news/840-bye-bye-joomlacode.html

(sorry for 2 PR's, on mobile)