### PR TITLE
s/carefull/careful

### DIFF
--- a/libraries/fof/encrypt/randval.php
+++ b/libraries/fof/encrypt/randval.php
@@ -23,7 +23,7 @@ class FOFEncryptRandval implements FOFEncryptRandvalinterface
 	 *
 	 * The reason this method exists is backwards compatibility with older versions of FOF. It also allows us to quickly
 	 * address any future issues if Joomla drops the polyfill or otherwise find problems with PHP's random_bytes() on
-	 * some weird host (you can't be too carefull when releasing mass-distributed software).
+	 * some weird host (you can't be too careful when releasing mass-distributed software).
 	 *
 	 * @param   integer  $bytes  How many bytes to return
 	 *
@@ -42,7 +42,7 @@ class FOFEncryptRandval implements FOFEncryptRandvalinterface
 	 *
 	 * The reason this method exists is backwards compatibility with older versions of FOF. It also allows us to quickly
 	 * address any future issues if Joomla drops the polyfill or otherwise find problems with PHP's random_bytes() on
-	 * some weird host (you can't be too carefull when releasing mass-distributed software).
+	 * some weird host (you can't be too careful when releasing mass-distributed software).
 	 *
 	 * @param   integer  $length  Length of the random data to generate
 	 *


### PR DESCRIPTION
s/carefull/careful

another typo in the Joomla 3.9.25 security release. 

UK: https://dictionary.cambridge.org/dictionary/english/careful
USA: https://www.merriam-webster.com/dictionary/careful
