### PR TITLE
s/404/500

### DIFF
--- a/administrator/components/com_media/media.php
+++ b/administrator/components/com_media/media.php
@@ -42,7 +42,7 @@ $mediaBaseDir = JPATH_ROOT . '/' . $params->get($path, 'images');
 
 if (!is_dir($mediaBaseDir))
 {
-	throw new \InvalidArgumentException(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 404);
+	throw new \InvalidArgumentException(JText::_('JERROR_AN_ERROR_HAS_OCCURRED'), 500);
 }
 
 define('COM_MEDIA_BASE', $mediaBaseDir);


### PR DESCRIPTION
This is triggered If the path to the images folder is not a directory.

The error raised is not a `HTTP 404 Page Not Found`, this is factually incorrect, there is no "page" that is not found.

Its an `InvalidArgumentException` therefore it should be a `HTTP 500 Internal Server Error`, the error is internal, its not a page not found. Its an Error like JERROR_AN_ERROR_HAS_OCCURRED states. a 404 is not an error. 

Prior to Joomla 3.9.25 you would get a more helpful message: 

<img width="480" alt="Screenshot 2021-03-03 at 20 50 29" src="https://user-images.githubusercontent.com/400092/109870523-1b348c80-7c62-11eb-8dda-ecc81e92524c.png">

After 3.9.25 you get this which is less helpful:

<img width="429" alt="Screenshot 2021-03-03 at 20 50 57" src="https://user-images.githubusercontent.com/400092/109870585-2f788980-7c62-11eb-98bd-bab48b86261c.png">
