### PR TITLE
s/1.6.0/3.9.25

### DIFF
--- a/libraries/src/Filesystem/Path.php
+++ b/libraries/src/Filesystem/Path.php
@@ -350,7 +350,7 @@ class Path
 	 *
 	 * @return  string  The resolved path
 	 *
-	 * @since   1.6.0
+	 * @since   3.9.25
 	 */
 	public static function resolve($path)
 	{


### PR DESCRIPTION
Correct factually incorrect `@since` tag which is a copy and paste error

This method was added in in Joomla 3.9.25 https://github.com/joomla/joomla-cms/commit/aadf6979f8b99308c3621ea3af2ca98e678a477d and not Joomla 1.6.0, but it was probably copied from the framework Filesystem 1.6.0.  

1.6.0 relates to joomla framework 1.6.0 and not Joomla CMS 1.6.0

