### PR TITLE
[4.0] Fix deletion of files in script.php on updates

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -5045,6 +5045,9 @@ class JoomlaInstallerScript
 			'/templates/cassiopeia/html/layouts/chromes/cardGrey.php',
 			'/templates/cassiopeia/html/layouts/chromes/default.php',
 			'/templates/cassiopeia/scss/vendor/bootstrap/_card.scss',
+			// Joomla 4.0 Beta 7
+			'/media/vendor/skipto/js/dropMenu.js',
+			'/media/vendor/skipto/css/SkipTo.css'
 		);
 
 		$folders = array(
@@ -6233,10 +6236,8 @@ class JoomlaInstallerScript
 			'/libraries/vendor/joomla/controller',
 			// Joomla 4.0 Beta 5
 			'/plugins/content/imagelazyload',
-			// Joomla 4.0 Beta 6
-			'/media/vendor/skipto/js/skipTo.js',
-			'/media/vendor/skipto/js/dropMenu.js',
-			'/media/vendor/skipto/css/SkipTo.css'
+			// Joomla 4.0 Beta 7
+			'/media/vendor/skipto/css'
 		);
 
 		$status['files_checked'] = $files;


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/32043#issuecomment-789712210 .

### Summary of Changes

This pull request (PR) fixes following issues:

1. With PR #32043 , css and js files of the skipto plugin were removed, and that PR should have added these files to the list of files to be deleted (array `$files`) in script.php below the last file here here:
https://github.com/joomla/joomla-cms/blob/5185266c50004b5fb550bec276250c44e886ce15/administrator/components/com_admin/script.php#L5047-L5048
But it has added them to the list of folders (array `$folders`) here:
https://github.com/joomla/joomla-cms/blob/5185266c50004b5fb550bec276250c44e886ce15/administrator/components/com_admin/script.php#L6236-L6239
This PR here corrects it by moving the files to the right place, except of file `skipTo.js`, see point 4 below. 
2. Because after the removal of file `SkipTo.css` folder `/media/vendor/skipto/css` will be empty, that folder has to be removed, too, so this PR adds it to the list of folders.
3. The files and the folder have been removed after Beta 6 and before Beta 7, i.e. the removal was released with Beta 7, and so the comment "// Joomla 4.0 Beta 6" used by PR #32043 was wrong, it has to be "// Joomla 4.0 Beta 7".
4. Since PR #31804 has been merged, there is a new function in script.php which is used to rename files with a wrong name regarding upper and lower case. The file `skipTo.js` is such a case and has been added to that function by that PR here:
https://github.com/joomla/joomla-cms/blob/5185266c50004b5fb550bec276250c44e886ce15/administrator/components/com_admin/script.php#L7170
Files which are renamed like this shall not be in the list of files to be deleted. PR #31804 should have removed it from that list, but this was missed, possibly due to issue 1. That's why this PR leaves it away as mentioned above in issue 1.

### Testing Instructions

Code review by someone who is familiar with what this PR deals with should be sufficient, but for those who insist on a real test:

1. Update a Joomla 4 Beta 6 or an earlier Joomla 4 version to Beta 7.
2. Check if the following files are there:
- `/media/vendor/skipto/js/dropMenu.js`
- `/media/vendor/skipto/css/SkipTo.css`
Result: The files are still there.
3. Check if folder `/media/vendor/skipto/css` would be empty if file `SkipTo.css` had been removed.
Result: The folder would be empty because `SkipTo.css` is the only file in it.
4. Now update to Beta 8 dev + this PR using the update package or custom update URL built by drone for this PR.
5. Check if the following files are there:
- `/media/vendor/skipto/js/dropMenu.js`
- `/media/vendor/skipto/css/SkipTo.css`
Result: The files have been removed.
6. Check if folder `/media/vendor/skipto/css` is there.
Result: The folder has been removed.

### Actual result BEFORE applying this Pull Request

After an update from Joomla 4 Beta 6 or an earlier Joomla 4 version to Beta 7, files `/media/vendor/skipto/js/dropMenu.js` and `/media/vendor/skipto/css/SkipTo.css` are still present.

### Expected result AFTER applying this Pull Request

After an update from Joomla 4 Beta 6 or an earlier Joomla 4 version to Beta 7, file `/media/vendor/skipto/js/dropMenu.js` and folder `/media/vendor/skipto/css` have been removed.

### Additional information

This PR doesn't fix other issues (missing stuff from Beta 6 and 7 and later up to now) in the files and folder deletion of script.php.

I will later (weekend or so, latest before the next Beta or RC) make another PR to fix these.

### Documentation Changes Required

None.