### PR TITLE
[4.0] Add missing comma to last element of deleted files and folders arrays in script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -5047,7 +5047,7 @@ class JoomlaInstallerScript
 			'/templates/cassiopeia/scss/vendor/bootstrap/_card.scss',
 			// Joomla 4.0 Beta 7
 			'/media/vendor/skipto/js/dropMenu.js',
-			'/media/vendor/skipto/css/SkipTo.css'
+			'/media/vendor/skipto/css/SkipTo.css',
 		);
 
 		$folders = array(
@@ -6237,7 +6237,7 @@ class JoomlaInstallerScript
 			// Joomla 4.0 Beta 5
 			'/plugins/content/imagelazyload',
 			// Joomla 4.0 Beta 7
-			'/media/vendor/skipto/css'
+			'/media/vendor/skipto/css',
 		);
 
 		$status['files_checked'] = $files;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With my recently merged PR #32582 I've forgotten to add a comma at the end of the last element of each array.

This is code style only, but the missing comma makes it harder to add new elements to the end.

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

No comma after the last element of each of the 2 arrays.

### Expected result AFTER applying this Pull Request

Comma after the last element of each of the 2 arrays.

### Documentation Changes Required

None.