### PR TITLE
[4.0-dev] Add limit settings to fancy-select

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -37,10 +37,6 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
 
   get termKey() { return this.getAttribute('term-key') || 'term'; }
 
-  get maxResults() { return parseInt(this.getAttribute('data-max-results'), 10) || 30; }
-
-  get maxRender() { return parseInt(this.getAttribute('data-max-render'), 10) || 30; }
-
   get minTermLength() { return parseInt(this.getAttribute('min-term-length'), 10) || 1; }
 
   get newItemPrefix() { return this.getAttribute('new-item-prefix') || ''; }
@@ -130,8 +126,8 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
       searchPlaceholderValue: this.searchPlaceholder,
       removeItemButton: true,
       searchFloor: this.minTermLength,
-      searchResultLimit: this.maxResults,
-      renderChoiceLimit: this.maxRender,
+      searchResultLimit: parseInt(this.dataset.maxResults, 10) || 4,
+      renderChoiceLimit: parseInt(this.dataset.maxRender, 10) || -1,
       shouldSort: false,
       fuseOptions: {
         threshold: 0.3, // Strict search

--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -126,7 +126,7 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
       searchPlaceholderValue: this.searchPlaceholder,
       removeItemButton: true,
       searchFloor: this.minTermLength,
-      searchResultLimit: parseInt(this.select.dataset.maxResults, 10) || 4,
+      searchResultLimit: parseInt(this.select.dataset.maxResults, 10) || 10,
       renderChoiceLimit: parseInt(this.select.dataset.maxRender, 10) || -1,
       shouldSort: false,
       fuseOptions: {

--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -126,8 +126,8 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
       searchPlaceholderValue: this.searchPlaceholder,
       removeItemButton: true,
       searchFloor: this.minTermLength,
-      searchResultLimit: parseInt(this.dataset.maxResults, 10) || 4,
-      renderChoiceLimit: parseInt(this.dataset.maxRender, 10) || -1,
+      searchResultLimit: parseInt(this.select.dataset.maxResults, 10) || 4,
+      renderChoiceLimit: parseInt(this.select.dataset.maxRender, 10) || -1,
       shouldSort: false,
       fuseOptions: {
         threshold: 0.3, // Strict search

--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -23,9 +23,9 @@
  * min-term-length="1"   The minimum length a search value should be before choices are searched.
  * placeholder=""        The value of the inputs placeholder.
  * search-placeholder="" The value of the search inputs placeholder.
- * 
+ *
  * data-max-results="30" The maximum amount of search results to be displayed.
- * data-max-render="30"  The maximum amount of items to be rendered, critical for large lists. 
+ * data-max-render="30"  The maximum amount of items to be rendered, critical for large lists.
  */
 window.customElements.define('joomla-field-fancy-select', class extends HTMLElement {
   // Attributes to monitor
@@ -37,9 +37,9 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
 
   get termKey() { return this.getAttribute('term-key') || 'term'; }
 
-  get maxResults() { return parseInt(this.dataset('maxResults')) || 30; }
+  get maxResults() { return parseInt(this.getAttribute('data-max-results'), 10) || 30; }
 
-  get maxRender() { return parseInt(this.dataset('maxRender')) || 30; }
+  get maxRender() { return parseInt(this.getAttribute('data-max-render'), 10) || 30; }
 
   get minTermLength() { return parseInt(this.getAttribute('min-term-length'), 10) || 1; }
 

--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -23,6 +23,9 @@
  * min-term-length="1"   The minimum length a search value should be before choices are searched.
  * placeholder=""        The value of the inputs placeholder.
  * search-placeholder="" The value of the search inputs placeholder.
+ * 
+ * data-max-results="30" The maximum amount of search results to be displayed.
+ * data-max-render="30"  The maximum amount of items to be rendered, critical for large lists. 
  */
 window.customElements.define('joomla-field-fancy-select', class extends HTMLElement {
   // Attributes to monitor
@@ -33,6 +36,10 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
   get url() { return this.getAttribute('url'); }
 
   get termKey() { return this.getAttribute('term-key') || 'term'; }
+
+  get maxResults() { return parseInt(this.dataset('maxResults')) || 30; }
+
+  get maxRender() { return parseInt(this.dataset('maxRender')) || 30; }
 
   get minTermLength() { return parseInt(this.getAttribute('min-term-length'), 10) || 1; }
 
@@ -123,7 +130,8 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
       searchPlaceholderValue: this.searchPlaceholder,
       removeItemButton: true,
       searchFloor: this.minTermLength,
-      searchResultLimit: 10,
+      searchResultLimit: this.maxResults,
+      renderChoiceLimit: this.maxRender,
       shouldSort: false,
       fuseOptions: {
         threshold: 0.3, // Strict search


### PR DESCRIPTION
Re-commit for #30836, originally committed for #30288, now following up on #27212 and #29252 as suggested by @Fedik 

The previous commit is obsolete since the above mentioned PRs have been merged, which means the previously suggested changes for PHP files are no longer necessary to improve the `fancy-select` layout.

This commit is much more inline with the current codebase and far better implementation.

### Summary of Changes
As explained with the issue at hand, the `choices.js` provides support for a render limit of the `<option>`s and a search results limit, the first is much more important.

The source at `build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js` now can use `data-max-render` and `data-max-results` attributes to set `searchResultLimit` and `renderChoiceLimit` options for `choices.js`.

### Testing Instructions
* Open any `extensionName.xml` and add this field in any `<fieldset>`
```markup
    <field
      name="fancy-select"
      type="List"
      label="List Demo"
      default="5"
      data-max-render="5"
      data-max-results="15"
      layout="joomla.form.field.list-fancy-select">
      <option value="alpha0">Option Alpha</option>
      <option value="alpha1">Option Alpha 1</option>
      <option value="alpha2">Option Alpha 2</option>
      <option value="alpha3">Option Alpha 3</option>
      <option value="alpha4">Option Alpha 4</option>
      <option value="alpha5">Option Alpha 5</option>
      <option value="alpha6">Option Alpha 6</option>
      <option value="alpha7">Option Alpha 7</option>
      <option value="alpha8">Option Alpha 8</option>
      <option value="alpha9">Option Alpha 9</option>
      <option value="beta0">Option Beta</option>
      <option value="beta1">Option Beta 1</option>
      <option value="beta2">Option Beta 2</option>
      <option value="beta3">Option Beta 3</option>
      <option value="beta4">Option Beta 4</option>
      <option value="beta5">Option Beta 5</option>
      <option value="beta6">Option Beta 6</option>
      <option value="beta7">Option Beta 7</option>
      <option value="beta8">Option Beta 8</option>
      <option value="beta9">Option Beta 9</option>
      <option value="gama0">Option Gama</option>
      <option value="gama1">Option Gama 1</option>
      <option value="gama2">Option Gama 2</option>
      <option value="gama3">Option Gama 3</option>
      <option value="gama4">Option Gama 4</option>
      <option value="gama5">Option Gama 5</option>
      <option value="gama6">Option Gama 6</option>
      <option value="gama7">Option Gama 7</option>
      <option value="gama8">Option Gama 8</option>
      <option value="gama9">Option Gama 9</option>
      <option value="gama10">Option Gama 10</option>
    </field>
```
* save and go to that extension config
* open the field dropdown, there should be 5 options as configured;
* type in 'option' in the search box of the field, you should get 15 results as configured.

### Actual result BEFORE applying this Pull Request
Large lists are initialized extremely slow, also the initial `max-results` of 10 was not enough. Imagine more than 10 Roboto font family styles, or much more articles that contain a certain keyword / combination of keywords.

### Expected result AFTER applying this Pull Request
Much faster initialization, no more browser notices on slow render, also more flexible configuration.

### Documentation Changes Required
The following is a documentation draft on the use of the `layouts/joomla/form/field/list-fancy-select.php` layout with the new specific `data-*` attributes to be updated [here](https://docs.joomla.org/List_form_field_type).

**Documentation Draft**

The **list** form field comes with an alternate layout called "joomla.form.field.list-fancy-select" which enables additional functionality powered by [Choices](https://github.com/jshjohnson/Choices): 
* the ability to search though options;
* the ability to limit the rendered options.

Example usage:
```markup
<field
    name="fieldc"
    type="list"
    label="FIELDC_LABEL"
    description="FIELDC_DESC"
    layout="joomla.form.field.list-fancy-select"
    data-max-render="-1"
    data-max-results="5"
    >
    <option value="0">JNO</option>
    <option value="1">Option 1</option>
    <option value="2">Option 2</option>
    <option value="3">Option 3</option>
    <option value="4">Option 4</option>
    <option value="5">Option 5</option>
    ....
    <option value="n">Option n</option>
</field>
```

The "joomla.form.field.list-fancy-select" layout uses two additional field properties:
* the `data-max-render="-1"` property will limit the amount of visible options that are rendered on initialization as well as when expanded to the user; this option is useful when working with hundreds options, making them snappy and responsive; the default value is **-1** which means unlimited;
* the `data-max-results="5"` property will limit the amount of search results that are displayed to the user, which would suggest the user should use more specific keywords; the default value is **10**.
