### PR TITLE
[3.x] Make database schema check ignore display widths for all integer types on MySQL or MariaDB databases

### DIFF
--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -180,7 +180,7 @@ class MysqlChangeItem extends ChangeItem
 				{
 					$type = $this->fixInteger($wordArray[6], $wordArray[7]);
 				}
-				
+
 				// Detect changes in NULL and in DEFAULT column attributes
 				$changesArray = array_slice($wordArray, 6);
 				$defaultCheck = $this->checkDefault($changesArray, $type);
@@ -286,8 +286,8 @@ class MysqlChangeItem extends ChangeItem
 	 * Make check query for column changes/modifications tolerant
 	 * for automatic type changes of text columns, e.g. from TEXT
 	 * to MEDIUMTEXT, after conversion from utf8 to utf8mb4, and
-	 * fix integer (int or tinyint) columns without display length
-	 * for MySQL 8.
+	 * fix integer columns without display length for MySQL 8
+	 * (see also function "fixInteger" above).
 	 *
 	 * @param   string  $type  The column type found in the update query
 	 *
@@ -299,73 +299,49 @@ class MysqlChangeItem extends ChangeItem
 	{
 		$uType = strtoupper(str_replace(';', '', $type));
 
-		if ($uType === 'TINYINT UNSIGNED')
+		switch ($uType)
 		{
-			$typeCheck = 'UPPER(LEFT(type, 7)) = ' . $this->db->quote('TINYINT')
-				. ' AND UPPER(RIGHT(type, 9)) = ' . $this->db->quote(' UNSIGNED');
-		}
-		elseif ($uType === 'TINYINT')
-		{
-			$typeCheck = 'UPPER(LEFT(type, 7)) = ' . $this->db->quote('TINYINT');
-		}
-		elseif ($uType === 'SMALLINT UNSIGNED')
-		{
-			$typeCheck = 'UPPER(LEFT(type, 8)) = ' . $this->db->quote('SMALLINT')
-				. ' AND UPPER(RIGHT(type, 9)) = ' . $this->db->quote(' UNSIGNED');
-		}
-		elseif ($uType === 'SMALLINT')
-		{
-			$typeCheck = 'UPPER(LEFT(type, 8)) = ' . $this->db->quote('SMALLINT');
-		}
-		elseif ($uType === 'MEDIUMINT UNSIGNED')
-		{
-			$typeCheck = 'UPPER(LEFT(type, 9)) = ' . $this->db->quote('MEDIUMINT')
-				. ' AND UPPER(RIGHT(type, 9)) = ' . $this->db->quote(' UNSIGNED');
-		}
-		elseif ($uType === 'MEDIUMINT')
-		{
-			$typeCheck = 'UPPER(LEFT(type, 9)) = ' . $this->db->quote('MEDIUMINT');
-		}
-		elseif ($uType === 'INT UNSIGNED')
-		{
-			$typeCheck = 'UPPER(LEFT(type, 3)) = ' . $this->db->quote('INT')
-				. ' AND UPPER(RIGHT(type, 9)) = ' . $this->db->quote(' UNSIGNED');
-		}
-		elseif ($uType === 'INT')
-		{
-			$typeCheck = 'UPPER(LEFT(type, 3)) = ' . $this->db->quote('INT');
-		}
-		elseif ($uType === 'BIGINT UNSIGNED')
-		{
-			$typeCheck = 'UPPER(LEFT(type, 6)) = ' . $this->db->quote('BIGINT')
-				. ' AND UPPER(RIGHT(type, 9)) = ' . $this->db->quote(' UNSIGNED');
-		}
-		elseif ($uType === 'BIGINT')
-		{
-			$typeCheck = 'UPPER(LEFT(type, 6)) = ' . $this->db->quote('BIGINT');
-		}
-		elseif ($this->db->hasUTF8mb4Support())
-		{
-			if ($uType === 'TINYTEXT')
-			{
-				$typeCheck = 'UPPER(type) IN (' . $this->db->quote('TINYTEXT') . ',' . $this->db->quote('TEXT') . ')';
-			}
-			elseif ($uType === 'TEXT')
-			{
-				$typeCheck = 'UPPER(type) IN (' . $this->db->quote('TEXT') . ',' . $this->db->quote('MEDIUMTEXT') . ')';
-			}
-			elseif ($uType === 'MEDIUMTEXT')
-			{
-				$typeCheck = 'UPPER(type) IN (' . $this->db->quote('MEDIUMTEXT') . ',' . $this->db->quote('LONGTEXT') . ')';
-			}
-			else
-			{
+			case 'BIGINT UNSIGNED':
+			case 'INT UNSIGNED':
+			case 'MEDIUMINT UNSIGNED':
+			case 'SMALLINT UNSIGNED':
+			case 'TINYINT UNSIGNED':
+				// Eg for "INT": "UPPER(type) REGEXP '^INT(\([0-9]+\))? UNSIGNED$'"
+				$typeCheck = 'UPPER(type) REGEXP ' . $this->db->quote('^' . str_replace(' ', '([(][0-9]+[)])? ', $uType) . '$');
+				break;
+
+			case 'BIGINT':
+			case 'INT':
+			case 'MEDIUMINT':
+			case 'SMALLINT':
+			case 'TINYINT':
+				// Eg for "INT": "UPPER(type) REGEXP '^INT(\([0-9]+\))?$'"
+				$typeCheck = 'UPPER(type) REGEXP ' . $this->db->quote('^' . $uType . '([(][0-9]+[)])?$');
+				break;
+
+			case 'MEDIUMTEXT':
+				$typeCheck
+					= $this->db->hasUTF8mb4Support()
+					? 'UPPER(type) IN (' . $this->db->quote('MEDIUMTEXT') . ',' . $this->db->quote('LONGTEXT') . ')'
+					: 'UPPER(type) = ' . $this->db->quote('MEDIUMTEXT');
+				break;
+
+			case 'TEXT':
+				$typeCheck
+					= $this->db->hasUTF8mb4Support()
+					? 'UPPER(type) IN (' . $this->db->quote('TEXT') . ',' . $this->db->quote('MEDIUMTEXT') . ')'
+					: 'UPPER(type) = ' . $this->db->quote('TEXT');
+				break;
+
+			case 'TINYTEXT':
+				$typeCheck
+					= $this->db->hasUTF8mb4Support()
+					? 'UPPER(type) IN (' . $this->db->quote('TINYTEXT') . ',' . $this->db->quote('TEXT') . ')'
+					: 'UPPER(type) = ' . $this->db->quote('TINYTEXT');
+				break;
+
+			default:
 				$typeCheck = 'UPPER(type) = ' . $this->db->quote($uType);
-			}
-		}
-		else
-		{
-			$typeCheck = 'UPPER(type) = ' . $this->db->quote($uType);
 		}
 
 		return $typeCheck;
@@ -422,7 +398,7 @@ class MysqlChangeItem extends ChangeItem
 
 		// Find DEFAULT keyword
 		$index = array_search('default', array_map('strtolower', $changesArray));
-	
+
 		// Create the check
 		if ($index !== false)
 		{

--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -235,7 +235,8 @@ class MysqlChangeItem extends ChangeItem
 	 * On MySQL 8 display length is not shown anymore.
 	 * This means we have to match e.g. both "int(10) unsigned" and
 	 * "int unsigned", or both "int(11)" and "int" and so on.
-	 * The same applies to tinyint.
+	 * The same applies to the other integer data types "tinyint",
+	 * "smallint", "mediumint" and "bigint".
 	 *
 	 * @param   string  $type1  the column type
 	 * @param   string  $type2  the column attributes
@@ -248,28 +249,14 @@ class MysqlChangeItem extends ChangeItem
 	{
 		$result = $type1;
 
+		if (preg_match('/^(?P<type>(big|medium|small|tiny)?int)(\([0-9]+\))?$/i', $type1, $matches))
+		{
+			$result = strtolower($matches['type']);
+		}
+
 		if (strtolower(substr($type2, 0, 8)) === 'unsigned')
 		{
-			if (strtolower(substr($type1, 0, 7)) === 'tinyint')
-			{
-				$result = 'tinyint unsigned';
-			}
-			elseif (strtolower(substr($type1, 0, 3)) === 'int')
-			{
-				$result = 'int unsigned';
-			}
-			else
-			{
-				$result = $type1 . ' unsigned';
-			}
-		}
-		elseif (strtolower(substr($type1, 0, 7)) === 'tinyint')
-		{
-			$result = 'tinyint';
-		}
-		elseif (strtolower(substr($type1, 0, 3)) === 'int')
-		{
-			$result = 'int';
+			$result .= ' unsigned';
 		}
 
 		return $result;

--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -320,22 +320,19 @@ class MysqlChangeItem extends ChangeItem
 				break;
 
 			case 'MEDIUMTEXT':
-				$typeCheck
-					= $this->db->hasUTF8mb4Support()
+				$typeCheck = $this->db->hasUTF8mb4Support()
 					? 'UPPER(type) IN (' . $this->db->quote('MEDIUMTEXT') . ',' . $this->db->quote('LONGTEXT') . ')'
 					: 'UPPER(type) = ' . $this->db->quote('MEDIUMTEXT');
 				break;
 
 			case 'TEXT':
-				$typeCheck
-					= $this->db->hasUTF8mb4Support()
+				$typeCheck = $this->db->hasUTF8mb4Support()
 					? 'UPPER(type) IN (' . $this->db->quote('TEXT') . ',' . $this->db->quote('MEDIUMTEXT') . ')'
 					: 'UPPER(type) = ' . $this->db->quote('TEXT');
 				break;
 
 			case 'TINYTEXT':
-				$typeCheck
-					= $this->db->hasUTF8mb4Support()
+				$typeCheck = $this->db->hasUTF8mb4Support()
 					? 'UPPER(type) IN (' . $this->db->quote('TINYTEXT') . ',' . $this->db->quote('TEXT') . ')'
 					: 'UPPER(type) = ' . $this->db->quote('TINYTEXT');
 				break;

--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -306,7 +306,7 @@ class MysqlChangeItem extends ChangeItem
 			case 'MEDIUMINT UNSIGNED':
 			case 'SMALLINT UNSIGNED':
 			case 'TINYINT UNSIGNED':
-				// Eg for "INT": "UPPER(type) REGEXP '^INT(\([0-9]+\))? UNSIGNED$'"
+				// Eg for "INT": "UPPER(type) REGEXP '^INT([(][0-9]+[)])? UNSIGNED$'"
 				$typeCheck = 'UPPER(type) REGEXP ' . $this->db->quote('^' . str_replace(' ', '([(][0-9]+[)])? ', $uType) . '$');
 				break;
 
@@ -315,7 +315,7 @@ class MysqlChangeItem extends ChangeItem
 			case 'MEDIUMINT':
 			case 'SMALLINT':
 			case 'TINYINT':
-				// Eg for "INT": "UPPER(type) REGEXP '^INT(\([0-9]+\))?$'"
+				// Eg for "INT": "UPPER(type) REGEXP '^INT([(][0-9]+[)])?$'"
 				$typeCheck = 'UPPER(type) REGEXP ' . $this->db->quote('^' . $uType . '([(][0-9]+[)])?$');
 				break;
 

--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -308,6 +308,24 @@ class MysqlChangeItem extends ChangeItem
 		{
 			$typeCheck = 'UPPER(LEFT(type, 7)) = ' . $this->db->quote('TINYINT');
 		}
+		elseif ($uType === 'SMALLINT UNSIGNED')
+		{
+			$typeCheck = 'UPPER(LEFT(type, 8)) = ' . $this->db->quote('SMALLINT')
+				. ' AND UPPER(RIGHT(type, 9)) = ' . $this->db->quote(' UNSIGNED');
+		}
+		elseif ($uType === 'SMALLINT')
+		{
+			$typeCheck = 'UPPER(LEFT(type, 8)) = ' . $this->db->quote('SMALLINT');
+		}
+		elseif ($uType === 'MEDIUMINT UNSIGNED')
+		{
+			$typeCheck = 'UPPER(LEFT(type, 9)) = ' . $this->db->quote('MEDIUMINT')
+				. ' AND UPPER(RIGHT(type, 9)) = ' . $this->db->quote(' UNSIGNED');
+		}
+		elseif ($uType === 'MEDIUMINT')
+		{
+			$typeCheck = 'UPPER(LEFT(type, 9)) = ' . $this->db->quote('MEDIUMINT');
+		}
 		elseif ($uType === 'INT UNSIGNED')
 		{
 			$typeCheck = 'UPPER(LEFT(type, 3)) = ' . $this->db->quote('INT')
@@ -316,6 +334,15 @@ class MysqlChangeItem extends ChangeItem
 		elseif ($uType === 'INT')
 		{
 			$typeCheck = 'UPPER(LEFT(type, 3)) = ' . $this->db->quote('INT');
+		}
+		elseif ($uType === 'BIGINT UNSIGNED')
+		{
+			$typeCheck = 'UPPER(LEFT(type, 6)) = ' . $this->db->quote('BIGINT')
+				. ' AND UPPER(RIGHT(type, 9)) = ' . $this->db->quote(' UNSIGNED');
+		}
+		elseif ($uType === 'BIGINT')
+		{
+			$typeCheck = 'UPPER(LEFT(type, 6)) = ' . $this->db->quote('BIGINT');
 		}
 		elseif ($this->db->hasUTF8mb4Support())
 		{


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/28501#issuecomment-792267368 .

### Summary of Changes

This pull request (PR) extends the fix from #28501 for the database schema check to integer data types other than `int` and `tinyint`.

It only relevant for MySQL and MariaDB databases, ie not PostgreSQL.

As stated in PR #28501 and issue #32542 , the display width modifier has no impact on value range or storage size of a database column of one of the integer data types.

While MySQL deprecated these display widths beginning with version 8.0.17 and doesn't include them anymore in the type returned by a `SHOW COLUMNS` statement, MariaDB still supports and uses display widths modifiers for integer types so it still behaves like MySQL <= 5.7.

With this PR I took the chance for refactoring the parts which have been modified before with #28501 for `int` and `tinyint` types, so that code is more readable and also more precise with checking the types and so doesn't hide anymore typos in update SQL scripts.

### Testing Instructions

**_Requirement:_** Have an installation of current staging or latest 3.9.x nightly build which uses a MySQL or MariaDB database.

Testers please report back which of the following 2 kinds of databases you have used for the test:
- MySQL database servers with versions lower than 8.0.17 or on any server version of MariaDB
- MySQL database servers with version 8.0.17 or later

If you have both scenarios available, please test both.

**_Step 1:_** Add 2 new update SQL scripts as follows to folder `administrator/components/com_admin/sql/updates/mysql`:

If you are not comfortable with editing you can also download them using the link in the script names.

- Script [3.9.26-2021-03-05.sql](https://test5.richard-fath.de/3.9.26-2021-03-05.sql)
```
CREATE TABLE `#__test_table_1` (
  `id`              int NOT NULL AUTO_INCREMENT,
  `col_int`         int,
  `col_int_u`       int unsigned,
  `col_tinyint`     tinyint,
  `col_tinyint_u`   tinyint unsigned,
  `col_smallint`    smallint,
  `col_smallint_u`  smallint unsigned,
  `col_mediumint`   mediumint,
  `col_mediumint_u` mediumint unsigned,
  `col_bigint`      bigint,
  `col_bigint_u`    bigint unsigned,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

CREATE TABLE `#__test_table_2` (
  `id`              int(10) NOT NULL AUTO_INCREMENT,
  `col_int`         int(9),
  `col_int_u`       int(9) unsigned,
  `col_tinyint`     tinyint(2),
  `col_tinyint_u`   tinyint(2) unsigned,
  `col_smallint`    smallint(4),
  `col_smallint_u`  smallint(4) unsigned,
  `col_mediumint`   mediumint(6),
  `col_mediumint_u` mediumint(6) unsigned,
  `col_bigint`      bigint(11),
  `col_bigint_u`    bigint(11) unsigned,
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
```
- Script [3.9.26-2021-03-06.sql](https://test5.richard-fath.de/3.9.26-2021-03-06.sql)
```
ALTER TABLE `#__test_table_1` MODIFY `col_int` int DEFAULT 0;
ALTER TABLE `#__test_table_1` MODIFY `col_int_u` int unsigned DEFAULT 0;
ALTER TABLE `#__test_table_1` MODIFY `col_tinyint` tinyint DEFAULT 0;
ALTER TABLE `#__test_table_1` MODIFY `col_tinyint_u` tinyint unsigned DEFAULT 0;
ALTER TABLE `#__test_table_1` MODIFY `col_smallint` smallint DEFAULT 0;
ALTER TABLE `#__test_table_1` MODIFY `col_smallint_u` smallint unsigned DEFAULT 0;
ALTER TABLE `#__test_table_1` MODIFY `col_mediumint` mediumint DEFAULT 0;
ALTER TABLE `#__test_table_1` MODIFY `col_mediumint_u` mediumint unsigned DEFAULT 0;
ALTER TABLE `#__test_table_1` MODIFY `col_bigint` bigint DEFAULT 0;
ALTER TABLE `#__test_table_1` MODIFY `col_bigint_u` bigint unsigned DEFAULT 0;

ALTER TABLE `#__test_table_2` MODIFY `col_int` int(9) DEFAULT 0;
ALTER TABLE `#__test_table_2` MODIFY `col_int_u` int(9) unsigned DEFAULT 0;
ALTER TABLE `#__test_table_2` MODIFY `col_tinyint` tinyint(2) DEFAULT 0;
ALTER TABLE `#__test_table_2` MODIFY `col_tinyint_u` tinyint(2) unsigned DEFAULT 0;
ALTER TABLE `#__test_table_2` MODIFY `col_smallint` smallint(4) DEFAULT 0;
ALTER TABLE `#__test_table_2` MODIFY `col_smallint_u` smallint(4) unsigned DEFAULT 0;
ALTER TABLE `#__test_table_2` MODIFY `col_mediumint` mediumint(6) DEFAULT 0;
ALTER TABLE `#__test_table_2` MODIFY `col_mediumint_u` mediumint(6) unsigned DEFAULT 0;
ALTER TABLE `#__test_table_2` MODIFY `col_bigint` bigint(11) DEFAULT 0;
ALTER TABLE `#__test_table_2` MODIFY `col_bigint_u` bigint(11) unsigned DEFAULT 0;
```

The reason why it needs the 2nd script is that the database schema checker checks only for the existence of the table for `CREATE TABLE` statements but not for the columns. This is checked eg for `ALTER TABLE ... MODIFY` statements which here just add a default value for having some change but don't touch the data type.

**_Step 2:_** Go to "Extensions -> Manage Database".

**_Result:_** An error alert about the 2 tables missing is shown, and some 23 database problems have been found (the exact number may differ, but it doesn't matter for this test step here):
![step-1_mysql-8](https://user-images.githubusercontent.com/7413183/110240684-69d97380-7f4d-11eb-9a14-4a6de1a007e1.png)

**_Step 3:_** Close the red error alert by using the "x" button at its top right corner (only visible on hover).

**_Step 4:_** Use the "Fix" button.

**_Result:_** See section "Actual result BEFORE applying this Pull Request" below.

**_Step 5:_** Edit the 2nd SQL script `3.9.26-2021-03-06.sql` and _apply a typo by appending something to the data type for the database table for which no database problem is shown_, ie:
- For MySQL database with versions lower than 8.0.17 or on any server version of MariaDB chose `#__test_table_2`
- For MySQL database with version 8.0.17 or later chose `#__test_table_1`

See example here with an `X` appended to the `int` type of the `col_int` column:
```
ALTER TABLE `#__test_table_2` MODIFY `col_int` intX DEFAULT 0;
```
Then go again to "Extensions -> Manage Database", or if still there reload the page.

**_Result:_** There is still no database problem shown for that table, i.e. the typo is silently ignored.

**_Step 6:_** Revert the change with the typo made in the previous step in the 2nd SQL script.

**_Step 7:_** Only for MySQL database servers with versions lower than 8.0.17 or on any server version of MariaDB.

If you have a MySQL database servers with version 8.0.17 or later, skip this test step.

This test step doesn't test this PR but proofs that display widths don't matter for the value range and so safely can be ignored.

Using a tool like eg phpMyAdmin, insert a row as follows into the 2nd table `#__test_table_2`:
```
INSERT INTO `#__test_table_2` (`col_int`, `col_int_u`, `col_tinyint`, `col_tinyint_u`, `col_smallint`, `col_smallint_u`, `col_mediumint`, `col_mediumint_u`, `col_bigint`, `col_bigint_u`)
     VALUES (2147483647, 4294967295, 127, 255, 32767, 65535, 8388607, 16777215, 999999999999, 999999999999);
```
Replace `#__` with your table prefix before executing the statement.

Verify that the values of all columns have been saved for that record with the values specified in the insert statement, regardless of the fact that they all exceed the display width of the particular column.

**_Step 8:_** Apply the changes from this PR.

**_Step 9:_** Go again to "Extensions -> Manage Database", or if still there reload the page.

**_Result:_** See section "Expected result AFTER applying this Pull Request" below.

**_Step 10:_** Repeat **_Step 5:_** with the typo having something appended to the data type for any column of any of the 2 tables.

**_Result:_** A database problem is shown due to the not matching type with the typo, ie the typo in the SQL script becomes obvious now. Don't use the "Fix" button now, it would cause an SQL error.

### Actual result BEFORE applying this Pull Request

- On MySQL database servers with versions lower than 8.0.17 or on any server version of MariaDB:
6 errors reported for `#__test_table_1`, no errors reported for `#__test_table_2`.
![step-2_mysql-5-or-mariadb](https://user-images.githubusercontent.com/7413183/110240079-7a3c1f00-7f4a-11eb-8423-17cc6998434e.png)
- On MySQL database servers with version 8.0.17 or later:
6 errors reported for `#__test_table_2`, no errors reported for `#__test_table_1`.
![step-2_mysql-8](https://user-images.githubusercontent.com/7413183/110240082-7d370f80-7f4a-11eb-90de-597ca957a8b0.png)
- Certain typos in update SQL scripts are silently ignored.

### Expected result AFTER applying this Pull Request

- On all versions of MySQL or MariaDB databases:
No database problems found.
![step-3](https://user-images.githubusercontent.com/7413183/110240073-74463e00-7f4a-11eb-952f-da308998285f.png)
- The check for the data types is precise now, so typos will not be ignored.

### Additional info for maintainers / release leads

This PR should go up to 3.10-dev and 4.0-dev, too.

It's most urgent for 4.0-dev since in J4 the database checker is also used for extensions and non only the core, so the likelihood to get a relevant SQL statement in an update SQL script which triggers the error (false database problems found) is much higher than in 3.9.x/3.10.

### Documentation Changes Required

None.