### PR TITLE
[4.0] Fix table semantics

### DIFF
--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -56,12 +56,12 @@ if (!empty($editor))
 			</div>
 		<?php else : ?>
 			<table class="table table-sm">
+				<caption class="visually-hidden">
+					<?php echo Text::_('COM_CONTACT_TABLE_CAPTION'); ?>,
+						<span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
+						<span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
+				</caption>
 				<thead>
-					<caption class="visually-hidden">
-						<?php echo Text::_('COM_CONTACT_TABLE_CAPTION'); ?>,
-							<span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
-							<span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
-					</caption>
 					<tr>
 						<th scope="col" class="w-1 text-center">
 							<?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'a.published', $listDirn, $listOrder); ?>


### PR DESCRIPTION
### Summary of Changes

The `<caption>` elements' parent must be `<table>`. It cannot go inside `<thead>`

