### PR TITLE
[4.0] User Notes icons

### DIFF
--- a/administrator/components/com_users/src/Service/HTML/Users.php
+++ b/administrator/components/com_users/src/Service/HTML/Users.php
@@ -66,8 +66,8 @@ class Users
 		$title = Text::_('COM_USERS_ADD_NOTE');
 
 		return '<a href="' . Route::_('index.php?option=com_users&task=note.add&u_id=' . (int) $userId)
-			. '" class="btn btn-secondary btn-sm"><span class="icon-plus" aria-hidden="true">'
-			. '</span> ' . $title . '</a>';
+			. '" class="btn btn-secondary btn-sm"><span class="icon-plus pe-1" aria-hidden="true">'
+			. '</span>' . $title . '</a>';
 	}
 
 	/**
@@ -90,7 +90,7 @@ class Users
 		$title = Text::_('COM_USERS_FILTER_NOTES');
 
 		return '<a href="' . Route::_('index.php?option=com_users&view=notes&filter[search]=uid:' . (int) $userId)
-			. '" class="dropdown-item"><span class="icon-list" aria-hidden="true"></span> ' . $title . '</a>';
+			. '" class="dropdown-item"><span class="icon-list pe-1" aria-hidden="true"></span>' . $title . '</a>';
 	}
 
 	/**
@@ -113,7 +113,7 @@ class Users
 		$title = Text::plural('COM_USERS_N_USER_NOTES', $count);
 
 		return '<button  type="button" data-bs-target="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId
-			. '" data-bs-toggle="modal" class="dropdown-item"><span class="icon-eye" aria-hidden="true"></span> ' . $title . '</button>';
+			. '" data-bs-toggle="modal" class="dropdown-item"><span class="icon-eye pe-1" aria-hidden="true"></span>' . $title . '</button>';
 	}
 
 	/**


### PR DESCRIPTION
Use padding instead of a space between the icon and the text to avoid the link styling on the space

### Before
![image](https://user-images.githubusercontent.com/1296369/110442636-efc2ff00-80b2-11eb-9e70-8eac0437244e.png)

### After
![image](https://user-images.githubusercontent.com/1296369/110442650-f487b300-80b2-11eb-835f-e9f2825d35f2.png)


This is a change in markup only so can be tested with patchtester