### PR TITLE
Fix articles limit for category view

### DIFF
--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -194,7 +194,7 @@ class ContentModelCategory extends JModelList
 		}
 		else
 		{
-			$limit = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.limit', 'limit', $params->get('display_num'), 'uint');
+			$limit = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.limit', 'limit', $params->get('display_num', $app->get('list_limit')), 'uint');
 		}
 
 		$this->setState('list.limit', $limit);
@@ -229,27 +229,27 @@ class ContentModelCategory extends JModelList
 
 		if ($this->_articles === null && $category = $this->getCategory())
 		{
-			$model = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
-			$model->setState('params', JFactory::getApplication()->getParams());
-			$model->setState('filter.category_id', $category->id);
-			$model->setState('filter.published', $this->getState('filter.published'));
-			$model->setState('filter.access', $this->getState('filter.access'));
-			$model->setState('filter.language', $this->getState('filter.language'));
-			$model->setState('filter.featured', $this->getState('filter.featured'));
-			$model->setState('list.ordering', $this->_buildContentOrderBy());
-			$model->setState('list.start', $this->getState('list.start'));
-			$model->setState('list.limit', $limit);
-			$model->setState('list.direction', $this->getState('list.direction'));
-			$model->setState('list.filter', $this->getState('list.filter'));
-			$model->setState('filter.tag', $this->getState('filter.tag'));
-
-			// Filter.subcategories indicates whether to include articles from subcategories in the list or blog
-			$model->setState('filter.subcategories', $this->getState('filter.subcategories'));
-			$model->setState('filter.max_category_levels', $this->getState('filter.max_category_levels'));
-			$model->setState('list.links', $this->getState('list.links'));
-
-			if ($limit >= 0)
+			if ($limit > 0)
 			{
+				$model = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
+				$model->setState('params', JFactory::getApplication()->getParams());
+				$model->setState('filter.category_id', $category->id);
+				$model->setState('filter.published', $this->getState('filter.published'));
+				$model->setState('filter.access', $this->getState('filter.access'));
+				$model->setState('filter.language', $this->getState('filter.language'));
+				$model->setState('filter.featured', $this->getState('filter.featured'));
+				$model->setState('list.ordering', $this->_buildContentOrderBy());
+				$model->setState('list.start', $this->getState('list.start'));
+				$model->setState('list.limit', $limit);
+				$model->setState('list.direction', $this->getState('list.direction'));
+				$model->setState('list.filter', $this->getState('list.filter'));
+				$model->setState('filter.tag', $this->getState('filter.tag'));
+
+				// Filter.subcategories indicates whether to include articles from subcategories in the list or blog
+				$model->setState('filter.subcategories', $this->getState('filter.subcategories'));
+				$model->setState('filter.max_category_levels', $this->getState('filter.max_category_levels'));
+				$model->setState('list.links', $this->getState('list.links'));
+
 				$this->_articles = $model->getItems();
 
 				if ($this->_articles === false)

--- a/components/com_content/models/category.php
+++ b/components/com_content/models/category.php
@@ -115,7 +115,7 @@ class ContentModelCategory extends JModelList
 		$this->setState('category.id', $pk);
 
 		// Load the parameters. Merge Global and Menu Item params into new object
-		$params = $app->getParams();
+		$params     = $app->getParams();
 		$menuParams = new Registry;
 
 		if ($menu = $app->getMenu()->getActive())
@@ -127,7 +127,7 @@ class ContentModelCategory extends JModelList
 		$mergedParams->merge($params);
 
 		$this->setState('params', $mergedParams);
-		$user  = JFactory::getUser();
+		$user = JFactory::getUser();
 
 		$asset = 'com_content';
 
@@ -136,7 +136,7 @@ class ContentModelCategory extends JModelList
 			$asset .= '.category.' . $pk;
 		}
 
-		if ((!$user->authorise('core.edit.state', $asset)) &&  (!$user->authorise('core.edit', $asset)))
+		if ((!$user->authorise('core.edit.state', $asset)) && (!$user->authorise('core.edit', $asset)))
 		{
 			// Limit to published for people who can't edit or edit.state.
 			$this->setState('filter.published', 1);
@@ -194,7 +194,8 @@ class ContentModelCategory extends JModelList
 		}
 		else
 		{
-			$limit = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.limit', 'limit', $params->get('display_num', $app->get('list_limit')), 'uint');
+			$limit = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.limit', 'limit',
+				$params->get('display_num', $app->get('list_limit')), 'uint');
 		}
 
 		$this->setState('list.limit', $limit);
@@ -229,9 +230,10 @@ class ContentModelCategory extends JModelList
 
 		if ($this->_articles === null && $category = $this->getCategory())
 		{
+			$model = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
+
 			if ($limit > 0)
 			{
-				$model = JModelLegacy::getInstance('Articles', 'ContentModel', array('ignore_request' => true));
 				$model->setState('params', JFactory::getApplication()->getParams());
 				$model->setState('filter.category_id', $category->id);
 				$model->setState('filter.published', $this->getState('filter.published'));


### PR DESCRIPTION
Pull Request for Issue #18529 and #32612 .

### Summary of Changes
This PR proposes a solution to fix the two issues #18529 and #32612. Basically, it now will only load articles if limit > 0  (users want to display articles using the category layout)

See #18529 and #32612 to understand the actual issue. However, this PR has a backward incompatible change, so I'm unsure if it should be accepted (especially for staging).


### Testing Instructions
1. Create two menu items, one links to Category Blog Layout menu item type and one to Category List menu item type.
2.  Apply patch, confirm that two menu items still display articles same as before.

### Backward Incompatible Changes
Please note that there is a backward incompatible changes here then the site has no menu item to link to one of the three menu item types (basically, no suitable menu item could be found to link to a category)

- List All Categories
- Category Blog Layout
- Category List 

For example, when you unpublish all menu items (keep home menu but links to a different component than com_content) and access to a category display in Articles - Categories. Before this PR, it will display all articles from that category, after this PR, only number of articles will be displayed (controlled by Default List Limit parameter in Global Configuration)