### PR TITLE
Add use xml options

### DIFF
--- a/libraries/src/Form/Field/ModuletagField.php
+++ b/libraries/src/Form/Field/ModuletagField.php
@@ -36,7 +36,7 @@ class ModuletagField extends ListField
 	 */
 	protected function getOptions()
 	{
-		$options = array();
+		$options = parent::getOptions();
 		$tags    = array('address', 'article', 'aside', 'details', 'div', 'footer', 'header', 'main', 'nav', 'section', 'summary');
 
 		// Create one new option object for each tag


### PR DESCRIPTION
Replace code in field
**`$options = array();`**
to
**`$options = parent::getOptions();`**
This will allow you to add additional tags to the XML field at your own discretion.
Example:
```
<field name="user_tag" type="moduletag"
           label="HTML-Tag" 
           default="div" >
        <option value="span">span</option>
 </field>
```
The same is true for the **`headertag`** type field
.
In principle, it is desirable to make corrections for many fields.
For the **`Tag`**  field is desirable.
But for the **`User`** field, this is clearly not necessary.


