### PR TITLE
Add use xml castom options.

### DIFF
--- a/libraries/src/Form/Field/HeadertagField.php
+++ b/libraries/src/Form/Field/HeadertagField.php
@@ -36,7 +36,7 @@ class HeadertagField extends ListField
 	 */
 	protected function getOptions()
 	{
-		$options = array();
+		$options = parent::getOptions();
 		$tags = array('h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div');
 
 		// Create one new option object for each tag


### PR DESCRIPTION
Replace code in field
**`$options = array();`**
to
**`$options = parent::getOptions();`**
This will allow you to add additional tags to the XML field at your own discretion.
Example:
```
<field name="userHeader_tag" type="headertag"
           label="HTML-Tag" 
           default="div" >
        <option value="span">span</option>
 </field>
``` 
.

