### PR TITLE
[4.0] Helper factory

### DIFF
--- a/administrator/modules/mod_quickicon/services/provider.php
+++ b/administrator/modules/mod_quickicon/services/provider.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Extension\Service\Provider\HelperFactory;
 use Joomla\CMS\Extension\Service\Provider\Module;
 use Joomla\CMS\Extension\Service\Provider\ModuleDispatcherFactory;
 use Joomla\DI\Container;
@@ -33,6 +34,7 @@ return new class implements ServiceProviderInterface
 	public function register(Container $container)
 	{
 		$container->registerServiceProvider(new ModuleDispatcherFactory('\\Joomla\\Module\\Quickicon'));
+		$container->registerServiceProvider(new HelperFactory('\\Joomla\\Module\\Quickicon\\Administrator\\Helper'));
 
 		$container->registerServiceProvider(new Module);
 	}

--- a/administrator/modules/mod_quickicon/src/Dispatcher/Dispatcher.php
+++ b/administrator/modules/mod_quickicon/src/Dispatcher/Dispatcher.php
@@ -32,7 +32,8 @@ class Dispatcher extends AbstractModuleDispatcher
 	{
 		$data = parent::getLayoutData();
 
-		$data['buttons'] = QuickIconHelper::getButtons($data['params'], $this->getApplication());
+		$helper          = $this->app->bootModule('mod_quickicon', 'administrator')->getHelper('QuickIconHelper');
+		$data['buttons'] = $helper->getButtons($data['params'], $this->getApplication());
 
 		return $data;
 	}

--- a/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
@@ -23,7 +23,7 @@ use Joomla\Registry\Registry;
  *
  * @since  1.6
  */
-abstract class QuickIconHelper
+class QuickIconHelper
 {
 	/**
 	 * Stack to hold buttons
@@ -31,7 +31,7 @@ abstract class QuickIconHelper
 	 * @var     array[]
 	 * @since   1.6
 	 */
-	protected static $buttons = array();
+	protected $buttons = array();
 
 	/**
 	 * Helper method to return button list.
@@ -46,7 +46,7 @@ abstract class QuickIconHelper
 	 *
 	 * @since   1.6
 	 */
-	public static function &getButtons(Registry $params, CMSApplication $application = null)
+	public function getButtons(Registry $params, CMSApplication $application = null)
 	{
 		if ($application == null)
 		{
@@ -56,12 +56,12 @@ abstract class QuickIconHelper
 		$key     = (string) $params;
 		$context = (string) $params->get('context', 'mod_quickicon');
 
-		if (!isset(self::$buttons[$key]))
+		if (!isset($this->buttons[$key]))
 		{
 			// Load mod_quickicon language file in case this method is called before rendering the module
 			$application->getLanguage()->load('mod_quickicon');
 
-			self::$buttons[$key] = [];
+			$this->buttons[$key] = [];
 
 			if ($params->get('show_users'))
 			{
@@ -79,7 +79,7 @@ abstract class QuickIconHelper
 					$tmp['ajaxurl'] = 'index.php?option=com_users&amp;task=users.getQuickiconContent&amp;format=json';
 				}
 
-				self::$buttons[$key][] = $tmp;
+				$this->buttons[$key][] = $tmp;
 			}
 
 			if ($params->get('show_menuitems'))
@@ -98,7 +98,7 @@ abstract class QuickIconHelper
 					$tmp['ajaxurl'] = 'index.php?option=com_menus&amp;task=items.getQuickiconContent&amp;format=json';
 				}
 
-				self::$buttons[$key][] = $tmp;
+				$this->buttons[$key][] = $tmp;
 			}
 
 			if ($params->get('show_articles'))
@@ -117,7 +117,7 @@ abstract class QuickIconHelper
 					$tmp['ajaxurl'] = 'index.php?option=com_content&amp;task=articles.getQuickiconContent&amp;format=json';
 				}
 
-				self::$buttons[$key][] = $tmp;
+				$this->buttons[$key][] = $tmp;
 			}
 
 			if ($params->get('show_categories'))
@@ -136,12 +136,12 @@ abstract class QuickIconHelper
 					$tmp['ajaxurl'] = 'index.php?option=com_categories&amp;task=categories.getQuickiconContent&amp;format=json';
 				}
 
-				self::$buttons[$key][] = $tmp;
+				$this->buttons[$key][] = $tmp;
 			}
 
 			if ($params->get('show_media'))
 			{
-				self::$buttons[$key][] = [
+				$this->buttons[$key][] = [
 					'image'  => 'icon-images',
 					'link'   => Route::_('index.php?option=com_media'),
 					'name'   => 'MOD_QUICKICON_MEDIA_MANAGER',
@@ -166,7 +166,7 @@ abstract class QuickIconHelper
 					$tmp['ajaxurl'] = 'index.php?option=com_modules&amp;task=modules.getQuickiconContent&amp;format=json';
 				}
 
-				self::$buttons[$key][] = $tmp;
+				$this->buttons[$key][] = $tmp;
 			}
 
 			if ($params->get('show_plugins'))
@@ -184,12 +184,12 @@ abstract class QuickIconHelper
 					$tmp['ajaxurl'] = 'index.php?option=com_plugins&amp;task=plugins.getQuickiconContent&amp;format=json';
 				}
 
-				self::$buttons[$key][] = $tmp;
+				$this->buttons[$key][] = $tmp;
 			}
 
 			if ($params->get('show_template_styles'))
 			{
-				self::$buttons[$key][] = [
+				$this->buttons[$key][] = [
 					'image'  => 'icon-paint-brush',
 					'link'   => Route::_('index.php?option=com_templates&view=styles&client_id=0'),
 					'name'   => 'MOD_QUICKICON_TEMPLATE_STYLES',
@@ -200,7 +200,7 @@ abstract class QuickIconHelper
 
 			if ($params->get('show_template_code'))
 			{
-				self::$buttons[$key][] = [
+				$this->buttons[$key][] = [
 					'image'  => 'icon-code',
 					'link'   => Route::_('index.php?option=com_templates&view=templates&client_id=0'),
 					'name'   => 'MOD_QUICKICON_TEMPLATE_CODE',
@@ -224,7 +224,7 @@ abstract class QuickIconHelper
 					$tmp['ajaxurl'] = 'index.php?option=com_checkin&amp;task=getQuickiconContent&amp;format=json';
 				}
 
-				self::$buttons[$key][] = $tmp;
+				$this->buttons[$key][] = $tmp;
 			}
 
 			if ($params->get('show_cache'))
@@ -242,12 +242,12 @@ abstract class QuickIconHelper
 					$tmp['ajaxurl'] = 'index.php?option=com_cache&amp;task=display.getQuickiconContent&amp;format=json';
 				}
 
-				self::$buttons[$key][] = $tmp;
+				$this->buttons[$key][] = $tmp;
 			}
 
 			if ($params->get('show_global'))
 			{
-				self::$buttons[$key][] = [
+				$this->buttons[$key][] = [
 					'image'  => 'icon-cog',
 					'link'   => Route::_('index.php?option=com_config'),
 					'name'   => 'MOD_QUICKICON_GLOBAL_CONFIGURATION',
@@ -287,12 +287,12 @@ abstract class QuickIconHelper
 
 					if (!\is_null($icon['link']) && !\is_null($icon['text']))
 					{
-						self::$buttons[$key][] = $icon;
+						$this->buttons[$key][] = $icon;
 					}
 				}
 			}
 		}
 
-		return self::$buttons[$key];
+		return $this->buttons[$key];
 	}
 }

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -58,10 +58,11 @@ if (!$format)
 elseif ($input->get('module'))
 {
 	$module   = $input->get('module');
+	$method   = $input->get('method') ?: 'get';
 	$table    = Table::getInstance('extension');
 	$moduleId = $table->find(array('type' => 'module', 'element' => 'mod_' . $module));
-
-	$parts   = [];
+	$results  = null;
+	$parts    = [];
 
 	if (strpos($module, '_'))
 	{
@@ -88,17 +89,11 @@ elseif ($input->get('module'))
 		$class = ucfirst($module) . 'Helper';
 	}
 
-	$method = $input->get('method') ?: 'get';
-
-	$results        = null;
 	$moduleInstance = $app->bootModule('mod_' . $module, $app->getName());
 
-	if ($moduleInstance instanceof \Joomla\CMS\Helper\HelperFactoryInterface)
+	if ($moduleInstance instanceof \Joomla\CMS\Helper\HelperFactoryInterface && $helper = $moduleInstance->getHelper($class))
 	{
-		if ($helper = $moduleInstance->getHelper($class))
-		{
-			$results = $helper->{$method . 'Ajax'}();
-		}
+		$results = $helper->{$method . 'Ajax'}();
 	}
 
 	if ($results === null && $moduleId && $table->load($moduleId) && $table->enabled)

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -62,6 +62,7 @@ elseif ($input->get('module'))
 	$moduleId = $table->find(array('type' => 'module', 'element' => 'mod_' . $module));
 
 	$parts   = [];
+
 	if (strpos($module, '_'))
 	{
 		$parts = explode('_', $module);
@@ -94,8 +95,7 @@ elseif ($input->get('module'))
 
 	if ($moduleInstance instanceof \Joomla\CMS\Helper\HelperFactoryInterface)
 	{
-		$helper = $moduleInstance->getHelper($class);
-		if ($helper)
+		if ($helper = $moduleInstance->getHelper($class))
 		{
 			$results = $helper->{$method . 'Ajax'}();
 		}

--- a/libraries/src/Extension/ExtensionManagerTrait.php
+++ b/libraries/src/Extension/ExtensionManagerTrait.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\Extension;
 
 use Joomla\CMS\Dispatcher\ModuleDispatcherFactory;
 use Joomla\CMS\Event\AbstractEvent;
+use Joomla\CMS\Helper\HelperFactory;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\DI\Container;
@@ -152,7 +153,7 @@ trait ExtensionManagerTrait
 					$container->set($type, new LegacyComponent('com_' . $extensionName));
 					break;
 				case ModuleInterface::class:
-					$container->set($type, new Module(new ModuleDispatcherFactory('')));
+					$container->set($type, new Module(new ModuleDispatcherFactory(''), new HelperFactory('')));
 					break;
 				case PluginInterface::class:
 					list($pluginName, $pluginType) = explode(':', $extensionName);

--- a/libraries/src/Extension/Module.php
+++ b/libraries/src/Extension/Module.php
@@ -38,7 +38,7 @@ class Module implements ModuleInterface, HelperFactoryInterface
 	 *
 	 * @var HelperFactoryInterface
 	 *
-	 * @since  4.0.0
+	 * @since  __DEPLOY_VERSION__
 	 */
 	private $helperFactory;
 

--- a/libraries/src/Extension/Module.php
+++ b/libraries/src/Extension/Module.php
@@ -13,6 +13,8 @@ namespace Joomla\CMS\Extension;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Dispatcher\DispatcherInterface;
 use Joomla\CMS\Dispatcher\ModuleDispatcherFactoryInterface;
+use Joomla\CMS\Helper\HelperFactory;
+use Joomla\CMS\Helper\HelperFactoryInterface;
 use Joomla\Input\Input;
 
 /**
@@ -20,7 +22,7 @@ use Joomla\Input\Input;
  *
  * @since  4.0.0
  */
-class Module implements ModuleInterface
+class Module implements ModuleInterface, HelperFactoryInterface
 {
 	/**
 	 * The dispatcher factory.
@@ -32,15 +34,26 @@ class Module implements ModuleInterface
 	private $dispatcherFactory;
 
 	/**
+	 * The helper factory.
+	 *
+	 * @var HelperFactoryInterface
+	 *
+	 * @since  4.0.0
+	 */
+	private $helperFactory;
+
+	/**
 	 * Module constructor.
 	 *
 	 * @param   ModuleDispatcherFactoryInterface  $dispatcherFactory  The dispatcher factory
+	 * @param   HelperFactoryInterface            $helperFactory      The helper factory
 	 *
 	 * @since   4.0.0
 	 */
-	public function __construct(ModuleDispatcherFactoryInterface $dispatcherFactory)
+	public function __construct(ModuleDispatcherFactoryInterface $dispatcherFactory, HelperFactoryInterface $helperFactory)
 	{
 		$this->dispatcherFactory = $dispatcherFactory;
+		$this->helperFactory     = $helperFactory;
 	}
 
 	/**
@@ -57,5 +70,20 @@ class Module implements ModuleInterface
 	public function getDispatcher(\stdClass $module, CMSApplicationInterface $application, Input $input = null): DispatcherInterface
 	{
 		return $this->dispatcherFactory->createDispatcher($module, $application, $input);
+	}
+
+	/**
+	 * Returns a helper instance for the given name.
+	 *
+	 * @param   string  $name    The name
+	 * @param   array   $config  The config
+	 *
+	 * @return  \stdClass
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getHelper(string $name, array $config = [])
+	{
+		return $this->helperFactory->getHelper($name, $config);
 	}
 }

--- a/libraries/src/Extension/Service/Provider/HelperFactory.php
+++ b/libraries/src/Extension/Service/Provider/HelperFactory.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Extension\Service\Provider;
+
+\defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Helper\HelperFactoryInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+
+/**
+ * Service provider for the service helper factory.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class HelperFactory implements ServiceProviderInterface
+{
+	/**
+	 * The namespace
+	 *
+	 * @var  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private $namespace;
+
+	/**
+	 * HelperFactory constructor.
+	 *
+	 * @param   string  $namespace  The namespace
+	 *
+	 * @since   HelperFactory
+	 */
+	public function __construct(string $namespace)
+	{
+		$this->namespace = $namespace;
+	}
+
+	/**
+	 * Registers the service provider with a DI container.
+	 *
+	 * @param   Container  $container  The DI container.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function register(Container $container)
+	{
+		$container->set(
+			HelperFactoryInterface::class,
+			function (Container $container)
+			{
+				return new \Joomla\CMS\Helper\HelperFactory($this->namespace);
+			}
+		);
+	}
+}

--- a/libraries/src/Extension/Service/Provider/Module.php
+++ b/libraries/src/Extension/Service/Provider/Module.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\Extension\Service\Provider;
 
 use Joomla\CMS\Dispatcher\ModuleDispatcherFactoryInterface;
 use Joomla\CMS\Extension\ModuleInterface;
+use Joomla\CMS\Helper\HelperFactoryInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 
@@ -37,7 +38,10 @@ class Module implements ServiceProviderInterface
 			ModuleInterface::class,
 			function (Container $container)
 			{
-				return new \Joomla\CMS\Extension\Module($container->get(ModuleDispatcherFactoryInterface::class));
+				return new \Joomla\CMS\Extension\Module(
+					$container->get(ModuleDispatcherFactoryInterface::class),
+					$container->get(HelperFactoryInterface::class)
+				);
 			}
 		);
 	}

--- a/libraries/src/Helper/HelperFactory.php
+++ b/libraries/src/Helper/HelperFactory.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Helper;
+
+\defined('_JEXEC') or die;
+
+/**
+ * Namespace based implementation of the HelperFactoryInterface
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class HelperFactory implements HelperFactoryInterface
+{
+	/**
+	 * The extension namespace
+	 *
+	 * @var  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private $namespace;
+
+	/**
+	 * HelperFactory constructor.
+	 *
+	 * @param   string  $namespace  The namespace
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(string $namespace)
+	{
+		$this->namespace = $namespace;
+	}
+
+	/**
+	 * Returns a helper instance for the given name.
+	 *
+	 * @param   string  $name    The name
+	 * @param   array   $config  The config
+	 *
+	 * @return  \stdClass
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getHelper(string $name, array $config = [])
+	{
+		$className = '\\' . trim($this->namespace, '\\') . '\\' . $name;
+
+		if (!class_exists($className))
+		{
+			return null;
+		}
+
+		return new $className($config);
+	}
+}

--- a/libraries/src/Helper/HelperFactoryInterface.php
+++ b/libraries/src/Helper/HelperFactoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Helper;
+
+\defined('JPATH_PLATFORM') or die;
+
+/**
+ * Factory to load helper classes.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface HelperFactoryInterface
+{
+	/**
+	 * Returns a helper instance for the given name.
+	 *
+	 * @param   string  $name    The name
+	 * @param   array   $config  The config
+	 *
+	 * @return  \stdClass
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getHelper(string $name, array $config = []);
+}


### PR DESCRIPTION
Pull Request for pr #32291.

### Summary of Changes
All over joomla are helpers manually loaded. Better to load them through a factory from the booted extension.

### Testing Instructions
- Open the dashboard.
- Add the following code to the file administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php:  
```php
public static function getDataAjax()
{
	$data = ['test'];

	return $data;
}
```
- Open the url /administrator/index.php?option=com_ajax&module=quickIcon&method=getData&format=json

### Actual result BEFORE applying this Pull Request
- Icons are loaded.
- Ajax url shows `{"success":true,"message":null,"messages":null,"data":["test"]}`

### Expected result AFTER applying this Pull Request
- Icons are loaded.
- Ajax url shows `{"success":false,"message":"The file at mod_quickIcon\/helper.php does not exist.","messages":null,"data":null}`

### Documentation Changes Required
Should be documented on the same place where the new extension setup is documented.