### PR TITLE
[4.0] fixes the long login page issue.

### DIFF
--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -129,7 +129,7 @@ Text::script('JGLOBAL_WARNCOOKIES');
 	</div>
 
 	<?php // Sidebar ?>
-	<div id="sidebar-wrapper" class="sidebar-wrapper order-0 px-3">
+	<div id="sidebar-wrapper" class="sidebar-wrapper px-3">
 		<div id="main-brand" class="main-brand">
 			<h1><?php echo $app->get('sitename'); ?></h1>
 			<h2><?php echo Text::_('TPL_ATUM_BACKEND_LOGIN'); ?></h2>

--- a/administrator/templates/atum/scss/blocks/_login.scss
+++ b/administrator/templates/atum/scss/blocks/_login.scss
@@ -135,6 +135,7 @@
     flex: 1 0 33%;
     flex-direction: column;
     max-width: $sidebar-width-login;
+    order: 0;
 
     @include media-breakpoint-down(md) {
       order: 2;
@@ -181,6 +182,7 @@
     @include media-breakpoint-down(md) {
       flex: 1 0 100% !important;
       max-width: 100% !important;
+      min-height: auto;
     }
   }
 


### PR DESCRIPTION
This pull request is a fix for #32560 and #29119. 

### Summary of Changes
As was being discussed on the issue #32560, I did exactly what @infograf768 did, and as mentioned by @drmenzelit for changing the order, I removed `order-0` class from `side-wrapper` div in login.php and added `order: 0;` for `#side-wrapper` in _login.scss.



### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/42460131/110677138-d200b180-81fa-11eb-9547-7058f2b417d3.png)




### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/42460131/110676460-fe67fe00-81f9-11eb-9c16-40fec43fe2d6.png)




