### PR TITLE
Updated search.php to display proper title in search results 

### DIFF
--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -265,7 +265,7 @@ class SearchHelper
 		$str = JLanguageTransliterate::utf8_latin_to_ascii($str);
 
 		// @TODO: remove other prefixes as well?
-		return preg_replace("/([a-z])/ui", '\1', $str);
+		return $str;
 	}
 
 	/**

--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -265,7 +265,7 @@ class SearchHelper
 		$str = JLanguageTransliterate::utf8_latin_to_ascii($str);
 
 		// @TODO: remove other prefixes as well?
-		return preg_replace("/[\"'^]([a-z])/ui", '\1', $str);
+		return preg_replace("/([a-z])/ui", '\1', $str);
 	}
 
 	/**

--- a/tests/unit/suites/administrator/components/com_search/helpers/SearchTest.php
+++ b/tests/unit/suites/administrator/components/com_search/helpers/SearchTest.php
@@ -21,13 +21,13 @@ class SearchHelperTest extends TestCase
 			SearchHelper::remove_accents('This "is a" test')
 		);
 
-		// test single quotes.
+		// Test single quotes.
 		$this->assertEquals(
 			"The 'Ledger' Contents may settle during",
 			SearchHelper::remove_accents("The 'Ledger' Contents may settle during")
 		);
 
-		// Test other
+		// Test other...
 		$this->assertEquals(
 			"ue => ue, ae => ae, ae => ae, et cetera",
 			SearchHelper::remove_accents("ü => ue, ä => ae, æ => ae, et cetera")

--- a/tests/unit/suites/administrator/components/com_search/helpers/SearchTest.php
+++ b/tests/unit/suites/administrator/components/com_search/helpers/SearchTest.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * @package    Joomla.UnitTest
+ *
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+require_once JPATH_ADMINISTRATOR . '/components/com_search/helpers/search.php';
+
+/**
+ * Test class for SearchHelperTest.
+ */
+class SearchHelperTest extends TestCase
+{
+	public function testRemoveAccents()
+	{
+		// Test double quotes.
+		$this->assertEquals(
+			'This "is a" test',
+			SearchHelper::remove_accents('This "is a" test')
+		);
+
+		// test single quotes.
+		$this->assertEquals(
+			"The 'Ledger' Contents may settle during",
+			SearchHelper::remove_accents("The 'Ledger' Contents may settle during")
+		);
+
+		// Test other
+		$this->assertEquals(
+			"ue => ue, ae => ae, ae => ae, et cetera",
+			SearchHelper::remove_accents("ü => ue, ä => ae, æ => ae, et cetera")
+		);
+	}
+}


### PR DESCRIPTION
Summary of Changes
Line 268 has been changed....
From: return preg_replace("/'"^/ui", '\1', $str);
To: return preg_replace("/([a-z])/ui", '\1', $str);

Testing Instructions
1. Add an article whose title contains a word with double or single quotes (For eg: Typescript's Uses)
2. Search a for the title
3. Look out for the title of the search result

Actual result BEFORE applying this Pull Request

![Untitled (1)](https://user-images.githubusercontent.com/76894046/110888956-3dd63d80-8313-11eb-9bdc-b17a195c5c79.jpg)


Expected result AFTER applying this Pull Request

![2 (1)](https://user-images.githubusercontent.com/76894046/110888932-357e0280-8313-11eb-8613-a50c459836c4.jpg)

Documentation Changes Required
None