### PR TITLE
Display proper search results

### DIFF
--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -347,7 +347,7 @@ class SearchHelper
 		}
 		else
 		{
-			if (($wordpos = @StringHelper::strpos($text, ' ', $length)) !== false)
+			if (($wordpos = @StringHelper::strpos($text, ' ', $wordpos)) !== false)
 			{
 				return StringHelper::substr($text, 0, $wordpos) . '&#160;...';
 			}


### PR DESCRIPTION
Pull Request for Issue #32115  .

### Summary of Changes

Starting index of search changed from $length to $wordpos on line 350.

### Testing Instructions

Add an article and search for any keyword you had added to its title or description.

### Actual result BEFORE applying this Pull Request

Fatal error: mb_strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)

### Expected result AFTER applying this Pull Request

Proper search results appear with listing filters.

### Documentation Changes Required

No documentation changes required
