### PR TITLE
[4.0] fixes Cassiopeia footer not being responsive

### DIFF
--- a/templates/cassiopeia/scss/blocks/_footer.scss
+++ b/templates/cassiopeia/scss/blocks/_footer.scss
@@ -33,7 +33,7 @@
       flex-direction: column;
 
       .mod-footer {
-        margin: 6px 0;
+        margin: 0.375rem 0;
       }
     }
   }

--- a/templates/cassiopeia/scss/blocks/_footer.scss
+++ b/templates/cassiopeia/scss/blocks/_footer.scss
@@ -33,7 +33,7 @@
       flex-direction: column;
 
       .mod-footer {
-        margin: 0.375rem 0;
+        margin: .375rem 0;
       }
     }
   }

--- a/templates/cassiopeia/scss/blocks/_footer.scss
+++ b/templates/cassiopeia/scss/blocks/_footer.scss
@@ -27,4 +27,15 @@
       }
     }
   }
+
+  @include media-breakpoint-down(md) {
+    .grid-child {
+      display: flex;
+      flex-direction: column;
+
+      .mod-footer {
+        margin: 6px 0;
+      }
+    }
+  }
 }

--- a/templates/cassiopeia/scss/blocks/_footer.scss
+++ b/templates/cassiopeia/scss/blocks/_footer.scss
@@ -30,7 +30,6 @@
 
   @include media-breakpoint-down(md) {
     .grid-child {
-      display: flex;
       flex-direction: column;
 
       .mod-footer {


### PR DESCRIPTION
Pull Request for Issue #32553  .

### Summary of Changes
This pull request addresses the issue where the footer isn't responsive in mobile view for Cassiopeia when there's more than one module in footer, by adding a media query in `_footer.scss`  to change the `flex-direction` to `column` and to add margins of `6px` in y direction for adequate spacing.



### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/42460131/110752392-38bdb380-826b-11eb-9982-82797f8132a1.png)


### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/42460131/110751743-4a528b80-826a-11eb-8b2a-a482b2d20514.png)

