### PR TITLE
[4.0] Skip to update

### DIFF
--- a/administrator/language/en-GB/plg_system_skipto.ini
+++ b/administrator/language/en-GB/plg_system_skipto.ini
@@ -4,7 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_SKIPTO="System - Skip-To Navigation"
-PLG_SYSTEM_SKIPTO_ACCESS_KEY_NOT_SUPPORTED="The use of Access keys is not supported on this browser."
+; do not translate $key
+PLG_SYSTEM_SKIPTO_ACCCESS_KEY="Access key is $key"
 PLG_SYSTEM_SKIPTO_HEADING="Page Outline"
 PLG_SYSTEM_SKIPTO_HEADING_LEVEL="Heading level"
 ; next line begins with a space. $m is count, %n is total
@@ -25,8 +26,5 @@ PLG_SYSTEM_SKIPTO_SECTION="Site Section"
 PLG_SYSTEM_SKIPTO_SECTION_ADMIN="Administrator (Backend)"
 PLG_SYSTEM_SKIPTO_SECTION_BOTH="Both"
 PLG_SYSTEM_SKIPTO_SECTION_SITE="Site (Frontend)"
-PLG_SYSTEM_SKIPTO_SKIP_TO="Skip To"
 PLG_SYSTEM_SKIPTO_TITLE="Keyboard Navigation"
-; do not translate $key
-PLG_SYSTEM_SKIPTO_TITLE_WITH_ACCCESS_KEY="Keyboard Navigation - Access key is $key"
 PLG_SYSTEM_SKIPTO_XML_DESCRIPTION="The plugin creates a dropdown menu consisting of the links to the important places on a given web page. This makes it easier for keyboard and screen reader users to quickly jump to the desired location by choosing it from the list of options."

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -126,14 +126,6 @@ ul {
 
 // skipto
 .skip-to {
-  &.popup {
-    right: -3000em;
-    left: 0 !important;
-    &.focus {
-      right: 46%;
-      left: 0 !important;
-    }
-  }
   [role="separator"] {
     text-align: right !important;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2533,7 +2533,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },
@@ -7474,9 +7474,9 @@
       }
     },
     "skipto": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/skipto/-/skipto-4.0.1.tgz",
-      "integrity": "sha512-Pq5pO62ku5Xt7d1dvygb5pkNgkrG9jKvmkn8oUUKiunQv5tvgnzCw3mcn/H4nCVSFw9QQMYef3IF3mMIeVB0Gg=="
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/skipto/-/skipto-4.0.4.tgz",
+      "integrity": "sha512-OH51p7day6bz9cdBXYbmWC66rfK/+u8kdG/2Zy3iAcMXszFz7ODKweKKflvC6PkZzgSGgiHW7QbKEI2Q8NUDoA=="
     },
     "slash": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "qrcode-generator": "^1.4.4",
     "roboto-fontface": "^0.10.0",
     "short-and-sweet": "^1.0.2",
-    "skipto": "^4.0.0",
+    "skipto": "^4.0.4",
     "tinymce": "^5.6.2",
     "vue": "^2.6.12",
     "vue-focus-lock": "^1.3.2",

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -76,10 +76,8 @@ class PlgSystemSkipto extends CMSPlugin
 						'displayOption' => 'popup',
 
 						// Button labels and messages
-						'accesskeyNotSupported'    => Text::_('PLG_SYSTEM_SKIPTO_ACCESS_KEY_NOT_SUPPORTED'),
-						'buttonTitle'              => Text::_('PLG_SYSTEM_SKIPTO_TITLE'),
-						'buttonTitleWithAccesskey' => Text::_('PLG_SYSTEM_SKIPTO_TITLE_WITH_ACCCESS_KEY'),
-						'buttonLabel'              => Text::_('PLG_SYSTEM_SKIPTO_SKIP_TO'),
+						'buttonLabel'            => Text::_('PLG_SYSTEM_SKIPTO_TITLE'),
+						'buttonTooltipAccesskey' => Text::_('PLG_SYSTEM_SKIPTO_ACCCESS_KEY'),
 
 						// Menu labels and messages
 						'landmarkGroupLabel'  => Text::_('PLG_SYSTEM_SKIPTO_LANDMARK'),

--- a/templates/cassiopeia/scss/template-rtl.scss
+++ b/templates/cassiopeia/scss/template-rtl.scss
@@ -60,14 +60,6 @@ body,
 
 // skipto
 .skip-to {
-  &.popup {
-    right: -3000em;
-    left: 0 !important;
-    &.focus {
-      right: 46%;
-      left: 0 !important;
-    }
-  }
   [role="separator"] {
     text-align: right !important;
   }


### PR DESCRIPTION
The plugin was updated to 4.0.4 but I am still trying to get them to understand semantic versioning :(

The main issues of interest to us are :
1. We no longer need the css override for RTL template width
2. There is now no log message in the console log

This may be the last release of this plugin under the scope of paypal as the University of Illinois are really running it
