### PR TITLE
[4.0] fixes missing search message for no result found

### DIFF
--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -50,6 +50,10 @@ endif;
 
 <div id="new-modules-list">
 	<div class="new-modules">
+		<div class="alert alert-info d-none">
+			<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+			<?php echo Text::_('COM_MODULES_MSG_MANAGE_NO_MODULES'); ?>
+		</div>
 		<div class="card-columns">
 			<?php foreach ($this->items as &$item) : ?>
 				<div class="card mb-4 comModulesSelectCard">

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -82,7 +82,7 @@
       }
     });
 
-    if (countOfMatchFound <= 0){
+    if (countOfMatchFound <= 0) {
       alert.classList.remove('d-none');
     } else {
       alert.classList.add('d-none');

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -47,7 +47,10 @@
   elSearch.addEventListener('keyup', (event) => {
     /** @type {KeyboardEvent} event */
     const partialSearch = event.target.value;
+    const alert = document.querySelector('.alert');
     const elCards = document.querySelectorAll('.comModulesSelectCard');
+
+    let countOfMatchFound = 0;
 
     // Save the search string into session storage
     if (typeof (sessionStorage) !== 'undefined') {
@@ -63,9 +66,11 @@
 
       // First remove the classes which hide the module cards
       card.classList.remove('d-none');
+      countOfMatchFound += 1;
 
       // An empty search string means that we should show everything
       if (partialSearch === '') {
+        countOfMatchFound = elCards.length;
         return;
       }
 
@@ -73,8 +78,15 @@
       if (!title.toLowerCase().includes(partialSearch.toLowerCase())
         && !description.toLowerCase().includes(partialSearch.toLowerCase())) {
         card.classList.add('d-none');
+        countOfMatchFound -= 1;
       }
     });
+
+    if (countOfMatchFound <= 0){
+      alert.classList.remove('d-none');
+    } else {
+      alert.classList.add('d-none');
+    }
   });
 
   // For reasons of progressive enhancement the search box is hidden by default.


### PR DESCRIPTION
Pull Request for Issue #31351 .

### Summary of Changes
This PR adds a alert message for when a module is not found in search while selecting a new module in Administrator or Site section.

It adds a `div` for alert in `administrator/components/com_modules/tmpl/select/default.php` and adds the code to count the number of modules that are currently shown in `build/media_source/com_modules/js/admin-module-search.es6.js`. If the count turns to zero or less than that, an alert is shown. 


### Testing Instructions

- Login to admin panel
- Go to Site/administrator modules
- Click on New module
- Search the module name which is not present



### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/42460131/110987029-808c2a00-8394-11eb-9071-9a598f9a3877.png)


### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/42460131/110987119-a0bbe900-8394-11eb-867b-b5c842d8164f.png)





