### PR TITLE
[4.0] Unused string

### DIFF
--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -114,7 +114,6 @@ $wam->useScript('webcomponent.image-select');
 
 Text::script('JFIELD_MEDIA_LAZY_LABEL');
 Text::script('JFIELD_MEDIA_ALT_LABEL');
-Text::script('JFIELD_MEDIA_CONFIRM_TEXT');
 Text::script('JLIB_APPLICATION_ERROR_SERVER');
 Text::script('JLIB_FORM_MEDIA_PREVIEW_EMPTY', true);
 


### PR DESCRIPTION
Removes javascript call to a language string that is no longer used and does not exist in the language files.

Code review only

Pull Request for Issue #32655 .
