### PR TITLE
Removed deprecated iframe attributes from com/mod_wrapper #32598

### DIFF
--- a/components/com_wrapper/views/wrapper/tmpl/default.php
+++ b/components/com_wrapper/views/wrapper/tmpl/default.php
@@ -30,8 +30,6 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 		src="<?php echo $this->escape($this->wrapper->url); ?>"
 		width="<?php echo $this->escape($this->params->get('width')); ?>"
 		height="<?php echo $this->escape($this->params->get('height')); ?>"
-		scrolling="<?php echo $this->escape($this->params->get('scrolling')); ?>"
-		frameborder="<?php echo $this->escape($this->params->get('frameborder', 1)); ?>"
 		<?php if ($this->escape($this->params->get('page_heading'))) : ?>
 			title="<?php echo $this->escape($this->params->get('page_heading')); ?>"
 		<?php else : ?>

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -17,8 +17,6 @@ JHtml::_('script', 'com_wrapper/iframe-height.min.js', array('version' => 'auto'
 	src="<?php echo $url; ?>"
 	width="<?php echo $width; ?>"
 	height="<?php echo $height; ?>"
-	scrolling="<?php echo $scroll; ?>"
-	frameborder="<?php echo $frameborder; ?>"
 	title="<?php echo $ititle; ?>"
 	class="wrapper<?php echo $moduleclass_sfx; ?>" >
 	<?php echo JText::_('MOD_WRAPPER_NO_IFRAMES'); ?>


### PR DESCRIPTION
Pull Request for Issue #32598.

### Summary of Changes

Removed deprecated iframe attributes from 'components/com_wrapper/views/wrapper/tmpl/default.php' & 'modules/mod_wrapper/tmpl/default.php'





