### PR TITLE
[4.0][a11y] fixes intended labels not being shown for search in searchtools

### DIFF
--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -39,13 +39,9 @@ $filters = $data['view']->filterForm->getGroup('filter');
 					<?php echo htmlspecialchars(Text::_($filters['filter_search']->description), ENT_COMPAT, 'UTF-8'); ?>
 				</div>
 				<?php endif; ?>
-				<label for="filter_search" class="visually-hidden">
-				<?php if (isset($filters['filter_search']->label)) : ?>
-					<?php echo Text::_($filters['filter_search']->label); ?>
-				<?php else : ?>
-					<?php echo Text::_('JSEARCH_FILTER'); ?>
-				<?php endif; ?>
-				</label>
+				<span class="visually-hidden">
+					<?php echo $filters['filter_search']->label; ?>
+				</span>
 				<button type="submit" class="btn btn-primary" aria-label="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>">
 					<span class="icon-search" aria-hidden="true"></span>
 				</button>


### PR DESCRIPTION
### Summary of Changes
Removes this particular redundant condition, since this condition always failed and hence the actual labels were never rendered.
Further, this condition was being used as a fallback in case there wasn't any label present. But no fallback was actually required since in case there wasn't any label defined, it was already set to the default "search". 

Also, `$filters['filter_search']->label` isn't a label value, rather an html `label` element.

https://github.com/joomla/joomla-cms/blob/e317fe221b00d67b9e72cc9c4a359e829f20830d/layouts/joomla/searchtools/default/bar.php#L42-L48


### Testing Instructions

- Login to Administrator.
- In content category, go to articles.
- Use dev tools to select the search bar.
- Look for the `label` element below the `input` field.

This could be tested in other categories as well which uses search from `layouts/joomla/searchtools`.

### Actual result BEFORE applying this Pull Request
Default "search" label is displayed.

![image](https://user-images.githubusercontent.com/42460131/111041007-13dc6280-845c-11eb-9c4c-656e960d8f48.png)


### Expected result AFTER applying this Pull Request
Actual label should be displayed.

![image](https://user-images.githubusercontent.com/42460131/111040920-9f092880-845b-11eb-9123-26c8ce674dd2.png)

Discovered this issue through PR #32660.

