### PR TITLE
Use node v12 compatible notation

### DIFF
--- a/build/build-modules-js/javascript/compile-to-es2017.es6.js
+++ b/build/build-modules-js/javascript/compile-to-es2017.es6.js
@@ -1,4 +1,4 @@
-const { access } = require('fs/promises');
+const { access } = require('fs').promises;
 const { constants } = require('fs');
 const Autoprefixer = require('autoprefixer');
 const CssNano = require('cssnano');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/32315#issuecomment-798888753 .

### Summary of Changes

In node v14 you can write `const { access } = require('fs/promises');` which is equivalent to `const { access } = require('fs').promises;` but it's not ok for v12. So, this PR reverts to the v12 notation

### Testing Instructions
`npm ci` doesn't throw on v12


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

No, this is a bug and my mistake