### PR TITLE
[4.0] Fix filters not translated for com_mails

### DIFF
--- a/administrator/components/com_mails/src/Helper/MailsHelper.php
+++ b/administrator/components/com_mails/src/Helper/MailsHelper.php
@@ -96,7 +96,6 @@ abstract class MailsHelper
 					$source = JPATH_PLUGINS . '/' . $parts[1] . '/' . $parts[2];
 				}
 				break;
-
 		}
 
 		$lang->load($extension, JPATH_ADMINISTRATOR)

--- a/administrator/components/com_mails/src/Helper/MailsHelper.php
+++ b/administrator/components/com_mails/src/Helper/MailsHelper.php
@@ -32,7 +32,6 @@ abstract class MailsHelper
 	 */
 	public static function mailtags($mail, $fieldname)
 	{
-		$app = Factory::getApplication();
 		Factory::getApplication()->triggerEvent('onMailBeforeTagsRendering', array($mail->template_id, &$mail));
 
 		if (!isset($mail->params['tags']) || !count($mail->params['tags']))
@@ -53,5 +52,62 @@ abstract class MailsHelper
 		$html .= '</ul>';
 
 		return $html;
+	}
+
+	/**
+	 * Load the translation files for an extension
+	 *
+	 * @param   string  $extension  Extension name
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function loadTranslationFiles($extension)
+	{
+		static $cache = array();
+
+		$extension = strtolower($extension);
+
+		if (isset($cache[$extension]))
+		{
+			return;
+		}
+
+		$lang   = Factory::getLanguage();
+		$source = '';
+
+		switch (substr($extension, 0, 3))
+		{
+			case 'com':
+			default:
+				$source = JPATH_ADMINISTRATOR . '/components/' . $extension;
+				break;
+
+			case 'mod':
+				$source = JPATH_SITE . '/modules/' . $extension;
+				break;
+
+			case 'plg':
+				$parts = explode('_', $extension, 3);
+
+				if (count($parts) > 2)
+				{
+					$source = JPATH_PLUGINS . '/' . $parts[1] . '/' . $parts[2];
+				}
+				break;
+
+		}
+
+		$lang->load($extension, JPATH_ADMINISTRATOR)
+		|| $lang->load($extension, $source);
+
+		if (!$lang->hasKey(strtoupper($extension)))
+		{
+			$lang->load($extension . '.sys', JPATH_ADMINISTRATOR)
+			|| $lang->load($extension . '.sys', $source);
+		}
+
+		$cache[$extension] = true;
 	}
 }

--- a/administrator/components/com_mails/src/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/src/Model/TemplatesModel.php
@@ -184,8 +184,9 @@ class TemplatesModel extends ListModel
 	{
 		$db    = $this->getDbo();
 		$query = $db->getQuery(true)
-			->select("DISTINCT SUBSTRING(template_id, 1, POSITION('.' IN template_id) - 1) AS extension")
-			->from('#__mail_templates');
+			->select('DISTINCT SUBSTRING(' . $db->quoteName('template_id')
+				. ', 1, POSITION("." IN ' . $db->quoteName('template_id') . ') - 1) AS extension')
+			->from($db->quoteName('#__mail_templates'));
 		$db->setQuery($query);
 
 		return $db->loadColumn();

--- a/administrator/components/com_mails/src/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/src/Model/TemplatesModel.php
@@ -174,6 +174,24 @@ class TemplatesModel extends ListModel
 	}
 
 	/**
+	 * Get list of extensions which are using mail templates
+	 *
+	 * @return array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function getExtensions()
+	{
+		$db    = $this->getDbo();
+		$query = $db->getQuery(true)
+			->select("DISTINCT SUBSTRING(template_id, 1, POSITION('.' IN template_id) - 1) AS extension")
+			->from('#__mail_templates');
+		$db->setQuery($query);
+
+		return $db->loadColumn();
+	}
+
+	/**
 	 * Get a list of the current content languages
 	 *
 	 * @return  array

--- a/administrator/components/com_mails/src/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/src/Model/TemplatesModel.php
@@ -186,7 +186,7 @@ class TemplatesModel extends ListModel
 		$query = $db->getQuery(true)
 			->select(
 				'DISTINCT SUBSTRING(' . $db->quoteName('template_id')
-				. ', 1, POSITION(' . $db->quote('.') . ' IN ' . $db->quoteName('template_id') . ') - 1) AS ' . $db->quoteName(extension)
+				. ', 1, POSITION(' . $db->quote('.') . ' IN ' . $db->quoteName('template_id') . ') - 1) AS ' . $db->quoteName('extension')
 			)
 			->from($db->quoteName('#__mail_templates'));
 		$db->setQuery($query);

--- a/administrator/components/com_mails/src/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/src/Model/TemplatesModel.php
@@ -185,7 +185,7 @@ class TemplatesModel extends ListModel
 		$db    = $this->getDbo();
 		$query = $db->getQuery(true)
 			->select('DISTINCT SUBSTRING(' . $db->quoteName('template_id')
-				. ', 1, POSITION("." IN ' . $db->quoteName('template_id') . ') - 1) AS extension')
+				. ', 1, POSITION(' . $db->quote('.') . ' IN ' . $db->quoteName('template_id') . ') - 1) AS ' .  $db->quoteName(extension))
 			->from($db->quoteName('#__mail_templates'));
 		$db->setQuery($query);
 

--- a/administrator/components/com_mails/src/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/src/Model/TemplatesModel.php
@@ -184,8 +184,10 @@ class TemplatesModel extends ListModel
 	{
 		$db    = $this->getDbo();
 		$query = $db->getQuery(true)
-			->select('DISTINCT SUBSTRING(' . $db->quoteName('template_id')
-				. ', 1, POSITION(' . $db->quote('.') . ' IN ' . $db->quoteName('template_id') . ') - 1) AS ' .  $db->quoteName(extension))
+			->select(
+				'DISTINCT SUBSTRING(' . $db->quoteName('template_id')
+				. ', 1, POSITION(' . $db->quote('.') . ' IN ' . $db->quoteName('template_id') . ') - 1) AS ' . $db->quoteName(extension)
+			)
 			->from($db->quoteName('#__mail_templates'));
 		$db->setQuery($query);
 

--- a/administrator/components/com_mails/src/View/Templates/HtmlView.php
+++ b/administrator/components/com_mails/src/View/Templates/HtmlView.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Mails\Administrator\Helper\MailsHelper;
 
 /**
  * View for the mail templates configuration
@@ -87,6 +88,7 @@ class HtmlView extends BaseHtmlView
 		$this->state         = $this->get('State');
 		$this->filterForm    = $this->get('FilterForm');
 		$this->activeFilters = $this->get('ActiveFilters');
+		$extensions          = $this->get('Extensions');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
@@ -94,20 +96,9 @@ class HtmlView extends BaseHtmlView
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
-		$cache = array();
-		$language = Factory::getLanguage();
-
-		foreach ($this->items as $item)
+		foreach ($extensions as $extension)
 		{
-			list($component, $template_id) = explode('.', $item->template_id, 2);
-
-			if (isset($cache[$component]))
-			{
-				continue;
-			}
-
-			$language->load($component, JPATH_ADMINISTRATOR);
-			$cache[$component] = true;
+			MailsHelper::loadTranslationFiles($extension);
 		}
 
 		$this->addToolbar();


### PR DESCRIPTION
Pull Request for Issue #32675.

### Summary of Changes
This PR loads language files for not only components but also for plugins (borrow some code from ActionlogsHelper for loading translation) to make sure filters translated properly for com_mails component.


### Testing Instructions
1. See https://github.com/joomla/joomla-cms/issues/32675 , confirm the issue
2. Apply patch, confirm that the issue is fixed.