### PR TITLE
[4.0] fixes table overflow in Mail templates

### DIFF
--- a/administrator/components/com_mails/tmpl/templates/default.php
+++ b/administrator/components/com_mails/tmpl/templates/default.php
@@ -38,22 +38,22 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 						</caption>
 						<thead>
 							<tr>
-								<th scope="col" class="w-25" style="min-width:100px">
+								<th scope="col" class="w-20" style="min-width:100px">
 									<?php echo Text::_('JGLOBAL_TITLE'); ?>
 								</th>
 								<th scope="col" class="w-15 d-none d-md-table-cell">
 									<?php echo Text::_('COM_MAILS_HEADING_COMPONENT'); ?>
 								</th>
-								<th scope="col" class="w-10 d-md-table-cell">
+								<th scope="col" class="w-10 d-none d-md-table-cell">
 									<?php echo Text::_('COM_MAILS_HEADING_TEMPLATES_FOR_LANGUAGES'); ?>
 								</th>
-								<th scope="col" class="w-10 d-none d-md-table-cell text-center">
+								<th scope="col" class="w-10 d-none d-md-table-cell">
 									<?php echo Text::_('COM_MAILS_HEADING_NO_TEMPLATES_FOR_LANGUAGES'); ?>
 								</th>
-								<th scope="col" class="w-25 d-none d-md-table-cell text-center">
+								<th scope="col" class="w-25 d-none d-md-table-cell">
 									<?php echo Text::_('COM_MAILS_HEADING_DESCRIPTION'); ?>
 								</th>
-								<th scope="col" class="w-10 d-none d-md-table-cell">
+								<th scope="col" class="w-20 d-none d-md-table-cell">
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.template_id', $listDirn, $listOrder); ?>
 								</th>
 							</tr>
@@ -64,7 +64,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 							$sub_id = str_replace('.', '_', $sub_id);
 							?>
 							<tr class="row<?php echo $i % 2; ?>">
-								<td class="break-word text-center">
+								<td class="break-word">
 									<div class="dropdown">
 										<a class="dropdown-toggle" href="#" role="button" id="mTemplate<?php echo $i; ?>"  data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 											<?php echo Text::_($component . '_MAIL_' . $sub_id . '_TITLE'); ?>
@@ -82,10 +82,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 										</div>
 									</div>
 								</td>
-								<td class="d-none d-md-table-cell text-center">
+								<td class="d-none d-md-table-cell">
 									<?php echo Text::_($component); ?>
 								</td>
-								<td class="d-none d-md-table-cell text-center">
+								<td class="d-none d-md-table-cell">
 									<?php foreach ($this->languages as $language) : ?>
 										<?php if (in_array($language->lang_code, $item->languages)) : ?>
 											<?php if ($language->image) : ?>
@@ -96,7 +96,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 										<?php endif; ?>
 									<?php endforeach; ?>
 								</td>
-								<td class="d-none d-md-table-cell text-center">
+								<td class="d-none d-md-table-cell">
 									<?php foreach ($this->languages as $language) : ?>
 										<?php if (!in_array($language->lang_code, $item->languages)) : ?>
 											<?php if ($language->image) : ?>
@@ -107,10 +107,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 										<?php endif; ?>
 									<?php endforeach; ?>
 								</td>
-								<td class="d-none d-md-table-cell text-justify">
+								<td class="d-none d-md-table-cell">
 									<?php echo Text::_($component . '_MAIL_' . $sub_id . '_DESC'); ?>
 								</td>
-								<td class="d-none d-md-table-cell text-break text-center">
+								<td class="d-none d-md-table-cell text-break">
 									<?php echo $item->template_id; ?>
 								</td>
 							</tr>

--- a/administrator/components/com_mails/tmpl/templates/default.php
+++ b/administrator/components/com_mails/tmpl/templates/default.php
@@ -38,7 +38,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 						</caption>
 						<thead>
 							<tr>
-								<th scope="col" class="w-20" style="min-width:100px">
+								<th scope="col" class="w-20">
 									<?php echo Text::_('JGLOBAL_TITLE'); ?>
 								</th>
 								<th scope="col" class="w-15 d-none d-md-table-cell">

--- a/administrator/components/com_mails/tmpl/templates/default.php
+++ b/administrator/components/com_mails/tmpl/templates/default.php
@@ -47,10 +47,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 								<th scope="col" class="w-10 d-md-table-cell">
 									<?php echo Text::_('COM_MAILS_HEADING_TEMPLATES_FOR_LANGUAGES'); ?>
 								</th>
-								<th scope="col" class="w-10 d-none d-md-table-cell">
+								<th scope="col" class="w-10 d-none d-md-table-cell text-center">
 									<?php echo Text::_('COM_MAILS_HEADING_NO_TEMPLATES_FOR_LANGUAGES'); ?>
 								</th>
-								<th scope="col" class="w-30 d-none d-md-table-cell">
+								<th scope="col" class="w-25 d-none d-md-table-cell text-center">
 									<?php echo Text::_('COM_MAILS_HEADING_DESCRIPTION'); ?>
 								</th>
 								<th scope="col" class="w-10 d-none d-md-table-cell">
@@ -64,7 +64,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 							$sub_id = str_replace('.', '_', $sub_id);
 							?>
 							<tr class="row<?php echo $i % 2; ?>">
-								<td class="break-word">
+								<td class="break-word text-center">
 									<div class="dropdown">
 										<a class="dropdown-toggle" href="#" role="button" id="mTemplate<?php echo $i; ?>"  data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 											<?php echo Text::_($component . '_MAIL_' . $sub_id . '_TITLE'); ?>
@@ -82,10 +82,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 										</div>
 									</div>
 								</td>
-								<td class="d-none d-md-table-cell">
+								<td class="d-none d-md-table-cell text-center">
 									<?php echo Text::_($component); ?>
 								</td>
-								<td class="d-none d-md-table-cell">
+								<td class="d-none d-md-table-cell text-center">
 									<?php foreach ($this->languages as $language) : ?>
 										<?php if (in_array($language->lang_code, $item->languages)) : ?>
 											<?php if ($language->image) : ?>
@@ -96,7 +96,7 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 										<?php endif; ?>
 									<?php endforeach; ?>
 								</td>
-								<td class="d-none d-md-table-cell">
+								<td class="d-none d-md-table-cell text-center">
 									<?php foreach ($this->languages as $language) : ?>
 										<?php if (!in_array($language->lang_code, $item->languages)) : ?>
 											<?php if ($language->image) : ?>
@@ -107,10 +107,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 										<?php endif; ?>
 									<?php endforeach; ?>
 								</td>
-								<td class="d-none d-md-table-cell">
+								<td class="d-none d-md-table-cell text-justify">
 									<?php echo Text::_($component . '_MAIL_' . $sub_id . '_DESC'); ?>
 								</td>
-								<td class="d-none d-md-table-cell">
+								<td class="d-none d-md-table-cell text-break text-center">
 									<?php echo $item->template_id; ?>
 								</td>
 							</tr>


### PR DESCRIPTION
Pull Request for Issue #32679 .

### Summary of Changes
This PR fixes the issue where the table in Mailing templates would fail to be responsive because of long `ID`s since they are treated as a single word, causing an overflow. Hence, to fix this problem, `text-break` class for ID column has been added.

Further, this PR tweaks alignment of text in Mail templates table to visually make it better.

### Testing Instructions

- Login to Administrator.
- Go to System > Mail Templates.
- Use Dev tools to resize the window. The overflow could be seen at around 1024px.


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/42460131/111064929-f26f8b00-84dc-11eb-9e9a-0835b87e1732.png)
![image](https://user-images.githubusercontent.com/42460131/111064938-07e4b500-84dd-11eb-97bf-7ee0c6d56ffd.png)


### Expected result AFTER applying this Pull Request
The table should be responsive and be able to adapt to smaller widths.

![image](https://user-images.githubusercontent.com/42460131/111071863-1abbb180-84fe-11eb-92a7-dd1819332346.png)



