### PR TITLE
Drop Nodejs v10

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Joomla! CMS™ [![Analytics](https://ga-beacon.appspot.com/UA-544070-3/joomla-cm
 
 Build Status
 ---------------------
-| Drone-CI | AppVeyor |
-| ------------- | ------------- |
-| [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg?branch=4.0-dev)](https://ci.joomla.org/joomla/joomla-cms)  | [![Build status](https://ci.appveyor.com/api/projects/status/ru6sxal8jmfckvjc/branch/4.0-dev?svg=true)](https://ci.appveyor.com/project/release-joomla/joomla-cms)  |
+| Drone-CI      | AppVeyor      | PHP           |  Node         | npm           |
+| ------------- | ------------- | ------------- | ------------- | ------------- |
+| [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg?branch=4.0-dev)](https://ci.joomla.org/joomla/joomla-cms) | [![Build status](https://ci.appveyor.com/api/projects/status/ru6sxal8jmfckvjc/branch/4.0-dev?svg=true)](https://ci.appveyor.com/project/release-joomla/joomla-cms) | [![PHP](https://img.shields.io/badge/PHP-V7.2-green)](https://www.php.net/) | [![node-lts](https://img.shields.io/badge/Node-V12.0-green)](https://nodejs.org/en/) | [![npm](https://img.shields.io/badge/npm-v6.13.4-green)](https://nodejs.org/en/) |
 
 Overview
 ---------------------

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Build Status
 ---------------------
 | Drone-CI      | AppVeyor      | PHP           |  Node         | npm           |
 | ------------- | ------------- | ------------- | ------------- | ------------- |
-| [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg?branch=4.0-dev)](https://ci.joomla.org/joomla/joomla-cms) | [![Build status](https://ci.appveyor.com/api/projects/status/ru6sxal8jmfckvjc/branch/4.0-dev?svg=true)](https://ci.appveyor.com/project/release-joomla/joomla-cms) | [![PHP](https://img.shields.io/badge/PHP-V7.2-green)](https://www.php.net/) | [![node-lts](https://img.shields.io/badge/Node-V12.0-green)](https://nodejs.org/en/) | [![npm](https://img.shields.io/badge/npm-v6.13.4-green)](https://nodejs.org/en/) |
+| [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg?branch=4.0-dev)](https://ci.joomla.org/joomla/joomla-cms) | [![Build status](https://ci.appveyor.com/api/projects/status/ru6sxal8jmfckvjc/branch/4.0-dev?svg=true)](https://ci.appveyor.com/project/release-joomla/joomla-cms) | [![PHP](https://img.shields.io/badge/PHP-V7.2.5-green)](https://www.php.net/) | [![node-lts](https://img.shields.io/badge/Node-V12.0-green)](https://nodejs.org/en/) | [![npm](https://img.shields.io/badge/npm-v6.13.4-green)](https://nodejs.org/en/) |
 
 Overview
 ---------------------

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/joomla/joomla-cms.git"
   },
   "engines": {
-    "node": ">=10.19",
+    "node": ">=12.0",
     "npm": ">=6.13.4"
   },
   "scripts": {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Nodejs v10 goes EOL on April 30th.
This PR raises the requirement to v12

Also added the minimum version for PHP, node, npm as badges in the readme 

![Screenshot 2021-03-14 at 16 51 44](https://user-images.githubusercontent.com/3889375/111074925-b0971280-84e5-11eb-9479-a74e3d0b829e.png)

### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

The docs for setting up the dev environment should also mention the minimum nodejs version as 12, eg here:

https://docs.joomla.org/J4.x:Setting_Up_Your_Local_Environment