### PR TITLE
[4.0] LDAP plugin

### DIFF
--- a/plugins/authentication/ldap/ldap.xml
+++ b/plugins/authentication/ldap/ldap.xml
@@ -135,6 +135,7 @@
 					type="password"
 					label="PLG_LDAP_FIELD_PASSWORD_LABEL"
 					description="PLG_LDAP_FIELD_PASSWORD_DESC"
+					hiddenDescription="true"
 					size="20"
 				/>
 


### PR DESCRIPTION
Prevent the duplicate display of the description of the LDAP password (password fields are non-standaard in this respect)

### Before
![image](https://user-images.githubusercontent.com/1296369/111077380-78450380-84e8-11eb-949a-fefe5899ca9a.png)

### After
![image](https://user-images.githubusercontent.com/1296369/111077364-62374300-84e8-11eb-822a-fb0e711f9c31.png)
