### PR TITLE
Disable Displays error messages about missing XML attributes addition…

### DIFF
--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -811,7 +811,7 @@ abstract class FormField
 		}
 
 		// Get the label text from the XML element, defaulting to the element name.
-		$title = $this->element['label'] ? (string) $this->element['label'] : (string) $this->element['name'];
+		$title = isset($this->element['label']) && $this->element['label'] ? (string) $this->element['label'] : (isset($this->element['name']) && $this->element['name'] ? (string) $this->element['name'] : '');
 		$title = $this->translateLabel ? Text::_($title) : $title;
 
 		return $title;
@@ -1314,8 +1314,7 @@ abstract class FormField
 	protected function getLayoutData()
 	{
 		// Label preprocess
-		$label = $this->element['label'] ? (string) $this->element['label'] : (string) $this->element['name'];
-		$label = $this->translateLabel ? Text::_($label) : $label;
+		$label = $this->getTitle();
 
 		// Description preprocess
 		$description = !empty($this->description) ? $this->description : null;


### PR DESCRIPTION
…al for fields.

Operation of Joomla in the configuration mode "Error messages: Maximum".
Displays error messages about missing XML attributes for fields.
But the absence of these fields is acceptable for Joomla fields to work.
No error message should be displayed for optional attributes for Joomla in the "Error Messages: Maximum" mode, because the attributes are additional.
On the other hand, these error messages do not inform the administrator about the error, from these messages it is not at all clear what field we are talking about, what attribute we are talking about, and what the error is in general.
Messages appear when there is no **Label** attribute, or there is no **Name** attribute.

![img-2021-03-14-23-54-21](https://user-images.githubusercontent.com/6898474/111084605-38037680-8524-11eb-9107-e47dd5e38c60.png)
