### PR TITLE
[4.0] Fixing No-ID setting for nomenu router rule

### DIFF
--- a/libraries/src/Component/Router/Rules/NomenuRules.php
+++ b/libraries/src/Component/Router/Rules/NomenuRules.php
@@ -74,10 +74,26 @@ class NomenuRules implements RulesInterface
 			if (isset($views[$segments[0]]))
 			{
 				$vars['view'] = array_shift($segments);
+				$view = $views[$vars['view']];
 
 				if (isset($views[$vars['view']]->key) && isset($segments[0]))
 				{
-					$vars[$views[$vars['view']]->key] = preg_replace('/-/', ':', array_shift($segments), 1);
+					if (\is_callable(array($this->router, 'get' . ucfirst($view->name) . 'Id')))
+					{
+						if ($this->router->app->input->get($view->parent_key))
+						{
+							$vars[$view->parent->key] = $this->router->app->input->get($view->parent_key);
+							$vars[$view->parent_key] = $this->router->app->input->get($view->parent_key);
+						}
+
+						$result = \call_user_func_array(array($this->router, 'get' . ucfirst($view->name) . 'Id'), array($segments[0], $vars));
+						array_shift($segments);
+						$vars[$view->key] = preg_replace('/-/', ':', $result, 1);
+					}
+					else
+					{
+						$vars[$view->key] = preg_replace('/-/', ':', array_shift($segments), 1);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Pull Request for Issue #32248.

### Summary of Changes
When generating a URL to a content item that has no menu item leading to it, uses the rule-based-routers AND the "Remove IDs from URLs" option for the component is active, the router can't parse the URL again. This should fix that.

### Testing Instructions
1. In the settings of the contact component, enable "Remove IDs from URLs" and save that.
2. Create a contact with a tag
3. Create a menu item of type "Tags -> tagged items" with the previously used tag
4. Go to the frontend and click on your new menu item.
5. See the contact being listed and click on it.
6. You get an error page. Oh no!
7. Apply the PR.
8. Reload the page and see that it works fine.

Thanks to @PhilETaylor for reporting this issue with good instructions.