### PR TITLE
Fixes button margin

### DIFF
--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -24,6 +24,7 @@
     background-color: $gray-100;
   }
 }
+
 @include media-breakpoint-down(md) {
   .btn {
     margin-bottom: .25rem;

--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -24,7 +24,7 @@
     background-color: $gray-100;
   }
 }
-@media (max-width: 22.75rem) {
+@include media-breakpoint-down(md) {
   .btn {
     margin-bottom: .25rem;
   }

--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -24,3 +24,8 @@
     background-color: $gray-100;
   }
 }
+@media (max-width: 22.75rem) {  
+  .btn {
+    margin-bottom: .25rem;
+  }
+}

--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -24,7 +24,7 @@
     background-color: $gray-100;
   }
 }
-@media (max-width: 22.75rem) {  
+@media (max-width: 22.75rem) {
   .btn {
     margin-bottom: .25rem;
   }


### PR DESCRIPTION
Pull Request for Issue # .

**Summary of Changes**
bootstrap margin class was added to the danger button

**Testing Instructions**
open the cassiopeia page[frontend] on (http://localhost/joomla-cms/index.php?option=com_config&view=modules&id=1&Itemid=101&return=aHR0cDovL2xvY2FsaG9zdC9qb29tbGEtY21zLw%3D%3D)
2)open edit module on the right hand side of the page.

set the toggle device toolbar to mobile view.
4)before applying the patch it would show improper margin between the buttons, but after applying the patch proper margin is there.

**Actual result BEFORE applying this Pull Request**

![image](https://user-images.githubusercontent.com/70388131/111203969-a65f3c00-85eb-11eb-858c-3da4a2d4e066.png)


**Expected result AFTER applying this Pull Request**
![image](https://user-images.githubusercontent.com/70388131/111264997-74cb8c80-864e-11eb-8c48-38a31e7b98e4.png)


