### PR TITLE
Fixes the Inconsistent placement of frontend action buttons

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -146,21 +146,7 @@ Text::script('TPL_ATUM_MORE_ELEMENTS');
 
 	<?php // container-fluid ?>
 	<div class="container-fluid container-main">
-		<?php if (!$cpanel) : ?>
-			<?php // Subheader ?>
-			<?php HTMLHelper::_('bootstrap.collapse', '.toggler-toolbar'); ?>
-			<button class="navbar-toggler toggler-toolbar toggler-burger collapsed" type="button" data-bs-toggle="collapse" data-bs-target=".subhead" aria-controls="subhead" aria-expanded="false" aria-label="<?php echo Text::_('TPL_ATUM_TOOLBAR'); ?>">
-				<span class="toggler-toolbar-icon"></span>
-			</button>
-			<div id="subhead" class="subhead mb-3">
-				<div id="container-collapse" class="container-collapse"></div>
-				<div class="row">
-					<div class="col-md-12">
-						<jdoc:include type="modules" name="toolbar" style="no" />
-					</div>
-				</div>
-			</div>
-		<?php endif; ?>
+		
 		<section id="content" class="content">
 			<?php // Begin Content ?>
 			<jdoc:include type="modules" name="top" style="xhtml" />
@@ -177,6 +163,21 @@ Text::script('TPL_ATUM_MORE_ELEMENTS');
 			</div>
 			<?php // End Content ?>
 		</section>
+		<?php if (!$cpanel) : ?>
+			<?php // Subheader ?>
+			<?php HTMLHelper::_('bootstrap.collapse', '.toggler-toolbar'); ?>
+			<button class="navbar-toggler toggler-toolbar toggler-burger collapsed" type="button" data-bs-toggle="collapse" data-bs-target=".subhead" aria-controls="subhead" aria-expanded="false" aria-label="<?php echo Text::_('TPL_ATUM_TOOLBAR'); ?>">
+				<span class="toggler-toolbar-icon"></span>
+			</button>
+			<div id="subhead" class="subhead mb-3">
+				<div id="container-collapse" class="container-collapse"></div>
+				<div class="row">
+					<div class="col-md-12">
+						<jdoc:include type="modules" name="toolbar" style="no" />
+					</div>
+				</div>
+			</div>
+		<?php endif; ?>
 	</div>
 </div>
 <jdoc:include type="modules" name="debug" style="none" />

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -176,7 +176,7 @@ Text::script('TPL_ATUM_MORE_ELEMENTS');
 				<?php endif; ?>
 			</div>
 			<?php // End Content ?>
-		</section
+		</section>
 	</div>
 </div>
 <jdoc:include type="modules" name="debug" style="none" />

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -146,23 +146,6 @@ Text::script('TPL_ATUM_MORE_ELEMENTS');
 
 	<?php // container-fluid ?>
 	<div class="container-fluid container-main">
-		
-		<section id="content" class="content">
-			<?php // Begin Content ?>
-			<jdoc:include type="modules" name="top" style="xhtml" />
-			<div class="row">
-				<div class="col-md-12">
-					<main>
-						<jdoc:include type="message" />
-						<jdoc:include type="component" />
-					</main>
-				</div>
-				<?php if ($this->countModules('bottom')) : ?>
-					<jdoc:include type="modules" name="bottom" style="xhtml" />
-				<?php endif; ?>
-			</div>
-			<?php // End Content ?>
-		</section>
 		<?php if (!$cpanel) : ?>
 			<?php // Subheader ?>
 			<?php HTMLHelper::_('bootstrap.collapse', '.toggler-toolbar'); ?>
@@ -178,6 +161,22 @@ Text::script('TPL_ATUM_MORE_ELEMENTS');
 				</div>
 			</div>
 		<?php endif; ?>
+		<section id="content" class="content">
+			<?php // Begin Content ?>
+			<jdoc:include type="modules" name="top" style="xhtml" />
+			<div class="row">
+				<div class="col-md-12">
+					<main>
+						<jdoc:include type="message" />
+						<jdoc:include type="component" />
+					</main>
+				</div>
+				<?php if ($this->countModules('bottom')) : ?>
+					<jdoc:include type="modules" name="bottom" style="xhtml" />
+				<?php endif; ?>
+			</div>
+			<?php // End Content ?>
+		</section
 	</div>
 </div>
 <jdoc:include type="modules" name="debug" style="none" />

--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -23,6 +23,15 @@ $wa->useScript('keepalive')
 
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="application-form" method="post" name="adminForm" class="form-validate">
 
+	<?php echo $this->loadTemplate('site'); ?>
+	<?php echo $this->loadTemplate('seo'); ?>
+	<?php echo $this->loadTemplate('metadata'); ?>
+
+	<input type="hidden" name="task" value="">
+	<?php echo HTMLHelper::_('form.token'); ?>
+
+	<hr>
+	<div class="mb-2">
 	<button type="button" class="btn btn-primary" data-submit-task="config.apply">
 		<span class="icon-check" aria-hidden="true"></span>
 		<?php echo Text::_('JSAVE') ?>
@@ -31,14 +40,6 @@ $wa->useScript('keepalive')
 		<span class="icon-times" aria-hidden="true"></span>
 		<?php echo Text::_('JCANCEL') ?>
 	</button>
-
-	<hr>
-
-	<?php echo $this->loadTemplate('site'); ?>
-	<?php echo $this->loadTemplate('seo'); ?>
-	<?php echo $this->loadTemplate('metadata'); ?>
-
-	<input type="hidden" name="task" value="">
-	<?php echo HTMLHelper::_('form.token'); ?>
+	</div>
 
 </form>

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -47,7 +47,7 @@ if (Multilanguage::isEnabled())
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="modules-form" class="form-validate">
 	<div class="row">
 		<div class="col-md-12">
-			<legend><b><h2><?php echo Text::_('COM_CONFIG_MODULES_SETTINGS_TITLE'); ?></h2></b></legend>
+			<legend><?php echo Text::_('COM_CONFIG_MODULES_SETTINGS_TITLE'); ?></legend>
 
 			<div>
 				<?php echo Text::_('COM_CONFIG_MODULES_MODULE_NAME'); ?>

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -47,23 +47,7 @@ if (Multilanguage::isEnabled())
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="modules-form" class="form-validate">
 	<div class="row">
 		<div class="col-md-12">
-
-			<button type="button" class="btn btn-primary" data-submit-task="modules.apply">
-				<span class="icon-check" aria-hidden="true"></span>
-				<?php echo Text::_('JAPPLY'); ?>
-			</button>
-			<button type="button" class="btn btn-primary" data-submit-task="modules.save">
-				<span class="icon-check" aria-hidden="true"></span>
-				<?php echo Text::_('JSAVE'); ?>
-			</button>
-			<button type="button" class="btn btn-danger" data-submit-task="modules.cancel">
-				<span class="icon-times" aria-hidden="true"></span>
-				<?php echo Text::_('JCANCEL'); ?>
-			</button>
-
-			<hr>
-
-			<legend><?php echo Text::_('COM_CONFIG_MODULES_SETTINGS_TITLE'); ?></legend>
+			<legend><b><h2><?php echo Text::_('COM_CONFIG_MODULES_SETTINGS_TITLE'); ?></h2></b></legend>
 
 			<div>
 				<?php echo Text::_('COM_CONFIG_MODULES_MODULE_NAME'); ?>
@@ -186,9 +170,22 @@ if (Multilanguage::isEnabled())
 				<input type="hidden" name="return" value="<?php echo Factory::getApplication()->input->get('return', null, 'base64'); ?>">
 				<input type="hidden" name="task" value="">
 				<?php echo HTMLHelper::_('form.token'); ?>
-
+				<hr>
 			</div>
-
+			<div class="mb-2">
+			<button type="button" class="btn btn-primary" data-submit-task="modules.apply">
+				<span class="icon-check" aria-hidden="true"></span>
+				<?php echo Text::_('JAPPLY'); ?>
+			</button>
+			<button type="button" class="btn btn-primary" data-submit-task="modules.save">
+				<span class="icon-check" aria-hidden="true"></span>
+				<?php echo Text::_('JSAVE'); ?>
+			</button>
+			<button type="button" class="btn btn-danger" data-submit-task="modules.cancel">
+				<span class="icon-times" aria-hidden="true"></span>
+				<?php echo Text::_('JCANCEL'); ?>
+			</button>
+			</div>
 		</div>
 	</div>
 </form>

--- a/components/com_config/tmpl/templates/default.php
+++ b/components/com_config/tmpl/templates/default.php
@@ -26,17 +26,6 @@ $wa->useScript('keepalive')
 
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate">
 
-	<button type="button" class="btn btn-primary" data-submit-task="templates.apply">
-		<span class="icon-check text-white" aria-hidden="true"></span>
-		<?php echo Text::_('JSAVE') ?>
-	</button>
-	<button type="button" class="btn btn-danger" data-submit-task="templates.cancel">
-		<span class="icon-times text-white" aria-hidden="true"></span>
-		<?php echo Text::_('JCANCEL') ?>
-	</button>
-
-	<hr>
-
 	<div id="page-site" class="tab-pane active">
 		<div class="row">
 			<div class="col-md-12">
@@ -47,5 +36,17 @@ $wa->useScript('keepalive')
 
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>
+
+	<hr>
+	<div class="mb-2">
+	<button type="button" class="btn btn-primary " data-submit-task="templates.apply">
+		<span class="icon-check text-white" aria-hidden="true"></span>
+		<?php echo Text::_('JSAVE') ?>
+	</button>
+	<button type="button" class="btn btn-danger" data-submit-task="templates.cancel">
+		<span class="icon-times text-white" aria-hidden="true"></span>
+		<?php echo Text::_('JCANCEL') ?>
+	</button>
+</div>
 
 </form>


### PR DESCRIPTION
Pull Request for Issue #32250

**Summary of Changes**

This PR changes the placement of buttons from top to bottom in the front-end "module editing" panel so as to make the page alignment consistent with the other front-end editing panels (eg: article editing).

**Testing Instructions**

1, Login to your front-end Joomla website.
2. Click on the edit button next to Main Menu.

**Actual result BEFORE applying this Pull Request**

![moduleBefore](https://user-images.githubusercontent.com/47187878/111331561-065eec80-8697-11eb-9a77-3f9850f10f6e.PNG)

**Expected result AFTER applying this Pull Request**

![1](https://user-images.githubusercontent.com/47187878/111331999-6d7ca100-8697-11eb-91bc-7538907fd95f.PNG)

![2](https://user-images.githubusercontent.com/47187878/111332007-6eadce00-8697-11eb-8307-e7117e1fb61b.PNG)



