### PR TITLE
[4.0] Remove testing code

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -26,9 +26,6 @@ use Joomla\Utilities\ArrayHelper;
 
 HTMLHelper::_('behavior.multiselect');
 
-// Just for the tests :(
-HTMLHelper::_('jquery.framework');
-
 $app       = Factory::getApplication();
 $user      = Factory::getUser();
 $userId    = $user->get('id');


### PR DESCRIPTION
Removes some code left behind from Dimitris testing when adding BS5

I see now that it wasnt for testing BS5 it was to make the unit test pass. Not touching that