### PR TITLE
[4.0] Ensure templatePath is always absolute and not a broken relative url

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -35,7 +35,7 @@ $menu     = $app->getMenu()->getActive();
 $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 
 // Template path
-$templatePath = 'templates/' . $this->template;
+$templatePath = Uri::root() . 'templates/' . $this->template;
 
 // Color Theme
 $paramsColorName = $this->params->get('colorName', 'colors_standard');


### PR DESCRIPTION
Pull Request for Issue Closes #31989

### Summary of Changes

Prepend templatePath with Uri:root to Ensure templatePath is always absolute and not a broken relative url

### Testing Instructions

See #31989

Visit frontend **, click a menu link in the left menu to get to an article**
Note that the CASSIOPEIA logo (white text on blue background) is present

In Joomla Admin disable the "System - SEF" plugin

Refresh your article page on the frontend

Note the logo is now a broken image


### Actual result BEFORE applying this Pull Request

paths are relative, and therefore image doesn't display when non-SEF mode and not at / (ie. in a sub folder or not on the home page where url contains /index.php/path/to  like http://127.0.0.1:4444/index.php/component/users/reset?Itemid=101)

### Expected result AFTER applying this Pull Request

regardless of SEF plugin status, the image and assets loaded from $templatePath load correctly. 

### Documentation Changes Required

none