### PR TITLE
Update captive.php

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
+++ b/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
@@ -77,14 +77,14 @@ $twofactormethods = \Joomla\CMS\Helper\AuthenticationHelper::getTwoFactorMethods
 		<?php endif; ?>
 		<div class="control-group">
 			<div class="controls">
-				<div class="btn-group">
+				<button type="button" class="btn">
 					<a tabindex="4" class="btn btn-danger" href="index.php?option=com_joomlaupdate">
 						<span class="icon-cancel icon-white" aria-hidden="true"></span> <?php echo JText::_('JCANCEL'); ?>
 					</a>
-					<button tabindex="5" class="btn btn-primary">
-						<span class="icon-play icon-white" aria-hidden="true"></span> <?php echo JText::_('COM_INSTALLER_INSTALL_BUTTON'); ?>
-					</button>
-				</div>
+				</button>
+				<button type="submit" class="btn btn-primary">
+					<span class="icon-play icon-white" aria-hidden="true"></span> <?php echo JText::_('COM_INSTALLER_INSTALL_BUTTON'); ?>
+				</button>
 			</div>
 		</div>
 


### PR DESCRIPTION
Add some space betweeb two buttons (CANCEL and INSTALL) when doing update.
See Issue [#32700]
Thanks @infograf768 

Pull Request for Issue #32700 .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request

![buttons-attached](https://user-images.githubusercontent.com/3976174/111481889-aec28e80-8733-11eb-9e32-f6ef05a2cb68.png)



### Expected result AFTER applying this Pull Request

![Screenshot_2021-03-17 Joomla Update - Joomla 4 Demo - Administration](https://user-images.githubusercontent.com/3976174/111481955-beda6e00-8733-11eb-8fbb-000a9fdec643.png)



### Documentation Changes Required

