### PR TITLE
Fix b/c issue with folders for files and images of com_media from the 3.9.25 release

### DIFF
--- a/libraries/src/Form/Rule/FilePathRule.php
+++ b/libraries/src/Form/Rule/FilePathRule.php
@@ -58,7 +58,7 @@ class FilePathRule extends FormRule
 		// Check the exclude setting
 		$path = preg_split('/[\/\\\\]/', $value);
 
-		if (!empty($exclude) && (in_array(strtolower($path[0]), $exclude) || empty($path[0])))
+		if (in_array(strtolower($path[0]), $exclude) || empty($path[0]))
 		{
 			return false;
 		}

--- a/libraries/src/Form/Rule/FilePathRule.php
+++ b/libraries/src/Form/Rule/FilePathRule.php
@@ -49,15 +49,14 @@ class FilePathRule extends FormRule
 			return true;
 		}
 
-		// Make sure $value starts with an a-z/A-Z character in order to not allow to break out of the current path
-		if (!preg_match("/^[A-Za-z]*$/", substr($value, 0, 1)))
-		{
-			return false;
-		}
-
-		// Check the exclude setting from the xml
+		// Get the exclude setting from the xml
 		$exclude = (array) explode('|', (string) $element['exclude']);
-		$path = explode('/', $value);
+
+		// Exclude current folder '.' to be safe from full path disclosure
+		$exclude[] = '.';
+
+		// Check the exclude setting
+		$path = preg_split('/[\/\\\\]/', $value);
 
 		if (!empty($exclude) && (in_array(strtolower($path[0]), $exclude) || empty($path[0])))
 		{
@@ -67,6 +66,7 @@ class FilePathRule extends FormRule
 		// Prepend the root path
 		$value = JPATH_ROOT . '/' . $value;
 
+		// Check if $value is a valid path, which includes not allowing to break out of the current path
 		try
 		{
 			Path::check($value);

--- a/tests/unit/suites/libraries/cms/form/rule/FilePathRuleTest.php
+++ b/tests/unit/suites/libraries/cms/form/rule/FilePathRuleTest.php
@@ -52,6 +52,8 @@ class FilePathRuleTest extends TestCase
 			array(false, $xml, '/media'),
 			array(false, $xml, '/administrator'),
 			array(false, $xml, '/4711images'),
+			array(false, $xml, 'media'),
+			array(false, $xml, 'administrator'),
 			array(true, $xml, '4711images'),
 			array(true, $xml, '1'),
 			array(true, $xml, '_'),

--- a/tests/unit/suites/libraries/cms/form/rule/FilePathRuleTest.php
+++ b/tests/unit/suites/libraries/cms/form/rule/FilePathRuleTest.php
@@ -36,6 +36,7 @@ class FilePathRuleTest extends TestCase
 			size="50"
 			default="images"
 			validate="filePath"
+			exclude="administrator|media"
 		/>');
 
 		return array(

--- a/tests/unit/suites/libraries/cms/form/rule/FilePathRuleTest.php
+++ b/tests/unit/suites/libraries/cms/form/rule/FilePathRuleTest.php
@@ -40,7 +40,7 @@ class FilePathRuleTest extends TestCase
 
 		return array(
 			array(true, $xml, ''),
-			array(false, $xml, '.images'),
+			array(true, $xml, '.images'),
 			array(false, $xml, './images'),
 			array(false, $xml, '.\images'),
 			array(false, $xml, '../images'),
@@ -52,16 +52,16 @@ class FilePathRuleTest extends TestCase
 			array(false, $xml, '/media'),
 			array(false, $xml, '/administrator'),
 			array(false, $xml, '/4711images'),
-			array(false, $xml, '4711images'),
-			array(false, $xml, '1'),
-			array(false, $xml, '_'),
-			array(false, $xml, '*'),
-			array(false, $xml, '%'),
-			array(false, $xml, '://foo'),
+			array(true, $xml, '4711images'),
+			array(true, $xml, '1'),
+			array(true, $xml, '_'),
+			array(true, $xml, '*'),
+			array(true, $xml, '%'),
+			array(true, $xml, '://foo'),
 			array(false, $xml, '/4711i/images'),
 			array(false, $xml, '../4711i/images'),
-			array(false, $xml, 'Εικόνες'),
-			array(false, $xml, 'Изображений'),
+			array(true, $xml, 'Εικόνες'),
+			array(true, $xml, 'Изображений'),
 		);
 	}
 


### PR DESCRIPTION
Pull Request for Issue #32567 .

### Summary of Changes

This pull request fixes the b/c issue with folders for files and images of com_media starting with something else than a letter a-z (upper or lower case) introduced with a security fix into the 3.9.25 release without introducing back the original security issue.

This is done by removing the check for the 1st character which was introduced to disable both full path disclosure by using a path like `./` or `.\` and break out of the parent folder by using `../` or `..\` (depending on your server's OS).

The usage of `./` or `.\` is handled instead by adding `'.'` to the exclude list for the parent folders:
https://github.com/joomla/joomla-cms/blob/754850e72495ca8cbdbc29c0e0debd51db26fce5/libraries/src/Form/Rule/FilePathRule.php#L55-L56

The breakout from the parent folder by using something like `../` or `..\` (depending on your OS) is already handled by the `Path::check($value)` a few lines further down. I've added the comment in line 69 to make that more clear:
https://github.com/joomla/joomla-cms/blob/754850e72495ca8cbdbc29c0e0debd51db26fce5/libraries/src/Form/Rule/FilePathRule.php#L69-L78

In addition to this fix, this PR also fixes the splitting of the value into parts for the exclude list check.

When on a Windows server. you perfectly can set and later use a path to images or files separates with either a Linux or a Windows directory separator.

In case if your site has been migrated from a Windows server e.g. for local development to the final Linux server, you still might have a `\` in a path, which would lead to false results when splitting the path for the exclude list check.

Therefore the change from `$path = explode('/', $value);` to `$path = preg_split('/[\/\\\\]/', $value);`.

### Testing Instructions

1. On a current staging or latest 3.9.x nightly build or 3.9.25, go to the media manager options in backend.
2. Either in the "Path to Files Folder" or for "Path to Images Folder" field, enter a path that starts with something else than a letter a to Z or A to Z.
3. Use the "Save" button.
Result: You **_can't_** save the changes, you get a red error message shown for the particular field.
4. Repeat steps 2 and 3 so you cover at least the following cases for both of these fields:
- Hidden folder like eg `.mysecretimages` as root.
- Root folder starting with a number, eg `1mississippi`, `2mississippi`, ...
- Root folder starting with a Unicode character, e.g. Cyrillic `Изображений`, Greece `Εικόνες`, ...
- Root folder starting with a symbol which is allowed for folder names on your server's OS, e.g. `-dada`, `_gaga`, ...

Result: Same as for step 3.

5. Apply the patch of this PR.
6. Repeat step 4, i.e. steps 2 and 3 at least for the cases mentioned in step 4.
Result: You **_can_** save the changes.
7. Enter a path starting with `./` or `.\` and use the "Save" button.
Result: You **_can't_** save the changes, you get a red error message shown for the particular field.
8. Enter a path which starts with `../` or contains `/../` (replace `/` by the actual directory separator of your server's OS) and use the "Save" button.
Result: You **_can't_** save the changes, you get a red error message shown for the particular field.
9. Enter a path which has one of the folders from the exclude list (see below) as the root folder, followed by a slash `/`, e.g. `administrator/`, and use the "Save" button.
Result: You **_can't_** save the changes, you get a red error message shown for the particular field.
10. Enter a path which has one of the folders from the exclude list (see below) as the root folder, followed by a backslash `\`, e.g. `administrator\`, and use the "Save" button.
Result: You **_can't_** save the changes, you get a red error message shown for the particular field.

The exclude list for field "Path to Files Folder" can be found here:
https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_media/config.xml#L41

The exclude list for field "Path to Images Folder" can be found here:
https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_media/config.xml#L52

### Actual result BEFORE applying this Pull Request

You **_can't_** save com_media settings when using a `Path to Files Folder` or a `Path to Images Folder` not starting with one of the letters a to z (case-insensitive).

This means eg the following is not allowed with 3.9.25 or current staging, which is a b/c break because it was allowed with 3.9.24 and older:
- Hidden folder like eg `.mysecretimages` as root.
- Root folder starting with a number.
- Root folder starting a Unicode character, e.g. Cyrillic, Greece, ...
- Root folder starting with a symbol which is allowed for folder names on your server's OS, e.g. `-` or `_`

### Expected result AFTER applying this Pull Request

You **_can_** save com_media settings when using a `Path to Files Folder` or a `Path to Images Folder` not starting with one of the letters a to z (case-insensitive).

You still can't save when one of these paths starts with something like `./` or `.\` on any OS or when it contains something like `../` on Linux or `..\` on Windows.

The check for the exclude list works with both kinds of directory separators `/`and `\`.

### Documentation Changes Required

None.