### PR TITLE
[4.0] Simplify PHP version number to remove vendor suffixes

### DIFF
--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -139,7 +139,7 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 		$activePhpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
 
 		// Handle non standard strings like PHP 7.2.34-8+ubuntu18.04.1+deb.sury.org+1
-		$PHP_VERSION = preg_split('/-/', PHP_VERSION)[0];
+		$phpVersion = preg_split('/-/', PHP_VERSION)[0];
 
 		// Do we have the PHP version's data?
 		if (isset($phpSupportData[$activePhpVersion]))
@@ -163,7 +163,7 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 						$supportStatus['status']  = self::PHP_UNSUPPORTED;
 						$supportStatus['message'] = Text::sprintf(
 							'PLG_QUICKICON_PHPVERSIONCHECK_UNSUPPORTED',
-							$PHP_VERSION,
+							$phpVersion,
 							$version,
 							$versionEndOfSupport->format(Text::_('DATE_FORMAT_LC4'))
 						);
@@ -176,7 +176,7 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 				$supportStatus['status']  = self::PHP_UNSUPPORTED;
 				$supportStatus['message'] = Text::sprintf(
 					'PLG_QUICKICON_PHPVERSIONCHECK_UNSUPPORTED_JOOMLA_OUTDATED',
-					$PHP_VERSION
+					$phpVersion
 				);
 
 				return $supportStatus;
@@ -190,7 +190,7 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 			{
 				$supportStatus['status']  = self::PHP_SECURITY_ONLY;
 				$supportStatus['message'] = Text::sprintf(
-					'PLG_QUICKICON_PHPVERSIONCHECK_SECURITY_ONLY', $PHP_VERSION, $phpEndOfSupport->format(Text::_('DATE_FORMAT_LC4'))
+					'PLG_QUICKICON_PHPVERSIONCHECK_SECURITY_ONLY', $phpVersion, $phpEndOfSupport->format(Text::_('DATE_FORMAT_LC4'))
 				);
 			}
 		}

--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -138,6 +138,9 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 		// Check the PHP version's support status using the minor version
 		$activePhpVersion = PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION;
 
+		// Handle non standard strings like PHP 7.2.34-8+ubuntu18.04.1+deb.sury.org+1
+		$PHP_VERSION = preg_split('/-/', PHP_VERSION)[0];
+
 		// Do we have the PHP version's data?
 		if (isset($phpSupportData[$activePhpVersion]))
 		{
@@ -160,7 +163,7 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 						$supportStatus['status']  = self::PHP_UNSUPPORTED;
 						$supportStatus['message'] = Text::sprintf(
 							'PLG_QUICKICON_PHPVERSIONCHECK_UNSUPPORTED',
-							PHP_VERSION,
+							$PHP_VERSION,
 							$version,
 							$versionEndOfSupport->format(Text::_('DATE_FORMAT_LC4'))
 						);
@@ -173,7 +176,7 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 				$supportStatus['status']  = self::PHP_UNSUPPORTED;
 				$supportStatus['message'] = Text::sprintf(
 					'PLG_QUICKICON_PHPVERSIONCHECK_UNSUPPORTED_JOOMLA_OUTDATED',
-					PHP_VERSION
+					$PHP_VERSION
 				);
 
 				return $supportStatus;
@@ -187,7 +190,7 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
 			{
 				$supportStatus['status']  = self::PHP_SECURITY_ONLY;
 				$supportStatus['message'] = Text::sprintf(
-					'PLG_QUICKICON_PHPVERSIONCHECK_SECURITY_ONLY', PHP_VERSION, $phpEndOfSupport->format(Text::_('DATE_FORMAT_LC4'))
+					'PLG_QUICKICON_PHPVERSIONCHECK_SECURITY_ONLY', $PHP_VERSION, $phpEndOfSupport->format(Text::_('DATE_FORMAT_LC4'))
 				);
 			}
 		}


### PR DESCRIPTION
Closes #32721

### Summary of Changes

Simplify `PHP 7.2.34-8+ubuntu18.04.1+deb.sury.org+1` to `PHP 7.2.34`

### Testing Instructions

Install PHP 7.2 - visit admin console 


### Actual result BEFORE applying this Pull Request

<img width="852" alt="Screenshot 2021-03-17 at 18 16 20" src="https://user-images.githubusercontent.com/400092/111519184-ba6f7e80-874e-11eb-9033-1d065c42f62e.png">



### Expected result AFTER applying this Pull Request

<img width="955" alt="Screenshot 2021-03-17 at 18 28 37" src="https://user-images.githubusercontent.com/400092/111519151-b6436100-874e-11eb-8942-2652149b95ed.png">

### Documentation Changes Required

none