### PR TITLE
[4.0] Add passing unit test for FilePathRule

### DIFF
--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
@@ -3,7 +3,7 @@
  * @package     Joomla.UnitTest
  * @subpackage  HTML
  *
- * @copyright   (C) 2019 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
@@ -50,6 +50,11 @@ class FilePathRuleTest extends UnitTestCase
 			[true,	$xml, '\\images'], // Means \images
 			[true,	$xml, 'ftp://images'],
 			[true,	$xml, 'http://images'],
+			[true,	$xml, '/media'],
+			[true,	$xml, '/administrator'],
+			[true,	$xml, '/4711images'],
+			[true,	$xml, '/4711i/images'],
+			[false,	$xml, '../4711i/images'],
 		];
 	}
 

--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
@@ -41,20 +41,28 @@ class FilePathRuleTest extends UnitTestCase
 		/>');
 
 		return [
-			[true,	$xml, '.images'],
-			[true,	$xml, './images'],
-			[true,	$xml, '.\images'],
-			[false,	$xml, '../images'],
-			[false,	$xml, '.../images'],
-			[true,	$xml, 'c:\images'],
-			[true,	$xml, '\\images'], // Means \images
-			[true,	$xml, 'ftp://images'],
-			[true,	$xml, 'http://images'],
-			[true,	$xml, '/media'],
-			[true,	$xml, '/administrator'],
-			[true,	$xml, '/4711images'],
-			[true,	$xml, '/4711i/images'],
-			[false,	$xml, '../4711i/images'],
+			[false, $xml, '.images'],
+			[false, $xml, './images'],
+			[false, $xml, '.\images'],
+			[false, $xml, '../images'],
+			[false, $xml, '.../images'],
+			[true, $xml, 'c:\images'],
+			[false, $xml, '\\images'], // Means \images
+			[true, $xml, 'ftp://images'],
+			[true, $xml, 'http://images'],
+			[false, $xml, '/media'],
+			[false, $xml, '/administrator'],
+			[false, $xml, '/4711images'],
+			[false, $xml, '4711images'],
+			[false, $xml, '1'],
+			[false, $xml, '_'],
+			[false, $xml, '*'],
+			[false, $xml, '%'],
+			[false, $xml, '://foo'],
+			[false, $xml, '/4711i/images'],
+			[false, $xml, '../4711i/images'],
+			[false, $xml, 'Εικόνες'],
+			[false, $xml, 'Изображений'],
 		];
 	}
 

--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  HTML
+ *
+ * @copyright   (C) 2019 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\FilePathRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for FilePathRule.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ * @since       __DEPLOY_VERSION__
+ */
+class FilePathRuleTest extends UnitTestCase
+{
+	/**
+	 * Test data for the testRule method
+	 *
+	 * @return  array
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function dataTest(): array
+	{
+		$xml = new \SimpleXMLElement('<field
+			name="file_path"
+			type="text"
+			label="COM_MEDIA_FIELD_PATH_FILE_FOLDER_LABEL"
+			description="COM_MEDIA_FIELD_PATH_FILE_FOLDER_DESC"
+			size="50"
+			default="images"
+			validate="filePath"
+		/>');
+
+		return [
+			[true,	$xml, '.images'],
+			[true,	$xml, './images'],
+			[true,	$xml, '.\images'],
+			[false,	$xml, '../images'],
+			[false,	$xml, '.../images'],
+			[true,	$xml, 'c:\images'],
+			[true,	$xml, '\\images'], // Means \images
+			[true,	$xml, 'ftp://images'],
+			[true,	$xml, 'http://images'],
+		];
+	}
+
+	/**
+	 * Tests the FilePathRule::test method.
+	 *
+	 * @param   string             $expected  The expected test result
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 * @dataProvider dataTest
+	 */
+	public function testRule($expected, $element, $value)
+	{
+		$this->assertEquals($expected, (new FilePathRule())->test($element, $value));
+	}
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
@@ -53,8 +53,8 @@ class FilePathRuleTest extends UnitTestCase
 			[true, $xml, '\\images'], // Means \images
 			[true, $xml, 'ftp://images'],
 			[true, $xml, 'http://images'],
-			[true, $xml, '/media'],
-			[true, $xml, '/administrator'],
+			[true, $xml, 'media'],
+			[true, $xml, 'administrator'],
 			[true, $xml, '/4711images'],
 			[true, $xml, '4711images'],
 			[true, $xml, '1'],

--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
@@ -40,29 +40,32 @@ class FilePathRuleTest extends UnitTestCase
 			validate="filePath"
 		/>');
 
+		// These all pass today,
+		// BUT, Joomla 3.9.26 SHOULD break this test, as a security fix is applied, thus proving the test valuable
 		return [
-			[false, $xml, '.images'],
-			[false, $xml, './images'],
-			[false, $xml, '.\images'],
+			[true, $xml, ''],
+			[true, $xml, '.images'],
+			[true, $xml, './images'],
+			[true, $xml, '.\images'],
 			[false, $xml, '../images'],
 			[false, $xml, '.../images'],
 			[true, $xml, 'c:\images'],
-			[false, $xml, '\\images'], // Means \images
+			[true, $xml, '\\images'], // Means \images
 			[true, $xml, 'ftp://images'],
 			[true, $xml, 'http://images'],
-			[false, $xml, '/media'],
-			[false, $xml, '/administrator'],
-			[false, $xml, '/4711images'],
-			[false, $xml, '4711images'],
-			[false, $xml, '1'],
-			[false, $xml, '_'],
-			[false, $xml, '*'],
-			[false, $xml, '%'],
-			[false, $xml, '://foo'],
-			[false, $xml, '/4711i/images'],
+			[true, $xml, '/media'],
+			[true, $xml, '/administrator'],
+			[true, $xml, '/4711images'],
+			[true, $xml, '4711images'],
+			[true, $xml, '1'],
+			[true, $xml, '_'],
+			[true, $xml, '*'],
+			[true, $xml, '%'],
+			[true, $xml, '://foo'],
+			[true, $xml, '/4711i/images'],
 			[false, $xml, '../4711i/images'],
-			[false, $xml, 'Εικόνες'],
-			[false, $xml, 'Изображений'],
+			[true, $xml, 'Εικόνες'],
+			[true, $xml, 'Изображений'],
 		];
 	}
 


### PR DESCRIPTION
### Summary of Changes

A Joomla 4 version of the unit test to cover b/c and security fixes in 3.9.25/26

Regardless of that, its a working unit test of the current code in 4.0-dev and can be improved upon in the future. 

## NOTE 
**NOTE: These tests are designed for, and pass, with 4.0-dev as it is today. When the security fixes for Joomla 3.9.26 are rolled into 4.0-dev eventually (by @wilsonge) then these tests SHOULD start to fail and will need true/false tweaking so that those test cases that are fixed by the security patches in Joomla 3.9.26 are now returning false...**

### Testing Instructions

run 

> libraries/vendor/phpunit/phpunit/phpunit tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php

at the command line. 

### Actual result BEFORE applying this Pull Request

No testing of this important validation rule that has been subjected to Security issues in Joomla 3

### Expected result AFTER applying this Pull Request

Some working testing based on the current state of Joomla 4.0-dev.

```
PHPUnit 8.5.13 by Sebastian Bergmann and contributors.

..............                                                    14 / 14 (100%)

Time: 38 ms, Memory: 8.00 MB

OK (14 tests, 14 assertions)
```

### Documentation Changes Required

none


// https://github.com/joomla/joomla-cms/pull/32718 for context.