### PR TITLE
Update _header.scss

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -130,6 +130,7 @@
 
         &:hover,
         &[aria-expanded="true"] {
+          transform:scale(1.2,1.4);
           color: var(--atum-text-light);
           text-decoration: none;
           background-color: var(--atum-bg-dark-40);

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -130,7 +130,7 @@
 
         &:hover,
         &[aria-expanded="true"] {
-          transform:scale(1.2,1.4);
+          transform: scale(1.2,1.4);
           color: var(--atum-text-light);
           text-decoration: none;
           background-color: var(--atum-bg-dark-40);

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -134,7 +134,6 @@
           text-decoration: none;
           background-color: var(--atum-bg-dark-40);
           box-shadow: $atum-box-shadow;
-          transform: scale(1.26,1.26);
         }
 
         &.disabled,

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -131,10 +131,10 @@
         &:hover,
         &[aria-expanded="true"] {
           color: var(--atum-text-light);
-          transform: scale(1.2,1.4);          
           text-decoration: none;
           background-color: var(--atum-bg-dark-40);
           box-shadow: $atum-box-shadow;
+          transform: scale(1.2,1.4);
         }
 
         &.disabled,

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -132,7 +132,7 @@
         &[aria-expanded="true"] {
           color: var(--atum-text-light);
           text-decoration: none;
-          background-color: var(--atum-bg-dark);
+          background-color: var(--atum-bg-dark-40);
           box-shadow: $atum-box-shadow;
         }
 

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -130,8 +130,8 @@
 
         &:hover,
         &[aria-expanded="true"] {
-          transform: scale(1.2,1.4);
           color: var(--atum-text-light);
+          transform: scale(1.2,1.4);          
           text-decoration: none;
           background-color: var(--atum-bg-dark-40);
           box-shadow: $atum-box-shadow;

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -134,7 +134,7 @@
           text-decoration: none;
           background-color: var(--atum-bg-dark-40);
           box-shadow: $atum-box-shadow;
-          transform: scale(1.2,1.4);
+          transform: scale(1.26,1.26);
         }
 
         &.disabled,


### PR DESCRIPTION
Pull Request for Issue #32711

### Summary of Changes

background color of the icons in navbar on hover  is changed from var(--atum-bg-dark) to var(--atum-bg-dark-40)

### Testing Instructions
Open the Joomla backend , and in the navbar on the top hover on any icon , hover effect is almost invisible

![image](https://user-images.githubusercontent.com/70388131/111441449-58525180-872d-11eb-9ad4-9b86fb2765eb.png)

### Actual result BEFORE applying this Pull Request
1) before hover :
![image](https://user-images.githubusercontent.com/70388131/111441546-6e601200-872d-11eb-8801-1a44b54a66f5.png)
2) on hover :
![image](https://user-images.githubusercontent.com/70388131/111441573-73bd5c80-872d-11eb-8a4a-bf9df62dfdd7.png)

### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/70388131/111456861-8049b100-873d-11eb-9b4b-b310a80cd76b.png)

