### PR TITLE
[4.0] Introduce an HTML sanitiser

### DIFF
--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -3,6 +3,8 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+import { sanitizeHtml } from 'bootstrap/js/src/util/sanitizer.js';
+
 // Only define the Joomla namespace if not defined.
 window.Joomla = window.Joomla || {};
 
@@ -620,6 +622,17 @@ window.Joomla.Modal = window.Joomla.Modal || {
   };
 
   /**
+   * Sanitize HTML string
+   *
+   * @param {string} unsafeHtml
+   * @param {array} allowList
+   * @param {function} sanitizeFn
+   *
+   * @return string
+   */
+  Joomla.sanitizeHtml = sanitizeHtml;
+
+  /**
    * Render messages send via JSON
    * Used by some javascripts such as validate.js
    *
@@ -685,7 +698,7 @@ window.Joomla.Modal = window.Joomla.Modal || {
       if (typeof title !== 'undefined') {
         titleWrapper = document.createElement('div');
         titleWrapper.className = 'alert-heading';
-        titleWrapper.innerHTML = `<span class="${type}"></span><span class="visually-hidden">${Joomla.Text._(type) ? Joomla.Text._(type) : type}</span>`;
+        titleWrapper.innerHTML = `<span class="${type}"></span><span class="visually-hidden">${Joomla.Text._(type) ? Joomla.Text._(sanitizeHtml(type)) : type}</span>`;
         messagesBox.appendChild(titleWrapper);
       }
 
@@ -693,7 +706,7 @@ window.Joomla.Modal = window.Joomla.Modal || {
       messageWrapper = document.createElement('div');
       messageWrapper.className = 'alert-wrapper';
       typeMessages.forEach((typeMessage) => {
-        messageWrapper.innerHTML += `<div class="alert-message">${typeMessage}</div>`;
+        messageWrapper.innerHTML += `<div class="alert-message">${sanitizeHtml(typeMessage)}</div>`;
       });
       messagesBox.appendChild(messageWrapper);
 

--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -5,6 +5,43 @@
 
 import { sanitizeHtml } from 'bootstrap/js/src/util/sanitizer.js';
 
+const ARIA_ATTRIBUTE_PATTERN = /^aria-[\w-]*$/i;
+const DATA_ATTRIBUTE_PATTERN = /^data-[\w-]*$/i;
+
+const DefaultAllowlist = {
+  // Global attributes allowed on any supplied element below.
+  '*': ['class', 'dir', 'id', 'lang', 'role', ARIA_ATTRIBUTE_PATTERN, DATA_ATTRIBUTE_PATTERN],
+  a: ['target', 'href', 'title', 'rel'],
+  area: [],
+  b: [],
+  br: [],
+  col: [],
+  code: [],
+  div: [],
+  em: [],
+  hr: [],
+  h1: [],
+  h2: [],
+  h3: [],
+  h4: [],
+  h5: [],
+  h6: [],
+  i: [],
+  img: ['src', 'srcset', 'alt', 'title', 'width', 'height'],
+  li: [],
+  ol: [],
+  p: [],
+  pre: [],
+  s: [],
+  small: [],
+  span: [],
+  sub: [],
+  sup: [],
+  strong: [],
+  u: [],
+  ul: [],
+};
+
 // Only define the Joomla namespace if not defined.
 window.Joomla = window.Joomla || {};
 
@@ -624,13 +661,17 @@ window.Joomla.Modal = window.Joomla.Modal || {
   /**
    * Sanitize HTML string
    *
-   * @param {string} unsafeHtml
-   * @param {array} allowList
-   * @param {function} sanitizeFn
+   * @param {string} unsafeHtml The html for sanitization
+   * @param {object} allowList The list of HTMLElements with an array of allowed attributes
+   * @param {function} sanitizeFn A custom sanitization function
    *
    * @return string
    */
-  Joomla.sanitizeHtml = sanitizeHtml;
+  Joomla.sanitizeHtml = (unsafeHtml, allowList, sanitizeFn) => {
+    const allowed = (allowList === undefined || allowList === null)
+      ? DefaultAllowlist : Object.assign(DefaultAllowlist, allowList);
+    return sanitizeHtml(unsafeHtml, allowed, sanitizeFn);
+  };
 
   /**
    * Render messages send via JSON
@@ -698,7 +739,7 @@ window.Joomla.Modal = window.Joomla.Modal || {
       if (typeof title !== 'undefined') {
         titleWrapper = document.createElement('div');
         titleWrapper.className = 'alert-heading';
-        titleWrapper.innerHTML = `<span class="${type}"></span><span class="visually-hidden">${Joomla.Text._(type) ? Joomla.Text._(sanitizeHtml(type)) : type}</span>`;
+        titleWrapper.innerHTML = Joomla.sanitizeHtml(`<span class="${type}"></span><span class="visually-hidden">${Joomla.Text._(type) ? Joomla.Text._(type) : type}</span>`);
         messagesBox.appendChild(titleWrapper);
       }
 
@@ -706,7 +747,7 @@ window.Joomla.Modal = window.Joomla.Modal || {
       messageWrapper = document.createElement('div');
       messageWrapper.className = 'alert-wrapper';
       typeMessages.forEach((typeMessage) => {
-        messageWrapper.innerHTML += `<div class="alert-message">${sanitizeHtml(typeMessage)}</div>`;
+        messageWrapper.innerHTML += Joomla.sanitizeHtml(`<div class="alert-message">${typeMessage}</div>`);
       });
       messagesBox.appendChild(messageWrapper);
 

--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -661,9 +661,9 @@ window.Joomla.Modal = window.Joomla.Modal || {
   /**
    * Sanitize HTML string
    *
-   * @param {string} unsafeHtml The html for sanitization
-   * @param {object} allowList The list of HTMLElements with an array of allowed attributes
-   * @param {function} sanitizeFn A custom sanitization function
+   * @param {string}   unsafeHtml The html to be sanitized
+   * @param {object}   allowList  The list of HTML elements with an array of allowed attributes
+   * @param {function} sanitizeFn A custom sanitize function
    *
    * @return string
    */


### PR DESCRIPTION
Pull Request for Issue # .

This [when applied to all the scripts using innerHTML] fixes XSS vulnerabilities, so although it could be categorised as a new feature actually it's a feature to strengthen the security, so I guess an exception should NOT be debatable here. (then again I might be wrong, won't be the first time)

### Summary of Changes
- Since the build tools allow us now to utilise properly the `import` of the modern JS we will do exactly that!!!
- Use the Bootstrap sanitiser
- Expose it as `Joomla.sanitizeHtml`
- Patch the `Joomla.renderMessages` as an example case

There is a slight penalty since we're adding code here, but I think it's acceptable, benefits outweigh the performance here:

Without the sanitiser:

<img width="744" alt="Screenshot 2021-03-18 at 22 08 50" src="https://user-images.githubusercontent.com/3889375/111698202-d8b0a980-8836-11eb-987e-898bec4ed3f8.png">

With:

<img width="732" alt="Screenshot 2021-03-18 at 22 07 07" src="https://user-images.githubusercontent.com/3889375/111698267-ec5c1000-8836-11eb-9638-698c0bb1cd0e.png">

 
### Testing Instructions
- Either download the installable zip from the PR's github page or apply the PR using git
- Try to login using wrong username or password
- There should be an alert warning you that username and password were incorrect
- Disable the Smart Search and all the plugins
- Check the components->Smart Search -> Index page (the page should have an alert with a link)
- That's it

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required
The bootstrap documentation: https://getbootstrap.com/docs/5.0/getting-started/javascript/#sanitizer

Documenting ALL the core.js functions should be done at some point

BUT more importantly, if this PR is approved and merged, there are countless instances of `innerHTML` that will have to be patched.

@wilsonge @zero-24 @SniperSister 
