### PR TITLE
Two icons on some buttons

### DIFF
--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -63,7 +63,7 @@
     cursor: not-allowed;
     opacity: 1;
   }
-
+  npm run build:css
   &.disabled .#{$jicon-css-prefix}-home,
   &.disabled .#{$fa-css-prefix}-home {
     color: $state-warning-bg;
@@ -84,4 +84,9 @@
 
 .plg_system_webauthn_login_button svg path {
   fill: var(--white);
+}
+
+a[target=_blank]:before{
+  float: right;
+  padding-left: 2px;
 }


### PR DESCRIPTION
Pull Request for Issue #30018 

### Summary of Changes
modified _icon.scss to move the external link icon after the text of the button.


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/59737567/111746026-75b12800-88b3-11eb-97a1-5c1037061bdc.png)


### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/59737567/111746082-88c3f800-88b3-11eb-90c3-5bf3b90a4a93.png)

(If I try to add padding of more than 2px, it squashes the alignment of buttons like this: 
![image](https://user-images.githubusercontent.com/59737567/111746325-e7897180-88b3-11eb-8c2f-94c7cd25781c.png)
so that is why I added a padding of only 2px. )

