### PR TITLE
Temp#30018 1

### DIFF
--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -63,7 +63,7 @@
     cursor: not-allowed;
     opacity: 1;
   }
-
+  npm run build:css
   &.disabled .#{$jicon-css-prefix}-home,
   &.disabled .#{$fa-css-prefix}-home {
     color: $state-warning-bg;
@@ -84,4 +84,9 @@
 
 .plg_system_webauthn_login_button svg path {
   fill: var(--white);
+}
+
+a[target=_blank]:before{
+  float: right;
+  padding-left: 2px;
 }

--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -86,7 +86,7 @@
   fill: var(--white);
 }
 
-a[target=_blank]:before{
+a[target=_blank]:before {
   float: right;
   padding-left: 2px;
 }


### PR DESCRIPTION
Pull Request for Issue #30018 

### Summary of Changes

modified _icon.scss to move the external link icon after the text of the button.

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/59737567/111747806-c7f34880-88b5-11eb-829b-12eb543b5867.png)


### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/59737567/111747835-d0e41a00-88b5-11eb-9eea-b440170a6fb5.png)
(If I try to add padding of more than 2px, it squashes the alignment of buttons like this:
![image](https://user-images.githubusercontent.com/59737567/111747912-e2c5bd00-88b5-11eb-9a8d-36ea7929ea02.png)

so that is why I added a padding of only 2px. )

