### PR TITLE
[4.0] Irrelevent portions of code removed

### DIFF
--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -113,7 +113,7 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 	<?php endif; ?>
 
 	<?php
-	if (!empty($this->item->pagination) && $this->item->pagination && $this->item->paginationposition && !$this->item->paginationrelative) :
+	if (!empty($this->item->pagination) && $this->item->paginationposition && !$this->item->paginationrelative) :
 		echo $this->item->pagination;
 	?>
 	<?php endif; ?>
@@ -135,7 +135,7 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 	<?php endif; ?>
 	<?php endif; ?>
 	<?php
-	if (!empty($this->item->pagination) && $this->item->pagination && $this->item->paginationposition && $this->item->paginationrelative) :
+	if (!empty($this->item->pagination) && $this->item->paginationposition && $this->item->paginationrelative) :
 		echo $this->item->pagination;
 	?>
 	<?php endif; ?>

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -46,7 +46,6 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 	}
 	?>
 
-	<?php // Todo Not that elegant would be nice to group the params ?>
 	<?php $useDefList = $params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')
 	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author') || $assocParam; ?>
 

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -40,15 +40,15 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
 	</div>
 	<?php endif;
-	if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && $this->item->paginationrelative)
+	if (!empty($this->item->pagination) && !$this->item->paginationposition && $this->item->paginationrelative)
 	{
 		echo $this->item->pagination;
 	}
 	?>
 
 	<?php // Todo Not that elegant would be nice to group the params ?>
-	<?php $useDefList = ($params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')
-	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author') || $assocParam); ?>
+	<?php $useDefList = $params->get('show_modify_date') || $params->get('show_publish_date') || $params->get('show_create_date')
+	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author') || $assocParam; ?>
 
 	<?php if ($params->get('show_title')) : ?>
 	<div class="page-header">


### PR DESCRIPTION
Pull Request for Issue #32725 .

### Summary of Changes

1. && $this->item->pagination removed from https://github.com/joomla/joomla-cms/blob/4.0.0-beta7/components/com_content/tmpl/article/default.php#L43.

2. Brackets around OR removed from https://github.com/joomla/joomla-cms/blob/4.0.0-beta7/components/com_content/tmpl/article/default.php#L49-L51.

### Documentation Changes Required

None.