### PR TITLE
[4.0] Remove the events wrapper from core.js

### DIFF
--- a/build/media_source/com_associations/js/sidebyside.es5.js
+++ b/build/media_source/com_associations/js/sidebyside.es5.js
@@ -71,7 +71,10 @@ jQuery(document).ready(function($) {
       var currentLang = targetLang.replace(/_/,'-');
       $('#jform_itemlanguage option[value=\"' + currentSwitcher + '\"]').val(currentLang + ':0:add');
       currentLangSelect.val('');
-      Joomla.Event.dispatch(currentLangSelect[0], 'change');
+      currentLangSelect[0].dispatchEvent(new CustomEvent('change', {
+        bubbles: true,
+        cancelable: true,
+      }));
 
       // Save one of the items to confirm action
       Joomla.submitbutton('reference');

--- a/build/media_source/mod_menu/js/admin-menu.es6.js
+++ b/build/media_source/mod_menu/js/admin-menu.es6.js
@@ -39,13 +39,21 @@
       menuToggleIcon.classList.remove('icon-toggle-off');
       menuToggleIcon.classList.add('icon-toggle-on');
       localStorage.setItem('atum-sidebar', 'open');
-      Joomla.Event.dispatch('joomla:menu-toggle', 'open');
+      window.dispatchEvent(new CustomEvent('joomla:menu-toggle', {
+        detail: 'open',
+        bubbles: true,
+        cancelable: true,
+      }));
     } else {
       wrapper.classList.add('closed');
       menuToggleIcon.classList.remove('icon-toggle-on');
       menuToggleIcon.classList.add('icon-toggle-off');
       localStorage.setItem('atum-sidebar', 'closed');
-      Joomla.Event.dispatch('joomla:menu-toggle', 'closed');
+      window.dispatchEvent(new CustomEvent('joomla:menu-toggle', {
+        detail: 'closed',
+        bubbles: true,
+        cancelable: true,
+      }));
     }
   }
 
@@ -96,12 +104,20 @@
         if (storageEnabled) {
           localStorage.setItem('atum-sidebar', 'closed');
         }
-        Joomla.Event.dispatch('joomla:menu-toggle', 'closed');
+        window.dispatchEvent(new CustomEvent('joomla:menu-toggle', {
+          detail: 'closed',
+          bubbles: true,
+          cancelable: true,
+        }));
       } else {
         if (storageEnabled) {
           localStorage.setItem('atum-sidebar', 'open');
         }
-        Joomla.Event.dispatch('joomla:menu-toggle', 'open');
+        window.dispatchEvent(new CustomEvent('joomla:menu-toggle', {
+          detail: 'open',
+          bubbles: true,
+          cancelable: true,
+        }));
       }
     });
 
@@ -162,7 +178,11 @@
         }
       }
 
-      Joomla.Event.dispatch('joomla:menu-toggle', 'open');
+      window.dispatchEvent(new CustomEvent('joomla:menu-toggle', {
+        detail: 'open',
+        bubbles: true,
+        cancelable: true,
+      }));
     };
 
     menuParents.forEach((parent) => {

--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -363,7 +363,10 @@ window.Joomla.Modal = window.Joomla.Modal || {
 
     if (checkbox.form.boxchecked) {
       checkbox.form.boxchecked.value = state;
-      Joomla.Event.dispatch(checkbox.form.boxchecked, 'change');
+      checkbox.form.boxchecked.dispatchEvent(new CustomEvent('change', {
+        bubbles: true,
+        cancelable: true,
+      }));
     }
 
     return true;
@@ -393,7 +396,10 @@ window.Joomla.Modal = window.Joomla.Modal || {
       ? parseInt(newForm.boxchecked.value, 10) + 1
       : parseInt(newForm.boxchecked.value, 10) - 1;
 
-    Joomla.Event.dispatch(newForm.boxchecked, 'change');
+    newForm.boxchecked.dispatchEvent(new CustomEvent('change', {
+      bubbles: true,
+      cancelable: true,
+    }));
 
     // If we don't have a checkall-toggle, done.
     if (!newForm.elements['checkall-toggle']) {
@@ -774,88 +780,3 @@ window.Joomla.Modal = window.Joomla.Modal || {
     return msg;
   };
 })(Joomla);
-
-/**
- * Joomla! Custom events
- *
- * @since  4.0.0
- */
-((window, Joomla) => {
-  'use strict';
-
-  if (Joomla.Event) {
-    return;
-  }
-
-  Joomla.Event = {};
-
-  /**
-   * Dispatch custom event.
-   *
-   * An event name convention:
-   *     The event name has at least two part, separated ":", eg `foo:bar`.
-   *     Where the first part is an "event supporter",
-   *     and second part is the event name which happened.
-   *     Which is allow us to avoid possible collisions with another scripts
-   *     and native DOM events.
-   *     Joomla! CMS standard events should start from `joomla:`.
-   *
-   * Joomla! events:
-   *     `joomla:updated`  Dispatch it over the changed container,
-   *      example after the content was updated via ajax
-   *     `joomla:removed`  The container was removed
-   *
-   * @param {HTMLElement|string}  element  DOM element, the event target. Or the event name,
-   * then the target will be a Window
-   * @param {String|Object}       name     The event name, or an optional parameters in case
-   * when "element" is an event name
-   * @param {Object}              params   An optional parameters. Allow to send a custom data
-   * through the event.
-   *
-   * @example
-   *
-   *   Joomla.Event.dispatch(myElement, 'joomla:updated', {for: 'bar', foo2: 'bar2'});
-   *   // Will dispatch event to myElement
-   *   or:
-   *   Joomla.Event.dispatch('joomla:updated', {for: 'bar', foo2: 'bar2'});
-   *   // Will dispatch event to Window
-   *
-   * @since   4.0.0
-   */
-  Joomla.Event.dispatch = (element, name, params) => {
-    let newElement = element;
-    let newName = name;
-    let newParams = params;
-    if (typeof element === 'string') {
-      newParams = name;
-      newName = element;
-      newElement = window;
-    }
-    newParams = newParams || {};
-
-    newElement.dispatchEvent(new CustomEvent(newName, {
-      detail: newParams,
-      bubbles: true,
-      cancelable: true,
-    }));
-  };
-
-  /**
-   * Once listener. Add EventListener to the Element and auto-remove it
-   * after the event was dispatched.
-   *
-   * @param {HTMLElement}  element   DOM element
-   * @param {String}       name      The event name
-   * @param {Function}     callback  The event callback
-   *
-   * @since   4.0.0
-   */
-  Joomla.Event.listenOnce = (element, name, callback) => {
-    const onceCallback = (event) => {
-      element.removeEventListener(name, onceCallback);
-      return callback.call(element, event);
-    };
-
-    element.addEventListener(name, onceCallback);
-  };
-})(window, Joomla);

--- a/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
@@ -212,7 +212,10 @@
       }));
 
       if (window.Joomla) {
-        Joomla.Event.dispatch(row, 'joomla:updated');
+        row.dispatchEvent(new CustomEvent('joomla:updated', {
+          bubbles: true,
+          cancelable: true,
+        }));
       }
 
       return row;
@@ -236,7 +239,10 @@
       }));
 
       if (window.Joomla) {
-        Joomla.Event.dispatch(row, 'joomla:removed');
+        row.dispatchEvent(new CustomEvent('joomla:removed', {
+          bubbles: true,
+          cancelable: true,
+        }));
       }
 
       row.parentNode.removeChild(row);

--- a/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
@@ -211,12 +211,10 @@
         bubbles: true,
       }));
 
-      if (window.Joomla) {
-        row.dispatchEvent(new CustomEvent('joomla:updated', {
-          bubbles: true,
-          cancelable: true,
-        }));
-      }
+      row.dispatchEvent(new CustomEvent('joomla:updated', {
+        bubbles: true,
+        cancelable: true,
+      }));
 
       return row;
     }
@@ -238,12 +236,10 @@
         bubbles: true,
       }));
 
-      if (window.Joomla) {
-        row.dispatchEvent(new CustomEvent('joomla:removed', {
-          bubbles: true,
-          cancelable: true,
-        }));
-      }
+      row.dispatchEvent(new CustomEvent('joomla:removed', {
+        bubbles: true,
+        cancelable: true,
+      }));
 
       row.parentNode.removeChild(row);
     }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Earlier in the development of Joomla 4 we rolled out a wrapper around Events. At that time this was a good idea as we also had a polyfill for `customEvent` and our own implementation of `{once: true}`. Well, we don't need any of these anymore. Also, the introduction of a wrapper of a Platform feature seems counterproductive. IT's harder for newcomers to figure out their way around. Just use the propper docs from MDN ( https://developer.mozilla.org/en-US/docs/Web/Events ), job done!

### Testing Instructions
Apply the PR and check:
- that the admin menu is fully functional (resize, etc)
- Install the multilingual test data and check the side by side feature
- Install https://github.com/joomla/joomla-cms/files/5113835/4.zip and confirm that subforms work fine

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

No, actually this PR removes something that if we end up rolling in Joomla 4 we have to document. For the native Javascript events, we could just refer devs to MDN. Win!


@Fedik I know that you're against this, but honestly, I see no reason for Joomla to have such a wrapper

@wilsonge your decision