### PR TITLE
[4.0] Better css for frontend edit buttons

### DIFF
--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -40,7 +40,7 @@ $moduleHtml = preg_replace(
 	'/^(\s*<(?:div|span|nav|ul|ol|h\d|section|aside|address|article|form) [^>]*>)/',
 	// Create and add the edit link and tooltip
 	'\\1 <a class="btn btn-link jmodedit" href="' . $editUrl . '" target="' . $target . '" aria-describedby="tip-' . (int) $mod->id . '">
-	<span class="icon-edit" aria-hidden="true"></span>' . Text::_('JGLOBAL_EDIT') . '</a>
+	<span class="icon-edit" aria-hidden="true"></span><span class="sr-only">' . Text::_('JGLOBAL_EDIT') . '</span></a>
 	<div role="tooltip" id="tip-' . (int) $mod->id . '">' . Text::_('JLIB_HTML_EDIT_MODULE') . '<br>' . htmlspecialchars($mod->title, ENT_COMPAT, 'UTF-8') . '<br>'. sprintf(Text::_('JLIB_HTML_EDIT_MODULE_IN_POSITION'), htmlspecialchars($position, ENT_COMPAT, 'UTF-8')) . '</div>',
 	$moduleHtml,
 	1,

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -40,7 +40,7 @@ $moduleHtml = preg_replace(
 	'/^(\s*<(?:div|span|nav|ul|ol|h\d|section|aside|address|article|form) [^>]*>)/',
 	// Create and add the edit link and tooltip
 	'\\1 <a class="btn btn-link jmodedit" href="' . $editUrl . '" target="' . $target . '" aria-describedby="tip-' . (int) $mod->id . '">
-	<span class="icon-edit" aria-hidden="true"></span><span class="sr-only">' . Text::_('JGLOBAL_EDIT') . '</span></a>
+	<span class="icon-edit" aria-hidden="true"></span><span class="visually-hidden">' . Text::_('JGLOBAL_EDIT') . '</span></a>
 	<div role="tooltip" id="tip-' . (int) $mod->id . '">' . Text::_('JLIB_HTML_EDIT_MODULE') . '<br>' . htmlspecialchars($mod->title, ENT_COMPAT, 'UTF-8') . '<br>'. sprintf(Text::_('JLIB_HTML_EDIT_MODULE_IN_POSITION'), htmlspecialchars($position, ENT_COMPAT, 'UTF-8')) . '</div>',
 	$moduleHtml,
 	1,

--- a/templates/cassiopeia/scss/blocks/_footer.scss
+++ b/templates/cassiopeia/scss/blocks/_footer.scss
@@ -20,6 +20,10 @@
     background-image: $cassiopeia-header-grad-rtl;
   }
 
+  .mod-menu {
+    position: relative;
+  }
+
   @if $metismenu==true {
     .metismenu.mod-menu {
       .mm-collapse {

--- a/templates/cassiopeia/scss/blocks/_frontend-edit.scss
+++ b/templates/cassiopeia/scss/blocks/_frontend-edit.scss
@@ -2,10 +2,11 @@
 
 .btn.jmodedit {
   position: absolute;
-  right: 0;
   top: 0;
+  right: 0;
   color: var(--cassiopeia-color-link);
   background-color: rgba(255,255,255, 0.5);
   border: 1px solid #58595a;
   border-radius: .25rem;
+  z-index:900;
 }

--- a/templates/cassiopeia/scss/blocks/_frontend-edit.scss
+++ b/templates/cassiopeia/scss/blocks/_frontend-edit.scss
@@ -3,13 +3,9 @@
 .btn.jmodedit {
   position: absolute;
   right: 0;
-  top:0;
+  top: 0;
   color: var(--cassiopeia-color-link);
   background-color: rgba(255,255,255, 0.5);
   border: 1px solid #58595a;
   border-radius: .25rem;
 }
-
-a.jmenuedit {
-}
-

--- a/templates/cassiopeia/scss/blocks/_frontend-edit.scss
+++ b/templates/cassiopeia/scss/blocks/_frontend-edit.scss
@@ -2,15 +2,14 @@
 
 .btn.jmodedit {
   position: absolute;
-  right: 10px;
+  right: 0;
+  top:0;
   color: var(--cassiopeia-color-link);
-  background-color: $white;
-  border: 1px solid #dfe3e7;
+  background-color: rgba(255,255,255, 0.5);
+  border: 1px solid #58595a;
   border-radius: .25rem;
 }
 
 a.jmenuedit {
-  padding-inline-start: 0;
-  padding-inline-end: .5rem;
 }
 

--- a/templates/cassiopeia/scss/blocks/_frontend-edit.scss
+++ b/templates/cassiopeia/scss/blocks/_frontend-edit.scss
@@ -4,9 +4,15 @@
   position: absolute;
   top: 0;
   right: 0;
+  left: auto;
   z-index: 900;
   color: var(--cassiopeia-color-link);
   background-color: rgba(255,255,255,.5);
   border: 1px solid #58595a;
   border-radius: .25rem;
+}
+
+[dir="rtl"] .btn.jmodedit {
+  right: auto;
+  left: 0;
 }

--- a/templates/cassiopeia/scss/blocks/_frontend-edit.scss
+++ b/templates/cassiopeia/scss/blocks/_frontend-edit.scss
@@ -4,9 +4,9 @@
   position: absolute;
   top: 0;
   right: 0;
+  z-index: 900;
   color: var(--cassiopeia-color-link);
-  background-color: rgba(255,255,255, 0.5);
+  background-color: rgba(255,255,255,.5);
   border: 1px solid #58595a;
   border-radius: .25rem;
-  z-index:900;
 }

--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -224,6 +224,7 @@
   }
 
   .mod-finder {
+    position: relative;
     display: flex;
     flex: 1 0 20rem;
     max-width: 100%;

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -34,8 +34,8 @@
 .container-top-b,
 .container-bottom-a,
 .container-bottom-b {
-  padding: 4rem 0;
   position: relative;
+  padding: 4rem 0;
   > * {
     flex: 1;
     margin: ($cassiopeia-grid-gutter / 2);

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -8,6 +8,10 @@
   margin-left: auto;
 }
 
+.mod-custom {
+  position: relative;
+}
+
 .container-header header .site {
   background-color: $gray-100;
 
@@ -31,7 +35,7 @@
 .container-bottom-a,
 .container-bottom-b {
   padding: 4rem 0;
-
+  position: relative;
   > * {
     flex: 1;
     margin: ($cassiopeia-grid-gutter / 2);

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -46,6 +46,10 @@
   }
 }
 
+.container-component nav {
+  position: relative;
+}
+
 .container-component,
 .container-sidebar-left,
 .container-sidebar-right {

--- a/templates/cassiopeia/scss/vendor/bootstrap/_bootstrap-rtl.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_bootstrap-rtl.scss
@@ -194,8 +194,3 @@
     color: $breadcrumb-active-color;
   }
 }
-
-.btn.jmodedit {
-  right: auto;
-  left: 0;
-}

--- a/templates/cassiopeia/scss/vendor/bootstrap/_bootstrap-rtl.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_bootstrap-rtl.scss
@@ -194,3 +194,8 @@
     color: $breadcrumb-active-color;
   }
 }
+
+.btn.jmodedit {
+  left: 0;
+  right: auto;
+}

--- a/templates/cassiopeia/scss/vendor/bootstrap/_bootstrap-rtl.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_bootstrap-rtl.scss
@@ -196,6 +196,6 @@
 }
 
 .btn.jmodedit {
-  left: 0;
   right: auto;
+  left: 0;
 }


### PR DESCRIPTION
Pull Request for Issue #32170 .

### Summary of Changes

A bit better css for the edit buttons,  I made the background half transparent and made the "Edit" text sr-only.

### Testing Instructions

* apply patch
*  node build/build.js --compile-css templates/cassiopeia/scss


### Actual result BEFORE applying this Pull Request
![grafik](https://user-images.githubusercontent.com/467356/111868006-d86bf780-8977-11eb-8c73-88e7183d6cdc.png)



### Expected result AFTER applying this Pull Request
#### LTR
![grafik](https://user-images.githubusercontent.com/467356/111904331-b2f9ef00-8a46-11eb-82fb-6215eb91d765.png)

#### RTL
![grafik](https://user-images.githubusercontent.com/467356/111904343-c73dec00-8a46-11eb-923b-a8f431fe1611.png)

### Documentation Changes Required
none
