### PR TITLE
[4.0] skipto plugin typo

### DIFF
--- a/administrator/language/en-GB/plg_system_skipto.ini
+++ b/administrator/language/en-GB/plg_system_skipto.ini
@@ -5,7 +5,7 @@
 
 PLG_SYSTEM_SKIPTO="System - Skip-To Navigation"
 ; do not translate $key
-PLG_SYSTEM_SKIPTO_ACCCESS_KEY="Access key is $key"
+PLG_SYSTEM_SKIPTO_ACCESS_KEY="Access key is $key"
 PLG_SYSTEM_SKIPTO_HEADING="Page Outline"
 PLG_SYSTEM_SKIPTO_HEADING_LEVEL="Heading level"
 ; next line begins with a space. $m is count, %n is total

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -77,7 +77,7 @@ class PlgSystemSkipto extends CMSPlugin
 
 						// Button labels and messages
 						'buttonLabel'            => Text::_('PLG_SYSTEM_SKIPTO_TITLE'),
-						'buttonTooltipAccesskey' => Text::_('PLG_SYSTEM_SKIPTO_ACCCESS_KEY'),
+						'buttonTooltipAccesskey' => Text::_('PLG_SYSTEM_SKIPTO_ACCESS_KEY'),
 
 						// Menu labels and messages
 						'landmarkGroupLabel'  => Text::_('PLG_SYSTEM_SKIPTO_LANDMARK'),


### PR DESCRIPTION
Obvious mistake by me. Thanks to @tecpromotion for spotting it
