### PR TITLE
[4.0] Clean up com_contact category breadcrumbs code

### DIFF
--- a/components/com_contact/src/View/Category/HtmlView.php
+++ b/components/com_contact/src/View/Category/HtmlView.php
@@ -87,7 +87,7 @@ class HtmlView extends CategoryView
 			}
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**
@@ -99,30 +99,41 @@ class HtmlView extends CategoryView
 	{
 		parent::prepareDocument();
 
-		$menu = $this->menu;
-		$id = (int) @$menu->query['id'];
+		parent::addFeed();
 
-		if ($menu && (!isset($menu->query['option']) || $menu->query['option'] != $this->extension || $menu->query['view'] == $this->viewName
-			|| $id != $this->category->id))
+		if ($this->menuItemMatchCategory)
 		{
-			$path = array(array('title' => $this->category->title, 'link' => ''));
-			$category = $this->category->getParent();
-
-			while ((!isset($menu->query['option']) || $menu->query['option'] !== 'com_contact' || $menu->query['view'] === 'contact'
-				|| $id != $category->id) && $category->id > 1)
-			{
-				$path[] = array('title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id, $category->language));
-				$category = $category->getParent();
-			}
-
-			$path = array_reverse($path);
-
-			foreach ($path as $item)
-			{
-				$this->pathway->addItem($item['title'], $item['link']);
-			}
+			// If the active menu item is linked directly to the category being displayed, no further process is needed
+			return;
 		}
 
-		parent::addFeed();
+		// Get ID of the category from active menu item
+		$menu = $this->menu;
+
+		if ($menu && $menu->component == 'com_contact' && isset($menu->query['view'])
+			&& in_array($menu->query['view'], ['categories', 'category']))
+		{
+			$id = $menu->query['id'];
+		}
+		else
+		{
+			$id = 0;
+		}
+
+		$path     = [['title' => $this->category->title, 'link' => '']];
+		$category = $this->category->getParent();
+
+		while ($id != $category->id && $category->id > 1)
+		{
+			$path[]   = ['title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id, $category->language)];
+			$category = $category->getParent();
+		}
+
+		$path = array_reverse($path);
+
+		foreach ($path as $item)
+		{
+			$this->pathway->addItem($item['title'], $item['link']);
+		}
 	}
 }

--- a/components/com_contact/src/View/Category/HtmlView.php
+++ b/components/com_contact/src/View/Category/HtmlView.php
@@ -123,7 +123,7 @@ class HtmlView extends CategoryView
 		$path     = [['title' => $this->category->title, 'link' => '']];
 		$category = $this->category->getParent();
 
-		while ($id != $category->id && $category->id > 1)
+		while ($category !== null && $category->id != $id && $category->id !== 'root')
 		{
 			$path[]   = ['title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id, $category->language)];
 			$category = $category->getParent();


### PR DESCRIPTION
### Summary of Changes
Similar to the merged PR https://github.com/joomla/joomla-cms/pull/32535 , this PR improves the code add breadcrumbs in category view of com_contact component. The code which we are having right now is a mess, hard to understand and difficult to maintain.

### Testing Instructions
1. Update your site to latest 4.0-dev.
2. Access to Components -> Contacts-> Categories, create several categories and sub-categories.
3. Apply patch
4. Test and make sure the breadcrumbs are still handled properly.

#### Test 1:
- Create a menu item to link to **List All Categories in a Contact Category Tree** menu item type of contacts component. Choose the parent category in the menu item parameter.
- Access to that menu item, you will see categories list. Access to a child category , look at the breadcrumbs module, make sure  breadcrumbs  items are added properly (should have the format **Home -> Menu Item Title -> Child Category**)

#### Test 2:
- Create a menu item to link to **List Contacts in a Category** menu item type of contact component. Choose a child category (which contains contacts)
- Access to that menu item, you should see list of contacts added to that category, look at look at the breadcrumbs module, make sure breadcrumb item are added properly (should have the format **Home -> Menu Item Title**)

If someone can review the code changes, that would be great.