### PR TITLE
Fix warnings on php 8

### DIFF
--- a/components/com_contact/views/category/view.html.php
+++ b/components/com_contact/views/category/view.html.php
@@ -101,8 +101,8 @@ class ContactViewCategory extends JViewCategory
 			$path = array(array('title' => $this->category->title, 'link' => ''));
 			$category = $this->category->getParent();
 
-			while ((!isset($menu->query['option']) || $menu->query['option'] !== 'com_contact' || $menu->query['view'] === 'contact'
-				|| $id != $category->id) && $category->id > 1)
+			while ($category !== null && $category->id !== 'root ' &&
+				(!isset($menu->query['option']) || $menu->query['option'] !== 'com_contact' || $menu->query['view'] === 'contact' || $id != $category->id))
 			{
 				$path[] = array('title' => $category->title, 'link' => ContactHelperRoute::getCategoryRoute($category->id));
 				$category = $category->getParent();

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -252,7 +252,7 @@ class ContentViewArticle extends JViewLegacy
 			$category = JCategories::getInstance('Content')->get($this->item->catid);
 
 			while ($category && (!isset($menu->query['option']) || $menu->query['option'] !== 'com_content' || $menu->query['view'] === 'article'
-				|| $id != $category->id) && $category->id > 1)
+				|| $id != $category->id) && $category->id !== 'root')
 			{
 				$path[]   = array('title' => $category->title, 'link' => ContentHelperRoute::getCategoryRoute($category->id));
 				$category = $category->getParent();

--- a/components/com_content/views/category/view.html.php
+++ b/components/com_content/views/category/view.html.php
@@ -267,8 +267,8 @@ class ContentViewCategory extends JViewCategory
 			$path = array(array('title' => $this->category->title, 'link' => ''));
 			$category = $this->category->getParent();
 
-			while ((!isset($menu->query['option']) || $menu->query['option'] !== 'com_content' || $menu->query['view'] === 'article'
-				|| $id != $category->id) && $category->id > 1)
+			while ($category !== null && $category->id !== 'root'
+				&& (!isset($menu->query['option']) || $menu->query['option'] !== 'com_content' || $menu->query['view'] === 'article' || $id != $category->id))
 			{
 				$path[] = array('title' => $category->title, 'link' => ContentHelperRoute::getCategoryRoute($category->id));
 				$category = $category->getParent();


### PR DESCRIPTION
Pull Request for Issue #31473.

### Summary of Changes
This PR fixes PHP warnings on PHP 8. The error happens in some of our view classes because some changes in how php handles string to number comparision:

- Before php 8: **'root' > 1** return **false**, so the code inside this block https://github.com/joomla/joomla-cms/blob/staging/components/com_content/views/category/view.html.php#L270-L275 won't be run, thus $category variable never has null value, thus we do not get the warnings
- With php8: **'root' > 1** return true, the code inside the block is executed, $category return null and we have the warnings.


### Testing Instructions
1. You need to have PHP 8 running to test this PR
2. Unpublish all menu items you created to link to one of the following menu item types: List All Categories, Category List, Category Blog.
3. Create an instance of **Articles - Categories**, publish it
4. Access to a category which is displayed in the module above

Before patch: You would get the warning like 

>Attempt to read property "id" on null in components/com_content/views/category/view.html.php

After patch: No warning anymore