### PR TITLE
[4.0] Fix warning on PHP 8 for com_content Category view

### DIFF
--- a/components/com_content/src/View/Category/HtmlView.php
+++ b/components/com_content/src/View/Category/HtmlView.php
@@ -240,7 +240,7 @@ class HtmlView extends CategoryView
 		$path     = [['title' => $this->category->title, 'link' => '']];
 		$category = $this->category->getParent();
 
-		while ($id != $category->id && $category->id > 1)
+		while ($category !== null && $category->id !== 'root' && $category->id != $id)
 		{
 			$path[]   = ['title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id, $category->language)];
 			$category = $category->getParent();


### PR DESCRIPTION
Pull Request for Issue #31473.

### Summary of Changes
Similar PR with https://github.com/joomla/joomla-cms/pull/32767 , but this is for Joomla 4. The fix for warning on category view of com_contact not included because I have a separate PR to clean up code for com_contact

### Testing Instructions
1. You need to have PHP 8 running to test this PR
2. Install latest Joomla 4.0-dev
3. Unpublish all menu items you created to link to one of the following menu item types: **List All Categories in an Article Category Tree**, **Category List**, **Category Blog** .
4. Create an instance of Articles - Categories, publish it
5. Access to a category which is displayed in the module above
Before patch: You would get the warning like

> Attempt to read property "id" on null in components/com_content/src/View/Category/HtmlView.php

After patch: No warning anymore.