### PR TITLE
[4.0] subform buttons

### DIFF
--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -48,8 +48,9 @@ $sublayout = empty($groupByFieldset) ? 'section' : 'section-byfieldsets';
 			<?php if (!empty($buttons['add'])) : ?>
 			<div class="btn-toolbar">
 				<div class="btn-group">
-					<a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0">
-						<span class="icon-plus icon-white" aria-hidden="true"></span> </a>
+					<button type="button" class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
+						<span class="icon-plus icon-white" aria-hidden="true"></span>
+					</button>
 				</div>
 			</div>
 			<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
@@ -27,9 +27,9 @@ extract($displayData);
 	<?php if (!empty($buttons)) : ?>
 	<div class="btn-toolbar text-end">
 		<div class="btn-group">
-			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><span class="icon-plus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
-			<?php if (!empty($buttons['remove'])) : ?><a class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>" tabindex="0"><span class="icon-minus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
-			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </a><?php endif; ?>
+			<?php if (!empty($buttons['add'])) : ?><button type="button" class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>"><span class="icon-plus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['remove'])) : ?><button type="button" class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>"><span class="icon-minus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['move'])) : ?><button type="button" class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </button><?php endif; ?>
 		</div>
 	</div>
 	<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable/section.php
+++ b/layouts/joomla/form/field/subform/repeatable/section.php
@@ -27,9 +27,9 @@ extract($displayData);
 	<?php if (!empty($buttons)) : ?>
 	<div class="btn-toolbar text-end">
 		<div class="btn-group">
-			<?php if (!empty($buttons['add'])) : ?><a class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>" tabindex="0"><span class="icon-plus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
-			<?php if (!empty($buttons['remove'])) : ?><a class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>" tabindex="0"><span class="icon-minus icon-white" aria-hidden="true"></span> </a><?php endif; ?>
-			<?php if (!empty($buttons['move'])) : ?><a class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </a><?php endif; ?>
+			<?php if (!empty($buttons['add'])) : ?><button type="button" class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>"><span class="icon-plus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['remove'])) : ?><button type="button" class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>"><span class="icon-minus icon-white" aria-hidden="true"></button> </a><?php endif; ?>
+			<?php if (!empty($buttons['move'])) : ?><button type="button" class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </button><?php endif; ?>
 		</div>
 	</div>
 	<?php endif; ?>


### PR DESCRIPTION
Does it go somewhere? It's a link
Does it do something? It's a button

This PR corrects the usage of an `a` when it should be a `button` in the non-table repeatable layouts. You can see this in action in the CSP options after selecting custom mode and scrolling down the page.

There is no visible or functional change.

Note the javascript can probably be updated to not listen for a spacebar key as that is native for a button - this is beyond the scope of this PR.

PS I already did this once before in #26614 