### PR TITLE
[4.0] Allow users edit account via com_users without core.manager permission

### DIFF
--- a/administrator/components/com_users/src/Controller/UserController.php
+++ b/administrator/components/com_users/src/Controller/UserController.php
@@ -105,7 +105,7 @@ class UserController extends FormController
 	{
 		$result = parent::save($key, $urlVar);
 
-		$task  = $this->getTask();
+		$task   = $this->getTask();
 
 		if ($task === 'save' && $return = $this->input->get('return', '', 'BASE64'))
 		{

--- a/administrator/components/com_users/src/Controller/UserController.php
+++ b/administrator/components/com_users/src/Controller/UserController.php
@@ -53,7 +53,7 @@ class UserController extends FormController
 			}
 		}
 
-		// Allow user to edit his profile
+		// Allow users to edit their own account
 		if (isset($data[$key]) && $this->app->getIdentity()->id == $data[$key])
 		{
 			return true;

--- a/administrator/components/com_users/src/Controller/UserController.php
+++ b/administrator/components/com_users/src/Controller/UserController.php
@@ -39,7 +39,7 @@ class UserController extends FormController
 	 *
 	 * @return  boolean  True if allowed, false otherwise.
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @since   1.6
 	 */
 	protected function allowEdit($data = array(), $key = 'id')
 	{
@@ -99,7 +99,7 @@ class UserController extends FormController
 	 *
 	 * @return  boolean  True if successful, false otherwise.
 	 *
-	 * @since   1.6
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function save($key = null, $urlVar = null)
 	{

--- a/administrator/components/com_users/src/Controller/UserController.php
+++ b/administrator/components/com_users/src/Controller/UserController.php
@@ -54,7 +54,7 @@ class UserController extends FormController
 		}
 
 		// Allow user to edit his profile
-		if (isset($data[$key]) && $this->app->getIdentity()->id == $data['id'])
+		if (isset($data[$key]) && $this->app->getIdentity()->id == $data[$key])
 		{
 			return true;
 		}

--- a/administrator/components/com_users/src/Controller/UserController.php
+++ b/administrator/components/com_users/src/Controller/UserController.php
@@ -53,10 +53,9 @@ class UserController extends FormController
 			}
 		}
 
-		// Check if user is editing his account, if Yes, allow him to edit
+		// Allow user to edit his profile
 		if (isset($data[$key]) && $this->app->getIdentity()->id == $data['id'])
 		{
-
 			return true;
 		}
 
@@ -93,7 +92,7 @@ class UserController extends FormController
 	}
 
 	/**
-	 * Override parent cancel to redirect when using status edit account.
+	 * Override parent save to redirect when using status edit account.
 	 *
 	 * @param   string  $key     The name of the primary key of the URL variable.
 	 * @param   string  $urlVar  The name of the URL variable if different from the primary key (sometimes required to avoid router collisions).

--- a/administrator/components/com_users/src/Controller/UserController.php
+++ b/administrator/components/com_users/src/Controller/UserController.php
@@ -53,6 +53,13 @@ class UserController extends FormController
 			}
 		}
 
+		// Check if user is editing his account, if Yes, allow him to edit
+		if (isset($data[$key]) && $this->app->getIdentity()->id == $data['id'])
+		{
+
+			return true;
+		}
+
 		return parent::allowEdit($data, $key);
 	}
 
@@ -80,6 +87,38 @@ class UserController extends FormController
 			}
 
 			$this->app->redirect($return);
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Override parent cancel to redirect when using status edit account.
+	 *
+	 * @param   string  $key     The name of the primary key of the URL variable.
+	 * @param   string  $urlVar  The name of the URL variable if different from the primary key (sometimes required to avoid router collisions).
+	 *
+	 * @return  boolean  True if successful, false otherwise.
+	 *
+	 * @since   1.6
+	 */
+	public function save($key = null, $urlVar = null)
+	{
+		$result = parent::save($key, $urlVar);
+
+		$task  = $this->getTask();
+
+		if ($task === 'save' && $return = $this->input->get('return', '', 'BASE64'))
+		{
+			$return = base64_decode($return);
+
+			// Don't redirect to an external URL.
+			if (!Uri::isInternal($return))
+			{
+				$return = Uri::base();
+			}
+
+			$this->setRedirect($return);
 		}
 
 		return $result;

--- a/administrator/components/com_users/src/Controller/UserController.php
+++ b/administrator/components/com_users/src/Controller/UserController.php
@@ -54,7 +54,7 @@ class UserController extends FormController
 		}
 
 		// Allow users to edit their own account
-		if (isset($data[$key]) && $this->app->getIdentity()->id == $data[$key])
+		if (isset($data[$key]) && $this->app->getIdentity()->id === (int) $data[$key])
 		{
 			return true;
 		}

--- a/administrator/components/com_users/src/Controller/UserController.php
+++ b/administrator/components/com_users/src/Controller/UserController.php
@@ -39,7 +39,7 @@ class UserController extends FormController
 	 *
 	 * @return  boolean  True if allowed, false otherwise.
 	 *
-	 * @since   1.6
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected function allowEdit($data = array(), $key = 'id')
 	{

--- a/administrator/components/com_users/src/Controller/UserController.php
+++ b/administrator/components/com_users/src/Controller/UserController.php
@@ -54,7 +54,7 @@ class UserController extends FormController
 		}
 
 		// Allow users to edit their own account
-		if (isset($data[$key]) && $this->app->getIdentity()->id === (int) $data[$key])
+		if (isset($data[$key]) && (int) $this->app->getIdentity()->id === (int) $data[$key])
 		{
 			return true;
 		}

--- a/administrator/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_users/src/Dispatcher/Dispatcher.php
@@ -35,12 +35,12 @@ class Dispatcher extends ComponentDispatcher
 		$allowedTasks = ['user.edit', 'user.apply', 'user.save', 'user.cancel'];
 
 		// Allow users to edit their own account
-		if (in_array($task, $allowedTasks) || ($view === 'user' && $layout == 'edit'))
+		if (in_array($task, $allowedTasks, true) || ($view === 'user' && $layout === 'edit'))
 		{
 			$user = $this->app->getIdentity();
 			$id   = $this->input->getInt('id');
 
-			if ($user->id === $id)
+			if ((int) $user->id === $id)
 			{
 				return;
 			}

--- a/administrator/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_users/src/Dispatcher/Dispatcher.php
@@ -40,7 +40,7 @@ class Dispatcher extends ComponentDispatcher
 			$user = $this->app->getIdentity();
 			$id   = $this->input->getInt('id');
 
-			if ($user->id == $id)
+			if ($user->id === $id)
 			{
 				return;
 			}

--- a/administrator/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_users/src/Dispatcher/Dispatcher.php
@@ -24,8 +24,8 @@ class Dispatcher extends ComponentDispatcher
 	 * Override checkAccess to allow users edit profile without having to have core.manager permission
 	 *
 	 * @return  void
-  *
-  * @since  __DEPLOY_VERSION__
+	 *
+	 * @since  __DEPLOY_VERSION__
 	 */
 	protected function checkAccess()
 	{

--- a/administrator/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_users/src/Dispatcher/Dispatcher.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package         Joomla.Administrator
- * @subpackage      com_admin
+ * @subpackage      com_users
  *
  * @copyright   (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
  * @license         GNU General Public License version 2 or later; see LICENSE.txt
@@ -35,7 +35,6 @@ class Dispatcher extends ComponentDispatcher
 		// Allow user to edit data from his own account
 		if (in_array($task, $allowedTasks) || ($view === 'user' && $layout == 'edit'))
 		{
-
 			$user = $this->app->getIdentity();
 			$id   = $this->input->getInt('id');
 

--- a/administrator/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_users/src/Dispatcher/Dispatcher.php
@@ -3,7 +3,7 @@
  * @package         Joomla.Administrator
  * @subpackage      com_users
  *
- * @copyright   (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license         GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/administrator/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_users/src/Dispatcher/Dispatcher.php
@@ -32,7 +32,7 @@ class Dispatcher extends ComponentDispatcher
 		$layout       = $this->input->getCmd('layout');
 		$allowedTasks = ['user.edit', 'user.apply', 'user.save', 'user.cancel'];
 
-		// Allow user to edit data from his own account
+		// Allow users to edit their own account
 		if (in_array($task, $allowedTasks) || ($view === 'user' && $layout == 'edit'))
 		{
 			$user = $this->app->getIdentity();

--- a/administrator/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_users/src/Dispatcher/Dispatcher.php
@@ -21,7 +21,7 @@ use Joomla\CMS\Dispatcher\ComponentDispatcher;
 class Dispatcher extends ComponentDispatcher
 {
 	/**
-	 * com_admin does not require check permission, so we override checkAccess method and have it empty
+	 * Override checkAccess to allow users edit profile without having to have core.manager permission
 	 *
 	 * @return  void
 	 */

--- a/administrator/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_users/src/Dispatcher/Dispatcher.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * @package         Joomla.Administrator
+ * @subpackage      com_admin
+ *
+ * @copyright   (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license         GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Users\Administrator\Dispatcher;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Dispatcher\ComponentDispatcher;
+
+/**
+ * ComponentDispatcher class for com_admin
+ *
+ * @since  4.0.0
+ */
+class Dispatcher extends ComponentDispatcher
+{
+	/**
+	 * com_admin does not require check permission, so we override checkAccess method and have it empty
+	 *
+	 * @return  void
+	 */
+	protected function checkAccess()
+	{
+		$task         = $this->input->getCmd('task');
+		$view         = $this->input->getCmd('view');
+		$layout       = $this->input->getCmd('layout');
+		$allowedTasks = ['user.edit', 'user.apply', 'user.save', 'user.cancel'];
+
+		// Allow user to edit data from his own account
+		if (in_array($task, $allowedTasks) || ($view === 'user' && $layout == 'edit'))
+		{
+
+			$user = $this->app->getIdentity();
+			$id   = $this->input->getInt('id');
+
+			if ($user->id == $id)
+			{
+				return;
+			}
+		}
+
+		parent::checkAccess();
+	}
+}

--- a/administrator/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_users/src/Dispatcher/Dispatcher.php
@@ -14,9 +14,9 @@ namespace Joomla\Component\Users\Administrator\Dispatcher;
 use Joomla\CMS\Dispatcher\ComponentDispatcher;
 
 /**
- * ComponentDispatcher class for com_admin
+ * ComponentDispatcher class for com_users
  *
- * @since  4.0.0
+ * @since  __DEPLOY_VERSION__
  */
 class Dispatcher extends ComponentDispatcher
 {

--- a/administrator/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_users/src/Dispatcher/Dispatcher.php
@@ -24,6 +24,8 @@ class Dispatcher extends ComponentDispatcher
 	 * Override checkAccess to allow users edit profile without having to have core.manager permission
 	 *
 	 * @return  void
+  *
+  * @since  __DEPLOY_VERSION__
 	 */
 	protected function checkAccess()
 	{

--- a/administrator/components/com_users/src/View/User/HtmlView.php
+++ b/administrator/components/com_users/src/View/User/HtmlView.php
@@ -144,7 +144,7 @@ class HtmlView extends BaseHtmlView
 
 		$toolbarButtons = [];
 
-		if ($canDo->get('core.edit') || $canDo->get('core.create'))
+		if ($canDo->get('core.edit') || $canDo->get('core.create') || $isProfile)
 		{
 			ToolbarHelper::apply('user.apply');
 			$toolbarButtons[] = ['save', 'user.save'];

--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -37,12 +37,12 @@ $hideLinks = $app->input->getBool('hidemainmenu');
 			<?php echo Text::sprintf('MOD_USER_TITLE', $user->name); ?>
 		</div>
 		<?php $uri   = Uri::getInstance(); ?>
-		<?php $route = 'index.php?option=com_admin&task=profile.edit&id=' . $user->id . '&return=' . base64_encode($uri) . '#attrib-user_details'; ?>
+		<?php $route = 'index.php?option=com_users&task=user.edit&id=' . $user->id . '&return=' . base64_encode($uri) . '#attrib-user_details'; ?>
 		<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
 			<span class="icon-user icon-fw" aria-hidden="true"></span>
 			<?php echo Text::_('MOD_USER_EDIT_ACCOUNT'); ?>
 		</a>
-		<?php $route = 'index.php?option=com_admin&task=profile.edit&id=' . $user->id . '&return=' . base64_encode($uri) . '#attrib-accessibility'; ?>
+		<?php $route = 'index.php?option=com_users&task=user.edit&id=' . $user->id . '&return=' . base64_encode($uri) . '#attrib-accessibility'; ?>
 		<a class="dropdown-item" href="<?php echo Route::_($route); ?>">
 			<span class="icon-universal-access icon-fw" aria-hidden="true"></span>
 			<?php echo Text::_('MOD_USER_ACCESSIBILITY_SETTINGS'); ?>


### PR DESCRIPTION
Pull Request for Issue #30217.

### Summary of Changes
This PR allows users to edit their account from administrator area of the site without requiring to have **core.manager** permission. If it is accepted, it will solve the release blocker issue https://github.com/joomla/joomla-cms/issues/30217. Also, it allows us to removing the code which we have to add to **com_admin** to allow editing profile at the moment.

### Testing instructions

- Apply patch.
- Create a user account, assign this account to Manager user group
- Login to administrator account of the site using that manager account
- Try to access to **User Account** section at the top right of administrator area, click on **Edit Account** and **Accessibility Settings**, make sure you can still access to the page and update the account data without any problem.