### PR TITLE
[4.0] Clean up article breadcrumb code

### DIFF
--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -79,7 +79,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The flag to mark if the active menu item is linked to the being displayed article
 	 *
-	 * @var bool
+	 * @var boolean
 	 */
 	protected $menuItemMatchArticle = false;
 

--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -77,6 +77,13 @@ class HtmlView extends BaseHtmlView
 	protected $pageclass_sfx = '';
 
 	/**
+	 * The flag to mark if the active menu item is linked to the being displayed article
+	 *
+	 * @var bool
+	 */
+	protected $menuItemMatchArticle = false;
+
+	/**
 	 * Execute and display a template script.
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
@@ -134,6 +141,8 @@ class HtmlView extends BaseHtmlView
 			&& $active->query['view'] == 'article'
 			&& $active->query['id'] == $item->id)
 		{
+			$this->menuItemMatchArticle = true;
+
 			// Load layout from active query (in case it is an alternative menu item)
 			if (isset($active->query['layout']))
 			{
@@ -273,20 +282,27 @@ class HtmlView extends BaseHtmlView
 
 		$title = $this->params->get('page_title', '');
 
-		$id = (int) @$menu->query['id'];
-
-		// If the menu item does not concern this article
-		if ($menu && (!isset($menu->query['option']) || $menu->query['option'] !== 'com_content' || $menu->query['view'] !== 'article'
-			|| $id != $this->item->id))
+		// If the menu item is not linked to this article
+		if (!$this->menuItemMatchArticle)
 		{
 			// If a browser page title is defined, use that, then fall back to the article title if set, then fall back to the page_title option
 			$title = $this->item->params->get('article_page_title', $this->item->title ?: $title);
 
+			// Get ID of the category from active menu item
+			if ($menu && $menu->component == 'com_content' && isset($menu->query['view'])
+				&& in_array($menu->query['view'], ['categories', 'category']))
+			{
+				$id = $menu->query['id'];
+			}
+			else
+			{
+				$id = 0;
+			}
+
 			$path     = array(array('title' => $this->item->title, 'link' => ''));
 			$category = Categories::getInstance('Content')->get($this->item->catid);
 
-			while ($category && (!isset($menu->query['option']) || $menu->query['option'] !== 'com_content' || $menu->query['view'] === 'article'
-				|| $id !== (int) $category->id) && (int) $category->id > 1)
+			while ($category !== null && $category->id != $id && $category->id !== 'root')
 			{
 				$path[]   = array('title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id, $category->language));
 				$category = $category->getParent();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR improves the code add which handle breadcrumb for article view of com_content component. The code which we are having right now is a mess, hard to understand and difficult to maintain.


### Testing Instructions
1. Create menu items to the following menu item types of Articles component:
- List All Categories in an Article Category Tree
- Category Blog
- Single Article
2. Apply patch
3. Access to above menu items, then try to access to article, make sure breadcrumb is handled properly

- For articles accessed base on the first two menu item types, the breadcrumb displayed in the breadcrumb has this format:
**Home / Active Menu Item / [Sub Category] / Article Title**

- For article accessed from Single Article menu item type, the breadcrumb should have this format:
**Home / Active Menu Item**