### PR TITLE
[4] s/Retuns/Returns

### DIFF
--- a/tests/Unit/Libraries/Cms/Toolbar/ToolbarTest.php
+++ b/tests/Unit/Libraries/Cms/Toolbar/ToolbarTest.php
@@ -231,7 +231,7 @@ class ToolbarTest extends \PHPUnit\Framework\TestCase
 	 *
 	 * @since   3.0
 	 */
-	public function testLoadButtonTypeRetunsFalseForUnkownButtonTypes()
+	public function testLoadButtonTypeReturnsFalseForUnkownButtonTypes()
 	{
 		$toolbarFactoryMock = $this->createMock(ToolbarFactoryInterface::class);
 		$toolbarFactoryMock

--- a/tests/Unit/Libraries/Cms/Toolbar/ToolbarTest.php
+++ b/tests/Unit/Libraries/Cms/Toolbar/ToolbarTest.php
@@ -231,7 +231,7 @@ class ToolbarTest extends \PHPUnit\Framework\TestCase
 	 *
 	 * @since   3.0
 	 */
-	public function testLoadButtonTypeReturnsFalseForUnkownButtonTypes()
+	public function testLoadButtonTypeReturnsFalseForUnknownButtonTypes()
 	{
 		$toolbarFactoryMock = $this->createMock(ToolbarFactoryInterface::class);
 		$toolbarFactoryMock


### PR DESCRIPTION
s/Retuns/Returns

Although a function name, not strictly a b/c issue as its a Unit Test so the method name is not important and is only descriptive