### PR TITLE
[4.0] Check if parent class exists in renderfield

### DIFF
--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -36,7 +36,7 @@ $id              = $name . '-desc';
 $hide            = empty($options['hiddenLabel']) ? '' : ' visually-hidden';
 $hideDescription = empty($options['hiddenDescription']) ? false : $options['hiddenDescription'];
 
-if ($parentclass)
+if (!empty($parentclass))
 {
 	$class .= ' ' . $parentclass;
 }


### PR DESCRIPTION
Pull Request for pr #32488.

### Summary of Changes
The new parent class doesn't exist on every occasion. A check if it exists removes a warning. Discovered while running the system tests of DPCalendar on J4.

Merge on code review @wilsonge.

