### PR TITLE
Expound some knowledge

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -133,8 +133,11 @@ class PlgSystemRedirect extends CMSPlugin implements SubscriberInterface
 			}
 		}
 
-		// Why is this (still) here?
-		if ($skipUrl || (strpos($url, 'mosConfig_') !== false) || (strpos($url, '=http://') !== false))
+		/**
+		 * Why is this (still) here?
+		 * Because hackers still try urls with mosConfig_* and Url Injection with =http[s]:// and we dont want to log/redirect these requests
+		 */
+		if ($skipUrl || (strpos($url, 'mosConfig_') !== false) || (strpos($url, '=http') !== false))
 		{
 			return;
 		}


### PR DESCRIPTION
Signed-off-by: Phil E. Taylor <phil@phil-taylor.com>

Pull Request for Issue # .

### Summary of Changes

Expound some knowledge..

`Why is this (still) here?`

`Because hackers still try urls with mosConfig_* and Url Injection with =http[s]:// and we dont want to log/redirect these requests`

Also improved the test to check for Url Injection with https:// urls. 

### Testing Instructions

Enable redirects, create a redirect FROM 123 to 321

go to `http://example.com/123?asd=http://` and note your get a 404 NOT FOUND and not the redirect to /321

### Actual result BEFORE applying this Pull Request

A question unanswered
A badly implemented security test which doesn't take into account https:// prefixed hacker Url Injection urls

### Expected result AFTER applying this Pull Request

Institutional knowledge is preserved.

A "better" implemented security test which takes into account https:// prefixed hacker Url Injection urls

### Documentation Changes Required

None