### PR TITLE
[4.0] Fix suggestions navigation in smart search

### DIFF
--- a/build/media_source/com_finder/js/finder.es6.js
+++ b/build/media_source/com_finder/js/finder.es6.js
@@ -10,7 +10,7 @@
   }
 
   // Handle the autocomplete
-  const onKeyUp = ({ target }) => {
+  const onInputChange = ({ target }) => {
     if (target.value.length > 1) {
       target.awesomplete.list = [];
 
@@ -62,7 +62,7 @@
         searchword.awesomplete = new Awesomplete(searchword);
 
         // If the current value is empty, set the previous value.
-        searchword.addEventListener('keyup', onKeyUp);
+        searchword.addEventListener('input', onInputChange);
       }
     });
 


### PR DESCRIPTION
Pull Request for Issue #30744.

### Summary of Changes
When using the suggest feature of Smart Search, it is impossible to select a suggested term by navigating to it with the keyboard. This is due to the issue that we are reacting to the onKeyUp event, which triggers a new search for suggestions whenever we press for example the arrow-down-key. The solution here is to switch to the "input" event, which fires only when the content of an input field has changed. This also has the benefit that it reacts to content which has been inserted from the clipboard via the mouse.


### Testing Instructions
1. Setup Smart Search and index content, for example by using the sample data plugins
2. Make sure you have a menu item of type Smart Search
3. In the search field in the frontend, start typing a term and wait for the suggestions. Keep in mind that you need at least 2 characters to get a suggestion.
4. Press the down-key of your direction keys on the keyboad.
5. Notice that the suggestion list flickers and doesn't select the suggested term.
6. Apply the patch and reload the page
7. Again type in a term and wait for the suggestions.
8. Press the down key again and now see that an entry in the list is selected.
