### PR TITLE
[4.0] Fix JS error for Joomla update

### DIFF
--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -20,7 +20,10 @@ Joomla = window.Joomla || {};
     if (element.value === 'direct') {
       dom.map((el) => { document.getElementById(el).style.display = 'none' });
     } else {
-      dom.map((el) => { document.getElementById(el).style.display = '' });
+      dom.map((el) => {
+        document.getElementById(el).style.display = '';
+        return el;
+        });
     }
   };
 

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -18,9 +18,9 @@ Joomla = window.Joomla || {};
     ];
 
     if (element.value === 'direct') {
-      dom.map((el) => document.getElementById(el).style.display = 'none');
+      dom.map((el) => { document.getElementById(el).style.display = 'none' });
     } else {
-      dom.map((el) => document.getElementById(el).style.display = '');
+      dom.map((el) => { document.getElementById(el).style.display = '' });
     }
   };
 

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -26,7 +26,7 @@ Joomla = window.Joomla || {};
       dom.map((el) => {
         document.getElementById(el).style.display = '';
         return el;
-        });
+      });
     }
   };
 

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -18,9 +18,9 @@ Joomla = window.Joomla || {};
     ];
 
     if (element.value === 'direct') {
-      dom.map((el) => document.getElementById(el).classList.add('hidden'));
+      dom.map((el) => document.getElementById(el).style.display = 'none');
     } else {
-      dom.map((el) => document.getElementById(el).classList.remove('hidden'));
+      dom.map((el) => document.getElementById(el).style.display = '');
     }
   };
 

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -18,7 +18,10 @@ Joomla = window.Joomla || {};
     ];
 
     if (element.value === 'direct') {
-      dom.map((el) => { document.getElementById(el).style.display = 'none' });
+      dom.map((el) => {
+        document.getElementById(el).style.display = 'none';
+        return el;
+      });
     } else {
       dom.map((el) => {
         document.getElementById(el).style.display = '';


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This small PR fixes small error on Joomla Update screen: when you choose **Hybrid (use FTP only if needed)** or **Write files using FTP**, ftp parameters are not displayed


### Testing Instructions
1. Apply patch
2. Run **npm run build:js** to compile and transpile the JavaScript files to the correct format and create minified files.
3. Go to System -> Update -> Joomla, look at **Upload and Update** tab, in the **Installation method** , select **Hybrid (use FTP only if needed)** or **Write files using FTP**
- Before patch: No inputs are being displayed to allow enter **FTP Host**, **FTP Port**....
- After patch: Inputs are being displayed properly.