### PR TITLE
fix cog icon position for mobile view

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -142,7 +142,7 @@
 
 @include media-breakpoint-down(sm) {
   .toggler-toolbar {
-    top: 20px;
+    top: 0px;
     z-index: $zindex-alerts;
 
     [dir=ltr] & {


### PR DESCRIPTION
Pull Request for Issue #32794 .

### Summary of Changes
Changed position of cog icon for mobile view such that it does not overlaps with search button.

### Actual result BEFORE applying this Pull Request
![cog icon before](https://user-images.githubusercontent.com/60576636/112098897-8bcb2b00-8bc8-11eb-8eda-d4b19fb2517c.png)



### Expected result AFTER applying this Pull Request
![cog icon after](https://user-images.githubusercontent.com/60576636/112098968-aa312680-8bc8-11eb-812b-baf22c559ac8.png)



### Documentation Changes Required
None
