### PR TITLE
fix cog icon for mobile view

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -142,7 +142,7 @@
 
 @include media-breakpoint-down(sm) {
   .toggler-toolbar {
-    top: 20px;
+    top: 0;
     z-index: $zindex-alerts;
 
     [dir=ltr] & {


### PR DESCRIPTION
Pull Request for Issue #32794.

### Summary of Changes
Changed position of cog icon for mobile view so that it does not overlap with search button.





### Actual result BEFORE applying this Pull Request
![cog icon before](https://user-images.githubusercontent.com/60576636/112102156-d7cc9e80-8bcd-11eb-98c6-2fde821c0a18.png)




### Expected result AFTER applying this Pull Request
![cog icon after](https://user-images.githubusercontent.com/60576636/112102214-ee72f580-8bcd-11eb-9a20-1c9f9090e403.png)



### Documentation Changes Required
None
