### PR TITLE
[4] Ensure template logo has relative links regardless of SEF Settings

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -74,7 +74,7 @@ elseif ($this->params->get('siteTitle'))
 }
 else
 {
-	$logo = HTMLHelper::_('image', '/' . $templatePath . '/images/logo.svg', $sitename, ['class' => 'logo d-inline-block'], true, -1);
+	$logo = HTMLHelper::_('image', 'logo.svg', $sitename, ['class' => 'logo d-inline-block'], true, 0);
 }
 
 $hasClass = '';

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -66,7 +66,7 @@ $wa->registerStyle('template.active', '', [], [], ['template.cassiopeia.' . ($th
 // Logo file or site title param
 if ($this->params->get('logoFile'))
 {
-	$logo = '<img src="' . Uri::root() . htmlspecialchars($this->params->get('logoFile'), ENT_QUOTES) . '" alt="' . $sitename . '">';
+	$logo = '<img src="' . Uri::root(true) . '/' . htmlspecialchars($this->params->get('logoFile'), ENT_QUOTES) . '" alt="' . $sitename . '">';
 }
 elseif ($this->params->get('siteTitle'))
 {
@@ -74,7 +74,7 @@ elseif ($this->params->get('siteTitle'))
 }
 else
 {
-	$logo = '<img src="' . $templatePath . '/images/logo.svg" class="logo d-inline-block" alt="' . $sitename . '">';
+	$logo = '<img src="' . Uri::root(true) . '/' . $templatePath . '/images/logo.svg" class="logo d-inline-block" alt="' . $sitename . '">';
 }
 
 $hasClass = '';

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -74,7 +74,7 @@ elseif ($this->params->get('siteTitle'))
 }
 else
 {
-	$logo = HTMLHelper::_('image', '/'.$templatePath . '/images/logo.svg', $sitename, ['class' => 'logo d-inline-block'], true, -1);
+	$logo = HTMLHelper::_('image', '/' . $templatePath . '/images/logo.svg', $sitename, ['class' => 'logo d-inline-block'], true, -1);
 }
 
 $hasClass = '';

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -74,7 +74,7 @@ elseif ($this->params->get('siteTitle'))
 }
 else
 {
-	$logo = '<img src="' . Uri::root(true) . '/' . $templatePath . '/images/logo.svg" class="logo d-inline-block" alt="' . $sitename . '">';
+	$logo = HTMLHelper::_('image', '/'.$templatePath . '/images/logo.svg', $sitename, ['class' => 'logo d-inline-block'], true, -1);
 }
 
 $hasClass = '';


### PR DESCRIPTION
Pull Request for Issue Closes #31989
Replacement PR for https://github.com/joomla/joomla-cms/pull/32714

### Summary of Changes

Prepend templatePath with Uri:root to Ensure templatePath is always absolute and not a broken relative url

### Testing Instructions

See #31989

Visit frontend **, click a menu link in the left menu to get to an article**
Note that the CASSIOPEIA logo (white text on blue background) is present

In Joomla Admin disable the "System - SEF" plugin

Refresh your article page on the frontend

Note the logo is now a broken image

### Actual result BEFORE applying this Pull Request

paths are relative, and therefore image doesn't display when non-SEF mode and not at / (ie. in a sub folder or not on the home page where url contains /index.php/path/to  like http://127.0.0.1:4444/index.php/component/users/reset?Itemid=101)

### Expected result AFTER applying this Pull Request

regardless of SEF plugin status, the image and assets loaded from $templatePath load correctly. 

### Documentation Changes Required

none