### PR TITLE
[4.0] Fix Media Manager cant insert in content unless logged in as admin

### DIFF
--- a/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
@@ -190,7 +190,7 @@
       return;
     }
 
-    const apiBaseUrl = `${Joomla.getOptions('system.paths').rootFull}index.php?option=com_media&format=json`;
+    const apiBaseUrl = `${Joomla.getOptions('system.paths').baseFull}index.php?option=com_media&format=json`;
 
     Joomla.request({
       url: `${apiBaseUrl}&task=api.files&url=true&path=${data.path}&${Joomla.getOptions('csrf.token')}=1&format=json`,

--- a/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
@@ -190,7 +190,7 @@
       return;
     }
 
-    const apiBaseUrl = `${Joomla.getOptions('system.paths').rootFull}administrator/index.php?option=com_media&format=json`;
+    const apiBaseUrl = `${Joomla.getOptions('system.paths').rootFull}index.php?option=com_media&format=json`;
 
     Joomla.request({
       url: `${apiBaseUrl}&task=api.files&url=true&path=${data.path}&${Joomla.getOptions('csrf.token')}=1&format=json`,


### PR DESCRIPTION
Pull Request for Issue #32734 .

### Summary of Changes

Fix the base path in js

### Testing Instructions

1.  Ensure you are not logged into site administrator
2. Login to front-end of site as super user
3. Edit any article and click Image in the CMS Content dropdown to bring up Media Manager
4. Select and attempt to insert any image

* Appy patch  
* npm run build:js

Do the same steps, bonus points when you try the same in the backend. 

### Actual result BEFORE applying this Pull Request

Image is not inserted


### Expected result AFTER applying this Pull Request

Image is inserted

### Documentation Changes Required

None