### PR TITLE
[4.0] fixes title column not responsive in mail templates

### DIFF
--- a/administrator/components/com_mails/tmpl/templates/default.php
+++ b/administrator/components/com_mails/tmpl/templates/default.php
@@ -66,9 +66,9 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 							<tr class="row<?php echo $i % 2; ?>">
 								<td class="break-word">
 									<div class="dropdown">
-										<a href="#" role="button" id="mTemplate<?php echo $i; ?>"  data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+										<a href="#" role="button" id="mTemplate<?php echo $i; ?>" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 											<?php echo Text::_($component . '_MAIL_' . $sub_id . '_TITLE'); ?>
-											<span class="dropdown-toggle" />
+											<span class="dropdown-toggle"></span>
 										</a>
 										<div class="dropdown-menu" aria-labelledby="mTemplate<?php echo $i; ?>">
 											<?php foreach ($this->languages as $language) : ?>

--- a/administrator/components/com_mails/tmpl/templates/default.php
+++ b/administrator/components/com_mails/tmpl/templates/default.php
@@ -66,8 +66,9 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 							<tr class="row<?php echo $i % 2; ?>">
 								<td class="break-word">
 									<div class="dropdown">
-										<a class="dropdown-toggle" href="#" role="button" id="mTemplate<?php echo $i; ?>"  data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+										<a href="#" role="button" id="mTemplate<?php echo $i; ?>"  data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
 											<?php echo Text::_($component . '_MAIL_' . $sub_id . '_TITLE'); ?>
+											<span class="dropdown-toggle" />
 										</a>
 										<div class="dropdown-menu" aria-labelledby="mTemplate<?php echo $i; ?>">
 											<?php foreach ($this->languages as $language) : ?>


### PR DESCRIPTION
This one is a quick fix to my original PR #32689 and Issue #32679.

### Summary of Changes
The Mail Templates is completely fine in *Firefox* with which I tested the original PR. This PR addresses Mail templates being unresponsive in *Chrome* and *Edge* (latest) because the title column isn't able to resize.

This was caused due to the `dropdown-toggle` class that was applied to `a` element.

### Testing Instructions

- Login to Administrator.
- Go to System > Mail Templates.
- Use Dev tools to resize the window. 


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/42460131/112282440-2309ae80-8cad-11eb-9b84-b4dab0e5bc9f.png)


### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/42460131/112282575-3fa5e680-8cad-11eb-8992-915ba2a73dc3.png)


