### PR TITLE
[4.0] Load the correct polyfill

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -30,3 +30,16 @@ There are three options here:
 
 ## CSS
 - CSS files will only get minified
+
+
+## NPM commands
+- `npm run build:js`: compiles ALL the JS (excluding Bootstrap and Media Manager)
+- `npm run build:js -- build/media_source/com_actionlogs`: compiles ALL the JS ONLY in the folder `build/media_source/com_actionlogs`
+- `npm run build:css`: compiles ALL the SCSS
+- `npm run build:css -- templates/cassiopeia`: compiles ALL the SCSS ONLY in the folder `templates/cassiopeia`
+- `npm run build:bs5`: Builds the Bootstrap Javascript components
+- `npm run build:com_media`: Builds the Media Manager Vue Application
+- `npm run lint:js`: Check the code style for all the Javascript/vue files
+- `npm run lint:css`: Check the code style for all the SCSS files
+- `npm run gzip`: Creates `.gz` files for all the `.min.js` and `.min.css`
+- `npm run versioning`: Creates the correct version hash for all the assets inside the joomla.asset.json files (excluding templates)

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,32 @@
+# Joomla build tools
+
+Joomla provides a set of tools for managing the static assets dependencies based on popular NodeJS tools and also a couple of PHP scripts that automate the release process.
+
+## Node based tools
+The responsibilities of these tools are:
+- to copy files from the `node-modules` folder to the `media` folder
+- do any transformations on the copied files
+- Update the version numbers on the xml files of the editors tinyMCE and Codemirror
+- Copy files from the `build/media_source` folder to the `media` folder
+- Transform any modern JS to both ES2017 and transpile it to ES5
+- Transform any SCSS file to the respected CSS file
+
+For some of these operations some conventions were established, to simplify and speed up the process.
+
+## Javascript
+There are three options here:
+- Modern Javascript files should have an extension `.es6.js`.
+  This allows the ESLint to check the style code, Joomla is using the AirBnB preset https://github.com/airbnb/javascript
+  Also it instructs Rollup to do the transforms for ES2017 and then transpile to ES5. This step creates normal and minified files.
+  Production code WILL NOT have the `.es6` part part for ES2017+ files but WILL HAVE a `-es5.js` for the ES5 ones
+
+- Legacy Javascript files should have an extension `.es5.js`.
+  This instructs ESLint to skip checking this file
+  Also it instructs the tools to create a minified version (production code WILL NOT have the `.es5` part)
+
+## SCSS
+- SCSS files starting with `_` will not become entry points for SCSS.
+  SCSS files will be transformed to CSS both normal and minified versions
+
+## CSS
+- CSS files will only get minified

--- a/build/build-modules-js/compress.es6.js
+++ b/build/build-modules-js/compress.es6.js
@@ -24,6 +24,6 @@ module.exports.compressFiles = async (enableBrotli = false) => {
 
   await Promise.all(compressTasks);
   // eslint-disable-next-line no-console
-  console.log('Done 👍');
+  console.log('✅ Done 👍');
   bench.stop();
 };

--- a/build/build-modules-js/error-pages.es6.js
+++ b/build/build-modules-js/error-pages.es6.js
@@ -150,7 +150,7 @@ module.exports.createErrorPages = async (options) => {
     );
 
     // eslint-disable-next-line no-console
-    console.error(`Created the file: ${options.settings.errorPages[name].destFile}`);
+    console.error(`✅ Created the file: ${options.settings.errorPages[name].destFile}`);
   };
 
   Object.keys(options.settings.errorPages).forEach((name) => processPages.push(processPage(name)));

--- a/build/build-modules-js/init/minify-vendor.es6.js
+++ b/build/build-modules-js/init/minify-vendor.es6.js
@@ -23,10 +23,7 @@ const noMinified = [
 ];
 
 const alreadyMinified = [
-  'media/vendor/webcomponentsjs/js/webcomponents-ce.js',
-  'media/vendor/webcomponentsjs/js/webcomponents-sd.js',
-  'media/vendor/webcomponentsjs/js/webcomponents-sd-ce.js',
-  'media/vendor/webcomponentsjs/js/webcomponents-sd-ce-pf.js',
+  'media/vendor/webcomponentsjs/js/webcomponents-bundle.js',
 ];
 
 /**

--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -158,7 +158,7 @@ module.exports.bootstrapJs = async () => {
 
   return Promise.all(tasks).then(async () => {
     // eslint-disable-next-line no-console
-    console.log('ES6 components ready ✅');
+    console.log('✅ ES6 components ready');
 
     try {
       await buildLegacy(inputFolder, 'index.es6.js');
@@ -166,7 +166,7 @@ module.exports.bootstrapJs = async () => {
       const mini = await minify(es5File, { sourceMap: false, format: { comments: false } });
       await writeFile(resolve(outputFolder, 'bootstrap-es5.min.js'), mini.code, { encoding: 'utf8' });
       // eslint-disable-next-line no-console
-      console.log('Legacy done! ✅');
+      console.log('✅ Legacy done!');
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error);

--- a/build/build-modules-js/javascript/build-com_media-js.es6.js
+++ b/build/build-modules-js/javascript/build-com_media-js.es6.js
@@ -76,6 +76,7 @@ module.exports.mediaManager = async () => {
       }),
       nodeResolve(),
       replace({
+        preventAssignment: true,
         'process.env.NODE_ENV': JSON.stringify('production'),
       }),
       babel({
@@ -87,7 +88,11 @@ module.exports.mediaManager = async () => {
             '@babel/preset-env',
             {
               targets: {
-                esmodules: true,
+                browsers: [
+                  '> 1%',
+                  'not ie 11',
+                  'not op_mini all',
+                ],
               },
               loose: true,
               bugfixes: false,
@@ -109,7 +114,7 @@ module.exports.mediaManager = async () => {
   await bundle.close();
 
   // eslint-disable-next-line no-console
-  console.log('ES2017 Media Manager ready ✅');
+  console.log('✅ ES2017 Media Manager ready');
   minifyJs('media/com_media/js/media-manager.js');
   return buildLegacy(resolve('media/com_media/js/media-manager.js'));
 };

--- a/build/build-modules-js/javascript/compile-to-es2017.es6.js
+++ b/build/build-modules-js/javascript/compile-to-es2017.es6.js
@@ -60,6 +60,7 @@ module.exports.handleESMFile = async (file) => {
         preferBuiltins: false,
       }),
       replace({
+        preventAssignment: true,
         CSS_CONTENTS_PLACEHOLDER: minifiedCss,
         delimiters: ['{{', '}}'],
       }),
@@ -72,7 +73,11 @@ module.exports.handleESMFile = async (file) => {
             '@babel/preset-env',
             {
               targets: {
-                esmodules: true,
+                browsers: [
+                  '> 1%',
+                  'not ie 11',
+                  'not op_mini all',
+                ],
               },
               bugfixes: true,
               loose: true,
@@ -91,7 +96,7 @@ module.exports.handleESMFile = async (file) => {
   });
 
   // eslint-disable-next-line no-console
-  console.log(`ES2017 file: ${basename(file).replace('.es6.js', '.js')}: transpiled ✅`);
+  console.log(`ES2017 file: ${basename(file).replace('.es6.js', '.js')}: ✅ transpiled`);
 
   await handleESMToLegacy(resolve(`${newPath}.js`));
   await minifyJs(resolve(`${newPath}.js`));

--- a/build/build-modules-js/javascript/compile-to-es5.es6.js
+++ b/build/build-modules-js/javascript/compile-to-es5.es6.js
@@ -49,7 +49,7 @@ module.exports.handleESMToLegacy = async (file) => {
   });
 
   // eslint-disable-next-line no-console
-  console.log(`ES5 file: ${basename(file).replace('.js', '-es5.js')}: transpiled ✅`);
+  console.log(`ES5 file: ${basename(file).replace('.js', '-es5.js')}: ✅ transpiled`);
 
   minifyJs(resolve(`${file.replace(/\.js$/, '')}-es5.js`));
 };

--- a/build/build-modules-js/javascript/handle-es5.es6.js
+++ b/build/build-modules-js/javascript/handle-es5.es6.js
@@ -11,7 +11,7 @@ module.exports.handleES5File = async (file) => {
     await FsExtra.ensureDir(dirname(file).replace(`${sep}build${sep}media_source${sep}`, `${sep}media${sep}`));
     await FsExtra.copy(file, file.replace(`${sep}build${sep}media_source${sep}`, `${sep}media${sep}`).replace('.es5.js', '.js'));
     // eslint-disable-next-line no-console
-    console.log(`Legacy js file: ${basename(file)}: copied ✅`);
+    console.log(`Legacy js file: ${basename(file)}: ✅ copied`);
 
     minifyJs(file.replace(`${sep}build${sep}media_source${sep}`, `${sep}media${sep}`).replace('.es5.js', '.js'));
   }

--- a/build/build-modules-js/javascript/minify.es6.js
+++ b/build/build-modules-js/javascript/minify.es6.js
@@ -12,7 +12,7 @@ const minifyFile = async (file) => {
   const content = await minify(fileContent, { sourceMap: false, format: { comments: false } });
   await writeFile(file.replace('.js', '.min.js'), content.code, { encoding: 'utf8' });
   // eslint-disable-next-line no-console
-  console.log(`Legacy js file: ${basename(file)}: minified ✅`);
+  console.log(`Legacy js file: ${basename(file)}: ✅ minified`);
 };
 
 module.exports.minifyJs = minifyFile;

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -579,10 +579,7 @@
       "@webcomponents/webcomponentsjs": {
         "name": "webcomponentsjs",
         "js": {
-          "bundles/webcomponents-ce.js": "js/webcomponents-ce.js",
-          "bundles/webcomponents-sd.js": "js/webcomponents-sd.js",
-          "bundles/webcomponents-sd-ce.js": "js/webcomponents-sd-ce.js",
-          "bundles/webcomponents-sd-ce-pf.js": "js/webcomponents-sd-ce-pf.js"
+          "webcomponents-bundle.js": "js/webcomponents-bundle.js"
         },
         "dependencies": [],
         "licenseFilename": "LICENSE.md",
@@ -590,7 +587,7 @@
           {
             "name": "wcpolyfill",
             "type": "script",
-            "uri": "webcomponents-sd-ce-pf.js",
+            "uri": "webcomponents-bundle.js",
             "attributes": {
               "nomodule": true,
               "defer": true

--- a/build/build-modules-js/stylesheets/handle-css.es6.js
+++ b/build/build-modules-js/stylesheets/handle-css.es6.js
@@ -24,7 +24,7 @@ module.exports.handleCssFile = async (file) => {
     await writeFile(outputFile.replace('.css', '.min.css'), cssMin.css.toString(), { encoding: 'utf8', mode: 0o2644 });
 
     // eslint-disable-next-line no-console
-    console.log(`CSS file copied/minified: ${file}`);
+    console.log(`✅ CSS file copied/minified: ${file}`);
   } catch (err) {
     // eslint-disable-next-line no-console
     console.log(err);

--- a/build/build-modules-js/stylesheets/handle-scss.es6.js
+++ b/build/build-modules-js/stylesheets/handle-scss.es6.js
@@ -43,5 +43,5 @@ module.exports.handleScssFile = async (file) => {
   );
 
   // eslint-disable-next-line no-console
-  console.log(`SCSS File compiled: ${cssFile}`);
+  console.log(`✅ SCSS File compiled: ${cssFile}`);
 };

--- a/build/build-modules-js/stylesheets/scss-transform.es6.js
+++ b/build/build-modules-js/stylesheets/scss-transform.es6.js
@@ -45,7 +45,7 @@ module.exports.compile = async (file) => {
   );
 
   // eslint-disable-next-line no-console
-  console.log(`SCSS File compiled: ${cssFile}`);
+  console.log(`✅ SCSS File compiled: ${cssFile}`);
   // });
 
   // forked.send({ file });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3219,7 +3219,7 @@
     },
     "css-color-names": {
       "version": "0.0.4",
-      "resolved": "http://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
+      "resolved": "https://registry.npmjs.org/css-color-names/-/css-color-names-0.0.4.tgz",
       "integrity": "sha1-gIrcLnnPhHOAabZGyyDsJ762KeA=",
       "dev": true
     },


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Changes the web components polyfill to `webcomponents-bundle.js`
- Remove the redundant web component polyfills
- Adds the correct target for the Rollup ESM setups
- Move the emoji icon at the beginning so it won't get cut in some terminals
- adds a README file in the build folder 

### Testing Instructions
- `npm ci` works as before
- browser loads the webcomponent polyfill

![Screenshot 2021-03-24 at 17 30 57](https://user-images.githubusercontent.com/3889375/112346986-c9ae7900-8cc6-11eb-82c8-ce55454849a1.png)

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required
No, bug fixes

@wilsonge 