### PR TITLE
[4] s/DateTime/DateTimeInterface for RFC2822

### DIFF
--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -466,7 +466,7 @@ class Date extends \DateTime
 	 */
 	public function toRFC822($local = false)
 	{
-		return $this->format(\DateTime::RFC2822, $local, false);
+		return $this->format(\DateTimeInterface::RFC2822, $local, false);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes

According to phpStorm, "RFC2822 was removed in PHP 7.2"

Reference in phpStorm https://github.com/JetBrains/phpstorm-stubs/pull/297/files

Reference in php-src https://github.com/php/php-src/pull/2483

<img width="949" alt="Screenshot 2021-03-24 at 22 02 30" src="https://user-images.githubusercontent.com/400092/112389453-a5fe2980-8cec-11eb-8acc-01f895462235.png">

I believe what they are trying to say is that the constants were moved from the `DateTime` to the `DateTimeInterface` in PHP 7.2 

### Testing Instructions

The new unit tests cover this - cough cough - test those at https://github.com/joomla/joomla-cms/pull/32848

Manually run:
```
$date = new Date("8th March 1978 6:06pm", new \DateTimeZone('UTC'));

echo $date->toRFC822(); // Should give 'Wed, 08 Mar 1978 18:06:00 +0000'
```

### Actual result BEFORE applying this Pull Request

`'Wed, 08 Mar 1978 18:06:00 +0000'`

### Expected result AFTER applying this Pull Request

`'Wed, 08 Mar 1978 18:06:00 +0000'` but phpStorm is happy 

### Documentation Changes Required

none