### PR TITLE
[4] Missing code style

### DIFF
--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
@@ -38,7 +38,8 @@ class FilePathRuleTest extends UnitTestCase
 			size="50"
 			default="images"
 			validate="filePath"
-		/>');
+		/>'
+		);
 
 		// These all pass today,
 		// BUT, Joomla 3.9.26 SHOULD break this test, as a security fix is applied, thus proving the test valuable
@@ -83,6 +84,6 @@ class FilePathRuleTest extends UnitTestCase
 	 */
 	public function testRule($expected, $element, $value)
 	{
-		$this->assertEquals($expected, (new FilePathRule())->test($element, $value));
+		$this->assertEquals($expected, (new FilePathRule)->test($element, $value));
 	}
 }


### PR DESCRIPTION
phpcs locally says this is needed to my last commits, to comply with 

`./libraries/vendor/bin/phpcs --standard=libraries/vendor/joomla/cms-coding-standards/lib/Joomla-CMS tests`

Pushing to see if it passes code style at drone, if so can be merged on code review. 