### PR TITLE
Fix category created/modified date

### DIFF
--- a/administrator/components/com_categories/models/category.php
+++ b/administrator/components/com_categories/models/category.php
@@ -185,32 +185,7 @@ class CategoriesModelCategory extends JModelAdmin
 			// Convert the metadata field to an array.
 			$registry = new Registry($result->metadata);
 			$result->metadata = $registry->toArray();
-
-			// Convert the created and modified dates to local user time for display in the form.
-			$tz = new DateTimeZone(JFactory::getApplication()->get('offset'));
-
-			if ((int) $result->created_time)
-			{
-				$date = new JDate($result->created_time);
-				$date->setTimezone($tz);
-				$result->created_time = $date->toSql(true);
-			}
-			else
-			{
-				$result->created_time = null;
-			}
-
-			if ((int) $result->modified_time)
-			{
-				$date = new JDate($result->modified_time);
-				$date->setTimezone($tz);
-				$result->modified_time = $date->toSql(true);
-			}
-			else
-			{
-				$result->modified_time = null;
-			}
-
+			
 			if (!empty($result->id))
 			{
 				$result->tags = new JHelperTags;


### PR DESCRIPTION
Pull Request for Issue #32856.

### Summary of Changes
This PR fixes wrong category created/modified date each time it is saved. The calendar form field does Timezone conversion already, so the **getItem** method in Category does not have to do this work.


### Testing Instructions
1. See https://github.com/joomla/joomla-cms/issues/32856 , confirm the issue
2. Apply patch, confirm that the issue is fixed
3. You should also now see the modified date is displayed in correct timezone, too
