### PR TITLE
Adding an attribute aria-valuemin and aria-valuemax in Progress bar

### DIFF
--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -45,7 +45,7 @@ $app->getDocument()->addScriptOptions(
 			<?php // Progress bar ?>
 			<li class="list-group-item sampledata-progress-<?php echo $item->name; ?> d-none">
 				<div class="progress">
-					<div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"></div>
+					<div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width:10%"></div>
 				</div>
 			</li>
 			<?php // Progress messages ?>


### PR DESCRIPTION
Pull Request for Issue # .
aria-valuemin attribute is used to define the minimum value allowed for a range widget such as a slider, spinbutton or progressbar.
aria-valuemax attribute is used to define the maximum value allowed for a range widget such as a slider, spinbutton or progressbar.