### PR TITLE
[3] Preserve update site extra_query on rebuild and use extra_query from update site if update has none

### DIFF
--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -358,7 +358,18 @@ class InstallerModelUpdate extends JModelList
 			$instance = JTable::getInstance('update');
 			$instance->load($uid);
 			$update->loadFromXml($instance->detailsurl, $minimumStability);
-			$update->set('extra_query', $instance->extra_query);
+
+			// If the update has an extra_query use it
+			if ($instance->extra_query) {
+				$update->set('extra_query', $instance->extra_query);
+			} else {
+				// if the update has no extra_query, the update_site providing this update might have one, so check, and use that if found
+				$updateSiteInstance = JTable::getInstance('Updatesite');
+				$updateSiteInstance->load($instance->update_site_id);
+				if ($updateSiteInstance->extra_query){
+					$update->set('extra_query', $updateSiteInstance->extra_query);
+				}
+			}
 
 			$this->preparePreUpdate($update, $instance);
 

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -369,6 +369,7 @@ class InstallerModelUpdate extends JModelList
 				// If the update has no extra_query, the update_site providing this update might have one, so check, and use that if found
 				$updateSiteInstance = JTable::getInstance('Updatesite');
 				$updateSiteInstance->load($instance->update_site_id);
+
 				if ($updateSiteInstance->extra_query)
 				{
 					$update->set('extra_query', $updateSiteInstance->extra_query);

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -358,22 +358,14 @@ class InstallerModelUpdate extends JModelList
 			$instance = JTable::getInstance('update');
 			$instance->load($uid);
 			$update->loadFromXml($instance->detailsurl, $minimumStability);
+			
+			// Find and use extra_query from update_site if available
+			$updateSiteInstance = JTable::getInstance('Updatesite');
+			$updateSiteInstance->load($instance->update_site_id);
 
-			// If the update has an extra_query use it
-			if ($instance->extra_query)
+			if ($updateSiteInstance->extra_query)
 			{
-				$update->set('extra_query', $instance->extra_query);
-			}
-			else
-			{
-				// If the update has no extra_query, the update_site providing this update might have one, so check, and use that if found
-				$updateSiteInstance = JTable::getInstance('Updatesite');
-				$updateSiteInstance->load($instance->update_site_id);
-
-				if ($updateSiteInstance->extra_query)
-				{
-					$update->set('extra_query', $updateSiteInstance->extra_query);
-				}
+				$update->set('extra_query', $updateSiteInstance->extra_query);
 			}
 
 			$this->preparePreUpdate($update, $instance);

--- a/administrator/components/com_installer/models/update.php
+++ b/administrator/components/com_installer/models/update.php
@@ -360,13 +360,17 @@ class InstallerModelUpdate extends JModelList
 			$update->loadFromXml($instance->detailsurl, $minimumStability);
 
 			// If the update has an extra_query use it
-			if ($instance->extra_query) {
+			if ($instance->extra_query)
+			{
 				$update->set('extra_query', $instance->extra_query);
-			} else {
-				// if the update has no extra_query, the update_site providing this update might have one, so check, and use that if found
+			}
+			else
+			{
+				// If the update has no extra_query, the update_site providing this update might have one, so check, and use that if found
 				$updateSiteInstance = JTable::getInstance('Updatesite');
 				$updateSiteInstance->load($instance->update_site_id);
-				if ($updateSiteInstance->extra_query){
+				if ($updateSiteInstance->extra_query)
+				{
 					$update->set('extra_query', $updateSiteInstance->extra_query);
 				}
 			}

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -359,7 +359,7 @@ class InstallerModelUpdatesites extends InstallerModel
 							{
 								foreach ($backupExtraQuerys as $extra_queries)
 								{
-									// Trim is needed here, trust me, some developers update urls are preceded/appended by spaces in the XML!
+									// Trim is required to remove any additional spaces in the XML
 									if (trim((string) $tmpInstaller->manifest->updateservers->server) === trim($extra_queries['location']))
 									{
 										$tmpInstaller->extra_query = $extra_queries['extra_query'];

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -359,6 +359,7 @@ class InstallerModelUpdatesites extends InstallerModel
 							{
 								foreach ($backupExtraQuerys as $extra_queries)
 								{
+									// Trim is needed here, trust me, some developers update urls are preceded/appended by spaces in the XML!
 									if (trim((string) $tmpInstaller->manifest->updateservers->server) === trim($extra_queries['location']))
 									{
 										$tmpInstaller->extra_query = $extra_queries['extra_query'];

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -275,7 +275,7 @@ class InstallerModelUpdatesites extends InstallerModel
 		// Gets Joomla core update sites Ids.
 		$joomlaUpdateSitesIds = implode(', ', $this->getJoomlaUpdateSitesIds(0));
 
-		// first backup any custom extra_query for the sties
+		// First backup any custom extra_query for the sites
 		$query = $db->getQuery(true)
 			->select('location, extra_query')
 			->from('#__update_sites');
@@ -351,11 +351,16 @@ class InstallerModelUpdatesites extends InstallerModel
 							// Set the manifest object and path
 							$tmpInstaller->manifest = $manifest;
 							$tmpInstaller->setPath('manifest', $file);
-							$tmpInstaller->extra_query = ''; // remove last extra_query as we are in a foreach
 
-							if ($tmpInstaller->manifest->updateservers && $tmpInstaller->manifest->updateservers->server){
-								foreach ($backupExtraQuerys as $extra_queries){
-									if (trim((string)$tmpInstaller->manifest->updateservers->server) === trim($extra_queries['location'])){
+							// Remove last extra_query as we are in a foreach
+							$tmpInstaller->extra_query = '';
+
+							if ($tmpInstaller->manifest->updateservers && $tmpInstaller->manifest->updateservers->server)
+							{
+								foreach ($backupExtraQuerys as $extra_queries)
+								{
+									if (trim((string) $tmpInstaller->manifest->updateservers->server) === trim($extra_queries['location']))
+									{
 										$tmpInstaller->extra_query = $extra_queries['extra_query'];
 									}
 								}

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -353,13 +353,13 @@ class InstallerModelUpdatesites extends InstallerModel
 							$tmpInstaller->setPath('manifest', $file);
 
 							// Remove last extra_query as we are in a foreach
-							$tmpInstaller->extra_query = '';
+							$tmpInstaller->extraQuery = '';
 
 							if ($tmpInstaller->manifest->updateservers
 								&& $tmpInstaller->manifest->updateservers->server
 								&& isset($backupExtraQuerys[trim((string) $tmpInstaller->manifest->updateservers->server)]))
 							{
-								$tmpInstaller->extra_query = $backupExtraQuerys[trim((string) $tmpInstaller->manifest->updateservers->server)]['extra_query'];
+								$tmpInstaller->extraQuery = $backupExtraQuerys[trim((string) $tmpInstaller->manifest->updateservers->server)]['extra_query'];
 							}
 
 							// Load the extension plugin (if not loaded yet).

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -277,8 +277,8 @@ class InstallerModelUpdatesites extends InstallerModel
 
 		// First backup any custom extra_query for the sites
 		$query = $db->getQuery(true)
-			->select('TRIM(location) AS location, extra_query')
-			->from('#__update_sites');
+			->select('TRIM(' . $db->quoteName('location') . ') AS ' . $db->quoteName('location') . ', ' . $db->quoteName('extra_query'))
+			->from($db->quoteName('#__update_sites'));
 		$db->setQuery($query);
 		$backupExtraQuerys = $db->loadAssocList('location');
 

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -277,10 +277,10 @@ class InstallerModelUpdatesites extends InstallerModel
 
 		// First backup any custom extra_query for the sites
 		$query = $db->getQuery(true)
-			->select('location, extra_query')
+			->select('TRIM(location) AS location, extra_query')
 			->from('#__update_sites');
 		$db->setQuery($query);
-		$backupExtraQuerys = $db->loadAssocList();
+		$backupExtraQuerys = $db->loadAssocList('location');
 
 		// Delete from all tables (except joomla core update sites).
 		$query = $db->getQuery(true)
@@ -355,16 +355,11 @@ class InstallerModelUpdatesites extends InstallerModel
 							// Remove last extra_query as we are in a foreach
 							$tmpInstaller->extra_query = '';
 
-							if ($tmpInstaller->manifest->updateservers && $tmpInstaller->manifest->updateservers->server)
+							if ($tmpInstaller->manifest->updateservers
+								&& $tmpInstaller->manifest->updateservers->server
+								&& isset($backupExtraQuerys[trim((string) $tmpInstaller->manifest->updateservers->server)]))
 							{
-								foreach ($backupExtraQuerys as $extra_queries)
-								{
-									// Trim is required to remove any additional spaces in the XML
-									if (trim((string) $tmpInstaller->manifest->updateservers->server) === trim($extra_queries['location']))
-									{
-										$tmpInstaller->extra_query = $extra_queries['extra_query'];
-									}
-								}
+								$tmpInstaller->extra_query = $backupExtraQuerys[trim((string) $tmpInstaller->manifest->updateservers->server)]['extra_query'];
 							}
 
 							// Load the extension plugin (if not loaded yet).

--- a/administrator/components/com_installer/views/updatesites/tmpl/default.php
+++ b/administrator/components/com_installer/views/updatesites/tmpl/default.php
@@ -88,6 +88,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								<br />
 								<span class="small break-word">
 									<a href="<?php echo $item->location; ?>" target="_blank" rel="noopener noreferrer"><?php echo $this->escape($item->location); ?></a>
+									<?php if ($item->extra_query): ?>
+										<br/><pre><?php echo $item->extra_query; ?></pre>
+									<?php endif; ?>
 								</span>
 							</label>
 						</td>

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -117,6 +117,14 @@ class Installer extends \JAdapter
 	protected $packageUninstall = false;
 
 	/**
+	 * Backup extra_query during update_sites rebuild
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION
+	 */
+	public $extra_query = '';
+
+	/**
 	 * Installer instance container.
 	 *
 	 * @var    Installer

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -122,7 +122,7 @@ class Installer extends \JAdapter
 	 * @var    string
 	 * @since  __DEPLOY_VERSION
 	 */
-	public $extra_query = '';
+	public $extraQuery = '';
 
 	/**
 	 * Installer instance container.

--- a/plugins/extension/joomla/joomla.php
+++ b/plugins/extension/joomla/joomla.php
@@ -39,17 +39,17 @@ class PlgExtensionJoomla extends JPlugin
 	/**
 	 * Adds an update site to the table if it doesn't exist.
 	 *
-	 * @param   string   $name         The friendly name of the site
-	 * @param   string   $type         The type of site (e.g. collection or extension)
-	 * @param   string   $location     The URI for the site
-	 * @param   boolean  $enabled      If this site is enabled
-	 * @param   string   $extra_query  Any additional request query to use when updating
+	 * @param   string   $name        The friendly name of the site
+	 * @param   string   $type        The type of site (e.g. collection or extension)
+	 * @param   string   $location    The URI for the site
+	 * @param   boolean  $enabled     If this site is enabled
+	 * @param   string   $extraQuery  Any additional request query to use when updating
 	 *
 	 * @return  void
 	 *
 	 * @since   1.6
 	 */
-	private function addUpdateSite($name, $type, $location, $enabled, $extra_query = '')
+	private function addUpdateSite($name, $type, $location, $enabled, $extraQuery = '')
 	{
 		$db = JFactory::getDbo();
 
@@ -81,7 +81,7 @@ class PlgExtensionJoomla extends JPlugin
 					// Trim to remove any whitespace from the XML file before saving the location to the db
 					. $db->quote(trim($location)) . ', '
 					. (int) $enabled . ', '
-					. $db->quote($extra_query)
+					. $db->quote($extraQuery)
 				);
 			$db->setQuery($query);
 

--- a/plugins/extension/joomla/joomla.php
+++ b/plugins/extension/joomla/joomla.php
@@ -66,8 +66,22 @@ class PlgExtensionJoomla extends JPlugin
 		{
 			$query->clear()
 				->insert('#__update_sites')
-				->columns(array($db->quoteName('name'), $db->quoteName('type'), $db->quoteName('location'), $db->quoteName('enabled'), $db->quoteName('extra_query')))
-				->values($db->quote($name) . ', ' . $db->quote($type) . ', ' . $db->quote($location) . ', ' . (int) $enabled . ', ' . $db->quote($extra_query) );
+				->columns(
+					array(
+						$db->quoteName('name'),
+						$db->quoteName('type'),
+						$db->quoteName('location'),
+						$db->quoteName('enabled'),
+						$db->quoteName('extra_query')
+					)
+				)
+				->values(
+					$db->quote($name) . ', '
+					. $db->quote($type) . ', '
+					. $db->quote($location) . ', '
+					. (int) $enabled . ', '
+					. $db->quote($extra_query)
+				);
 			$db->setQuery($query);
 
 			if ($db->execute())

--- a/plugins/extension/joomla/joomla.php
+++ b/plugins/extension/joomla/joomla.php
@@ -39,16 +39,17 @@ class PlgExtensionJoomla extends JPlugin
 	/**
 	 * Adds an update site to the table if it doesn't exist.
 	 *
-	 * @param   string   $name      The friendly name of the site
-	 * @param   string   $type      The type of site (e.g. collection or extension)
-	 * @param   string   $location  The URI for the site
-	 * @param   boolean  $enabled   If this site is enabled
+	 * @param   string   $name         The friendly name of the site
+	 * @param   string   $type         The type of site (e.g. collection or extension)
+	 * @param   string   $location     The URI for the site
+	 * @param   boolean  $enabled      If this site is enabled
+	 * @param   string   $extra_query  Any additional request query to use when updating
 	 *
 	 * @return  void
 	 *
 	 * @since   1.6
 	 */
-	private function addUpdateSite($name, $type, $location, $enabled)
+	private function addUpdateSite($name, $type, $location, $enabled, $extra_query = '')
 	{
 		$db = JFactory::getDbo();
 
@@ -65,8 +66,8 @@ class PlgExtensionJoomla extends JPlugin
 		{
 			$query->clear()
 				->insert('#__update_sites')
-				->columns(array($db->quoteName('name'), $db->quoteName('type'), $db->quoteName('location'), $db->quoteName('enabled')))
-				->values($db->quote($name) . ', ' . $db->quote($type) . ', ' . $db->quote($location) . ', ' . (int) $enabled);
+				->columns(array($db->quoteName('name'), $db->quoteName('type'), $db->quoteName('location'), $db->quoteName('enabled'), $db->quoteName('extra_query')))
+				->values($db->quote($name) . ', ' . $db->quote($type) . ', ' . $db->quote($location) . ', ' . (int) $enabled . ', ' . $db->quote($extra_query) );
 			$db->setQuery($query);
 
 			if ($db->execute())
@@ -247,7 +248,7 @@ class PlgExtensionJoomla extends JPlugin
 			foreach ($children as $child)
 			{
 				$attrs = $child->attributes();
-				$this->addUpdateSite($attrs['name'], $attrs['type'], trim($child), true);
+				$this->addUpdateSite($attrs['name'], $attrs['type'], trim($child), true, $this->installer->extra_query);
 			}
 		}
 		else

--- a/plugins/extension/joomla/joomla.php
+++ b/plugins/extension/joomla/joomla.php
@@ -78,7 +78,8 @@ class PlgExtensionJoomla extends JPlugin
 				->values(
 					$db->quote($name) . ', '
 					. $db->quote($type) . ', '
-					. $db->quote($location) . ', '
+					// Trim to remove any whitespace from the XML file before saving the location to the db
+					. $db->quote(trim($location)) . ', '
 					. (int) $enabled . ', '
 					. $db->quote($extra_query)
 				);

--- a/plugins/extension/joomla/joomla.php
+++ b/plugins/extension/joomla/joomla.php
@@ -263,7 +263,7 @@ class PlgExtensionJoomla extends JPlugin
 			foreach ($children as $child)
 			{
 				$attrs = $child->attributes();
-				$this->addUpdateSite($attrs['name'], $attrs['type'], trim($child), true, $this->installer->extra_query);
+				$this->addUpdateSite($attrs['name'], $attrs['type'], trim($child), true, $this->installer->extraQuery);
 			}
 		}
 		else


### PR DESCRIPTION
### Summary of Changes

This PR is a first pass attempt at resolving some of the long running issues with the storage and passing of the `extra_query` to update urls.

Namely these issues are addressed in this PR:

1) Once an update has been discovered, the `#__updates` table is populated with a copy of the `extra_query` from the `#__update_sites` table. If a user then goes and adds a new/updates a `extra_query` using an extension (this populates the `#__update_sites.extra_query` table ONLY!) then the *already discovered update* will fail to work, as the `#__updates. extra_query` is the one appended to the update URL at update time. 

2) On clicking `Rebuild` button on the update sites page, any previously entered `extra_query` that is stored in `#__update_sites.extra_query` is lost. This PR will preserve the `#__update_sites.extra_query` value based on the URL of the `location` of a URL. As long as the URL remains the same, the newly inserted row in `#__update_sites` after rebuild will still contain the value of the `#__update_sites.extra_query` from before the rebuild - thus preserving this value. 

3) Updates sites do not display in the admin interface the `extra_query` value like Joomla 4 does.

4) Location URLS can contain whitespace at the start and end of a URL if the XML has whitespace for formatting

### Background

Well, `#__update_sites.extra_query` is any string value a developer wants to place in that table column, which, when checking for updates, will be appended to the update Url. 

It is commonly used to positively identify a particular user, site, subscription or "license" for commercial (but not exclusively commercial use!) 

### Testing Instructions

as below

### Actual result BEFORE applying this Pull Request

1) Install an old version of an extension that requires an `extra_query` to update it later. Go to check for updates in Joomla Update Manager, see that you have discovered the update. Go to your extension and enter your new download id/`extra_query` provided by your supplier. Go back to the updates page and attempt to apply the cached update. See that the *update fails!* with some kind of rejection/403 from your supplier.

2) View your `#__update_sites` table, enter some values for `#__update_sites.extra_query` - Click Rebuild on the Update Sites Page - note that `#__update_sites.extra_query` values are now *missing*.

3)  Install an old version of an extension that requires an `extra_query` to update it later. Add the Download ID/Update Id/`extra_query` provided by the vendor. Go to the Update Sites screen and see *no visual indication that there is a `extra_query` stored for this update site.*

### Expected result AFTER applying this Pull Request

1) Install an old version of an extension that requires an `extra_query` to update it later. Go to check for updates in Joomla Update Manager, see that you have discovered the update. Go to your extension and enter your new download id/`extra_query` provided by your supplier. Go back to the updates page and attempt to apply the cached update. See that the *update succeeds!*

2) View your `#__update_sites` table, enter some values for `#__update_sites.extra_query` - Click Rebuild on the Update Sites Page - note that `#__update_sites.extra_query` values are now *preserved*.

3)  Install an old version of an extension that requires an `extra_query` to update it later. Add the Download ID/Update Id/`extra_query` provided by the vendor. Go to the Update Sites screen and see *a new visual indication that there is a `extra_query` stored for this update site.*

4) All urls imported from XML are trimmed of their surrounding whitespace

### Documentation Changes Required

None. 

### Testing Instructions

Edit lin 420 of administrator/components/com_installer/models/update.php to add `echo $url; die;` this will echo out the URL that Joomla will attempt to download any updates from, and we can look at that debug output and see if an extra query was used or not in our tests.  We are not interested in the actual download of the file or applying the update, as those code areas have not been touched, we are only interested in the URL used.


1) 
Install Joomla 3
install https://www.joomlacontenteditor.net/downloads/editor/core?task=release.download&id=223
Go to Extensions -> Manage -> update -> clear cache -> find updates -> You will see JCE 2.9.4 available
Edit your `#__update_sites` table and set extra_query = `ABCDEF` where the name = JCE Editor Package (this simulated a Pro version of an extension saving an extra query)
Attempt to apply the update - note that the debug print of the URL DOESNT CONTAIN THE ABCDEF appended.
Rebuild your site then Apply PR and repeat above -> Note that the  debug print of the URL DOES CONTAIN THE ABCDEF appended.


2) 
Install Joomla 3
install https://www.joomlacontenteditor.net/downloads/editor/core?task=release.download&id=223
Edit your `#__update_sites` table and set extra_query = `ABCDEF` where the name = JCE Editor Package (this simulated a Pro version of an extension saving an extra query)
In Joomla Admin -> Extensions-> Manage -> Update Sites -> Click rebuild
Inspect the database - `#__update_sites` table entry you added for ABCDEF is removed
Rebuild your site then Apply PR and repeat above, this time the ABCDEF is retained after Rebuild button is pressed, and the extra_query is also displayed on the page

3) 
Install Joomla 3
install https://www.joomlacontenteditor.net/downloads/editor/core?task=release.download&id=223
Edit your `#__update_sites` table and set extra_query = `ABCDEF` where the name = JCE Editor Package (this simulated a Pro version of an extension saving an extra query)
Visit Joomla Admin -> Extensions-> Manage -> Update Sites 
Note there is nothing to indicate that there is an extra_query
Apply PR
refresh the page and you can now see the extra_query in a new pre box. 

4) 
Install Joomla 3
install https://www.joomlacontenteditor.net/downloads/editor/core?task=release.download&id=223
Inspect your `#__update_sites` table and see additional whitespace before the URL 
Rebuild your site then Apply PR and repeat above 
Inspect your `#__update_sites` table and see NO additional whitespace before the URL 

4) 
Install Joomla 3
install an extension that has trailing or prepended space to the update server url in its XML file. 
Inspect your `#__update_sites` table and see additional whitespace before the URL 
Rebuild your site then Apply PR and repeat above 
Inspect your `#__update_sites` table and see NO additional whitespace before the URL 


### History

This addresses some of https://github.com/joomla/joomla-cms/issues/32592 / https://github.com/joomla/joomla-cms/issues/32597