### PR TITLE
[4.0] Fix for Button Log out staying when session manager is file

### DIFF
--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -431,6 +431,23 @@ class PlgUserJoomla extends CMSPlugin
 			{
 				return false;
 			}
+
+			// If session manager is not database we need to clean up the internal session table
+			if ('database' !== $this->app->get('session_handler', 'filesystem'))
+			{
+				$query = $this->db->getQuery(true)
+					->delete($this->db->quoteName('#__session'))
+					->whereIn($this->db->quoteName('session_id'),  $sessionIds, ParameterType::STRING);
+
+				try
+				{
+					$this->db->setQuery($query)->execute();
+				}
+				catch (ExecutionFailureException $e)
+				{
+					return false;
+				}
+			}
 		}
 
 		// Delete "user state" cookie used for reverse caching proxies like Varnish, Nginx etc.


### PR DESCRIPTION
Follow up  on PR #29007

### Summary of Changes

When the session manager is file and you are trying to log out a user in the frontend, the Log Out Button doesn't go away. The reason is that we still have a row in the session table. 

The user is loged out and when you refresh the frontend the button is going away in the backend. That's kind of confusing because it looks as it hadn't worked.

### Testing Instructions

* Set session mananger to file
* Create a user
* Login with the user in the frontend
* Login with a superuser account in the backend
* Try to log out the user you are logged in in frontend

You should see that the button stays

* Go to the frontend an refresh the page

Now you can see that the Button is not longer there after refreshing the backend

* Apply this PR
* Login with the user in the frontend
* Login with a superuser account in the backend
* Try to log out the user you are logged in in frontend

Button goes away.

### Actual result BEFORE applying this Pull Request

![grafik](https://user-images.githubusercontent.com/467356/112487297-e73e1a00-8d7c-11eb-9fd8-60b48e27fe91.png)


### Expected result AFTER applying this Pull Request

![grafik](https://user-images.githubusercontent.com/467356/112487489-09d03300-8d7d-11eb-84fe-82461b750bde.png)


### Documentation Changes Required

no