### PR TITLE
[4.0] Subforms/subfields

### DIFF
--- a/administrator/language/en-GB/plg_fields_subfields.ini
+++ b/administrator/language/en-GB/plg_fields_subfields.ini
@@ -3,10 +3,10 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_FIELDS_SUBFIELDS="Fields - Subfields"
-PLG_FIELDS_SUBFIELDS_LABEL="Subfields (%s)"
-PLG_FIELDS_SUBFIELDS_PARAMS_CUSTOMFIELD_LABEL="Subfield"
-PLG_FIELDS_SUBFIELDS_PARAMS_OPTIONS_LABEL="Subfields"
+PLG_FIELDS_SUBFIELDS="Fields - Subform"
+PLG_FIELDS_SUBFIELDS_LABEL="Subform (%s)"
+PLG_FIELDS_SUBFIELDS_PARAMS_CUSTOMFIELD_LABEL="Field"
+PLG_FIELDS_SUBFIELDS_PARAMS_OPTIONS_LABEL="Fields"
 PLG_FIELDS_SUBFIELDS_PARAMS_RENDER_VALUES_LABEL="Render Values"
 PLG_FIELDS_SUBFIELDS_PARAMS_REPEAT_LABEL="Repeatable"
-PLG_FIELDS_SUBFIELDS_XML_DESCRIPTION="This plugin lets you create new fields of type 'subfields' in any extension where custom fields are supported."
+PLG_FIELDS_SUBFIELDS_XML_DESCRIPTION="This plugin lets you create new fields of type 'subform' which contain one or more fields in any extension where custom fields are supported."

--- a/administrator/language/en-GB/plg_fields_subfields.sys.ini
+++ b/administrator/language/en-GB/plg_fields_subfields.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_FIELDS_SUBFIELDS="Fields - Subfields"
-PLG_FIELDS_SUBFIELDS_XML_DESCRIPTION="This plugin lets you create new fields of type 'subfields' in any extension where custom fields are supported."
+PLG_FIELDS_SUBFIELDS="Fields - Subform"
+PLG_FIELDS_SUBFIELDS_XML_DESCRIPTION="This plugin lets you create new fields of type 'subform' which contain one or more fields in any extension where custom fields are supported."


### PR DESCRIPTION
I was doing some work today with the new subfields and I found it quite difficult to explain. I think that instead of saying

"This plugin lets you create new fields of type 'subfields' in any extension where custom fields are supported."

We change it so that field is called subform and the fields inside it are just fields

"This plugin lets you create new fields of type 'subform' that contains one or more fields in any extension where custom fields are supported."