### PR TITLE
Bug: Correcting Administrator menu items types display

### DIFF
--- a/administrator/components/com_menus/views/items/view.html.php
+++ b/administrator/components/com_menus/views/items/view.html.php
@@ -156,12 +156,14 @@ class MenusViewItems extends JViewLegacy
 							}
 							else
 							{
+								$base = $this->state->get('filter.client_id') == 0 ? JPATH_SITE : JPATH_ADMINISTRATOR;
+
 								// Get XML file from component folder for standard layouts
-								$file = JPATH_SITE . '/components/' . $item->componentname . '/views/' . $vars['view'] . '/tmpl/' . $vars['layout'] . '.xml';
+								$file = $base . '/components/' . $item->componentname . '/views/' . $vars['view'] . '/tmpl/' . $vars['layout'] . '.xml';
 
 								if (!file_exists($file))
 								{
-									$file = JPATH_SITE . '/components/' . $item->componentname . '/view/' . $vars['view'] . '/tmpl/' . $vars['layout'] . '.xml';
+									$file = $base . '/components/' . $item->componentname . '/view/' . $vars['view'] . '/tmpl/' . $vars['layout'] . '.xml';
 								}
 							}
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/32855

### Summary of Changes
Backend custom menu items types should fetch the correct xml. Path modified to fit depending on filter state.
For example instead of `article` we will correctly get `Create Article`
Instead of `articles` we will get `List All Articles`
etc.


### Testing Instructions
Create an admin menu and some menu items.

<img width="432" alt="Screen Shot 2021-03-26 at 09 19 10" src="https://user-images.githubusercontent.com/869724/112602768-629eda80-8e14-11eb-96f0-fca4616d5ef7.png">

Set Debug Language on.
Display the menu items manager filtered by administrator

### Actual result BEFORE applying this Pull Request

<img width="586" alt="Screen Shot 2021-03-26 at 09 13 57" src="https://user-images.githubusercontent.com/869724/112602974-a2fe5880-8e14-11eb-8d32-5fd0e37acf5c.png">


### Expected result AFTER applying this Pull Request

<img width="672" alt="Screen Shot 2021-03-26 at 09 11 47" src="https://user-images.githubusercontent.com/869724/112603002-aa256680-8e14-11eb-80ab-dc8e96281240.png">

