### PR TITLE
[4.0] Repeatable grouped buttons [a11y]

### DIFF
--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -94,7 +94,7 @@ else
 						<td style="width:8%;">
 							<?php if (!empty($buttons['add'])) : ?>
 								<div class="btn-group">
-									<button type="button" class="group-add btn btn-sm btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
+									<button type="button" class="group-add btn btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
 										<span class="icon-plus" aria-hidden="true"></span>
 									</button>
 								</div>

--- a/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
@@ -35,17 +35,17 @@ extract($displayData);
 	<td>
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?>
-				<button type="button" class="group-add btn btn-sm btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
+				<button type="button" class="group-add btn btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
 					<span class="icon-plus" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?>
-				<button type="button" class="group-remove btn btn-sm btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>">
+				<button type="button" class="group-remove btn btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>">
 					<span class="icon-minus" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?>
-				<button type="button" class="group-move btn btn-sm btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>">
+				<button type="button" class="group-move btn btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>">
 					<span class="icon-arrows-alt" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable-table/section.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section.php
@@ -33,17 +33,17 @@ extract($displayData);
 	<td>
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?>
-				<button type="button" class="group-add btn btn-sm btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
+				<button type="button" class="group-add btn btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
 					<span class="icon-plus" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?>
-				<button type="button" class="group-remove btn btn-sm btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>">
+				<button type="button" class="group-remove btn btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>">
 					<span class="icon-minus" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?>
-				<button type="button" class="group-move btn btn-sm btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>">
+				<button type="button" class="group-move btn btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>">
 					<span class="icon-arrows-alt" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -48,7 +48,7 @@ $sublayout = empty($groupByFieldset) ? 'section' : 'section-byfieldsets';
 			<?php if (!empty($buttons['add'])) : ?>
 			<div class="btn-toolbar">
 				<div class="btn-group">
-					<button type="button" class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
+					<button type="button" class="group-add btn button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
 						<span class="icon-plus icon-white" aria-hidden="true"></span>
 					</button>
 				</div>

--- a/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
@@ -27,9 +27,9 @@ extract($displayData);
 	<?php if (!empty($buttons)) : ?>
 	<div class="btn-toolbar text-end">
 		<div class="btn-group">
-			<?php if (!empty($buttons['add'])) : ?><button type="button" class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>"><span class="icon-plus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
-			<?php if (!empty($buttons['remove'])) : ?><button type="button" class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>"><span class="icon-minus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
-			<?php if (!empty($buttons['move'])) : ?><button type="button" class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['add'])) : ?><button type="button" class="group-add btn button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>"><span class="icon-plus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['remove'])) : ?><button type="button" class="group-remove btn button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>"><span class="icon-minus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['move'])) : ?><button type="button" class="group-move btn button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </button><?php endif; ?>
 		</div>
 	</div>
 	<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable/section.php
+++ b/layouts/joomla/form/field/subform/repeatable/section.php
@@ -27,9 +27,9 @@ extract($displayData);
 	<?php if (!empty($buttons)) : ?>
 	<div class="btn-toolbar text-end">
 		<div class="btn-group">
-			<?php if (!empty($buttons['add'])) : ?><button type="button" class="group-add btn btn-sm button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>"><span class="icon-plus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
-			<?php if (!empty($buttons['remove'])) : ?><button type="button" class="group-remove btn btn-sm button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>"><span class="icon-minus icon-white" aria-hidden="true"></button> </a><?php endif; ?>
-			<?php if (!empty($buttons['move'])) : ?><button type="button" class="group-move btn btn-sm button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['add'])) : ?><button type="button" class="group-add btn button btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>"><span class="icon-plus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['remove'])) : ?><button type="button" class="group-remove btn button btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>"><span class="icon-minus icon-white" aria-hidden="true"></button> </a><?php endif; ?>
+			<?php if (!empty($buttons['move'])) : ?><button type="button" class="group-move btn button btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </button><?php endif; ?>
 		</div>
 	</div>
 	<?php endif; ?>


### PR DESCRIPTION
The three buttons for add/delete/move that are displayed as a group for repeatable fields are too small. This is an accessibility and usability problem as it makes it difficult to select the correct button.

The apple ios guidelines for touch targets suggest 44px and the equivalent for android is 48.

By simply removing the btn-sm class from these buttons we satisfy those guidelines and its much much easier to select the correct button

This can be tested by creating a field of type subform and/or in the User options go to the email domain settings

### Before
![image](https://user-images.githubusercontent.com/1296369/112618864-81a26a00-8e1e-11eb-84aa-848383476f74.png)

### After
![image](https://user-images.githubusercontent.com/1296369/112618628-3c7e3800-8e1e-11eb-95ad-fcb62527cb38.png)
