### PR TITLE
[4.0] Email Domain Options

### DIFF
--- a/administrator/components/com_users/config.xml
+++ b/administrator/components/com_users/config.xml
@@ -128,13 +128,13 @@
 	<fieldset
 		name="domain_options"
 		label="COM_USERS_CONFIG_DOMAIN_OPTIONS"
+		description="COM_USERS_CONFIG_FIELD_DOMAINS_DESC"
 		>
 
 		<field
 			name="domains"
 			type="subform"
 			label="COM_USERS_CONFIG_FIELD_DOMAINS_LABEL"
-			description="COM_USERS_CONFIG_FIELD_DOMAINS_DESC"
 			hiddenLabel="true"
 			multiple="true"
 			layout="joomla.form.field.subform.repeatable-table"


### PR DESCRIPTION
The description of this option was on the repeatable subform. (See image 1) This is fine until you have some entries and the description is now lost at the bottom (see image 2). This PR moves the description to the fieldset which keeps it at the top and changes the styling so is much more consistent with similar tabs eg Mass Mail Users See image 3

### Image 1
![image](https://user-images.githubusercontent.com/1296369/112641256-1d8d9f00-8e3a-11eb-9ea2-c6cdf679aace.png)

### Image 2
![image](https://user-images.githubusercontent.com/1296369/112641306-29796100-8e3a-11eb-8f92-5c92179cc70a.png)

### Image 3 (after PR)
![image](https://user-images.githubusercontent.com/1296369/112641344-34cc8c80-8e3a-11eb-9f58-7b2daa5c8605.png)
