### PR TITLE
[4.0] Remove .bg-white

### DIFF
--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -71,7 +71,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 				</div>
 			</div>
 			<div class="col-lg-3">
-				<div class="bg-white px-3">
+				<div class="px-3">
 				<?php echo LayoutHelper::render('joomla.edit.global', $this); ?>
 				</div>
 			</div>

--- a/build/media_source/templates/atum/js/template.es6.js
+++ b/build/media_source/templates/atum/js/template.es6.js
@@ -278,9 +278,9 @@
     if (subhead) {
       doc.addEventListener('scroll', () => {
         if (window.scrollY > 0) {
-          subhead.classList.add('bg-white', 'shadow-sm');
+          subhead.classList.add('shadow-sm');
         } else {
-          subhead.classList.remove('bg-white', 'shadow-sm');
+          subhead.classList.remove('shadow-sm');
         }
       });
     }


### PR DESCRIPTION
### Summary of Changes
The background color is already white. No need to add .bg-white which affects dark themes.

For the subhead, it has the white background, thus, no need to add .bg-white.

### Testing Instructions
Code review.

or

1. Install a dark theme: https://github.com/C-Lodder/joomla4-backend-template
Add/Edit an article.

![bg-white](https://user-images.githubusercontent.com/368084/112667217-3d14cf80-8e1a-11eb-9b2d-4810353f7091.jpg)

2. Run `npm run build:js`
Switch to Atum.
Scroll up to display the subhead in Atum as before.
