### PR TITLE
[3] Ensure that url alias segments correspond to real aliases of articles/categories

### DIFF
--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -468,7 +468,6 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 			}
 			else
 			{
-
 				$alias = str_replace(':', '-',  $segments[$count - 1]);
 
 				if (!$this->checkCategoryEqualsProvided($alias))

--- a/components/com_content/helpers/legacyrouter.php
+++ b/components/com_content/helpers/legacyrouter.php
@@ -560,7 +560,7 @@ class ContentRouterRulesLegacy implements JComponentRouterRulesInterface
 	/**
 	 * Checks if the user supplied alias in the URL is a valid alias in the db
 	 *
-	 * @param   array  $alias  The user supplied alias in the URL
+	 * @param   string  $alias  The user supplied alias in the URL
 	 *
 	 * @return bool
 	 *


### PR DESCRIPTION
Issue #32490 and many others

### Summary of Changes

This PR attempts to close a long standing issue where you can manipulate Joomla's urls and the router will still work. 

This can be easily seen on the official Joomla.org site at: 

https://www.joomla.org/announcements/BLAHBLAHBLAHBLAHBLAHBLAH/5834-LALALALALALALLALALALALALA

https://www.joomla.org/announcements/i/HACK/HACKED/YOUR/SITE/YOU/SUCK/5834-LALALALALALALLALALALALALA

Where BLAHBLAHBLAHBLAHBLAHBLAH is a made up category name and `LALALALALALALLALALALALALA` is a made up article alias. 

That fake url still loads the "Joomla 3.9.25 Release" article which has id 5834. It should, IMHO, and in the opinion of others, be a 404, as `LALALALALALALLALALALALALA` could be `Joomla-Sucks` or anything else SEO that a hacker wants to use. 

### Testing Instructions

Enabled SEF and rewrite. (Legacy, not modern)

Create yourself a category tree of lets say three categories (as a real test, you choose how many you want, it should still work), each a child of the last, and then an article (with alias my-article) in the bottom most category

Top Most -> Middle Most -> Bottom Most -> my-article

Visit the home page and you should see the link to My Article in the Latest Articles Module, click it and get a SEF url of 

https://example.com/9-top-most/middle-most/bottom-most/3-my-article

Where 9 is the id of my category "Bottom Most" and 3 is the id of My Article (Yours might be different ids) 

### Actual result BEFORE applying this Pull Request

Before this PR you can manipulate the url and replace one or more of aliases with HHHH like below, **these urls STILL WORK:**

https://example.com/9-top-most/middle-most/bottom-most/3-HAHA
https://example.com/9-top-most/middle-most/HAHA/3-HAHA
https://example.com/9-top-most/HAHA/HAHA/3-HAHA
https://example.com/9-HAHA/HAHA/HAHA/3-HAHA

### Expected result AFTER applying this Pull Request

After this P, when you manipulate the url and replace one or more of aliases with HHHH like below, **these urls DONT WORK:** and now lead correctly to a 404 page.

https://example.com/9-top-most/middle-most/bottom-most/3-HAHA
https://example.com/9-top-most/middle-most/HAHA/3-HAHA
https://example.com/9-top-most/HAHA/HAHA/3-HAHA
https://example.com/9-HAHA/HAHA/HAHA/3-HAHA

But accessing the full generated url with aliases correct STILL WORKS

https://example.com/9-top-most/middle-most/bottom-most/3-my-article

### Documentation Changes Required

~~**This is backward compatible**~~ _apparently not, people disagree with me, Cool. Not my decision to make._ 

All the new code is doing is running 2n more queries to validate the aliases provided against either the alias of a category or article with a known id, or in the case of nested categories, that ANY category in the db has the provided alias (nor perfect, I know, but much better than it currently is, and this is only for the Middle Most and Top Most category if there are 3 or more nested categories). 

There is one more case I wanted to address but ran out of time and that is with the new MODERN routing its possible to generate a url like: 

https://example.com/?view=article&id=3:my-article&catid=9

where `my-article` is the alias of the My Article (id:3) article. This can also be manipulated like:

https://example.com/?view=article&id=3:HAHA&catid=9

and that url will still work correctly. This still needs addressing and has been forked to https://github.com/joomla/joomla-cms/issues/32880 as not to be forgotten

// cc @brianteeman  @Ruud68