### PR TITLE
Featuredmobile

### DIFF
--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -118,7 +118,7 @@ $assoc = Associations::isEnabled();
 									<?php echo HTMLHelper::_('searchtools.sort', '', 'fp.ordering', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-sort'); ?>
 								</th>
 								<?php if ($workflow_enabled) : ?>
-								<th scope="col" class="w-1 text-center d-none d-md-table-cell">
+								<th scope="col" class="w-1 text-center">
 									<?php echo HTMLHelper::_('searchtools.sort', 'JSTAGE', 'ws.title', $listDirn, $listOrder); ?>
 								</th>
 								<?php endif; ?>

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -118,9 +118,9 @@ $assoc = Associations::isEnabled();
 									<?php echo HTMLHelper::_('searchtools.sort', '', 'fp.ordering', $listDirn, $listOrder, null, 'asc', 'JGRID_HEADING_ORDERING', 'icon-sort'); ?>
 								</th>
 								<?php if ($workflow_enabled) : ?>
-								<th scope="col" class="w-1 text-center">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JSTAGE', 'ws.title', $listDirn, $listOrder); ?>
-								</th>
+									<th scope="col" class="w-1 text-center">
+										<?php echo HTMLHelper::_('searchtools.sort', 'JSTAGE', 'ws.title', $listDirn, $listOrder); ?>
+									</th>
 								<?php endif; ?>
 								<th scope="col" class="w-1 text-center d-none d-md-table-cell">
 									<?php echo Text::_('JFEATURED'); ?>

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -122,7 +122,7 @@ $assoc = Associations::isEnabled();
 									<?php echo HTMLHelper::_('searchtools.sort', 'JSTAGE', 'ws.title', $listDirn, $listOrder); ?>
 								</th>
 								<?php endif; ?>
-								<th scope="col" class="w-1 text-center">
+								<th scope="col" class="w-1 text-center d-none d-md-table-cell">
 									<?php echo Text::_('JFEATURED'); ?>
 								</th>
 								<th scope="col" style="min-width:85px" class="w-1 text-center">
@@ -229,7 +229,7 @@ $assoc = Associations::isEnabled();
 									</div>
 								</td>
 								<?php endif; ?>
-								<td class="text-center">
+								<td class="text-center d-none d-md-table-cell">
 								<?php
 									$options = [
 										'task_prefix' => 'articles.',


### PR DESCRIPTION
The number of cells in the table header should be the same as the number of cells in the table.

When workflow is enabled and you switch to mobile view then the status header is hidden but the content is not.

This PR makes sure the header is displayed at all sizes.

This PR also hides the featured column on mobile. Its already hidden on the regular articles view.

### Before
![image](https://user-images.githubusercontent.com/1296369/112695748-83027f80-8e7c-11eb-8d74-b15bef86af6b.png)

### After
![image](https://user-images.githubusercontent.com/1296369/112695655-649c8400-8e7c-11eb-8ceb-1ba4010e45f4.png)
