### PR TITLE
[3.10] Fix wrong td in thead of pre-update check

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_preupdatecheck.php
@@ -130,17 +130,17 @@ $compatibilityTypes = array(
 			</p>
 			<table class="table">
 				<thead>
-				<tr>
-					<td>
-						<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_DIRECTIVE'); ?>
-					</td>
-					<td>
-						<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_RECOMMENDED'); ?>
-					</td>
-					<td>
-						<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_ACTUAL'); ?>
-					</td>
-				</tr>
+					<tr>
+						<th>
+							<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_DIRECTIVE'); ?>
+						</th>
+						<th>
+							<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_RECOMMENDED'); ?>
+						</th>
+						<th>
+							<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_ACTUAL'); ?>
+						</th>
+					</tr>
 				</thead>
 				<tbody>
 					<?php foreach ($this->phpSettings as $setting) : ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Change wrong `<td>` to `<th>` in table header of the required PHP settings in the pre-update checker.

### Testing Instructions

Code review, or check the update checker and inspect markup before and after applying the patch for this PR.

### Actual result BEFORE applying this Pull Request

See the green elliptic marks in the following screenshots for how it should be, and red what is wrong.

![2021-03-27_j310-pre-update-check-before-th-fix](https://user-images.githubusercontent.com/7413183/112722739-7e38dc80-8f0b-11eb-9263-5b201507c939.png)

![2021-03-27_j310-pre-update-check-before-th-fix_html](https://user-images.githubusercontent.com/7413183/112722745-83962700-8f0b-11eb-880a-3e71d3e424c5.png)

### Expected result AFTER applying this Pull Request

![2021-03-27_j310-pre-update-check-after-th-fix](https://user-images.githubusercontent.com/7413183/112722747-88f37180-8f0b-11eb-80cb-bb591c8aa187.png)

![2021-03-27_j310-pre-update-check-after-th-fix_html](https://user-images.githubusercontent.com/7413183/112722749-8bee6200-8f0b-11eb-8c45-87dd8ca45082.png)

### Documentation Changes Required

None.