### PR TITLE
[4] After authentication failure, return to the login page with a GET request

### DIFF
--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -77,27 +77,19 @@ class DisplayController extends BaseController
 		$credentials = $model->getState('credentials');
 		$return = $model->getState('return');
 
-		$result = $app->login($credentials, array('action' => 'core.login.admin'));
+		$app->login($credentials, array('action' => 'core.login.admin'));
 
-		if ($result && !($result instanceof \Exception))
+		if (Uri::isInternal($return))
 		{
-			// Only redirect to an internal URL.
-			if (Uri::isInternal($return))
+			// If &tmpl=component don't redirect to index.php
+			if (strpos($return, 'tmpl=component') === false)
 			{
-				// If &tmpl=component don't redirect to index.php
-				if (strpos($return, 'tmpl=component') === false)
-				{
-					$app->redirect($return);
-				}
-				else
-				{
-					$app->redirect('index.php');
-				}
+				$app->redirect($return);
 			}
-		}
-		else
-		{
-			$app->redirect('index.php');
+			else
+			{
+				$app->redirect('index.php');
+			}
 		}
 	}
 

--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -79,17 +79,13 @@ class DisplayController extends BaseController
 
 		$app->login($credentials, array('action' => 'core.login.admin'));
 
-		if (Uri::isInternal($return))
+		if (Uri::isInternal($return) && strpos($return, 'tmpl=component') === false)
 		{
-			// If &tmpl=component don't redirect to index.php
-			if (strpos($return, 'tmpl=component') === false)
-			{
-				$app->redirect($return);
-			}
-			else
-			{
-				$app->redirect('index.php');
-			}
+			$app->redirect($return);
+		}
+		else
+		{
+			$app->redirect('index.php');
 		}
 	}
 

--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -84,7 +84,7 @@ class DisplayController extends BaseController
 			// Only redirect to an internal URL.
 			if (Uri::isInternal($return))
 			{
-				// If &tmpl=component - redirect to index.php
+				// If &tmpl=component don't redirect to index.php
 				if (strpos($return, 'tmpl=component') === false)
 				{
 					$app->redirect($return);
@@ -95,8 +95,10 @@ class DisplayController extends BaseController
 				}
 			}
 		}
-
-		$this->display();
+		else
+		{
+			$app->redirect('index.php');
+		}
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # https://github.com/joomla/joomla-cms/issues/32895

### Summary of Changes

After attempting to login with invalid credentials, you are not redirected back to the login page, so pressing refresh actually attempts to send the POST request a second time. 

Administrator login form doesn't follow Post/Redirect/Get pattern

(also a quick typo fix in comment)

### Testing Instructions

Attempt to login to Joomla 4 with invalid credentials. 
Inspect the requests/responses with browser inspector tools

### Actual result BEFORE applying this Pull Request

Request: POST of invalid credentials 
Response: HTML with error message, if you refresh the page the browser asks to resend the form

### Expected result AFTER applying this Pull Request

Request: POST of invalid credentials 
Response: 303 Other redirect to /administrator/index.php
browser follows redirect (not always shown in the inspector on some browsers, look hard, it fooled me too) 
Response: GET /administrator/index.php, if you refresh the page the browser just performs a refresh (GET) and validation message is missing as its already displayed

### Documentation Changes Required

none