### PR TITLE
[4][com_finder] Remove redundant sql query from running twice

### DIFF
--- a/administrator/components/com_finder/src/Model/IndexModel.php
+++ b/administrator/components/com_finder/src/Model/IndexModel.php
@@ -327,8 +327,6 @@ class IndexModel extends ListModel
 			->from($db->quoteName('#__finder_links'));
 		$db->setQuery($query);
 
-		$db->execute();
-
 		return (int) $db->loadResult();
 	}
 


### PR DESCRIPTION
### Summary of Changes

This is clearly wrong on code review. 

### Testing Instructions

Enable debug mode 
visit https://example.com/administrator/index.php?option=com_finder&view=index
inspect the db queries run

### Actual result BEFORE applying this Pull Request

The following SQL query is run twice, once on `execute` and once on `loadResult`

```sql
SELECT COUNT(link_id)
FROM `jos_finder_links`
```

<img width="973" alt="Screenshot 2021-03-28 at 18 58 00" src="https://user-images.githubusercontent.com/400092/112762426-8c642700-8ff7-11eb-96fd-47a4214734b6.png">


### Expected result AFTER applying this Pull Request

The following SQL query is run once, on `loadResult`

```sql
SELECT COUNT(link_id)
FROM `jos_finder_links`
```

Page loads 2.53ms faster ;-) 

### Documentation Changes Required

none