### PR TITLE
[4] Display relative date instead of date stamp in user action log module

### DIFF
--- a/administrator/modules/mod_latestactions/tmpl/default.php
+++ b/administrator/modules/mod_latestactions/tmpl/default.php
@@ -29,7 +29,7 @@ use Joomla\CMS\Language\Text;
 				<?php echo $item->message; ?>
 			</td>
 			<td>
-				<?php echo HTMLHelper::_('date', $item->log_date, Text::_('DATE_FORMAT_LC5')); ?>
+				<?php echo HTMLHelper::_('date.relative', $item->log_date); ?>
 			</td>
 		</tr>
 		<?php endforeach; ?>


### PR DESCRIPTION
### Summary of Changes

Propose to use a relative date (5 minutes ago) in the Latest Actions module rather than a date stamp. (2020-02-01)

### Testing Instructions

Ensure you have some Actions in your User Action Log 
Check the Home Dashboard -> Latest Actions module - look at it
Apply PR
Look at it again and note the times are now relative

### Actual result BEFORE applying this Pull Request

<img width="654" alt="Screenshot 2021-03-28 at 21 04 36" src="https://user-images.githubusercontent.com/400092/112766381-79f2e900-9009-11eb-8dc1-3f97489037d1.png">

### Expected result AFTER applying this Pull Request

<img width="651" alt="Screenshot 2021-03-28 at 21 04 18" src="https://user-images.githubusercontent.com/400092/112766383-7b241600-9009-11eb-9517-89445dd9c1dd.png">

### Documentation Changes Required

none