### PR TITLE
[4] Show relative date instead of date time in logged in module

### DIFF
--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 ?>
@@ -54,7 +55,7 @@ use Joomla\CMS\Language\Text;
 					<?php endif; ?>
 				</td>
 				<td>
-					<?php echo HTMLHelper::_('date.relative', JFactory::getDate($user->time)); ?>
+					<?php echo HTMLHelper::_('date.relative', Factory::getDate($user->time)); ?>
 				</td>
 			</tr>
 		<?php endforeach; ?>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -54,7 +54,7 @@ use Joomla\CMS\Language\Text;
 					<?php endif; ?>
 				</td>
 				<td>
-					<?php echo HTMLHelper::_('date.relative', date('Y-m-d H:i:s', $user->time)); ?>
+					<?php echo HTMLHelper::_('date.relative', JFactory::getDate($user->time)); ?>
 				</td>
 			</tr>
 		<?php endforeach; ?>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -54,7 +54,7 @@ use Joomla\CMS\Language\Text;
 					<?php endif; ?>
 				</td>
 				<td>
-					<?php echo HTMLHelper::_('date', $user->time, Text::_('DATE_FORMAT_LC5')); ?>
+					<?php echo HTMLHelper::_('date.relative', date('Y-m-d H:i:s', $user->time)); ?>
 				</td>
 			</tr>
 		<?php endforeach; ?>


### PR DESCRIPTION
### Summary of Changes

Propose showing of relative date instead of date time in the Logged in Users module in admin.

### Testing Instructions

Check the Home Dashboard -> Logged In Users module - look at it
Apply PR
Look at it again and note the times are now relative

### Actual result BEFORE applying this Pull Request

<img width="650" alt="Screenshot 2021-03-28 at 21 14 12" src="https://user-images.githubusercontent.com/400092/112766656-90e60b00-900a-11eb-9970-14d6f1ad4338.png">


### Expected result AFTER applying this Pull Request

<img width="652" alt="Screenshot 2021-03-28 at 21 14 02" src="https://user-images.githubusercontent.com/400092/112766660-95122880-900a-11eb-8057-0b2c704568bd.png">


### Documentation Changes Required

none