### PR TITLE
[3] Ensure opcache file invalidate on file copy & delete

### DIFF
--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -27,6 +27,12 @@ use Joomla\CMS\Client\FtpClient;
 class File
 {
 	/**
+	 * @var    boolean  true if OPCache enabled, and we have permission to invalidate files
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected static $canFlushFileCache;
+
+	/**
 	 * Gets the extension of a file name
 	 *
 	 * @param   string  $file  The file name
@@ -183,36 +189,60 @@ class File
 	/**
 	 * Invalidate opcache for a newly written/deleted file immediately, if opcache* functions exist and if this was a PHP file.
 	 *
-	 * First we check if opcache is enabled, and if the filepath given is a path to a PHP file.
-	 * Then we check if the opcache_invalidate function is available, and if the host has restricted which scripts can use it.
-	 * We do this to avoid a PHP warning.
-	 *
-	 * `opcache.restrict_api` can specify the path for files allowed to call `opcache_invalidate()`.
-	 *
-	 * `$_SERVER['SCRIPT_FILENAME']` approximates the origin file's path, but `realpath()`
-	 * is necessary because `SCRIPT_FILENAME` can be a relative path when run from CLI.
-	 *
-	 * If the host has this set, check whether the path in `opcache.restrict_api` matches
-	 * the beginning of the path of the origin file.
-	 *
 	 * @param   string   $filepath  The path to the file just written to, to flush from opcache
 	 * @param   boolean  $force     If set to true, the script will be invalidated regardless of whether invalidation is necessary
 	 *
-	 * @return boolean TRUE if the opcode cache for script was invalidated/nothing to invalidate, or FALSE if the opcode cache is disabled.
+	 * @return boolean TRUE if the opcode cache for script was invalidated/nothing to invalidate,
+	 *                 or FALSE if the opcode cache is disabled or other conditions returning
+	 *                 FALSE from opcache_invalidate (like file not found).
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
 	public static function invalidateFileCache($filepath, $force = true)
 	{
-		if (ini_get('opcache.enable')
-			&& '.php' === strtolower(substr($filepath, -4))
-			&& function_exists('opcache_invalidate')
-			&& (!ini_get('opcache.restrict_api') || stripos(realpath($_SERVER['SCRIPT_FILENAME']), ini_get('opcache.restrict_api')) === 0))
+		if (self::canFlushFileCache() && '.php' === strtolower(substr($filepath, -4)))
 		{
 			return opcache_invalidate($filepath, $force);
 		}
 
 		return false;
+	}
+
+	/**
+	 * `opcache_invalidate` is only available from PHP 5.5.0 onwards.
+	 *
+	 * First we check if opcache is enabled
+	 * Then we check if the opcache_invalidate function is available
+	 * Lastly we check if the host has restricted which scripts can use opcache_invalidate using opcache.restrict_api.
+	 *
+	 * `$_SERVER['SCRIPT_FILENAME']` approximates the origin file's path, but `realpath()`
+	 * is necessary because `SCRIPT_FILENAME` can be a relative path when run from CLI.
+	 * If the host has this set, check whether the path in `opcache.restrict_api` matches
+	 * the beginning of the path of the origin file.
+	 *
+	 * @return boolean TRUE if we can proceed to use opcache_invalidate to flush a file from the OPCache
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public static function canFlushFileCache()
+	{
+		if (isset(static::$canFlushFileCache))
+		{
+			return static::$canFlushFileCache;
+		}
+
+		if (function_exists('opcache_invalidate')
+			&& ini_get('opcache.enable')
+			&& (!ini_get('opcache.restrict_api') || stripos(realpath($_SERVER['SCRIPT_FILENAME']), ini_get('opcache.restrict_api')) === 0))
+		{
+			static::$canFlushFileCache = true;
+		}
+		else
+		{
+			static::$canFlushFileCache = false;
+		}
+
+		return static::$canFlushFileCache;
 	}
 
 	/**

--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -193,7 +193,7 @@ class File
 		{
 			$info = pathinfo($file);
 
-			if ($info['extension'] === 'php')
+			if (isset($info['extension']) && $info['extension'] === 'php')
 			{
 				// Force invalidation to be absolutely sure the opcache is cleared for this file.
 				opcache_invalidate($file, true);

--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -254,12 +254,23 @@ class File
 				continue;
 			}
 
-			// Try making the file writable first. If it's read-only, it can't be deleted
-			// on Windows, even if the parent folder is writable
+			/**
+			 * Try making the file writable first. If it's read-only, it can't be deleted
+			 * on Windows, even if the parent folder is writable
+			 */
 			@chmod($file, 0777);
 
-			// In case of restricted permissions we zap it one way or the other
-			// as long as the owner is either the webserver or the ftp
+			/**
+			 * Invalidate the OPCache for the file before actually deleting it
+			 * @see https://github.com/joomla/joomla-cms/pull/32915#issuecomment-812865635
+			 * @see https://www.php.net/manual/en/function.opcache-invalidate.php#116372
+			 */
+			self::invalidateFileCache($file);
+
+			/**
+			 * In case of restricted permissions we delete it one way or the other
+			 * as long as the owner is either the webserver or the ftp
+			 */
 			if (@unlink($file))
 			{
 				// Do nothing
@@ -282,8 +293,6 @@ class File
 
 				return false;
 			}
-
-			self::invalidateFileCache($file);
 		}
 
 		return true;

--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -131,6 +131,8 @@ class File
 				return false;
 			}
 
+			self::invalidateOpcache($dest);
+
 			return true;
 		}
 		else
@@ -172,7 +174,30 @@ class File
 				$ret = true;
 			}
 
+			self::invalidateOpcache($dest);
+
 			return $ret;
+		}
+	}
+
+	/**
+	 * Invalidate any opcache for a newly written file immediately, if opcache* functions exist and if this was a PHP file.
+	 *
+	 * @param   string  $file  The path to the file just written to, to flush from opcache
+	 *
+	 * @return void
+	 */
+	public static function invalidateOpcache($file)
+	{
+		if (function_exists('opcache_invalidate'))
+		{
+			$info = pathinfo($file);
+
+			if ($info['extension'] === 'php')
+			{
+				// Force invalidation to be absolutely sure the opcache is cleared for this file.
+				opcache_invalidate($file, true);
+			}
 		}
 	}
 
@@ -243,6 +268,8 @@ class File
 
 				return false;
 			}
+
+			self::invalidateOpcache($file);
 		}
 
 		return true;

--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -131,7 +131,7 @@ class File
 				return false;
 			}
 
-			self::invalidateOpcache($dest);
+			self::invalidateFileCache($dest);
 
 			return true;
 		}
@@ -174,7 +174,7 @@ class File
 				$ret = true;
 			}
 
-			self::invalidateOpcache($dest);
+			self::invalidateFileCache($dest);
 
 			return $ret;
 		}
@@ -187,7 +187,7 @@ class File
 	 *
 	 * @return void
 	 */
-	public static function invalidateOpcache($file)
+	public static function invalidateFileCache($file)
 	{
 		if (function_exists('opcache_invalidate'))
 		{
@@ -269,7 +269,7 @@ class File
 				return false;
 			}
 
-			self::invalidateOpcache($file);
+			self::invalidateFileCache($file);
 		}
 
 		return true;

--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -181,24 +181,38 @@ class File
 	}
 
 	/**
-	 * Invalidate any opcache for a newly written file immediately, if opcache* functions exist and if this was a PHP file.
+	 * Invalidate opcache for a newly written/deleted file immediately, if opcache* functions exist and if this was a PHP file.
 	 *
-	 * @param   string  $file  The path to the file just written to, to flush from opcache
+	 * First we check if opcache is enabled, and if the filepath given is a path to a PHP file.
+	 * Then we check if the opcache_invalidate function is available, and if the host has restricted which scripts can use it.
+	 * We do this to avoid a PHP warning.
 	 *
-	 * @return void
+	 * `opcache.restrict_api` can specify the path for files allowed to call `opcache_invalidate()`.
+	 *
+	 * `$_SERVER['SCRIPT_FILENAME']` approximates the origin file's path, but `realpath()`
+	 * is necessary because `SCRIPT_FILENAME` can be a relative path when run from CLI.
+	 *
+	 * If the host has this set, check whether the path in `opcache.restrict_api` matches
+	 * the beginning of the path of the origin file.
+	 *
+	 * @param   string   $filepath  The path to the file just written to, to flush from opcache
+	 * @param   boolean  $force     If set to true, the script will be invalidated regardless of whether invalidation is necessary
+	 *
+	 * @return boolean TRUE if the opcode cache for script was invalidated/nothing to invalidate, or FALSE if the opcode cache is disabled.
+	 *
+	 * @since __DEPLOY_VERSION__
 	 */
-	public static function invalidateFileCache($file)
+	public static function invalidateFileCache($filepath, $force = true)
 	{
-		if (function_exists('opcache_invalidate'))
+		if (ini_get('opcache.enable')
+			&& '.php' === strtolower(substr($filepath, -4))
+			&& function_exists('opcache_invalidate')
+			&& (!ini_get('opcache.restrict_api') || stripos(realpath($_SERVER['SCRIPT_FILENAME']), ini_get('opcache.restrict_api')) === 0))
 		{
-			$info = pathinfo($file);
-
-			if (isset($info['extension']) && $info['extension'] === 'php')
-			{
-				// Force invalidation to be absolutely sure the opcache is cleared for this file.
-				opcache_invalidate($file, true);
-			}
+			return opcache_invalidate($filepath, $force);
 		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
This is part 2 of https://github.com/joomla/joomla-cms/issues/32592 and directed at Joomla 3

### Summary of Changes

When PHP is configured to use modern Opcache, PHP will attempt to hold the compiled version cached in memory. 

There are many ways to configure opcache invalidations, including never revisiting the source PHP to compile it again ever (if [opcache.validate_timestamps](https://www.php.net/manual/en/opcache.configuration.php#ini.opcache.validate-timestamps) is disabled for example) 

To fully ensure that files that Joomla writes to the hard disk are taken into account by a server with a correct configured (or badly configured) opcache, we need to invalidate files from the opcache after writing a new version to the disk. 

Joomla has previously used `opcache_reset` to do this, but its clear this is not good enough.

### Testing Instructions

Hard to test unless you really know what you are doing and can reconfigure all your PHP stack to include opcaching. Also some of the edge cases this fixes will only become clear if you are an extension developer mass distributing extensions. 

Install some extensions - nothing should break. 

### Actual result BEFORE applying this Pull Request

You can install extensions

### Expected result AFTER applying this Pull Request

You can install extensions and opcache for each file is invalidated

### Documentation Changes Required

none

// cc @nikosdion 