### PR TITLE
[4.0] Article hits (site)

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -280,17 +280,6 @@
 		/>
 
 		<field
-			name="show_hits"
-			type="radio"
-			label="JGLOBAL_SHOW_HITS_LABEL"
-			layout="joomla.form.field.radio.switcher"
-			default="1"
-			>
-			<option value="0">JHIDE</option>
-			<option value="1">JSHOW</option>
-		</field>
-
-		<field
 			name="record_hits"
 			type="radio"
 			label="JGLOBAL_RECORD_HITS_LABEL"
@@ -299,6 +288,18 @@
 			>
 			<option value="0">JNO</option>
 			<option value="1">JYES</option>
+		</field>
+
+		<field
+			name="show_hits"
+			type="radio"
+			label="JGLOBAL_SHOW_HITS_LABEL"
+			layout="joomla.form.field.radio.switcher"
+			default="1"
+			showon="record_hits:1"
+			>
+			<option value="0">JHIDE</option>
+			<option value="1">JSHOW</option>
 		</field>
 
 		<field


### PR DESCRIPTION
If you are not recording the hits then there is no point in showing the hits. This PR changes the order of the two fields and makes the show_hits field display only if record_hits is set to yes

### before
![image](https://user-images.githubusercontent.com/1296369/112808602-0f759380-9071-11eb-8a3e-92c596e4bce7.png)


### after
![hits](https://user-images.githubusercontent.com/1296369/112808724-3633ca00-9071-11eb-8ed6-5cdc6ece329b.gif)
