### PR TITLE
[4.0] Hits column in admin

### DIFF
--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -87,6 +87,7 @@ class HtmlView extends BaseHtmlView
 		$this->filterForm    = $this->get('FilterForm');
 		$this->activeFilters = $this->get('ActiveFilters');
 		$this->vote          = PluginHelper::isEnabled('content', 'vote');
+		$this->hits          = ComponentHelper::getParams('com_content')->get('record_hits');
 
 		if (ComponentHelper::getParams('com_content')->get('workflow_enabled'))
 		{

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -156,9 +156,11 @@ $assoc = Associations::isEnabled();
 								<th scope="col" class="w-10 d-none d-md-table-cell text-center">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_CONTENT_HEADING_DATE_' . strtoupper($orderingColumn), 'a.' . $orderingColumn, $listDirn, $listOrder); ?>
 								</th>
-								<th scope="col" class="w-3 d-none d-lg-table-cell text-center">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
-								</th>
+								<?php if ($this->hits) : ?>
+									<th scope="col" class="w-3 d-none d-lg-table-cell text-center">
+										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<?php if ($this->vote) : ?>
 									<th scope="col" class="w-3 d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_VOTES', 'rating_count', $listDirn, $listOrder); ?>
@@ -359,11 +361,13 @@ $assoc = Associations::isEnabled();
 									echo $date > 0 ? HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC4')) : '-';
 									?>
 								</td>
-								<td class="d-none d-lg-table-cell text-center">
-									<span class="badge bg-info">
-										<?php echo (int) $item->hits; ?>
-									</span>
-								</td>
+								<?php if ($this->hits) : ?>
+									<td class="d-none d-lg-table-cell text-center">
+										<span class="badge bg-info">
+											<?php echo (int) $item->hits; ?>
+										</span>
+									</td>
+								<?php endif; ?>
 								<?php if ($this->vote) : ?>
 									<td class="d-none d-md-table-cell text-center">
 										<span class="badge bg-success">

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -150,9 +150,11 @@ $assoc = Associations::isEnabled();
 								<th scope="col" class="w-10 d-none d-md-table-cell text-center">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_CONTENT_HEADING_DATE_' . strtoupper($orderingColumn), 'a.' . $orderingColumn, $listDirn, $listOrder); ?>
 								</th>
-								<th scope="col" class="w-3 d-none d-lg-table-cell text-center">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
-								</th>
+								<?php if ($this->vote) : ?>
+									<th scope="col" class="w-3 d-none d-lg-table-cell text-center">
+										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<?php if ($this->vote) : ?>
 									<th scope="col" class="w-3 d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_VOTES', 'rating_count', $listDirn, $listOrder); ?>
@@ -356,11 +358,13 @@ $assoc = Associations::isEnabled();
 									echo $date > 0 ? HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC4')) : '-';
 									?>
 								</td>
-								<td class="d-none d-lg-table-cell text-center">
-									<span class="badge bg-info">
-									<?php echo (int) $item->hits; ?>
-									</span>
-								</td>
+								<?php if ($this->vote) : ?>
+									<td class="d-none d-lg-table-cell text-center">
+										<span class="badge bg-info">
+											<?php echo (int) $item->hits; ?>
+										</span>
+									</td>
+								<?php endif; ?>
 								<?php if ($this->vote) : ?>
 									<td class="d-none d-md-table-cell text-center">
 										<span class="badge bg-success" >

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -150,7 +150,7 @@ $assoc = Associations::isEnabled();
 								<th scope="col" class="w-10 d-none d-md-table-cell text-center">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_CONTENT_HEADING_DATE_' . strtoupper($orderingColumn), 'a.' . $orderingColumn, $listDirn, $listOrder); ?>
 								</th>
-								<?php if ($this->vote) : ?>
+								<?php if ($this->hits) : ?>
 									<th scope="col" class="w-3 d-none d-lg-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
 									</th>

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -358,7 +358,7 @@ $assoc = Associations::isEnabled();
 									echo $date > 0 ? HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC4')) : '-';
 									?>
 								</td>
-								<?php if ($this->vote) : ?>
+								<?php if ($this->hits) : ?>
 									<td class="d-none d-lg-table-cell text-center">
 										<span class="badge bg-info">
 											<?php echo (int) $item->hits; ?>


### PR DESCRIPTION
If you are not recording the number of hits for an article then there is no point in displaying the count of hits.

In the component options for com_content set "record hits" to NO and this will remove the hots column from the article and featured article lists

### with hits displayed
![image](https://user-images.githubusercontent.com/1296369/112813157-cffd7600-9075-11eb-8696-7d80c7c69408.png)

### without hits displayed
![image](https://user-images.githubusercontent.com/1296369/112813267-ed324480-9075-11eb-8fdf-d068b9e27abe.png)

