### PR TITLE
[4.0] Apostrophe in alias

### DIFF
--- a/libraries/src/Filter/OutputFilter.php
+++ b/libraries/src/Filter/OutputFilter.php
@@ -90,6 +90,9 @@ class OutputFilter extends BaseOutputFilter
 		// Trim white spaces at beginning and end of alias and make lowercase
 		$str = trim(StringHelper::strtolower($str));
 
+		// Remove any apostrophe. We do it here to ensure it is not replaced by a '-'
+		$str = preg_replace('/\'/', '', $str);
+
 		// Remove any duplicate whitespace, and ensure all characters are alphanumeric
 		$str = preg_replace('/(\s|[^A-Za-z0-9\-])+/', '-', $str);
 

--- a/libraries/src/Filter/OutputFilter.php
+++ b/libraries/src/Filter/OutputFilter.php
@@ -91,7 +91,7 @@ class OutputFilter extends BaseOutputFilter
 		$str = trim(StringHelper::strtolower($str));
 
 		// Remove any apostrophe. We do it here to ensure it is not replaced by a '-'
-		$str = preg_replace('/\'/', '', $str);
+		$str = str_replace("'", '', $str);
 
 		// Remove any duplicate whitespace, and ensure all characters are alphanumeric
 		$str = preg_replace('/(\s|[^A-Za-z0-9\-])+/', '-', $str);

--- a/tests/Unit/Libraries/Cms/Filter/OutputFilterTest.php
+++ b/tests/Unit/Libraries/Cms/Filter/OutputFilterTest.php
@@ -68,7 +68,7 @@ class OutputFilterTest extends UnitTestCase
 			'joomlas-version',
 			OutputFilter::stringURLSafe('joomla\'s version'),
 			'Should remove apostrophe from the string'
-		)
+		);
 	}
 
 	/**

--- a/tests/Unit/Libraries/Cms/Filter/OutputFilterTest.php
+++ b/tests/Unit/Libraries/Cms/Filter/OutputFilterTest.php
@@ -63,6 +63,12 @@ class OutputFilterTest extends UnitTestCase
 			OutputFilter::stringURLSafe('`1234567890-=~!@#$%^&*()_+	qwertyuiop[]\QWERTYUIOP{}|asdfghjkl;\'ASDFGHJKL:"zxcvbnm,./ZXCVBNM<>?'),
 			'Should clean keyboard string down to ASCII-7'
 		);
+
+		$this->assertEquals(
+			'joomlas-version',
+			OutputFilter::stringURLSafe('joomla\'s version'),
+			'Should remove apostrophe from the string'
+		)
 	}
 
 	/**


### PR DESCRIPTION
Add an additional filter to the alias generator to remove any apostrophe instead of replacing it with a dash. This has annoyed me forever and I waste so much time doing this manually for every alias

### Example
For example the alias for an article "Brian's Pull Request"

### before
"brian-s-pull-request"

### after
"brians-pull-request"


**Note** Includes unit test