### PR TITLE
[4] Standardise all four support urls in the "support" section of composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
         "github-protocols": ["https"]
     },
     "support": {
-        "issues": "https://issues.joomla.org",
+        "issues": "https://issues.joomla.org/",
         "irc": "irc://chat.freenode.net/joomla/",
         "forum": "https://forum.joomla.org/",
-        "docs": "https://docs.joomla.org"
+        "docs": "https://docs.joomla.org/"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Standardise all four urls in the "support" section of composer.json

If you dont like this then we can flop the other way and remove all the trailing slashes

At the moment there are 2 with and 2 without which just looks messy