### PR TITLE
[4.0] Fix README.md for unit tests

### DIFF
--- a/tests/Unit/README.md
+++ b/tests/Unit/README.md
@@ -8,7 +8,7 @@ When you are checking out the current development branch of 4.0 and run `compose
 
 1. Checkout the current Joomla 4.0 development branch from Github. (https://github.com/joomla/joomla-cms.git Branch `4.0-dev`)
 2. Run `composer install` in the root of your checkout.
-3. Add the file `joomla-cms/phpunit.xml` depending on your environment. You can use the files `joomla-cms/phpunit.xml.dist` and/or `joomla-cms/phpunit-pgsql.xml.dist` as an example.
+3. Add the file `phpunit.xml` depending on your environment. You can use the files `phpunit.xml.dist` and/or `phpunit-pgsql.xml.dist` as an example.
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>

--- a/tests/Unit/README.md
+++ b/tests/Unit/README.md
@@ -8,7 +8,7 @@ When you are checking out the current development branch of 4.0 and run `compose
 
 1. Checkout the current Joomla 4.0 development branch from Github. (https://github.com/joomla/joomla-cms.git Branch `4.0-dev`)
 2. Run `composer install` in the root of your checkout.
-3. Add the file `joomla-cms/phpunit-xml` depending on your environment. You can use the files `joomla-cms/phpunit.xml.dist` and/or `joomla-cms/phpunit-pgsql.xml.dist` as an example.
+3. Add the file `joomla-cms/phpunit.xml` depending on your environment. You can use the files `joomla-cms/phpunit.xml.dist` and/or `joomla-cms/phpunit-pgsql.xml.dist` as an example.
 
 ```
 <?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

1. Fix typo `phpunit-xml` instead of `phpunit.xml` from PR #32758 .
2. Remove the `joomla-cms` from paths in the description added by PR #32758 so that relative paths below the root folder of the checkout are used, like it is already for the given instructions "2. Run `composer install` in the root of your checkout." and "4. Run `libraries/vendor/bin/phpunit`".

I should have noticed that when reviewing that PR #32758 , but seems I was sleeping or blind.

### Testing Instructions

Review.

### Actual result BEFORE applying this Pull Request

Wong file name `phpunit-xml` instead of `phpunit.xml` used.

Inconsistent use of paths with and without the checkout root folder `joomla-cms`.

### Expected result AFTER applying this Pull Request

Right file name `phpunit.xml` used.

Consistent use of relative paths below the checkout root folder`.

### Documentation Changes Required

This is the documentation change.