### PR TITLE
[4] Ensure updates installed by previous package updates dont error

### DIFF
--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -352,7 +352,13 @@ class UpdateModel extends ListModel
 		{
 			$update = new Update;
 			$instance = new \Joomla\CMS\Table\Update($this->getDbo());
-			$instance->load($uid);
+
+			if (!$instance->load($uid))
+			{
+				// Update no longer available, maybe already updated by a package.
+				continue;
+			}
+
 			$update->loadFromXml($instance->detailsurl, $minimumStability);
 			$update->set('extra_query', $instance->extra_query);
 


### PR DESCRIPTION
Pull Request for Issue #32917

### Summary of Changes

Break out of the foreach loop if we cannot load the update information from the database instead of generating an error message. 

### Testing Instructions

Joomla 4.0-dev (Enable Debug mode in Joomla Global Config)

Install an old version (only just old!) of Akeeba Backup Core (FREE) from https://www.akeeba.com/download/akeeba-backup/8-0-2/pkg_akeeba-8-0-2-core-zip.zip

Once installed go to:

System -> Update -> Extensions 
Click Clear Cache
Click Find Updates
See three available updates
Select ALL THREE UPDATES and click UPDATE..... wait.....

<img width="733" alt="Screenshot 2021-03-28 at 23 02 56" src="https://user-images.githubusercontent.com/400092/112769610-ee358880-9019-11eb-9c6b-a98758f34072.png">




### Actual result BEFORE applying this Pull Request

<img width="1301" alt="Screenshot 2021-03-28 at 23 06 40" src="https://user-images.githubusercontent.com/400092/112769693-44a2c700-901a-11eb-9af2-b90ed380874e.png">


### Expected result AFTER applying this Pull Request

Depending on when you test there might be more updates available and found, but you should now at least be able to select a package (Akeeba Backup) and all the other updates, and the package (Akeeba Backup) will update the others (as that's what a package is for - doh!) and the others will not error like they did before.

<img width="723" alt="Screenshot 2021-03-30 at 20 37 42" src="https://user-images.githubusercontent.com/400092/113046290-ce2bd380-9197-11eb-9b69-495e6d5e034c.png">

### Documentation Changes Required

None.


### Additional comments
// @nikosdion @joomdonation @alikon 