### PR TITLE
[4.0] Use votelist field type for "Voting" option fields

### DIFF
--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -487,6 +487,7 @@
 			</fieldset>
 
 			<fieldset name="other" label="COM_CONTENT_OTHER_OPTIONS">
+
 				<field
 					name="show_item_navigation"
 					type="list"

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -487,7 +487,6 @@
 			</fieldset>
 
 			<fieldset name="other" label="COM_CONTENT_OTHER_OPTIONS">
-
 				<field
 					name="show_item_navigation"
 					type="list"

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -486,7 +486,10 @@
 				</field>
 			</fieldset>
 
-			<fieldset name="other" label="COM_CONTENT_OTHER_OPTIONS">
+			<fieldset name="other" label="COM_CONTENT_OTHER_OPTIONS"
+				addfieldprefix="Joomla\Component\Content\Administrator\Field"
+			>
+
 				<field
 					name="show_item_navigation"
 					type="list"
@@ -500,7 +503,7 @@
 
 				<field
 					name="show_vote"
-					type="list"
+					type="votelist"
 					label="JGLOBAL_SHOW_VOTE_LABEL"
 					useglobal="true"
 					validate="options"

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -486,9 +486,7 @@
 				</field>
 			</fieldset>
 
-			<fieldset name="other" label="COM_CONTENT_OTHER_OPTIONS"
-				addfieldprefix="Joomla\Component\Content\Administrator\Field"
-			>
+			<fieldset name="other" label="COM_CONTENT_OTHER_OPTIONS">
 
 				<field
 					name="show_item_navigation"

--- a/components/com_content/tmpl/article/default.xml
+++ b/components/com_content/tmpl/article/default.xml
@@ -229,7 +229,7 @@
 
 			<field
 				name="show_vote"
-				type="list"
+				type="votelist"
 				label="JGLOBAL_SHOW_VOTE_LABEL"
 				useglobal="true"
 				class="form-select-color-state"

--- a/components/com_content/tmpl/categories/default.xml
+++ b/components/com_content/tmpl/categories/default.xml
@@ -25,8 +25,8 @@
 	</fields>
 
 	<!-- Add fields to the parameters object for the layout. -->
-<fields name="params">
-	<fieldset name="basic" label="JGLOBAL_CATEGORIES_OPTIONS">
+	<fields name="params">
+		<fieldset name="basic" label="JGLOBAL_CATEGORIES_OPTIONS">
 
 			<field
 				name="show_base_description"
@@ -448,7 +448,9 @@
 			</field>
 		</fieldset>
 
-	<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL">
+		<fieldset name="article" label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL"
+			addfieldprefix="Joomla\Component\Content\Administrator\Field"
+		>
 
 			<field
 				name="article_layout"
@@ -619,7 +621,7 @@
 
 			<field
 				name="show_vote"
-				type="list"
+				type="votelist"
 				label="JGLOBAL_SHOW_VOTE_LABEL"
 				useglobal="true"
 				class="form-select-color-state"
@@ -677,9 +679,9 @@
 				>
 				<option value="0">JNO</option>
 				<option value="1">JYES</option>
-		</field>
-	</fieldset>
-	<fieldset name="integration">
+			</field>
+		</fieldset>
+		<fieldset name="integration">
 
 			<field
 				name="show_feed_link"
@@ -704,5 +706,5 @@
 				<option value="1">JGLOBAL_FULL_TEXT</option>
 			</field>
 		</fieldset>
-</fields>
+	</fields>
 </metadata>

--- a/components/com_content/tmpl/category/blog.xml
+++ b/components/com_content/tmpl/category/blog.xml
@@ -576,7 +576,7 @@
 
 			<field
 				name="show_vote"
-				type="list"
+				type="votelist"
 				label="JGLOBAL_SHOW_VOTE_LABEL"
 				useglobal="true"
 				class="form-select-color-state"

--- a/components/com_content/tmpl/category/default.xml
+++ b/components/com_content/tmpl/category/default.xml
@@ -582,7 +582,7 @@
 
 			<field
 				name="show_vote"
-				type="list"
+				type="votelist"
 				label="JGLOBAL_SHOW_VOTE_LABEL"
 				useglobal="true"
 				class="form-select-color-state"

--- a/components/com_content/tmpl/featured/default.xml
+++ b/components/com_content/tmpl/featured/default.xml
@@ -182,12 +182,12 @@
 				size="20"
 			/>
 
-	</fieldset>
+		</fieldset>
 
-	<fieldset name="article"
-		label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL"
-		addfieldprefix="Joomla\Component\Content\Administrator\Field"
-	>
+		<fieldset name="article"
+			label="COM_CONTENT_ATTRIBS_FIELDSET_LABEL"
+			addfieldprefix="Joomla\Component\Content\Administrator\Field"
+		>
 			<field
 				name="show_title"
 				type="list"
@@ -398,7 +398,7 @@
 
 			<field
 				name="show_vote"
-				type="list"
+				type="votelist"
 				label="JGLOBAL_SHOW_VOTE_LABEL"
 				useglobal="true"
 				class="form-select-color-state"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Continue the work of PR #31381 for other places where we have "Voting" option fields, i.e. use the "vote list" field type for these fields so they are not shown when the vote plugin is disabled, and fix a few code style issues in the XML files touched.

Thanks @infograf768 for the initial work for this PR.

### Testing Instructions

1. Without the patch of this PR applied, make sure that the "Content - Vote" plugin is disabled.

2. In Global Configuration, tab "Site", set "Frontend Editing" to "Modules & Menus".

3. In backend, create a new or edit an existing item of the following types, and check in tab "Options" of the form in section "Options" if there is a field "Voting" shown:
- Article
- Menu item of type "Single Article"
- Menu item of type "Category Blog"
- Menu item of type "Category List"
- Menu item of type "Featured Articles"
- Menu item of type "List All Categories ..."

Result: See section "Actual result BEFORE applying this Pull Request", the "Voting" field is shown.

4. Login to frontend and repeat the previous step in frontend editing for the menu items.

Result: See section "Actual result BEFORE applying this Pull Request", the "Voting" field is shown.

5. Apply the patch of this PR.

6. Repeat steps 3 and 4.

Result: See section "Expected result AFTER applying this Pull Request", the "Voting" field is not shown.

7. Enable the "Content - Vote" plugin.

8. Repeat again steps 3 and 4.

Result: The "Voting" field is shown.

### Actual result BEFORE applying this Pull Request

The "Voting" field is shown regardless if the "Content - Vote" plugin is enabled or not in the following forms in tab "Options", section "Options":
- Article edit in backend
- Menu item edit for menu item types "Single Article", "Category Blog", "Category List", "Featured Articles" and "List All Categories ..." (backend and frontend).

### Expected result AFTER applying this Pull Request

The "Voting" field in the forms mentioned above in section "Actual result BEFORE applying this Pull Request" is only shown if the "Content - Vote" plugin is enabled.

### Documentation Changes Required

Possibly docs need to be updated to mention that the "Voting" fields handled by this PR are not shown when the "Content - Vote" plugin is disabled.