### PR TITLE
[4.0] Atum badge borders

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_badge.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_badge.scss
@@ -15,13 +15,13 @@
   &.bg-success {
     color: $success-txt;
     background-color: $success-bg !important;
-    border: 1px solid lighten($success-txt, 20%);
+    border: 1px solid lighten($atum-text-dark, 30%);
   }
 
   &.bg-danger {
     color: $danger-txt;
     background-color: $danger-bg !important;
-    border: 1px solid lighten($danger-txt, 30%);
+    border: 1px solid lighten($atum-text-dark, 30%);
   }
 
   &.bg-secondary,


### PR DESCRIPTION
Some of the badges are set to have a border that is a color lighter than the badge text. Unfortunately that doesn't work if the text is white you get a white border.

All the badges need to have a visible border otherwise the badges will appear visually to be of different sizes.

This PR changes the border of the two existing white bordered badges to use the same shade of the dark text that the bg-info badge uses.

Testers dont forget to run npm to rebuild the css

The easies way to to check this would be in the article list after enabling the voting plugin

### before
![image](https://user-images.githubusercontent.com/1296369/113222851-cb0c1280-927f-11eb-88e3-bdea312b2018.png)

### after
![image](https://user-images.githubusercontent.com/1296369/113222859-ce070300-927f-11eb-9214-53fcdfbdad56.png)
