### PR TITLE
[4.0] table head font weight

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
@@ -10,7 +10,6 @@
 
     th,
     td {
-      font-weight: $font-weight-normal;
       white-space: nowrap;
 
       @include media-breakpoint-down(md) {
@@ -19,7 +18,6 @@
     }
 
     a {
-      font-weight: $font-weight-normal;
       color: var(--atum-link-color);
 
       &#sorted {


### PR DESCRIPTION
Maybe its just me but I find it very unusual that the cells in the table head are not "bold" which is pretty normal.

It's not that obvious on a page like the article manager as all the cells are links but its really noticeable in the modules on the dashboard and in lists where not everything is a link eg access levels

On the assumption that its not just me here is a pr for consideration. As with all scss changes you will need to npm to build the css

### Before
![image](https://user-images.githubusercontent.com/1296369/113335932-8e8ef400-931d-11eb-8446-1a4926838485.png)

![image](https://user-images.githubusercontent.com/1296369/113335990-a1a1c400-931d-11eb-8cf1-850bdc206018.png)

![image](https://user-images.githubusercontent.com/1296369/113336054-b716ee00-931d-11eb-8f11-7eb3596e4855.png)


### After
![image](https://user-images.githubusercontent.com/1296369/113335804-5ab3ce80-931d-11eb-9b48-b3bee8629f53.png)

![image](https://user-images.githubusercontent.com/1296369/113335832-67382700-931d-11eb-96d2-5a93b8a4613a.png)

![image](https://user-images.githubusercontent.com/1296369/113335867-7323e900-931d-11eb-9d46-375dda395267.png)
