### PR TITLE
[4.0] Fix form data lost when create category fail

### DIFF
--- a/administrator/components/com_categories/src/Controller/CategoryController.php
+++ b/administrator/components/com_categories/src/Controller/CategoryController.php
@@ -134,7 +134,7 @@ class CategoryController extends FormController
 
 		$oldKey = $this->option . '.edit.category.data';
 		$newKey = $this->option . '.edit.category.' . substr($this->extension, 4) . '.data';
-		$this->app->setUserState($newKey, $this->app->getUserState($oldKey, $newKey));
+		$this->app->setUserState($newKey, $this->app->getUserState($oldKey));
 
 		return $result;
 	}

--- a/administrator/components/com_categories/src/Controller/CategoryController.php
+++ b/administrator/components/com_categories/src/Controller/CategoryController.php
@@ -140,6 +140,25 @@ class CategoryController extends FormController
 	}
 
 	/**
+	 * Override cancel method to clear form data for a failed edit action
+	 *
+	 * @param   string  $key  The name of the primary key of the URL variable.
+	 *
+	 * @return  boolean  True if access level checks pass, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function cancel($key = null)
+	{
+		$result = parent::cancel($key);
+
+		$newKey = $this->option . '.edit.category.' . substr($this->extension, 4) . '.data';
+		$this->app->setUserState($newKey, null);
+
+		return $result;
+	}
+
+	/**
 	 * Method to run batch operations.
 	 *
 	 * @param   object|null  $model  The model.

--- a/administrator/components/com_categories/src/Controller/CategoryController.php
+++ b/administrator/components/com_categories/src/Controller/CategoryController.php
@@ -119,6 +119,27 @@ class CategoryController extends FormController
 	}
 
 	/**
+	 * Override parent save method to store form data with right key as expected by edit category page
+	 *
+	 * @param   string  $key     The name of the primary key of the URL variable.
+	 * @param   string  $urlVar  The name of the URL variable if different from the primary key (sometimes required to avoid router collisions).
+	 *
+	 * @return  boolean  True if successful, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function save($key = null, $urlVar = null)
+	{
+		$result = parent::save($key, $urlVar);
+
+		$oldKey = $this->option . '.edit.category.data';
+		$newKey = $this->option . '.edit.category.' . substr($this->extension, 4) . '.data';
+		$this->app->setUserState($newKey, $this->app->getUserState($oldKey, $newKey));
+
+		return $result;
+	}
+
+	/**
 	 * Method to run batch operations.
 	 *
 	 * @param   object|null  $model  The model.


### PR DESCRIPTION
Pull Request for Issue #32829.

### Summary of Changes
This PR fix issue https://github.com/joomla/joomla-cms/issues/32829. **category** view uses different key to get form data from session, so we need to override save method in the controller to set this data using the right key.


### Testing Instructions
1. Access to Content -> Categories, create a new category
2. Enter an existing Alias into Alias field (so that category could not be saved)
3. Apply patch
4. Before patch: Error message displayed, but form data lost when you are redirected back to add category screen
5. After patch: Error message displayed, you are redirected back to add category screen but the data you entered before is kept so that you don't have to re-enter.
6. Click on Cancel button to cancel adding the category with that same Alias, you will be redirected back to Categories List screen.
7. Press New button to add new category again, make sure you don't see the old data from previous failed add.