### PR TITLE
[4.x] Inject installer via service provider

### DIFF
--- a/libraries/src/Console/ExtensionDiscoverInstallCommand.php
+++ b/libraries/src/Console/ExtensionDiscoverInstallCommand.php
@@ -53,9 +53,17 @@ class ExtensionDiscoverInstallCommand extends AbstractCommand
 	 * Database connector
 	 *
 	 * @var    DatabaseInterface
-	 * @since  4.0.0
+	 * @since  __DEPLOY_VERSION__
 	 */
 	private $db;
+
+	/**
+	 * Installer
+	 *
+	 * @var    	Installer Installer object
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $installer = null;
 
 	/**
 	 * Exit Code For Discover Failure
@@ -74,13 +82,15 @@ class ExtensionDiscoverInstallCommand extends AbstractCommand
 	/**
 	 * Instantiate the command.
 	 *
-	 * @param   DatabaseInterface  $db  Database connector
+	 * @param   DatabaseInterface  $db         Database connector
+	 * @param   Installer          $installer  Installer object
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function __construct(DatabaseInterface $db)
+	public function __construct(DatabaseInterface $db, Installer $installer)
 	{
 		$this->db = $db;
+		$this->installer = $installer;
 		parent::__construct();
 	}
 
@@ -134,7 +144,7 @@ class ExtensionDiscoverInstallCommand extends AbstractCommand
 	 */
 	public function processDiscover($eid): bool
 	{
-		$jInstaller = new Installer;
+		$installer = $this->installer;
 		$result = true;
 
 		if ($eid === -1)
@@ -149,7 +159,7 @@ class ExtensionDiscoverInstallCommand extends AbstractCommand
 
 			foreach ($eidsToDiscover as $eidToDiscover)
 			{
-				if (!$jInstaller->discover_install($eidToDiscover->extension_id))
+				if (!$installer->discover_install($eidToDiscover->extension_id))
 				{
 					$this->ioStyle->warning('There was a problem installing the extension with ID ' . $eidToDiscover->extension_id . '.');
 					$result = false;
@@ -165,7 +175,7 @@ class ExtensionDiscoverInstallCommand extends AbstractCommand
 		}
 		else
 		{
-			return $jInstaller->discover_install($eid);
+			return $installer->discover_install($eid);
 		}
 	}
 

--- a/libraries/src/Service/Provider/Console.php
+++ b/libraries/src/Service/Provider/Console.php
@@ -24,6 +24,7 @@ use Joomla\CMS\Console\SetConfigurationCommand;
 use Joomla\CMS\Console\SiteDownCommand;
 use Joomla\CMS\Console\SiteUpCommand;
 use Joomla\CMS\Console\UpdateCoreCommand;
+use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Session\MetadataManager;
 use Joomla\Database\Command\ExportCommand;
 use Joomla\Database\Command\ImportCommand;
@@ -167,7 +168,7 @@ class Console implements ServiceProviderInterface
 			ExtensionDiscoverInstallCommand::class,
 			function (Container $container)
 			{
-				return new ExtensionDiscoverInstallCommand($container->get('db'));
+				return new ExtensionDiscoverInstallCommand($container->get('db'), new Installer);
 			},
 			true
 		);


### PR DESCRIPTION
Pull Request for Issue # https://github.com/joomla/joomla-cms/pull/31524#discussion_r532580652.

### Summary of Changes

Inject the installer the same way as the database.

@laoneo Was that what you meant in your comment, and @wilsonge  is that how it's generally intended ? Then I would standardize it in all places for the CLI.


### Testing Instructions

Code review

### Additional Questions

I realized while working on this PR, that the container is not in the Joomla Repo but in the Framework. Should not the framework be unified with the Joomla CMS in version 4? The [roadmap](https://developer.joomla.org/roadmap.html#4) includes this text:
The power of the Joomla Framework merged into the CMS


