### PR TITLE
[4] add ext-ldap requirement to composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -81,6 +81,7 @@
         "ext-simplexml": "*",
         "psr/log": "~1.0",
         "ext-gd": "*",
+        "ext-ldap": "*",
         "web-auth/webauthn-lib": "2.1.*"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc3ee4f2bb425d887d0db9c8414ef048",
+    "content-hash": "60ae27102056b4a04184308be68cd8c3",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -1350,6 +1350,10 @@
                 "joomla",
                 "ldap"
             ],
+            "support": {
+                "issues": "https://github.com/joomla-framework/ldap/issues",
+                "source": "https://github.com/joomla-framework/ldap/tree/2.0.0-beta"
+            },
             "time": "2020-06-05T11:32:05+00:00"
         },
         {
@@ -8292,7 +8296,8 @@
         "php": "^7.2.5",
         "ext-json": "*",
         "ext-simplexml": "*",
-        "ext-gd": "*"
+        "ext-gd": "*",
+        "ext-ldap": "*"
     },
     "platform-dev": [],
     "platform-overrides": {


### PR DESCRIPTION
### Summary of Changes

As `composer.json` is going to install `joomla/ldap` and `symfonty/ldap` it is a requirement of the server to also have the LDAP PHP extension installed and this should be defined as a requirement in the composer.json

Also phpStorm moans if its not defined in the `composer.json` when viewing the LDAP Packages. 

### Testing Instructions

Code review. 

### Actual result BEFORE applying this Pull Request

phpStorm moans:

<img width="794" alt="Screenshot 2021-04-02 at 18 04 51" src="https://user-images.githubusercontent.com/400092/113437113-f3118800-93dd-11eb-889a-ab07383c98f5.png">

Composer doesn't moan enough about the missing requirements (like it correctly moans about GD)

<img width="956" alt="Screenshot 2021-04-02 at 18 05 08" src="https://user-images.githubusercontent.com/400092/113437162-0b81a280-93de-11eb-88da-9a9622a5ad53.png">


### Expected result AFTER applying this Pull Request

No Moaning. 


<img width="822" alt="Screenshot 2021-04-02 at 18 06 16" src="https://user-images.githubusercontent.com/400092/113437201-23592680-93de-11eb-957e-012c4033f96a.png">


### Documentation Changes Required

None