### PR TITLE
[4] Ensure arrays and objects from a config object can be dumped by cli

### DIFF
--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -286,11 +286,11 @@ class GetConfigurationCommand extends AbstractCommand
 		}
 		elseif (\is_array($value))
 		{
-			return json_encode($value);
+			return \json_encode($value);
 		}
 		elseif (\is_object($value))
 		{
-			return json_encode(get_object_vars($value));
+			return \json_encode(get_object_vars($value));
 		}
 		else
 		{

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -290,7 +290,7 @@ class GetConfigurationCommand extends AbstractCommand
 		}
 		elseif (\is_object($value))
 		{
-			return \json_encode(get_object_vars($value));
+			return \json_encode(\get_object_vars($value));
 		}
 		else
 		{

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -284,6 +284,14 @@ class GetConfigurationCommand extends AbstractCommand
 		{
 			return 'Not Set';
 		}
+		elseif (\is_array($value))
+		{
+			return json_encode($value);
+		}
+		elseif (\is_object($value))
+		{
+			return json_encode(get_object_vars($value));
+		}
 		else
 		{
 			return $value;
@@ -356,7 +364,7 @@ class GetConfigurationCommand extends AbstractCommand
 			array_walk(
 				$configs,
 				function ($value, $key) use (&$options) {
-					$options[] = [$key, $value];
+					$options[] = [$key, $this->formatConfigValue($value)];
 				}
 			);
 


### PR DESCRIPTION
Signed-off-by: Phil E. Taylor <phil@phil-taylor.com>

Pull Request for Issue https://github.com/joomla/joomla-cms/issues/31896

### Summary of Changes

Add ability to dump arrays and objects that are in JConfig class when using CLI 

### Testing Instructions

add the following property to your JConfig class (simulates a profiling session)

```php
public $execution = array('datetime' => '2020-06-29 22:34:47', 'timestamp' => 1593470087, 'microtimestamp' => 1593470087.0546);
```

`php cli/joomla.php config:get`

### Actual result BEFORE applying this Pull Request

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/400092/113440458-60c0b280-93e4-11eb-96ee-7147fe02045b.png">


### Expected result AFTER applying this Pull Request

The following commands all work with no errors:

```
 php cli/joomla.php config:get

php cli/joomla.php config:get execution  -vvvv
```

### Documentation Changes Required

none