### PR TITLE
[4][ReleaseBlocker] Users lose user groups after password reset via frontend

### DIFF
--- a/libraries/src/Table/User.php
+++ b/libraries/src/Table/User.php
@@ -170,7 +170,7 @@ class User extends Table
 				->select($this->_db->quoteName('id'))
 				->select($this->_db->quoteName('title'))
 				->from($this->_db->quoteName('#__usergroups'))
-				->whereIn($this->_db->quoteName('id'), $this->groups);
+				->whereIn($this->_db->quoteName('id'), array_values($this->groups));
 			$this->_db->setQuery($query);
 
 			// Set the titles for the user groups.


### PR DESCRIPTION
Pull Request for Issue #32981 .

### Summary of Changes

The [proposed "Quick fix"](https://github.com/joomla/joomla-cms/issues/32981#issuecomment-812891426) implemented to resolve this issue. 

### Testing Instructions

If a user attempt to use the "forgot password" function at the frontend, the assigned user groups are lost.

### Actual result BEFORE applying this Pull Request

Some groups assigned to a user are lost on saving 

### Expected result AFTER applying this Pull Request

User retains group membership

### Documentation Changes Required

none

### References
https://github.com/joomla/joomla-cms/issues/32981#issuecomment-812891426
https://github.com/joomla-framework/database/pull/247
https://github.com/joomla-framework/database/pull/211#issuecomment-594139754

// cc: @joomdonation @joni142 @brianteeman @Jere2000