### PR TITLE
[4.0] Articles frontend associations badges changed to buttons and more

### DIFF
--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -190,7 +190,7 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
 								<?php else : ?>
 									<?php $class = 'btn btn-secondary btn-sm btn-' . strtolower($association['language']->lang_code); ?>
 									<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo $association['language']->lang_code; ?>
-										<span class="sr-only"><?php echo $association['language']->title_native; ?></span>
+										<span class="visually-hidden"><?php echo $association['language']->title_native; ?></span>
 									</a>
 								<?php endif; ?>
 							<?php endforeach; ?>
@@ -216,7 +216,7 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
 								<?php else : ?>
 									<?php $class = 'btn btn-secondary btn-sm btn-' . strtolower($association['language']->lang_code); ?>
 									<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo $association['language']->lang_code; ?>
-										<span class="sr-only"><?php echo $association['language']->title_native; ?></span>
+										<span class="visually-hidden"><?php echo $association['language']->title_native; ?></span>
 									</a>
 								<?php endif; ?>
 							<?php endforeach; ?>

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -181,14 +181,14 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
 							<?php echo $this->escape($article->title); ?>
 						</a>
 						<?php if (Associations::isEnabled() && $this->params->get('show_associations')) : ?>
-							<div>
+							<div class="cat-list-association">
 							<?php $associations = AssociationHelper::displayAssociations($article->id); ?>
 							<?php foreach ($associations as $association) : ?>
 								<?php if ($this->params->get('flags', 1) && $association['language']->image) : ?>
 									<?php $flag = HTMLHelper::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
 									<a href="<?php echo Route::_($association['item']); ?>"><?php echo $flag; ?></a>
 								<?php else : ?>
-									<?php $class = 'btn btn-badge btn-vsm btn-' . strtolower($association['language']->lang_code); ?>
+									<?php $class = 'btn btn-secondary btn-sm btn-' . strtolower($association['language']->lang_code); ?>
 									<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo $association['language']->lang_code; ?>
 										<span class="sr-only"><?php echo $association['language']->title_native; ?></span>
 									</a>
@@ -207,14 +207,14 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
 							<?php echo Text::_('COM_CONTENT_REGISTER_TO_READ_MORE'); ?>
 						</a>
 						<?php if (Associations::isEnabled() && $this->params->get('show_associations')) : ?>
-							<div>
+							<div class="cat-list-association">
 							<?php $associations = AssociationHelper::displayAssociations($article->id); ?>
 							<?php foreach ($associations as $association) : ?>
 								<?php if ($this->params->get('flags', 1)) : ?>
 									<?php $flag = HTMLHelper::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
 									<a href="<?php echo Route::_($association['item']); ?>"><?php echo $flag; ?></a>
 								<?php else : ?>
-									<?php $class = 'btn btn-badge btn-vsm btn-' . strtolower($association['language']->lang_code); ?>
+									<?php $class = 'btn btn-secondary btn-sm btn-' . strtolower($association['language']->lang_code); ?>
 									<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo $association['language']->lang_code; ?>
 										<span class="sr-only"><?php echo $association['language']->title_native; ?></span>
 									</a>

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -186,10 +186,12 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
 							<?php foreach ($associations as $association) : ?>
 								<?php if ($this->params->get('flags', 1) && $association['language']->image) : ?>
 									<?php $flag = HTMLHelper::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
-									&nbsp;<a href="<?php echo Route::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
+									<a href="<?php echo Route::_($association['item']); ?>"><?php echo $flag; ?></a>
 								<?php else : ?>
-									<?php $class = 'badge bg-secondary badge-' . $association['language']->sef; ?>
-									&nbsp;<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
+									<?php $class = 'btn btn-badge btn-vsm btn-' . strtolower($association['language']->lang_code); ?>
+									<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo $association['language']->lang_code; ?>
+										<span class="sr-only"><?php echo $association['language']->title_native; ?></span>
+									</a>
 								<?php endif; ?>
 							<?php endforeach; ?>
 							</div>
@@ -210,10 +212,12 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
 							<?php foreach ($associations as $association) : ?>
 								<?php if ($this->params->get('flags', 1)) : ?>
 									<?php $flag = HTMLHelper::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
-									&nbsp;<a href="<?php echo Route::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
+									<a href="<?php echo Route::_($association['item']); ?>"><?php echo $flag; ?></a>
 								<?php else : ?>
-									<?php $class = 'badge bg-secondary badge-' . $association['language']->sef; ?>
-									&nbsp;<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
+									<?php $class = 'btn btn-badge btn-vsm btn-' . strtolower($association['language']->lang_code); ?>
+									<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo $association['language']->lang_code; ?>
+										<span class="sr-only"><?php echo $association['language']->title_native; ?></span>
+									</a>
 								<?php endif; ?>
 							<?php endforeach; ?>
 							</div>

--- a/layouts/joomla/content/info_block/associations.php
+++ b/layouts/joomla/content/info_block/associations.php
@@ -24,10 +24,12 @@ use Joomla\CMS\Router\Route;
 	<?php foreach ($associations as $association) : ?>
 		<?php if ($displayData['item']->params->get('flags', 1) && $association['language']->image) : ?>
 			<?php $flag = HTMLHelper::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
-			&nbsp;<a href="<?php echo Route::_($association['item']); ?>"><?php echo $flag; ?></a>&nbsp;
+			<a href="<?php echo Route::_($association['item']); ?>"><?php echo $flag; ?></a>
 		<?php else : ?>
-			<?php $class = 'badge bg-secondary badge-' . $association['language']->sef; ?>
-			&nbsp;<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo strtoupper($association['language']->sef); ?></a>&nbsp;
+			<?php $class = 'btn btn-badge btn-vsm btn-' . strtolower($association['language']->lang_code); ?>
+			<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo $association['language']->lang_code; ?>
+				<span class="sr-only"><?php echo $association['language']->title_native; ?></span>
+			</a>
 		<?php endif; ?>
 	<?php endforeach; ?>
 </dd>

--- a/layouts/joomla/content/info_block/associations.php
+++ b/layouts/joomla/content/info_block/associations.php
@@ -28,7 +28,7 @@ use Joomla\CMS\Router\Route;
 		<?php else : ?>
 			<?php $class = 'btn btn-secondary btn-sm btn-' . strtolower($association['language']->lang_code); ?>
 			<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo $association['language']->lang_code; ?>
-				<span class="sr-only"><?php echo $association['language']->title_native; ?></span>
+				<span class="visually-hidden"><?php echo $association['language']->title_native; ?></span>
 			</a>
 		<?php endif; ?>
 	<?php endforeach; ?>

--- a/layouts/joomla/content/info_block/associations.php
+++ b/layouts/joomla/content/info_block/associations.php
@@ -26,7 +26,7 @@ use Joomla\CMS\Router\Route;
 			<?php $flag = HTMLHelper::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
 			<a href="<?php echo Route::_($association['item']); ?>"><?php echo $flag; ?></a>
 		<?php else : ?>
-			<?php $class = 'btn btn-badge btn-vsm btn-' . strtolower($association['language']->lang_code); ?>
+			<?php $class = 'btn btn-secondary btn-sm btn-' . strtolower($association['language']->lang_code); ?>
 			<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo $association['language']->lang_code; ?>
 				<span class="sr-only"><?php echo $association['language']->title_native; ?></span>
 			</a>

--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -25,7 +25,8 @@
   }
 }
 
-.btn-badge {
+.article-info .association .btn-secondary,
+.cat-list-association .btn-secondary, {
   font-weight: 700;
   color: $white;
   background-color: $gray-600;
@@ -38,7 +39,8 @@
   }
 }
 
-.btn-vsm, .btn-group-vsm > .btn {
+.article-info .association .btn-sm, .btn-group-sm > .btn,
+.cat-list-association .btn-sm, .btn-group-sm > .btn {
   padding: 0 .25rem;
   font-size: .8rem;
   border-radius: .2rem;

--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -39,9 +39,9 @@
 }
 
 .btn-vsm, .btn-group-vsm > .btn {
-  padding: 0 0.25rem;
-  font-size: 0.800rem;
-  border-radius: 0.2rem;
+  padding: 0 .25rem;
+  font-size: .8rem;
+  border-radius: .2rem;
 }
 
 @include media-breakpoint-down(md) {

--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -39,10 +39,7 @@
       background-color: $gray-800;
     }
   }
-}
 
-.article-info .association,
-.cat-list-association {
   .btn-sm {
     padding: 0 .25rem;
     font-size: .8rem;

--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -25,25 +25,29 @@
   }
 }
 
-.article-info .association .btn-secondary,
-.cat-list-association .btn-secondary, {
-  font-weight: 700;
-  color: $white;
-  background-color: $gray-600;
-  border-color: $gray-400;
-
-  &:hover,
-  &:focus {
+.article-info .association,
+.cat-list-association {
+  .btn-secondary {
+    font-weight: 700;
     color: $white;
-    background-color: $gray-800;
+    background-color: $gray-600;
+    border-color: $gray-400;
+
+    &:hover,
+    &:focus {
+      color: $white;
+      background-color: $gray-800;
+    }
   }
 }
 
-.article-info .association .btn-sm, .btn-group-sm > .btn,
-.cat-list-association .btn-sm, .btn-group-sm > .btn {
-  padding: 0 .25rem;
-  font-size: .8rem;
-  border-radius: .2rem;
+.article-info .association,
+.cat-list-association {
+  btn-sm {
+    padding: 0 .25rem;
+    font-size: .8rem;
+    border-radius: .2rem;
+  }
 }
 
 @include media-breakpoint-down(md) {

--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -43,7 +43,7 @@
 
 .article-info .association,
 .cat-list-association {
-  btn-sm {
+  .btn-sm {
     padding: 0 .25rem;
     font-size: .8rem;
     border-radius: .2rem;

--- a/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_buttons.scss
@@ -25,6 +25,25 @@
   }
 }
 
+.btn-badge {
+  font-weight: 700;
+  color: $white;
+  background-color: $gray-600;
+  border-color: $gray-400;
+
+  &:hover,
+  &:focus {
+    color: $white;
+    background-color: $gray-800;
+  }
+}
+
+.btn-vsm, .btn-group-vsm > .btn {
+  padding: 0 0.25rem;
+  font-size: 0.800rem;
+  border-radius: 0.2rem;
+}
+
 @include media-breakpoint-down(md) {
   .btn {
     margin-bottom: .25rem;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/32978

### Summary of Changes
Using buttons instead of badges to display lang tags for articles associations.
(see https://github.com/joomla/joomla-cms/commit/f7833a496c5519e073933b957c5135b237ace50e as example)

Using full lang tag in button to let choose when we have the same language for different countries: de-DE, de-AT,

----EDIT: Creating btn-secondary and btn-sm overrides

### Testing Instructions
Create a multilingual site with the specific sample data.
Create a list category for the category concerned by the associated articles per default.
Make sure Articles Options Associations are set and not use flags

<img width="536" alt="Screen Shot 2021-04-04 at 11 11 41" src="https://user-images.githubusercontent.com/869724/113504162-a68d9000-9536-11eb-80e5-2ccb2332c2f4.png">


Load Home page. Load list category menu item.

patch and test again.

Needs npm
### Actual result BEFORE applying this Pull Request
![Bildschirmfoto 2021-04-03 um 09 59 50](https://user-images.githubusercontent.com/78906980/113472570-8b525000-9464-11eb-9a58-4ccee4cb0159.png) 


### Expected result AFTER applying this Pull Request
![assoc_front-home-2](https://user-images.githubusercontent.com/869724/113504135-6f1ee380-9536-11eb-8861-691a0065b66f.gif)

![assoc_front-list-2](https://user-images.githubusercontent.com/869724/113504139-77771e80-9536-11eb-9ec2-9c7ab48b6e53.gif)


Note: may need some more concerning a11y

