### PR TITLE
[4] Invalidate opcache on cache file deletion without using Filesystem API for 'performance reasons'

### DIFF
--- a/libraries/src/Cache/Storage/FileStorage.php
+++ b/libraries/src/Cache/Storage/FileStorage.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Cache\Storage;
 \defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Cache\CacheStorage;
+use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 
@@ -68,6 +69,7 @@ class FileStorage extends CacheStorage
 				// Delete only the existing file if it is empty.
 				if (@filesize($path) === 0)
 				{
+					File::invalidateFileCache($path);
 					@unlink($path);
 				}
 
@@ -240,6 +242,7 @@ class FileStorage extends CacheStorage
 	{
 		$path = $this->_getFilePath($id, $group);
 
+		File::invalidateFileCache($path);
 		if (!@unlink($path))
 		{
 			return false;
@@ -319,6 +322,7 @@ class FileStorage extends CacheStorage
 
 			if (($time + $this->_lifetime) < $this->_now || empty($time))
 			{
+				File::invalidateFileCache($file);
 				$result |= @unlink($file);
 			}
 		}
@@ -437,6 +441,7 @@ class FileStorage extends CacheStorage
 
 			if (($time + $this->_lifetime) < $this->_now || empty($time))
 			{
+				File::invalidateFileCache($path);
 				@unlink($path);
 
 				return false;
@@ -523,6 +528,7 @@ class FileStorage extends CacheStorage
 
 		if (!empty($files) && !\is_array($files))
 		{
+			File::invalidateFileCache($files);
 			if (@unlink($files) !== true)
 			{
 				return false;
@@ -534,7 +540,8 @@ class FileStorage extends CacheStorage
 			{
 				$file = $this->_cleanPath($file);
 
-				// In case of restricted permissions we zap it one way or the other as long as the owner is either the webserver or the ftp
+				// In case of restricted permissions we delete it one way or the other as long as the owner is either the webserver or the ftp
+				File::invalidateFileCache($file);
 				if (@unlink($file) !== true)
 				{
 					Log::add(__METHOD__ . ' ' . Text::sprintf('JLIB_FILESYSTEM_DELETE_FAILED', basename($file)), Log::WARNING, 'jerror');

--- a/libraries/src/Cache/Storage/FileStorage.php
+++ b/libraries/src/Cache/Storage/FileStorage.php
@@ -542,6 +542,7 @@ class FileStorage extends CacheStorage
 
 				// In case of restricted permissions we delete it one way or the other as long as the owner is either the webserver or the ftp
 				File::invalidateFileCache($file);
+
 				if (@unlink($file) !== true)
 				{
 					Log::add(__METHOD__ . ' ' . Text::sprintf('JLIB_FILESYSTEM_DELETE_FAILED', basename($file)), Log::WARNING, 'jerror');


### PR DESCRIPTION
Pull Request for Issue #32961

### Summary of Changes

When purging your cache, we need to clear the PHP Opcache of these files you are deleting. 

### Testing Instructions

THIS PR RELIES ON THE NEW METHODS IN https://github.com/joomla/joomla-cms/pull/32915 and so you first need to apply that PR, or wait until its merged before testing this. 

Set up your PHP to aggressively use the PHP Opcache and never use the files on the disk after compiling. Instructions for that are in https://github.com/joomla/joomla-cms/pull/32915#issuecomment-812562008

Turn on Joomla Global Configuration Caching to file system. Generate a load of cache. Purge your cache in the cache manner in admin. 

### Actual result BEFORE applying this Pull Request

Files are removed from the hard disk, but not from the PHP OPcache

### Expected result AFTER applying this Pull Request

Files are removed from the hard disk, and expired in the PHP OPcache

### Documentation Changes Required

None.