### PR TITLE
[4] Disable auto complete on url field in extension installer

### DIFF
--- a/plugins/installer/urlinstaller/tmpl/default.php
+++ b/plugins/installer/urlinstaller/tmpl/default.php
@@ -26,7 +26,7 @@ $this->app->getDocument()->getWebAssetManager()
 		<?php echo Text::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?>
 	</label>
 	<div class="controls">
-		<input type="text" id="install_url" name="install_url" class="form-control" placeholder="https://">
+		<input type="text" id="install_url" name="install_url" class="form-control" placeholder="https://" autocomplete="off">
 	</div>
 </div>
 <hr>


### PR DESCRIPTION
### Summary of Changes

When installing from url, the input field allows autocomplete, and browsers then store this for use later.

This has lead to urls being stored in the browser, and `extra_query` values also being stored

As the chances of having to install the same url to the same site multiple times is very very low, there is no reason for the browser to be storing the URL values for future use, and there's no point in autofill on this field.

Also another bug, is if your autofill cache has a longer url of the same one you are trying to install (for example the same url with an appended `extra_query`) then after pasting in your URL (without  `extra_query`), the browser sometimes auto-appends with the  `extra_query` on blur, or just before blur, just when you are clicking the button, at the worst time! 

Most browsers the autofill cache is PER SITE, so you lose nothing by disabling this. 

### Testing Instructions

Apply PR, check the field doesn't present any autofill suggestions. 

### Actual result BEFORE applying this Pull Request

![Screen Recording 2021-04-04 at 01 30 56 pm](https://user-images.githubusercontent.com/400092/113508810-0ccfde00-954a-11eb-9d00-24b1d7702b5f.gif)


![Screen Recording 2021-04-04 at 01 24 29 pm](https://user-images.githubusercontent.com/400092/113508676-3b998480-9549-11eb-80ca-bb6956ba1974.gif)


### Expected result AFTER applying this Pull Request

Browser doesn't store, or present a saved listed of urls for autocompletion. 

### Documentation Changes Required

None