### PR TITLE
[4] Remove unused & undefined variables from sprintf

### DIFF
--- a/libraries/src/Http/Transport/StreamTransport.php
+++ b/libraries/src/Http/Transport/StreamTransport.php
@@ -163,7 +163,7 @@ class StreamTransport extends AbstractTransport implements TransportInterface
 			if (!$php_errormsg)
 			{
 				// Error but nothing from php? Create our own
-				$php_errormsg = sprintf('Could not connect to resource: %s', $uri, $err, $errno);
+				$php_errormsg = sprintf('Could not connect to resource: %s', $uri);
 			}
 
 			// Restore error tracking to give control to the exception handler


### PR DESCRIPTION
Code review.

The subject of the `sprintf` only has 1 placeholder but yet we are providing 3 variables to it.

`$err` and `$errno` are also not defined before being used here

Psalm static analysis also highlights this as an issue.

```
ERROR: UndefinedVariable - libraries/src/Http/Transport/StreamTransport.php:166:72 - Cannot find referenced variable $err (see https://psalm.dev/024)
				$php_errormsg = sprintf('Could not connect to resource: %s', $uri, $err, $errno);


ERROR: UndefinedVariable - libraries/src/Http/Transport/StreamTransport.php:166:78 - Cannot find referenced variable $errno (see https://psalm.dev/024)
				$php_errormsg = sprintf('Could not connect to resource: %s', $uri, $err, $errno);
```
