### PR TITLE
[4] s/string/array

### DIFF
--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -157,7 +157,7 @@ class WebAssetManager implements WebAssetManagerInterface
 	 * Adds support for magic method calls
 	 *
 	 * @param   string  $method     A method name
-	 * @param   string  $arguments  An arguments for a method
+	 * @param   array   $arguments  An arguments for a method
 	 *
 	 * @return mixed
 	 *

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -157,7 +157,7 @@ class WebAssetManager implements WebAssetManagerInterface
 	 * Adds support for magic method calls
 	 *
 	 * @param   string  $method     A method name
-	 * @param   array   $arguments  An arguments for a method
+	 * @param   array   $arguments  Arguments for a method
 	 *
 	 * @return mixed
 	 *


### PR DESCRIPTION
`$arguments` has to be an array as its used as an array and even used with the spread operator later on as `...$arguments`

Code review 