### PR TITLE
[4] s/int/mixed 

### DIFF
--- a/libraries/src/Utility/Utility.php
+++ b/libraries/src/Utility/Utility.php
@@ -54,7 +54,7 @@ class Utility
 	 *
 	 * @param   mixed  $custom  A custom upper limit, if the PHP settings are all above this then this will be used
 	 *
-	 * @return  integer  Size in number of bytes
+	 * @return  mixed  Size in number of bytes
 	 *
 	 * @since   3.7.0
 	 */


### PR DESCRIPTION
Code review

The `min()` function in PHP returns a `mixed` and not `int`

https://www.php.net/manual/en/function.min.php