### PR TITLE
[4] s/object/string

### DIFF
--- a/libraries/src/Updater/UpdateAdapter.php
+++ b/libraries/src/Updater/UpdateAdapter.php
@@ -97,7 +97,7 @@ abstract class UpdateAdapter extends AdapterInstance
 	/**
 	 * Gets the reference to the current direct parent
 	 *
-	 * @return  object
+	 * @return  string
 	 *
 	 * @since   1.7.0
 	 */


### PR DESCRIPTION
s/object/string

The result of `implode()` can only be a string, not an object 

https://www.php.net/implode