### PR TITLE
[4] Cast data object to string

### DIFF
--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -453,7 +453,7 @@ class Update extends CMSObject
 		{
 			// Grab the last source so we can append the URL
 			$source = end($this->downloadSources);
-			$source->url = $data;
+			$source->url = (string) $data;
 
 			return;
 		}


### PR DESCRIPTION
Code review

When `$data` is passed into this method it has type `object` according to the docblock for this method.

There is already a case on line 447 where the object is cast to string

`$source->url` has a docblock type (in DownloadSource.php) of string.

Therefore assign an object to an object property of type string is incorrect and we first need to cast to a string before assigning. 