### PR TITLE
[4] s/object/string

### DIFF
--- a/libraries/src/Updater/Adapter/CollectionAdapter.php
+++ b/libraries/src/Updater/Adapter/CollectionAdapter.php
@@ -66,7 +66,7 @@ class CollectionAdapter extends UpdateAdapter
 	/**
 	 * Gets the reference to the current direct parent
 	 *
-	 * @return  object
+	 * @return  string
 	 *
 	 * @since   1.7.0
 	 */


### PR DESCRIPTION
s/object/string

The result of implode() can only be a string, not an object

https://www.php.net/implode