### PR TITLE
[4] append additional type to type hint

### DIFF
--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -159,8 +159,8 @@ class Toolbar
 	/**
 	 * Append a button to toolbar.
 	 *
-	 * @param   ToolbarButton  $button  The button instance.
-	 * @param   array          $args    The more arguments.
+	 * @param   ToolbarButton|string  $button  The button instance.
+	 * @param   array                 $args    The more arguments.
 	 *
 	 * @return  ToolbarButton|boolean  Return button instance to help chaining configure. If using legacy arguments
 	 *                                 returns true

--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -158,8 +158,9 @@ class Toolbar
 
 	/**
 	 * Append a button to toolbar.
+	 * @deprecated 5.0  Note that the passing of $button as a (string) is deprecated and will be removed with Joomla 5.0.
 	 *
-	 * @param   ToolbarButton|string  $button  The button instance. String type is deprecated and will be removed with Joomla 5.0
+	 * @param   ToolbarButton|string  $button  The button instance.
 	 * @param   array                 $args    The more arguments.
 	 *
 	 * @return  ToolbarButton|boolean  Return button instance to help chaining configure. If using legacy arguments

--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -159,7 +159,7 @@ class Toolbar
 	/**
 	 * Append a button to toolbar.
 	 *
-	 * @param   ToolbarButton|string  $button  The button instance.
+	 * @param   ToolbarButton|string  $button  The button instance. String type is deprecated and will be removed with Joomla 5.0
 	 * @param   array                 $args    The more arguments.
 	 *
 	 * @return  ToolbarButton|boolean  Return button instance to help chaining configure. If using legacy arguments


### PR DESCRIPTION
Code review.

This method can and is called many times with a string as the value for `$button`

E.g:

```php
$bar->appendButton('Custom', $layout->render($options), 'versions');

$bar->appendButton('Standard', 'cancel', $alt, $task, false);
```