### PR TITLE
[4] s/[]/'' Correct default initial property value

### DIFF
--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -49,7 +49,7 @@ class Toolbar
 	 * @var    string
 	 * @since  1.5
 	 */
-	protected $_name = [];
+	protected $_name = '';
 
 	/**
 	 * Toolbar array


### PR DESCRIPTION
Code review

This is clearly a string, the name of the toolbar and not an array. Its used as a string throughout.