### PR TITLE
[4] add boolean to return type

### DIFF
--- a/libraries/src/Table/Nested.php
+++ b/libraries/src/Table/Nested.php
@@ -1472,7 +1472,7 @@ class Nested extends Table
 	 * @param   array  $idArray   id numbers of rows to be reordered.
 	 * @param   array  $lftArray  lft values of rows to be reordered.
 	 *
-	 * @return  integer  1 + value of root rgt on success, false on failure.
+	 * @return  integer|boolean  1 + value of root rgt on success, false on failure.
 	 *
 	 * @since   1.7.0
 	 * @throws  \Exception on database error.


### PR DESCRIPTION
code review

As per the description of the return, this method returns an int or false, so it needs a boolean flag on the return as well as the integer