### PR TITLE
[4.0] Test fix, code style in core.js

### DIFF
--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -567,7 +567,7 @@ window.Joomla.Modal = window.Joomla.Modal || {
           xhr.setRequestHeader('X-CSRF-Token', token);
         }
 
-        if (typeof(newOptions.data) === 'string' && (!newOptions.headers || !newOptions.headers['Content-Type'])) {
+        if (typeof newOptions.data === 'string' && (!newOptions.headers || !newOptions.headers['Content-Type'])) {
           xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded');
         }
       }


### PR DESCRIPTION
### Summary of Changes

Changes `typeof(variable)` to `typeof variable`
No idea why eslint complain, it the same construction.


### Testing Instructions

JavaScript CS test should pass


