### PR TITLE
[3] Flush administrator system cache after rebuilding update sites

### DIFF
--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -383,6 +383,10 @@ class InstallerModelUpdatesites extends InstallerModel
 		{
 			$app->enqueueMessage(JText::_('COM_INSTALLER_MSG_UPDATESITES_REBUILD_MESSAGE'), 'message');
 		}
+		
+		// Flush both system caches.
+		$this->cleanCache('_system', 0);
+		$this->cleanCache('_system', 1);
 	}
 
 	/**

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -384,8 +384,7 @@ class InstallerModelUpdatesites extends InstallerModel
 			$app->enqueueMessage(JText::_('COM_INSTALLER_MSG_UPDATESITES_REBUILD_MESSAGE'), 'message');
 		}
 		
-		// Flush both system caches.
-		$this->cleanCache('_system', 0);
+		// Flush the system cache to ensure extra_query is correctly loaded next time.
 		$this->cleanCache('_system', 1);
 	}
 


### PR DESCRIPTION
Flush both system caches after rebuilding update sites

Last bit missing from already merged https://github.com/joomla/joomla-cms/pull/32862

// @richard67 