### PR TITLE
[4.0] Fix Spinner Styling

### DIFF
--- a/build/media_source/com_languages/css/overrider.css
+++ b/build/media_source/com_languages/css/overrider.css
@@ -20,7 +20,6 @@
 	display: grid;
 }
 
-
 #refresh-status.show{
 	display: block;
 }

--- a/build/media_source/com_languages/css/overrider.css
+++ b/build/media_source/com_languages/css/overrider.css
@@ -14,11 +14,15 @@
 	display: none;
 }
 #overrider-spinner.show,
-#refresh-status.show,
 #more-results.show,
 #results-container.show,
 #language-results.show {
 	display: grid;
+}
+
+
+#refresh-status.show{
+	display: block;
 }
 
 #overrider-spinner-btn.show {

--- a/build/media_source/com_languages/css/overrider.css
+++ b/build/media_source/com_languages/css/overrider.css
@@ -20,7 +20,7 @@
 	display: grid;
 }
 
-#refresh-status.show{
+#refresh-status.show {
 	display: block;
 }
 


### PR DESCRIPTION
Pull Request for Issue #32948 .

### Summary of Changes
Changes  
`#refresh-status.show {
	display: grid;
}` 
to 
`#refresh-status.show {
	display: block;
}`
in https://github.com/joomla/joomla-cms/blob/6d32e9491bc90490ba321ead7c471a9d8d5b2ac4/build/media_source/com_languages/css/overrider.css#L10

The spinner (refer to the gif below) was going out of bounds when user focuses the input field above it. This happened because of the JavaScript function which changed the class of the span enclosing the icon to `.show`. This new class would function to make the block visible but the implementation behind this was done by changing the span's display from `none` to `grid` which caused the spin animation to behave in a funny manner

### Testing Instructions
1. npm ci 
2. Launch Joomla
3. Visit Joomla Administrator Panel
4. System Settings
5. Language Overrides
6. Select a pre-existing language
7. Click on New
8. Click on the search input field

### Actual result BEFORE applying this Pull Request
![original](https://user-images.githubusercontent.com/368084/113182425-bc821480-9207-11eb-861c-f10a6a8b6476.gif)


### Expected result AFTER applying this Pull Request
![Ouput](https://user-images.githubusercontent.com/53610833/113731274-45bcae00-9716-11eb-81b1-ac4744b1535c.gif)

### Documentation Changes Required
N/A
