### PR TITLE
[4] msg: You cannot add or remove authenticators on behalf of users

### DIFF
--- a/administrator/language/en-GB/plg_system_webauthn.ini
+++ b/administrator/language/en-GB/plg_system_webauthn.ini
@@ -4,6 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SYSTEM_WEBAUTHN="System - WebAuthn Passwordless Login"
+PLG_SYSTEM_WEBAUTHN_CANNOT_ADD_FOR_A_USER="You cannot add or remove authenticators on behalf of users. Users must login, and set up their own devices."
 PLG_SYSTEM_WEBAUTHN_DESCRIPTION="Enables passwordless authentication using the W3C Web Authentication (WebAuthn) API. Please note that the WebAuthn tab in the user profile editor and the WebAuthn login buttons will only be displayed if the user is accessing the site over HTTPS. Furthermore, registering WebAuthn authenticators and using them to log into your site will only work when your site is using a valid certificate, signed by a Certificate Authority the user's browser trusts."
 PLG_SYSTEM_WEBAUTHN_ERR_CANNOT_FIND_USERNAME="Cannot find the username field in the login module. Sorry, Passwordless authentication will not work on this site unless you use a different login module."
 PLG_SYSTEM_WEBAUTHN_ERR_CANT_STORE_FOR_GUEST="Cannot possibly store credentials for Guest user!"

--- a/layouts/plugins/system/webauthn/manage.php
+++ b/layouts/plugins/system/webauthn/manage.php
@@ -57,8 +57,14 @@ $defaultDisplayData = [
 ];
 extract(array_merge($defaultDisplayData, $displayData));
 
+if ($displayData['allow_add'] === false)
+{
+	$error = Text::_('PLG_SYSTEM_WEBAUTHN_CANNOT_ADD_FOR_A_USER');
+	$allow_add = false;
+}
+
 // Ensure the GMP or BCmath extension is loaded in PHP - as this is required by third party library
-if ((function_exists('gmp_intval') === false) && (function_exists('bccomp') === false))
+if (!$error && (function_exists('gmp_intval') === false) && (function_exists('bccomp') === false))
 {
 	$error = Text::_('PLG_SYSTEM_WEBAUTHN_REQUIRES_GMP');
 	$allow_add = false;

--- a/layouts/plugins/system/webauthn/manage.php
+++ b/layouts/plugins/system/webauthn/manage.php
@@ -64,7 +64,7 @@ if ($displayData['allow_add'] === false)
 }
 
 // Ensure the GMP or BCmath extension is loaded in PHP - as this is required by third party library
-if (!$error && (function_exists('gmp_intval') === false) && (function_exists('bccomp') === false))
+if ($allow_add && function_exists('gmp_intval') === false && function_exists('bccomp') === false)
 {
 	$error = Text::_('PLG_SYSTEM_WEBAUTHN_REQUIRES_GMP');
 	$allow_add = false;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/33056

### Summary of Changes

Provide feedback for a legitimate gotcha. 

Admin A should not be able to add authenticators for user B. 

### Testing Instructions

Login as Admin A on a `https://` site. 

Edit User B with intention of adding an authenticators

### Actual result BEFORE applying this Pull Request

No button to add an authenticator 
No feedback why
Confusion as evidenced in https://github.com/joomla/joomla-cms/issues/33056

### Expected result AFTER applying this Pull Request

<img width="1593" alt="Screenshot 2021-04-07 at 23 50 01" src="https://user-images.githubusercontent.com/400092/113944582-ab836580-97fc-11eb-9772-ab7baac9822a.png">


### Documentation Changes Required

None.

// @nikosdion might be able to provide the link to the exact reason he added this reasonable requirement, IIRC it was a WebAuthn standard thing? I might remember wrong. 

// @Dr-Sommer for testing. 

// @brianteeman to make my English Joomlafied. 