### PR TITLE
[4.0] Private messages view

### DIFF
--- a/administrator/components/com_messages/tmpl/message/default.php
+++ b/administrator/components/com_messages/tmpl/message/default.php
@@ -23,7 +23,7 @@ HTMLHelper::_('behavior.core');
 					<div class="control-label">
 						<?php echo Text::_('COM_MESSAGES_FIELD_USER_ID_FROM_LABEL'); ?>
 					</div>
-					<div class="p-3 bg-light">
+					<div class="p-3 bg-light border rounded">
 						<?php echo $this->item->get('from_user_name'); ?>
 					</div>
 				</div>
@@ -31,7 +31,7 @@ HTMLHelper::_('behavior.core');
 					<div class="control-label">
 						<?php echo Text::_('COM_MESSAGES_FIELD_DATE_TIME_LABEL'); ?>
 					</div>
-					<div class="p-3 bg-light">
+					<div class="p-3 bg-light border rounded">
 						<?php echo HTMLHelper::_('date', $this->item->date_time, Text::_('DATE_FORMAT_LC2')); ?>
 					</div>
 				</div>
@@ -39,7 +39,7 @@ HTMLHelper::_('behavior.core');
 					<div class="control-label">
 						<?php echo Text::_('COM_MESSAGES_FIELD_SUBJECT_LABEL'); ?>
 					</div>
-					<div class="p-3 bg-light">
+					<div class="p-3 bg-light border rounded">
 						<?php echo $this->item->subject; ?>
 					</div>
 				</div>
@@ -47,7 +47,7 @@ HTMLHelper::_('behavior.core');
 					<div class="control-label">
 						<?php echo Text::_('COM_MESSAGES_FIELD_MESSAGE_LABEL'); ?>
 					</div>
-					<div class="p-3 bg-light">
+					<div class="p-3 bg-light border rounded">
 						<?php echo $this->item->message; ?>
 					</div>
 				</div>


### PR DESCRIPTION
### Summary of Changes
The view that displays a received private message is very hard to read.  The background that is applied is so light it just merges into the background. This pr just adds a rounded border. 

Adds a border around the message fields.


### Testing Instructions
Create two users with admin access
Login as user1 and send a private message to user2
Logout as user1 and log back in as user2 to read the message


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/114100558-5e66c880-98bc-11eb-9530-9ebae9edf349.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/114100505-4abb6200-98bc-11eb-9add-17fea22a4f4e.png)



### Documentation Changes Required
none
