### PR TITLE
[4.0] Language Switcher: correcting dropdown when no flags

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -24,7 +24,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 
 <?php if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1)) : ?>
 	<form name="lang" method="post" action="<?php echo htmlspecialchars_decode(htmlspecialchars(Uri::current(), ENT_COMPAT, 'UTF-8'), ENT_NOQUOTES); ?>">
-	<select class="inputbox advancedSelect" onchange="document.location.replace(this.value);" >
+	<select class="inputbox form-select" onchange="document.location.replace(this.value);" >
 	<?php foreach ($list as $language) : ?>
 		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
 		<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?></option>


### PR DESCRIPTION
### Summary of Changes
As title says. Modifying class.


### Testing Instructions
Create a multilingual site with the sample data (2 languages minimum).
Edit mod_languages settings to:

<img width="706" alt="Screen Shot 2021-04-09 at 09 24 41" src="https://user-images.githubusercontent.com/869724/114144599-cc8ba980-9915-11eb-939f-a0c7cc5d36a7.png">

Display the switcher in frontend

### Actual result BEFORE applying this Pull Request

<img width="374" alt="Screen Shot 2021-04-09 at 09 08 14" src="https://user-images.githubusercontent.com/869724/114144620-d1505d80-9915-11eb-85db-f0995e9451d0.png">


### Expected result AFTER applying this Pull Request

<img width="410" alt="Screen Shot 2021-04-09 at 09 02 27" src="https://user-images.githubusercontent.com/869724/114144651-d6ada800-9915-11eb-9acb-1e9c01386d12.png">


### Documentation Changes Required
None
