### PR TITLE
[4.0][RFC] toolbars are not dev friendly

### DIFF
--- a/administrator/components/com_content/layouts/list-toolbar.php
+++ b/administrator/components/com_content/layouts/list-toolbar.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_categories
+ *
+ * @copyright   (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+use Joomla\CMS\Toolbar\Toolbar;
+use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Content\Administrator\Extension\ContentComponent;
+use Joomla\Component\Content\Administrator\Helper\ContentHelper;
+
+/**
+ * @var $state {}
+ * @var $transitions []
+ */
+extract($displayData);
+
+$canDo = ContentHelper::getActions('com_content', 'category', $state->get('filter.category_id'));
+$user  = Factory::getUser();
+
+// Get the toolbar object instance
+$toolbar = Toolbar::getInstance('toolbar');
+
+ToolbarHelper::title(Text::_('COM_CONTENT_ARTICLES_TITLE'), 'copy article');
+
+if ($canDo->get('core.create') || count($user->getAuthorisedCategories('com_content', 'core.create')) > 0)
+{
+	$toolbar->addNew('article.add');
+}
+
+if ($canDo->get('core.edit.state') || count($transitions))
+{
+	$dropdown = $toolbar->dropdownButton('status-group')
+		->text('JTOOLBAR_CHANGE_STATUS')
+		->toggleSplit(false)
+		->icon('icon-ellipsis-h')
+		->buttonClass('btn btn-action')
+		->listCheck(true);
+
+	$childBar = $dropdown->getChildToolbar();
+
+	if (count($transitions))
+	{
+		$childBar->separatorButton('transition-headline')
+			->text('COM_CONTENT_RUN_TRANSITIONS')
+			->buttonClass('text-center py-2 h3');
+
+		$cmd = "Joomla.submitbutton('articles.runTransition');";
+		$messages = "{error: [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
+		$alert = 'Joomla.renderMessages(' . $messages . ')';
+		$cmd   = 'if (document.adminForm.boxchecked.value == 0) { ' . $alert . ' } else { ' . $cmd . ' }';
+
+		foreach ($transitions as $transition)
+		{
+			$childBar->standardButton('transition')
+				->text($transition['text'])
+				->buttonClass('transition-' . (int) $transition['value'])
+				->icon('icon-project-diagram')
+				->onclick('document.adminForm.transition_id.value=' . (int) $transition['value'] . ';' . $cmd);
+		}
+
+		$childBar->separatorButton('transition-separator');
+	}
+
+	if ($canDo->get('core.edit.state'))
+	{
+		$childBar->publish('articles.publish')->listCheck(true);
+
+		$childBar->unpublish('articles.unpublish')->listCheck(true);
+
+		$childBar->standardButton('featured')
+			->text('JFEATURE')
+			->task('articles.featured')
+			->listCheck(true);
+
+		$childBar->standardButton('unfeatured')
+			->text('JUNFEATURE')
+			->task('articles.unfeatured')
+			->listCheck(true);
+
+		$childBar->archive('articles.archive')->listCheck(true);
+
+		$childBar->checkin('articles.checkin')->listCheck(true);
+
+		if ($state->get('filter.published') != ContentComponent::CONDITION_TRASHED)
+		{
+			$childBar->trash('articles.trash')->listCheck(true);
+		}
+	}
+
+	// Add a batch button
+	if ($user->authorise('core.create', 'com_content')
+		&& $user->authorise('core.edit', 'com_content')
+		&& $user->authorise('core.execute.transition', 'com_content'))
+	{
+		$childBar->popupButton('batch')
+			->text('JTOOLBAR_BATCH')
+			->selector('collapseModal')
+			->listCheck(true);
+	}
+}
+
+if ($state->get('filter.published') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
+{
+	$toolbar->delete('articles.delete')
+		->text('JTOOLBAR_EMPTY_TRASH')
+		->message('JGLOBAL_CONFIRM_DELETE')
+		->listCheck(true);
+}
+
+if ($user->authorise('core.admin', 'com_content') || $user->authorise('core.options', 'com_content'))
+{
+	$toolbar->preferences('com_content');
+}
+
+$toolbar->help('JHELP_CONTENT_ARTICLE_MANAGER');

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -104,8 +104,6 @@ class HtmlView extends BaseHtmlView
 		// We don't need toolbar in the modal window.
 		if ($this->getLayout() !== 'modal')
 		{
-//			$this->addToolbar();
-
 			// We do not need to filter by language when multilingual is disabled
 			if (!Multilanguage::isEnabled())
 			{

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -104,7 +104,7 @@ class HtmlView extends BaseHtmlView
 		// We don't need toolbar in the modal window.
 		if ($this->getLayout() !== 'modal')
 		{
-			$this->addToolbar();
+//			$this->addToolbar();
 
 			// We do not need to filter by language when multilingual is disabled
 			if (!Multilanguage::isEnabled())
@@ -132,115 +132,5 @@ class HtmlView extends BaseHtmlView
 		}
 
 		return parent::display($tpl);
-	}
-
-	/**
-	 * Add the page title and toolbar.
-	 *
-	 * @return  void
-	 *
-	 * @since   1.6
-	 */
-	protected function addToolbar()
-	{
-		$canDo = ContentHelper::getActions('com_content', 'category', $this->state->get('filter.category_id'));
-		$user  = Factory::getUser();
-
-		// Get the toolbar object instance
-		$toolbar = Toolbar::getInstance('toolbar');
-
-		ToolbarHelper::title(Text::_('COM_CONTENT_ARTICLES_TITLE'), 'copy article');
-
-		if ($canDo->get('core.create') || count($user->getAuthorisedCategories('com_content', 'core.create')) > 0)
-		{
-			$toolbar->addNew('article.add');
-		}
-
-		if ($canDo->get('core.edit.state') || count($this->transitions))
-		{
-			$dropdown = $toolbar->dropdownButton('status-group')
-				->text('JTOOLBAR_CHANGE_STATUS')
-				->toggleSplit(false)
-				->icon('icon-ellipsis-h')
-				->buttonClass('btn btn-action')
-				->listCheck(true);
-
-			$childBar = $dropdown->getChildToolbar();
-
-			if (count($this->transitions))
-			{
-				$childBar->separatorButton('transition-headline')
-					->text('COM_CONTENT_RUN_TRANSITIONS')
-					->buttonClass('text-center py-2 h3');
-
-				$cmd = "Joomla.submitbutton('articles.runTransition');";
-				$messages = "{error: [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
-				$alert = 'Joomla.renderMessages(' . $messages . ')';
-				$cmd   = 'if (document.adminForm.boxchecked.value == 0) { ' . $alert . ' } else { ' . $cmd . ' }';
-
-				foreach ($this->transitions as $transition)
-				{
-					$childBar->standardButton('transition')
-						->text($transition['text'])
-						->buttonClass('transition-' . (int) $transition['value'])
-						->icon('icon-project-diagram')
-						->onclick('document.adminForm.transition_id.value=' . (int) $transition['value'] . ';' . $cmd);
-				}
-
-				$childBar->separatorButton('transition-separator');
-			}
-
-			if ($canDo->get('core.edit.state'))
-			{
-				$childBar->publish('articles.publish')->listCheck(true);
-
-				$childBar->unpublish('articles.unpublish')->listCheck(true);
-
-				$childBar->standardButton('featured')
-					->text('JFEATURE')
-					->task('articles.featured')
-					->listCheck(true);
-
-				$childBar->standardButton('unfeatured')
-					->text('JUNFEATURE')
-					->task('articles.unfeatured')
-					->listCheck(true);
-
-				$childBar->archive('articles.archive')->listCheck(true);
-
-				$childBar->checkin('articles.checkin')->listCheck(true);
-
-				if ($this->state->get('filter.published') != ContentComponent::CONDITION_TRASHED)
-				{
-					$childBar->trash('articles.trash')->listCheck(true);
-				}
-			}
-
-			// Add a batch button
-			if ($user->authorise('core.create', 'com_content')
-				&& $user->authorise('core.edit', 'com_content')
-				&& $user->authorise('core.execute.transition', 'com_content'))
-			{
-				$childBar->popupButton('batch')
-					->text('JTOOLBAR_BATCH')
-					->selector('collapseModal')
-					->listCheck(true);
-			}
-		}
-
-		if ($this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
-		{
-			$toolbar->delete('articles.delete')
-				->text('JTOOLBAR_EMPTY_TRASH')
-				->message('JGLOBAL_CONFIRM_DELETE')
-				->listCheck(true);
-		}
-
-		if ($user->authorise('core.admin', 'com_content') || $user->authorise('core.options', 'com_content'))
-		{
-			$toolbar->preferences('com_content');
-		}
-
-		$toolbar->help('JHELP_CONTENT_ARTICLE_MANAGER');
 	}
 }

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -21,6 +21,9 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Toolbar\Toolbar;
+use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 use Joomla\Utilities\ArrayHelper;
 
@@ -93,6 +96,109 @@ $workflow_featured = Factory::getApplication()->bootComponent('com_content')->is
 endif;
 
 $assoc = Associations::isEnabled();
+
+// We don't need toolbar in the modal window.
+if ($this->getLayout() !== 'modal') {
+	$canDo = ContentHelper::getActions('com_content', 'category', $this->state->get('filter.category_id'));
+	$user  = Factory::getUser();
+
+	// Get the toolbar object instance
+	$toolbar = Toolbar::getInstance('toolbar');
+
+	ToolbarHelper::title(Text::_('COM_CONTENT_ARTICLES_TITLE'), 'copy article');
+
+	if ($canDo->get('core.create') || count($user->getAuthorisedCategories('com_content', 'core.create')) > 0)
+	{
+		$toolbar->addNew('article.add');
+	}
+
+	if ($canDo->get('core.edit.state') || count($this->transitions))
+	{
+		$dropdown = $toolbar->dropdownButton('status-group')
+				->text('JTOOLBAR_CHANGE_STATUS')
+				->toggleSplit(false)
+				->icon('icon-ellipsis-h')
+				->buttonClass('btn btn-action')
+				->listCheck(true);
+
+		$childBar = $dropdown->getChildToolbar();
+
+		if (count($this->transitions))
+		{
+			$childBar->separatorButton('transition-headline')
+					->text('COM_CONTENT_RUN_TRANSITIONS')
+					->buttonClass('text-center py-2 h3');
+
+			$cmd = "Joomla.submitbutton('articles.runTransition');";
+			$messages = "{error: [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
+			$alert = 'Joomla.renderMessages(' . $messages . ')';
+			$cmd   = 'if (document.adminForm.boxchecked.value == 0) { ' . $alert . ' } else { ' . $cmd . ' }';
+
+			foreach ($this->transitions as $transition)
+			{
+				$childBar->standardButton('transition')
+						->text($transition['text'])
+						->buttonClass('transition-' . (int) $transition['value'])
+						->icon('icon-project-diagram')
+						->onclick('document.adminForm.transition_id.value=' . (int) $transition['value'] . ';' . $cmd);
+			}
+
+			$childBar->separatorButton('transition-separator');
+		}
+
+		if ($canDo->get('core.edit.state'))
+		{
+			$childBar->publish('articles.publish')->listCheck(true);
+
+			$childBar->unpublish('articles.unpublish')->listCheck(true);
+
+			$childBar->standardButton('featured')
+					->text('JFEATURE')
+					->task('articles.featured')
+					->listCheck(true);
+
+			$childBar->standardButton('unfeatured')
+					->text('JUNFEATURE')
+					->task('articles.unfeatured')
+					->listCheck(true);
+
+			$childBar->archive('articles.archive')->listCheck(true);
+
+			$childBar->checkin('articles.checkin')->listCheck(true);
+
+			if ($this->state->get('filter.published') != ContentComponent::CONDITION_TRASHED)
+			{
+				$childBar->trash('articles.trash')->listCheck(true);
+			}
+		}
+
+		// Add a batch button
+		if ($user->authorise('core.create', 'com_content')
+				&& $user->authorise('core.edit', 'com_content')
+				&& $user->authorise('core.execute.transition', 'com_content'))
+		{
+			$childBar->popupButton('batch')
+					->text('JTOOLBAR_BATCH')
+					->selector('collapseModal')
+					->listCheck(true);
+		}
+	}
+
+	if ($this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
+	{
+		$toolbar->delete('articles.delete')
+				->text('JTOOLBAR_EMPTY_TRASH')
+				->message('JGLOBAL_CONFIRM_DELETE')
+				->listCheck(true);
+	}
+
+	if ($user->authorise('core.admin', 'com_content') || $user->authorise('core.options', 'com_content'))
+	{
+		$toolbar->preferences('com_content');
+	}
+
+	$toolbar->help('JHELP_CONTENT_ARTICLE_MANAGER');
+}
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_content&view=articles'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -21,9 +21,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
-use Joomla\CMS\Toolbar\Toolbar;
-use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 use Joomla\Utilities\ArrayHelper;
 
@@ -99,105 +96,7 @@ $assoc = Associations::isEnabled();
 
 // We don't need toolbar in the modal window.
 if ($this->getLayout() !== 'modal') {
-	$canDo = ContentHelper::getActions('com_content', 'category', $this->state->get('filter.category_id'));
-	$user  = Factory::getUser();
-
-	// Get the toolbar object instance
-	$toolbar = Toolbar::getInstance('toolbar');
-
-	ToolbarHelper::title(Text::_('COM_CONTENT_ARTICLES_TITLE'), 'copy article');
-
-	if ($canDo->get('core.create') || count($user->getAuthorisedCategories('com_content', 'core.create')) > 0)
-	{
-		$toolbar->addNew('article.add');
-	}
-
-	if ($canDo->get('core.edit.state') || count($this->transitions))
-	{
-		$dropdown = $toolbar->dropdownButton('status-group')
-				->text('JTOOLBAR_CHANGE_STATUS')
-				->toggleSplit(false)
-				->icon('icon-ellipsis-h')
-				->buttonClass('btn btn-action')
-				->listCheck(true);
-
-		$childBar = $dropdown->getChildToolbar();
-
-		if (count($this->transitions))
-		{
-			$childBar->separatorButton('transition-headline')
-					->text('COM_CONTENT_RUN_TRANSITIONS')
-					->buttonClass('text-center py-2 h3');
-
-			$cmd = "Joomla.submitbutton('articles.runTransition');";
-			$messages = "{error: [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
-			$alert = 'Joomla.renderMessages(' . $messages . ')';
-			$cmd   = 'if (document.adminForm.boxchecked.value == 0) { ' . $alert . ' } else { ' . $cmd . ' }';
-
-			foreach ($this->transitions as $transition)
-			{
-				$childBar->standardButton('transition')
-						->text($transition['text'])
-						->buttonClass('transition-' . (int) $transition['value'])
-						->icon('icon-project-diagram')
-						->onclick('document.adminForm.transition_id.value=' . (int) $transition['value'] . ';' . $cmd);
-			}
-
-			$childBar->separatorButton('transition-separator');
-		}
-
-		if ($canDo->get('core.edit.state'))
-		{
-			$childBar->publish('articles.publish')->listCheck(true);
-
-			$childBar->unpublish('articles.unpublish')->listCheck(true);
-
-			$childBar->standardButton('featured')
-					->text('JFEATURE')
-					->task('articles.featured')
-					->listCheck(true);
-
-			$childBar->standardButton('unfeatured')
-					->text('JUNFEATURE')
-					->task('articles.unfeatured')
-					->listCheck(true);
-
-			$childBar->archive('articles.archive')->listCheck(true);
-
-			$childBar->checkin('articles.checkin')->listCheck(true);
-
-			if ($this->state->get('filter.published') != ContentComponent::CONDITION_TRASHED)
-			{
-				$childBar->trash('articles.trash')->listCheck(true);
-			}
-		}
-
-		// Add a batch button
-		if ($user->authorise('core.create', 'com_content')
-				&& $user->authorise('core.edit', 'com_content')
-				&& $user->authorise('core.execute.transition', 'com_content'))
-		{
-			$childBar->popupButton('batch')
-					->text('JTOOLBAR_BATCH')
-					->selector('collapseModal')
-					->listCheck(true);
-		}
-	}
-
-	if ($this->state->get('filter.published') == ContentComponent::CONDITION_TRASHED && $canDo->get('core.delete'))
-	{
-		$toolbar->delete('articles.delete')
-				->text('JTOOLBAR_EMPTY_TRASH')
-				->message('JGLOBAL_CONFIRM_DELETE')
-				->listCheck(true);
-	}
-
-	if ($user->authorise('core.admin', 'com_content') || $user->authorise('core.options', 'com_content'))
-	{
-		$toolbar->preferences('com_content');
-	}
-
-	$toolbar->help('JHELP_CONTENT_ARTICLE_MANAGER');
+	LayoutHelper::render('list-toolbar', ['transitions' => $this->transitions, 'state' => $this->state]);
 }
 ?>
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary

Toolbars (either on J3 or J4) are rendered in the HTML part of the view. The process makes them inaccessible for front end devs to tweak/change/add/remove anything! **WHY??**

All it takes is to move the `addToolbar()` function's content to the view. That's it but I genuinely want to know why this totally unfriendly approach is the preferred way.

On top of that, I wanted to point out that both the old and the new code for the toolbar/buttons is totally useless. There's a factory that takes some arguments and calls a JLayout to render the button. **WHY??** Just call the JLayout directly also JLayouts support `sublayout`s meaning there's a solution to the composition of the dropdown buttons.

In short, there's a lot of code that is totally useless as the JLayouts meet the requirements and then the whole output is not accessible to the front end developers. Not a good combo here...

### Testing Instructions
To prove my point here's a version of com_content's articles view that uses JLayout and is completely accessible to frontenders and also 100% B/C (assuming that the bloated code is left there)


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

Well the toolbar factory is not documented or am I missing the docs there?