### PR TITLE
[4.0] Remove unnecessary version compare

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1048,16 +1048,8 @@ ENDDATA;
 		$tmp_src  = $userfile['tmp_name'];
 
 		// Move uploaded file.
-		if (version_compare(\JVERSION, '3.4.0', 'ge'))
-		{
-			$result = File::upload($tmp_src, $tmp_dest, false, true);
-		}
-		else
-		{
-			// Old Joomla! versions didn't have UploadShield and don't need the fourth parameter to accept uploads
-			$result = File::upload($tmp_src, $tmp_dest);
-		}
-
+		$result = File::upload($tmp_src, $tmp_dest, false, true);
+		
 		if (!$result)
 		{
 			throw new \RuntimeException(Text::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR'), 500);

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1049,7 +1049,7 @@ ENDDATA;
 
 		// Move uploaded file.
 		$result = File::upload($tmp_src, $tmp_dest, false, true);
-		
+
 		if (!$result)
 		{
 			throw new \RuntimeException(Text::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR'), 500);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
We are on Joomla 4!, so **version_compare(\JVERSION, '3.4.0', 'ge')** always return true, thus the check could be removed. I found this while trying to look at the the issue with Ftp update


### Testing Instructions
Could be merged on review.