### PR TITLE
[J4] btn-group-yesno: success color only applied to 1 value

### DIFF
--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -92,20 +92,25 @@ if ($dataAttribute)
 			if ($isBtnYesNo)
 			{
 				// Set the button classes for the yes/no group
-				if ($option->value === "0")
+				switch ($option->value)
 				{
-					$optionClass = 'btn btn-outline-danger';
-				}
-				else
-				{
-					$optionClass = 'btn btn-outline-success';
+					case '0':
+						$optionClass = 'btn btn-outline-danger';
+						break;
+					case '1':
+						$optionClass = 'btn btn-outline-success';
+						break;
+					default:
+						$optionClass = 'btn btn-outline-secondary';
+						break;
 				}
 			}
 			else
 			{
 				$optionClass = !empty($option->class) ? $option->class : $btnClass;
-				$optionClass = trim($optionClass . ' ' . $disabled);
 			}
+
+			$optionClass = trim($optionClass . ' ' . $disabled);
 			$checked     = ((string) $option->value === $value) ? 'checked="checked"' : '';
 
 			// Initialize some JavaScript option attributes.

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -95,21 +95,18 @@ if ($dataAttribute)
 				switch ($option->value)
 				{
 					case '0':
-						$optionClass = 'btn btn-outline-danger';
+						$btnClass = 'btn btn-outline-danger';
 						break;
 					case '1':
-						$optionClass = 'btn btn-outline-success';
+						$btnClass = 'btn btn-outline-success';
 						break;
 					default:
-						$optionClass = 'btn btn-outline-secondary';
+						$btnClass = 'btn btn-outline-secondary';
 						break;
 				}
 			}
-			else
-			{
-				$optionClass = !empty($option->class) ? $option->class : $btnClass;
-			}
 
+			$optionClass = !empty($option->class) ? $option->class : $btnClass;
 			$optionClass = trim($optionClass . ' ' . $disabled);
 			$checked     = ((string) $option->value === $value) ? 'checked="checked"' : '';
 


### PR DESCRIPTION
When using the `btn-group-yesno` class on radio buttons in XML forms, the green `btn-outline-success` is applied to options with a value other than `0`.
This causes multiple buttons to be green.

This PR fixes that and more:

1. Changes class of options other than 0 or 1 to be use `btn-outline-secundary`
2. Fixes issue with the `disabled` attribute not being added to the options when using the `btn-group-yesno` class.
3. Fixes issue with the class not being overridable via the xml

Example:
```
<field name="testing" type="radio" default="0"
	   class="btn-group btn-group-yesno"
	   label="Testing">
	<option value="0">JNO</option>
	<option value="1">JYES</option>
	<option value="2">JDEFAULT</option>
</field>
```
Before:
![image](https://user-images.githubusercontent.com/13553242/114278951-5af54d80-9a32-11eb-85df-d663e66c271b.png)

After:
![image](https://user-images.githubusercontent.com/13553242/114278934-4a44d780-9a32-11eb-9f3e-950ff5dc8abe.png)

Example:
```
<field name="testing" type="radio" default="0"
	   class="btn-group btn-group-yesno"
	   label="Testing">
	<option value="0">JNO</option>
	<option value="1">JYES</option>
	<option value="2" class="btn btn-outline-info">JDEFAULT</option>
</field>
```
Before:
![image](https://user-images.githubusercontent.com/13553242/114278872-0fdb3a80-9a32-11eb-8076-c77973b5f4bf.png)

After:
![image](https://user-images.githubusercontent.com/13553242/114278901-28e3eb80-9a32-11eb-9661-6c4bde3544ba.png)

