### PR TITLE
[4.0] Simplify .form-text markup

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
@@ -62,8 +62,8 @@ Text::script('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', true);
 				<?php $maxSizeBytes = Utility::getMaxUploadSize(); ?>
 				<?php $maxSize = HTMLHelper::_('number.bytes', $maxSizeBytes); ?>
 				<input id="max_upload_size" name="max_upload_size" type="hidden" value="<?php echo $maxSizeBytes; ?>"/>
-				<small class="form-text text-muted"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', '&#x200E;' . $maxSize); ?></small>
-				<small class="form-text text-muted hidden" id="file_size" name="file_size"><?php echo Text::sprintf('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', '&#x200E;' . ''); ?></small>
+				<span class="form-text"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', '&#x200E;' . $maxSize); ?></span>
+				<span class="form-text hidden" id="file_size" name="file_size"><?php echo Text::sprintf('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', '&#x200E;' . ''); ?></span>
 				<div class="alert alert-warning hidden" id="max_upload_size_warn">
 					<?php echo Text::_('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG'); ?>
 				</div>

--- a/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
@@ -264,7 +264,7 @@
       <div class="form-check">
         <input class="form-check-input" type="checkbox" id="${this.parentId}-alt-check">
         <label class="form-check-label" for="${this.parentId}-alt-check">${this.altchecktext}</label>
-        <div><small class="form-text text-muted">${this.altcheckdesctext}</small></div>
+        <div class="form-text">${this.altcheckdesctext}</div>
       </div>
     </div>
     <div class="form-group">

--- a/installation/template/error.php
+++ b/installation/template/error.php
@@ -72,7 +72,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 								</div>
 								<div class="alert-text">
 									<h2><?php echo Text::_('JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST'); ?></h2>
-									<p class="form-text text-muted small"><span class="badge bg-secondary"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+									<p class="form-text"><span class="badge bg-secondary"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
 								</div>
 							</div>
 							<?php if ($this->debug) : ?>

--- a/installation/tmpl/preinstall/default.php
+++ b/installation/tmpl/preinstall/default.php
@@ -31,7 +31,7 @@ HTMLHelper::_('behavior.formvalidator');
 									</div>
 									<div class="alert-text">
 										<strong><?php echo $option->label; ?></strong>
-										<p class="form-text text-muted small"><?php echo $option->notice; ?></p>
+										<p class="form-text"><?php echo $option->notice; ?></p>
 									</div>
 								</div>
 							<?php endif; ?>

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -136,7 +136,7 @@ if ($rules && !empty($description))
 }
 ?>
 <?php if (!empty($description)) : ?>
-	<div id="<?php echo $name . '-desc'; ?>" class="small text-muted">
+	<div id="<?php echo $name . '-desc'; ?>" class="form-text mt-0">
 		<?php if ($rules) : ?>
 			<?php echo Text::sprintf($description, implode(', ', $requirements)); ?>
 		<?php else : ?>

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -47,10 +47,8 @@ if (!empty($parentclass))
 	<div class="controls">
 		<?php echo $input; ?>
 		<?php if (!$hideDescription && !empty($description)) : ?>
-			<div id="<?php echo $id; ?>">
-				<small class="form-text text-muted">
-					<?php echo $description; ?>
-				</small>
+			<div id="<?php echo $id; ?>" class="form-text">
+				<?php echo $description; ?>
 			</div>
 		<?php endif; ?>
 	</div>

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -96,7 +96,7 @@ $maxSize = HTMLHelper::_('number.bytes', $maxSizeBytes);
 		<div class="controls">
 			<input class="form-control-file" id="install_package" name="install_package" type="file">
 			<input id="max_upload_size" name="max_upload_size" type="hidden" value="<?php echo $maxSizeBytes; ?>" />
-			<small class="form-text text-muted"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?></small>
+			<span class="form-text"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?></span>
 		</div>
 	</div>
 	<div class="form-actions">


### PR DESCRIPTION
### Summary of Changes

With BS5, `.form-text` sets color and font-size. Thus no need to use `small` tag , `.small`, `.text-muted`.

Note: 2 instances related to FTP were not changed until further decision on FTP. 

### Testing Instructions
Code review.

or

Go to Global Configuration.
No visible changes to help description under a field.

Edit account.
No visible changes to help description above password field.

Go to System > Update > Joomla > Upload & Update
No visible changes to `Maximum upload size:`.

