### PR TITLE
[4.0] Fix non lazy loaded images

### DIFF
--- a/plugins/fields/media/tmpl/media.php
+++ b/plugins/fields/media/tmpl/media.php
@@ -34,7 +34,9 @@ if ($value)
 	{
 		if ($img->attributes['width'] > 0 && $img->attributes['height'] > 0)
 		{
-			$buffer = sprintf('<img src="%s"%s%s>',
+			$buffer = sprintf('<img loading="lazy" width="%s" height="%s" src="%s"%s%s>',
+				$img->attributes['width'],
+				$img->attributes['height'],
 				$imgUrl,
 				$class,
 				$alt
@@ -42,9 +44,7 @@ if ($value)
 		}
 		else
 		{
-			$buffer = sprintf('<img loading="lazy" width="%s" height="%s" src="%s"%s%s>',
-				$img->attributes['width'],
-				$img->attributes['height'],
+			$buffer = sprintf('<img src="%s"%s%s>',
 				$imgUrl,
 				$class,
 				$alt

--- a/plugins/fields/media/tmpl/media.php
+++ b/plugins/fields/media/tmpl/media.php
@@ -24,8 +24,6 @@ if ($class)
 
 $value  = $field->value;
 
-$buffer = '';
-
 if ($value)
 {
 	$img       = HTMLHelper::cleanImageURL($value['imagefile']);
@@ -34,14 +32,26 @@ if ($value)
 
 	if (file_exists($img->url))
 	{
-		$buffer .= sprintf('<img loading="lazy" width="%s" height="%s" src="%s"%s%s>',
-			$img->attributes['width'],
-			$img->attributes['height'],
-			$imgUrl,
-			$class,
-			$alt
-		);
+		if ($img->attributes['width'] > 0 && $img->attributes['height'] > 0)
+		{
+			$buffer = sprintf('<img src="%s"%s%s>',
+				$imgUrl,
+				$class,
+				$alt
+			);
+		}
+		else
+		{
+			$buffer = sprintf('<img loading="lazy" width="%s" height="%s" src="%s"%s%s>',
+				$img->attributes['width'],
+				$img->attributes['height'],
+				$imgUrl,
+				$class,
+				$alt
+			);
+		}
+
+		echo $buffer;
 	}
 }
 
-echo $buffer;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/32611#issuecomment-817163943 .

### Summary of Changes

Non lazyloaded images get a width/height of 0. Obviously a bug

### Testing Instructions

Create a media custom field
Select an image without ticking the lazyload checkbox
Check that the image is displayed

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

No this is a bug