### PR TITLE
[4.0] Fix media field value on Subfield

### DIFF
--- a/plugins/fields/media/media.php
+++ b/plugins/fields/media/media.php
@@ -67,6 +67,31 @@ class PlgFieldsMedia extends \Joomla\Component\Fields\Administrator\Plugin\Field
 	}
 
 	/**
+	 * Prepares the field
+	 *
+	 * @param   string    $context  The context.
+	 * @param   stdclass  $item     The item.
+	 * @param   stdclass  $field    The field.
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function onCustomFieldsPrepareField($context, $item, $field)
+	{
+		/**
+		 * At this stage, $field->value supposes to be an array, however, in case it is part of a subfield with data
+		 * migrated repeatable field from Joomla! 3, it is still a string, so we need to to do some conversion here
+		 */
+		if (is_string($field->value) && strlen($field->value))
+		{
+			$field->value = $this->checkValue($field->value);
+		}
+
+		return parent::onCustomFieldsPrepareField($context, $item, $field);
+	}
+
+	/**
 	 * Before prepares the field value.
 	 *
 	 * @param   string  $value  The value to check.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
When data for a Repeatable field from Joomla 3 migrated to a SubField on Joomla 4, the value for media field type is stored in String, not in JSON format as expected, thus it throws some warnings when the field is being displayed (see https://github.com/joomla/joomla-cms/pull/32611#issuecomment-816985442 )

This PR solves that error by overriding method onCustomFieldsPrepareField for Media field to make sure $field->value is an array (for Media field not belong to a Subfield, that's prepared on onCustomFieldsBeforePrepareField already)

### Testing Instructions
This only affect Repetable field migrated to Subfield, so @HLeithner can take a look and if it solves the issue, he can get it merged. I don't want to waste time of tester by having to install Joomla 3.10.0, upgrade to Joomla 4, then test this small fix.