### PR TITLE
[4.0] Joomla.request: callback on the request completed

### DIFF
--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -525,7 +525,7 @@ window.Joomla.Modal = window.Joomla.Modal || {
    *    onBefore:  (xhr) => {}            // Callback on before the request
    *    onSuccess: (response, xhr) => {}, // Callback on the request success
    *    onError:   (xhr) => {},           // Callback on the request error
-   *    onComplete: (xhr) => {},          // Callback on the request completed, with or without error
+   *    onComplete: (xhr) => {},          // Callback on the request completed, with/without error
    * }
    *
    * @return XMLHttpRequest|Boolean

--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -525,6 +525,7 @@ window.Joomla.Modal = window.Joomla.Modal || {
    *    onBefore:  (xhr) => {}            // Callback on before the request
    *    onSuccess: (response, xhr) => {}, // Callback on the request success
    *    onError:   (xhr) => {},           // Callback on the request error
+   *    onComplete: (xhr) => {},          // Callback on the request completed, with or without error
    * }
    *
    * @return XMLHttpRequest|Boolean
@@ -598,6 +599,10 @@ window.Joomla.Modal = window.Joomla.Modal || {
           }
         } else if (newOptions.onError) {
           newOptions.onError.call(window, xhr);
+        }
+
+        if (newOptions.onComplete) {
+          newOptions.onComplete.call(window, xhr);
         }
       };
 


### PR DESCRIPTION
Pull Request for Issue #28980 .

### Summary of Changes
Add `onComplete` callback for Joomla.request()


### Testing Instructions
Run `npm install`
Add to index.php of any template:
```html
<script type="module">
  Joomla.request({
    url: Joomla.getOptions('system.paths').base + '/index.php?option=com_ajax&type=plugin',
    onSuccess:  () => console.log('success'),
    onError:  () => console.log('error'),
    onComplete: () => console.log('complete')
  });
  Joomla.request({
    url: Joomla.getOptions('system.paths').base + '/index.php?option=com_ajax&type=plugin&format=raw',
    onSuccess:  () => console.log('success'),
    onError:  () => console.log('error'),
    onComplete: () => console.log('complete')
  });
</script>
```
Watch result in the browser console.


### Actual result BEFORE applying this Pull Request
2 message (1 per request):
```
error
success
```


### Expected result AFTER applying this Pull Request
4 message (2 per request):
```
error
complete

success
complete
```


### Documentation Changes Required
If we have a documentation for core.js and Joomla.request, then it need to update.
