### PR TITLE
[4.0] Cassiopeia unpublished badges

### DIFF
--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -106,21 +106,21 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 							</a>
 							<?php if ($item->published == 0) : ?>
 								<div>
-									<span class="list-published badge bg-warning text-dark">
+									<span class="list-published badge bg-warning text-light">
 										<?php echo Text::_('JUNPUBLISHED'); ?>
 									</span>
 								</div>
 							<?php endif; ?>
 							<?php if (strtotime($item->publish_up) > strtotime(Factory::getDate())) : ?>
 								<div>
-									<span class="list-published badge bg-warning text-dark">
+									<span class="list-published badge bg-warning text-light">
 										<?php echo Text::_('JNOTPUBLISHEDYET'); ?>
 									</span>
 								</div>
 							<?php endif; ?>
 							<?php if (!is_null($item->publish_down) && strtotime($item->publish_down) < strtotime(Factory::getDate())) : ?>
 								<div>
-									<span class="list-published badge bg-warning text-dark">
+									<span class="list-published badge bg-warning text-light">
 										<?php echo Text::_('JEXPIRED'); ?>
 									</span>
 								</div

--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -127,7 +127,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 							<?php endif; ?>
 							<?php if ($item->published == -2) : ?>
 								<div>
-									<span class="badge bg-warning text-dark">
+									<span class="badge bg-warning text-light">
 										<?php echo Text::_('JTRASHED'); ?>
 									</span>
 								</div>

--- a/components/com_contact/tmpl/contact/default.php
+++ b/components/com_contact/tmpl/contact/default.php
@@ -34,7 +34,7 @@ $canEdit = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->i
 		<div class="page-header">
 			<h2>
 				<?php if ($this->item->published == 0) : ?>
-					<span class="badge bg-warning text-dark"><?php echo Text::_('JUNPUBLISHED'); ?></span>
+					<span class="badge bg-warning text-light"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 				<?php endif; ?>
 				<span class="contact-name" itemprop="name"><?php echo $this->item->name; ?></span>
 			</h2>

--- a/components/com_contact/tmpl/featured/default_items.php
+++ b/components/com_contact/tmpl/featured/default_items.php
@@ -133,7 +133,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</a>
 						<?php if ($item->published == 0) : ?>
 							<div>
-								<span class="list-published badge bg-warning text-dark">
+								<span class="list-published badge bg-warning text-light">
 									<?php echo Text::_('JUNPUBLISHED'); ?>
 								</span>
 							</div>

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -55,13 +55,13 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 			<?php echo $this->escape($this->item->title); ?>
 		</<?php echo $htag; ?>>
 		<?php if ($this->item->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
-			<span class="badge bg-warning text-dark"><?php echo Text::_('JUNPUBLISHED'); ?></span>
+			<span class="badge bg-warning text-light"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>
 		<?php if ($isNotPublishedYet) : ?>
-			<span class="badge bg-warning text-dark"><?php echo Text::_('JNOTPUBLISHEDYET'); ?></span>
+			<span class="badge bg-warning text-light"><?php echo Text::_('JNOTPUBLISHEDYET'); ?></span>
 		<?php endif; ?>
 		<?php if ($isExpired) : ?>
-			<span class="badge bg-warning text-dark"><?php echo Text::_('JEXPIRED'); ?></span>
+			<span class="badge bg-warning text-light"><?php echo Text::_('JEXPIRED'); ?></span>
 		<?php endif; ?>
 	</div>
 	<?php endif; ?>

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -221,21 +221,21 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
 					<?php endif; ?>
 					<?php if ($article->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
 						<div>
-							<span class="list-published badge bg-warning text-dark">
+							<span class="list-published badge bg-warning text-light">
 								<?php echo Text::_('JUNPUBLISHED'); ?>
 							</span>
 						</div>
 					<?php endif; ?>
 					<?php if ($article->publish_up > $currentDate) : ?>
 						<div>
-							<span class="list-published badge bg-warning text-dark">
+							<span class="list-published badge bg-warning text-light">
 								<?php echo Text::_('JNOTPUBLISHEDYET'); ?>
 							</span>
 						</div>
 					<?php endif; ?>
 					<?php if (!is_null($article->publish_down) && $article->publish_down < $currentDate) : ?>
 						<div>
-							<span class="list-published badge bg-warning text-dark">
+							<span class="list-published badge bg-warning text-light">
 								<?php echo Text::_('JEXPIRED'); ?>
 							</span>
 						</div>

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -295,7 +295,7 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
 				<?php endif; ?>
 				<?php if ($this->params->get('list_show_ratings', 0) && $this->vote) : ?>
 					<td class="list-ratings">
-						<span class="badge bg-warning text-dark">
+						<span class="badge bg-warning text-light">
 							<?php if ($this->params->get('show_headings')) : ?>
 								<?php echo $article->rating; ?>
 							<?php else : ?>

--- a/components/com_content/tmpl/featured/default_item.php
+++ b/components/com_content/tmpl/featured/default_item.php
@@ -52,13 +52,13 @@ $isUnpublished     = $this->item->state == ContentComponent::CONDITION_UNPUBLISH
 	<?php endif; ?>
 
 	<?php if ($this->item->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
-		<span class="badge bg-warning text-dark"><?php echo Text::_('JUNPUBLISHED'); ?></span>
+		<span class="badge bg-warning text-light"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 	<?php endif; ?>
 	<?php if ($isNotPublishedYet) : ?>
-		<span class="badge bg-warning text-dark"><?php echo Text::_('JNOTPUBLISHEDYET'); ?></span>
+		<span class="badge bg-warning text-light"><?php echo Text::_('JNOTPUBLISHEDYET'); ?></span>
 	<?php endif; ?>
 	<?php if ($isExpired) : ?>
-		<span class="badge bg-warning text-dark"><?php echo Text::_('JEXPIRED'); ?></span>
+		<span class="badge bg-warning text-light"><?php echo Text::_('JEXPIRED'); ?></span>
 	<?php endif; ?>
 
 	<?php if ($canEdit) : ?>

--- a/components/com_newsfeeds/tmpl/category/default_items.php
+++ b/components/com_newsfeeds/tmpl/category/default_items.php
@@ -30,7 +30,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php if ($this->params->get('filter_field') !== 'hide' && $this->params->get('filter_field') == '1') : ?>
 						<div class="btn-group">
 							<label class="filter-search-lbl visually-hidden" for="filter-search">
-								<span class="badge bg-warning text-dark">
+								<span class="badge bg-warning text-light">
 									<?php echo Text::_('JUNPUBLISHED'); ?>
 								</span>
 								<?php echo Text::_('COM_NEWSFEEDS_FILTER_LABEL') . '&#160;'; ?>
@@ -68,7 +68,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 						</div>
 					</span>
 					<?php if ($this->items[$i]->published == 0) : ?>
-						<span class="badge bg-warning text-dark">
+						<span class="badge bg-warning text-light">
 							<?php echo Text::_('JUNPUBLISHED'); ?>
 						</span>
 					<?php endif; ?>

--- a/components/com_newsfeeds/tmpl/newsfeed/default.php
+++ b/components/com_newsfeeds/tmpl/newsfeed/default.php
@@ -46,7 +46,7 @@ use Joomla\CMS\Layout\FileLayout;
 		<?php endif; ?>
 		<h2 class="<?php echo $direction; ?>">
 			<?php if ($this->item->published == 0) : ?>
-				<span class="badge bg-warning text-dark"><?php echo Text::_('JUNPUBLISHED'); ?></span>
+				<span class="badge bg-warning text-light"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 			<?php endif; ?>
 			<a href="<?php echo $this->item->link; ?>" target="_blank" rel="noopener">
 				<?php echo str_replace('&apos;', "'", $this->item->name); ?>

--- a/components/com_tags/tmpl/tag/list_items.php
+++ b/components/com_tags/tmpl/tag/list_items.php
@@ -92,7 +92,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									</a>
 								<?php endif; ?>
 								<?php if ($item->core_state == 0) : ?>
-									<span class="list-published badge bg-warning text-dark">
+									<span class="list-published badge bg-warning text-light">
 										<?php echo Text::_('JUNPUBLISHED'); ?>
 									</span>
 								<?php endif; ?>


### PR DESCRIPTION
The markup for the Unpublished, Not Published Yet and Expired badges that is displayed in various views on the front end to administrators was incorrect.

### Before
![image](https://user-images.githubusercontent.com/1296369/114309127-158e5a00-9ade-11eb-9078-394901db3d4b.png)

![image](https://user-images.githubusercontent.com/1296369/114309310-a5cc9f00-9ade-11eb-9dfe-313894d0bbff.png)

### After
![image](https://user-images.githubusercontent.com/1296369/114309128-17f0b400-9ade-11eb-92b3-b213c38ed41c.png)

![image](https://user-images.githubusercontent.com/1296369/114309304-a36a4500-9ade-11eb-9a0d-c01143255261.png)
