### PR TITLE
[4.0] Move markup to not display bottom border in sample data list

### DIFF
--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -41,16 +41,16 @@ $app->getDocument()->addScriptOptions(
 					</button>
 				</div>
 				<p class="small mt-1"><?php echo $item->description; ?></p>
-			</li>
-			<?php // Progress bar ?>
-			<li class="list-group-item sampledata-progress-<?php echo $item->name; ?> d-none">
-				<div class="progress">
-					<div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"></div>
+				<?php // Progress bar ?>
+				<div class="sampledata-progress-<?php echo $item->name; ?> d-none mb-3">
+					<div class="progress">
+						<div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar"></div>
+					</div>
 				</div>
-			</li>
-			<?php // Progress messages ?>
-			<li class="list-group-item sampledata-progress-<?php echo $item->name; ?> d-none">
-				<ul class="list-unstyled"></ul>
+				<?php // Progress messages ?>
+				<div class="sampledata-progress-<?php echo $item->name; ?> d-none">
+					<ul class="list-unstyled"></ul>
+				</div>
 			</li>
 		<?php endforeach; ?>
 	</ul>


### PR DESCRIPTION
Pull Request for Issue #33067 .

### Summary of Changes
After each sample data, there are progress bar/messages in list items and hidden by default.
The last bottom border is from the sample data and technically not the last child, thus it is not hidden.
Move the progress bar/messages into the sample data list item and not make them be list items.


### Testing Instructions
Go to Home Dashboard
See no bottom border in Sample Data box.

