### PR TITLE
[4.0] Remove popovers from grid.sort table headers

### DIFF
--- a/libraries/src/HTML/Helpers/Grid.php
+++ b/libraries/src/HTML/Helpers/Grid.php
@@ -61,8 +61,7 @@ abstract class Grid
 			$form = ', document.getElementById(\'' . $form . '\')';
 		}
 
-		$html = '<a href="#" onclick="Joomla.tableOrdering(\'' . $order . '\',\'' . $direction . '\',\'' . $task . '\'' . $form . ');return false;"'
-			. ' title="' . htmlspecialchars(Text::_($tip ?: $title)) . '" >';
+		$html = '<a href="#" onclick="Joomla.tableOrdering(\'' . $order . '\',\'' . $direction . '\',\'' . $task . '\'' . $form . ');return false;" >';
 
 		if (isset($title['0']) && $title['0'] === '<')
 		{

--- a/libraries/src/HTML/Helpers/Grid.php
+++ b/libraries/src/HTML/Helpers/Grid.php
@@ -41,7 +41,6 @@ abstract class Grid
 	public static function sort($title, $order, $direction = 'asc', $selected = '', $task = null, $newDirection = 'asc', $tip = '', $form = null)
 	{
 		HTMLHelper::_('behavior.core');
-		HTMLHelper::_('bootstrap.popover', '.hasPopover', ['trigger' => 'hover focus']);
 
 		$direction = strtolower($direction);
 		$icon = array('arrow-up-3', 'arrow-down-3');

--- a/libraries/src/HTML/Helpers/Grid.php
+++ b/libraries/src/HTML/Helpers/Grid.php
@@ -62,8 +62,7 @@ abstract class Grid
 		}
 
 		$html = '<a href="#" onclick="Joomla.tableOrdering(\'' . $order . '\',\'' . $direction . '\',\'' . $task . '\'' . $form . ');return false;"'
-			. ' class="hasPopover" title="' . htmlspecialchars(Text::_($tip ?: $title)) . '"'
-			. ' data-bs-content="' . htmlspecialchars(Text::_('JGLOBAL_CLICK_TO_SORT_THIS_COLUMN')) . '" data-bs-placement="top">';
+			. ' title="' . htmlspecialchars(Text::_($tip ?: $title)) . '" >';
 
 		if (isset($title['0']) && $title['0'] === '<')
 		{


### PR DESCRIPTION
Pull Request for Issue #33048 .

### Summary of Changes
Removed `class="hasPopover"`, `title` and the `data-` tags associated with the Popover content from the table header's `<a>` tag.


### Testing Instructions
1. Add Category List to frontend (Joomla Admin Panel -> Menus -> Pick a Menu -> Add Menu Item -> Category List)
2. Visit the frontend page and hover over the table's header.


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/114318479-c3bff100-9b2a-11eb-9bdb-2b4d86ce2f46.png)


### Expected result AFTER applying this Pull Request
![output)](https://user-images.githubusercontent.com/53610833/114264359-11900880-9a08-11eb-8eeb-cd776e8489f2.gif)


### Documentation Changes Required
None
