### PR TITLE
[J4] Removes fixed max-height on sidebar-nav on wide screen

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar-nav.scss
@@ -1,10 +1,11 @@
 // Sidebar
 
 .sidebar-nav {
-
+  @include media-breakpoint-down(md) {
+    max-height: 75vh;
+    overflow-y: scroll;
+  }
   // override bootstrap important
-  max-height: 75vh;
-  overflow-y: scroll;
   background: var(--atum-sidebar-bg) !important;
   box-shadow: $atum-box-shadow;
 


### PR DESCRIPTION
In PR #31092 a fixed height was introduced to the sidebar-nav to fix things on mobile screens (smaller than md).
But this causes a useless scrollbar and height limit on the sidebar nav on wider screens.

So this PR removes it.

Check the styling of the sidebar in the global configuration before and after this PR.

Before:
![image](https://user-images.githubusercontent.com/13553242/114320535-88b3c280-9b16-11eb-8b93-c69e160c48d3.png)

After:
![image](https://user-images.githubusercontent.com/13553242/114320458-4e4a2580-9b16-11eb-8364-86d7add042d6.png)

