### PR TITLE
[4.0] TinyMCE editor.css

### DIFF
--- a/templates/cassiopeia/scss/editor.scss
+++ b/templates/cassiopeia/scss/editor.scss
@@ -1,0 +1,64 @@
+/* STYLES FOR JOOMLA! EDITOR */
+body {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #22262a;
+  background-color: #fff;
+  -webkit-text-size-adjust: 100%;
+  -webkit-tap-highlight-color: rgba(0,0,0,0)
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: 700;
+  margin-top: 0;
+  margin-bottom: .5rem;
+  line-height: 1.2;
+}
+
+h1 {
+	font-size: calc(1.375rem + 1.5vw);
+}
+
+h2 {
+	font-size: calc(1.325rem + .9vw);
+}
+
+h3 {
+	font-size: calc(1.3rem + .6vw);
+}
+
+h4 {
+	font-size: calc(1.275rem + .3vw);
+}
+
+h5 {
+  font-size: 1.25rem;
+}
+
+h6 {
+  font-size: 1rem;
+}
+
+a {
+  text-decoration: none;
+	&:link {
+    color: #224faa;
+	}
+  &:hover {
+    color: #424077;
+	}
+}
+
+p {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+/* STYLES FOR JOOMLA! EDITOR */
+hr#system-readmore {
+	color: #f00;
+	border: #f00 dashed 1px;
+}
+

--- a/templates/cassiopeia/scss/editor.scss
+++ b/templates/cassiopeia/scss/editor.scss
@@ -6,31 +6,29 @@ body {
   line-height: 1.5;
   color: #22262a;
   background-color: #fff;
-  -webkit-text-size-adjust: 100%;
-  -webkit-tap-highlight-color: rgba(0,0,0,0)
 }
 
 h1, h2, h3, h4, h5, h6 {
-  font-weight: 700;
   margin-top: 0;
   margin-bottom: .5rem;
+  font-weight: 700;
   line-height: 1.2;
 }
 
 h1 {
-	font-size: calc(1.375rem + 1.5vw);
+  font-size: calc(1.375rem + 1.5vw);
 }
 
 h2 {
-	font-size: calc(1.325rem + .9vw);
+  font-size: calc(1.325rem + .9vw);
 }
 
 h3 {
-	font-size: calc(1.3rem + .6vw);
+  font-size: calc(1.3rem + .6vw);
 }
 
 h4 {
-	font-size: calc(1.275rem + .3vw);
+  font-size: calc(1.275rem + .3vw);
 }
 
 h5 {
@@ -43,12 +41,12 @@ h6 {
 
 a {
   text-decoration: none;
-	&:link {
+  &:link {
     color: #224faa;
-	}
+  }
   &:hover {
     color: #424077;
-	}
+  }
 }
 
 p {
@@ -58,7 +56,7 @@ p {
 
 /* STYLES FOR JOOMLA! EDITOR */
 hr#system-readmore {
-	color: #f00;
-	border: #f00 dashed 1px;
+  color: #f00;
+  border: #f00 dashed 1px;
 }
 


### PR DESCRIPTION
Our configuration for TinyMCE supports the use of an editor.css file located in the template css folder. This allows for the heading levels etc to be displayed correctly in the wysiwyg editor.

It is not simply a case of including the entire template.css as the editor is then loading 13 thousand lines of css most of which is not needed and fills the tinymce toolbar dropdowns with lots and lots of useless fluff

With this latest version of TinyMCE it is possible to import the template.css file and then have a series of rules on what to include and exclude. This would be useful if there were seperate css files for layout and design etc but there aren't and I am of the opinion that this approach is far more work than is needed.

So I have taken the fallback editor.css from the system template and created a cassiopeia version with this PR.

It has to be an scss file for our build tools.

It can not include the fonts used in cassiopeia as they are defined in the template php and not the css.

To test this PR install the blog sample data and go to the typography content item

Apply the PR and run `npm ci` or `npm run build:css` and compare the typography content item again

Note while this editor.css file may not be absolutely required it serves as a good example to follow for template designers.

The only significant difference in the before and after images is the font size. Making it closer to a wysiwyg editor.

### Before
![image](https://user-images.githubusercontent.com/1296369/114388523-b25b0100-9b8b-11eb-86c9-95f29ea91d65.png)

### After
![image](https://user-images.githubusercontent.com/1296369/114388534-b555f180-9b8b-11eb-9f0b-6c88b6f0bcab.png)
