### PR TITLE
[3.9.24+, PHP8] com_search. Fix fatal error "mb_strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)"

### DIFF
--- a/administrator/components/com_search/helpers/search.php
+++ b/administrator/components/com_search/helpers/search.php
@@ -347,7 +347,12 @@ class SearchHelper
 		}
 		else
 		{
-			if (($wordpos = @StringHelper::strpos($text, ' ', $length)) !== false)
+			if (($mbtextlen = StringHelper::strlen($text)) < $length)
+			{
+				$length = $mbtextlen;
+			}
+
+			if (($wordpos = StringHelper::strpos($text, ' ', $length)) !== false)
 			{
 				return StringHelper::substr($text, 0, $wordpos) . '&#160;...';
 			}


### PR DESCRIPTION
Pull Request for issue https://github.com/joomla/joomla-cms/issues/32115

Replaces pr https://github.com/joomla/joomla-cms/pull/32638

### Summary of Changes
- Check `mb_strlen` of provided text before calling `mb_strpos`.
- Remove `@` . Not needed anymore because of that check and senseless with PHP8.

### Testing Instructions
- Joomla 3.9.25 or Joomla 3.9.26-dev. **PHP 8**.
- Create an article that contains a search word in article text **BUT NOT** in article title. 
E.g. `modulstil`
- Enter an article title that contains one or more UTF8 characters like german umlauts.
E.g. `Größte Blödheit grämt den Lümmel`
- Save article.
- In front-end search with `com_search` (Module or Component) with search word `modulstil`

### Actual result BEFORE applying this Pull Request
- Fatal error `0 mb_strpos(): Argument #3 ($offset) must be contained in argument #1 ($haystack)`
- For the interested ones: See call stack: https://github.com/joomla/joomla-cms/issues/32115#issue-792405971

### Expected result AFTER applying this Pull Request
- No errors. Search result displayed in list of search results.
