### PR TITLE
Fix custom field edit own permission

### DIFF
--- a/administrator/components/com_fields/controllers/field.php
+++ b/administrator/components/com_fields/controllers/field.php
@@ -99,7 +99,7 @@ class FieldsControllerField extends JControllerForm
 			}
 
 			// Grant if current user is owner of the record
-			return $user->id == $record->created_by;
+			return $user->id == $record->created_user_id;
 		}
 
 		return false;


### PR DESCRIPTION
Pull Request for Issue #31649.

### Summary of Changes
There was a typo in allowEdit method of Field controller makes user is not allowed to edit his own custom field if he has Edit Own permission but not Edit permission. This PR fixes that issue


### Testing Instructions
1. Login to administrator area of your site using Super User account
2. Access to Content -> Fields, then click on Options button in the toolbar, navigate to Permissions tab, select Manager user group:
- Set Edit permission to Denied
- Set Edit Own permission to Allowed
3. Logout, then login to administrator area again using a manager account. Access to Content -> Fields. Create a new custom field, then go back to Fields list screen and click on that field to edit:
- Before patch: You get get error could not edit field
- After patch, you can edit field.
