### PR TITLE
Remove unused declaration in build js file

### DIFF
--- a/build/bootstrap/js/bootstrap-dropdown-joomla.js
+++ b/build/bootstrap/js/bootstrap-dropdown-joomla.js
@@ -82,7 +82,7 @@
   , keydown: function (e) {
       var $this
         , $items
-        , $active
+        
         , $parent
         , isActive
         , index

--- a/build/bootstrap/js/bootstrap-dropdown.js
+++ b/build/bootstrap/js/bootstrap-dropdown.js
@@ -67,7 +67,7 @@
   , keydown: function (e) {
       var $this
         , $items
-        , $active
+        
         , $parent
         , isActive
         , index


### PR DESCRIPTION
Pull Request for Issue 
Local variable '$active' is not used.

### Summary of Changes
An unused variable is removed which is declared in build/bootstrap/js/bootstrap-dropdown.js 




