### PR TITLE
[4.0] Hide header links

### DIFF
--- a/administrator/modules/mod_messages/tmpl/default.php
+++ b/administrator/modules/mod_messages/tmpl/default.php
@@ -14,12 +14,18 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
 $hideLinks = $app->input->getBool('hidemainmenu');
+
+if ($hideLinks)
+{
+	return;
+}
+
 $uri   = Uri::getInstance();
 $route = 'index.php?option=com_messages&view=messages&id=' . $app->getIdentity()->id . '&return=' . base64_encode($uri);
 ?>
 
 <div class="header-item-content">
-	<a class="d-flex align-items-stretch <?php echo ($hideLinks ? 'disabled' : ''); ?>" <?php echo ($hideLinks ? '' : 'href="' . Route::_($route) . '"'); ?> title="<?php echo Text::_('MOD_MESSAGES_PRIVATE_MESSAGES'); ?>">
+	<a class="d-flex align-items-stretch" href="<?php echo Route::_($route); ?>" title="<?php echo Text::_('MOD_MESSAGES_PRIVATE_MESSAGES'); ?>">
 		<div class="d-flex align-items-end mx-auto">
 			<span class="icon-envelope" aria-hidden="true"></span>
 		</div>

--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -13,7 +13,9 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-if (!$multilanguageEnabled)
+$hideLinks = $app->input->getBool('hidemainmenu');
+
+if (!$multilanguageEnabled || $hideLinks)
 {
 	return;
 }

--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -13,10 +13,15 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
 $hideLinks = $app->input->getBool('hidemainmenu');
+
+if ($hideLinks)
+{
+	return;
+}
 ?>
 <?php if ($app->getIdentity()->authorise('core.manage', 'com_postinstall')) : ?>
 	<div class="header-item-content">
-		<a class="d-flex flex-column <?php echo ($hideLinks ? 'disabled' : ''); ?>"
+		<a class="d-flex flex-column"
 			href="<?php echo Route::_('index.php?option=com_postinstall&eid=' . $joomlaFilesExtensionId); ?>" title="<?php echo Text::_('MOD_POST_INSTALLATION_MESSAGES'); ?>">
 			<div class="d-flex align-items-end mx-auto">
 				<span class="icon-bell" aria-hidden="true"></span>

--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -15,13 +15,18 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 
+$hideLinks = $app->input->getBool('hidemainmenu');
+
+if ($hideLinks)
+{
+	return;
+}
+
 // Load the Bootstrap Dropdown
 HTMLHelper::_('bootstrap.dropdown', '.dropdown-toggle');
-
-$hideLinks = $app->input->getBool('hidemainmenu');
 ?>
 <div class="header-item-content dropdown header-profile d-flex">
-	<button class="dropdown-toggle d-flex flex-column align-items-stretch <?php echo ($hideLinks ? 'disabled' : ''); ?>" data-bs-toggle="dropdown" type="button" <?php echo ($hideLinks ? 'disabled' : ''); ?>
+	<button class="dropdown-toggle d-flex flex-column align-items-stretch" data-bs-toggle="dropdown" type="button"
 		title="<?php echo Text::_('MOD_USER_MENU'); ?>">
 		<div class="d-flex align-items-end mx-auto">
 			<span class="icon-user-circle" aria-hidden="true"></span>


### PR DESCRIPTION
### Summary of Changes
Instead of disabling links/buttons in header in edit mode, it is better to not display them.

Thanks @dgrammatiko for the code and @brianteeman for the suggestion to move unrelated changes in #33100 to separate PRs.

### Testing Instructions
Edit an article.
See no links/buttons except for the version # and open frontend in header.


