### PR TITLE
[4] Suppress errors on broken images

### DIFF
--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -71,7 +71,8 @@ class MediaHelper
 		{
 			if ($isImage && \function_exists('exif_imagetype'))
 			{
-				$mime = image_type_to_mime_type(exif_imagetype($file));
+				// Must use @ Error Suppressor here to avoid "Notice: exif_imagetype(): Error reading from" message on invalid image.
+				$mime = image_type_to_mime_type(@exif_imagetype($file));
 			}
 			elseif ($isImage && \function_exists('getimagesize'))
 			{

--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -181,8 +181,12 @@ class Image
 			throw new \InvalidArgumentException('The image file does not exist.');
 		}
 
-		// Get the image file information.
-		$info = getimagesize($path);
+		//
+		/**
+		 * Get the image file information.
+		 * Must use @ Error Suppressor here to avoid "Notice: getimagesize(): Error reading from" message on invalid image.
+		 */
+		$info = @getimagesize($path);
 
 		if (!$info)
 		{

--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -181,7 +181,6 @@ class Image
 			throw new \InvalidArgumentException('The image file does not exist.');
 		}
 
-		//
 		/**
 		 * Get the image file information.
 		 * Must use @ Error Suppressor here to avoid "Notice: getimagesize(): Error reading from" message on invalid image.


### PR DESCRIPTION
Pull Request for Issue #33062

### Summary of Changes

**After considering all the alternatives, reluctantly** use the `@` error suppressor to avoid outputting PHP Notices when you have any broken (unparseable) images in your folder.

yes yes yes I know use of the  `@` error suppressor is highly frowned upon, but there honestly seems to be no alternative here. 

### Testing Instructions

https://user-images.githubusercontent.com/400092/113942022-17170400-97f8-11eb-88a3-f4164ed1eccc.png

Download this broken image (which was actually [generated by Joomla's broken media manager feature](https://github.com/joomla/joomla-cms/issues/33063)s) and place in your /images folder as broken.png

Set error reporting to maximum in Joomla global config

Visit media manager in the backend.

### Actual result BEFORE applying this Pull Request

Ajax call has 2 warnings:

```
<br/>
<b>Notice</b>
:  exif_imagetype(): Error reading from /application/images/broken.png! in 
<b>/application/libraries/src/Helper/MediaHelper.php</b>
 on line 
<b>74</b>
<br/>
<br/>
<b>Notice</b>
:  getimagesize(): Error reading from /application/images/broken.png! in 
<b>/application/libraries/src/Image/Image.php</b>
 on line 
<b>185</b>
<br/>
```

### Expected result AFTER applying this Pull Request

Media manager loads correctly. 

### Documentation Changes Required

None. 