### PR TITLE
[4] Port new session handling to the CLI to fix errors on dealing with sessions

### DIFF
--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -214,7 +214,19 @@ class Session implements ServiceProviderInterface
 					$options['force_ssl'] = true;
 				}
 
-				return $this->buildSession(new RuntimeStorage, $app, $container->get(DispatcherInterface::class), $options);
+				$handler = $container->get('session.factory')->createSessionHandler($options);
+
+				if (!$container->has('session.handler'))
+				{
+					$this->registerSessionHandlerAsService($container, $handler);
+				}
+
+				return $this->buildSession(
+					new JoomlaStorage($app->input, $handler),
+					$app,
+					$container->get(DispatcherInterface::class),
+					$options
+				);
 			},
 			true
 		);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/32966

### Summary of Changes

Implements the session handler as a service in the CLI to fix issues when touching the session with CLI commands such as user:delete

### Testing Instructions

```
php cli/joomla.php  user:add
test
test
test@example.xom
6

php cli/joomla.php  user:delete
test
yes

```
### Actual result BEFORE applying this Pull Request


Bug 1:
` The "session.handler" service has not been created, make sure you have created the "session" service first.`

Bug 2:
The `Delete users` in yellow appears AFTER you have entered a username when it should be the first thing shown after typing the command like it is when you add a user. 

Full context, first adding, then deleting a user:

<img width="1145" alt="Screenshot 2021-04-02 at 16 34 23" src="https://user-images.githubusercontent.com/400092/113429996-4c26ef00-93d1-11eb-88c2-315dd488b461.png">

### Expected result AFTER applying this Pull Request

User is deleted.

No red errors about the session

### Documentation Changes Required

None