### PR TITLE
[4] Show cli command title before asking a question

### DIFF
--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -74,8 +74,10 @@ class DeleteUserCommand extends AbstractCommand
 	protected function doExecute(InputInterface $input, OutputInterface $output): int
 	{
 		$this->configureIO($input, $output);
-		$this->username = $this->getStringFromOption('username', 'Please enter a username');
+
 		$this->ioStyle->title('Delete users');
+
+		$this->username = $this->getStringFromOption('username', 'Please enter a username');
 
 		$userId = UserHelper::getUserId($this->username);
 		$db = Factory::getDbo();


### PR DESCRIPTION
Pull Request for Part 2 of Issue https://github.com/joomla/joomla-cms/issues/32966

### Summary of Changes

Show cli command title before asking a question

### Testing Instructions

`php cli/joomla.php user:delete`

### Actual result BEFORE applying this Pull Request

You get asked a question before the title of the command is shown underlined

<img width="709" alt="Screenshot 2021-04-15 at 20 23 17" src="https://user-images.githubusercontent.com/400092/114926623-7db7a580-9e28-11eb-92fa-c9560b94c3c4.png">


### Expected result AFTER applying this Pull Request

You get the command title before being asked a question

<img width="524" alt="Screenshot 2021-04-15 at 20 23 57" src="https://user-images.githubusercontent.com/400092/114926671-8ad49480-9e28-11eb-8e78-6694f25542c7.png">


### Documentation Changes Required

none