### PR TITLE
[4] unpublish stats plugin on selecting once or never

### DIFF
--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -199,6 +199,11 @@ class PlgSystemStats extends CMSPlugin
 			throw new RuntimeException('Unable to save plugin settings', 500);
 		}
 
+		if (!$this->unpublishPlugin())
+		{
+			throw new RuntimeException('Unable to unpublish stats plugin', 500);
+		}
+
 		echo json_encode(['sent' => 0]);
 	}
 
@@ -210,7 +215,7 @@ class PlgSystemStats extends CMSPlugin
 	 * @since   3.5
 	 *
 	 * @throws  Exception         If user is not allowed.
-	 * @throws  RuntimeException  If there is an error saving the params or sending the data.
+	 * @throws  RuntimeException  If there is an error saving the params, unpublishing the plugin or sending the data.
 	 */
 	public function onAjaxSendOnce()
 	{
@@ -228,6 +233,11 @@ class PlgSystemStats extends CMSPlugin
 
 		$this->sendStats();
 
+		if (!$this->unpublishPlugin())
+		{
+			throw new RuntimeException('Unable to unpublish stats plugin', 500);
+		}
+
 		echo json_encode(['sent' => 1]);
 	}
 
@@ -240,7 +250,7 @@ class PlgSystemStats extends CMSPlugin
 	 * @since   3.5
 	 *
 	 * @throws  Exception         If user is not allowed.
-	 * @throws  RuntimeException  If there is an error saving the params or sending the data.
+	 * @throws  RuntimeException  If there is an error saving the params, unpublishing the plugin or sending the data.
 	 */
 	public function onAjaxSendStats()
 	{
@@ -613,5 +623,63 @@ class PlgSystemStats extends CMSPlugin
 				// Ignore it
 			}
 		}
+	}
+
+	/**
+	 * Unpublish this plugin, if user selects once or never, to stop Joomla loading the plugin on every page load and
+	 * therefore regaining a tiny bit of performance
+	 *
+	 * @since __DEPLOY_VERSION__
+	 *
+	 * @return  boolean
+	 */
+	private function unpublishPlugin()
+	{
+		$db = $this->db;
+
+		$query = $db->getQuery(true)
+			->update($db->quoteName('#__extensions'))
+			->set($db->quoteName('enabled') . ' = 0')
+			->where($db->quoteName('type') . ' = ' . $db->quote('plugin'))
+			->where($db->quoteName('folder') . ' = ' . $db->quote('system'))
+			->where($db->quoteName('element') . ' = ' . $db->quote('stats'));
+
+		try
+		{
+			// Lock the tables to prevent multiple plugin executions causing a race condition
+			$db->lockTable('#__extensions');
+		}
+		catch (Exception $e)
+		{
+			// If we can't lock the tables it's too risky to continue execution
+			return false;
+		}
+
+		try
+		{
+			// Update the plugin parameters
+			$result = $db->setQuery($query)->execute();
+
+			$this->clearCacheGroups(['com_plugins']);
+		}
+		catch (Exception $exc)
+		{
+			// If we failed to execute
+			$db->unlockTables();
+			$result = false;
+		}
+
+		try
+		{
+			// Unlock the tables after writing
+			$db->unlockTables();
+		}
+		catch (Exception $e)
+		{
+			// If we can't lock the tables assume we have somehow failed
+			$result = false;
+		}
+
+		return $result;
 	}
 }


### PR DESCRIPTION
### Steps to reproduce the issue

Joomla 4 asks for stats collection after installation.

A user can answer with a click on "NEVER" or "once" button

However this just sets a flag in the params of the plugin, it doesn't actually unpublish the plugin

### Expected result

The plugin is then disabled on clicking NEVER/ONCE, so that it doesn't take up any processing time/power/cpu/ms on page load ever again to ensure Joomla remains running a peak performance but the user has the option to reenable the plugin at any time

### To test:
install joomla 4
login to admin and ignore the stats message
navigate the plugins screen and search for stats
you can now see the stats message and the status of the stats plugin
click NEVER or once, the page reloads and the message has gone away and you can see instantly that the plugin has been disabled also 

### Actual result

The PlgSystemStats plugin loads on every page load, runs some checks, takes some time, and in the end doesn't even send stats because we have said never. 

There are 7 different `if` statements run in onAfterInitialise/onAfterDispatch, several of these have 2 conditions to check, objects to retrieve etc...

Retrieving the params from the database is an extra db query that's not needed if NEVER is selected.
