### PR TITLE
[4] show result of checking for updates in CLI

### DIFF
--- a/libraries/src/Console/CheckUpdatesCommand.php
+++ b/libraries/src/Console/CheckUpdatesCommand.php
@@ -55,9 +55,17 @@ class CheckUpdatesCommand extends AbstractCommand
 		$cache_timeout = 3600 * (int) $component->getParams()->get('cachetimeout', 6);
 
 		// Find all updates
-		Updater::getInstance()->findUpdates(0, $cache_timeout);
-
-		$symfonyStyle->success('Finished fetching updates');
+		$ret = Updater::getInstance()->findUpdates(0, $cache_timeout);
+		
+		if ($ret)
+		{
+			$symfonyStyle->note('There are available updates to apply');
+			$symfonyStyle->success('Check complete.');
+		}
+		else
+		{
+			$symfonyStyle->success('There are no available updates');
+		}
 
 		return Command::SUCCESS;
 	}

--- a/libraries/src/Console/CheckUpdatesCommand.php
+++ b/libraries/src/Console/CheckUpdatesCommand.php
@@ -56,7 +56,6 @@ class CheckUpdatesCommand extends AbstractCommand
 
 		// Find all updates
 		$ret = Updater::getInstance()->findUpdates(0, $cache_timeout);
-		
 		if ($ret)
 		{
 			$symfonyStyle->note('There are available updates to apply');

--- a/libraries/src/Console/CheckUpdatesCommand.php
+++ b/libraries/src/Console/CheckUpdatesCommand.php
@@ -56,6 +56,7 @@ class CheckUpdatesCommand extends AbstractCommand
 
 		// Find all updates
 		$ret = Updater::getInstance()->findUpdates(0, $cache_timeout);
+
 		if ($ret)
 		{
 			$symfonyStyle->note('There are available updates to apply');


### PR DESCRIPTION
### Summary of Changes

The CLI command for checking for updates doesn't currently report if it actually found any updates to apply! 

This PR changes the output so that it tells you if updates were found. 

### Testing Instructions

Run the command with and without old version of a Joomla 4 compatible plugin installed that has updates available. 

```
php cli/joomla.php update:extensions:check
```

### Actual result BEFORE applying this Pull Request

Same message regardless of the number of updates found or not found

<img width="861" alt="Screenshot 2021-04-15 at 22 06 38" src="https://user-images.githubusercontent.com/400092/114938374-f45b9f80-9e36-11eb-99fe-c06c49e522fc.png">


### Expected result AFTER applying this Pull Request

Different output if updates are found (its not currently within this command to actually tell you what they are... that can come later) 

<img width="855" alt="Screenshot 2021-04-15 at 22 07 51" src="https://user-images.githubusercontent.com/400092/114938512-181ee580-9e37-11eb-9193-b53c9c74ce28.png">


### Documentation Changes Required

