### PR TITLE
[4] When we have finished with sample data, unpublish its module and plugins

### DIFF
--- a/administrator/modules/mod_sampledata/src/Helper/SampledataHelper.php
+++ b/administrator/modules/mod_sampledata/src/Helper/SampledataHelper.php
@@ -34,4 +34,30 @@ abstract class SampledataHelper
 
 		return Factory::getApplication()->triggerEvent('onSampledataGetOverview', array('test', 'foo'));
 	}
+
+	/**
+	 * When we have finished with sample data, unpublish its module and plugins
+	 *
+	 * @since __DEPLOY_VERSION__
+	 */
+	public static function unpublish()
+	{
+		$db = Factory::getContainer()->get('DatabaseDriver');
+
+		$query = $db->getQuery(true)
+			->update('#__modules')
+			->set($db->quoteName('published') . ' = 0')
+			->where($db->quoteName('module') . ' = ' . $db->quote('mod_sampledata'));
+
+		$db->setQuery($query);
+		$db->execute();
+
+		$query = $db->getQuery(true)
+			->update('#__extensions')
+			->set($db->quoteName('enabled') . ' = 0')
+			->where($db->quoteName('folder') . ' = ' . $db->quote('sampledata'));
+
+		$db->setQuery($query);
+		$db->execute();
+	}
 }

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
 use Joomla\Database\ParameterType;
+use Joomla\Module\Sampledata\Administrator\Helper\SampledataHelper;
 
 /**
  * Sampledata - Blog Plugin
@@ -1790,6 +1791,8 @@ class PlgSampledataBlog extends CMSPlugin
 
 		$response['success'] = true;
 		$response['message'] = Text::_('PLG_SAMPLEDATA_BLOG_STEP4_SUCCESS');
+
+		SampledataHelper::unpublish();
 
 		return $response;
 	}

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -23,6 +23,7 @@ use Joomla\CMS\Table\Table;
 use Joomla\CMS\Workflow\Workflow;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
+use Joomla\Module\Sampledata\Administrator\Helper\SampledataHelper;
 
 /**
  * Sampledata - Multilang Plugin
@@ -486,6 +487,8 @@ class PlgSampledataMultilang extends CMSPlugin
 
 		$response['success'] = true;
 		$response['message'] = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP8_SUCCESS');
+
+		SampledataHelper::unpublish();
 
 		return $response;
 	}

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -488,7 +488,11 @@ class PlgSampledataMultilang extends CMSPlugin
 		$response['success'] = true;
 		$response['message'] = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP8_SUCCESS');
 
-		SampledataHelper::unpublish();
+		// If only one language then unpublish the module/plugins
+		if (count(LanguageHelper::getContentLanguages(array(0, 1))) === 1)
+		{
+			SampledataHelper::unpublish();
+		}
 
 		return $response;
 	}

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -489,7 +489,7 @@ class PlgSampledataMultilang extends CMSPlugin
 		$response['message'] = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP8_SUCCESS');
 
 		// If only one language then unpublish the module/plugins
-		if (count(LanguageHelper::getContentLanguages(array(0, 1))) === 1)
+		if (count(LanguageHelper::getContentLanguages(array(0, 1))) < 2)
 		{
 			SampledataHelper::unpublish();
 		}

--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Component\Categories\Administrator\Model\CategoryModel;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Module\Sampledata\Administrator\Helper\SampledataHelper;
 
 /**
  * Sampledata - Testing Plugin
@@ -4535,6 +4536,8 @@ class PlgSampledataTesting extends CMSPlugin
 	{
 		$response['success'] = true;
 		$response['message'] = Text::_('PLG_SAMPLEDATA_TESTING_STEP9_SUCCESS');
+
+		SampledataHelper::unpublish();
 
 		return $response;
 	}


### PR DESCRIPTION
As requested in https://github.com/joomla/joomla-cms/pull/33150

### Summary of Changes

When we have finished with sample data, unpublish its module and plugins - therefore gaining a tiny bit of performance.

### Testing Instructions

Install Joomla 4
Install any of the sample data
refresh the Home Dashboard - note the module is no longer there
visit the Plugins and see they are unpublished
No side effects. 

### Actual result BEFORE applying this Pull Request

After using the sample data plugins, the module and plugins remain published, which is more db calls, more code running on each page load

### Expected result AFTER applying this Pull Request

module and plugins are uninstalled for the life of a live site - gaining a tiny bit of performance as code is not run. 

### Documentation Changes Required

none