### PR TITLE
[4] Remove use of deprecated triggerEvent call

### DIFF
--- a/administrator/modules/mod_sampledata/src/Helper/SampledataHelper.php
+++ b/administrator/modules/mod_sampledata/src/Helper/SampledataHelper.php
@@ -11,6 +11,7 @@ namespace Joomla\Module\Sampledata\Administrator\Helper;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 
@@ -32,6 +33,17 @@ abstract class SampledataHelper
 	{
 		PluginHelper::importPlugin('sampledata');
 
-		return Factory::getApplication()->triggerEvent('onSampledataGetOverview', array('test', 'foo'));
+		return Factory::getApplication()
+			->getDispatcher()
+			->dispatch(
+				'onSampledataGetOverview',
+				AbstractEvent::create(
+					'onSampledataGetOverview',
+					[
+						'subject'	=> new \stdClass,
+					]
+				)
+			)
+			->getArgument('result');
 	}
 }

--- a/administrator/modules/mod_sampledata/src/Helper/SampledataHelper.php
+++ b/administrator/modules/mod_sampledata/src/Helper/SampledataHelper.php
@@ -44,6 +44,6 @@ abstract class SampledataHelper
 					]
 				)
 			)
-			->getArgument('result');
+			->getArgument('result') ?? [];
 	}
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Remove use of deprecated triggerEvent call in favour of a Joomla 4 way of dispatching events

### Testing Instructions

Load Home Dashboard in Joomla 4 freshly installed. Note the sample plugins are all listed in the Sample data plugin 

### Actual result BEFORE applying this Pull Request

Load Home Dashboard in Joomla 4 freshly installed. Note the sample plugins are all listed in the Sample data plugin 

### Expected result AFTER applying this Pull Request

Load Home Dashboard in Joomla 4 freshly installed. Note the sample plugins are all listed in the Sample data plugin 

### Documentation Changes Required

None. Code review only.