### PR TITLE
[4.0] Rename Web Services api-authentication plugins (See #31306)

### DIFF
--- a/administrator/language/en-GB/plg_api-authentication_basic.ini
+++ b/administrator/language/en-GB/plg_api-authentication_basic.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_API-AUTHENTICATION_BASIC="API Authentication - Basic Auth"
+PLG_API-AUTHENTICATION_BASIC="API Authentication - Web Services Basic Auth"
 PLG_API-AUTHENTICATION_BASIC_XML_DESCRIPTION="Used to allow basic authentication to Web services in Joomla."

--- a/administrator/language/en-GB/plg_api-authentication_basic.sys.ini
+++ b/administrator/language/en-GB/plg_api-authentication_basic.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_API-AUTHENTICATION_BASIC="API Authentication - Basic Auth"
+PLG_API-AUTHENTICATION_BASIC="API Authentication - Web Services Basic Auth"
 PLG_API-AUTHENTICATION_BASIC_XML_DESCRIPTION="Used to allow basic authentication to Web services in Joomla."

--- a/administrator/language/en-GB/plg_api-authentication_token.ini
+++ b/administrator/language/en-GB/plg_api-authentication_token.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_API-AUTHENTICATION_TOKEN="API Authentication - Joomla Token"
+PLG_API-AUTHENTICATION_TOKEN="API Authentication - Web Services Joomla Token"
 PLG_API-AUTHENTICATION_TOKEN_XML_DESCRIPTION="Used to allow token-based authentication to Web services in Joomla."

--- a/administrator/language/en-GB/plg_api-authentication_token.sys.ini
+++ b/administrator/language/en-GB/plg_api-authentication_token.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt, see LICENSE.php
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_API-AUTHENTICATION_TOKEN="API Authentication - Joomla Token"
+PLG_API-AUTHENTICATION_TOKEN="API Authentication - Web Services Joomla Token"
 PLG_API-AUTHENTICATION_TOKEN_XML_DESCRIPTION="Used to allow token-based authentication to Web services in Joomla."


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/31306#issuecomment-819338347

### Summary of Changes
Rename the Basic Authentication and Token Authentication plugins to include Web Services in their plugin name and the plugin title.

### Testing Instructions
- Go to System > Plugins
- Filter for api-authentication plugin type
- View the plugin name (loaded from the .sys.ini files), as well as looking at the plugin settings to see the titles (from .ini files)

### Actual result BEFORE applying this Pull Request
- Plugin names will not have web services in them.
- Plugin title on the plugin settings will not have web services in the title.

### Expected result AFTER applying this Pull Request
- Plugin names will have web services in them.
- Plugin title on the plugin settings will have web services in the title.
![image](https://user-images.githubusercontent.com/5515866/115118877-cb7b0c00-9fe8-11eb-9009-2993295a0bd0.png)

### Documentation Changes Required
Not specifically. Web Services documentation is still to be comprehensively written, so when it is it will be incorporated in screen grabs and instructions at that time.
