### PR TITLE
[4.0] Fixes radio fields layout

### DIFF
--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -47,7 +47,7 @@ $isBtnGroup  = strpos(trim($class), 'btn-group') !== false;
 $isBtnYesNo  = strpos(trim($class), 'btn-group-yesno') !== false;
 $classToggle = $isBtnGroup ? ' class="btn-check"' : '';
 $btnClass    = $isBtnGroup ? 'btn btn-outline-secondary' : 'form-check-label';
-$divClass	 = $isBtnYesNo || $isBtnGroup ? 'form-check-inline' : 'form-check';
+$divClass    = $isBtnYesNo || $isBtnGroup ? 'form-check-inline' : 'form-check';
 
 // Add the attributes of the fieldset in an array
 $attribs = ['class="' . trim(

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -46,7 +46,8 @@ $alt         = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 $isBtnGroup  = strpos(trim($class), 'btn-group') !== false;
 $isBtnYesNo  = strpos(trim($class), 'btn-group-yesno') !== false;
 $classToggle = $isBtnGroup ? ' class="btn-check"' : '';
-$btnClass    = $isBtnGroup ? 'btn btn-outline-secondary' : 'form-check';
+$btnClass    = $isBtnGroup ? 'btn btn-outline-secondary' : 'form-check-label';
+$divClass	 = $isBtnYesNo || $isBtnGroup ? 'form-check-inline' : 'form-check';
 
 // Add the attributes of the fieldset in an array
 $attribs = ['class="' . trim(
@@ -84,7 +85,7 @@ if ($dataAttribute)
 	</legend>
 	<div <?php echo implode(' ', $attribs); ?>>
 		<?php foreach ($options as $i => $option) : ?>
-			<div>
+			<div class="<?php echo $divClass ?>">
 				<?php
 				$disabled    = !empty($option->disable) ? 'disabled' : '';
 				$style       = $disabled ? 'style="pointer-events: none"' : '';
@@ -121,8 +122,8 @@ if ($dataAttribute)
 				<?php if ($required) : ?>
 					<?php $attributes[] = 'required'; ?>
 				<?php endif; ?>
-				<input<?php echo $classToggle; ?> type="radio" id="<?php echo $oid; ?>" name="<?php echo $name; ?>" value="<?php echo $ovalue; ?>" <?php echo implode(' ', $attributes); ?>>
-				<label for="<?php echo $oid; ?>">
+				<input<?php echo $classToggle; ?> type="radio" id="<?php echo $oid; ?>" name="<?php echo $name; ?>" value="<?php echo $ovalue; ?>" <?php echo implode(' ', $attributes); ?> class="form-check-input">
+				<label for="<?php echo $oid; ?>" class="<?php echo trim($optionClass . ' ' . $style); ?>"> 
 					<?php echo $option->text; ?>
 				</label>
 			</div>

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -89,8 +89,8 @@ if ($dataAttribute)
 		<?php foreach ($options as $i => $option) : ?>
 			<?php echo $blockStart; ?>
 				<?php
-				$disabled    = !empty($option->disable) ? 'disabled' : '';
-				$style       = $disabled ? 'style="pointer-events: none"' : '';
+				$disabled = !empty($option->disable) ? 'disabled' : '';
+				$style    = $disabled ? 'style="pointer-events: none"' : '';
 
 				// Initialize some option attributes.
 				if ($isBtnYesNo)

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -45,6 +45,7 @@ extract($displayData);
 $alt         = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 $isBtnGroup  = strpos(trim($class), 'btn-group') !== false;
 $isBtnYesNo  = strpos(trim($class), 'btn-group-yesno') !== false;
+$divClass    = $isBtnGroup ? 'btn-group' : '';
 $classToggle = $isBtnGroup ? 'btn-check' : 'form-check-input';
 $btnClass    = $isBtnGroup ? 'btn btn-outline-secondary' : 'form-check-label';
 $blockStart  = $isBtnGroup ? '' : '<div class="form-check">';
@@ -52,7 +53,7 @@ $blockEnd    = $isBtnGroup ? '' : '</div>';
 
 // Add the attributes of the fieldset in an array
 $attribs = ['class="' . trim(
-		$class . ' radio' . ($readonly || $disabled ? ' disabled' : '') . ($readonly ? ' readonly' : '')
+		$divClass . ' radio' . ($readonly || $disabled ? ' disabled' : '') . ($readonly ? ' readonly' : '')
 	) . '"',];
 
 if (!empty($disabled))

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -45,9 +45,10 @@ extract($displayData);
 $alt         = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
 $isBtnGroup  = strpos(trim($class), 'btn-group') !== false;
 $isBtnYesNo  = strpos(trim($class), 'btn-group-yesno') !== false;
-$classToggle = $isBtnGroup ? ' class="btn-check"' : '';
+$classToggle = $isBtnGroup ? 'btn-check' : 'form-check-input';
 $btnClass    = $isBtnGroup ? 'btn btn-outline-secondary' : 'form-check-label';
-$divClass    = $isBtnYesNo || $isBtnGroup ? 'form-check-inline' : 'form-check';
+$blockStart  = $isBtnGroup ? '' : '<div class="form-check">';
+$blockEnd    = $isBtnGroup ? '' : '</div>';
 
 // Add the attributes of the fieldset in an array
 $attribs = ['class="' . trim(
@@ -85,7 +86,7 @@ if ($dataAttribute)
 	</legend>
 	<div <?php echo implode(' ', $attribs); ?>>
 		<?php foreach ($options as $i => $option) : ?>
-			<div class="<?php echo $divClass ?>">
+			<?php echo $blockStart; ?>
 				<?php
 				$disabled    = !empty($option->disable) ? 'disabled' : '';
 				$style       = $disabled ? 'style="pointer-events: none"' : '';
@@ -122,11 +123,11 @@ if ($dataAttribute)
 				<?php if ($required) : ?>
 					<?php $attributes[] = 'required'; ?>
 				<?php endif; ?>
-				<input<?php echo $classToggle; ?> type="radio" id="<?php echo $oid; ?>" name="<?php echo $name; ?>" value="<?php echo $ovalue; ?>" <?php echo implode(' ', $attributes); ?> class="form-check-input">
+				<input class="<?php echo $classToggle; ?>" type="radio" id="<?php echo $oid; ?>" name="<?php echo $name; ?>" value="<?php echo $ovalue; ?>" <?php echo implode(' ', $attributes); ?>>
 				<label for="<?php echo $oid; ?>" class="<?php echo trim($optionClass . ' ' . $style); ?>"> 
 					<?php echo $option->text; ?>
 				</label>
-			</div>
+			<?php echo $blockEnd; ?>
 		<?php endforeach; ?>
 	</div>
 </fieldset>

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -84,46 +84,48 @@ if ($dataAttribute)
 	</legend>
 	<div <?php echo implode(' ', $attribs); ?>>
 		<?php foreach ($options as $i => $option) : ?>
-			<?php
-			$disabled    = !empty($option->disable) ? 'disabled' : '';
-			$style       = $disabled ? 'style="pointer-events: none"' : '';
+			<div>
+				<?php
+				$disabled    = !empty($option->disable) ? 'disabled' : '';
+				$style       = $disabled ? 'style="pointer-events: none"' : '';
 
-			// Initialize some option attributes.
-			if ($isBtnYesNo)
-			{
-				// Set the button classes for the yes/no group
-				switch ($option->value)
+				// Initialize some option attributes.
+				if ($isBtnYesNo)
 				{
-					case '0':
-						$btnClass = 'btn btn-outline-danger';
-						break;
-					case '1':
-						$btnClass = 'btn btn-outline-success';
-						break;
-					default:
-						$btnClass = 'btn btn-outline-secondary';
-						break;
+					// Set the button classes for the yes/no group
+					switch ($option->value)
+					{
+						case '0':
+							$btnClass = 'btn btn-outline-danger';
+							break;
+						case '1':
+							$btnClass = 'btn btn-outline-success';
+							break;
+						default:
+							$btnClass = 'btn btn-outline-secondary';
+							break;
+					}
 				}
-			}
 
-			$optionClass = !empty($option->class) ? $option->class : $btnClass;
-			$optionClass = trim($optionClass . ' ' . $disabled);
-			$checked     = ((string) $option->value === $value) ? 'checked="checked"' : '';
+				$optionClass = !empty($option->class) ? $option->class : $btnClass;
+				$optionClass = trim($optionClass . ' ' . $disabled);
+				$checked     = ((string) $option->value === $value) ? 'checked="checked"' : '';
 
-			// Initialize some JavaScript option attributes.
-			$onclick    = !empty($option->onclick) ? 'onclick="' . $option->onclick . '"' : '';
-			$onchange   = !empty($option->onchange) ? 'onchange="' . $option->onchange . '"' : '';
-			$oid        = $id . $i;
-			$ovalue     = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-			$attributes = array_filter(array($checked, $disabled, $style, $onchange, $onclick));
-			?>
-			<?php if ($required) : ?>
-				<?php $attributes[] = 'required'; ?>
-			<?php endif; ?>
-			<input<?php echo $classToggle; ?> type="radio" id="<?php echo $oid; ?>" name="<?php echo $name; ?>" value="<?php echo $ovalue; ?>" <?php echo implode(' ', $attributes); ?>>
-			<label for="<?php echo $oid; ?>" class="<?php echo trim($optionClass . ' ' . $style); ?>">
-				<?php echo $option->text; ?>
-			</label>
+				// Initialize some JavaScript option attributes.
+				$onclick    = !empty($option->onclick) ? 'onclick="' . $option->onclick . '"' : '';
+				$onchange   = !empty($option->onchange) ? 'onchange="' . $option->onchange . '"' : '';
+				$oid        = $id . $i;
+				$ovalue     = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
+				$attributes = array_filter(array($checked, $disabled, $style, $onchange, $onclick));
+				?>
+				<?php if ($required) : ?>
+					<?php $attributes[] = 'required'; ?>
+				<?php endif; ?>
+				<input<?php echo $classToggle; ?> type="radio" id="<?php echo $oid; ?>" name="<?php echo $name; ?>" value="<?php echo $ovalue; ?>" <?php echo implode(' ', $attributes); ?>>
+				<label for="<?php echo $oid; ?>">
+					<?php echo $option->text; ?>
+				</label>
+			</div>
 		<?php endforeach; ?>
 	</div>
 </fieldset>


### PR DESCRIPTION
Pull Request for Issue #33144

### Summary of Changes
This PR changes the CSS class and styling applied to the input type=radio's label.  Refer to https://github.com/joomla/joomla-cms/blob/2c302641aaad823ac91421a0b11f14e3f8e2fd27/layouts/joomla/form/field/radio/buttons.php#L49
Bootstrap suggests that you organize the radio options as:
```
<div class="form-check">
  <input class="form-check-input" type="radio" name="exampleRadios" id="exampleRadios1" value="option1" checked>
  <label class="form-check-label" for="exampleRadios1">
    Default radio
  </label>
</div>
<div class="form-check">
  <input class="form-check-input" type="radio" name="exampleRadios" id="exampleRadios2" value="option2">
  <label class="form-check-label" for="exampleRadios2">
    Second default radio
  </label>
</div>
```
This PR changes the `form-check` class applied to each option's `<label>`  to `form-check-label` and encloses each option's input-label pair in a `<div class="form-check">`


### Testing Instructions
Change the XML form for any plugin's admin console page to include a radio field like: (similar to the [example in Joomla 4 docs](https://docs.joomla.org/J4.x:Creating_a_Plugin_for_Joomla))
```
<field
  name="search_archived"
  type="radio"
  class="switcher"
  label="LABEL_NAME"
  default="0"
>
  <option value="1">JYES</option>
  <option value="0">JNO</option>
</field>
```
Note that there is **NO** `layout="joomla.form.field.radio.switcher"` part.
Please also test for `class="btn-group"` and `class="btn-group-yesno"`

For example, in the screenshots below I've removed line 37 from plugins/content/vote/vote.xml to achieve the desired testing condition
https://github.com/joomla/joomla-cms/blob/2c302641aaad823ac91421a0b11f14e3f8e2fd27/plugins/content/vote/vote.xml#L37

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/115119355-8ee9e900-9fc5-11eb-8f9b-81394bc4bef8.png)



### Expected result AFTER applying this Pull Request

### `no class`
![image](https://user-images.githubusercontent.com/53610833/115140139-6f010680-a053-11eb-8264-86fef2589e6f.png)

### `btn-group`
![image](https://user-images.githubusercontent.com/53610833/115139959-7e338480-a052-11eb-878f-bd153ac5f321.png)

### `btn-group-yesno`
![image](https://user-images.githubusercontent.com/53610833/115139972-8c81a080-a052-11eb-8233-dec951fbccd9.png)


### Documentation Changes Required
 `layout="joomla.form.field.radio.switcher"` should be mentioned in the [Joomla 4 Plugin Tutorial Page's XML Section](https://docs.joomla.org/J4.x:Creating_a_Plugin_for_Joomla) for making radio fields with 2 options.