### PR TITLE
[4.0] drop the es5 files from the package

### DIFF
--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -8,7 +8,7 @@ const rollup = require('rollup');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const replace = require('@rollup/plugin-replace');
 const { babel } = require('@rollup/plugin-babel');
-const commonjs = require('@rollup/plugin-commonjs');
+// const commonjs = require('@rollup/plugin-commonjs');
 
 const tasks = [];
 const inputFolder = 'build/media_source/vendor/bootstrap/js';
@@ -98,54 +98,54 @@ const build = async () => {
   await bundle.close();
 };
 
-const buildLegacy = async () => {
-  // eslint-disable-next-line no-console
-  console.log('Building Legacy...');
-
-  const bundle = await rollup.rollup({
-    input: resolve(inputFolder, 'index.es6.js'),
-    plugins: [
-      commonjs(),
-      nodeResolve(),
-      replace({
-        preventAssignment: true,
-        'process.env.NODE_ENV': '\'production\'',
-      }),
-      babel({
-        exclude: 'node_modules/core-js/**',
-        babelHelpers: 'bundled',
-        babelrc: false,
-        presets: [
-          [
-            '@babel/preset-env',
-            {
-              corejs: '3.8',
-              useBuiltIns: 'usage',
-              targets: {
-                chrome: '58',
-                ie: '11',
-              },
-              loose: true,
-              bugfixes: true,
-              modules: false,
-            },
-          ],
-        ],
-      }),
-    ],
-    external: [],
-  });
-
-  await bundle.write({
-    format: 'iife',
-    sourcemap: false,
-    name: 'bootstrap',
-    file: resolve(outputFolder, 'bootstrap-es5.js'),
-  });
-
-  // closes the bundle
-  await bundle.close();
-};
+// const buildLegacy = async () => {
+//   // eslint-disable-next-line no-console
+//   console.log('Building Legacy...');
+//
+//   const bundle = await rollup.rollup({
+//     input: resolve(inputFolder, 'index.es6.js'),
+//     plugins: [
+//       commonjs(),
+//       nodeResolve(),
+//       replace({
+//         preventAssignment: true,
+//         'process.env.NODE_ENV': '\'production\'',
+//       }),
+//       babel({
+//         exclude: 'node_modules/core-js/**',
+//         babelHelpers: 'bundled',
+//         babelrc: false,
+//         presets: [
+//           [
+//             '@babel/preset-env',
+//             {
+//               corejs: '3.8',
+//               useBuiltIns: 'usage',
+//               targets: {
+//                 chrome: '58',
+//                 ie: '11',
+//               },
+//               loose: true,
+//               bugfixes: true,
+//               modules: false,
+//             },
+//           ],
+//         ],
+//       }),
+//     ],
+//     external: [],
+//   });
+//
+//   await bundle.write({
+//     format: 'iife',
+//     sourcemap: false,
+//     name: 'bootstrap',
+//     file: resolve(outputFolder, 'bootstrap-es5.js'),
+//   });
+//
+//   // closes the bundle
+//   await bundle.close();
+// };
 
 module.exports.bootstrapJs = async () => {
   rimraf.sync(resolve(outputFolder));
@@ -167,18 +167,18 @@ module.exports.bootstrapJs = async () => {
     // eslint-disable-next-line no-console
     console.log('✅ ES6 components ready');
 
-    try {
-      await buildLegacy(inputFolder, 'index.es6.js');
-      const es5File = await readFile(resolve(outputFolder, 'bootstrap-es5.js'), { encoding: 'utf8' });
-      const mini = await minify(es5File, { sourceMap: false, format: { comments: false } });
-      await writeFile(resolve(outputFolder, 'bootstrap-es5.min.js'), mini.code, { encoding: 'utf8' });
-      // eslint-disable-next-line no-console
-      console.log('✅ Legacy done!');
-    } catch (error) {
-      // eslint-disable-next-line no-console
-      console.error(error);
-      process.exit(1);
-    }
+    // try {
+    //   await buildLegacy(inputFolder, 'index.es6.js');
+    //   const es5File = await readFile(resolve(outputFolder, 'bootstrap-es5.js'), { encoding: 'utf8' });
+    //   const mini = await minify(es5File, { sourceMap: false, format: { comments: false } });
+    //   await writeFile(resolve(outputFolder, 'bootstrap-es5.min.js'), mini.code, { encoding: 'utf8' });
+    //   // eslint-disable-next-line no-console
+    //   console.log('✅ Legacy done!');
+    // } catch (error) {
+    //   // eslint-disable-next-line no-console
+    //   console.error(error);
+    //   process.exit(1);
+    // }
   }).catch((er) => {
     // eslint-disable-next-line no-console
     console.log(er);

--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -169,9 +169,11 @@ module.exports.bootstrapJs = async () => {
 
     // try {
     //   await buildLegacy(inputFolder, 'index.es6.js');
-    //   const es5File = await readFile(resolve(outputFolder, 'bootstrap-es5.js'), { encoding: 'utf8' });
+    //   const es5File = await readFile(resolve(outputFolder, 'bootstrap-es5.js'),
+    //   { encoding: 'utf8' });
     //   const mini = await minify(es5File, { sourceMap: false, format: { comments: false } });
-    //   await writeFile(resolve(outputFolder, 'bootstrap-es5.min.js'), mini.code, { encoding: 'utf8' });
+    //   await writeFile(resolve(outputFolder, 'bootstrap-es5.min.js'), mini.code,
+    //   { encoding: 'utf8' });
     //   // eslint-disable-next-line no-console
     //   console.log('✅ Legacy done!');
     // } catch (error) {

--- a/build/build-modules-js/javascript/build-com_media-js.es6.js
+++ b/build/build-modules-js/javascript/build-com_media-js.es6.js
@@ -4,60 +4,60 @@ const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const replace = require('@rollup/plugin-replace');
 const { babel } = require('@rollup/plugin-babel');
 const VuePlugin = require('rollup-plugin-vue');
-const commonjs = require('@rollup/plugin-commonjs');
+// const commonjs = require('@rollup/plugin-commonjs');
 const { minifyJs } = require('./minify.es6.js');
 
 const inputJS = 'administrator/components/com_media/resources/scripts/mediamanager.es6.js';
 
-const buildLegacy = async (file) => {
-  // eslint-disable-next-line no-console
-  console.log('Building Legacy Media Manager...');
-
-  const bundle = await rollup.rollup({
-    input: file,
-    plugins: [
-      nodeResolve(),
-      commonjs(),
-      babel({
-        exclude: 'node_modules/core-js/**',
-        babelHelpers: 'bundled',
-        babelrc: false,
-        presets: [
-          [
-            '@babel/preset-env',
-            {
-              corejs: '3.8',
-              useBuiltIns: 'usage',
-              targets: {
-                ie: '11',
-              },
-              loose: true,
-              bugfixes: true,
-              modules: false,
-              ignoreBrowserslistConfig: true,
-            },
-          ],
-        ],
-      }),
-    ],
-    external: [],
-  });
-
-  await bundle.write({
-    format: 'iife',
-    sourcemap: false,
-    name: 'JoomlaMediaManager',
-    file: 'media/com_media/js/media-manager-es5.js',
-  });
-
-  // closes the bundle
-  await bundle.close();
-
-  // eslint-disable-next-line no-console
-  console.log('Legacy Media Manager ready ✅');
-
-  minifyJs('media/com_media/js/media-manager-es5.js');
-};
+// const buildLegacy = async (file) => {
+//   // eslint-disable-next-line no-console
+//   console.log('Building Legacy Media Manager...');
+//
+//   const bundle = await rollup.rollup({
+//     input: file,
+//     plugins: [
+//       nodeResolve(),
+//       commonjs(),
+//       babel({
+//         exclude: 'node_modules/core-js/**',
+//         babelHelpers: 'bundled',
+//         babelrc: false,
+//         presets: [
+//           [
+//             '@babel/preset-env',
+//             {
+//               corejs: '3.8',
+//               useBuiltIns: 'usage',
+//               targets: {
+//                 ie: '11',
+//               },
+//               loose: true,
+//               bugfixes: true,
+//               modules: false,
+//               ignoreBrowserslistConfig: true,
+//             },
+//           ],
+//         ],
+//       }),
+//     ],
+//     external: [],
+//   });
+//
+//   await bundle.write({
+//     format: 'iife',
+//     sourcemap: false,
+//     name: 'JoomlaMediaManager',
+//     file: 'media/com_media/js/media-manager-es5.js',
+//   });
+//
+//   // closes the bundle
+//   await bundle.close();
+//
+//   // eslint-disable-next-line no-console
+//   console.log('Legacy Media Manager ready ✅');
+//
+//   minifyJs('media/com_media/js/media-manager-es5.js');
+// };
 
 module.exports.mediaManager = async () => {
   // eslint-disable-next-line no-console
@@ -116,5 +116,5 @@ module.exports.mediaManager = async () => {
   // eslint-disable-next-line no-console
   console.log('✅ ES2017 Media Manager ready');
   minifyJs('media/com_media/js/media-manager.js');
-  return buildLegacy(resolve('media/com_media/js/media-manager.js'));
+  // return buildLegacy(resolve('media/com_media/js/media-manager.js'));
 };

--- a/build/build-modules-js/javascript/compile-to-es2017.es6.js
+++ b/build/build-modules-js/javascript/compile-to-es2017.es6.js
@@ -10,7 +10,7 @@ const { babel } = require('@rollup/plugin-babel');
 const Postcss = require('postcss');
 const { renderSync } = require('sass');
 const { minifyJs } = require('./minify.es6.js');
-const { handleESMToLegacy } = require('./compile-to-es5.es6.js');
+// const { handleESMToLegacy } = require('./compile-to-es5.es6.js');
 
 const getWcMinifiedCss = async (file) => {
   let scssFileExists = false;
@@ -98,6 +98,6 @@ module.exports.handleESMFile = async (file) => {
   // eslint-disable-next-line no-console
   console.log(`ES2017 file: ${basename(file).replace('.es6.js', '.js')}: ✅ transpiled`);
 
-  await handleESMToLegacy(resolve(`${newPath}.js`));
+  // await handleESMToLegacy(resolve(`${newPath}.js`));
   await minifyJs(resolve(`${newPath}.js`));
 };


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- Does what the title says: the build tools would not create es5 js files
- Keep the references in the asset,json files
- I could create a repo that fetches the latest release creates all the es5 files and package them as an installable library, if supporting es5 is still on your radar

### Testing Instructions

`npm ci` on a clean (no media folder) clone

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

