### PR TITLE
[4.0] J4 Modules should require an element field

### DIFF
--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -338,6 +338,11 @@ class ModuleAdapter extends InstallerAdapter
 	{
 		if (!$element)
 		{
+			if (isset($this->getManifest()->element))
+			{
+				return (string) $this->getManifest()->element;
+			}
+
 			if (\count($this->getManifest()->files->children()))
 			{
 				foreach ($this->getManifest()->files->children() as $file)

--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -330,30 +330,34 @@ class ModuleAdapter extends InstallerAdapter
 	 *
 	 * @param   string  $element  Optional element name to be converted
 	 *
-	 * @return  string  The filtered element
+	 * @return  string|null  The filtered element
 	 *
 	 * @since   3.4
 	 */
 	public function getElement($element = null)
 	{
-		if (!$element)
+		if ($element)
 		{
-			if ((string) $this->getManifest()->element)
-			{
-				return (string) $this->getManifest()->element;
-			}
+			return $element;
+		}
 
-			if (\count($this->getManifest()->files->children()))
-			{
-				foreach ($this->getManifest()->files->children() as $file)
-				{
-					if ((string) $file->attributes()->module)
-					{
-						$element = strtolower((string) $file->attributes()->module);
+		// Joomla 4 Module.
+		if ((string) $this->getManifest()->element)
+		{
+			return (string) $this->getManifest()->element;
+		}
 
-						break;
-					}
-				}
+		if (!\count($this->getManifest()->files->children()))
+		{
+			return $element;
+		}
+
+		foreach ($this->getManifest()->files->children() as $file)
+		{
+			if ((string) $file->attributes()->module)
+			{
+				// Joomla 3 (legacy) Module.
+				return strtolower((string) $file->attributes()->module);
 			}
 		}
 

--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -338,7 +338,7 @@ class ModuleAdapter extends InstallerAdapter
 	{
 		if (!$element)
 		{
-			if (isset($this->getManifest()->element))
+			if ((string) $this->getManifest()->element)
 			{
 				return (string) $this->getManifest()->element;
 			}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Since https://github.com/joomla/joomla-cms/pull/32633 J4 (non legacy) Modules don't have a `module.php` file in their root folder
https://github.com/joomla/joomla-cms/blob/2c302641aaad823ac91421a0b11f14e3f8e2fd27/administrator/modules/mod_quickicon/mod_quickicon.xml#L14

and thus it's impossible to install a module that uses namespace, check the existing code: https://github.com/joomla/joomla-cms/blob/2c302641aaad823ac91421a0b11f14e3f8e2fd27/libraries/src/Installer/Adapter/ModuleAdapter.php#L337-L356.

To mitigate this in the easiest possible way I propose to require (for the J4 native modules, not the legacy) one field in the XML: eg `<element>mod_wow</element>`;



### Testing Instructions

You could test this in 2 different ways:
- go to your db and delete in the extension table the `mod_quickicon`
- Then move the `administrator/mopdules/mod_quickicon` to a folder outside of the Joomla folder
- Zip the content of the folder and try to install it (it will fail with a message `file mod_quickicon.php doesn't exist`)
- Edit the XML file removing the line `<filename module="mod_quickicon">mod_quickicon.php</filename>` and adding after line 3 `<element>mod_quickicon</element>` then zip the contents of the folder and try again

Alternative you can download `https://jinvalidate.netlify.app/dist/j4/mod_invalidatecache_0.0.6.zip` and observe that the module installs correctly

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required



@laoneo some feedback here?
@wilsonge ?