### PR TITLE
Reverse ordering is hardcoded to articles

### DIFF
--- a/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
+++ b/administrator/components/com_categories/views/categories/tmpl/default_batch_body.php
@@ -55,15 +55,17 @@ $extension = $this->escape($this->state->get('filter.extension'));
 			</div>
 		</div>
 	</div>
-	<div class="row-fluid">
-		<div class="span6">
-			<div class="control-group">
-				<label id="flip-ordering-id-lbl" for="flip-ordering-id" class="control-label">
-					<?php echo JText::_('JLIB_HTML_BATCH_FLIPORDERING_LABEL'); ?>
-				</label>
-				<?php echo JHtml::_('select.booleanlist', 'batch[flip_ordering]', array(), 0, 'JYES', 'JNO', 'flip-ordering-id'); ?>
+	<?php if ($extension === 'com_content') : ?>
+		<div class="row-fluid">
+			<div class="span6">
+				<div class="control-group">
+					<label id="flip-ordering-id-lbl" for="flip-ordering-id" class="control-label">
+						<?php echo JText::_('JLIB_HTML_BATCH_FLIPORDERING_LABEL'); ?>
+					</label>
+					<?php echo JHtml::_('select.booleanlist', 'batch[flip_ordering]', array(), 0, 'JYES', 'JNO', 'flip-ordering-id'); ?>
+				</div>
 			</div>
 		</div>
-	</div>
+	<?php endif; ?>
 </div>
 


### PR DESCRIPTION
Batch copying a category allows to reverse order all articles in the selected categories. But categories are not only for articles. It can be anything. So this function should not be proposed to other components.

If someone is wondering if it really only works for articles, the code would be here:
https://github.com/joomla/joomla-cms/blob/staging/administrator/components/com_categories/models/category.php#L853
As you will see, it is hardcoded to com_content:
https://github.com/joomla/joomla-cms/blob/b7fb043acc1cac8b89c7b2872b3ea7df01707d31/administrator/components/com_categories/models/category.php#L877-L879

### Summary of Changes
Make the "Reverse the ordering of all articles...." conditional to only show when we're in com_content categories.

### Testing Instructions
Go to any categories manager (eg articles categories, banner categories, contact categories), select at least one category and then select "Batch" from the "Actions" dropdown.


### Actual result BEFORE applying this Pull Request
Regardless if we're managing categories from com_content or com_contact (or any other component), it always offers to reorder the articles:
![image](https://user-images.githubusercontent.com/1018684/115153614-4559d680-a077-11eb-90e4-b2f0d45cc731.png)



### Expected result AFTER applying this Pull Request
The option only shows for com_content. In other components it isn't show.


### Documentation Changes Required
None
