### PR TITLE
[4.0] Fixing component ID in testing sampledata

### DIFF
--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -2135,7 +2135,7 @@ class PlgSampledataTesting extends CMSPlugin
 				'menutype'     => $menuTypes[6],
 				'title'        => Text::_('PLG_SAMPLEDATA_TESTING_SAMPLEDATA_MENUS_ITEM_44_TITLE'),
 				'link'         => 'index.php?option=com_users&view=login',
-				'component_id' => 25,
+				'component_id' => ComponentHelper::getComponent('com_users')->id,
 				'params'       => array(
 					'logindescription_show'  => 1,
 					'logoutdescription_show' => 1,


### PR DESCRIPTION
The sampledata "Login Form" menu item has a component ID of the tags component instead of the users component. This PR fixes that field. A simple code review should be enough here.