### PR TITLE
[4.0] Adapt unit tests to PR 32718 having been merged up from 3.10

### DIFF
--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
@@ -41,11 +41,9 @@ class FilePathRuleTest extends UnitTestCase
 		/>'
 		);
 
-		// These all pass today,
-		// BUT, Joomla 3.9.26 SHOULD break this test, as a security fix is applied, thus proving the test valuable
 		return [
 			[true, $xml, ''],
-			[false, $xml, '.images'],
+			[true, $xml, '.images'],
 			[false, $xml, './images'],
 			[false, $xml, '.\images'],
 			[false, $xml, '../images'],
@@ -54,19 +52,19 @@ class FilePathRuleTest extends UnitTestCase
 			[false, $xml, '\\images'], // Means \images
 			[true, $xml, 'ftp://images'],
 			[true, $xml, 'http://images'],
-			[true, $xml, 'media'],
-			[true, $xml, 'administrator'],
+			[false, $xml, 'media'],
+			[false, $xml, 'administrator'],
 			[false, $xml, '/4711images'],
-			[false, $xml, '4711images'],
-			[false, $xml, '1'],
-			[false, $xml, '_'],
-			[false, $xml, '*'],
-			[false, $xml, '%'],
-			[false, $xml, '://foo'],
+			[true, $xml, '4711images'],
+			[true, $xml, '1'],
+			[true, $xml, '_'],
+			[true, $xml, '*'],
+			[true, $xml, '%'],
+			[true, $xml, '://foo'],
 			[false, $xml, '/4711i/images'],
 			[false, $xml, '../4711i/images'],
-			[false, $xml, 'Εικόνες'],
-			[false, $xml, 'Изображений'],
+			[true, $xml, 'Εικόνες'],
+			[true, $xml, 'Изображений'],
 		];
 	}
 

--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathRuleTest.php
@@ -38,6 +38,7 @@ class FilePathRuleTest extends UnitTestCase
 			size="50"
 			default="images"
 			validate="filePath"
+			exclude="administrator|media"
 		/>'
 		);
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Adapt the unit tests for the FilePathRule validation rule to PR #32718 , which meanwhile has been merged up from 3.10-dev.

### Testing Instructions

Check if unit tests are passing in Appveyor and Drone.

### Actual result BEFORE applying this Pull Request

Unit tests failing on the 4.0-dev branch.

### Expected result AFTER applying this Pull Request

Unit tests passing for this PR here.

### Documentation Changes Required

None.