### PR TITLE
[4] Disable debug mode before inserting translated data to db

### DIFF
--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -119,6 +119,9 @@ class PlgSampledataBlog extends CMSPlugin
 		$language   = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : '*';
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
+		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		Factory::getLanguage()->setDebug(false);
+
 		/** @var \Joomla\Component\Tags\Administrator\Model\TagModel $model */
 		$modelTag = $this->app->bootComponent('com_tags')->getMVCFactory()->createModel('Tag', 'Administrator', ['ignore_request' => true]);
 
@@ -834,6 +837,9 @@ class PlgSampledataBlog extends CMSPlugin
 		$language   = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : '*';
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
+		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		Factory::getLanguage()->setDebug(false);
+
 		// Create the menu types.
 		$menuTable = new \Joomla\Component\Menus\Administrator\Table\MenuTypeTable($this->db);
 		$menuTypes = array();
@@ -1406,6 +1412,9 @@ class PlgSampledataBlog extends CMSPlugin
 		// Detect language to be used.
 		$language   = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : '*';
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
+
+		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		Factory::getLanguage()->setDebug(false);
 
 		// Add Include Paths.
 		$model  = new \Joomla\Component\Modules\Administrator\Model\ModuleModel;

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -119,7 +119,7 @@ class PlgSampledataBlog extends CMSPlugin
 		$language   = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : '*';
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
-		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		// Set debugging to false to prevent saving of prepend/appended debug_lang_const
 		Factory::getLanguage()->setDebug(false);
 
 		/** @var \Joomla\Component\Tags\Administrator\Model\TagModel $model */
@@ -837,7 +837,7 @@ class PlgSampledataBlog extends CMSPlugin
 		$language   = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : '*';
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
-		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		// Set debugging to false to prevent saving of prepend/appended debug_lang_const
 		Factory::getLanguage()->setDebug(false);
 
 		// Create the menu types.
@@ -1413,7 +1413,7 @@ class PlgSampledataBlog extends CMSPlugin
 		$language   = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : '*';
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
-		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		// Set debugging to false to prevent saving of prepend/appended debug_lang_const
 		Factory::getLanguage()->setDebug(false);
 
 		// Add Include Paths.

--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -112,6 +112,9 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
+		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		Factory::getLanguage()->setDebug(false);
+
 		/** @var \Joomla\Component\Tags\Administrator\Model\TagModel $model */
 		$model = $this->app->bootComponent('com_tags')->getMVCFactory()->createModel('Tag', 'Administrator', ['ignore_request' => true]);
 		$access = (int) $this->app->get('access', 1);
@@ -219,6 +222,9 @@ class PlgSampledataTesting extends CMSPlugin
 
 			return $response;
 		}
+
+		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		Factory::getLanguage()->setDebug(false);
 
 		$factory = $this->app->bootComponent('com_banners')->getMVCFactory();
 
@@ -399,6 +405,9 @@ class PlgSampledataTesting extends CMSPlugin
 
 			return $response;
 		}
+
+		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		Factory::getLanguage()->setDebug(false);
 
 		// Insert first level of categories.
 		$categories   = array();
@@ -1050,6 +1059,9 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
+		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		Factory::getLanguage()->setDebug(false);
+
 		$model  = $this->app->bootComponent('com_contact')->getMVCFactory()->createModel('Contact', 'Administrator', ['ignore_request' => true]);
 		$access = (int) $this->app->get('access', 1);
 		$user   = Factory::getUser();
@@ -1402,6 +1414,9 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
+		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		Factory::getLanguage()->setDebug(false);
+
 		/** @var \Joomla\Component\Newsfeeds\Administrator\Model\NewsfeedModel $model */
 		$model  = $this->app->bootComponent('com_newsfeeds')->getMVCFactory()->createModel('Newsfeed', 'Administrator', ['ignore_request' => true]);
 		$access = (int) $this->app->get('access', 1);
@@ -1529,6 +1544,9 @@ class PlgSampledataTesting extends CMSPlugin
 
 			return $response;
 		}
+
+		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		Factory::getLanguage()->setDebug(false);
 
 		/** @var \Joomla\Component\Menus\Administrator\Model\MenuModel $model */
 		$factory = $this->app->bootComponent('com_menus')->getMVCFactory();
@@ -3242,6 +3260,9 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
+		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		Factory::getLanguage()->setDebug(false);
+
 		$model = $this->app->bootComponent('com_modules')->getMVCFactory()->createModel('Module', 'Administrator', ['ignore_request' => true]);
 		$access = (int) $this->app->get('access', 1);
 
@@ -4620,6 +4641,9 @@ class PlgSampledataTesting extends CMSPlugin
 		$access = (int) $this->app->get('access', 1);
 		$user   = Factory::getUser();
 		$mvcFactory = $this->app->bootComponent('com_content')->getMVCFactory();
+
+		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		Factory::getLanguage()->setDebug(false);
 
 		foreach ($articles as $i => $article)
 		{

--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -112,7 +112,7 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
-		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		// Set debugging to false to prevent saving of prepend/appended debug_lang_const
 		Factory::getLanguage()->setDebug(false);
 
 		/** @var \Joomla\Component\Tags\Administrator\Model\TagModel $model */
@@ -223,7 +223,7 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
-		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		// Set debugging to false to prevent saving of prepend/appended debug_lang_const
 		Factory::getLanguage()->setDebug(false);
 
 		$factory = $this->app->bootComponent('com_banners')->getMVCFactory();
@@ -406,7 +406,7 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
-		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		// Set debugging to false to prevent saving of prepend/appended debug_lang_const
 		Factory::getLanguage()->setDebug(false);
 
 		// Insert first level of categories.
@@ -1059,7 +1059,7 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
-		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		// Set debugging to false to prevent saving of prepend/appended debug_lang_const
 		Factory::getLanguage()->setDebug(false);
 
 		$model  = $this->app->bootComponent('com_contact')->getMVCFactory()->createModel('Contact', 'Administrator', ['ignore_request' => true]);
@@ -1414,7 +1414,7 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
-		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		// Set debugging to false to prevent saving of prepend/appended debug_lang_const
 		Factory::getLanguage()->setDebug(false);
 
 		/** @var \Joomla\Component\Newsfeeds\Administrator\Model\NewsfeedModel $model */
@@ -1545,7 +1545,7 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
-		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		// Set debugging to false to prevent saving of prepend/appended debug_lang_const
 		Factory::getLanguage()->setDebug(false);
 
 		/** @var \Joomla\Component\Menus\Administrator\Model\MenuModel $model */
@@ -3260,7 +3260,7 @@ class PlgSampledataTesting extends CMSPlugin
 			return $response;
 		}
 
-		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		// Set debugging to false to prevent saving of prepend/appended debug_lang_const
 		Factory::getLanguage()->setDebug(false);
 
 		$model = $this->app->bootComponent('com_modules')->getMVCFactory()->createModel('Module', 'Administrator', ['ignore_request' => true]);
@@ -4642,7 +4642,7 @@ class PlgSampledataTesting extends CMSPlugin
 		$user   = Factory::getUser();
 		$mvcFactory = $this->app->bootComponent('com_content')->getMVCFactory();
 
-		// Set debugging to false to prevent savving of prepend/appended debug_lang_const
+		// Set debugging to false to prevent saving of prepend/appended debug_lang_const
 		Factory::getLanguage()->setDebug(false);
 
 		foreach ($articles as $i => $article)


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/31160 https://github.com/joomla/cassiopeia/issues/185

### Summary of Changes

Disable language debugging before inserting translated sample data (blog or testing).


### Testing Instructions

Enable language debugging on a fresh installation, then install sample data (blog or testing).


### Actual result BEFORE applying this Pull Request

Where `**` = `debug_lang_const`

Titles and texts have surrounding ** from language debugging, and these values are stored into the db by mistake


### Expected result AFTER applying this Pull Request

Sample/Testing data installed with no hard coded `debug_lang_const` / `**` value saved to the db

### Documentation Changes Required

none

// @chmst @infograf768 