### PR TITLE
Added plugin enable/disable with AJAX

### DIFF
--- a/administrator/components/com_plugins/controller.php
+++ b/administrator/components/com_plugins/controller.php
@@ -50,4 +50,64 @@ class PluginsController extends JControllerLegacy
 
 		parent::display();
 	}
+
+	public function ajaxControlPlugin()
+	{
+		// check token to prevent CSRF
+		JSession::checkToken('get') or die( 'Invalid Token' );
+
+		$input = JFactory::getApplication()->input;
+
+		$db    = JFactory::getDbo();
+		$query = $db->getQuery(true);
+
+		// query to get plugin name
+		$query
+			->clear()
+			->select('name')
+			->from($db->quoteName('#__extensions'))
+			->where($db->qn('extension_id') . ' = ' . $input->get('extension_id'));
+
+		$db->setQuery($query);
+
+		try
+		{
+			$plgName = $db->loadResult();
+		}
+		catch (JDatabaseExceptionExecuting $e)
+		{
+			die;
+		}
+
+		if (empty($plgName))
+		{
+			die;
+		}
+
+		$query = $db->getQuery(true);
+
+		// enable or disable plugin
+
+		$plgAction = $input->get('pluginAction') == true ? 1 : 0;
+
+		$query
+			->clear()
+			->update($db->qn('#__extensions'))
+			->set($db->qn('enabled') . ' = ' . $plgAction)
+			->where($db->qn('name') . ' = ' . $db->q($plgName))
+			->where($db->qn('type') . ' = ' . $db->q('plugin'));
+
+		$db->setQuery($query);
+
+		try
+		{
+			$db->execute();
+		}
+		catch (JDatabaseExceptionExecuting $e)
+		{
+			die;
+		}
+
+		die;
+    }
 }

--- a/administrator/components/com_plugins/views/plugin/tmpl/edit.php
+++ b/administrator/components/com_plugins/views/plugin/tmpl/edit.php
@@ -38,6 +38,50 @@ JFactory::getDocument()->addScriptDeclaration("
 		}
 	};
 ");
+
+// Add plugin enable/disable AJAX
+JFactory::getDocument()->addScriptDeclaration("
+	jQuery(document).ready(function() {
+		jQuery('#jform_enabled').change(function(e) {
+			let pluginAction = e.target.value;
+			let coverDiv = document.createElement('div');
+
+			jQuery.ajax(
+				'index.php?option=com_plugins&extension_id=" . (int) $this->item->extension_id . "&".JSession::getFormToken()."=1',
+				{
+					cache: false,
+					data: { task: 'ajaxControlPlugin', pluginAction },
+					beforeSend: function() {
+						coverDiv.style.background = 'rgba(13, 13, 13, 0.5)';
+						coverDiv.style.zIndex = '9999';
+						coverDiv.style.height = '100vh';
+						coverDiv.style.width = '100vw';
+						coverDiv.style.position = 'fixed';
+						coverDiv.style.top = '0';
+						coverDiv.style.left = '0';
+
+						document.body.append(coverDiv);
+					},
+					complete: onComplete,
+					success: function(result, status, xhr) {
+						if (pluginAction == 1) {
+							alert('".JText::_( 'COM_PLUGINS_N_ITEMS_PUBLISHED_1')."');
+						} else {
+							alert('".JText::_( 'COM_PLUGINS_N_ITEMS_UNPUBLISHED_1')."');
+						}
+					},
+					error: function() {
+						alert('Something went wrong');
+					},
+				}
+			);
+
+			function onComplete() {
+				coverDiv.remove();
+			}
+		});
+	});
+");
 ?>
 
 <form action="<?php echo JRoute::_('index.php?option=com_plugins&view=plugin&layout=' . $layout . $tmpl . '&extension_id=' . (int) $this->item->extension_id); ?>" method="post" name="adminForm" id="style-form" class="form-validate">


### PR DESCRIPTION
### Summary of Changes

Added new feature to plugins component in administrator panel. Now if user change status of a plugin (enabled/disabled) he doesn't need to press "Save" button, everything is done live with AJAX technology.

### Testing Instructions

In administrator panel go to Extensions > Plugins > choose any plugin and then switch its status. Befor applying these changes you have to press "Save" button, but after applying these changes you are able to see "Plugin disabled" or "Plugin enabled" notification and plugin is really enabled/disabled.

### Actual result BEFORE applying this Pull Request

Nothing happens after switching plugin status on Extensions > Plugins > choose any plugin page

### Expected result AFTER applying this Pull Request

A plugin gets enabled/disabled after switching plugin status on Extensions > Plugins > choose any plugin page