### PR TITLE
[4.0] Change layout of filter search in articles (archive view)

### DIFF
--- a/components/com_content/src/View/Archive/HtmlView.php
+++ b/components/com_content/src/View/Archive/HtmlView.php
@@ -180,7 +180,7 @@ class HtmlView extends BaseHtmlView
 			$months,
 			'month',
 			array(
-				'list.attr' => 'class="form-control"',
+				'list.attr' => 'class="form-select"',
 				'list.select' => $state->get('filter.month'),
 				'option.key' => null
 			)
@@ -200,7 +200,7 @@ class HtmlView extends BaseHtmlView
 			'select.genericlist',
 			$years,
 			'year',
-			array('list.attr' => 'class="form-control"', 'list.select' => $state->get('filter.year'))
+			array('list.attr' => 'class="form-select"', 'list.select' => $state->get('filter.year'))
 		);
 		$form->limitField = $pagination->getLimitBox();
 

--- a/components/com_content/tmpl/archive/default.php
+++ b/components/com_content/tmpl/archive/default.php
@@ -34,13 +34,13 @@ use Joomla\CMS\Router\Route;
 
 		<span class="me-2">
 		<?php echo $this->form->monthField; ?>
-	</span>
+		</span>
 		<span class="me-2">
 		<?php echo $this->form->yearField; ?>
-	</span>
+		</span>
 		<span class="me-2">
 		<?php echo $this->form->limitField; ?>
-	</span>
+		</span>
 
 		<button type="submit" class="btn btn-primary" style="vertical-align: top;"><?php echo Text::_('JGLOBAL_FILTER_BUTTON'); ?></button>
 		<input type="hidden" name="view" value="archive">

--- a/components/com_content/tmpl/archive/default.php
+++ b/components/com_content/tmpl/archive/default.php
@@ -32,22 +32,21 @@ use Joomla\CMS\Router\Route;
 		</div>
 		<?php endif; ?>
 
-		<div class="me-2">
+		<span class="me-2">
 		<?php echo $this->form->monthField; ?>
-		</div>
-		<div class="me-2">
+	</span>
+		<span class="me-2">
 		<?php echo $this->form->yearField; ?>
-		</div>
-		<div class="me-2">
+	</span>
+		<span class="me-2">
 		<?php echo $this->form->limitField; ?>
-		</div>
+	</span>
 
 		<button type="submit" class="btn btn-primary" style="vertical-align: top;"><?php echo Text::_('JGLOBAL_FILTER_BUTTON'); ?></button>
 		<input type="hidden" name="view" value="archive">
 		<input type="hidden" name="option" value="com_content">
 		<input type="hidden" name="limitstart" value="0">
 	</div>
-	<br>
 	</fieldset>
 </form>
 <?php echo $this->loadTemplate('items'); ?>


### PR DESCRIPTION
### Summary of Changes
changed class `form-control` to `form-select`
changed `div` to `span`

### Testing Instructions
visit the link `http://localhost/joomla-cms/index.php/sample-layouts/articles?view=archive` and see the changes

### Actual result BEFORE applying this Pull Request

![before-patch-archive](https://user-images.githubusercontent.com/61203226/115584792-b0f6aa80-a2e8-11eb-9021-6e04d730b4a6.JPG)

### Expected result AFTER applying this Pull Request

![after-patch-archive](https://user-images.githubusercontent.com/61203226/115584813-b6ec8b80-a2e8-11eb-9f9d-946b8983f44e.JPG)

### Documentation Changes Required
No
