### PR TITLE
[4.0] Swap layout of buttons in com_media's delete confirmation modal

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/modals/confirm-delete-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/confirm-delete-modal.vue
@@ -24,17 +24,17 @@
     <template #footer>
       <div>
         <button
+          class="btn btn-success"
+          @click="close()"
+        >
+          {{ translate('JCANCEL') }}
+        </button>
+        <button
           id="media-delete-item"
           class="btn btn-danger"
           @click="deleteItem()"
         >
           {{ translate('COM_MEDIA_CONFIRM_DELETE_MODAL') }}
-        </button>
-        <button
-          class="btn btn-success"
-          @click="close()"
-        >
-          {{ translate('JCANCEL') }}
         </button>
       </div>
     </template>


### PR DESCRIPTION
Pull Request for Issue #33215 .

### Summary of Changes
The `delete` button to the right of the `cancel` button in `com_media`'s delete confirmation modal. 
The reasoning behind this is better explained in https://github.com/joomla/joomla-cms/issues/33215#issuecomment-824236014

### Testing Instructions
1. `npm ci`
2. Joomla Administrator Panel -> Sidebar -> Content -> Media
3. Select any file and click on the delete button

Ensure that the delete button is to the right of cancel and it works as intended.

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/115597185-a04d3100-a2f6-11eb-810d-1fb6b631ee86.png)


### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/115597513-f91cc980-a2f6-11eb-87a1-2edecabacda6.png)


### Documentation Changes Required
None
