### PR TITLE
[4.0] click to check the checkbox in com_installer&view=database

### DIFF
--- a/administrator/components/com_installer/tmpl/database/default.php
+++ b/administrator/components/com_installer/tmpl/database/default.php
@@ -74,7 +74,7 @@ $listDirection = $this->escape($this->state->get('list.direction'));
 									<?php $extension = $item['extension']; ?>
 									<?php $manifest = json_decode($extension->manifest_cache); ?>
 
-									<tr>
+									<tr class="row<?php echo $i % 2; ?>">
 										<td class="text-center">
 											<?php echo HTMLHelper::_('grid.id', $i, $extension->extension_id, false, 'cid', 'cb', $extension->name); ?>
 										</td>


### PR DESCRIPTION
### Summary of Changes
added `class="row<?php echo $i % 2; ?>"` in `<tr>`

### Testing Instructions
`Admin` -> `System` -> `Information` -> `Database`    

OR

Visit `http://localhost/joomla-cms/administrator/index.php?option=com_installer&view=database`

### Actual result BEFORE applying this Pull Request

The checkbox will not be checked when we clicked `<tr>` of `<tbody>`

### Expected result AFTER applying this Pull Request

The checkbox will be checked when we clicked `<tr>` of `<tbody>` 

![database](https://user-images.githubusercontent.com/61203226/115614077-d4cae800-a30a-11eb-84cd-31816cd107ac.gif)


### Documentation Changes Required
No
