### PR TITLE
[4.0] click to check the checkbox in com_finder&view=index

### DIFF
--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Finder\Administrator\Helper\LanguageHelper;
 
+HTMLHelper::_('behavior.multiselect');
+
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $lang      = Factory::getLanguage();


### PR DESCRIPTION
### Summary of Changes
Added `HTMLHelper::_('behavior.multiselect');`

### Testing Instructions
`Admin` -> `Components`-> `Smart Search` -> `Index`

OR

Visit `http://localhost/joomla-cms/administrator/index.php?option=com_finder&view=index`

### Actual result BEFORE applying this Pull Request
The checkbox will not be checked when we clicked `<tr>` of `<tbody>`

### Expected result AFTER applying this Pull Request
The checkbox will be checked when we clicked `<tr>` of `<tbody>`

![com_finder_index](https://user-images.githubusercontent.com/61203226/115660072-1edaba80-a359-11eb-8457-cf22ede41b2f.gif)

### Documentation Changes Required
No
