### PR TITLE
[4.0] click to check the checkbox in com_finder&view=maps

### DIFF
--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Finder\Administrator\Helper\LanguageHelper;
 
+HTMLHelper::_('behavior.multiselect');
+
 $listOrder     = $this->escape($this->state->get('list.ordering'));
 $listDirn      = $this->escape($this->state->get('list.direction'));
 $lang          = Factory::getLanguage();


### PR DESCRIPTION
### Summary of Changes
Added `HTMLHelper::_('behavior.multiselect');`

### Testing Instructions
`Admin` -> `Components`-> `Smart Search` -> `Content Maps`

OR

Visit `http://localhost/joomla-cms/administrator/index.php?option=com_finder&view=maps`

### Actual result BEFORE applying this Pull Request
The checkbox will not be checked when we clicked `<tr>` of `<tbody>`

### Expected result AFTER applying this Pull Request
The checkbox will be checked when we clicked `<tr>` of `<tbody>`

![com_finder_maps](https://user-images.githubusercontent.com/61203226/115661406-04a1dc00-a35b-11eb-9a4b-7c700c21bee3.gif)

### Documentation Changes Required
No
