### PR TITLE
Use null coalescing operator instead of if

### DIFF
--- a/administrator/components/com_plugins/src/Model/PluginsModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginsModel.php
@@ -116,10 +116,7 @@ class PluginsModel extends ListModel
 		$ordering = $this->getState('list.ordering', 'ordering');
 
 		// If "Sort Table By:" is not set, set ordering to name
-		if ($ordering == '')
-		{
-			$ordering = 'name';
-		}
+		$ordering = $ordering ?? 'name';
 
 		if ($ordering == 'name' || (!empty($search) && stripos($search, 'id:') !== 0))
 		{


### PR DESCRIPTION
### Summary of Changes

`if` block replaced with null coalescing operator to reduce code and make it more readable.

### Testing Instructions

Go to administrator/components/com_plugins/src/Model/PluginsModel.php