### PR TITLE
[4] Show stats preview when unpublished

### DIFF
--- a/plugins/system/stats/src/Field/DataField.php
+++ b/plugins/system/stats/src/Field/DataField.php
@@ -67,7 +67,7 @@ class DataField extends AbstractStatsField
 	}
 
 	/**
-	 * If the plugin is not published, we need to compile the stats manually, for that we need the params from the db.
+	 * If the plugin is disabled, we need to compile the stats manually, for that we need the params from the db.
 	 *
 	 * @return  string   The JSON of the params of this plugin.
 	 */

--- a/plugins/system/stats/src/Field/DataField.php
+++ b/plugins/system/stats/src/Field/DataField.php
@@ -53,7 +53,7 @@ class DataField extends AbstractStatsField
 
 		$result = Factory::getApplication()->triggerEvent('onGetStatsData', array('stats.field.data'));
 
-		// If the plugin is not published, we need to compile the stats manually
+		// If the plugin is disabled, we need to compile the stats manually
 		if (!$result)
 		{
 			$stats         = Factory::getApplication()->bootPlugin('stats', 'system');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/33253

### Summary of Changes

Show preview of stats even if the module is unpublished 

### Testing Instructions

Install Joomla 4 
edit "System - Joomla! Statistics" plugin
Disable the plugin and save it
edit "System - Joomla! Statistics" plugin
Click "Select here to see the information that will be sent."




### Actual result BEFORE applying this Pull Request

When the plugin is disabled there is no data preview


https://user-images.githubusercontent.com/400092/115774707-d3043180-a3a9-11eb-917e-a2d462a84f4e.mp4


### Expected result AFTER applying this Pull Request

a list of system info that will be sent to the stats server, to allow me to make an informed decision to enable this plugin


https://user-images.githubusercontent.com/400092/115774860-02b33980-a3aa-11eb-8c9a-f9596b43abf6.mp4


### Documentation Changes Required

none
