### PR TITLE
[4.0] XTD-Editor fields button disappears

### DIFF
--- a/plugins/editors-xtd/fields/fields.php
+++ b/plugins/editors-xtd/fields/fields.php
@@ -53,13 +53,6 @@ class PlgButtonFields extends CMSPlugin
 		$jinput = Factory::getApplication()->input;
 		$context = $jinput->get('option') . '.' . $jinput->get('view');
 
-		// Validate context.
-		$context = implode('.', FieldsHelper::extract($context));
-		if (!FieldsHelper::getFields($context))
-		{
-			return;
-		}
-
 		$link = 'index.php?option=com_fields&amp;view=fields&amp;layout=modal&amp;tmpl=component&amp;context='
 			. $context . '&amp;editor=' . $name . '&amp;' . Session::getFormToken() . '=1';
 


### PR DESCRIPTION
### Test instructions
In global configuration set the default editor to none
Make sure there are NO fields created for com_contacts and com_content

### Before PR
Open an article and a contact for editing. You will see that there is no Fields button
Create a field for both articles and contacts and you will see that there is a fields button
(hint miscellaneous info in contacts)

### After PR
Make sure there are NO fields created for com_contacts and com_content
Open an article and a contact for editing. You will see that there now is a Fields button
Click on the button and the modal appears with no fields to select
Create a field for both articles and contacts and you will see that there is still a fields button
Click on the button and the modal appears with fields to select
Make sure that com_content only shows content fields and com_contact only shows contact fields

Pull Request for #32586