### PR TITLE
[4] Hide empty stats when plugin disabled

### DIFF
--- a/plugins/system/stats/layouts/field/data.php
+++ b/plugins/system/stats/layouts/field/data.php
@@ -48,5 +48,7 @@ extract($displayData);
  * @var   array    $statsData       Statistics that will be sent to the stats server
  */
 ?>
-<a href="#" id="js-pstats-data-details-toggler"><?php echo Text::_('PLG_SYSTEM_STATS_MSG_WHAT_DATA_WILL_BE_SENT'); ?></a>
-<?php echo $field->render('stats', compact('statsData'));
+<?php if (\count($statsData)): ?>
+	<a href="#" id="js-pstats-data-details-toggler"><?php echo Text::_('PLG_SYSTEM_STATS_MSG_WHAT_DATA_WILL_BE_SENT'); ?></a>
+	<?php echo $field->render('stats', compact('statsData')); ?>
+<?php endif ?>

--- a/plugins/system/stats/layouts/field/data.php
+++ b/plugins/system/stats/layouts/field/data.php
@@ -51,4 +51,4 @@ extract($displayData);
 <?php if (\count($statsData)): ?>
 	<a href="#" id="js-pstats-data-details-toggler"><?php echo Text::_('PLG_SYSTEM_STATS_MSG_WHAT_DATA_WILL_BE_SENT'); ?></a>
 	<?php echo $field->render('stats', compact('statsData')); ?>
-<?php endif ?>
+<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/33253 replacement for https://github.com/joomla/joomla-cms/pull/33255

### Summary of Changes

Show no preview of stats when the module is disabled (as the stats are generated as a plugin trigger, which doesnt fire when the plugin is disabled)  

### Testing Instructions

Install Joomla 4 
edit "System - Joomla! Statistics" plugin
Disable the plugin and save it
edit "System - Joomla! Statistics" plugin
Click "Select here to see the information that will be sent."




### Actual result BEFORE applying this Pull Request

When the plugin is disabled there is no data preview


https://user-images.githubusercontent.com/400092/115774707-d3043180-a3a9-11eb-917e-a2d462a84f4e.mp4


### Expected result AFTER applying this Pull Request

The clickable header is now not shown so people cannot click it to view nothing... 


<img width="1184" alt="Screenshot 2021-04-23 at 10 55 12" src="https://user-images.githubusercontent.com/400092/115854689-6711df80-a422-11eb-92a1-baace71b6465.png">


### Documentation Changes Required

none
