### PR TITLE
[4.0] Subform Cleanup

### DIFF
--- a/administrator/components/com_fields/src/Table/FieldTable.php
+++ b/administrator/components/com_fields/src/Table/FieldTable.php
@@ -73,7 +73,7 @@ class FieldTable extends Table
 
 		if (isset($src['fieldparams']) && is_array($src['fieldparams']))
 		{
-			// Make sure $registry->options contains no duplicates when the field type is subfields
+			// Make sure $registry->options contains no duplicates when the field type is subform
 			if (isset($src['type']) && $src['type'] == 'subform' && isset($src['fieldparams']['options']))
 			{
 				// Fast lookup map to check which custom field ids we have already seen

--- a/administrator/components/com_fields/src/Table/FieldTable.php
+++ b/administrator/components/com_fields/src/Table/FieldTable.php
@@ -74,7 +74,7 @@ class FieldTable extends Table
 		if (isset($src['fieldparams']) && is_array($src['fieldparams']))
 		{
 			// Make sure $registry->options contains no duplicates when the field type is subfields
-			if (isset($src['type']) && $src['type'] == 'subfields' && isset($src['fieldparams']['options']))
+			if (isset($src['type']) && $src['type'] == 'subform' && isset($src['fieldparams']['options']))
 			{
 				// Fast lookup map to check which custom field ids we have already seen
 				$seen_customfields = array();

--- a/plugins/fields/subform/subform.php
+++ b/plugins/fields/subform/subform.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  Fields.Subfields
+ * @subpackage  Fields.Subform
  *
  * @copyright   (C) 2019 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
@@ -269,11 +269,7 @@ class PlgFieldsSubform extends FieldsPlugin
 		// Override the fieldname attribute of the subform - this is being used to index the rows
 		$parent_field->setAttribute('fieldname', 'row');
 
-		// Make sure this `field` DOMElement has an attribute type=subform - our parent set this to
-		// subfields, because that is our name. But we want the XML to be a subform.
-		$parent_field->setAttribute('type', 'subform');
-
-		// If the user configured this subfields instance as required
+		// If the user configured this subform instance as required
 		if ($field->required)
 		{
 			// Then we need to have at least one row

--- a/plugins/fields/subform/tmpl/subform.php
+++ b/plugins/fields/subform/tmpl/subform.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Plugin
- * @subpackage  Fields.Subfields
+ * @subpackage  Fields.Subform
  *
  * @copyright   (C) 2019 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
In the PR https://github.com/joomla/joomla-cms/pull/33200 (which was merged), I renamed the plugin from **Subfields** to **Subform**. However, there are still few instances of **Subfields** which should be updated to **Subform**. This PR just makes that final clean up.


### Testing Instructions
1. In update package for the original PR https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/33200/downloads/42161/Joomla_4.0.0-beta8-dev+pr.33200-Development-Update_Package.zip . You can go to System -> Update -> Joomla to update that package
2. Access to Content -> Fields, create a new Subform custom field
3. Before patch, in the Fields setting of that Subform custom field, you can choose the same field multiple times and the system still save it
4. After patch, if you choose same field multiple times, only one will be saved
![subform-fields](https://user-images.githubusercontent.com/977664/115862401-4f584c80-a45e-11eb-808a-b9c0649a1cb6.png)