### PR TITLE
[4] Allow in-memory autoload_psr4.php

### DIFF
--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -131,6 +131,16 @@ class JNamespacePsr4Map
 		}
 
 		$content[] = '];';
+		
+		/**
+		 * Backup the current error_reporting level and set a new level
+		 *
+		 * We do this because file_put_contents can raise a Warning if it cannot write the fautoload_psr4.php file
+		 * and this will output to the response BEFORE the session has started, causing the session start to fail
+		 * and ultimately leading us to a 500 Internal Server Error page just because of the output warning, which
+		 * we can safely ignore as we can use an in-memory autoload_psr4 map temporarily, and display real errors later.
+		 */
+		$error_reporting  = error_reporting(0);
 
 		if (!File::write($this->file, implode("\n", $content)))
 		{
@@ -154,6 +164,9 @@ class JNamespacePsr4Map
 
 			$this->cachedMap = $map;
 		}
+		
+		// Restore previous value of error_reporting
+		error_reporting($error_reporting);
 	}
 
 	/**

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -135,7 +135,7 @@ class JNamespacePsr4Map
 		/**
 		 * Backup the current error_reporting level and set a new level
 		 *
-		 * We do this because file_put_contents can raise a Warning if it cannot write the fautoload_psr4.php file
+		 * We do this because file_put_contents can raise a Warning if it cannot write the autoload_psr4.php file
 		 * and this will output to the response BEFORE the session has started, causing the session start to fail
 		 * and ultimately leading us to a 500 Internal Server Error page just because of the output warning, which
 		 * we can safely ignore as we can use an in-memory autoload_psr4 map temporarily, and display real errors later.

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -131,7 +131,7 @@ class JNamespacePsr4Map
 		}
 
 		$content[] = '];';
-		
+
 		/**
 		 * Backup the current error_reporting level and set a new level
 		 *
@@ -164,7 +164,7 @@ class JNamespacePsr4Map
 
 			$this->cachedMap = $map;
 		}
-		
+
 		// Restore previous value of error_reporting
 		error_reporting($error_reporting);
 	}

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -140,7 +140,7 @@ class JNamespacePsr4Map
 		 * and ultimately leading us to a 500 Internal Server Error page just because of the output warning, which
 		 * we can safely ignore as we can use an in-memory autoload_psr4 map temporarily, and display real errors later.
 		 */
-		$error_reporting  = error_reporting(0);
+		$error_reporting = error_reporting(0);
 
 		if (!File::write($this->file, implode("\n", $content)))
 		{

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -10,6 +10,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Log\Log;
 
 /**
  * Class JNamespacePsr4Map
@@ -25,6 +26,12 @@ class JNamespacePsr4Map
 	 * @since  4.0.0
 	 */
 	protected $file = JPATH_CACHE . '/autoload_psr4.php';
+
+	/**
+	 * @var array|null
+	 * @since __DEPLOY_VERSION__
+	 */
+	private $cachedMap = null;
 
 	/**
 	 * Check if the file exists
@@ -90,7 +97,7 @@ class JNamespacePsr4Map
 			$this->create();
 		}
 
-		$map = require $this->file;
+		$map = $this->cachedMap ?: require $this->file;
 
 		$loader = include JPATH_LIBRARIES . '/vendor/autoload.php';
 
@@ -125,7 +132,28 @@ class JNamespacePsr4Map
 
 		$content[] = '];';
 
-		File::write($this->file, implode("\n", $content));
+		if (!File::write($this->file, implode("\n", $content)))
+		{
+			Log::add('Could not save ' . $this->file, Log::WARNING);
+
+			$map = [];
+			$constants = ['JPATH_ADMINISTRATOR', 'JPATH_API', 'JPATH_SITE', 'JPATH_PLUGINS'];
+
+			foreach ($elements as $namespace => $path)
+			{
+				foreach ($constants as $constant)
+				{
+					$path = str_replace($constant,  constant($constant) , $path);
+				}
+
+				$path = str_replace(["'", " ", "."], "", $path);
+				$namespace = str_replace('\\\\', '\\', $namespace);
+
+				$map[$namespace] = [ $path ];
+			}
+
+			$this->cachedMap = $map;
+		}
 	}
 
 	/**

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -143,7 +143,7 @@ class JNamespacePsr4Map
 			{
 				foreach ($constants as $constant)
 				{
-					$path = str_replace($constant,  constant($constant) , $path);
+					$path = str_replace($constant, constant($constant), $path);
 				}
 
 				$path = str_replace(["'", " ", "."], "", $path);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/31982 and https://github.com/joomla/joomla-cms/issues/33019 and https://github.com/joomla/joomla-cms/pull/31857#issuecomment-824986563

### Summary of Changes

On page load, and on demand, Joomla 4 will attempt to write autoload_psr4.php to the JPATH_CACHE folder.

If that folder is unwritable for any reason (many reasons, incorrect permissions, doesnt exist, or needs a FTP Layer to be writable) then Joomla will crash and cannot be used, doesnt display any helpful error, shows a 500 Internal Server Error page. Its a dead end.

This PR, catches the failure of the creation of a physical file, and caches the mapping of the namespace to the path in memory and logs (if enabled) a note to the Joomla log to report the failure of file creation.

Of course it would be more performant to not then have to regenerate the map each page load, but equally, we dont want Joomla to "crash" just because it cannot write an important file. 

If the JPATH_CACHE folder exists and is writable, then the code in this PR is never used and full performance is kept, thus making this backward compatible.

### Testing Instructions

Many different ways, but quickest is to install 
 - install Joomla 4
 - Login to admin
 - DELETE /administrator/cache/autoload_psr4.php
 - chmod 000 /administrator/cache folder
 - Reload the page - See error messages
 - repeat this with debug/error reporting on in Joomla Global Config to see the other messages
 - Apply this PR
 - Repeat the process, note that Joomla doesnt "crash". With error reporting high then you might see a warning about file not being written which is not suppressed (outside the scope of this PR) 

### Actual result BEFORE applying this Pull Request

totally unusable Joomla if JPATH_CACHE path is unwritable. 

### Expected result AFTER applying this Pull Request

totally stable Joomla if JPATH_CACHE path is unwritable. 

### Documentation Changes Required

none.