### PR TITLE
margin added in joomla-toolbar-button

### DIFF
--- a/templates/cassiopeia/scss/template.scss
+++ b/templates/cassiopeia/scss/template.scss
@@ -58,8 +58,8 @@
   max-width: 240px;
 }
 
-.btn-toolbar{
-  joomla-toolbar-button{
-    margin:0.25rem;
+.btn-toolbar {
+  joomla-toolbar-button {
+    margin : .25rem;
   }
 }

--- a/templates/cassiopeia/scss/template.scss
+++ b/templates/cassiopeia/scss/template.scss
@@ -57,3 +57,9 @@
   width: 100% !important;
   max-width: 240px;
 }
+
+.btn-toolbar{
+  joomla-toolbar-button{
+    margin:0.25rem;
+  }
+}


### PR DESCRIPTION
### Summary of Changes
```css
.btn-toolbar{
  joomla-toolbar-button{
    margin:0.25rem;
  }
}
```

### Testing Instructions
* Apply PR
* Do `npm run build:css`
* Log In to the frontend
* Go to Template Setting in Author Menu model (If you have added it).


### Actual result BEFORE applying this Pull Request
No margin applied to buttons


### Expected result AFTER applying this Pull Request
margin applied to buttons


### Documentation Changes Required
None

#### Don't know whether I'm editing the right file or not.
