### PR TITLE
[4][Security] Modern routing, nonSEF & SEF urls alias manipulation

### DIFF
--- a/libraries/src/Component/Router/Rules/StandardRules.php
+++ b/libraries/src/Component/Router/Rules/StandardRules.php
@@ -142,9 +142,12 @@ class StandardRules implements RulesInterface
 					if ($key)
 					{
 						// Found the right view and the right item
+						$found        = true;
 						$parent       = $views[$vars['view']];
 						$vars['view'] = $view->name;
-						$found        = true;
+
+						// Store any left over part of the segment that is not the $key (Its the article alias)
+						$vars['alias'] = str_replace($key . '-', '', $segment);
 
 						if ($view->parent_key && isset($vars[$parent->key]))
 						{


### PR DESCRIPTION
### Summary of Changes

Following up on forked from #32879 about #32490 and closes https://github.com/joomla/joomla-cms/issues/32880

This PR closes the last security issue where a user provided slug/alias in a URL is not validated. 

It covers TWO situations.

1. When SEF is disabled a url is generated like https://example.com/?view=article&id=3:my-article&catid=9 which as `3:my-article` and loads that article correctly. Before this PR, you could change `my-article` to be `i-hacked-you` and the article would still load. After this PR, you will get a 404 Article Not Found if the `3` and the `my-article` alias/slug are not the same as the Articles ID and Alias in the db. 

2. When SEF is enabled, but you have gone to Articles -> Options -> Integration and disabled "Remove IDs from URLs" - this will generate URLS like: http://example.com/index.php/bottomc-menu-item/3-my-article where `3` is the article id and `my-article` is the slug/alias of the article. Before this PR, you could change `my-article` to be `i-hacked-you` and the article would still load. After this PR, you will get a 404 Article Not Found if the `3` and the `my-article` alias/slug are not the same as the Articles ID and Alias in the db. 


### Testing Instructions

As above.

### Actual result BEFORE applying this Pull Request

you could manually manipulate the URL segments, but Joomla ignored them and loaded the URL anyway. This allowed anyone to put anything (malicious) in your URL and Joomla would ignore it. 

### Expected result AFTER applying this Pull Request

Article aliases provided in URLs are now validated once the article has been loaded from the db using the article id. 

If the alias doesn't match the raw user input, then a 404 is thrown. 

### Documentation Changes Required

None. 

### Q&A

> I saw "Careful, unfiltered user input" in your PR - isn't this insecure.

No. The Joomla Input API doesn't allow you to collect "my-article-title" as a hyphen delimited string with any of its methods. 

We could call `getString` or `getWord` but these return the string without the hythens and therefore it cannot be directly compared to the alias from the db.

We are not "processing" the user supplied string at all. It is used in a single comparison using `!==`  against the string from the articles alias in the db. We do not use it for any other purpose, we do not store or render it. 

> @ReLater "Just a question: Is there a reason that the alias is included in id value? Does the router code need it somewhere?"

No, someone in the past decided that appending the article alias to the id in the url was "good for seo".  It serves no purpose, has never been used by Joomla, has never been filtered or validated before today. 

> @Hackwar "Are you planning to just check this during the parseing? Because I would be hesitant to get the aliases each time from the database for building the URLs. "

Joomla ALREADY appends the alias to the id. This PR doesn't change that. We do not validate it at the time Joomla creates (builds) the urls. There is no overhead caused by this PR at build time.

This PR only checks the url provided by the browser. There is no performance penalty because we are already loading the complete article form the db - there is basically only one more if statement before a 404. 

> That is what I described above. If you have a page with a hundred URLs, you get at least a 100 queries additionally to check the alias, which is why I'm asking to not do this in build, but in parse. We are not validating the ID during parseing of the URL. That is something that the component has to do later on. So it would be an additional query. But one additional query shouldn't really worry us. I'm just trying to bring up all the things that we have to keep in mind.

Correct. The PR doesn't actually validate in the parsing of the url, but after the article is actually loaded from the db, because to validate in the router or before then would mean additional SQL queries for no good reason when the article is loaded by a primary key lookup of an integer anyway.



// cc @Hackwar @MartinK63 @Ruud68 @Bakual 