### PR TITLE
[4.0] Move form text below field

### DIFF
--- a/administrator/components/com_redirect/tmpl/links/default_addform.php
+++ b/administrator/components/com_redirect/tmpl/links/default_addform.php
@@ -30,9 +30,9 @@ use Joomla\CMS\Language\Text;
 					</div>
 					<div class="controls">
 						<input class="form-control" type="text" name="new_url" id="new_url" value="" size="50">
-						<div id="new_url-desc" class="form-text">
+						<small id="new_url-desc" class="form-text">
 							<?php echo Text::_('COM_REDIRECT_FIELD_NEW_URL_DESC'); ?>
-						</div>
+						</small>
 					</div>
 				</div>
 				<div class="control-group">

--- a/administrator/components/com_redirect/tmpl/links/default_addform.php
+++ b/administrator/components/com_redirect/tmpl/links/default_addform.php
@@ -30,9 +30,9 @@ use Joomla\CMS\Language\Text;
 					</div>
 					<div class="controls">
 						<input class="form-control" type="text" name="new_url" id="new_url" value="" size="50">
-					</div>
-					<div id="new_url-desc" class="form-text">
-						<?php echo Text::_('COM_REDIRECT_FIELD_NEW_URL_DESC'); ?>
+						<div id="new_url-desc" class="form-text">
+							<?php echo Text::_('COM_REDIRECT_FIELD_NEW_URL_DESC'); ?>
+						</div>
 					</div>
 				</div>
 				<div class="control-group">


### PR DESCRIPTION
### Summary of Changes
Move form text under label to below field.


### Testing Instructions
Go to System > Redirects
Add a new redirect.
Click `Batch Update Selected URL(s) `button.

### Actual result BEFORE applying this Pull Request
![redirect-before](https://user-images.githubusercontent.com/368084/115935690-93d8ed80-a448-11eb-8b0a-ad0cd56123e0.jpg)



### Expected result AFTER applying this Pull Request
![redirect-after](https://user-images.githubusercontent.com/368084/115935693-96d3de00-a448-11eb-96de-2e610b511669.jpg)


