### PR TITLE
[4.0] Click to check the checkbox in actionlogs

### DIFF
--- a/administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+++ b/administrator/components/com_actionlogs/tmpl/actionlogs/default.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\Component\Actionlogs\Administrator\Helper\ActionlogsHelper;
 use Joomla\Component\Actionlogs\Administrator\View\Actionlogs\HtmlView;
 
+HTMLHelper::_('behavior.multiselect');
+
 /** @var HtmlView $this */
 
 $listOrder  = $this->escape($this->state->get('list.ordering'));
@@ -75,7 +77,7 @@ $wa->useScript('keepalive')
 					<?php foreach ($this->items as $i => $item) :
 						$extension = strtok($item->extension, '.');
 						ActionlogsHelper::loadTranslationFiles($extension); ?>
-						<tr>
+						<tr class="row<?php echo $i % 2; ?>">
 							<td class="text-center">
 								<?php echo HTMLHelper::_('grid.id', $i, $item->id); ?>
 							</td>


### PR DESCRIPTION
### Summary of Changes
Added `HTMLHelper::_('behavior.multiselect');` and  
 `class="row<?php echo $i % 2; ?>"` in `<tr>`

### Testing Instructions
`Admin` -> `Users` -> `User Actions Log`

OR

Visit `http://localhost/joomla-cms/administrator/index.php?option=com_actionlogs&view=actionlogs`

### Actual result BEFORE applying this Pull Request
The checkbox will not be checked when we clicked `<tr>` of `<tbody>`

### Expected result AFTER applying this Pull Request
The checkbox will be checked when we clicked `<tr>` of `<tbody>`

![actionlogs](https://user-images.githubusercontent.com/61203226/115952400-3fdf0f00-a503-11eb-8be3-b88c9d6e80e0.gif)

### Documentation Changes Required
None
