### PR TITLE
[4.0] Fix Update Joomla Using FTP

### DIFF
--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -1824,7 +1824,7 @@ class AKPostprocFTP extends AKAbstractPostproc
 		}
 
 		// Try to download ourselves
-		$testFilename = defined('KSSELFNAME') ? KSSELFNAME : basename(__FILE__);
+		$testFilename = defined('KSSELFNAME') ? KSSELFNAME : 'index.php';
 		$tempHandle   = fopen('php://temp', 'r+');
 		if (@ftp_fget($this->handle, $tempHandle, $testFilename, FTP_ASCII, 0) === false)
 		{

--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -278,6 +278,18 @@ class UpdateController extends BaseController
 		// Did a non Super User tried to upload something (a.k.a. pathetic hacking attempt)?
 		Factory::getUser()->authorise('core.admin') or jexit(Text::_('JLIB_APPLICATION_ERROR_ACCESS_FORBIDDEN'));
 
+		$method = $this->app->getUserStateFromRequest('com_joomlaupdate.method', 'method', 'direct', 'cmd');
+
+		if ($method !== 'direct')
+		{
+			// Get and store FTP Credentials into session to write to restoration.php in later steps
+			$this->app->getUserStateFromRequest('com_joomlaupdate.ftp_host', 'ftp_host', '', 'cmd');
+			$this->app->getUserStateFromRequest('com_joomlaupdate.ftp_port', 'ftp_port', '21', 'cmd');
+			$this->app->getUserStateFromRequest('com_joomlaupdate.ftp_user', 'ftp_user', '', 'string');
+			$this->app->getUserStateFromRequest('com_joomlaupdate.ftp_pass', 'ftp_pass', '', 'raw');
+			$this->app->getUserStateFromRequest('com_joomlaupdate.ftp_root', 'ftp_root', '', 'path');
+		}
+
 		$this->_applyCredentials();
 
 		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -503,7 +503,7 @@ class UpdateModel extends BaseDatabaseModel
 		$method = Factory::getApplication()->getUserStateFromRequest('com_joomlaupdate.method', 'method', 'direct', 'cmd');
 
 		// Get the absolute path to site's root.
-		$siteroot = JPATH_SITE;
+		$siteroot = Path::clean(JPATH_SITE, '/');
 
 		// If the package name is not specified, get it from the update info.
 		if (empty($basename))
@@ -515,7 +515,7 @@ class UpdateModel extends BaseDatabaseModel
 
 		// Get the package name.
 		$config  = $app->getConfig();
-		$tempdir = $config->get('tmp_path');
+		$tempdir = Path::clean($config->get('tmp_path'), '/');
 		$file    = $tempdir . '/' . $basename;
 
 		$filesize = @filesize($file);
@@ -546,11 +546,12 @@ ENDDATA;
 			 * allowed as raw mode, otherwise something like !@<sdf34>43H% would be
 			 * sanitised to !@43H% which is just plain wrong.
 			 */
-			$ftp_host = $app->input->get('ftp_host', '');
-			$ftp_port = $app->input->get('ftp_port', '21');
-			$ftp_user = $app->input->get('ftp_user', '');
-			$ftp_pass = addcslashes($app->input->get('ftp_pass', '', 'raw'), "'\\");
-			$ftp_root = $app->input->get('ftp_root', '');
+
+			$ftp_host = $app->getUserStateFromRequest('com_joomlaupdate.ftp_host', 'ftp_host', '', 'cmd');
+			$ftp_port = $app->getUserStateFromRequest('com_joomlaupdate.ftp_port', 'ftp_port', '21', 'cmd');
+			$ftp_user = $app->getUserStateFromRequest('com_joomlaupdate.ftp_user', 'ftp_user', '', 'string');
+			$ftp_pass = addcslashes($app->getUserStateFromRequest('com_joomlaupdate.ftp_pass', 'ftp_pass', '', 'raw'), "'\\");
+			$ftp_root = $app->getUserStateFromRequest('com_joomlaupdate.ftp_root', 'ftp_root', '', 'path');
 
 			// Is the tempdir really writable?
 			$writable = @is_writable($tempdir);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
During update process (using FTP or Hybrid installation method), Joomla! needs to write FTP credentials into  restoration.php file so that these data can be used by restore.php on restoration process.

Due to a bug in getting FTP credentials (trying to get directly from input but these fields are not available in the input at all), update Joomla using these two methods never works (or at least it never works in the recent version). Also, the code in restore.php file does not like the path with window style, so I added some code to change it to Linux path style

Tested on my local Joomla 4 using Filezilla server and it worked. Not sure how to give testing instructions because now it is hard to find testers for FTP stuffs.

### Testing Instructions