### PR TITLE
[4] Use CMS library which is FTP Layer aware

### DIFF
--- a/plugins/system/logrotation/logrotation.php
+++ b/plugins/system/logrotation/logrotation.php
@@ -12,8 +12,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Cache\Cache;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\CMSPlugin;
-use Joomla\Filesystem\File;
-use Joomla\Filesystem\Folder;
+use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Filesystem\Folder;
 use Joomla\Filesystem\Path;
 
 /**


### PR DESCRIPTION


### Summary of Changes

Logrotation currently uses the Joomla framework Filesystem package which is not FTP Layer aware. 

This leads to issues when log rotation attempts to move a file when it has no permissions to do so, when FTP is needed. 

This change starts using the Folder and File packages from the CMS and not the framework, although `Folder` doesn't yet need to be FTP aware, Im changing that so that if we ever did make Folder FTP Aware (hint: probably soon coming!) then it will "just work" in future. 

### Testing Instructions

Code review, unless you have a spare hour to follow along the whole FTP Layer set up.

### Actual result BEFORE applying this Pull Request

After installation, and clocking on the Open Site button on the last page of the installation wizard

<img width="1358" alt="Screenshot 2021-04-24 at 17 42 51" src="https://user-images.githubusercontent.com/400092/115966585-3915c380-a526-11eb-9b5c-2bee2a5c6611.png">


### Expected result AFTER applying this Pull Request

Use the CMS Filesystem lib, which is FTP aware, and can move the file with FTP. 

### Documentation Changes Required

none