### PR TITLE
[4] Correct link to private messages from module

### DIFF
--- a/administrator/modules/mod_messages/tmpl/default.php
+++ b/administrator/modules/mod_messages/tmpl/default.php
@@ -11,7 +11,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\CMS\Uri\Uri;
 
 $hideLinks = $app->input->getBool('hidemainmenu');
 
@@ -20,7 +19,6 @@ if ($hideLinks)
 	return;
 }
 
-$uri   = Uri::getInstance();
 $route = 'index.php?option=com_messages&view=messages';
 ?>
 

--- a/administrator/modules/mod_messages/tmpl/default.php
+++ b/administrator/modules/mod_messages/tmpl/default.php
@@ -21,7 +21,7 @@ if ($hideLinks)
 }
 
 $uri   = Uri::getInstance();
-$route = 'index.php?option=com_messages&view=messages&id=' . $app->getIdentity()->id . '&return=' . base64_encode($uri);
+$route = 'index.php?option=com_messages&view=messages';
 ?>
 
 <div class="header-item-content">
@@ -37,5 +37,3 @@ $route = 'index.php?option=com_messages&view=messages&id=' . $app->getIdentity()
 		<?php endif; ?>
 	</a>
 </div>
-
-


### PR DESCRIPTION
### Summary of Changes

Correct the link in the top menu bar to remove superfluous detail, which when appended, causes the left menu to collapse 

`id` is not needed, we know who we are based on the session data

`return` is only needed if we were redirecting to a form that had a save/cancel action

Whitespace at the end of the file also removed (automatically by #phpStorm because its amazing) 

### Testing Instructions

Click Private Messages icon in the header top right

### Actual result BEFORE applying this Pull Request

Left menu collapses regardless of where you are

### Expected result AFTER applying this Pull Request

Left menu highlights Private Messages menu item and you see only your messages

### Documentation Changes Required

