### PR TITLE
[4] Restyle the Post Installation No Messages page (Blank State Style)

### DIFF
--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -48,13 +48,17 @@ $params = array('params' => json_encode($param));
 	<div class="col-md-8">
 <?php endif; ?>
 <?php if (empty($this->items)) : ?>
-	<div class="bg-light p-3 rounded">
-		<h2><?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?></h2>
-		<p><?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC'); ?></p>
-		<a href="<?php echo Route::_('index.php?option=com_postinstall&view=messages&task=message.reset&eid=' . $this->eid . '&' . $this->token . '=1'); ?>" class="btn btn-warning btn-lg">
-			<span class="icon-eye" aria-hidden="true"></span>
-			<?php echo Text::_('COM_POSTINSTALL_BTN_RESET'); ?>
-		</a>
+	<div class="px-4 py-5 my-5 text-center">
+		<span class="fa-8x icon-generic mb-4 article" aria-hidden="true"></span>
+		<h1 class="display-5 fw-bold"><?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?></h1>
+		<div class="col-lg-6 mx-auto">
+			<p class="lead mb-4">
+				<?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC'); ?>
+			</p>
+			<div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
+				<a href="<?php echo Route::_('index.php?option=com_postinstall&view=messages&task=message.reset&eid=' . $this->eid . '&' . $this->token . '=1'); ?>" class="btn btn-primary btn-lg px-4 me-sm-3"><?php echo Text::_('COM_POSTINSTALL_BTN_RESET'); ?></a>
+			</div>
+		</div>
 	</div>
 <?php else : ?>
 	<?php foreach ($this->items as $item) : ?>

--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -48,16 +48,14 @@ $params = array('params' => json_encode($param));
 	<div class="col-md-8">
 <?php endif; ?>
 <?php if (empty($this->items)) : ?>
-	<div class="px-4 py-5 my-5 text-center">
-		<span class="fa-8x icon-generic mb-4 article" aria-hidden="true"></span>
+	<div class="py-5 text-center">
+		<span class="fa-8x icon-generic mb-4" aria-hidden="true"></span>
 		<h1 class="display-5 fw-bold"><?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?></h1>
-		<div class="col-lg-6 mx-auto">
+		<div>
 			<p class="lead mb-4">
 				<?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC'); ?>
 			</p>
-			<div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
-				<a href="<?php echo Route::_('index.php?option=com_postinstall&view=messages&task=message.reset&eid=' . $this->eid . '&' . $this->token . '=1'); ?>" class="btn btn-primary btn-lg px-4 me-sm-3"><?php echo Text::_('COM_POSTINSTALL_BTN_RESET'); ?></a>
-			</div>
+			<a href="<?php echo Route::_('index.php?option=com_postinstall&view=messages&task=message.reset&eid=' . $this->eid . '&' . $this->token . '=1'); ?>" class="btn btn-primary btn-lg px-4 me-sm-3"><?php echo Text::_('COM_POSTINSTALL_BTN_RESET'); ?></a>
 		</div>
 	</div>
 <?php else : ?>


### PR DESCRIPTION
### Summary of Changes

Change the look and feel of the Post Installation Messages screen when there are no messages to give it the same Blank State look and feel as other extensions. 

### Testing Instructions

Hide all your Post Installation Messages - view new look - click Reset Messages button to test it works. 

### Actual result BEFORE applying this Pull Request

<img width="1602" alt="Screenshot 2021-04-24 at 19 37 01" src="https://user-images.githubusercontent.com/400092/115969358-75e8b700-a534-11eb-8e73-973d3676e41b.png">


### Expected result AFTER applying this Pull Request

<img width="1598" alt="Screenshot 2021-04-24 at 19 36 26" src="https://user-images.githubusercontent.com/400092/115969340-5fdaf680-a534-11eb-8dd8-f3138a68b0a5.png">


### Documentation Changes Required

none other than the screenshot