### PR TITLE
[4.0] Edit profile icons

### DIFF
--- a/components/com_users/tmpl/profile/edit.php
+++ b/components/com_users/tmpl/profile/edit.php
@@ -113,9 +113,11 @@ $wa->useScript('keepalive')
 		<div class="com-users-profile__edit-submit control-group">
 			<div class="controls">
 				<button type="submit" class="btn btn-primary validate" name="task" value="profile.save">
+					<span class="icon-check" aria-hidden="true"></span>
 					<?php echo Text::_('JSAVE'); ?>
 				</button>
 				<button type="submit" class="btn btn-danger" name="task" value="profile.cancel" formnovalidate>
+					<span class="icon-times" aria-hidden="true"></span>
 					<?php echo Text::_('JCANCEL'); ?>
 				</button>
 				<input type="hidden" name="option" value="com_users">


### PR DESCRIPTION
Adds the missing icons to the save and cancel buttons on the front end edit profile page.

To test makes sure that the login module is set to display the profile link

Then on the front end login and seelct the profile and then the edit profile

Scroll down and you will see the two buttons without icons

Apply this pr and the icons are present

partial pr for #32250

![image](https://user-images.githubusercontent.com/1296369/115988963-c6ebc000-a5b3-11eb-97f9-256af0e07d07.png)
