### PR TITLE
[4.0] Front end edit contact incorrect icon

### DIFF
--- a/components/com_contact/tmpl/form/edit.php
+++ b/components/com_contact/tmpl/form/edit.php
@@ -70,7 +70,7 @@ $this->useCoreUI        = true;
 				<?php echo Text::_('JSAVE'); ?>
 			</button>
 			<button type="button" class="btn btn-danger" onclick="Joomla.submitbutton('contact.cancel')">
-				<span class="icon-times-cancel" aria-hidden="true"></span>
+				<span class="icon-times" aria-hidden="true"></span>
 				<?php echo Text::_('JCANCEL'); ?>
 			</button>
 			<?php if ($this->params->get('save_history', 0) && $this->item->id) : ?>


### PR DESCRIPTION
The incorrect (missing) icon was being used for the cancel button

To test make sure you have a contact form published and then when logged in as an admin click on the edit contact

Scroll down and you will see that the red cancel button has no icon

Apply this PR and the icon is present

Partial PR for #32250 

### Before
![image](https://user-images.githubusercontent.com/1296369/115989102-90fb0b80-a5b4-11eb-9b7a-52b5e21ebd97.png)

### After
![image](https://user-images.githubusercontent.com/1296369/115989127-aec87080-a5b4-11eb-9d8c-af9e374ea9fd.png)
