### PR TITLE
[4.0] Small code style fix: Alpha-order use statements in logrotation.php

### DIFF
--- a/plugins/system/logrotation/logrotation.php
+++ b/plugins/system/logrotation/logrotation.php
@@ -11,9 +11,9 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Cache\Cache;
 use Joomla\CMS\Factory;
-use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Filesystem\Path;
 
 /**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

The merged PR #33283 has introduced a small code style issue (use statements not alpha-ordered anymore).

This PR here fixes that.

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

Use statements in file `plugins/system/logrotation/logrotation.php` are not alpha-ordered.

### Expected result AFTER applying this Pull Request

Use statements in file `plugins/system/logrotation/logrotation.php` are alpha-ordered.

### Documentation Changes Required

None.