### PR TITLE
[4.0] Assign a color to Menu "Home"

### DIFF
--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -30,6 +30,7 @@
     border-color: var(--success);
   }
 
+  .#{$jicon-css-prefix}-home,
   .#{$jicon-css-prefix}-color-featured,
   .#{$jicon-css-prefix}-star.featured,
   .#{$fa-css-prefix}-star.featured {


### PR DESCRIPTION
PR for #31980

There are different icons for the home and regular menu items but they are both grey in colour. This PR adds the same colour used for featured to the home icon so it stands out a little more.

This is a css change

![image](https://user-images.githubusercontent.com/1296369/115990084-4def6700-a5b9-11eb-88ac-284c163757c2.png)
