### PR TITLE
[4.0] Sample Data menu permission

### DIFF
--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -1200,6 +1200,7 @@ class PlgSampledataBlog extends CMSPlugin
 				'link'         => 'index.php?option=com_config&view=templates',
 				'parent_id'    => $menuIdsLevel1[6],
 				'component_id' => ExtensionHelper::getExtensionRecord('com_config', 'component')->extension_id,
+				'access'       => 6,
 				'params'       => array(
 					'menu_text'         => 1,
 					'show_page_heading' => 0,


### PR DESCRIPTION
The permission for the template settings menu item was set to public. This meant that as long as you could log in to the site in the front end then you would see the link to edit the template. However only a super user can do this so you got an ugly error page.

This PR correctly sets it to Super Users the same as with the Site settings menu itm
