### PR TITLE
[4.0] com_postinstall: Display "Showing messages for" dropdown only if there's more than 1 options

### DIFF
--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -36,7 +36,7 @@ $extension_options_count = count((array) $this->extension_options);
 
 ?>
 
-<?php if ($extension_options_count != 1) : ?>
+<?php if ($extension_options_count > 1) : ?>
 	<form action="index.php" method="post" name="adminForm" class="form-inline mb-3" id="adminForm">
 		<input type="hidden" name="option" value="com_postinstall">
 		<input type="hidden" name="task" value="">

--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -32,19 +32,17 @@ $param    = array(
 	'cache'       => 0,
 	);
 $params = array('params' => json_encode($param));
-$extension_options_count = count($this->extension_options);
+$adminFormClass = count($this->extension_options) > 1 ? 'form-inline mb-3' : 'visually-hidden';
 
 ?>
 
-<?php if ($extension_options_count > 1) : ?>
-	<form action="index.php" method="post" name="adminForm" class="form-inline mb-3" id="adminForm">
-		<input type="hidden" name="option" value="com_postinstall">
-		<input type="hidden" name="task" value="">
-		<?php echo HTMLHelper::_('form.token'); ?>
-		<label for="eid" class="me-sm-2"><?php echo Text::_('COM_POSTINSTALL_MESSAGES_FOR'); ?></label>
-		<?php echo HTMLHelper::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'form-select'), 'value', 'text', $this->eid, 'eid'); ?>
-	</form>
-<?php endif; ?>
+<form action="index.php"  method="post" name="adminForm" class="<?php echo $adminFormClass; ?>" id="adminForm">
+	<input type="hidden" name="option" value="com_postinstall">
+	<input type="hidden" name="task" value="">
+	<?php echo HTMLHelper::_('form.token'); ?>
+	<label for="eid" class="me-sm-2"><?php echo Text::_('COM_POSTINSTALL_MESSAGES_FOR'); ?></label>
+	<?php echo HTMLHelper::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'form-select'), 'value', 'text', $this->eid, 'eid'); ?>
+</form>
 
 <?php if ($this->eid == $this->joomlaFilesExtensionId) : ?>
 <div class="row">

--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -32,7 +32,7 @@ $param    = array(
 	'cache'       => 0,
 	);
 $params = array('params' => json_encode($param));
-$extension_options_count = count((array) $this->extension_options);
+$extension_options_count = count($this->extension_options);
 
 ?>
 

--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -36,7 +36,7 @@ $adminFormClass = count($this->extension_options) > 1 ? 'form-inline mb-3' : 'vi
 
 ?>
 
-<form action="index.php"  method="post" name="adminForm" class="<?php echo $adminFormClass; ?>" id="adminForm">
+<form action="index.php" method="post" name="adminForm" class="<?php echo $adminFormClass; ?>" id="adminForm">
 	<input type="hidden" name="option" value="com_postinstall">
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -32,16 +32,19 @@ $param    = array(
 	'cache'       => 0,
 	);
 $params = array('params' => json_encode($param));
+$extension_options_count = count((array) $this->extension_options);
 
 ?>
 
-<form action="index.php" method="post" name="adminForm" class="form-inline mb-3" id="adminForm">
-	<input type="hidden" name="option" value="com_postinstall">
-	<input type="hidden" name="task" value="">
-	<?php echo HTMLHelper::_('form.token'); ?>
-	<label for="eid" class="me-sm-2"><?php echo Text::_('COM_POSTINSTALL_MESSAGES_FOR'); ?></label>
-	<?php echo HTMLHelper::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'form-select'), 'value', 'text', $this->eid, 'eid'); ?>
-</form>
+<?php if ($extension_options_count != 1) : ?>
+	<form action="index.php" method="post" name="adminForm" class="form-inline mb-3" id="adminForm">
+		<input type="hidden" name="option" value="com_postinstall">
+		<input type="hidden" name="task" value="">
+		<?php echo HTMLHelper::_('form.token'); ?>
+		<label for="eid" class="me-sm-2"><?php echo Text::_('COM_POSTINSTALL_MESSAGES_FOR'); ?></label>
+		<?php echo HTMLHelper::_('select.genericlist', $this->extension_options, 'eid', array('onchange' => 'this.form.submit()', 'class' => 'form-select'), 'value', 'text', $this->eid, 'eid'); ?>
+	</form>
+<?php endif; ?>
 
 <?php if ($this->eid == $this->joomlaFilesExtensionId) : ?>
 <div class="row">


### PR DESCRIPTION
Pull Request for Issue #33291 .

### Summary of Changes
Added a check to hide the dropdown form if the count of `$this->extensions_options` is not > 1 by setting it's class to `.visually-hidden`
**Reference**: `$this->extension_options` is given it's value by `getComponentOptions()` function in `MessageModel.php` where it's defined as an array  so the count has to be 0 or more (an integer)
https://github.com/joomla/joomla-cms/blob/4d831f7e6487df3356cbf3b597d85ff4e80ae04b/administrator/components/com_postinstall/src/Model/MessagesModel.php#L381

### Testing Instructions
1. Joomla Admin Panel
2. Select Post Installation messages (located on the top right)
3. The dropdown and text will be visible only if the select-able options are >1


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/115990857-2dd49d80-a5e3-11eb-87c2-07bfb58f8db8.png)
Link if the above image is broken: https://ibb.co/7Kk0Mt5


### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/115990734-6c1d8d00-a5e2-11eb-9c1e-9d55ae01c48f.png)
Link if the above  image is broken: https://ibb.co/yVQWQD0


### Documentation Changes Required
None
