### PR TITLE
[4.0] Set only_use_in_subform = 1 for subfields migrated from repeatable fields

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -324,22 +324,23 @@ class JoomlaInstallerScript
 							 * for each of the sub fields of the `repeatable` instance.
 							 */
 							$data = [
-								'context'          => $row->context,
-								'group_id'         => $row->group_id,
-								'title'            => $oldField->fieldname,
-								'name'             => (
+								'context'             => $row->context,
+								'group_id'            => $row->group_id,
+								'title'               => $oldField->fieldname,
+								'name'                => (
 									$fieldname_prefix
 									. $oldField->fieldname
 									. ($fieldname_suffix > 0 ? ('_' . $fieldname_suffix) : '')
 								),
-								'label'            => $oldField->fieldname,
-								'default_value'    => $row->default_value,
-								'type'             => $oldField->fieldtype,
-								'description'      => $row->description,
-								'state'            => '1',
-								'params'           => $row->params,
-								'language'         => '*',
-								'assigned_cat_ids' => [-1],
+								'label'               => $oldField->fieldname,
+								'default_value'       => $row->default_value,
+								'type'                => $oldField->fieldtype,
+								'description'         => $row->description,
+								'state'               => '1',
+								'params'              => $row->params,
+								'language'            => '*',
+								'assigned_cat_ids'    => [-1],
+								'only_use_in_subform' => 1,
 							];
 
 							// `number` is not a valid custom field type, so use `text` instead.


### PR DESCRIPTION
Pull Request for Issue #.

### Summary of Changes
PR https://github.com/joomla/joomla-cms/pull/33096 introduced a new setting **Only Use In Subform** . For subfields migrated from repeatable fields, that setting should be set to Yes as discussed in the original PR.

### Testing Instructions
@wilsonge Could you please trust me and merge this? I don't want to waste too much time of testers (have to setup Joomla 3.10.0, setup repeatable fields, then update to Joomla 4 to check the result) for this simple change.