### PR TITLE
[4.0] Remove padding between module positions

### DIFF
--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -35,7 +35,6 @@
 .container-bottom-a,
 .container-bottom-b {
   position: relative;
-  padding: 4rem 0;
   > * {
     flex: 1;
     margin: ($cassiopeia-grid-gutter / 2);


### PR DESCRIPTION
Pull Request for Issue #32165 .

### Summary of Changes
Removed padding for containers.


### Testing Instructions
See issue


### Actual result BEFORE applying this Pull Request
Big padding between containers.


### Expected result AFTER applying this Pull Request
No big space between container.


### Documentation Changes Required

