### PR TITLE
[4.0] Toolbar Close/Cancel

### DIFF
--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -159,7 +159,7 @@ class HtmlView extends BaseHtmlView
 				}
 			);
 
-			$toolbar->cancel('article.cancel', 'JTOOLBAR_CLOSE');
+			$toolbar->cancel('article.cancel');
 		}
 		else
 		{

--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -159,7 +159,7 @@ class HtmlView extends BaseHtmlView
 				}
 			);
 
-			$toolbar->cancel('article.cancel','JTOOLBAR_CANCEL');
+			$toolbar->cancel('article.cancel', 'JTOOLBAR_CANCEL');
 		}
 		else
 		{

--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -159,7 +159,7 @@ class HtmlView extends BaseHtmlView
 				}
 			);
 
-			$toolbar->cancel('article.cancel');
+			$toolbar->cancel('article.cancel','JTOOLBAR_CANCEL');
 		}
 		else
 		{

--- a/administrator/components/com_media/src/View/File/HtmlView.php
+++ b/administrator/components/com_media/src/View/File/HtmlView.php
@@ -72,6 +72,6 @@ class HtmlView extends BaseHtmlView
 		ToolbarHelper::save('save');
 		ToolbarHelper::custom('reset', 'refresh', '',  'COM_MEDIA_RESET', false);
 
-		ToolbarHelper::cancel('cancel','JTOOLBAR_CLOSE');
+		ToolbarHelper::cancel('cancel', 'JTOOLBAR_CLOSE');
 	}
 }

--- a/administrator/components/com_media/src/View/File/HtmlView.php
+++ b/administrator/components/com_media/src/View/File/HtmlView.php
@@ -72,6 +72,6 @@ class HtmlView extends BaseHtmlView
 		ToolbarHelper::save('save');
 		ToolbarHelper::custom('reset', 'refresh', '',  'COM_MEDIA_RESET', false);
 
-		ToolbarHelper::cancel('cancel');
+		ToolbarHelper::cancel('cancel','JTOOLBAR_CLOSE');
 	}
 }

--- a/administrator/components/com_messages/src/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Message/HtmlView.php
@@ -89,7 +89,7 @@ class HtmlView extends BaseHtmlView
 			Factory::getApplication()->input->set('hidemainmenu', true);
 			ToolbarHelper::title(Text::_('COM_MESSAGES_WRITE_PRIVATE_MESSAGE'), 'envelope-open-text new-privatemessage');
 			ToolbarHelper::custom('message.save', 'envelope', '', 'COM_MESSAGES_TOOLBAR_SEND', false);
-			ToolbarHelper::cancel('message.cancel', 'JTOOLBAR_CLOSE');
+			ToolbarHelper::cancel('message.cancel');
 			ToolbarHelper::help('JHELP_COMPONENTS_MESSAGING_WRITE');
 		}
 		else

--- a/administrator/components/com_workflow/src/View/Stage/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Stage/HtmlView.php
@@ -138,6 +138,10 @@ class HtmlView extends BaseHtmlView
 				$toolbarButtons,
 				'btn-success'
 			);
+
+			ToolbarHelper::cancel(
+				'stage.cancel'
+			);
 		}
 		else
 		{
@@ -161,9 +165,13 @@ class HtmlView extends BaseHtmlView
 				$toolbarButtons,
 				'btn-success'
 			);
+
+			ToolbarHelper::cancel(
+				'stage.cancel',
+				'JTOOLBAR_CLOSE'
+			);
 		}
 
-		ToolbarHelper::cancel('stage.cancel');
 		ToolbarHelper::divider();
 	}
 }

--- a/administrator/components/com_workflow/src/View/Transition/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Transition/HtmlView.php
@@ -170,6 +170,10 @@ class HtmlView extends BaseHtmlView
 				$toolbarButtons,
 				'btn-success'
 			);
+
+			ToolbarHelper::cancel(
+				'transition.cancel'
+			);
 		}
 		else
 		{
@@ -200,9 +204,13 @@ class HtmlView extends BaseHtmlView
 			{
 				ToolbarHelper::save('transition.save');
 			}
+
+			ToolbarHelper::cancel(
+				'transition.cancel',
+				'JTOOLBAR_CLOSE'
+			);
 		}
 
-		ToolbarHelper::cancel('transition.cancel');
 		ToolbarHelper::divider();
 	}
 }

--- a/administrator/components/com_workflow/src/View/Workflow/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Workflow/HtmlView.php
@@ -144,6 +144,10 @@ class HtmlView extends BaseHtmlView
 				$toolbarButtons,
 				'btn-success'
 			);
+
+			ToolbarHelper::cancel(
+				'workflow.cancel'
+			);
 		}
 		else
 		{
@@ -167,8 +171,12 @@ class HtmlView extends BaseHtmlView
 				$toolbarButtons,
 				'btn-success'
 			);
-		}
 
-		ToolbarHelper::cancel('workflow.cancel');
+			ToolbarHelper::cancel(
+				'workflow.cancel',
+				'JTOOLBAR_CLOSE'
+			);
+
+		}
 	}
 }

--- a/administrator/components/com_workflow/src/View/Workflow/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Workflow/HtmlView.php
@@ -176,7 +176,6 @@ class HtmlView extends BaseHtmlView
 				'workflow.cancel',
 				'JTOOLBAR_CLOSE'
 			);
-
 		}
 	}
 }


### PR DESCRIPTION
The cancel button should have the text
Cancel when its a new item
Close when its an existing item

With this PR I have fixed the few instances that incorrectly did not follow this pattern which is used in all the other 33 views.

Summary of changes
Create a New Article - Cancel
Edit an Article - Close
Create a Workflow - Cancel
Edit a Workflow - Close
Create a Workflow Stage - Cancel
Edit a Workflow Stage - Close
Create a Workflow Transition - Cancel
Edit a Workflow Transition - Close
Edit an image - Close
Create a private message - Cancel
Read a private message - Close
