### PR TITLE
[4] Remove deprecated function calls and use short array syntax

### DIFF
--- a/administrator/components/com_banners/tmpl/banners/blankstate.php
+++ b/administrator/components/com_banners/tmpl/banners/blankstate.php
@@ -12,14 +12,13 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
-$displayData = array(
-		'textPrefix' => 'COM_BANNERS',
-		'formURL'    => 'index.php?option=com_banners&view=banners',
-		'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Banners',
-);
-$user        = Factory::getUser();
+$displayData = [
+	'textPrefix' => 'COM_BANNERS',
+	'formURL'    => 'index.php?option=com_banners&view=banners',
+	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Banners',
+];
 
-if (count($user->getAuthorisedCategories('com_banners', 'core.create')) > 0)
+if (count(Factory::getApplication()->getIdentity()->getAuthorisedCategories('com_banners', 'core.create')) > 0)
 {
 	$displayData['createURL'] = 'index.php?option=com_banners&task=banner.add';
 }

--- a/administrator/components/com_contact/tmpl/contacts/blankstate.php
+++ b/administrator/components/com_contact/tmpl/contacts/blankstate.php
@@ -12,12 +12,13 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
-$displayData = array(
-		'textPrefix' => 'COM_CONTACT',
-		'formURL'    => 'index.php?option=com_contact',
-		'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help4.x:Contacts',
-);
-$user        = Factory::getUser();
+$displayData = [
+	'textPrefix' => 'COM_CONTACT',
+	'formURL'    => 'index.php?option=com_contact',
+	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help4.x:Contacts',
+];
+
+$user = Factory::getApplication()->getIdentity();
 
 if ($user->authorise('core.create', 'com_contact') || count($user->getAuthorisedCategories('com_contact', 'core.create')) > 0)
 {

--- a/administrator/components/com_content/tmpl/articles/blankstate.php
+++ b/administrator/components/com_content/tmpl/articles/blankstate.php
@@ -12,12 +12,13 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
-$displayData = array(
+$displayData = [
 	'textPrefix' => 'COM_CONTENT',
 	'formURL'    => 'index.php?option=com_content&view=articles',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Adding_a_new_article',
-);
-$user        = Factory::getUser();
+];
+
+$user = Factory::getApplication()->getIdentity();
 
 if ($user->authorise('core.create', 'com_content') || count($user->getAuthorisedCategories('com_content', 'core.create')) > 0)
 {

--- a/administrator/components/com_content/tmpl/featured/blankstate.php
+++ b/administrator/components/com_content/tmpl/featured/blankstate.php
@@ -12,12 +12,13 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
-$displayData = array(
+$displayData = [
 	'textPrefix' => 'COM_CONTENT',
 	'formURL'    => 'index.php?option=com_content&view=featured',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Adding_a_new_article',
-);
-$user        = Factory::getUser();
+];
+
+$user = Factory::getApplication()->getIdentity();
 
 if ($user->authorise('core.create', 'com_content') || count($user->getAuthorisedCategories('com_content', 'core.create')) > 0)
 {

--- a/administrator/components/com_messages/tmpl/messages/blankstate.php
+++ b/administrator/components/com_messages/tmpl/messages/blankstate.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
-$displayData =[
+$displayData = [
 	'textPrefix' => 'COM_MESSAGES',
 	'formURL'    => 'index.php?option=com_messages&view=messages',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Private_Messages',

--- a/administrator/components/com_messages/tmpl/messages/blankstate.php
+++ b/administrator/components/com_messages/tmpl/messages/blankstate.php
@@ -12,13 +12,13 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
-$displayData = array(
-		'textPrefix' => 'COM_MESSAGES',
-		'formURL'    => 'index.php?option=com_messages&view=messages',
-		'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Private_Messages',
-);
+$displayData =[
+	'textPrefix' => 'COM_MESSAGES',
+	'formURL'    => 'index.php?option=com_messages&view=messages',
+	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Private_Messages',
+];
 
-if (Factory::getUser()->authorise('core.create', 'com_messages'))
+if (Factory::getApplication()->getIdentity()->authorise('core.create', 'com_messages'))
 {
 	$displayData['createURL'] = 'index.php?option=com_messages&task=message.add';
 }

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/blankstate.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/blankstate.php
@@ -12,14 +12,13 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
-$displayData = array(
-		'textPrefix' => 'COM_NEWSFEEDS',
-		'formURL'    => 'index.php?option=com_newsfeeds&view=newsfeeds',
-		'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help4.x:News_Feeds',
-);
-$user        = Factory::getUser();
+$displayData = [
+	'textPrefix' => 'COM_NEWSFEEDS',
+	'formURL'    => 'index.php?option=com_newsfeeds&view=newsfeeds',
+	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help4.x:News_Feeds',
+];
 
-if (count($user->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0)
+if (count(Factory::getApplication()->getIdentity()->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0)
 {
 	$displayData['createURL'] = 'index.php?option=com_newsfeeds&task=newsfeed.add';
 }

--- a/administrator/components/com_privacy/tmpl/consents/blankstate.php
+++ b/administrator/components/com_privacy/tmpl/consents/blankstate.php
@@ -11,10 +11,10 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
-$displayData = array(
-		'textPrefix' => 'COM_PRIVACY_CONSENTS',
-		'formURL'    => 'index.php?option=com_privacy&view=consents',
-		'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Privacy:_Consents',
-);
+$displayData = [
+	'textPrefix' => 'COM_PRIVACY_CONSENTS',
+	'formURL'    => 'index.php?option=com_privacy&view=consents',
+	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Privacy:_Consents',
+];
 
 echo LayoutHelper::render('joomla.content.blankstate', $displayData);

--- a/administrator/components/com_privacy/tmpl/requests/blankstate.php
+++ b/administrator/components/com_privacy/tmpl/requests/blankstate.php
@@ -12,11 +12,11 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
-$displayData = array(
-		'textPrefix' => 'COM_PRIVACY_REQUESTS',
-		'formURL'    => 'index.php?option=com_privacy&view=requests',
-		'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Privacy:_Information_Requests',
-);
+$displayData = [
+	'textPrefix' => 'COM_PRIVACY_REQUESTS',
+	'formURL'    => 'index.php?option=com_privacy&view=requests',
+	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Privacy:_Information_Requests',
+];
 
 if (Factory::getApplication()->get('mailonline', 1))
 {

--- a/administrator/components/com_users/tmpl/notes/blankstate.php
+++ b/administrator/components/com_users/tmpl/notes/blankstate.php
@@ -12,13 +12,13 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
-$displayData = array(
-		'textPrefix' => 'COM_USERS_NOTES',
-		'formURL'    => 'index.php?option=com_users&view=notes',
-		'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:User_Notes',
-);
+$displayData = [
+	'textPrefix' => 'COM_USERS_NOTES',
+	'formURL'    => 'index.php?option=com_users&view=notes',
+	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:User_Notes',
+];
 
-if (Factory::getUser()->authorise('core.create', 'com_users'))
+if (Factory::getApplication()->getIdentity()->authorise('core.create', 'com_users'))
 {
 	$displayData['createURL'] = 'index.php?option=com_users&task=note.add';
 }


### PR DESCRIPTION
### Summary of Changes

Remove deprecated function calls and use short array syntax

Instead of `Factory::getUser()` which is deprecated use `Factory::getApplication()->getIdentity()`

Use short array syntax `[]` instead of long syntax `array()`

### Testing Instructions

Code Review only

@Bakual  :) 