### PR TITLE
[4.0] Media Manager - Can't preview entire image

### DIFF
--- a/build/media_source/com_media/scss/components/_media-modal.scss
+++ b/build/media_source/com_media/scss/components/_media-modal.scss
@@ -33,8 +33,6 @@
     position: fixed;
     top: 50%;
     left: 50%;
-    max-width: 70vw;
-    max-height: 70vh;
     transform: translate(-50%, -50%);
   }
   .modal-content {

--- a/build/media_source/com_media/scss/components/_media-modal.scss
+++ b/build/media_source/com_media/scss/components/_media-modal.scss
@@ -30,11 +30,11 @@
   color: $modal-preview-text-color;
 
   .modal-dialog {
-    max-width: 70vw;
-    max-height: 70vh;
     position: fixed;
     top: 50%;
     left: 50%;
+    max-width: 70vw;
+    max-height: 70vh;
     transform: translate(-50%, -50%);
   }
   .modal-content {

--- a/build/media_source/com_media/scss/components/_media-modal.scss
+++ b/build/media_source/com_media/scss/components/_media-modal.scss
@@ -32,6 +32,10 @@
   .modal-dialog {
     max-width: 70vw;
     max-height: 70vh;
+	position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
   }
   .modal-content {
     display: flex;

--- a/build/media_source/com_media/scss/components/_media-modal.scss
+++ b/build/media_source/com_media/scss/components/_media-modal.scss
@@ -32,7 +32,7 @@
   .modal-dialog {
     max-width: 70vw;
     max-height: 70vh;
-	position: fixed;
+    position: fixed;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);


### PR DESCRIPTION
Pull request for #29149

This requires npm ci as it's a css change

### Steps to reproduce the issue
- Download https://unsplash.com/photos/xnEZYWmfPwU/download?force=true (original size)
- Upload to the Media Manage or place in your images directory
- Double click the image to preview it

### Before
Half the image is cropped and you cannot scroll down to view the other half

### After
The entire image is visable
