### PR TITLE
[4] Blank State for com_cache

### DIFF
--- a/administrator/components/com_cache/src/View/Cache/HtmlView.php
+++ b/administrator/components/com_cache/src/View/Cache/HtmlView.php
@@ -106,6 +106,11 @@ class HtmlView extends BaseHtmlView
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
+		if (!count($this->data))
+		{
+			$this->setLayout('blankstate');
+		}
+
 		$this->addToolbar();
 
 		parent::display($tpl);

--- a/administrator/components/com_cache/src/View/Cache/HtmlView.php
+++ b/administrator/components/com_cache/src/View/Cache/HtmlView.php
@@ -130,10 +130,13 @@ class HtmlView extends BaseHtmlView
 		// Get the toolbar object instance
 		$toolbar = Toolbar::getInstance('toolbar');
 
-		ToolbarHelper::custom('delete', 'delete', '', 'JTOOLBAR_DELETE', true);
-		ToolbarHelper::custom('deleteAll', 'remove', '', 'JTOOLBAR_DELETE_ALL', false);
-		$toolbar->appendButton('Confirm', 'COM_CACHE_RESOURCE_INTENSIVE_WARNING', 'delete', 'COM_CACHE_PURGE_EXPIRED', 'purge', false);
-		ToolbarHelper::divider();
+		if (count($this->data))
+		{
+			ToolbarHelper::custom('delete', 'delete', '', 'JTOOLBAR_DELETE', true);
+			ToolbarHelper::custom('deleteAll', 'remove', '', 'JTOOLBAR_DELETE_ALL', false);
+			$toolbar->appendButton('Confirm', 'COM_CACHE_RESOURCE_INTENSIVE_WARNING', 'delete', 'COM_CACHE_PURGE_EXPIRED', 'purge', false);
+			ToolbarHelper::divider();
+		}
 
 		if (Factory::getUser()->authorise('core.admin', 'com_cache'))
 		{

--- a/administrator/components/com_cache/src/View/Cache/HtmlView.php
+++ b/administrator/components/com_cache/src/View/Cache/HtmlView.php
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
 
 		if (!\count($this->data))
 		{
-			$this->setLayout('blankstate');
+			$this->setLayout('emptystate');
 		}
 
 		$this->addToolbar();

--- a/administrator/components/com_cache/src/View/Cache/HtmlView.php
+++ b/administrator/components/com_cache/src/View/Cache/HtmlView.php
@@ -101,12 +101,12 @@ class HtmlView extends BaseHtmlView
 		$this->activeFilters = $model->getActiveFilters();
 
 		// Check for errors.
-		if (count($errors = $this->get('Errors')))
+		if (\count($errors = $this->get('Errors')))
 		{
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
-		if (!count($this->data))
+		if (!\count($this->data))
 		{
 			$this->setLayout('blankstate');
 		}
@@ -130,7 +130,7 @@ class HtmlView extends BaseHtmlView
 		// Get the toolbar object instance
 		$toolbar = Toolbar::getInstance('toolbar');
 
-		if (count($this->data))
+		if (\count($this->data))
 		{
 			ToolbarHelper::custom('delete', 'delete', '', 'JTOOLBAR_DELETE', true);
 			ToolbarHelper::custom('deleteAll', 'remove', '', 'JTOOLBAR_DELETE_ALL', false);

--- a/administrator/components/com_cache/tmpl/cache/blankstate.php
+++ b/administrator/components/com_cache/tmpl/cache/blankstate.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Administrator
  * @subpackage  com_content
  *
- * @copyright   (C) 2008 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/administrator/components/com_cache/tmpl/cache/blankstate.php
+++ b/administrator/components/com_cache/tmpl/cache/blankstate.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_content
+ *
+ * @copyright   (C) 2008 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Layout\LayoutHelper;
+
+$displayData = array(
+	'textPrefix' => 'COM_CACHE',
+	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Cache',
+);
+
+echo LayoutHelper::render('joomla.content.blankstate', $displayData);

--- a/administrator/components/com_cache/tmpl/cache/blankstate.php
+++ b/administrator/components/com_cache/tmpl/cache/blankstate.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.Administrator
- * @subpackage  com_content
+ * @subpackage  com_cache
  *
  * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/administrator/components/com_cache/tmpl/cache/blankstate.php
+++ b/administrator/components/com_cache/tmpl/cache/blankstate.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 $displayData = array(
 	'textPrefix' => 'COM_CACHE',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Cache',
+	'icon'       => 'icon-bolt clear',
 );
 
 echo LayoutHelper::render('joomla.content.blankstate', $displayData);

--- a/administrator/components/com_cache/tmpl/cache/emptystate.php
+++ b/administrator/components/com_cache/tmpl/cache/emptystate.php
@@ -11,10 +11,10 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
-$displayData = array(
+$displayData = [
 	'textPrefix' => 'COM_CACHE',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Cache',
 	'icon'       => 'icon-bolt clear',
-);
+];
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);

--- a/administrator/components/com_cache/tmpl/cache/emptystate.php
+++ b/administrator/components/com_cache/tmpl/cache/emptystate.php
@@ -17,4 +17,4 @@ $displayData = array(
 	'icon'       => 'icon-bolt clear',
 );
 
-echo LayoutHelper::render('joomla.content.blankstate', $displayData);
+echo LayoutHelper::render('joomla.content.emptystate', $displayData);

--- a/administrator/language/en-GB/com_cache.ini
+++ b/administrator/language/en-GB/com_cache.ini
@@ -5,7 +5,7 @@
 
 COM_CACHE="Cache"
 COM_CACHE_BLANKSTATE_TITLE="You have no cached content."
-COM_CACHE_BLANKSTATE_CONTENT="If you enable caching in Joomla Global Configuration, then the cached items will display here as they are generated."
+COM_CACHE_BLANKSTATE_CONTENT="If you enable caching in Joomla Global Configuration, then any cached items will display here as they are generated."
 COM_CACHE_CLEAR_CACHE="Maintenance: Clear Cache"
 COM_CACHE_CONFIGURATION="Cache: Options"
 COM_CACHE_ERROR_CACHE_CONNECTION_FAILED="Could not connect to the cache store to fetch the cache data."

--- a/administrator/language/en-GB/com_cache.ini
+++ b/administrator/language/en-GB/com_cache.ini
@@ -6,7 +6,7 @@
 COM_CACHE="Cache"
 COM_CACHE_CLEAR_CACHE="Maintenance: Clear Cache"
 COM_CACHE_CONFIGURATION="Cache: Options"
-COM_CACHE_EMPTYSTATE_CONTENT="If you enable caching in Joomla Global Configuration, then any cached items will display here as they are generated."
+COM_CACHE_EMPTYSTATE_CONTENT="If you enable caching in Joomla Global Configuration, then any cached items will be displayed here."
 COM_CACHE_EMPTYSTATE_TITLE="You have no cached content."
 COM_CACHE_ERROR_CACHE_CONNECTION_FAILED="Could not connect to the cache store to fetch the cache data."
 COM_CACHE_ERROR_CACHE_DRIVER_UNSUPPORTED="Could not read the cache data, the configured cache handler is not supported by this environment."

--- a/administrator/language/en-GB/com_cache.ini
+++ b/administrator/language/en-GB/com_cache.ini
@@ -4,10 +4,10 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_CACHE="Cache"
-COM_CACHE_BLANKSTATE_CONTENT="If you enable caching in Joomla Global Configuration, then any cached items will display here as they are generated."
-COM_CACHE_BLANKSTATE_TITLE="You have no cached content."
 COM_CACHE_CLEAR_CACHE="Maintenance: Clear Cache"
 COM_CACHE_CONFIGURATION="Cache: Options"
+COM_CACHE_EMPTYSTATE_CONTENT="If you enable caching in Joomla Global Configuration, then any cached items will display here as they are generated."
+COM_CACHE_EMPTYSTATE_TITLE="You have no cached content."
 COM_CACHE_ERROR_CACHE_CONNECTION_FAILED="Could not connect to the cache store to fetch the cache data."
 COM_CACHE_ERROR_CACHE_DRIVER_UNSUPPORTED="Could not read the cache data, the configured cache handler is not supported by this environment."
 COM_CACHE_EXPIRED_ITEMS_DELETE_ERROR="Error clearing cache group(s): %s."

--- a/administrator/language/en-GB/com_cache.ini
+++ b/administrator/language/en-GB/com_cache.ini
@@ -4,6 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_CACHE="Cache"
+COM_CACHE_BLANKSTATE_TITLE="You have no cached content."
+COM_CACHE_BLANKSTATE_CONTENT="You can enable caching in Joomla Global Configuration, then the cached items will display here as they are generated."
 COM_CACHE_CLEAR_CACHE="Maintenance: Clear Cache"
 COM_CACHE_CONFIGURATION="Cache: Options"
 COM_CACHE_ERROR_CACHE_CONNECTION_FAILED="Could not connect to the cache store to fetch the cache data."

--- a/administrator/language/en-GB/com_cache.ini
+++ b/administrator/language/en-GB/com_cache.ini
@@ -4,8 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_CACHE="Cache"
-COM_CACHE_BLANKSTATE_TITLE="You have no cached content."
 COM_CACHE_BLANKSTATE_CONTENT="If you enable caching in Joomla Global Configuration, then any cached items will display here as they are generated."
+COM_CACHE_BLANKSTATE_TITLE="You have no cached content."
 COM_CACHE_CLEAR_CACHE="Maintenance: Clear Cache"
 COM_CACHE_CONFIGURATION="Cache: Options"
 COM_CACHE_ERROR_CACHE_CONNECTION_FAILED="Could not connect to the cache store to fetch the cache data."

--- a/administrator/language/en-GB/com_cache.ini
+++ b/administrator/language/en-GB/com_cache.ini
@@ -5,7 +5,7 @@
 
 COM_CACHE="Cache"
 COM_CACHE_BLANKSTATE_TITLE="You have no cached content."
-COM_CACHE_BLANKSTATE_CONTENT="You can enable caching in Joomla Global Configuration, then the cached items will display here as they are generated."
+COM_CACHE_BLANKSTATE_CONTENT="If you enable caching in Joomla Global Configuration, then the cached items will display here as they are generated."
 COM_CACHE_CLEAR_CACHE="Maintenance: Clear Cache"
 COM_CACHE_CONFIGURATION="Cache: Options"
 COM_CACHE_ERROR_CACHE_CONNECTION_FAILED="Could not connect to the cache store to fetch the cache data."


### PR DESCRIPTION
### Summary of Changes

Add new blank slate when there are no cached items

Remove toolbar buttons when there is nothing for them to do

### Testing Instructions

Apply PR
Go to System -> Cache 
See blank state, or see cached items
If you see cached items, delete them all - see blank state
test learn more button

### Actual result BEFORE applying this Pull Request

<img width="1600" alt="Screenshot 2021-04-25 at 21 22 21" src="https://user-images.githubusercontent.com/400092/116008418-56bd5880-a60c-11eb-9df3-da5a1c35327c.png">


### Expected result AFTER applying this Pull Request

<img width="1585" alt="Screenshot 2021-04-25 at 21 21 45" src="https://user-images.githubusercontent.com/400092/116008402-42795b80-a60c-11eb-89cc-dc4322f39743.png">

<img width="1601" alt="Screenshot 2021-04-25 at 21 22 01" src="https://user-images.githubusercontent.com/400092/116008410-4b6a2d00-a60c-11eb-8a6b-18a95c3df606.png">


### Documentation Changes Required

