### PR TITLE
[4.0] Dont show create button in blankstate layout when loaded in a modal

### DIFF
--- a/layouts/joomla/content/blankstate.php
+++ b/layouts/joomla/content/blankstate.php
@@ -35,7 +35,7 @@ $helpURL    = $displayData['helpURL'] ?? '';
 				<?php echo Text::_($textPrefix . '_BLANKSTATE_CONTENT'); ?>
 			</p>
 			<div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
-				<?php if ($createURL) : ?>
+				<?php if ($createURL && Factory::getApplication()->input->get('tmpl') !== 'component') : ?>
 					<a href="<?php echo Route::_($createURL); ?>"
 					   class="btn btn-primary btn-lg px-4 me-sm-3"><?php echo Text::_($textPrefix . '_BLANKSTATE_BUTTON_ADD'); ?></a>
 				<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/33319 .

### Summary of Changes
Don't show the create button when the blankstate layout is loaded in a modal. Eg when using the "Select" button in a single article menuitem.
In modals, we also don't show the toolbar buttons, so this makes most sense to me.

### Testing Instructions
Brian did a good video to show the issue in https://github.com/joomla/joomla-cms/issues/33319


### Actual result BEFORE applying this Pull Request
Create button is shown in modal


### Expected result AFTER applying this Pull Request
Create button is not shown in modal


### Documentation Changes Required
None