### PR TITLE
[4] Add icons back to refactored blank state

### DIFF
--- a/administrator/components/com_banners/tmpl/banners/blankstate.php
+++ b/administrator/components/com_banners/tmpl/banners/blankstate.php
@@ -16,6 +16,7 @@ $displayData = [
 	'textPrefix' => 'COM_BANNERS',
 	'formURL'    => 'index.php?option=com_banners&view=banners',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Banners',
+	'icon'       => 'icon-bookmark banners',
 ];
 
 if (count(Factory::getApplication()->getIdentity()->getAuthorisedCategories('com_banners', 'core.create')) > 0)

--- a/administrator/components/com_contact/tmpl/contacts/blankstate.php
+++ b/administrator/components/com_contact/tmpl/contacts/blankstate.php
@@ -16,6 +16,7 @@ $displayData = [
 	'textPrefix' => 'COM_CONTACT',
 	'formURL'    => 'index.php?option=com_contact',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help4.x:Contacts',
+	'icon'       => 'icon-address-book contact',
 ];
 
 $user = Factory::getApplication()->getIdentity();

--- a/administrator/components/com_content/tmpl/articles/blankstate.php
+++ b/administrator/components/com_content/tmpl/articles/blankstate.php
@@ -16,6 +16,7 @@ $displayData = [
 	'textPrefix' => 'COM_CONTENT',
 	'formURL'    => 'index.php?option=com_content&view=articles',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Adding_a_new_article',
+	'icon'       => 'icon-copy article',
 ];
 
 $user = Factory::getApplication()->getIdentity();

--- a/administrator/components/com_messages/tmpl/messages/blankstate.php
+++ b/administrator/components/com_messages/tmpl/messages/blankstate.php
@@ -16,6 +16,7 @@ $displayData = [
 	'textPrefix' => 'COM_MESSAGES',
 	'formURL'    => 'index.php?option=com_messages&view=messages',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Private_Messages',
+	'icon'       => 'icon-envelope inbox',
 ];
 
 if (Factory::getApplication()->getIdentity()->authorise('core.create', 'com_messages'))

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/blankstate.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/blankstate.php
@@ -16,6 +16,7 @@ $displayData = [
 	'textPrefix' => 'COM_NEWSFEEDS',
 	'formURL'    => 'index.php?option=com_newsfeeds&view=newsfeeds',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help4.x:News_Feeds',
+	'icon'       => 'icon-rss newsfeeds',
 ];
 
 if (count(Factory::getApplication()->getIdentity()->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0)

--- a/administrator/components/com_privacy/tmpl/consents/blankstate.php
+++ b/administrator/components/com_privacy/tmpl/consents/blankstate.php
@@ -15,6 +15,7 @@ $displayData = [
 	'textPrefix' => 'COM_PRIVACY_CONSENTS',
 	'formURL'    => 'index.php?option=com_privacy&view=consents',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Privacy:_Consents',
+	'icon'       => 'icon-lock',
 ];
 
 echo LayoutHelper::render('joomla.content.blankstate', $displayData);

--- a/administrator/components/com_privacy/tmpl/requests/blankstate.php
+++ b/administrator/components/com_privacy/tmpl/requests/blankstate.php
@@ -16,6 +16,7 @@ $displayData = [
 	'textPrefix' => 'COM_PRIVACY_REQUESTS',
 	'formURL'    => 'index.php?option=com_privacy&view=requests',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:Privacy:_Information_Requests',
+	'icon'       => 'icon-lock',
 ];
 
 if (Factory::getApplication()->get('mailonline', 1))

--- a/administrator/components/com_users/tmpl/notes/blankstate.php
+++ b/administrator/components/com_users/tmpl/notes/blankstate.php
@@ -16,6 +16,7 @@ $displayData = [
 	'textPrefix' => 'COM_USERS_NOTES',
 	'formURL'    => 'index.php?option=com_users&view=notes',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help40:User_Notes',
+	'icon'       => 'icon-users user',
 ];
 
 if (Factory::getApplication()->getIdentity()->authorise('core.create', 'com_users'))

--- a/layouts/joomla/content/blankstate.php
+++ b/layouts/joomla/content/blankstate.php
@@ -23,12 +23,13 @@ if (!$textPrefix)
 $formURL    = $displayData['formURL'] ?? '';
 $createURL  = $displayData['createURL'] ?? '';
 $helpURL    = $displayData['helpURL'] ?? '';
+$icon       = $displayData['icon'] ?? 'icon-copy article';
 ?>
 
 <form action="<?php echo Route::_($formURL); ?>" method="post" name="adminForm" id="adminForm">
 
 	<div class="px-4 py-5 my-5 text-center">
-		<span class="fa-8x icon-copy mb-4 article" aria-hidden="true"></span>
+		<span class="fa-8x mb-4 <?php echo $icon; ?>" aria-hidden="true"></span>
 		<h1 class="display-5 fw-bold"><?php echo Text::_($textPrefix . '_BLANKSTATE_TITLE'); ?></h1>
 		<div class="col-lg-6 mx-auto">
 			<p class="lead mb-4">


### PR DESCRIPTION
Pull Request for Issue #33328 Replacement for https://github.com/joomla/joomla-cms/pull/33332

Summary of Changes

Adding the icon to the $displayData. The icon will default to the article one if none is given.
Restoring the original icons for the various blankstate layouts (eg contacts, newsfeeds, banners, user notes, ...)

Testing Instructions

Check the various views when no item is created yet and see what icon is used in the blankstate layout.

Actual result BEFORE applying this Pull Request

Always the same icon (copy) is used

Expected result AFTER applying this Pull Request

The views have different icons matching the context.

Documentation Changes Required

None