### PR TITLE
[4.0] Micro-optimisation com_actionlogs

### DIFF
--- a/administrator/components/com_actionlogs/src/Controller/ActionlogsController.php
+++ b/administrator/components/com_actionlogs/src/Controller/ActionlogsController.php
@@ -84,7 +84,7 @@ class ActionlogsController extends AdminController
 		// Get the logs data
 		$data = $model->getLogDataAsIterator($pks);
 
-		if (count($data))
+		if (\count($data))
 		{
 			try
 			{

--- a/administrator/components/com_actionlogs/src/Field/ExtensionField.php
+++ b/administrator/components/com_actionlogs/src/Field/ExtensionField.php
@@ -52,7 +52,7 @@ class ExtensionField extends ListField
 
 		$options = array();
 
-		if (count($context) > 0)
+		if (\count($context) > 0)
 		{
 			foreach ($context as $item)
 			{

--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -119,7 +119,7 @@ class ActionlogsHelper
 			case 'plg':
 				$parts = explode('_', $extension, 3);
 
-				if (count($parts) > 2)
+				if (\count($parts) > 2)
 				{
 					$source = JPATH_PLUGINS . '/' . $parts[1] . '/' . $parts[2];
 				}
@@ -363,7 +363,7 @@ class ActionlogsHelper
 			return $value;
 		}
 
-		if (in_array($value[0], self::$characters, true))
+		if (\in_array($value[0], self::$characters, true))
 		{
 			$value = ' ' . $value;
 		}

--- a/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
@@ -138,7 +138,7 @@ class ActionlogModel extends BaseDatabaseModel
 		{
 			$extensions = json_decode($user->extensions, true);
 
-			if ($extensions && in_array(strtok($context, '.'), $extensions))
+			if ($extensions && \in_array(strtok($context, '.'), $extensions))
 			{
 				$recipients[] = $user->email;
 			}

--- a/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
@@ -341,7 +341,7 @@ class ActionlogsModel extends ListModel
 			->from($db->quoteName('#__action_logs', 'a'))
 			->join('INNER', $db->quoteName('#__users', 'u') . ' ON ' . $db->quoteName('a.user_id') . ' = ' . $db->quoteName('u.id'));
 
-		if (is_array($pks) && count($pks) > 0)
+		if (\is_array($pks) && \count($pks) > 0)
 		{
 			$pks = ArrayHelper::toInteger($pks);
 			$query->whereIn($db->quoteName('a.id'), $pks);

--- a/administrator/components/com_actionlogs/src/View/Actionlogs/HtmlView.php
+++ b/administrator/components/com_actionlogs/src/View/Actionlogs/HtmlView.php
@@ -101,7 +101,7 @@ class HtmlView extends BaseHtmlView
 		$params              = ComponentHelper::getParams('com_actionlogs');
 		$this->showIpColumn  = (bool) $params->get('ip_logging', 0);
 
-		if (count($errors = $model->getErrors()))
+		if (\count($errors = $model->getErrors()))
 		{
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}


### PR DESCRIPTION
Since PHP 7.0, some functions are replaced by opcodes, producing much faster code.
Yet, for this to work, these functions need to be referenced in the root namespace at compile time:
Either there is no namespace, or they are prefixed by a \.

If accepted my plan is to do this for each component one at a time (easier to review)

Reference https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/3048
