### PR TITLE
[4.0] Postinstall reset hide fix

### DIFF
--- a/administrator/components/com_postinstall/src/Controller/MessageController.php
+++ b/administrator/components/com_postinstall/src/Controller/MessageController.php
@@ -36,8 +36,7 @@ class MessageController extends BaseController
 
 		/** @var MessagesModel $model */
 		$model = $this->getModel('Messages', '', array('ignore_request' => true));
-
-		$eid = (int) $model->getState('eid', $model->getJoomlaFilesExtensionId());
+		$eid = $this->input->get('eid');
 
 		if (empty($eid))
 		{

--- a/administrator/components/com_postinstall/src/Controller/MessageController.php
+++ b/administrator/components/com_postinstall/src/Controller/MessageController.php
@@ -128,7 +128,7 @@ class MessageController extends BaseController
 
 		/** @var MessagesModel $model */
 		$model = $this->getModel('Messages', '', array('ignore_request' => true));
-		$eid = (int) $model->getState('eid', $model->getJoomlaFilesExtensionId());
+		$eid = $this->input->get('eid');
 
 		if (empty($eid))
 		{

--- a/administrator/components/com_postinstall/src/Controller/MessageController.php
+++ b/administrator/components/com_postinstall/src/Controller/MessageController.php
@@ -36,7 +36,7 @@ class MessageController extends BaseController
 
 		/** @var MessagesModel $model */
 		$model = $this->getModel('Messages', '', array('ignore_request' => true));
-		$eid = $this->input->get('eid');
+		$eid = $this->input->getInt('eid');
 
 		if (empty($eid))
 		{
@@ -127,7 +127,7 @@ class MessageController extends BaseController
 
 		/** @var MessagesModel $model */
 		$model = $this->getModel('Messages', '', array('ignore_request' => true));
-		$eid = $this->input->get('eid');
+		$eid = $this->input->getInt('eid');
 
 		if (empty($eid))
 		{


### PR DESCRIPTION
Pull Request for Issue #33307.
All the 6 mentioned problems are fixed by this PR.

### Summary of Changes
The $eid variable was assigned it's value by `$model->getJoomlaFilesExtensionId())` which always returns the ID of Joomla CMS (212). This was causing the form to behave strangely by not considering the value of the selected extension from the dropdown


### Testing Instructions

Step 1: Run this SQL to add a fake post installation message (change the db prefix!)

```
INSERT INTO `o07n8_postinstall_messages` (`postinstall_message_id`, `extension_id`, `title_key`, `description_key`, `action_key`, `language_extension`, `language_client_id`, `type`, `action_file`, `action`, `condition_file`, `condition_method`, `version_introduced`, `enabled`)
VALUES
	(99, 210, 'TEST', 'TEST', '', 'com_cpanel', 1, 'message', '', '', '', '', '4.0.0', 1);
```

Step 2: Visit the Post Installation Message screen and follow through:

#### Before the PR
> - Load page, note its Joomla CMS in the dropdown and you see its messages shown
> - Select Atum Administrator template from the drop down - see there is one message
> - While we are on the "Atum Administrator template" selected page, click Hide all messages button
> - Note the page reloads back to the Joomla CMS page and all the Joomla CMS Messages are HIDDEN (Problem 1).
> - Select Atum Administrator template from the drop down - see there is one message (Problem 2, it should have been hidden)
> - While we are on the "Atum Administrator template" selected page, click Hide this message button
> - Note that we are now showing messages for Joomla CMS and not "Atum Administrator template" (Problem 3)
> - Select Atum Administrator template from the drop down - see there is no message (Correct).
> - Click RESET MESSAGES
> - Note that we are now showing messages for Joomla CMS and not "Atum Administrator template" (Problem 4)
> - Note that we are now showing messages for Joomla CMS, when we reset messages for "Atum Administrator template" (Problem 5)
> - Select Atum Administrator template from the drop down - see there is no message (Problem 6 - they were reset so should be showing!).

#### After the PR:
Problem 1: Atum's page will be shown on reload and messages will be hidden
Problem 2: Atum's messages won't be visible
Problem 3: Messages shown will be of Atum
Problem 4: Page will reload to display Atum's messages
Problem 5: Reset will only affect Atum's messages
Problem 6: Atum's messages will be displayed

The Problems and fixes mentioned above are shown in the video below.


### Actual result BEFORE applying this Pull Request
https://user-images.githubusercontent.com/53610833/116063995-37bdd580-a6a3-11eb-8eb9-76460fa4dbdc.mp4



### Expected result AFTER applying this Pull Request
https://user-images.githubusercontent.com/53610833/116064038-42786a80-a6a3-11eb-8fec-330e341b4e8f.mp4



### Documentation Changes Required
None
