### PR TITLE
[4.0] Add bottom-margin in vote

### DIFF
--- a/plugins/content/vote/tmpl/vote.php
+++ b/plugins/content/vote/tmpl/vote.php
@@ -36,7 +36,7 @@ for ($i = 1; $i < 6; $i++)
 }
 
 ?>
-<form method="post" action="<?php echo htmlspecialchars($uri->toString(), ENT_COMPAT, 'UTF-8'); ?>" class="form-inline pb-2">
+<form method="post" action="<?php echo htmlspecialchars($uri->toString(), ENT_COMPAT, 'UTF-8'); ?>" class="form-inline mb-2">
 	<span class="content_vote">
 		<label class="visually-hidden" for="content_vote_<?php echo (int) $row->id; ?>"><?php echo Text::_('PLG_VOTE_LABEL'); ?></label>
 		<?php echo HTMLHelper::_('select.genericlist', $options, 'user_rating', 'class="form-select form-select-sm w-auto"', 'value', 'text', '5', 'content_vote_' . (int) $row->id); ?>

--- a/plugins/content/vote/tmpl/vote.php
+++ b/plugins/content/vote/tmpl/vote.php
@@ -36,7 +36,7 @@ for ($i = 1; $i < 6; $i++)
 }
 
 ?>
-<form method="post" action="<?php echo htmlspecialchars($uri->toString(), ENT_COMPAT, 'UTF-8'); ?>" class="form-inline">
+<form method="post" action="<?php echo htmlspecialchars($uri->toString(), ENT_COMPAT, 'UTF-8'); ?>" class="form-inline pb-2">
 	<span class="content_vote">
 		<label class="visually-hidden" for="content_vote_<?php echo (int) $row->id; ?>"><?php echo Text::_('PLG_VOTE_LABEL'); ?></label>
 		<?php echo HTMLHelper::_('select.genericlist', $options, 'user_rating', 'class="form-select form-select-sm w-auto"', 'value', 'text', '5', 'content_vote_' . (int) $row->id); ?>


### PR DESCRIPTION
Pull Request for Issue #33337.
### Summary of Changes
Add `mb-2` in the voting form

### Testing Instructions
* Enable vote plugin with `position-top`
* Enable vote in article
And see the changes
### Actual result BEFORE applying this Pull Request
No bottom padding applied in vote form

![before-vote](https://user-images.githubusercontent.com/61203226/116074389-4f9b5680-a6af-11eb-8c64-db1ee1bfcec5.JPG)


### Expected result AFTER applying this Pull Request
Bottom padding applied in vote form

![after-vote](https://user-images.githubusercontent.com/61203226/116074406-5629ce00-a6af-11eb-8671-3867d5073528.JPG)



### Documentation Changes Required
None
