### PR TITLE
[4.0] Add png to default values

### DIFF
--- a/administrator/components/com_templates/config.xml
+++ b/administrator/components/com_templates/config.xml
@@ -34,7 +34,7 @@
 			name="image_formats"
 			type="text"
 			label="COM_TEMPLATES_CONFIG_IMAGE_LABEL"
-			default="gif,bmp,jpg,jpeg,webp"
+			default="gif,bmp,jpg,jpeg,png,webp"
 			extension="com_templates"
 		/>
 


### PR DESCRIPTION
### Summary of Changes
The default values of `Valid Image Formats` is missing `png`.


### Testing Instructions
Go to Global Configuration > Templates
Values of `Valid Image Formats`: gif,bmp,jpg,jpeg,png,webp
Clear values.
Click Save button.
Values of `Valid Image Formats` missing `png`: gif,bmp,jpg,jpeg,webp
Apply PR.
Clear values.
Click Save button.
Values of `Valid Image Formats` with `png`: gif,bmp,jpg,jpeg,png,webp

### Actual result BEFORE applying this Pull Request
> gif,bmp,jpg,jpeg,webp


### Expected result AFTER applying this Pull Request
> gif,bmp,jpg,jpeg,png,webp