### PR TITLE
[4] add native_function_invocation to php-cs-fixer config

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -56,6 +56,8 @@ return PhpCsFixer\Config::create()
 		    'no_whitespace_in_blank_line' => true,
 		    // contrib
 		    'concat_space' => ['spacing' => 'one'],
+		    // PHP7+
+		    'native_function_invocation'=> ['include' => ['@compiler_optimized'], 'scope' => 'namespaced', 'strict' => true],
       )
     )
     ->setFinder($mainFinder);


### PR DESCRIPTION
[4] add native_function_invocation to php-cs-fixer config

Code review

Add leading \ before function invocation to speed up resolving.

https://cs.symfony.com/doc/rules/function_notation/native_function_invocation.html