### PR TITLE
[4.0] Fix Reset Messages button being off-centered

### DIFF
--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -33,7 +33,7 @@ $adminFormClass = count($this->extension_options) > 1 ? 'form-inline mb-3' : 'vi
 			<p class="lead mb-4">
 				<?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_DESC'); ?>
 			</p>
-			<a href="<?php echo Route::_('index.php?option=com_postinstall&view=messages&task=message.reset&eid=' . $this->eid . '&' . $this->token . '=1'); ?>" class="btn btn-primary btn-lg px-4 me-sm-3"><?php echo Text::_('COM_POSTINSTALL_BTN_RESET'); ?></a>
+			<a href="<?php echo Route::_('index.php?option=com_postinstall&view=messages&task=message.reset&eid=' . $this->eid . '&' . $this->token . '=1'); ?>" class="btn btn-primary btn-lg px-4"><?php echo Text::_('COM_POSTINSTALL_BTN_RESET'); ?></a>
 		</div>
 	</div>
 <?php else : ?>


### PR DESCRIPTION
### Summary of Changes
Remove right margin on the `Reset Messages` button to fix it from being off-centered.


### Testing Instructions
Click `Post Installation Messages` icon.
Click `Hide all messages` button.
See `Reset Messages` button.


### Actual result BEFORE applying this Pull Request
![reset-messages](https://user-images.githubusercontent.com/368084/116134616-f74f5f00-a684-11eb-977a-543569a25c05.jpg)
