### PR TITLE
[4.0] [RFC] Add update SQL script for admin modules parameters

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-04-27.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-04-27.sql
@@ -8,7 +8,7 @@ UPDATE `#__modules`
        'mod_logged',
        'mod_popular',
        'mod_privacy_dashboard',
-       'mod_privacy_status'
+       'mod_privacy_status',
        'mod_quickicon',
        'mod_sampledata',
        'mod_submenu'
@@ -38,7 +38,7 @@ UPDATE `#__modules`
        'mod_logged',
        'mod_popular',
        'mod_privacy_dashboard',
-       'mod_privacy_status'
+       'mod_privacy_status',
        'mod_quickicon',
        'mod_sampledata',
        'mod_submenu'

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-04-27.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-04-27.sql
@@ -1,0 +1,59 @@
+UPDATE `#__modules`
+   SET `params` = JSON_SET(`params`, '$.bootstrap_size', '12')
+ WHERE `client_id` = 1
+   AND `module`
+    IN (
+       'mod_latest',
+       'mod_latestactions',
+       'mod_logged',
+       'mod_popular',
+       'mod_privacy_dashboard',
+       'mod_privacy_status'
+       'mod_quickicon',
+       'mod_sampledata',
+       'mod_submenu'
+       )
+   AND `position`
+    IN (
+       'cpanel',
+       'cpanel-components',
+       'cpanel-content',
+       'cpanel-help',
+       'cpanel-menus',
+       'cpanel-privacy',
+       'cpanel-system',
+       'cpanel-users',
+       'icon'
+       )
+   AND `params` LIKE '{%}'
+   AND (JSON_EXTRACT(`params`, '$.bootstrap_size') IS NULL OR JSON_EXTRACT(`params`, '$.bootstrap_size') != '12');
+
+UPDATE `#__modules`
+   SET `params` = JSON_SET(`params`, '$.header_tag', 'h2')
+ WHERE `client_id` = 1
+   AND `module`
+    IN (
+       'mod_latest',
+       'mod_latestactions',
+       'mod_logged',
+       'mod_popular',
+       'mod_privacy_dashboard',
+       'mod_privacy_status'
+       'mod_quickicon',
+       'mod_sampledata',
+       'mod_submenu'
+       )
+   AND `position`
+    IN (
+       'cpanel',
+       'cpanel-components',
+       'cpanel-content',
+       'cpanel-help',
+       'cpanel-menus',
+       'cpanel-privacy',
+       'cpanel-system',
+       'cpanel-users',
+       'icon'
+       )
+   AND `params` LIKE '{%}'
+   AND (JSON_EXTRACT(`params`, '$.header_tag') IS NULL OR JSON_EXTRACT(`params`, '$.header_tag') != 'h2');

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-04-27.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-04-27.sql
@@ -8,7 +8,7 @@ UPDATE "#__modules"
        'mod_logged',
        'mod_popular',
        'mod_privacy_dashboard',
-       'mod_privacy_status'
+       'mod_privacy_status',
        'mod_quickicon',
        'mod_sampledata',
        'mod_submenu'
@@ -38,7 +38,7 @@ UPDATE "#__modules"
        'mod_logged',
        'mod_popular',
        'mod_privacy_dashboard',
-       'mod_privacy_status'
+       'mod_privacy_status',
        'mod_quickicon',
        'mod_sampledata',
        'mod_submenu'

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-04-27.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-04-27.sql
@@ -1,0 +1,59 @@
+UPDATE "#__modules"
+   SET "params" = jsonb_set("params"::jsonb, '{bootstrap_size}', '"12"', true)
+ WHERE "client_id" = 1
+   AND "module"
+    IN (
+       'mod_latest',
+       'mod_latestactions',
+       'mod_logged',
+       'mod_popular',
+       'mod_privacy_dashboard',
+       'mod_privacy_status'
+       'mod_quickicon',
+       'mod_sampledata',
+       'mod_submenu'
+       )
+   AND "position"
+    IN (
+       'cpanel',
+       'cpanel-components',
+       'cpanel-content',
+       'cpanel-help',
+       'cpanel-menus',
+       'cpanel-privacy',
+       'cpanel-system',
+       'cpanel-users',
+       'icon'
+       )
+   AND "params" LIKE '{%}'
+   AND ("params"::json->>'bootstrap_size' IS NULL OR "params"::json->>'bootstrap_size' <> '12');
+
+UPDATE "#__modules"
+   SET "params" = jsonb_set("params"::jsonb, '{header_tag}', '"h2"', true)
+ WHERE "client_id" = 1
+   AND "module"
+    IN (
+       'mod_latest',
+       'mod_latestactions',
+       'mod_logged',
+       'mod_popular',
+       'mod_privacy_dashboard',
+       'mod_privacy_status'
+       'mod_quickicon',
+       'mod_sampledata',
+       'mod_submenu'
+       )
+   AND "position"
+    IN (
+       'cpanel',
+       'cpanel-components',
+       'cpanel-content',
+       'cpanel-help',
+       'cpanel-menus',
+       'cpanel-privacy',
+       'cpanel-system',
+       'cpanel-users',
+       'icon'
+       )
+   AND "params" LIKE '{%}'
+   AND ("params"::json->>'header_tag' IS NULL OR "params"::json->>'header_tag' <> 'h2');


### PR DESCRIPTION
Pull Request for Issue #33314 .

### Summary of Changes

This pull request (PR) adds an update SQL script (one for each db type) to fix the bootstrap size and header tag parameters of those admin modules touched by PR #33045 when updating from 4.0 Beta 7 or a previous 4.0 Beta.

In opposite to past cases when we had to manipulate JSON parameters with update SQL scripts, this script here uses JSON functions.

The reason for this is that
1. it is safer if you make sure that you are running the JSON functions only on a valid JSON string, and
2. in some case it was not only a value change to be made but a missing property to be added, and this would be at least complicated if not risky with a normal `REPLACE` for strings.

The requirement for point 1. is achieved by including the condition `params LIKE '{%}'` into the `WHERE`clause of the update statement before extracting the JSON values in subsequent conditions.

Beside this, the `WHERE` clause of the update statement is made as precise as necessary in order to update only the desired modules.

### Request For Comments

Unfortunately this PR can't be merged right now as the minimum version requirements of Joomla 4 for databases are lower than what is needed to support JSON functions.

- Minimum version requirement for MySQL is 5.6, but the JSON functions have been added with version 5.7.
- Minimum version requirement for MariaDB is 10.1, but the JSON functions have been added with version 10.2.3.
- PostgreSQL is no problem, there the JSON functions have been added with version 9.5 (or earlier), and J4 requires 11.0 or later.

=> Ping @wilsonge : One more reason to raise the version requirement for MySQL to 5.7 and for MariaDB to 10.2.3 in Joomla 4.

### Testing Instructions

#### Requirements

This PR needs to be tested for all supported database types (MySQL, MariaDB and PostgreSQL). In case of MySQL or MariaDB, if you can use both the "MySQLi" and the "MySQL (PDO)" database driver, test with both.

All testers please report back which database and driver types you have tested so it can be properly recorded.

The PR cannot be tested with patchtester because it needs to test database updates. It has to be tested as described below with use of update packages or custom update URL's.

1. Have an installation of Joomla 4.0 Beta 7 or earlier (but not before Beta 4) with clean admin control panel modules, i.e. you haven't modified them, or make a new installation of 4.0 Beta 7 if you don't have that.

2. In Global Configuration, switch on "Debug System" and set "Error Reporting" to "Maximum" to be sure to get notice of any PHP or SQL errors.

3. Update to the latest 4.0 nightly build.

4. Check the admin control panel.

Result: See section "Actual result BEFORE applying this Pull Request" below. The modules look weird.

5. Using a tool like e.g. phpMyAdmin or phpPgAdmin (depending on your database type), export the content of table `#__modules` (Replace `#__` by your table prefix).

6. Update to the update package built by Drone for this PR.

7. Check again the admin control panel.

Result: See section "Expected result AFTER applying this Pull Request" below. The modules look as they should.

8. Export again the content of table `#__modules` into a different file than the one used in step 5.

9. Compare the file created in step 8 with the one created in step 5, and compare the differences you can see with the differences shown in PR #33045 for the `base.sql` file for your database type..

Result:
- The records of table `#__modules` which have been modified in file `base.sql` with PR #33045 have also been modified when updating to the update package of this PR.
- Other records of table `#__modules` have not been modified during the update.
- The JSON changes done by the update are the same as shown for the `base.sql` file in PR #33045 .
- In addition, the JSON properties are alphabetically sorted and code-styled in the updated records.
This can't be avoided when using JSON functions for the update.
But only the `bootstrap_size` and the `header_tag` properties have been changed or have been added where missing in the same way as in the `base.sql` file in PR #33045 for new installations.
All other properties remain unchanged.

### Actual result BEFORE applying this Pull Request

See issue #33314.

After updating a Joomla 4.0 Beta 7 (or previous 4.0 Beta) to latest nightly build:

![grafik](https://user-images.githubusercontent.com/9153168/116002380-c413be00-a5f9-11eb-83af-f770e0ecf797.png)

### Expected result AFTER applying this Pull Request

After updating a Joomla 4.0 Beta 7 (or previous 4.0 Beta) to the update package built by drone for this PR, the admin dashboard looks the same as after a new installation of current 4.0-dev or latest nightly without this PR applied.

![2021-04-27_2](https://user-images.githubusercontent.com/7413183/116261973-72457200-a778-11eb-81c2-c3db7eb54c8e.png)

### Documentation Changes Required

None.