### PR TITLE
[4.0] Remove users dropdown in fields and field-groups

### DIFF
--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -54,7 +54,7 @@ if ($saveOrder && !empty($this->items))
 	<div class="row">
 		<div class="col-md-12">
 			<div id="j-main-container" class="j-main-container">
-				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'context'))); ?>
+				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
 						<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -49,7 +49,7 @@ $context = $this->escape($this->state->get('filter.context'));
 	<div class="row">
 		<div class="col-md-12">
 			<div id="j-main-container" class="j-main-container">
-				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'context'))); ?>
+				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
 						<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>


### PR DESCRIPTION
Pull Request for Issue #33368.

### Summary of Changes
Just remove the `context` in `joomla.searchtools.default`

### Testing Instructions
`Admin` > `Users` > `Fields` & `Admin` > `Users` > `Field Groups`

### Actual result BEFORE applying this Pull Request
Users dropdown present

![fields-before](https://user-images.githubusercontent.com/61203226/116246880-f9e6ad00-a787-11eb-89c5-56a5edccb712.JPG)
![field-groups-before](https://user-images.githubusercontent.com/61203226/116246897-fce19d80-a787-11eb-810b-f462c335c5fe.JPG)

### Expected result AFTER applying this Pull Request

![fields-after](https://user-images.githubusercontent.com/61203226/116246922-0539d880-a788-11eb-9455-731601769f2e.JPG)

![field-groups-after](https://user-images.githubusercontent.com/61203226/116246945-09fe8c80-a788-11eb-940f-847df55572fe.JPG)

### Documentation Changes Required
None
