### PR TITLE
[4.0] Remove users dropdown in fields and field-groups

### DIFF
--- a/administrator/components/com_fields/src/Field/FieldcontextsField.php
+++ b/administrator/components/com_fields/src/Field/FieldcontextsField.php
@@ -57,7 +57,10 @@ class FieldcontextsField extends ListField
 
 		if ($component instanceof FieldsServiceInterface)
 		{
-			return $component->getContexts();
+				if (count($component->getContexts()) > 1)
+				{
+					return $component->getContexts();
+				}
 		}
 
 		return [];

--- a/administrator/components/com_fields/src/Field/FieldcontextsField.php
+++ b/administrator/components/com_fields/src/Field/FieldcontextsField.php
@@ -57,7 +57,7 @@ class FieldcontextsField extends ListField
 
 		if ($component instanceof FieldsServiceInterface)
 		{
-			if (count($component->getContexts()) > 1)
+			if (\count($component->getContexts()) > 1)
 			{
 				return $component->getContexts();
 			}

--- a/administrator/components/com_fields/src/Field/FieldcontextsField.php
+++ b/administrator/components/com_fields/src/Field/FieldcontextsField.php
@@ -57,10 +57,10 @@ class FieldcontextsField extends ListField
 
 		if ($component instanceof FieldsServiceInterface)
 		{
-				if (count($component->getContexts()) > 1)
-				{
-					return $component->getContexts();
-				}
+			if (count($component->getContexts()) > 1)
+			{
+				return $component->getContexts();
+			}
 		}
 
 		return [];


### PR DESCRIPTION
Pull Request for Issue #33368.

### Summary of Changes
```php
if (count($component->getContexts()) > 1)
{
	return $component->getContexts();
}
```
### Testing Instructions
`Admin` > `Users` > `Fields` & `Admin` > `Users` > `Field Groups`

### Actual result BEFORE applying this Pull Request
Users dropdown present

![fields-before](https://user-images.githubusercontent.com/61203226/116246880-f9e6ad00-a787-11eb-89c5-56a5edccb712.JPG)
![field-groups-before](https://user-images.githubusercontent.com/61203226/116246897-fce19d80-a787-11eb-810b-f462c335c5fe.JPG)

### Expected result AFTER applying this Pull Request
Users dropdown absent

![fields-after](https://user-images.githubusercontent.com/61203226/116246922-0539d880-a788-11eb-9455-731601769f2e.JPG)

![field-groups-after](https://user-images.githubusercontent.com/61203226/116246945-09fe8c80-a788-11eb-940f-847df55572fe.JPG)

### Documentation Changes Required
None
