### PR TITLE
[4.0] Field context selector only if there are more than one contexts

### DIFF
--- a/administrator/components/com_fields/src/Field/FieldcontextsField.php
+++ b/administrator/components/com_fields/src/Field/FieldcontextsField.php
@@ -57,9 +57,9 @@ class FieldcontextsField extends ListField
 
 		if ($component instanceof FieldsServiceInterface)
 		{
-			return $component->getContexts();
+			$contexts = $component->getContexts();
 		}
 
-		return [];
+		return count($contexts) > 1 ? $contexts : [];
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #33368 .

### Summary of Changes
As title says.


### Testing Instructions
Apply the patch and check that in all components the field context selector appears only if there are at least 2 options.


### Actual result BEFORE applying this Pull Request
Fields overview in com_users has a context selector with only one option.


### Expected result AFTER applying this Pull Request
Fields overview in com_users has no context_selector


### Documentation Changes Required

