### PR TITLE
[4.0] Add update SQL script for admin modules parameters changed by PR #33045

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-04-27.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-04-27.sql
@@ -1,0 +1,57 @@
+UPDATE `#__modules`
+   SET `params` = REPLACE(`params`,'"bootstrap_size":"6"','"bootstrap_size":"12"')
+ WHERE `client_id` = 1
+   AND `module`
+    IN (
+       'mod_latest',
+       'mod_latestactions',
+       'mod_logged',
+       'mod_popular',
+       'mod_privacy_dashboard',
+       'mod_privacy_status',
+       'mod_quickicon',
+       'mod_sampledata',
+       'mod_submenu'
+       )
+   AND `position`
+    IN (
+       'cpanel',
+       'cpanel-components',
+       'cpanel-content',
+       'cpanel-help',
+       'cpanel-menus',
+       'cpanel-privacy',
+       'cpanel-system',
+       'cpanel-users',
+       'icon'
+       )
+   AND `params` LIKE '{%"bootstrap_size":"6"%}';
+
+UPDATE `#__modules`
+   SET `params` = REPLACE(`params`,'"header_tag":"h3"','"header_tag":"h2"')
+ WHERE `client_id` = 1
+   AND `module`
+    IN (
+       'mod_latest',
+       'mod_latestactions',
+       'mod_logged',
+       'mod_popular',
+       'mod_privacy_dashboard',
+       'mod_privacy_status',
+       'mod_quickicon',
+       'mod_sampledata',
+       'mod_submenu'
+       )
+   AND `position`
+    IN (
+       'cpanel',
+       'cpanel-components',
+       'cpanel-content',
+       'cpanel-help',
+       'cpanel-menus',
+       'cpanel-privacy',
+       'cpanel-system',
+       'cpanel-users',
+       'icon'
+       )
+   AND `params` LIKE '{%"header_tag":"h3"%}';

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-04-27.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-04-27.sql
@@ -28,6 +28,35 @@ UPDATE `#__modules`
    AND `params` LIKE '{%"bootstrap_size":"6"%}';
 
 UPDATE `#__modules`
+   SET `params` = REPLACE(`params`,'"bootstrap_size": "6"','"bootstrap_size":"12"')
+ WHERE `client_id` = 1
+   AND `module`
+    IN (
+       'mod_latest',
+       'mod_latestactions',
+       'mod_logged',
+       'mod_popular',
+       'mod_privacy_dashboard',
+       'mod_privacy_status',
+       'mod_quickicon',
+       'mod_sampledata',
+       'mod_submenu'
+       )
+   AND `position`
+    IN (
+       'cpanel',
+       'cpanel-components',
+       'cpanel-content',
+       'cpanel-help',
+       'cpanel-menus',
+       'cpanel-privacy',
+       'cpanel-system',
+       'cpanel-users',
+       'icon'
+       )
+   AND `params` LIKE '{%"bootstrap_size": "6"%}';
+
+UPDATE `#__modules`
    SET `params` = REPLACE(`params`,'"header_tag":"h3"','"header_tag":"h2"')
  WHERE `client_id` = 1
    AND `module`

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-04-27.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-04-27.sql
@@ -28,6 +28,35 @@ UPDATE "#__modules"
    AND "params" LIKE '{%"bootstrap_size":"6"%}';
 
 UPDATE "#__modules"
+   SET "params" = REPLACE("params",'"bootstrap_size": "6"','"bootstrap_size":"12"')
+ WHERE "client_id" = 1
+   AND "module"
+    IN (
+       'mod_latest',
+       'mod_latestactions',
+       'mod_logged',
+       'mod_popular',
+       'mod_privacy_dashboard',
+       'mod_privacy_status',
+       'mod_quickicon',
+       'mod_sampledata',
+       'mod_submenu'
+       )
+   AND "position"
+    IN (
+       'cpanel',
+       'cpanel-components',
+       'cpanel-content',
+       'cpanel-help',
+       'cpanel-menus',
+       'cpanel-privacy',
+       'cpanel-system',
+       'cpanel-users',
+       'icon'
+       )
+   AND "params" LIKE '{%"bootstrap_size": "6"%}';
+
+UPDATE "#__modules"
    SET "params" = REPLACE("params",'"header_tag":"h3"','"header_tag":"h2"')
  WHERE "client_id" = 1
    AND "module"

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-04-27.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-04-27.sql
@@ -1,0 +1,57 @@
+UPDATE "#__modules"
+   SET "params" = REPLACE("params",'"bootstrap_size":"6"','"bootstrap_size":"12"')
+ WHERE "client_id" = 1
+   AND "module"
+    IN (
+       'mod_latest',
+       'mod_latestactions',
+       'mod_logged',
+       'mod_popular',
+       'mod_privacy_dashboard',
+       'mod_privacy_status',
+       'mod_quickicon',
+       'mod_sampledata',
+       'mod_submenu'
+       )
+   AND "position"
+    IN (
+       'cpanel',
+       'cpanel-components',
+       'cpanel-content',
+       'cpanel-help',
+       'cpanel-menus',
+       'cpanel-privacy',
+       'cpanel-system',
+       'cpanel-users',
+       'icon'
+       )
+   AND "params" LIKE '{%"bootstrap_size":"6"%}';
+
+UPDATE "#__modules"
+   SET "params" = REPLACE("params",'"header_tag":"h3"','"header_tag":"h2"')
+ WHERE "client_id" = 1
+   AND "module"
+    IN (
+       'mod_latest',
+       'mod_latestactions',
+       'mod_logged',
+       'mod_popular',
+       'mod_privacy_dashboard',
+       'mod_privacy_status',
+       'mod_quickicon',
+       'mod_sampledata',
+       'mod_submenu'
+       )
+   AND "position"
+    IN (
+       'cpanel',
+       'cpanel-components',
+       'cpanel-content',
+       'cpanel-help',
+       'cpanel-menus',
+       'cpanel-privacy',
+       'cpanel-system',
+       'cpanel-users',
+       'icon'
+       )
+   AND "params" LIKE '{%"header_tag":"h3"%}';


### PR DESCRIPTION
Pull Request for Issue #33314 .

### Summary of Changes

This pull request (PR) adds an update SQL script (one for each db type) to fix the bootstrap size and header tag parameters of those admin modules touched by PR #33045 when updating from 4.0 Beta 7 or a previous 4.0 Beta.

The `WHERE` clause of the update statement is made as precise as possible in order to really make sure to update only the desired modules.

### Testing Instructions

#### Requirements

This PR needs to be tested for all supported database types (MySQL, MariaDB and PostgreSQL). In case of MySQL or MariaDB, if you can use both the "MySQLi" and the "MySQL (PDO)" database driver, test with both.

All testers please report back which database and driver types you have tested so it can be properly recorded.

The PR cannot be tested with patchtester because it needs to test database updates. It has to be tested as described below with use of update packages or custom update URL's.

1. Have an installation of Joomla 4.0 Beta 7 or earlier (but not before Beta 4) with clean admin control panel modules, i.e. you haven't modified them, or make a new installation of 4.0 Beta 7 if you don't have that.

2. In Global Configuration, switch on "Debug System" and set "Error Reporting" to "Maximum" to be sure to get notice of any PHP or SQL errors.

3. Update to the latest 4.0 nightly build.

4. Check the admin dashboard and other dashboards (users, privary, ...).

Result: See section "Actual result BEFORE applying this Pull Request" below. The modules look weird.

5. Using a tool like e.g. phpMyAdmin or phpPgAdmin (depending on your database type), export the content of table `#__modules` (Replace `#__` by your table prefix).

6. Update to the update package built by Drone for this PR.

7. Check again the admin dashboard and other dashboards (users, privary, ...).

Result: See section "Expected result AFTER applying this Pull Request" below. The modules look as they should.

8. Export again the content of table `#__modules` into a different file than the one used in step 5.

9. Compare the file created in step 8 with the one created in step 5, and compare the differences you can see with the differences shown in PR #33045 for the `base.sql` file for your database type..

Result:
- The bootstrap size parameter has been changed from "6" to "12" and the header tag parameter has been changed from "h3" to "h2" wherever the particular parameter is present among the records of table `#__modules` which have been modified in file `base.sql` with PR #33045.
- Other records of table `#__modules` have not been modified during the update.
- In opposite to what PR #33045 does for the base.sql` file, this PR here doesn't add the bootstrap size or the header tag parameter when it is missing.

### Actual result BEFORE applying this Pull Request

See issue #33314.

After updating a Joomla 4.0 Beta 7 (or previous 4.0 Beta) to latest nightly build:

![grafik](https://user-images.githubusercontent.com/9153168/116002380-c413be00-a5f9-11eb-83af-f770e0ecf797.png)

### Expected result AFTER applying this Pull Request

After updating a Joomla 4.0 Beta 7 (or previous 4.0 Beta) to the update package built by drone for this PR, the admin dashboard looks the same as after a new installation of current 4.0-dev or latest nightly without this PR applied.

![2021-04-27_2](https://user-images.githubusercontent.com/7413183/116261973-72457200-a778-11eb-81c2-c3db7eb54c8e.png)

### Documentation Changes Required

None.