### PR TITLE
[4.0] Field contexts filter improvement

### DIFF
--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -54,7 +54,7 @@ $searchToolsOptions = [];
 // Only show field contexts filter if there are more than one option
 if (count($this->filterForm->getField('context')->options) > 1)
 {
-    $searchToolsOptions['selectorFieldName'] = 'context';
+	$searchToolsOptions['selectorFieldName'] = 'context';
 }
 ?>
 

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -48,13 +48,21 @@ if ($saveOrder && !empty($this->items))
 	$saveOrderingUrl = 'index.php?option=com_fields&task=fields.saveOrderAjax&tmpl=component&' . Session::getFormToken() . '=1';
 	HTMLHelper::_('draggablelist.draggable');
 }
+
+$searchToolsOptions = [];
+
+// Only show field contexts filter if there are more than one option
+if (count($this->filterForm->getField('context')->options) > 1)
+{
+    $searchToolsOptions['selectorFieldName'] = 'context';
+}
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_fields&view=fields&context=' . $this->state->get('filter.context')); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">
 		<div class="col-md-12">
 			<div id="j-main-container" class="j-main-container">
-				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'context'))); ?>
+				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => $searchToolsOptions)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
 						<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -43,13 +43,21 @@ if ($saveOrder && !empty($this->items))
 }
 
 $context = $this->escape($this->state->get('filter.context'));
+
+$searchToolsOptions = [];
+
+// Only show field contexts filter if there are more than one option
+if (count($this->filterForm->getField('context')->options) > 1)
+{
+	$searchToolsOptions['selectorFieldName'] = 'context';
+}
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_fields&view=groups&context=' . $context); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">
 		<div class="col-md-12">
 			<div id="j-main-container" class="j-main-container">
-				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => array('selectorFieldName' => 'context'))); ?>
+				<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this, 'options' => $searchToolsOptions)); ?>
 				<?php if (empty($this->items)) : ?>
 					<div class="alert alert-info">
 						<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>


### PR DESCRIPTION
Pull Request for Issue #33368, alternative for #33372

### Summary of Changes
This PR modifies code so that the field contexts filter will only be displayed if there are more than one option. Compare to #33372, it also remove the unnecessary mark up, so it is a bit better.


### Testing Instructions
1. Apply patch
2. Go to Content -> Fields, Content -> Field Groups, make sure you still see contexts filter (contains Articles, Category).
3. Go to Users -> Fields, Users -> Field Groups, make sure you do not see the filter anymore (before, the filter only contains on option Users ,so it is useless)
4. Go to Users -> Fields, view source of the page, make sure you don't see the useless mark up which @Quy mentioned here https://github.com/joomla/joomla-cms/pull/33372#issuecomment-828122661