### PR TITLE
[4.0] Edit User: Make the forms uniform

### DIFF
--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -37,16 +37,15 @@ $this->useCoreUI = true;
 	<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
 		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('COM_USERS_USER_ACCOUNT_DETAILS')); ?>
-			<div class="card">
-				<div class="card-body">
-					<div class="row">
-						<div class="form-grid">
-						<?php echo $this->form->renderFieldset('user_details'); ?>
-						</div>
-					</div>
+			<fieldset class="options-form">
+				<legend><?php echo Text::_('COM_USERS_USER_ACCOUNT_DETAILS'); ?></legend>
+				<div class="form-grid">
+					<?php echo $this->form->renderFieldset('user_details'); ?>
 				</div>
-			</div>
+			</fieldset>
+
 		<?php echo HTMLHelper::_('uitab.endTab'); ?>
+	
 		<?php if ($this->grouplist) : ?>
 			<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'groups', Text::_('COM_USERS_ASSIGNED_GROUPS')); ?>
 				<fieldset id="fieldset-groups" class="options-form">
@@ -64,49 +63,52 @@ $this->useCoreUI = true;
 		?>
 
 	<?php if (!empty($this->tfaform) && $this->item->id) : ?>
-	<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'twofactorauth', Text::_('COM_USERS_USER_TWO_FACTOR_AUTH')); ?>
-	<div class="control-group">
-		<div class="control-label">
-			<label id="jform_twofactor_method-lbl" for="jform_twofactor_method">
-				<?php echo Text::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
-			</label>
-		</div>
-		<div class="controls">
-			<?php echo HTMLHelper::_('select.genericlist', UsersHelper::getTwoFactorMethods(), 'jform[twofactor][method]', array('onchange' => 'Joomla.twoFactorMethodChange();', 'class' => 'form-select'), 'value', 'text', $this->otpConfig->method, 'jform_twofactor_method', false); ?>
-		</div>
-	</div>
-	<div id="com_users_twofactor_forms_container">
-		<?php foreach ($this->tfaform as $form) : ?>
-			<?php $class = $form['method'] == $this->otpConfig->method ? '' : ' class="hidden"'; ?>
-			<div id="com_users_twofactor_<?php echo $form['method'] ?>"<?php echo $class; ?>>
-				<?php echo $form['form'] ?>
-			</div>
-		<?php endforeach; ?>
-	</div>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'twofactorauth', Text::_('COM_USERS_USER_TWO_FACTOR_AUTH')); ?>
+			<fieldset class="options-form">
+				<legend><?php echo Text::_('COM_USERS_USER_TWO_FACTOR_AUTH'); ?></legend>
+				<div class="control-group">
+					<div class="control-label">
+						<label id="jform_twofactor_method-lbl" for="jform_twofactor_method">
+							<?php echo Text::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
+						</label>
+					</div>
+					<div class="controls">
+						<?php echo HTMLHelper::_('select.genericlist', UsersHelper::getTwoFactorMethods(), 'jform[twofactor][method]', array('onchange' => 'Joomla.twoFactorMethodChange();', 'class' => 'form-select'), 'value', 'text', $this->otpConfig->method, 'jform_twofactor_method', false); ?>
+					</div>
+				</div>
+				<div id="com_users_twofactor_forms_container">
+					<?php foreach ($this->tfaform as $form) : ?>
+						<?php $class = $form['method'] == $this->otpConfig->method ? '' : ' class="hidden"'; ?>
+						<div id="com_users_twofactor_<?php echo $form['method'] ?>"<?php echo $class; ?>>
+							<?php echo $form['form'] ?>
+						</div>
+					<?php endforeach; ?>
+				</div>
 
-	<fieldset>
-		<legend>
-			<?php echo Text::_('COM_USERS_USER_OTEPS'); ?>
-		</legend>
-		<div class="alert alert-info">
-			<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
-			<?php echo Text::_('COM_USERS_USER_OTEPS_DESC'); ?>
-		</div>
-		<?php if (empty($this->otpConfig->otep)) : ?>
-			<div class="alert alert-warning">
-				<span class="icon-exclamation-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('WARNING'); ?></span>
-				<?php echo Text::_('COM_USERS_USER_OTEPS_WAIT_DESC'); ?>
-			</div>
-		<?php else : ?>
-		<?php foreach ($this->otpConfig->otep as $otep) : ?>
-		<span class="col-lg-3">
-			<?php echo substr($otep, 0, 4); ?>-<?php echo substr($otep, 4, 4); ?>-<?php echo substr($otep, 8, 4); ?>-<?php echo substr($otep, 12, 4); ?>
-		</span>
-		<?php endforeach; ?>
-		<?php endif; ?>
-	</fieldset>
-
-	<?php echo HTMLHelper::_('uitab.endTab'); ?>
+				<fieldset>
+					<legend>
+						<?php echo Text::_('COM_USERS_USER_OTEPS'); ?>
+					</legend>
+					<div class="alert alert-info">
+						<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+						<?php echo Text::_('COM_USERS_USER_OTEPS_DESC'); ?>
+					</div>
+					<?php if (empty($this->otpConfig->otep)) : ?>
+						<div class="alert alert-warning">
+							<span class="icon-exclamation-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('WARNING'); ?></span>
+							<?php echo Text::_('COM_USERS_USER_OTEPS_WAIT_DESC'); ?>
+						</div>
+					<?php else : ?>
+						<?php foreach ($this->otpConfig->otep as $otep) : ?>
+							<span class="col-lg-3">
+								<?php echo substr($otep, 0, 4); ?>-<?php echo substr($otep, 4, 4); ?>-<?php echo substr($otep, 8, 4); ?>-<?php echo substr($otep, 12, 4); ?>
+							</span>
+						<?php endforeach; ?>
+					<?php endif; ?>
+				</fieldset>
+			</fieldset>
+			
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 	<?php endif; ?>
 
 	<?php echo HTMLHelper::_('uitab.endTabSet'); ?>


### PR DESCRIPTION
Pull Request for Issue #33378 

### Summary of Changes
Wrapped the form(s) for Account Details and Two Factor Authentication in `<fieldset  class="options-form"> <legend>`
Added indentations on line 66 after if block opens and after `uitab.addTab`  on lIne 67 to make the indentations consistent

### Testing Instructions
Joomla Admin Panel -> Users -> Manage -> Click on a user to edit their profile
Verify that all forms follow a uniform style (fieldset with legends)

Note: You will have to enable 2FA to check the Two Factor Authentication tab or you can comment the following lines https://github.com/joomla/joomla-cms/blob/2559e120d9ef0903b2d09bd820789ebed00fc8c8/administrator/components/com_users/tmpl/user/edit.php#L66
https://github.com/joomla/joomla-cms/blob/2559e120d9ef0903b2d09bd820789ebed00fc8c8/administrator/components/com_users/tmpl/user/edit.php#L110

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/116357121-c05e8200-a819-11eb-8b06-d9620d360014.png)
![image](https://user-images.githubusercontent.com/53610833/116357298-f865c500-a819-11eb-9c5a-2f2e5fb2e6d7.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/116356749-51812900-a819-11eb-9923-5d20a426550f.png)
![image](https://user-images.githubusercontent.com/53610833/116356757-52b25600-a819-11eb-8240-1c87a2dc6b2b.png)



### Documentation Changes Required
None
