### PR TITLE
[4.0] Set color for text and links in position topbar

### DIFF
--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -12,6 +12,12 @@
   position: relative;
 }
 
+.container-topbar {
+  color: $white;
+  a {
+    color: currentColor;
+  }
+}
 .container-header header .site {
   background-color: $gray-100;
 

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -18,6 +18,7 @@
     color: currentColor;
   }
 }
+
 .container-header header .site {
   background-color: $gray-100;
 


### PR DESCRIPTION
Pull Request for Issue #33388  .

### Summary of Changes
Defined color for content inside position topbar.


### Testing Instructions
Create a custom module in position topbar, with text and a link


### Actual result BEFORE applying this Pull Request
Text and link not discernible 


### Expected result AFTER applying this Pull Request
Text and link are white


### Documentation Changes Required

