### PR TITLE
[4] Fix calling startTabSet twice causes PHP Error

### DIFF
--- a/libraries/src/HTML/Helpers/Bootstrap.php
+++ b/libraries/src/HTML/Helpers/Bootstrap.php
@@ -809,25 +809,24 @@ HTMLSTR;
 	 */
 	public static function startTabSet($selector = 'myTab', $params = []) :string
 	{
-		$sig = md5(serialize([$selector, $params]));
-
-		if (!isset(static::$loaded[__METHOD__][$sig]))
+		if (isset(static::$loaded[__METHOD__][$selector]))
 		{
-			// Setup options object
-			$opt['active'] = (isset($params['active']) && ($params['active'])) ? (string) $params['active'] : '';
-
-			// Initialise with the Joomla specifics
-			$opt['isJoomla'] = true;
-
-			// Include the Bootstrap Tab Component
-			HTMLHelper::_('bootstrap.tab', '#' . preg_replace('/^[\.#]/', '', $selector), $opt);
-
-			// Set static array
-			static::$loaded[__METHOD__][$sig] = true;
-			static::$loaded[__METHOD__][$selector]['active'] = $opt['active'];
-
-			return LayoutHelper::render('libraries.html.bootstrap.tab.starttabset', ['selector' => $selector]);
+			return '';
 		}
+
+		// Setup options object
+		$opt['active'] = (isset($params['active']) && ($params['active'])) ? (string) $params['active'] : '';
+
+		// Initialise with the Joomla specifics
+		$opt['isJoomla'] = true;
+
+		// Include the Bootstrap Tab Component
+		HTMLHelper::_('bootstrap.tab', '#' . preg_replace('/^[\.#]/', '', $selector), $opt);
+
+		// Set static array
+		static::$loaded[__METHOD__][$selector]['active'] = $opt['active'];
+
+		return LayoutHelper::render('libraries.html.bootstrap.tab.starttabset', ['selector' => $selector]);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/33396

### Summary of Changes

 Fix calling startTabSet twice causes PHP Error

### Testing Instructions

Run startTabSet twice with the same input params

```
\Joomla\CMS\HTML\Helpers\Bootstrap::startTabSet('asd', []);
\Joomla\CMS\HTML\Helpers\Bootstrap::startTabSet('asd', []);

```

### Actual result BEFORE applying this Pull Request

<img width="1061" alt="Screenshot 2021-04-28 at 21 22 35" src="https://user-images.githubusercontent.com/400092/116467691-df840080-a867-11eb-892a-9eed554dc4e4.png">


### Expected result AFTER applying this Pull Request

One set of output:

```html
<ul class="joomla-tabs nav nav-tabs" id="asdTabs" role="tablist"></ul>
<div class="tab-content" id="asdContent">
```

### Documentation Changes Required

none