### PR TITLE
[4.0] Empty Trash Button

### DIFF
--- a/administrator/components/com_contact/src/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contacts/HtmlView.php
@@ -197,14 +197,14 @@ class HtmlView extends BaseHtmlView
 					->selector('collapseModal')
 					->listCheck(true);
 			}
+		}
 
-			if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
-			{
-				$childBar->delete('contacts.delete')
-					->text('JTOOLBAR_EMPTY_TRASH')
-					->message('JGLOBAL_CONFIRM_DELETE')
-					->listCheck(true);
-			}
+		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
+		{
+			$toolbar->delete('contacts.delete')
+				->text('JTOOLBAR_EMPTY_TRASH')
+				->message('JGLOBAL_CONFIRM_DELETE')
+				->listCheck(true);
 		}
 
 		if ($user->authorise('core.admin', 'com_contact') || $user->authorise('core.options', 'com_contact'))

--- a/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
@@ -170,14 +170,14 @@ class HtmlView extends BaseHtmlView
 					->selector('collapseModal')
 					->listCheck(true);
 			}
+		}
 
-			if ($state->get('filter.published') == -2 && $canDo->get('core.delete'))
-			{
-				$childBar->delete('newsfeeds.delete')
-					->text('JTOOLBAR_EMPTY_TRASH')
-					->message('JGLOBAL_CONFIRM_DELETE')
-					->listCheck(true);
-			}
+		if ($state->get('filter.published') == -2 && $canDo->get('core.delete'))
+		{
+			$toolbar->delete('newsfeeds.delete')
+				->text('JTOOLBAR_EMPTY_TRASH')
+				->message('JGLOBAL_CONFIRM_DELETE')
+				->listCheck(true);
 		}
 
 		if ($user->authorise('core.admin', 'com_newsfeeds') || $user->authorise('core.options', 'com_newsfeeds'))

--- a/administrator/components/com_redirect/src/View/Links/HtmlView.php
+++ b/administrator/components/com_redirect/src/View/Links/HtmlView.php
@@ -184,14 +184,14 @@ class HtmlView extends BaseHtmlView
 			{
 				$childBar->trash('links.trash')->listCheck(true);
 			}
+		}
 
-			if ($canDo->get('core.delete'))
-			{
-				$childBar->delete('links.delete')
-					->text('JTOOLBAR_EMPTY_TRASH')
-					->message('JGLOBAL_CONFIRM_DELETE')
-					->listCheck(true);
-			}
+		if ($state->get('filter.state') == -2 && $canDo->get('core.delete'))
+		{
+			$toolbar->delete('links.delete')
+				->text('JTOOLBAR_EMPTY_TRASH')
+				->message('JGLOBAL_CONFIRM_DELETE')
+				->listCheck(true);
 		}
 
 		if (!$state->get('filter.state') == -2 && $canDo->get('core.delete'))

--- a/administrator/components/com_tags/src/View/Tags/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tags/HtmlView.php
@@ -165,14 +165,14 @@ class HtmlView extends BaseHtmlView
 					->selector('collapseModal')
 					->listCheck(true);
 			}
+		}
 
-			if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
-			{
-				$childBar->delete('tags.delete')
-					->text('JTOOLBAR_EMPTY_TRASH')
-					->message('JGLOBAL_CONFIRM_DELETE')
-					->listCheck(true);
-			}
+		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
+		{
+			$toolbar->delete('tags.delete')
+				->text('JTOOLBAR_EMPTY_TRASH')
+				->message('JGLOBAL_CONFIRM_DELETE')
+				->listCheck(true);
 		}
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))


### PR DESCRIPTION
When you have filtered your items by the trashed status in most components there is an empty trash button on the toolbar. However for contacts, newsfeeds, redirects and tags the button is in the actions dropdown.

For a consistent UI they should all be the same. If a user is familiar with the other components that have a button they might not look in the dropdown and assume they cant empty trash for this component

To test apply the pr
filter a component by trashed and observe the button

### Before
![image](https://user-images.githubusercontent.com/1296369/116512040-50a2d280-a8bf-11eb-812d-2b5e3c89bc71.png)

###After
![image](https://user-images.githubusercontent.com/1296369/116511955-2b15c900-a8bf-11eb-91fe-4ae4e58ae5a9.png)
