### PR TITLE
[4.0] Add toolbar.scss in Cassiopeia

### DIFF
--- a/templates/cassiopeia/scss/blocks/_toolbar.scss
+++ b/templates/cassiopeia/scss/blocks/_toolbar.scss
@@ -1,0 +1,217 @@
+.subhead {
+  position: sticky;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: $zindex-toolbar;
+  width: auto;
+  min-height: 43px;
+  padding: 10px 0;
+  color: #495057; //#0c192e;
+  background: $white;
+  box-shadow: -3px -2px 22px #ddd;
+
+  .row {
+    margin-right: 0;
+    margin-left: 0;
+  }
+
+  &.noshadow {
+    box-shadow: none;
+  }
+
+  joomla-toolbar-button,
+  .btn-group {
+    margin-inline-start: .75rem;
+
+    &:first-child {
+      margin-inline-start: 0;
+    }
+  }
+
+  joomla-toolbar-button {
+
+    .btn > span,
+    .dropdown-item > span {
+      margin-inline-end: .5rem;
+      width: 1.25em;
+      text-align: center;
+    }
+  }
+
+  .btn {
+    --subhead-btn-accent: #495057;
+    padding: 0 1rem;
+    margin: 5px 0;
+    font-size: 1rem;
+    line-height: 2.45rem;
+    color: #495057;
+    background: $white;
+    border-color: $gray-500;
+
+    > span {
+      display: inline-block;
+      color: var(--subhead-btn-accent);
+    }
+
+    &:not([disabled]):hover,
+    &:not([disabled]):active,
+    &:not([disabled]):focus {
+      color: rgba(255, 255, 255, .9);
+      background-color: var(--subhead-btn-accent);
+      border-color: var(--subhead-btn-accent);
+
+      > span {
+        color: rgba(255, 255, 255, .9);
+      }
+    }
+
+    &.btn-success {
+      --subhead-btn-accent: var(--success);
+    }
+
+    &.btn-danger {
+      --subhead-btn-accent: var(--danger);
+    }
+
+    &.btn-primary {
+      --subhead-btn-accent: #2a69b8;
+    }
+
+    &.btn-secondary {
+      --subhead-btn-accent: #001b4c;
+    }
+
+    &.btn-info {
+      --subhead-btn-accent: #132f53;
+    }
+
+    &.btn-action {
+      --subhead-btn-accent: #132f53;
+      display: flex;
+      align-items: center;
+
+      &::after {
+        width: 2.375rem;
+        font-family: "Font Awesome 5 Free";
+        font-weight: 900;
+        content: "\f078";
+        border: 0;
+
+      }
+    }
+
+    &[disabled],
+    &.dropdown-toggle[disabled] {
+      --subhead-btn-accent: #132f53;
+      background: rgba($gray-300, .8);
+      opacity: .5;
+
+      &:hover,
+      &:active,
+      &:focus {
+        cursor: not-allowed;
+      }
+    }
+  }
+
+  .dropdown-toggle {
+    &.btn {
+      padding-inline-end: 0;
+    }
+  }
+
+  .btn-group:not(:last-child) > .dropdown-toggle-split {
+    order: 1;
+    margin-inline-start: -$border-radius;
+
+    [dir="ltr"] & {
+      border-radius: 0 $border-radius $border-radius 0;
+    }
+
+    [dir="rtl"] & {
+      border-radius: $border-radius 0 0 $border-radius;
+    }
+  }
+
+  .dropdown-menu joomla-toolbar-button,
+  .btn-group joomla-toolbar-button {
+    margin-inline-start: 0;
+  }
+}
+
+@include media-breakpoint-down(sm) {
+  joomla-tab[view=accordion] .col-md-9,
+  joomla-tab[view=accordion] .col-md-3 {
+    padding: .5rem 1rem !important;
+  }
+
+  #myTab {
+    margin-top: 1rem;
+    margin-bottom: 1.5rem;
+  }
+
+  joomla-tab[view=accordion] ul li {
+    width: 100%;
+  }
+
+  .toggler-toolbar {
+    top: 4px;
+    z-index: $zindex-alerts;
+    width: 50px;
+    height: 50px;
+    border: 4px solid #f0f4fb;
+
+    [dir=ltr] & {
+      right: 4px;
+    }
+
+    [dir=rtl] & {
+      left: 4px;
+    }
+
+    .toggler-toolbar-icon::before {
+      font: normal normal 900 20px/1 "Font Awesome 5 Free";
+      color: $white;
+      content: "\f00d";
+    }
+
+    &.collapsed .toggler-toolbar-icon::before {
+      display: inline-block;
+      content: "\f085";
+      transform: translate(-4px);
+    }
+  }
+
+  .subhead {
+
+    joomla-toolbar-button,
+    .btn-group,
+    .btn {
+      width: 100%;
+      margin-left: 0;
+      text-align: left;
+    }
+
+    .btn-toolbar > .btn-group,
+    .btn-toolbar > joomla-toolbar-button {
+      margin-left: 0;
+    }
+
+    .btn.btn-action::after {
+      text-align: center;
+      margin-inline-start: auto;
+    }
+
+    .dropdown-toggle-split {
+      width: auto;
+    }
+  }
+}
+
+// In Microsoft Edge, sticky positioning doesn't work when combined with dir "rtl" attribute
+@supports (-ms-ime-align: auto) {
+  [dir=rtl] .subhead {
+    position: relative;
+  }
+}

--- a/templates/cassiopeia/scss/template.scss
+++ b/templates/cassiopeia/scss/template.scss
@@ -26,6 +26,7 @@
 @import "blocks/modals";
 @import "blocks/modifiers";
 @import "blocks/utilities";
+@import "blocks/toolbar";
 @import "blocks/legacy";
 @import "blocks/tags";
 @import "blocks/css-grid"; // Last to allow fallback


### PR DESCRIPTION
Pull Request for Issue #33392.

### Summary of Changes
Replicate `Atum` toolbar in `Cassiopeia`

### Testing Instructions
* Log In to the frontend
* Go to Template Setting in Author Menu module or Visit `http://localhost/joomla-cms/index.php/create-a-post/template-settings`
* Click `Select`
* Apply PR
* Do `npm run build:css`
* Refresh the page and Click `Select`
* See the difference

### Actual result BEFORE applying this Pull Request
`subhead noshadow` missing `CSS`

![before-subhead](https://user-images.githubusercontent.com/61203226/116517973-51525d80-a8ed-11eb-9684-eff350bb0307.JPG)

### Expected result AFTER applying this Pull Request
Added `CSS` in `subhead noshadow`

![after-subhead](https://user-images.githubusercontent.com/61203226/116517987-54e5e480-a8ed-11eb-9ca2-75266b879ec1.JPG)

### Documentation Changes Required
None
