### PR TITLE
[4] Allow newsfeed creation if no categories

### DIFF
--- a/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
@@ -130,7 +130,7 @@ class HtmlView extends BaseHtmlView
 
 		ToolbarHelper::title(Text::_('COM_NEWSFEEDS_MANAGER_NEWSFEEDS'), 'rss newsfeeds');
 
-		if (count($user->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0)
+		if ($canDo->get('core.create') || count($user->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0)
 		{
 			$toolbar->addNew('newsfeed.add');
 		}

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/emptystate.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/emptystate.php
@@ -19,7 +19,9 @@ $displayData = [
 	'icon'       => 'icon-rss newsfeeds',
 ];
 
-if (count(Factory::getApplication()->getIdentity()->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0)
+$user = Factory::getApplication()->getIdentity();
+
+if ($user->authorise('core.create', 'com_newsfeeds') || count($user->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0)
 {
 	$displayData['createURL'] = 'index.php?option=com_newsfeeds&task=newsfeed.add';
 }


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/33380#issuecomment-828825545

### Summary of Changes

Allow newsfeed creation if there are no newsfeed categories. 

### Testing Instructions

Delete all your newsfeed categories.
Note you cannot create any newsfeed as the NEW toolbar button doesn't show

### Actual result BEFORE applying this Pull Request

Note you cannot create any newsfeed as the NEW toolbar button doesn't show

### Expected result AFTER applying this Pull Request

You can click NEW to create a new newsfeed, and a new Uncategorised category is created on the fly when you save it. 

### Documentation Changes Required

None. 