### PR TITLE
[4.0] Sample Data focus ring

### DIFF
--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -22,7 +22,7 @@ Text::script('MOD_SAMPLEDATA_INVALID_RESPONSE');
 $app->getDocument()->addScriptOptions(
 	'sample-data',
 	[
-		'icon' => Uri::root(true) . '/media/system/images/ajax-loader.gif'
+		'icon' => Uri::root(true) . '/media/system/images/ajax-loader.gif',
 	]
 );
 ?>
@@ -54,7 +54,7 @@ $app->getDocument()->addScriptOptions(
 			</li>
 		<?php endforeach; ?>
 	</ul>
-	<a href="index.php?option=com_plugins&filter[folder]=sampledata" class="btn btn-secondary btn-sm manage-sample-data float-end me-3 mb-3">
+	<a href="index.php?option=com_plugins&filter[folder]=sampledata" class="btn btn-secondary btn-sm manage-sample-data float-end mt-1 me-3 mb-3">
 		<span class="icon-tasks" aria-hidden="true"></span> <?php echo Text::_('MOD_SAMPLEDATA_MANAGE_SAMPLEDATA'); ?>
 	</a>
 <?php endif; ?>


### PR DESCRIPTION
Adds some margin so that the entire focus ring is visible. (Usually seen when you navigate using the keyboard)

### Before
![image](https://user-images.githubusercontent.com/1296369/116547610-08010e80-a8eb-11eb-842a-f2e3955b2963.png)

### After
![image](https://user-images.githubusercontent.com/1296369/116547621-0afbff00-a8eb-11eb-8b00-a874d7b4ad3e.png)
