### PR TITLE
[4] Silently return early if this method has already been called for the given selector

### DIFF
--- a/libraries/src/HTML/Helpers/Bootstrap.php
+++ b/libraries/src/HTML/Helpers/Bootstrap.php
@@ -811,23 +811,26 @@ HTMLSTR;
 	{
 		$sig = md5(serialize([$selector, $params]));
 
-		if (!isset(static::$loaded[__METHOD__][$sig]))
+		if (isset(static::$loaded[__METHOD__][$sig]))
 		{
-			// Setup options object
-			$opt['active'] = (isset($params['active']) && ($params['active'])) ? (string) $params['active'] : '';
-
-			// Initialise with the Joomla specifics
-			$opt['isJoomla'] = true;
-
-			// Include the Bootstrap Tab Component
-			HTMLHelper::_('bootstrap.tab', '#' . preg_replace('/^[\.#]/', '', $selector), $opt);
-
-			// Set static array
-			static::$loaded[__METHOD__][$sig] = true;
-			static::$loaded[__METHOD__][$selector]['active'] = $opt['active'];
-
-			return LayoutHelper::render('libraries.html.bootstrap.tab.starttabset', ['selector' => $selector]);
+			// Silently return early if this method has already been called for the given selector
+			return '';
 		}
+
+		// Setup options object
+		$opt['active'] = (isset($params['active']) && ($params['active'])) ? (string) $params['active'] : '';
+
+		// Initialise with the Joomla specifics
+		$opt['isJoomla'] = true;
+
+		// Include the Bootstrap Tab Component
+		HTMLHelper::_('bootstrap.tab', '#' . preg_replace('/^[\.#]/', '', $selector), $opt);
+
+		// Set static array
+		static::$loaded[__METHOD__][$sig] = true;
+		static::$loaded[__METHOD__][$selector]['active'] = $opt['active'];
+
+		return LayoutHelper::render('libraries.html.bootstrap.tab.starttabset', ['selector' => $selector]);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/33396 replacement for https://github.com/joomla/joomla-cms/pull/33397

@dgrammatiko @brainforgeuk

### Summary of Changes

Reemploying the same tactic that the `startAccordion` [method uses to return early](https://github.com/joomla/joomla-cms/blob/7d02ff86b956064e1d12bc386f61ec28069c7633/libraries/src/HTML/Helpers/Bootstrap.php#L665) and ignore the fact that the method has been called incorrectly, with the same selector, twice by a developer. 

Prevents outputting a PHP error message. 

Please read the background here https://github.com/joomla/joomla-cms/pull/33397#issuecomment-829137212

For element ID's a safe strategy is to use a pattern like `company-product-specifier` which should guarantee uniqueness

### Testing Instructions

add the code below somewhere on a page you are looking at, refresh and see the error.

```php
\Joomla\CMS\HTML\Helpers\Bootstrap::startTabSet('asd', []);
\Joomla\CMS\HTML\Helpers\Bootstrap::startTabSet('asd', []);
```

### Actual result BEFORE applying this Pull Request

<img width="1037" alt="Screenshot 2021-04-29 at 17 57 14" src="https://user-images.githubusercontent.com/400092/116589240-5a0a5a00-a914-11eb-9633-8ea01fc4a539.png">


### Expected result AFTER applying this Pull Request

The page loads without a PHP error, albeit the developer still needs to fix their code as the second call to `startTabSet` doesn't actually do anything, but silently returns. 

This is by design, because of the history explained in the background here https://github.com/joomla/joomla-cms/pull/33397#issuecomment-829137212

### Documentation Changes Required

None. 