### PR TITLE
[4] Only show versions toolbar button if the article has been saved at least once

### DIFF
--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -204,13 +204,13 @@ class HtmlView extends BaseHtmlView
 
 			$toolbar->cancel('article.cancel', 'JTOOLBAR_CLOSE');
 
-			if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->params->get('save_history', 0) && $itemEditable)
-			{
-				$toolbar->versions('com_content.article', $this->item->id);
-			}
-
 			if (!$isNew)
 			{
+				if (ComponentHelper::isEnabled('com_contenthistory') && $this->state->params->get('save_history', 0) && $itemEditable)
+				{
+					$toolbar->versions('com_content.article', $this->item->id);
+				}
+
 				$url = Route::link(
 					'site',
 					RouteHelper::getArticleRoute($this->item->id . ':' . $this->item->alias, $this->item->catid, $this->item->language),


### PR DESCRIPTION
Closes https://github.com/joomla/joomla-cms/issues/33289

### Summary of Changes

Only show versions toolbar button if the article has been saved at least once

### Testing Instructions

Install Joomla 4
Trash all your Content Categories (Including the default uncategorised), empty the trash
Attempt to create a new article.

### Actual result BEFORE applying this Pull Request

```
An error has occurred.
    0 Joomla\CMS\Toolbar\Toolbar::versions(): Argument #2 ($itemId) must be of type int, null given, called in /application/administrator/components/com_content/src/View/Article/HtmlView.php on line 209 
```

<img width="1588" alt="Screenshot 2021-04-24 at 20 21 09" src="https://user-images.githubusercontent.com/400092/115970503-9fa4dc80-a53a-11eb-90cc-00c304d8ac53.png">

### Expected result AFTER applying this Pull Request

You get to the Article create screen and you can save, which creates the category on the fly on save. 

### Documentation Changes Required

none