### PR TITLE
[4.0] click to check the checkbox in com_cache

### DIFF
--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+HTMLHelper::_('behavior.multiselect');
+
 /** @var \Joomla\Component\Cache\Administrator\View\Cache\HtmlView $this */
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
@@ -66,14 +68,12 @@ $wa->useScript('keepalive')
 					<tbody>
 						<?php $i = 0; ?>
 						<?php foreach ($this->data as $folder => $item) : ?>
-							<tr>
+							<tr class="row<?php echo $i % 2; ?>">
 								<td>
-									<input class="form-check-input" type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $this->escape($item->group); ?>" class="cache-entry">
+									<input class="form-check-input cache-entry" type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $this->escape($item->group); ?>">
 								</td>
 								<th scope="row">
-									<label for="cb<?php echo $i; ?>">
 										<?php echo $this->escape($item->group); ?>
-									</label>
 								</th>
 								<td class="text-center">
 									<?php echo $item->count; ?>

--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -73,7 +73,9 @@ $wa->useScript('keepalive')
 									<input class="form-check-input cache-entry" type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $this->escape($item->group); ?>">
 								</td>
 								<th scope="row">
+									<label for="cb<?php echo $i; ?>">
 										<?php echo $this->escape($item->group); ?>
+									</label>
 								</th>
 								<td class="text-center">
 									<?php echo $item->count; ?>


### PR DESCRIPTION
### Summary of Changes
Added `HTMLHelper::_('behavior.multiselect');` and  `class="row<?php echo $i % 2; ?>"` in `<tr>`

### Testing Instructions
`Dashboard` > `System` > `Maintenance`  > `Clear Cache`

![clear_cache](https://user-images.githubusercontent.com/61203226/116605652-4cbd9180-a94d-11eb-92c3-e9dafb1e4477.JPG)

### Actual result BEFORE applying this Pull Request
Click on `<tr>` doesn't check the checkbox but Click on `Cache Group` checks the checkbox

https://user-images.githubusercontent.com/61203226/116606030-c3f32580-a94d-11eb-95b7-e51ab400f802.mp4

### Expected result AFTER applying this Pull Request
Click on `<tr>`  checks the checkbox

https://user-images.githubusercontent.com/61203226/116605953-ae7dfb80-a94d-11eb-8746-285aae431b50.mp4

### Documentation Changes Required
None