### PR TITLE
[4.0] icon for non featured

### DIFF
--- a/administrator/components/com_contact/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_contact/src/Service/HTML/AdministratorService.php
@@ -131,7 +131,7 @@ class AdministratorService
 			1 => array('featured', 'contacts.unfeatured', 'JFEATURED', 'JGLOBAL_ITEM_UNFEATURE'),
 		);
 		$state = ArrayHelper::getValue($states, (int) $value, $states[1]);
-		$icon = $state[0] === 'featured' ? 'star featured' : 'star';
+		$icon = $state[0] === 'featured' ? 'star featured' : 'circle';
 
 		if ($canChange)
 		{

--- a/administrator/components/com_contact/src/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contacts/HtmlView.php
@@ -170,7 +170,7 @@ class HtmlView extends BaseHtmlView
 				->text('JFEATURE')
 				->task('contacts.featured')
 				->listCheck(true);
-			$childBar->standardButton('unfeatured')
+			$childBar->standardButton('circle')
 				->text('JUNFEATURE')
 				->task('contacts.unfeatured')
 				->listCheck(true);

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -206,7 +206,7 @@ class HtmlView extends BaseHtmlView
 					->task('articles.featured')
 					->listCheck(true);
 
-				$childBar->standardButton('unfeatured')
+				$childBar->standardButton('circle')
 					->text('JUNFEATURE')
 					->task('articles.unfeatured')
 					->listCheck(true);

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -29,7 +29,7 @@ class FeaturedButton extends ActionButton
 	 */
 	protected function preprocess()
 	{
-		$this->addState(0, 'featured', 'icon-color-unfeatured icon-star',
+		$this->addState(0, 'featured', 'icon-icon-circle',
 			Text::_('JGLOBAL_TOGGLE_FEATURED'), ['tip_title' => Text::_('JUNFEATURED')]
 		);
 		$this->addState(1, 'unfeatured', 'icon-color-featured icon-star',

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -29,7 +29,7 @@ class FeaturedButton extends ActionButton
 	 */
 	protected function preprocess()
 	{
-		$this->addState(0, 'featured', 'icon-icon-circle',
+		$this->addState(0, 'featured', 'icon-circle',
 			Text::_('JGLOBAL_TOGGLE_FEATURED'), ['tip_title' => Text::_('JUNFEATURED')]
 		);
 		$this->addState(1, 'unfeatured', 'icon-color-featured icon-star',

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -270,7 +270,7 @@ abstract class JGrid
 	 * @see     JHtmlJGrid::state()
 	 * @since   1.6
 	 */
-	public static function isdefault($value, $i, $prefix = '', $enabled = true, $checkbox = 'cb', $formId = null, $active_class = 'icon-color-featured icon-star', $inactive_class = 'icon-color-unfeatured icon-star')
+	public static function isdefault($value, $i, $prefix = '', $enabled = true, $checkbox = 'cb', $formId = null, $active_class = 'icon-color-featured icon-star', $inactive_class = 'icon-circle')
 	{
 		if (is_array($prefix))
 		{


### PR DESCRIPTION
The icon used for featured/default is a yellow five pointed star
The icon used for non-featured/nondefault is a mono five pointed star

This fails basic accessibility as it is using color alone as an indicator

This PR changes the nonfeatured/nondefaault icon to a circle (this was already used in com_menus for non-home/non-default

To test apply pr and then
- check the icon used for featured in com_content, com_contact
- check the icon used for default in template styles
- check the icon used for default in com_workflows

Pull Request for Issue #33296


### After
![image](https://user-images.githubusercontent.com/1296369/116619172-090c5d00-a938-11eb-972b-f6a75b75cb3b.png)
