### PR TITLE
[4.0] user groups - col headers

### DIFF
--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -58,11 +58,11 @@ $wa->useScript('com_users.admin-users-groups');
 									<?php echo Text::_('COM_USERS_DEBUG_PERMISSIONS'); ?>
 								</th>
 								<th scope="col" class="w-10 text-center">
-									<span class="icon-check" aria-hidden="true" title="<?php echo Text::_('COM_USERS_COUNT_ENABLED_USERS'); ?>"></span>
+									<span class="icon-check" aria-hidden="true"></span>
 									<?php echo Text::_('COM_USERS_COUNT_ENABLED_USERS'); ?>
 								</th>
 								<th scope="col" class="w-10 text-center">
-									<span class="icon-times" aria-hidden="true" title="<?php echo Text::_('COM_USERS_COUNT_DISABLED_USERS'); ?>"></span>
+									<span class="icon-times" aria-hidden="true"></span>
 									<?php echo Text::_('COM_USERS_COUNT_DISABLED_USERS'); ?>
 								</th>
 								<th scope="col" class="w-5 d-none d-md-table-cell">

--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -59,13 +59,13 @@ $wa->useScript('com_users.admin-users-groups');
 								</th>
 								<th scope="col" class="w-10 text-center">
 									<span class="icon-check" aria-hidden="true" title="<?php echo Text::_('COM_USERS_COUNT_ENABLED_USERS'); ?>"></span>
-									<span class="visually-hidden"><?php echo Text::_('COM_USERS_COUNT_ENABLED_USERS'); ?></span>
+									<?php echo Text::_('COM_USERS_COUNT_ENABLED_USERS'); ?>
 								</th>
 								<th scope="col" class="w-10 text-center">
 									<span class="icon-times" aria-hidden="true" title="<?php echo Text::_('COM_USERS_COUNT_DISABLED_USERS'); ?>"></span>
-									<span class="visually-hidden"><?php echo Text::_('COM_USERS_COUNT_DISABLED_USERS'); ?></span>
+									<?php echo Text::_('COM_USERS_COUNT_DISABLED_USERS'); ?>
 								</th>
-								<th scope="col" class="w-10 d-none d-md-table-cell">
+								<th scope="col" class="w-5 d-none d-md-table-cell">
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
 								</th>
 							</tr>


### PR DESCRIPTION
There really is no need to hide the column header text here - there is more than enough space in the view

### Before
![image](https://user-images.githubusercontent.com/1296369/116687050-81146a80-a9ac-11eb-8224-802eb79fe36f.png)

### After
![image](https://user-images.githubusercontent.com/1296369/116686973-69d57d00-a9ac-11eb-8abe-0fc59967e3f1.png)
