### PR TITLE
[4.0] Debug Group scope

### DIFF
--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -51,9 +51,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 				<tbody>
 					<?php foreach ($this->items as $i => $item) : ?>
 						<tr class="row0">
-							<td scope="row">
+							<th scope="row">
 								<?php echo $this->escape(Text::_($item->title)); ?>
-							</td>
+							</th>
 							<td>
 								<?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level + 1)) . $this->escape($item->name); ?>
 							</td>


### PR DESCRIPTION
The attribute scope is essential to tell users of assistive technology if the header applies to the column or the row. However that means it can only be applied to a table header (th) and not to a table cell (td).

There is a small cosmetic change as a result in that the contents of the cell are now visually displayed in bold.

To test go to users-> groups and click on the permissions icon.

All the content in the first column should be in a th with a scope of row and visually displayed as bold
