### PR TITLE
[4.0] Modules modal scope

### DIFF
--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -92,11 +92,11 @@ if (!empty($editor))
 							<span class="<?php echo $iconStates[$this->escape($item->published)]; ?>" aria-hidden="true"></span>
 						</span>
 					</td>
-					<td scope="row" class="has-context">
+					<th scope="row" class="has-context">
 						<a class="js-module-insert btn btn-sm btn-success w-100" href="#" data-module="<?php echo $item->id; ?>" data-editor="<?php echo $this->escape($editor); ?>">
 							<?php echo $this->escape($item->title); ?>
 						</a>
-					</td>
+					</th>
 					<td class="small d-none d-md-table-cell">
 						<?php if ($item->position) : ?>
 						<a class="js-position-insert btn btn-sm btn-warning w-100" href="#" data-position="<?php echo $this->escape($item->position); ?>" data-editor="<?php echo $this->escape($editor); ?>"><?php echo $this->escape($item->position); ?></a>


### PR DESCRIPTION
The attribute scope is essential to tell users of assistive technology if the header applies to the column or the row. However that means it can only be applied to a table header (th) and not to a table cell (td).

There is no visual change as a result as the content of the cell is in a button and the button css overrides any th css

Easiest way to test is to try and insert a module into an article. The module modal will be displayed

All the content in the title column should be in a th with a scope of row

![image](https://user-images.githubusercontent.com/1296369/116698334-28e56480-a9bc-11eb-9cd9-6690348c8d81.png)
