### PR TITLE
[4.0] Private Messages: Add legend in Configuration Form

### DIFF
--- a/administrator/components/com_messages/tmpl/config/default.php
+++ b/administrator/components/com_messages/tmpl/config/default.php
@@ -22,7 +22,7 @@ HTMLHelper::_('behavior.keepalive');
 		<div class="card">
 			<div class="card-body">
 				<fieldset class="options-form">
-					<legend><?php echo Text::_('COM_MESSAGES_CONFIGURATION_FORM'); ?></legend>
+					<legend><?php echo Text::_('COM_MESSAGES_CONFIG_FORM'); ?></legend>
 					<?php echo $this->form->renderField('lock'); ?>
 					<?php echo $this->form->renderField('mail_on_new'); ?>
 					<?php echo $this->form->renderField('auto_purge'); ?>

--- a/administrator/components/com_messages/tmpl/config/default.php
+++ b/administrator/components/com_messages/tmpl/config/default.php
@@ -22,7 +22,7 @@ HTMLHelper::_('behavior.keepalive');
 		<div class="card">
 			<div class="card-body">
 				<fieldset class="options-form">
-					<legend><?php echo Text::_('COM_MESSAGES_CONFIGURATION'); ?></legend>
+					<legend><?php echo Text::_('COM_MESSAGES_CONFIGURATION_FORM'); ?></legend>
 					<?php echo $this->form->renderField('lock'); ?>
 					<?php echo $this->form->renderField('mail_on_new'); ?>
 					<?php echo $this->form->renderField('auto_purge'); ?>

--- a/administrator/components/com_messages/tmpl/config/default.php
+++ b/administrator/components/com_messages/tmpl/config/default.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Language\Text;
 
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');
@@ -20,9 +21,12 @@ HTMLHelper::_('behavior.keepalive');
 	<div class="form-grid">
 		<div class="card">
 			<div class="card-body">
-				<?php echo $this->form->renderField('lock'); ?>
-				<?php echo $this->form->renderField('mail_on_new'); ?>
-				<?php echo $this->form->renderField('auto_purge'); ?>
+				<fieldset class="options-form">
+					<legend><?php echo Text::_('COM_MESSAGES_CONFIGURATION'); ?></legend>
+					<?php echo $this->form->renderField('lock'); ?>
+					<?php echo $this->form->renderField('mail_on_new'); ?>
+					<?php echo $this->form->renderField('auto_purge'); ?>
+				</fieldset>
 			</div>
 		</div>
 	</div>

--- a/administrator/components/com_messages/tmpl/config/default.php
+++ b/administrator/components/com_messages/tmpl/config/default.php
@@ -10,8 +10,8 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Router\Route;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('behavior.formvalidator');
 HTMLHelper::_('behavior.keepalive');

--- a/administrator/language/en-GB/com_messages.ini
+++ b/administrator/language/en-GB/com_messages.ini
@@ -6,6 +6,7 @@
 COM_MESSAGES="Messaging"
 COM_MESSAGES_ADD="New Private Message"
 COM_MESSAGES_CONFIG_SAVED="Configuration saved."
+COM_MESSAGES_CONFIGURATION_FORM="My Settings"
 COM_MESSAGES_EMPTYSTATE_BUTTON_ADD="Send a message"
 COM_MESSAGES_EMPTYSTATE_CONTENT="Send messages to other administrators on your site and read their replies."
 COM_MESSAGES_EMPTYSTATE_TITLE="There are no messages for you in your inbox."

--- a/administrator/language/en-GB/com_messages.ini
+++ b/administrator/language/en-GB/com_messages.ini
@@ -5,8 +5,8 @@
 
 COM_MESSAGES="Messaging"
 COM_MESSAGES_ADD="New Private Message"
+COM_MESSAGES_CONFIG_FORM="My Settings"
 COM_MESSAGES_CONFIG_SAVED="Configuration saved."
-COM_MESSAGES_CONFIGURATION_FORM="My Settings"
 COM_MESSAGES_EMPTYSTATE_BUTTON_ADD="Send a message"
 COM_MESSAGES_EMPTYSTATE_CONTENT="Send messages to other administrators on your site and read their replies."
 COM_MESSAGES_EMPTYSTATE_TITLE="There are no messages for you in your inbox."

--- a/administrator/language/en-GB/com_messages.ini
+++ b/administrator/language/en-GB/com_messages.ini
@@ -6,7 +6,6 @@
 COM_MESSAGES="Messaging"
 COM_MESSAGES_ADD="New Private Message"
 COM_MESSAGES_CONFIG_SAVED="Configuration saved."
-COM_MESSAGES_CONFIGURATION="Messages: Options"
 COM_MESSAGES_EMPTYSTATE_BUTTON_ADD="Send a message"
 COM_MESSAGES_EMPTYSTATE_CONTENT="Send messages to other administrators on your site and read their replies."
 COM_MESSAGES_EMPTYSTATE_TITLE="There are no messages for you in your inbox."


### PR DESCRIPTION
Pull Request for Issue #33431

### Summary of Changes
1. Added `<fieldset class="options-form">` and <`legend>` to the form as suggested in the issue.
2. Removed a redundant language constant `COM_MESSAGES_CONFIGURATION`. This wasn't used in any file throughout the Joomla-CMS repository. (I ran a global search using two unique IDEs)
3. Added a new constant `COM_MESSAGES_CONFIGURATION_FORM="My Settings"` for the Form's Legend. (Read: https://github.com/joomla/joomla-cms/issues/33431#issuecomment-830280978) 

**Note**: As I have added a new constant, it must be added in other languages during translations

### Testing Instructions

1. Joomla Admin Panel -> Private Messages (Top Right in Toolbar)
2. Click on My Settings

A Legend can be seen after applying the patch

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/116738340-f06f7600-aa0f-11eb-9f02-b2592eda4048.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/116743863-26642880-aa17-11eb-8211-7b5aca66f508.png)



### Documentation Changes Required
None