### PR TITLE
[4.0] Separable buttons on Joomla Update Page

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
+++ b/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
@@ -84,14 +84,12 @@ Text::script('JHIDEPASSWORD');
 		<?php endif; ?>
 		<div class="control-group">
 			<div class="controls">
-			
 					<a class="btn btn-danger" href="index.php?option=com_joomlaupdate">
 						<span class="icon-times icon-white" aria-hidden="true"></span> <?php echo Text::_('JCANCEL'); ?>
 					</a>
 					<button type="submit" class="btn btn-primary">
 						<span class="icon-play icon-white" aria-hidden="true"></span> <?php echo Text::_('COM_INSTALLER_INSTALL_BUTTON'); ?>
 					</button>
-
 			</div>
 		</div>
 

--- a/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
+++ b/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
@@ -84,12 +84,12 @@ Text::script('JHIDEPASSWORD');
 		<?php endif; ?>
 		<div class="control-group">
 			<div class="controls">
-					<a class="btn btn-danger" href="index.php?option=com_joomlaupdate">
-						<span class="icon-times icon-white" aria-hidden="true"></span> <?php echo Text::_('JCANCEL'); ?>
-					</a>
-					<button type="submit" class="btn btn-primary">
-						<span class="icon-play icon-white" aria-hidden="true"></span> <?php echo Text::_('COM_INSTALLER_INSTALL_BUTTON'); ?>
-					</button>
+				<a class="btn btn-danger" href="index.php?option=com_joomlaupdate">
+					<span class="icon-times icon-white" aria-hidden="true"></span> <?php echo Text::_('JCANCEL'); ?>
+				</a>
+				<button type="submit" class="btn btn-primary">
+					<span class="icon-play icon-white" aria-hidden="true"></span> <?php echo Text::_('COM_INSTALLER_INSTALL_BUTTON'); ?>
+				</button>
 			</div>
 		</div>
 

--- a/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
+++ b/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
@@ -84,14 +84,14 @@ Text::script('JHIDEPASSWORD');
 		<?php endif; ?>
 		<div class="control-group">
 			<div class="controls">
-				<div class="btn-group">
+			
 					<a class="btn btn-danger" href="index.php?option=com_joomlaupdate">
 						<span class="icon-times icon-white" aria-hidden="true"></span> <?php echo Text::_('JCANCEL'); ?>
 					</a>
 					<button type="submit" class="btn btn-primary">
 						<span class="icon-play icon-white" aria-hidden="true"></span> <?php echo Text::_('COM_INSTALLER_INSTALL_BUTTON'); ?>
 					</button>
-				</div>
+
 			</div>
 		</div>
 


### PR DESCRIPTION
Pull Request for Issue #33430 

### Summary of Changes
remove class `btn-group`

### Testing Instructions
Go to System - Update (Joomla) - Download and Updates tab, select the update package, click the download button. Note that the buttons on the new page are inseparable.

### Actual result BEFORE applying this Pull Request
Inseparable buttons

![button_before](https://user-images.githubusercontent.com/61203226/116748618-557d9880-aa1d-11eb-8b68-868b47a216da.JPG)

### Expected result AFTER applying this Pull Request
Separable buttons

![button_after](https://user-images.githubusercontent.com/61203226/116748651-5f9f9700-aa1d-11eb-8dfd-b5e500122b3b.JPG)

### Documentation Changes Required
None
