### PR TITLE
[4.0] privacy request scope

### DIFF
--- a/administrator/components/com_privacy/tmpl/requests/default.php
+++ b/administrator/components/com_privacy/tmpl/requests/default.php
@@ -89,14 +89,14 @@ $urgentRequestDate->sub(new DateInterval('P' . $this->urgentRequestAge . 'D'));
 							<td class="text-center">
 								<?php echo HTMLHelper::_('privacy.statusLabel', $item->status); ?>
 							</td>
-							<td scope="row">
+							<th scope="row">
 								<?php if ($item->status == 1 && $urgentRequestDate >= $itemRequestedAt) : ?>
 									<span class="float-end badge bg-danger"><?php echo Text::_('COM_PRIVACY_BADGE_URGENT_REQUEST'); ?></span>
 								<?php endif; ?>
 								<a href="<?php echo Route::_('index.php?option=com_privacy&view=request&id=' . (int) $item->id); ?>" title="<?php echo Text::_('COM_PRIVACY_ACTION_VIEW'); ?>">
 									<?php echo PunycodeHelper::emailToUTF8($this->escape($item->email)); ?>
 								</a>
-							</td>
+							</th>
 							<td>
 								<?php echo Text::_('COM_PRIVACY_HEADING_REQUEST_TYPE_TYPE_' . $item->request_type); ?>
 							</td>


### PR DESCRIPTION
The attribute scope is essential to tell users of assistive technology if the header applies to the column or the row. However that means it can only be applied to a table header (th) and not to a table cell (td).

There is a small cosmetic change as a result in that the contents of the cell are now visually displayed in bold.

To test go to users-> privacy requests and create a new request and then save

All the content in the Email column should be in a th with a scope of row and visually displayed as bold
