### PR TITLE
[4.0] Removed <hr> tag in installation plugins

### DIFF
--- a/plugins/installer/folderinstaller/tmpl/default.php
+++ b/plugins/installer/folderinstaller/tmpl/default.php
@@ -26,7 +26,7 @@ $this->app->getDocument()->getWebAssetManager()
 
 ?>
 <legend><?php echo Text::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT'); ?></legend>
-<hr>
+
 <div class="control-group">
 	<label for="install_directory" class="control-label">
 		<?php echo Text::_('PLG_INSTALLER_FOLDERINSTALLER_TEXT'); ?>

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -31,13 +31,11 @@ $this->app->getDocument()->getWebAssetManager()
 		['core']
 	);
 
-$return  = $this->app->input->getBase64('return');
+$return = $this->app->input->getBase64('return');
 $maxSizeBytes = FilesystemHelper::fileUploadMaxSize(false);
 $maxSize = HTMLHelper::_('number.bytes', $maxSizeBytes);
 ?>
 <legend><?php echo Text::_('PLG_INSTALLER_PACKAGEINSTALLER_UPLOAD_INSTALL_JOOMLA_EXTENSION'); ?></legend>
-
-<hr>
 
 <div id="uploader-wrapper">
 	<div id="dragarea" data-state="pending">

--- a/plugins/installer/urlinstaller/tmpl/default.php
+++ b/plugins/installer/urlinstaller/tmpl/default.php
@@ -20,7 +20,7 @@ $this->app->getDocument()->getWebAssetManager()
 
 ?>
 <legend><?php echo Text::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?></legend>
-<hr>
+
 <div class="control-group">
 	<label for="install_url" class="control-label">
 		<?php echo Text::_('PLG_INSTALLER_URLINSTALLER_TEXT'); ?>


### PR DESCRIPTION
### Summary of Changes
A small fix that removes the `<hr>` tag in the installation plugin layouts.

I noticed that in other places in Joomla, the `<hr>` tag is placed only immediately before the button, and not BEFORE and AFTER. For example, the Joomla update page:

![Screenshot_5](https://user-images.githubusercontent.com/8440661/116775496-f3984f80-aa6b-11eb-968a-55969b7242bc.png)

Go to System - Install (Extension). Look at the tabs to install the extension. From the screenshots it is clear what changes the PR.

**BEFORE / AFTER**

![Screenshot_1](https://user-images.githubusercontent.com/8440661/116775587-63a6d580-aa6c-11eb-90f7-15d24196bb00.png)

![Screenshot_2](https://user-images.githubusercontent.com/8440661/116775588-64d80280-aa6c-11eb-870d-a30e3ce8c0b4.png)