### PR TITLE
[4] EmptyState replace custom sql with reusing existing methods

### DIFF
--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -158,18 +158,7 @@ class ListModel extends BaseDatabaseModel implements ListModelInterface
 	 */
 	public function getIsEmptyState()
 	{
-		$sql = $this->query
-			->clear('select')
-			->clear('values')
-			->clear('bounded')
-			->clear('limit')
-			->clear('order')
-			->clear('where')
-			->select('count(*)');
-
-		$this->_db->setQuery($sql);
-
-		return !($this->_db->loadResult() > 0);
+		return !($this->getTotal() > 0);
 	}
 
 	/**


### PR DESCRIPTION
@richard67 Please test this PR on all empty states except Categories and Tags (which have custom `getIsEmptyState` methods Im working on. 

If this works, then great an https://github.com/joomla/joomla-cms/issues/33466 is resolved. 