### PR TITLE
[4.0] toggle editor icon

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -23,6 +23,7 @@
       editors.forEach((editor) => {
         const currentEditor = editor.querySelector('textarea');
         const toggleButton = editor.querySelector('.js-tiny-toggler-button');
+        const toggleIcon = editor.querySelector('.icon-eye');
 
         // Setup the editor
         Joomla.JoomlaTinyMCE.setupEditor(currentEditor, pluginOptions);
@@ -32,8 +33,10 @@
           toggleButton.removeAttribute('disabled');
           toggleButton.addEventListener('click', () => {
             if (Joomla.editors.instances[currentEditor.id].instance.isHidden()) {
+              toggleIcon.setAttribute('class', 'icon-eye');
               Joomla.editors.instances[currentEditor.id].instance.show();
             } else {
+              toggleIcon.setAttribute('class', 'icon-eye-slash');
               Joomla.editors.instances[currentEditor.id].instance.hide();
             }
           });


### PR DESCRIPTION
Please be gentle javascript is not my thing

Pull Request for Issue ##33465

### Summary of Changes
change the icon when the toggle editor button is toggled


### Testing Instructions
- apply pr
- npm i
- new article and click on button


### Actual result BEFORE applying this Pull Request
button toggles the editor but does not visually change


### Expected result AFTER applying this Pull Request
button toggles the editor and the icon changes

![image](https://user-images.githubusercontent.com/1296369/116790058-442e9d80-aaaa-11eb-959e-92cbe544195a.png)

![image](https://user-images.githubusercontent.com/1296369/116790068-54df1380-aaaa-11eb-85c8-38bd2e0aa45b.png)
