### PR TITLE
[4.0] Fix tabs in User Access levels and Joomla Update Complete View

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/complete.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/complete.php
@@ -24,6 +24,7 @@ use Joomla\CMS\Router\Route;
 	<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
 <?php echo HTMLHelper::_('uitab.endTabSet'); ?>
+
 <form action="<?php echo Route::_('index.php?option=com_joomlaupdate'); ?>" method="post" id="adminForm">
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/complete.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/complete.php
@@ -14,18 +14,16 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
 ?>
+<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'complete')); ?>
 
-<fieldset class="options-form">
-	<legend>
-		<?php echo Text::_('COM_JOOMLAUPDATE_VIEW_COMPLETE_HEADING'); ?>
-	</legend>
-	<div>
+	<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'complete', Text::_('COM_JOOMLAUPDATE_VIEW_COMPLETE_HEADING')); ?>
 		<div class="alert alert-success">
 			<span class="icon-check-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('NOTICE'); ?></span>
 			<?php echo Text::sprintf('COM_JOOMLAUPDATE_VIEW_COMPLETE_MESSAGE', '&#x200E;' . JVERSION); ?>
 		</div>
-	</div>
-</fieldset>
+	<?php echo HTMLHelper::_('uitab.endTab'); ?>
+
+<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 <form action="<?php echo Route::_('index.php?option=com_joomlaupdate'); ?>" method="post" id="adminForm">
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>

--- a/administrator/components/com_users/tmpl/level/edit.php
+++ b/administrator/components/com_users/tmpl/level/edit.php
@@ -19,26 +19,35 @@ HTMLHelper::_('behavior.keepalive');
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_users&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="level-form" aria-label="<?php echo Text::_('COM_USERS_LEVEL_FORM_' . ( (int) $this->item->id === 0 ? 'NEW' : 'EDIT'), true); ?>" class="form-validate">
-	<fieldset class="options-form mt-4">
-		<legend><?php echo Text::_('COM_USERS_LEVEL_DETAILS'); ?></legend>
-		<div>
-		<div class="control-group">
-			<div class="control-label">
-				<?php echo $this->form->getLabel('title'); ?>
-			</div>
-			<div class="controls">
-				<?php echo $this->form->getInput('title'); ?>
-			</div>
-		</div>
-		</div>
-	</fieldset>
+	<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
-	<fieldset class="options-form">
-		<legend><?php echo Text::_('COM_USERS_USER_GROUPS_HAVING_ACCESS'); ?></legend>
-		<div>
-		<?php echo HTMLHelper::_('access.usergroups', 'jform[rules]', $this->item->rules, true); ?>
-		</div>
-	</fieldset>
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('COM_USERS_LEVEL_DETAILS')); ?>
+			<fieldset class="options-form mt-4">
+				<legend><?php echo Text::_('COM_USERS_LEVEL_DETAILS'); ?></legend>
+				<div>
+				<div class="control-group">
+					<div class="control-label">
+						<?php echo $this->form->getLabel('title'); ?>
+					</div>
+					<div class="controls">
+						<?php echo $this->form->getInput('title'); ?>
+					</div>
+				</div>
+				</div>
+			</fieldset>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
+
+		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'groups', Text::_('COM_USERS_USER_GROUPS_HAVING_ACCESS')); ?>
+			<fieldset class="options-form">
+				<legend><?php echo Text::_('COM_USERS_USER_GROUPS_HAVING_ACCESS'); ?></legend>
+				<div>
+				<?php echo HTMLHelper::_('access.usergroups', 'jform[rules]', $this->item->rules, true); ?>
+				</div>
+			</fieldset>
+		<?php echo HTMLHelper::_('uitab.endTab'); ?>
+
+	<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
+
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>
 </form>

--- a/administrator/components/com_users/tmpl/level/edit.php
+++ b/administrator/components/com_users/tmpl/level/edit.php
@@ -24,7 +24,6 @@ HTMLHelper::_('behavior.keepalive');
 		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('COM_USERS_LEVEL_DETAILS')); ?>
 			<fieldset class="options-form mt-4">
 				<legend><?php echo Text::_('COM_USERS_LEVEL_DETAILS'); ?></legend>
-				<div>
 				<div class="control-group">
 					<div class="control-label">
 						<?php echo $this->form->getLabel('title'); ?>
@@ -33,7 +32,6 @@ HTMLHelper::_('behavior.keepalive');
 						<?php echo $this->form->getInput('title'); ?>
 					</div>
 				</div>
-				</div>
 			</fieldset>
 		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 
@@ -41,7 +39,7 @@ HTMLHelper::_('behavior.keepalive');
 			<fieldset class="options-form">
 				<legend><?php echo Text::_('COM_USERS_USER_GROUPS_HAVING_ACCESS'); ?></legend>
 				<div>
-				<?php echo HTMLHelper::_('access.usergroups', 'jform[rules]', $this->item->rules, true); ?>
+					<?php echo HTMLHelper::_('access.usergroups', 'jform[rules]', $this->item->rules, true); ?>
 				</div>
 			</fieldset>
 		<?php echo HTMLHelper::_('uitab.endTab'); ?>


### PR DESCRIPTION
Pull Request for Issue #33440 

### Summary of Changes
1. Added Tabs to User Access Level View
2. Added tabs to Joomla Update Complete View and removed that fieldset and legend tag that enclosed the alert box.

### Testing Instructions

#### For User Access Levels
1. Joomla Admin Panel -> Users
2. Select Access Levels
3. Click on New

#### For Joomla Update Complete View
Visit  `/administrator/index.php?option=com_joomlaupdate&view=joomlaupdate&layout=complete`

<hr width="35%"/>
Verify that tabs are present on both of these views


### Actual result BEFORE applying this Pull Request
#### For User Access Levels
![image](https://user-images.githubusercontent.com/8440661/116741240-bfd31080-a9fe-11eb-8bb2-4e7339604367.png)
#### For Joomla Update Complete View
![image](https://user-images.githubusercontent.com/8440661/116741294-d11c1d00-a9fe-11eb-9131-5d4a1393ebc0.png)

### Expected result AFTER applying this Pull Request
#### For User Access Levels
Fieldsets and Legends are separated tab wise to keep the view consistent with other user forms like the ones in Manage Users

![image](https://user-images.githubusercontent.com/53610833/116792167-a4d6ce00-aadc-11eb-9bd7-1b67c45fc550.png)

#### For Joomla Update Complete View
Removed Fieldset that enclosed the alert-box and added a tab as requested in the issue.

![image](https://user-images.githubusercontent.com/53610833/116792689-dc934500-aadf-11eb-8a7a-e4ebcf528f81.png)


### Documentation Changes Required
None