### PR TITLE
[4] Cleanup output html of email field

### DIFF
--- a/layouts/joomla/form/field/email.php
+++ b/layouts/joomla/form/field/email.php
@@ -49,6 +49,13 @@ extract($displayData);
  */
 
 $attributes = array(
+	'<input',
+	'type="email"',
+	'inputmode="email"',
+	'name="' . $name . '"',
+	'class="form-control validate-email' . (!empty($class) ? ' ' . $class : '') . '"',
+	'id="' . $id . '"',
+	'value="' . htmlspecialchars(PunycodeHelper::emailToUTF8($value), ENT_COMPAT, 'UTF-8') . '"',
 	$spellcheck ? '' : 'spellcheck="false"',
 	!empty($size) ? 'size="' . $size . '"' : '',
 	!empty($description) ? 'aria-describedby="' . $name . '-desc"' : '',
@@ -64,12 +71,4 @@ $attributes = array(
 	$dataAttribute,
 );
 
-?>
-<input
-	type="email"
-	inputmode="email"
-	name="<?php echo $name; ?>"
-	<?php echo !empty($class) ? ' class="form-control validate-email ' . $class . '"' : ' class="form-control validate-email"'; ?>
-	id="<?php echo $id; ?>"
-	value="<?php echo htmlspecialchars(PunycodeHelper::emailToUTF8($value), ENT_COMPAT, 'UTF-8'); ?>"
-	<?php echo implode(' ', $attributes); ?>>
+echo implode(' ', array_values(array_filter($attributes))) . '>';

--- a/layouts/joomla/form/field/email.php
+++ b/layouts/joomla/form/field/email.php
@@ -48,8 +48,7 @@ extract($displayData);
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*.
  */
 
-$attributes = array(
-	'<input',
+$attributes = [
 	'type="email"',
 	'inputmode="email"',
 	'name="' . $name . '"',
@@ -69,6 +68,6 @@ $attributes = array(
 	$required ? 'required' : '',
 	$autofocus ? 'autofocus' : '',
 	$dataAttribute,
-);
+];
 
-echo implode(' ', array_values(array_filter($attributes))) . '>';
+echo '<input ' . implode(' ', array_values(array_filter($attributes))) . '>';


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Cleanup of the output HTML from the email layout

### Testing Instructions

Go to a page with an email input - a good enable is the "I forgot my username" page on the frontend 

https://example.com/index.php/component/users/remind?Itemid=101

View the source. 

### Actual result BEFORE applying this Pull Request

```html
		<input
	type="email"
	inputmode="email"
	name="jform[email]"
	 class="form-control validate-email required"	id="jform_email"
	value=""
	 size="30"     autocomplete="email"    required  >
```

### Expected result AFTER applying this Pull Request

```html
<input type="email" inputmode="email" name="jform[email]" class="form-control validate-email required" id="jform_email" value="" size="30" autocomplete="email" required>
```

### Documentation Changes Required

None