### PR TITLE
[4.0] Fix merge conflict remainder from upmerge from 3.10-dev

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1412,22 +1412,6 @@ ENDDATA;
 	}
 
 	/**
-<<<<<<< HEAD:administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
-=======
-	 * Checks if extension is non core extension.
-	 *
-	 * @param   object  $extension  The extension to be checked
-	 *
-	 * @return  bool  true if extension is not a core extension
-	 *
-	 * @since   3.10.0
-	 */
-	private static function isNonCoreExtension($extension)
-	{
-		return !ExtensionHelper::checkIfCoreExtension($extension->type, $extension->element, $extension->client_id, $extension->folder);
-	}
-
-	/**
 	 * Gets an array containing all installed and enabled plugins, that are not core plugins.
 	 *
 	 * @param   array  $folderFilter  Limit the list of plugins to a specific set of folder values


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

The recent upmerge from 3.10-dev (commit https://github.com/joomla/joomla-cms/commit/964d90f3a6cc5ca7d195599788dec09f5f72ffd1 ) left a remainder from a merge conflict here:

https://github.com/joomla/joomla-cms/commit/964d90f3a6cc5ca7d195599788dec09f5f72ffd1#diff-617530abeea53181b5e5f641ba3906dcbf758238861e8a5281422722533d8532R1415-R1416

This comes from PR #29480 having been merged in 4.0-dev before. With that PR, function `isNonCoreExtension` has ben removed since it's not used anymore. This is still true after the upmerge, but the function came back. That's why this not only removes the 

### Testing Instructions

1. Code review.
2. Check if PHPCS passes in drone.
3. Check if the pre-update checker works on current 4.0-dev without and with the PR.

### Actual result BEFORE applying this Pull Request

1. Code contains a remainder from a merge conflict.
2. PHPCS fails in drone.

### Expected result AFTER applying this Pull Request

1. Code doesn't contain a remainder from a merge conflict.
2. PHPCS passes in drone.

Pre-update check still works.

### Documentation Changes Required

None.