### PR TITLE
[4.0] [UX] Use number field for num_columns in blog and featured layout

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -744,16 +744,11 @@
 
 		<field
 			name="num_columns"
-			type="list"
+			type="number"
 			label="JGLOBAL_NUM_COLUMNS_LABEL"
 			default="1"
 			parentclass="stack span-1-inline"
-			>
-			<option value="1">J1</option>
-			<option value="2">J2</option>
-			<option value="3">J3</option>
-			<option value="4">J4</option>
-		</field>
+		/>
 
 		<field
 			name="multi_column_order"

--- a/components/com_content/tmpl/category/blog.xml
+++ b/components/com_content/tmpl/category/blog.xml
@@ -209,11 +209,17 @@
 
 			<field
 				name="num_columns"
-				type="text"
+				type="list"
 				label="JGLOBAL_NUM_COLUMNS_LABEL"
 				parentclass="stack span-1-inline"
 				useglobal="true"
-			/>
+				validate="options"
+			>
+				<option value="1">J1</option>
+				<option value="2">J2</option>
+				<option value="3">J3</option>
+				<option value="4">J4</option>
+			</field>
 
 			<field
 				name="multi_column_order"

--- a/components/com_content/tmpl/category/blog.xml
+++ b/components/com_content/tmpl/category/blog.xml
@@ -209,17 +209,11 @@
 
 			<field
 				name="num_columns"
-				type="list"
+				type="number"
 				label="JGLOBAL_NUM_COLUMNS_LABEL"
 				parentclass="stack span-1-inline"
 				useglobal="true"
-				validate="options"
-			>
-				<option value="1">J1</option>
-				<option value="2">J2</option>
-				<option value="3">J3</option>
-				<option value="4">J4</option>
-			</field>
+			/>
 
 			<field
 				name="multi_column_order"

--- a/components/com_content/tmpl/featured/default.xml
+++ b/components/com_content/tmpl/featured/default.xml
@@ -67,17 +67,11 @@
 
 			<field
 				name="num_columns"
-				type="list"
+				type="number"
 				label="JGLOBAL_NUM_COLUMNS_LABEL"
 				parentclass="stack span-1-inline"
 				useglobal="true"
-				validate="options"
-			>
-				<option value="1">J1</option>
-				<option value="2">J2</option>
-				<option value="3">J3</option>
-				<option value="4">J4</option>
-			</field>
+			/>
 
 			<field
 				name="multi_column_order"

--- a/components/com_content/tmpl/featured/default.xml
+++ b/components/com_content/tmpl/featured/default.xml
@@ -67,11 +67,17 @@
 
 			<field
 				name="num_columns"
-				type="text"
+				type="list"
 				label="JGLOBAL_NUM_COLUMNS_LABEL"
 				parentclass="stack span-1-inline"
 				useglobal="true"
-			/>
+				validate="options"
+			>
+				<option value="1">J1</option>
+				<option value="2">J2</option>
+				<option value="3">J3</option>
+				<option value="4">J4</option>
+			</field>
 
 			<field
 				name="multi_column_order"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Improve UX. Users can select a number of columns from a dropdown. (was a text input field).

### Testing Instructions
Compare menu items for blog and featured before and after Patch.


### Actual result BEFORE applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/116809292-881eb280-ab3d-11eb-8d5a-7dd8b542b455.png)


### Expected result AFTER applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/116809244-54438d00-ab3d-11eb-8f80-89c2440a2827.png)


### Documentation Changes Required

