### PR TITLE
[4.0] fixes issue where dropdown item doesn't have border radius

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -60,12 +60,12 @@
     color: var(--success);
   }
 
-  &.first {
+  &.first:not(.last) {
     border-bottom-right-radius: 0;
     border-bottom-left-radius: 0;
   }
 
-  &.last {
+  &.last:not(.first) {
     border-top-left-radius: 0;
     border-top-right-radius: 0;
   }


### PR DESCRIPTION
Pull Request for Issue #33443  .

### Summary of Changes
This Pull Request modifies ` administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss`. 
The issue was that if the dropdown menu contains only a single button, then there would be not border radius for the button. This was caused because if a dropdown menu contained only a single button, it would have both the classes `first` as well as `last`, hence overriding the border-radius property that has been set in `template-rtl.scss` and removing border radius from bottom and top respectively.

In this pull request a check has been added to see if the element contains both `first` and `last` classes, if it does then the style won't be applied.


### Testing Instructions

- Login to Administrator 
- Go to Menus > Manage > New
- Expand the `Save & Close` dropdown menu and hover over `Save & New`.
- Check if `Save & New` has the border radius for all 4 corners.

Check if other dropdown menus are fine ( Before & After results will be same for this one).
- Go to Menus > All Menu Items.
- Click on one of the items that are listed, for eg: `Home`.
- Expand the `Save & Close` dropdown menu and hover over `Save & New` and `Save as Copy`.
- Check if `Save & New` has the border radius for top corners and `Save as Copy` has border radius for bottom corners.


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/42460131/116812435-612ba500-ab6c-11eb-80d4-9800ac540bd2.png)



### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/42460131/116812511-b4055c80-ab6c-11eb-9107-2f0dad3ba477.png)


### Documentation Changes Required

Nope.
