### PR TITLE
[4.0] Remove cellspacing and cellpadding from Error Backtrace table

### DIFF
--- a/layouts/joomla/error/backtrace.php
+++ b/layouts/joomla/error/backtrace.php
@@ -21,7 +21,7 @@ if (!$backtraceList)
 
 $class = $displayData['class'] ?? 'table table-striped table-bordered';
 ?>
-<table cellpadding="0" cellspacing="0" class="<?php echo $class ?>">
+<table class="<?php echo $class ?>">
 	<tr>
 		<td colspan="3">
 			<strong>Call stack</strong>


### PR DESCRIPTION
### Summary of Changes
Similar to PR #33469
Removes `cellspacing` and `cellpadding` from the Error Backtrace Table
This was the only remaining occurrence of these deprecated attributes. Ran a global search with my IDE and couldn't find any other place where either of these was used.

### Testing Instructions
Visit any invalid view in backend like: 
`/administrator/index.php?option=com_content&view=articles1`
and use inspect element (Devtools) to ensure that the deprecated attributes are removed and the view is not affected


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/116815417-1cf3d100-ab7b-11eb-8841-aacf4f564fde.png)


### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/116815554-b02d0680-ab7b-11eb-95a6-6f1ea4082996.png)



### Documentation Changes Required
None
