### PR TITLE
[4.0] Make check for package ID or extension ID type safe in pre-update-check javascript

### DIFF
--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -456,7 +456,8 @@ Joomla = window.Joomla || {};
     if (extensionData.compatibilityData.resultGroup === 3) {
       PreUpdateChecker.nonCoreCriticalPlugins.foreach((cpi) => {
         if (parseInt(PreUpdateChecker.nonCoreCriticalPlugins[cpi].package_id, 10) === extensionId
-            || parseInt(PreUpdateChecker.nonCoreCriticalPlugins[cpi].extension_id, 10) === extensionId) {
+            || parseInt(PreUpdateChecker.nonCoreCriticalPlugins[cpi].extension_id, 10)
+               === extensionId) {
           document.getElementById(`#plg_${PreUpdateChecker.nonCoreCriticalPlugins[cpi].extension_id}`).remove();
           PreUpdateChecker.nonCoreCriticalPlugins.splice(cpi, 1);
         }

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -440,7 +440,7 @@ Joomla = window.Joomla || {};
       }
     }
     // Insert the generated html
-    const extensionId = extensionData.element.getAttribute('data-extension-id');
+    const extensionId = parseInt(extensionData.element.getAttribute('data-extension-id'), 10);
     document.getElementById(`available-version-${extensionId}`).innerText = html;
 
     const compatType = document.querySelector(`#compatibilitytype${extensionData.compatibilityData.resultGroup} tbody`);
@@ -455,9 +455,8 @@ Joomla = window.Joomla || {};
     // Process the nonCoreCriticalPlugin list
     if (extensionData.compatibilityData.resultGroup === 3) {
       PreUpdateChecker.nonCoreCriticalPlugins.foreach((cpi) => {
-        // TODO: Make this typesafe
-        if (PreUpdateChecker.nonCoreCriticalPlugins[cpi].package_id == extensionId
-            || PreUpdateChecker.nonCoreCriticalPlugins[cpi].extension_id == extensionId) {
+        if (parseInt(PreUpdateChecker.nonCoreCriticalPlugins[cpi].package_id, 10) === extensionId
+            || parseInt(PreUpdateChecker.nonCoreCriticalPlugins[cpi].extension_id, 10) === extensionId) {
           document.getElementById(`#plg_${PreUpdateChecker.nonCoreCriticalPlugins[cpi].extension_id}`).remove();
           PreUpdateChecker.nonCoreCriticalPlugins.splice(cpi, 1);
         }

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -440,7 +440,7 @@ Joomla = window.Joomla || {};
       }
     }
     // Insert the generated html
-    const extensionId = parseInt(extensionData.element.getAttribute('data-extension-id'), 10);
+    const extensionId = parseInt(extensionData.element.getAttribute('data-extension-id'), 10) || 0;
     document.getElementById(`available-version-${extensionId}`).innerText = html;
 
     const compatType = document.querySelector(`#compatibilitytype${extensionData.compatibilityData.resultGroup} tbody`);


### PR DESCRIPTION
Pull Request for Issue #33477 (part) .

### Summary of Changes

- Use `parseInt` to get values from `data-extension-id` and the `package_id` and `extension_id` properties of the particular non-core extension object.
- Let the `parseInt` from `data-extension-id` default to zero in order not to match with `NaN` in later type safe comparison.
- Use type safe comparison to compare the value from `data-extension-id` with the `package_id` and the `extension_id` properties of the non-core extension.

### Testing Instructions

Will be added soon.

### Actual result BEFORE applying this Pull Request

The pre-update check works more or less in the 4.0-dev branch after the recent upmerge from 3.10-dev.

The javascript cs in drone fails due to type safe comparison being required.

### Expected result AFTER applying this Pull Request

The pre-update check works as well or bad as without this PR.

The javascript cs in drone passes.

### Documentation Changes Required

None.

### Question

@zero-24 @wilsonge Should that be done in 3.10-dev, too?