### PR TITLE
[4] Allow cached namespacemap on folder structures not normally seen

### DIFF
--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -153,12 +153,10 @@ class JNamespacePsr4Map
 			{
 				foreach ($constants as $constant)
 				{
-					$path = str_replace($constant, constant($constant), $path);
+					$path = preg_replace(['/^(' . $constant . ")\s\.\s\'/", '/\'$/'], [constant($constant), ''], $path);
 				}
 
-				$path = str_replace(["'", " ", "."], "", $path);
 				$namespace = str_replace('\\\\', '\\', $namespace);
-
 				$map[$namespace] = [ $path ];
 			}
 


### PR DESCRIPTION
### Summary of Changes

History: https://github.com/joomla/joomla-cms/pull/33263

Allow in-memory autoload_psr4.php on REALLY strange servers (I.e. A server that cannot write to the folder `/administrator/cache`) so that Joomla can (albeit worse performance) run so that it can show more sensible errors on installation (Was originally designed for servers needing the FTP Layer, but as a decision to remove that layer has now been made, a further decision was made to keep the cached namespacemap so that Joomla could still load enough to show error messages (or even work fully) if the namespacemap cannot be written to `/administrator/cache`

I dont expect this code to ever be used on a site, however, as its already merged, I should address the fact that it *may* be used by 1 person in the next 20 years. 

This PR improves (fixes) the currently merged code, to allow the above to happen on servers with `[spaces, periods, single quotes]` in their `JPATH_BASE` folder structures, and with `/administrator/cache` unwritable - this is the only change here. 

### Testing Instructions

make yourself a folder with `[spaces, periods]` in it. I would go with something like

`My Folder.Old Stuff`

Use the above folder as your Joomla folder.
git checkout 4.0-dev
rm administrator/cache/autoload_psr4.php
chmod 000 administrator/cache
Load Joomla Installation (or site/admin if you already had Joomla installed)
See error
chmod 777 administrator/cache (to allow you to apply PR with git if needed)
Apply PR
rm administrator/cache/autoload_psr4.php (if exists, should not)
chmod 000 administrator/cache
Load Joomla - it works!

### Actual result BEFORE applying this Pull Request

With the already merged PR #33263 it "does not work in its current state", you could only use the cached namespacemap on folder structures that did not contain `[spaces, periods, single quotes]` in their folder structures (So a site in "My Sites.guru" folder would error).

This effects approx **0.0000297%** of sites following my research of the absolute path of 67,348 sites, even though those sites can actually write to the `/administrator/cache` and therefore would not actually use the cached namespacemap.

### Expected result AFTER applying this Pull Request

You can now expect the namespacemap to be generated on each page load, when it is unable to save `/administrator/cache/namespacemap.php` due to file/folder permissions.

Joomla can be installed and works perfectly without a physical file at `/administrator/cache/namespacemap.php`

### Documentation Changes Required

none.

// @wilsonge @SharkyKZ 