### PR TITLE
[4.0] Update download URL of composer 1 for appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -71,7 +71,7 @@ install:
     - IF %PHP%==1 echo opcache.enable_cli=1 >> php.ini
     - IF %PHP%==1 echo extension=php_ldap.dll >> php.ini
     - IF %PHP%==1 echo @php %%~dp0composer-1.phar %%* > composer.bat
-    - IF %PHP%==1 appveyor-retry appveyor DownloadFile https://getcomposer.org/composer-1.phar
+    - IF %PHP%==1 appveyor-retry appveyor DownloadFile https://getcomposer.org/download/latest-1.x/composer.phar
     - cd C:\projects\joomla-cms
     - appveyor-retry composer install --no-progress --profile
 before_test:

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -70,7 +70,7 @@ install:
     - IF %PHP%==1 echo zend_extension=php_opcache.dll >> php.ini
     - IF %PHP%==1 echo opcache.enable_cli=1 >> php.ini
     - IF %PHP%==1 echo extension=php_ldap.dll >> php.ini
-    - IF %PHP%==1 echo @php %%~dp0composer-1.phar %%* > composer.bat
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
     - IF %PHP%==1 appveyor-retry appveyor DownloadFile https://getcomposer.org/download/latest-1.x/composer.phar
     - cd C:\projects\joomla-cms
     - appveyor-retry composer install --no-progress --profile


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix appveyor being broken since today due to changed download URL.

### Testing Instructions

Check if appveyor CI checks are passing.

### Actual result BEFORE applying this Pull Request

All fail at downloading file https://getcomposer.org/composer-1.phar.

### Expected result AFTER applying this Pull Request

Appveyor works.

### Documentation Changes Required

None.