### PR TITLE
[3.x] Update download URL of composer for appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -126,7 +126,7 @@ install:
     - IF %PHP%==1 echo zend_extension=php_opcache.dll >> php.ini
     - IF %PHP%==1 echo opcache.enable_cli=1 >> php.ini
     - IF %PHP%==1 echo extension=php_ldap.dll >> php.ini
-    - IF %PHP%==1 echo @php %%~dp0composer-1.phar %%* > composer.bat
+    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
     - IF %PHP%==1 appveyor-retry appveyor DownloadFile https://getcomposer.org/download/latest-1.x/composer.phar
     - cd C:\projects\joomla-cms
     - appveyor-retry composer install --no-progress --profile

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -127,7 +127,7 @@ install:
     - IF %PHP%==1 echo opcache.enable_cli=1 >> php.ini
     - IF %PHP%==1 echo extension=php_ldap.dll >> php.ini
     - IF %PHP%==1 echo @php %%~dp0composer-1.phar %%* > composer.bat
-    - IF %PHP%==1 appveyor-retry appveyor DownloadFile https://getcomposer.org/composer-1.phar
+    - IF %PHP%==1 appveyor-retry appveyor DownloadFile https://getcomposer.org/download/latest-1.x/composer.phar
     - cd C:\projects\joomla-cms
     - appveyor-retry composer install --no-progress --profile
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

See #33507 ... you just can't see it broken on the staging branch or any PR because there hasn't been any new commit or PR since the URL has changed.

### Testing Instructions

Check if appveyor CI checks are passing.

### Actual result BEFORE applying this Pull Request

All would fail at downloading file https://getcomposer.org/composer-1.phar if being started right now.

### Expected result AFTER applying this Pull Request

Appveyor works.

### Documentation Changes Required

None.