### PR TITLE
[4.0] Fix the db schema checker in 4.0

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1383,12 +1383,12 @@ ENDDATA;
 	 *
 	 * @since   3.10.0
 	 */
-	private function getDatabaseSchemaCheck()
+	private function getDatabaseSchemaCheck(): bool
 	{
-		\JModelLegacy::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_installer/models', 'InstallerModel');
+		$mvcFactory = $this->bootComponent('com_installer')->getMVCFactory();
 
 		/** @var \Joomla\Component\Installer\Administrator\Model\DatabaseModel $model */
-		$model = \JModelLegacy::getInstance('Database', 'InstallerModel');
+		$model = $mvcFactory->createModel('Database', 'Administrator');
 
 		// Check if no default text filters found
 		if (!$model->getDefaultTextFilters())
@@ -1396,11 +1396,8 @@ ENDDATA;
 			return false;
 		}
 
-		$coreExtensionId = 700;
-
-		$table = \JTable::getInstance('Extension');
-		$table->load($coreExtensionId);
-		$cache = new \Joomla\Registry\Registry($table->manifest_cache);
+		$coreExtensionInfo = \Joomla\CMS\Extension\ExtensionHelper::getExtensionRecord('joomla', 'file');
+		$cache = new \Joomla\Registry\Registry($coreExtensionInfo->manifest_cache);
 
 		$updateVersion = $cache->get('version');
 
@@ -1410,17 +1407,21 @@ ENDDATA;
 			return false;
 		}
 
-		// Get the schema change set
-		$changeSet = $model->getItems();
+		// Ensure we only get information for core
+		$model->setState('filter.extension_id', $coreExtensionInfo->extension_id);
+
+		// We're filtering by a single extension which must always exist - so can safely access this through
+		// element 0 of the array
+		$changeInformation = $model->getItems()[0];
 
 		// Check if schema errors found
-		if (!empty($changeSet->check()))
+		if ($changeInformation['errorsCount'] !== 0)
 		{
 			return false;
 		}
 
 		// Check if database schema version does not match CMS version
-		if ($model->getSchemaVersion($coreExtensionId) != $changeSet->getSchema())
+		if ($model->getSchemaVersion($coreExtensionInfo->extension_id) != $changeInformation['schema'])
 		{
 			return false;
 		}


### PR DESCRIPTION
### Summary of Changes
Fixes the pre-upgrade check schema checker

### Testing Instructions
Set upstream to have a custom update site to the Joomla 4 nightly: URL is https://update.joomla.org/core/nightlies/next_major_list.xml 
<img width="676" alt="Screenshot 2021-05-03 at 16 05 13" src="https://user-images.githubusercontent.com/1986000/116893872-5daa2380-ac29-11eb-9937-8da404ecde05.png">

Ideally for this also install some other extensions so it's clear the data is returned for core rather than for any other core extension (as the major change in J4 is that the database fixer works for other extensions as well as core)

### Actual result BEFORE applying this Pull Request
Setup the update server above with a fresh install of J4. Note that the check for the Table Database Structure shows as out of date.

Apply patch


### Expected result AFTER applying this Pull Request
Table now shows successful:

<img width="463" alt="Screenshot 2021-05-03 at 16 10 13" src="https://user-images.githubusercontent.com/1986000/116894614-2c7e2300-ac2a-11eb-96de-9f4fd92401a8.png">

Now add a file `4.0.0-2021-05-03.sql` into the following directory `administrator/components/com_admin/sql/updates/mysql` (just copy and paste an existing file in the directory). Check that after refreshing that that the check now again shows correctly as failed.

### Documentation Changes Required
N/A
