### PR TITLE
Allow latest version of choco

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,9 +44,6 @@ services:
 ## Install PHP and composer, and run the appropriate composer command
 install:
     - IF EXIST C:\tools\php (SET PHP=0)
-    # TODO: This is a workaround for https://github.com/chocolatey/choco/issues/1843. Once this is fixed we
-    #       should go back to latest version in appveyor saving ourselves test time
-    - ps: choco upgrade chocolatey -y --version 0.10.13 --allow-downgrade --no-progress
     - ps: >-
         If ($env:php_ver_target -eq "5.6") {
           appveyor-retry cinst --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y --forcex86 php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')


### PR DESCRIPTION
The chocolatey bug that forced us to version pin has been fixed for some time - https://github.com/chocolatey/choco/issues/1843 - this removes our version downgrade