### PR TITLE
[4.0] Remove .text-muted used with .form-text

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_upload.php
@@ -62,8 +62,8 @@ Text::script('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', true);
 				<?php $maxSizeBytes = Utility::getMaxUploadSize(); ?>
 				<?php $maxSize = HTMLHelper::_('number.bytes', $maxSizeBytes); ?>
 				<input id="max_upload_size" name="max_upload_size" type="hidden" value="<?php echo $maxSizeBytes; ?>"/>
-				<div class="form-text text-muted"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', '&#x200E;' . $maxSize); ?></div>
-				<div class="form-text text-muted hidden" id="file_size" name="file_size"><?php echo Text::sprintf('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', '&#x200E;' . ''); ?></div>
+				<div class="form-text"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', '&#x200E;' . $maxSize); ?></div>
+				<div class="form-text hidden" id="file_size" name="file_size"><?php echo Text::sprintf('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', '&#x200E;' . ''); ?></div>
 				<div class="alert alert-warning hidden" id="max_upload_size_warn">
 					<?php echo Text::_('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG'); ?>
 				</div>

--- a/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
@@ -264,7 +264,7 @@
       <div class="form-check">
         <input class="form-check-input" type="checkbox" id="${this.parentId}-alt-check">
         <label class="form-check-label" for="${this.parentId}-alt-check">${this.altchecktext}</label>
-        <div><small class="form-text text-muted">${this.altcheckdesctext}</small></div>
+        <div><small class="form-text">${this.altcheckdesctext}</small></div>
       </div>
     </div>
     <div class="form-group">

--- a/installation/template/error.php
+++ b/installation/template/error.php
@@ -72,7 +72,7 @@ $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 								</div>
 								<div class="alert-text">
 									<h2><?php echo Text::_('JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST'); ?></h2>
-									<p class="form-text text-muted small"><span class="badge bg-secondary"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+									<p class="form-text small"><span class="badge bg-secondary"><?php echo $this->error->getCode(); ?></span> <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
 								</div>
 							</div>
 							<?php if ($this->debug) : ?>

--- a/installation/tmpl/preinstall/default.php
+++ b/installation/tmpl/preinstall/default.php
@@ -31,7 +31,7 @@ HTMLHelper::_('behavior.formvalidator');
 								</div>
 								<div class="alert-text">
 									<strong><?php echo $option->label; ?></strong>
-									<p class="form-text text-muted small"><?php echo $option->notice; ?></p>
+									<p class="form-text small"><?php echo $option->notice; ?></p>
 								</div>
 							</div>
 						<?php endif; ?>

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -48,7 +48,7 @@ if (!empty($parentclass))
 		<?php echo $input; ?>
 		<?php if (!$hideDescription && !empty($description)) : ?>
 			<div id="<?php echo $id; ?>">
-				<small class="form-text text-muted">
+				<small class="form-text">
 					<?php echo $description; ?>
 				</small>
 			</div>

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -94,7 +94,7 @@ $maxSize = HTMLHelper::_('number.bytes', $maxSizeBytes);
 		<div class="controls">
 			<input class="form-control-file" id="install_package" name="install_package" type="file">
 			<input id="max_upload_size" name="max_upload_size" type="hidden" value="<?php echo $maxSizeBytes; ?>" />
-			<small class="form-text text-muted"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?></small>
+			<small class="form-text"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', $maxSize); ?></small>
 		</div>
 	</div>
 	<div class="form-actions">


### PR DESCRIPTION
### Summary of Changes
In BS5, `.form-text` no longer sets display, but does set color and font-size. So it is not necessary to include `text-muted` to adjust color.

### Testing Instructions
Apply PR.
Run `npm run build:js`.

Go to Global Configuration > Server tab.
See description under `Force HTTPS`.

Go to System > Update > Joomla.
Click Upload & Update tab.
See `Maximum upload size: ‎48.00 MB`.

Edit an article.
Click CMS Content > Image.
Select an image.
See description under `No Description`.

In the other instances, please do code review.

### Expected result AFTER applying this Pull Request
Text color is slightly darker which is even better for readability.

