### PR TITLE
[4] Urgent fix to empty state on site/admin modules page

### DIFF
--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -647,7 +647,7 @@ class UpdateModel extends ListModel
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	protected function getEmptyStateQuery(): DatabaseQuery
+	protected function getEmptyStateQuery()
 	{
 		$query = parent::getEmptyStateQuery();
 

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\ListModel;
+use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
 use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
@@ -458,31 +459,21 @@ class ModulesModel extends ListModel
 	}
 
 	/**
-	 * Is this an empty state, I.e: no items of this type regardless of the searched for states.
+	 * Manipulate the query to be used to evaluate if this is an Empty State to provide specific conditions for this extension.
 	 *
-	 * @return boolean
+	 * @return DatabaseQuery
 	 *
 	 * @since __DEPLOY_VERSION__
 	 */
-	public function getisEmptyState()
+	protected function getEmptyStateQuery()
 	{
+		$query = parent::getEmptyStateQuery();
+
 		$clientId = (int) $this->getState('client_id');
 
-		$sql = $this->query
-			->clear('select')
-			->clear('values')
-			->clear('bounded')
-			->clear('limit')
-			->clear('order')
-			->clear('where')
-			->clear('where')
-			->select('count(*)');
-
-		$sql->where($this->_db->quoteName('a.client_id') . ' = :client_id')
+		$query->where($this->_db->quoteName('a.client_id') . ' = :client_id')
 			->bind(':client_id', $clientId, ParameterType::INTEGER);
 
-		$this->_db->setQuery($sql);
-
-		return !($this->_db->loadResult() > 0);
+		return $query;
 	}
 }


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/33100#issuecomment-831445767

### Summary of Changes

Sorry, looks like one of the PRs did not get refactored as time moved on and underlying changes were being merged. 

Refactor to use newly implemented `getEmptyStateQuery` method instead of `getisEmptyState`

### Testing Instructions

Joomla 4 admin -> System -> Site Modules - Error Page
Apply PR 
Joomla 4 admin -> System -> Site Modules - List of modules

Repeat for Joomla 4 admin -> System -> Administrator Modules 

### Actual result BEFORE applying this Pull Request

Red screen of death

### Expected result AFTER applying this Pull Request

List of modules

### Documentation Changes Required

