### PR TITLE
[4.0] Improve Frontend Statistics Module list item layout

### DIFF
--- a/modules/mod_stats/tmpl/default.php
+++ b/modules/mod_stats/tmpl/default.php
@@ -11,9 +11,9 @@ defined('_JEXEC') or die;
 ?>
 <ul class="mod-stats list-group">
 <?php foreach ($list as $item) : ?>
-	<li class="list-group-item justify-content-between">
+	<li class="list-group-item">
 		<?php echo $item->title; ?>
-		<span class="badge bg-secondary rounded-pill"><?php echo $item->data; ?></span>
+		<span class="badge bg-secondary float-end rounded-pill"><?php echo $item->data; ?></span>
 	</li>
 <?php endforeach; ?>
 </ul>


### PR DESCRIPTION
Pull Request for Issue #33526

### Summary of Changes
Adds `float-end` class to span.badge and removes `justify-content-between` class from it's parent `<li>` resulting in the badges being right aligned


### Testing Instructions
1. From the Admin Panel, add the Statistics Module to your frontend and publish it.
2. Visit Frontend and check that the badges are aligned to the right end after the patch is applied


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/116960386-da86dd00-acbd-11eb-88c6-ce4d5871d3be.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/116960392-dc50a080-acbd-11eb-8ffd-5f32ad8ba4f6.png)



### Documentation Changes Required
None
