### PR TITLE
[4.0] Frontend link and Joomla Version Information in Admin Module

### DIFF
--- a/administrator/modules/mod_frontend/tmpl/default.php
+++ b/administrator/modules/mod_frontend/tmpl/default.php
@@ -18,10 +18,7 @@ use Joomla\CMS\Uri\Uri;
 	<a class="d-flex" href="<?php echo Uri::root(); ?>"
 		title="<?php echo Text::sprintf('MOD_FRONTEND_PREVIEW', $sitename); ?>"
 		target="_blank">
-		<div class="d-flex align-items-end mx-auto">
-			<span class="icon-external-link-alt" aria-hidden="true"></span>
-		</div>
-		<div class="align-items-center tiny">
+		<div class="mx-auto">
 			<?php echo HTMLHelper::_('string.truncate', $sitename, 28, false, false); ?>
 		</div>
 	</a>

--- a/administrator/modules/mod_version/tmpl/default.php
+++ b/administrator/modules/mod_version/tmpl/default.php
@@ -14,10 +14,8 @@ use Joomla\CMS\Language\Text;
 ?>
 <div class="header-item-content">
 	<div class="joomlaversion d-flex text-muted">
-		<div class="d-flex align-items-end mx-auto">
+		<div class="mx-auto">
 			<span class="icon-joomla" aria-hidden="true"></span>
-		</div>
-		<div class="tiny mx-auto">
 			<span class="visually-hidden"><?php echo Text::sprintf('MOD_VERSION_CURRENT_VERSION_TEXT', $version); ?></span>
 			<span aria-hidden="true"><?php echo $version; ?></span>
 		</div>


### PR DESCRIPTION
Pull Request for Issue #33520 and #33522

### Summary of Changes


### Testing Instructions
Add an Admin Module of type link to frontend to an admin dashboard
Add admin module Joomla! Version Information to a dashboard - see the stretched output and icon/version disconnected

### Actual result BEFORE applying this Pull Request
![frontend_before](https://user-images.githubusercontent.com/61203226/116964622-a2859700-acc9-11eb-9531-9d19575392f7.JPG)

![joomlaversion-before](https://user-images.githubusercontent.com/61203226/116965420-618e8200-accb-11eb-873a-f76f958b98a8.JPG)



### Expected result AFTER applying this Pull Request
![frontend_after](https://user-images.githubusercontent.com/61203226/116964632-a6b1b480-acc9-11eb-8744-1ca574df8e0f.JPG)

![joomlaversion-after](https://user-images.githubusercontent.com/61203226/116965431-66533600-accb-11eb-916c-16861fa79ecc.JPG)



### Documentation Changes Required
None
