### PR TITLE
[4.0] Fix Description for Password Fields that do not have rules

### DIFF
--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -203,7 +203,6 @@
 			filter="raw"
 			autocomplete="off"
 			size="30"
-			hiddenDescription="true"
 			lock="true"
 		/>
 

--- a/administrator/components/com_users/forms/user.xml
+++ b/administrator/components/com_users/forms/user.xml
@@ -21,8 +21,6 @@
 			name="password"
 			type="password"
 			label="JGLOBAL_PASSWORD"
-			description="JFIELD_PASSWORD_RULES_MINIMUM_REQUIREMENTS"
-			hiddenDescription="true"
 			rules="true"
 			autocomplete="new-password"
 			class="validate-password-strength"

--- a/components/com_users/forms/registration.xml
+++ b/components/com_users/forms/registration.xml
@@ -34,7 +34,6 @@
 			name="password1"
 			type="password"
 			label="COM_USERS_PROFILE_PASSWORD1_LABEL"
-			description="JFIELD_PASSWORD_RULES_MINIMUM_REQUIREMENTS"
 			required="true"
 			autocomplete="new-password"
 			class="validate-password"
@@ -45,7 +44,6 @@
 			rules="true"
 			force="on"
 			filter="raw"
-			hiddenDescription="true"
 		/>
 
 		<field

--- a/components/com_users/forms/reset_complete.xml
+++ b/components/com_users/forms/reset_complete.xml
@@ -5,7 +5,6 @@
 			name="password1"
 			type="password"
 			label="COM_USERS_FIELD_RESET_PASSWORD1_LABEL"
-			description="JFIELD_PASSWORD_RULES_MINIMUM_REQUIREMENTS"
 			required="true"
 			autocomplete="new-password"
 			class="validate-password"
@@ -16,7 +15,6 @@
 			rules="true"
 			force="on"
 			filter="raw"
-			hiddenDescription="true"
 		/>
 		<field
 			name="password2"

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -92,7 +92,7 @@ $attributes = array(
 	strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
 	!empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '',
 	!empty($class) ? 'class="form-control ' . $class . '"' : 'class="form-control"',
-	!empty($ariaDescribedBy) ? 'aria-describedby="' . $ariaDescribedBy . '"' : '',
+	!empty($ariaDescribedBy) ? 'aria-describedby="' . trim($ariaDescribedBy) . '"' : '',
 	$readonly ? 'readonly' : '',
 	$disabled ? 'disabled' : '',
 	!empty($size) ? 'size="' . $size . '"' : '',

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -135,7 +135,7 @@ if ($rules && !empty($description))
 	}
 }
 ?>
-<?php if ($rules) : ?>
+<?php if (!empty($description) && $rules) : ?>
 	<div id="<?php echo $name . '-desc'; ?>" class="small text-muted">
 		<?php echo Text::sprintf($description, implode(', ', $requirements)); ?>
 	</div>

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -135,13 +135,9 @@ if ($rules && !empty($description))
 	}
 }
 ?>
-<?php if (!empty($description)) : ?>
+<?php if ($rules) : ?>
 	<div id="<?php echo $name . '-desc'; ?>" class="small text-muted">
-		<?php if ($rules) : ?>
-			<?php echo Text::sprintf($description, implode(', ', $requirements)); ?>
-		<?php else : ?>
-			<?php echo Text::_($description); ?>
-		<?php endif; ?>
+		<?php echo Text::sprintf($description, implode(', ', $requirements)); ?>
 	</div>
 <?php endif; ?>
 

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -136,7 +136,7 @@ if ($rules)
 }
 ?>
 <?php if ($rules) : ?>
-	<div id="<?php echo $name . '-desc'; ?>" class="small text-muted">
+	<div id="<?php echo $name . '-rules'; ?>" class="small text-muted">
 		<?php echo Text::sprintf('JFIELD_PASSWORD_RULES_MINIMUM_REQUIREMENTS', implode(', ', $requirements)); ?>
 	</div>
 <?php endif; ?>

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -85,11 +85,14 @@ if ($lock)
 	$value = '';
 }
 
+$ariaDescribedBy = $rules ? $name . '-rules ' : '';
+$ariaDescribedBy .= !empty($description) ? $name . '-desc' : '';
+
 $attributes = array(
 	strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
 	!empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '',
 	!empty($class) ? 'class="form-control ' . $class . '"' : 'class="form-control"',
-	!empty($description) ? 'aria-describedby="' . $name . '-desc"' : '',
+	!empty($ariaDescribedBy) ? 'aria-describedby="' . $ariaDescribedBy . '"' : '',
 	$readonly ? 'readonly' : '',
 	$disabled ? 'disabled' : '',
 	!empty($size) ? 'size="' . $size . '"' : '',

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -105,7 +105,7 @@ $attributes = array(
 	$dataAttribute,
 );
 
-if ($rules && !empty($description))
+if ($rules)
 {
 	$requirements = [];
 
@@ -135,9 +135,9 @@ if ($rules && !empty($description))
 	}
 }
 ?>
-<?php if (!empty($description) && $rules) : ?>
+<?php if ($rules) : ?>
 	<div id="<?php echo $name . '-desc'; ?>" class="small text-muted">
-		<?php echo Text::sprintf($description, implode(', ', $requirements)); ?>
+		<?php echo Text::sprintf('JFIELD_PASSWORD_RULES_MINIMUM_REQUIREMENTS', implode(', ', $requirements)); ?>
 	</div>
 <?php endif; ?>
 

--- a/plugins/authentication/ldap/ldap.xml
+++ b/plugins/authentication/ldap/ldap.xml
@@ -135,7 +135,6 @@
 					type="password"
 					label="PLG_LDAP_FIELD_PASSWORD_LABEL"
 					description="PLG_LDAP_FIELD_PASSWORD_DESC"
-					hiddenDescription="true"
 					size="20"
 				/>
 


### PR DESCRIPTION
Pull Request for Issue #33528
This also fixes an issue where Passwords fields without `rules="true"` had to include a misleading attribute: `hiddenDescription="true"` so that they could prevent the description being shown twice

**Edit**: Removed the dependency of rules on description as discussed in the conversation below. I've modified some of the testing conditions accordingly
Now, the description can be independent of the rules text and both can be used together with different text in a single field

### Summary of Changes
- Password fields use the rules attribute to check for the rules specified in the Description (These include max length, allowed chars, etc)
- If the rules attribute is set to true, then the description and rules are displayed above the password field like:

![image](https://user-images.githubusercontent.com/53610833/116969280-a1f1fe00-acd3-11eb-9eb6-9515833bd400.png)

- Along with this, the description is displayed again below the field because of  the echo in renderfield.php layout which is common to all the types of fields https://github.com/joomla/joomla-cms/blob/3cebcc73cd03f015807444ce69e52da0f58c8932/layouts/joomla/form/renderfield.php#L52
- So unless the field has an attribute of hiddenDescription="true", the output turns out to be something like: 
 
![image](https://user-images.githubusercontent.com/53610833/116969695-51c76b80-acd4-11eb-8da6-71c2a8ed133f.png)

- The bug occurs when you add a description without a rule. In this case, the description is repeated twice unless you add the hiddenDescription="true" attribute. But the catch here is that when you apply hiddenDescription, then the description that is present below the field is hidden while the description above the password field stays visible (resulting in issue #33528)
- Until now, fields with description and without rules had to use hiddenDescription="true" as a make-do way to show description only once. After this PR is merged, developers will no longer have to worry about why their description is being shown twice and they won't have to add a misleading hiddenDescription attribute to tix this.

### Testing Instructions

#### Test for the fixed Issue:
Admin Panel -> System -> Global Config -> Server-> Check the Password Field under Database Fieldset

#### Test for checking this works globally
<ol>
<li> Make a new form / Edit an Existing form </li>
<li> Add two fields of type password such that:

| Field 1 contains: | Field 2 contains: |
| --- | --- |
| <ul type="none"><li> ✔️ description</li><li>❌ **no** rules attribute</li><li>❌ **no** hidden description attribute</li></ul>  |<ul type="none"><li> ✔️ description</li><li> ✔️ rules="true"</li><li> ❌ **no** hidden description attribute</li></ul>|
</li>
</ol>
<br/>
For Example:

```
<field
	name="password1"
	type="password"
	label="COM_CONFIG_FIELD_DATABASE_PASSWORD_LABEL"
	description="COM_CONFIG_FIELD_DATABASE_PASSWORD_DESC"
	filter="raw"
	autocomplete="off"
	size="30"
	lock="true"
/>

<field
	name="password"
	type="password"
	label="JGLOBAL_PASSWORD"
	rules="true"
	description="COM_CONFIG_FIELD_DATABASE_PASSWORD_DESC"
	autocomplete="new-password"
	class="validate-password-strength"
	filter="raw"
	validate="password"
	strengthmeter="true"
	force="on"
	size="30"
/>
```

| Before | After |
| --- | --- |
| ![image](https://user-images.githubusercontent.com/53610833/117097973-cbba2c00-ad8a-11eb-8204-fa46f91e7d47.png) | ![image](https://user-images.githubusercontent.com/53610833/117097746-21da9f80-ad8a-11eb-91e4-4f0ef6fc781d.png) |
| Field 1 shows duplicate descriptions and Field 2 shows description instead of rules because it uses the description text to display rules and the language constants for it is missing a %s | Field 1 is fixed and Field 2 now shows unique text for rules message and description message |

You can also test out different combinations of the following attributes:
- description (valid or empty)
- rules (true or false)
- hiddenDescription (true or false)


### Actual result BEFORE applying this Pull Request (For  #33528)
![image](https://user-images.githubusercontent.com/53610833/116970879-55f48880-acd6-11eb-9178-cd5a7b5790ae.png)


### Expected result AFTER applying this Pull Request (For  #33528)
![image](https://user-images.githubusercontent.com/53610833/116968053-5a6a7280-acd1-11eb-82fb-89731ff1b092.png)



### Documentation Changes Required
None
