### PR TITLE
[4.0] Admin module feed display image

### DIFF
--- a/administrator/modules/mod_feed/tmpl/default.php
+++ b/administrator/modules/mod_feed/tmpl/default.php
@@ -83,7 +83,7 @@ else
 
 		<?php // Feed image ?>
 		<?php if ($params->get('rssimage', 1) && $feed->image) : ?>
-			<img src="<?php echo $feed->image->uri; ?>" alt="<?php echo $feed->image->title; ?>"/>
+			<img class="w-100" src="<?php echo $feed->image->uri; ?>" alt="<?php echo $feed->image->title; ?>"/>
 		<?php endif; ?>
 
 


### PR DESCRIPTION
Pull Request for Issue #33523 .

### Summary of Changes
add class `w-100`


### Testing Instructions
Add a new Admin Module of type Feed Display with feed with images in its feed - use url https://rss.art19.com/apology-line for example right now.

### Actual result BEFORE applying this Pull Request
![feed-before](https://user-images.githubusercontent.com/61203226/116981218-d5895400-ace4-11eb-8012-c90f86c2a9b8.JPG)

### Expected result AFTER applying this Pull Request
![feed-after](https://user-images.githubusercontent.com/61203226/116981259-e4700680-ace4-11eb-9411-e43ea0bcf211.JPG)

### Documentation Changes Required
None
