### PR TITLE
[4.0] a11y - prevent double announcement of readmore

### DIFF
--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -21,26 +21,34 @@ $direction = Factory::getLanguage()->isRtl() ? 'left' : 'right';
 <p class="readmore">
 	<?php if (!$params->get('access-view')) : ?>
 		<a class="btn btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo Text::_('JGLOBAL_REGISTER_TO_READ_MORE') . ' ' . $this->escape($item->title); ?>">
-			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
-			<?php echo Text::_('JGLOBAL_REGISTER_TO_READ_MORE'); ?>
+			<span class="aria-hidden">
+				<span class="icon-chevron-<?php echo $direction; ?>"></span>
+				<?php echo Text::_('JGLOBAL_REGISTER_TO_READ_MORE'); ?>
+			</span>
 		</a>
 	<?php elseif ($readmore = $item->alternative_readmore) : ?>
 		<a class="btn btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo $this->escape($readmore . ' ' . $item->title); ?>">
-			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
-			<?php echo $readmore; ?>
-			<?php if ($params->get('show_readmore_title', 0) != 0) : ?>
-				<?php echo HTMLHelper::_('string.truncate', $item->title, $params->get('readmore_limit')); ?>
-			<?php endif; ?>
+			<span class="aria-hidden">
+				<span class="icon-chevron-<?php echo $direction; ?>"></span>
+				<?php echo $this->escape($readmore); ?>
+				<?php if ($params->get('show_readmore_title', 0) != 0) : ?>
+					<?php echo HTMLHelper::_('string.truncate', $item->title, $params->get('readmore_limit')); ?>
+				<?php endif; ?>
+			</span>
 		</a>
 	<?php elseif ($params->get('show_readmore_title', 0) == 0) : ?>
 		<a class="btn btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo Text::sprintf('JGLOBAL_READ_MORE_TITLE', $this->escape($item->title)); ?>">
-			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
-			<?php echo Text::_('JGLOBAL_READ_MORE'); ?>
+			<span class="aria-hidden">
+				<span class="icon-chevron-<?php echo $direction; ?>"></span>
+				<?php echo Text::_('JGLOBAL_READ_MORE'); ?>
+			</span>
 		</a>
 	<?php else : ?>
 		<a class="btn btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo Text::sprintf('JGLOBAL_READ_MORE_TITLE', $this->escape($item->title)); ?>">
-			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
-			<?php echo Text::sprintf('JGLOBAL_READ_MORE_TITLE', HTMLHelper::_('string.truncate', $item->title, $params->get('readmore_limit'))); ?>
+			<span class="aria-hidden">
+				<span class="icon-chevron-<?php echo $direction; ?>"></span>
+				<?php echo Text::sprintf('JGLOBAL_READ_MORE_TITLE', HTMLHelper::_('string.truncate', $item->title, $params->get('readmore_limit'))); ?>
+			</span>
 		</a>
 	<?php endif; ?>
 </p>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Readmore has an aria-label. Additionally, the text on the button is announced by the screenreader. This results in a double announcement. This PR hides the button-text for screenreaders.
Credits: Accessibilty Team



### Testing Instructions
Make Articles with Readmore. Use different variants
- Readmore with title
- Readmore without title
- Readmore with request for login
Check the sourcecode or use a screenreader or another a11y testing tool.  

### Actual result BEFORE applying this Pull 



### Expected result AFTER applying this Pull Request
The text on the Readmore button remains as before. 
But the screenreader announces always the Readmore-text plus titile.



### Documentation Changes Required

