### PR TITLE
[4.0] Add options-form class in Cassiopeia

### DIFF
--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -127,7 +127,7 @@ $modalHTML = HTMLHelper::_('bootstrap.renderModal',
 				'width'       => '100%',
 				'modalWidth'  => '80',
 				'bodyHeight'  => '60',
-				'footer'      => '<button type="button" class="btn btn-secondary button-save-selected">' . Text::_('JSELECT') . '</button>'
+				'footer'      => '<button type="button" class="btn btn-success button-save-selected">' . Text::_('JSELECT') . '</button>'
 						. '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' . Text::_('JCANCEL') . '</button>',
 		)
 );

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -164,8 +164,8 @@ $wam->useStyle('webcomponent.field-media')
 	<div class="input-group">
 		<input type="text" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" readonly="readonly"<?php echo $attr; ?>>
 		<?php if ($disabled != true) : ?>
-			<button type="button" class="btn btn-secondary button-select"><?php echo Text::_("JLIB_FORM_BUTTON_SELECT"); ?></button>
-			<button type="button" class="btn btn-secondary button-clear"><span class="icon-times" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_("JLIB_FORM_BUTTON_CLEAR"); ?></span></button>
+			<button type="button" class="btn btn-success button-select"><?php echo Text::_("JLIB_FORM_BUTTON_SELECT"); ?></button>
+			<button type="button" class="btn btn-danger button-clear"><span class="icon-times" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_("JLIB_FORM_BUTTON_CLEAR"); ?></span></button>
 		<?php endif; ?>
 	</div>
 </joomla-field-media>

--- a/templates/cassiopeia/scss/blocks/_layout.scss
+++ b/templates/cassiopeia/scss/blocks/_layout.scss
@@ -112,3 +112,21 @@
 .system-debug {
   display: block;
 }
+
+.options-form {
+  width: 100%;
+  padding: 1vw 2vw;
+  margin-bottom: 1rem;
+  color: #495057;
+  background-color: $white;
+  border: 1px solid #b2bfcd;
+
+  > legend {
+    float: none;
+    width: auto;
+    padding: 0 .5rem;
+    font-weight: 700;
+    color: #495057;
+    background-color: $white;
+  }
+}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Replicate `options-form` class from `Atum` to `Cassiopeia` <br>
And change class from`btn-secondary` to `btn-success` for `Select` button

### Testing Instructions
* Log In to the frontend
* Go to Template Setting in Author Menu module or Visit http://localhost/joomla-cms/index.php/create-a-post/template-settings
* Click Select
* Try to edit an image with `pencil` icon
* Apply PR
* Do `npm run build:css`
* Refresh the page and Repeat above steps
* See the difference

### If you don't see any difference, please remove all your `Caches` from the browser and try again

https://user-images.githubusercontent.com/61203226/117054542-d39cb080-ad37-11eb-97c1-127900f26e48.mp4

### Actual result BEFORE applying this Pull Request
![frontend-before](https://user-images.githubusercontent.com/61203226/117054439-ba93ff80-ad37-11eb-9f14-6c56745359fc.JPG)

![logo-before](https://user-images.githubusercontent.com/61203226/117058130-e1eccb80-ad3b-11eb-973c-81d4ca3538f9.JPG)

### Expected result AFTER applying this Pull Request
![frontend-after](https://user-images.githubusercontent.com/61203226/117053896-23c74300-ad37-11eb-8576-ed0294f0f010.JPG)

![logo-after](https://user-images.githubusercontent.com/61203226/117058141-e618e900-ad3b-11eb-8022-d1fbce8b73f3.JPG)

### Documentation Changes Required
None
