### PR TITLE
[4.0] Frontend: Removes Extra hr at the end of Module Edit View

### DIFF
--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -58,7 +58,7 @@ if (Multilanguage::isEnabled())
 			</div>
 			<hr>
 
-			<div class="row">
+			<div class="row mb-4">
 				<div class="col-md-12">
 
 					<div class="control-group">
@@ -170,7 +170,6 @@ if (Multilanguage::isEnabled())
 				<input type="hidden" name="return" value="<?php echo Factory::getApplication()->input->get('return', null, 'base64'); ?>">
 				<input type="hidden" name="task" value="">
 				<?php echo HTMLHelper::_('form.token'); ?>
-				<hr>
 			</div>
 			<div class="mb-2">
 			<button type="button" class="btn btn-primary" data-submit-task="modules.apply">


### PR DESCRIPTION
Pull Request for Issue #33547 .

### Summary of Changes
Removes extra `<hr>` and adds margin to compensate for the gap


### Testing Instructions

Prerequisites: Install Blog Sample Data
1. Visit Frontend
2. Login as Administrator
3. Click on Edit for any module
4. Scroll to the bottom of the form


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/117099398-ad562f80-ad8e-11eb-99ab-322e01d213f7.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/117099389-a6c7b800-ad8e-11eb-81cd-910856872539.png)



### Documentation Changes Required
None
