### PR TITLE
[3.10] Correctly handle objects when storing data in tables with _jsonEncode being set

### DIFF
--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -602,18 +602,6 @@ abstract class Table extends \JObject implements \JObservableInterface, \JTableI
 	 */
 	public function bind($src, $ignore = array())
 	{
-		// JSON encode any fields required
-		if (!empty($this->_jsonEncode))
-		{
-			foreach ($this->_jsonEncode as $field)
-			{
-				if (isset($src[$field]) && is_array($src[$field]))
-				{
-					$src[$field] = json_encode($src[$field]);
-				}
-			}
-		}
-
 		// Check if the source value is an array or object
 		if (!is_object($src) && !is_array($src))
 		{
@@ -626,16 +614,28 @@ abstract class Table extends \JObject implements \JObservableInterface, \JTableI
 			);
 		}
 
+		// If the ignore value is a string, explode it over spaces.
+		if (!is_array($ignore))
+		{
+			$ignore = explode(' ', $ignore);
+		}
+
 		// If the source value is an object, get its accessible properties.
 		if (is_object($src))
 		{
 			$src = get_object_vars($src);
 		}
 
-		// If the ignore value is a string, explode it over spaces.
-		if (!is_array($ignore))
+		// JSON encode any fields required
+		if (!empty($this->_jsonEncode))
 		{
-			$ignore = explode(' ', $ignore);
+			foreach ($this->_jsonEncode as $field)
+			{
+				if (isset($src[$field]) && is_array($src[$field]))
+				{
+					$src[$field] = json_encode($src[$field]);
+				}
+			}
 		}
 
 		// Bind the source value, excluding the ignored fields.

--- a/tests/unit/suites/libraries/joomla/table/JTableTest.php
+++ b/tests/unit/suites/libraries/joomla/table/JTableTest.php
@@ -356,6 +356,48 @@ class JTableTest extends TestCaseDatabase
 	}
 
 	/**
+	 * Test for bind method with object.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function testBindWithObject()
+	{
+		TestReflection::setValue($this->object, '_jsonEncode', array('params'));
+
+		$data = new stdClass;
+		$data->id1    = 25;
+		$data->id2    = 50;
+		$data->title  = 'My Title';
+		$data->params = array('param1' => 'value1', 'param2' => 25);
+
+		$this->object->bind($data);
+
+		$this->assertEquals(
+			25,
+			$this->object->id1
+		);
+
+		$this->assertEquals(
+			50,
+			$this->object->id2
+		);
+
+		$this->assertEquals(
+			'My Title',
+			$this->object->title
+		);
+
+		// Check the object is json encoded properly
+		$this->assertEquals(
+			'{"param1":"value1","param2":25}',
+			$this->object->params,
+			'The object should be json encoded'
+		);
+	}
+
+	/**
 	 * Gets the data set to be loaded into the database during setup
 	 *
 	 * @return  PHPUnit_Extensions_Database_DataSet_CsvDataSet


### PR DESCRIPTION
Pull Request for Issue #33553 .

### Summary of Changes

Back-integrate from 4.0-dev to here (3.10-dev) the following changes from PR #25761 for fixing bind() with objects in the JTable class:
- Change order of processing in the bind() routine and add a `get_object_vars` if the `$src` parameter is an object, so that it is:
1. Check if the source value is an array or object and throw an exception if not.
2. If the ignore value is a string, explode it over spaces.
3. If the source value is an object, get its accessible properties with `get_object_vars`.
4. JSON encode any fields if required.
5. Bind the source value, excluding the ignored fields.

- Add a unit test for bind() with an object.

I'm wondering why the 4th step in the above list currently comes before the 1st without this PR.

### Testing Instructions

Step 1: On a current 3.10-dev branch or latest 3.10 nightly build, switch on ""Debug System" and set "Error Reporting" to "Maximum" or "Development".

Step 2: Add the following code to some administrator view:
```
// Test PR-33558 begin
JTable::addIncludePath(JPATH_ROOT . '/administrator/components/com_contact/tables');

$row1 = JTable::getInstance('Contact', 'ContactTable');

$contact1 = [
	'name'      => 'Bat Man',
	'alias'     => 'bat-man',
	'catid'     => 4,
	'params'    => ['show_contact_list' => 0, 'show_tags' => ''],
	'language'  => '*',
	'published' => 1,
	'access'    => 1,
];

$row1->bind($contact1);
$row1->store();

echo '<div>Contact 1 saved.<div>';

$row2 = JTable::getInstance('Contact', 'ContactTable');

$contact2            = new stdClass;
$contact2->name      = 'John Doe';
$contact2->alias     = 'john-doe';
$contact2->catid     = 4;
$contact2->params    = ['show_contact_list' => 0, 'show_tags' => ''];
$contact2->language  = '*';
$contact2->published = 1;
$contact2->access    = 1;

$row2->bind($contact2);
$row2->store();

echo '<div>Contact 2 saved.<div>';
// Test PR-33558 end
```
E.g. you can add it just before the following line in the users view's default template:
https://github.com/joomla/joomla-cms/blob/3.10-dev/administrator/components/com_users/views/users/tmpl/default.php#L20

The code creates or updates 2 new contact records in database, using bind() and store(), one contact given as array and the other one as object (stdClass).

Step 3: Navigate to the view modified in the previous step.
In my example: "Users -> Manage" (`administrator/index.php?option=com_users&view=users`).

Result: Error 'Cannot use object of type stdClass as array', see issue #33553 and section "Actual result BEFORE applying this Pull Request" below.

Step 4: Check in database if the two contacts have been created.

Result: Only the first contact "Bat Man" has been created.

Step 5: Delete that contact.

Step 6: Apply the patch of this PR.

Step 7: Navigate again to the view modified in the previous step, or reload the page if still there.

Result: No error, the debug output is shown, see section "Expected result AFTER applying this Pull Request" below.

Step 8: Check in database if the two contacts have been created.

Result: Both contacts "Bat Man" and "John Doe" have been created.

### Actual result BEFORE applying this Pull Request

Storing data fails with error 'Cannot use object of type stdClass as array'.

![2021-05-06_1](https://user-images.githubusercontent.com/7413183/117303611-2fbd1d00-ae7d-11eb-9e5f-64f08e855053.png)

### Expected result AFTER applying this Pull Request

Storing data succeeds.

The debug output is shown.

![2021-05-06_2](https://user-images.githubusercontent.com/7413183/117303655-3e0b3900-ae7d-11eb-8621-02db7140da47.png)

### Documentation Changes Required

None.