### PR TITLE
[4.0] Blog Sample Data - Move article image right

### DIFF
--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -612,7 +612,7 @@ class PlgSampledataBlog extends CMSPlugin
 					'image_intro_alt_empty'     => 1,
 					'image_intro_caption'       => '',
 					'image_fulltext'            => 'images/sampledata/cassiopeia/nasa3-400.jpg',
-					'float_fulltext'            => 'float-start',
+					'float_fulltext'            => 'float-end',
 					'image_fulltext_alt'        => Text::_('PLG_SAMPLEDATA_BLOG_SAMPLEDATA_CONTENT_ARTICLE_4_FULLTEXTIMAGE_ALT'),
 					'image_fulltext_alt_empty'  => '',
 					'image_fulltext_caption'    => 'www.nasa.gov/multimedia/imagegallery',


### PR DESCRIPTION
Pull Request for Issue #33501 .

### Summary of Changes
float-left in J3 and float-start in J4 look awkward when the surrounding text contains lists. 
Moving the image right is a purely cosmetic operation so the article looks better in blog sample data.

### Testing Instructions
Install blog sample data in an installation. 


### Actual result BEFORE applying this Pull Request
see #33501

### Expected result AFTER applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/117146362-6c711180-adb4-11eb-9d26-987feaa44292.png)



### Documentation Changes Required

