### PR TITLE
[4.0] Input slider in media manager

### DIFF
--- a/build/media_source/plg_media-action_resize/js/resize.es6.js
+++ b/build/media_source/plg_media-action_resize/js/resize.es6.js
@@ -42,6 +42,9 @@ Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
     // Update the height input box
     document.getElementById('jform_resize_height').value = parseInt(height, 10);
 
+    document.getElementById('jform_resize_h').value = height;
+      document.getElementById('jform_resize_w').value = width;
+
     // Notify the app that a change has been made
     window.dispatchEvent(new Event('mediaManager.history.point'));
   };

--- a/build/media_source/plg_media-action_resize/js/resize.es6.js
+++ b/build/media_source/plg_media-action_resize/js/resize.es6.js
@@ -39,11 +39,15 @@ Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
     // Update the width input box
     document.getElementById('jform_resize_width').value = parseInt(width, 10);
 
+    // Update the width input range slider
+    document.getElementById('jform_resize_w').value = parseInt(width, 10);
+
     // Update the height input box
     document.getElementById('jform_resize_height').value = parseInt(height, 10);
 
-    document.getElementById('jform_resize_h').value = height;
-      document.getElementById('jform_resize_w').value = width;
+    // Update the height input range slider
+    document.getElementById('jform_resize_h').value = parseInt(height, 10);
+
 
     // Notify the app that a change has been made
     window.dispatchEvent(new Event('mediaManager.history.point'));

--- a/build/media_source/plg_media-action_resize/js/resize.es6.js
+++ b/build/media_source/plg_media-action_resize/js/resize.es6.js
@@ -48,7 +48,6 @@ Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
     // Update the height input range slider
     document.getElementById('jform_resize_h').value = parseInt(height, 10);
 
-
     // Notify the app that a change has been made
     window.dispatchEvent(new Event('mediaManager.history.point'));
   };


### PR DESCRIPTION
### Summary of Changes
Add Javascript code to change the other input slider accordingly
```javascript
document.getElementById('jform_resize_w').value = parseInt(width, 10);
document.getElementById('jform_resize_h').value = parseInt(height, 10);
```

### Testing Instructions
* `Dashboard` > `Content` > `Media` > `Try to edit an image using pencil icon` > `Go to Resize tab`
*  Apply PR
* Do `npm i`

### Actual result BEFORE applying this Pull Request
![resize-before](https://user-images.githubusercontent.com/61203226/117247650-4dc65580-ae5c-11eb-8b58-5683ccd9c531.gif)

### Expected result AFTER applying this Pull Request
https://user-images.githubusercontent.com/61203226/117536534-25378a80-b019-11eb-9334-9394c77bb33b.mp4

### Documentation Changes Required
Don't know



