### PR TITLE
[4.0] (Issue Resolved) Backend - Add padding to module card headers

### DIFF
--- a/administrator/templates/atum/html/layouts/chromes/well.php
+++ b/administrator/templates/atum/html/layouts/chromes/well.php
@@ -37,7 +37,7 @@ $headerTag      = htmlspecialchars($params->get('header_tag', 'h2'), ENT_QUOTES,
 $moduleClassSfx = $params->get('moduleclass_sfx', '');
 
 // Temporarily store header class in variable
-$headerClass = $params->get('header_class') ? ' class="' . htmlspecialchars($params->get('header_class'), ENT_QUOTES, 'UTF-8') . '"' : '';
+$headerClass = $params->get('header_class') ? htmlspecialchars($params->get('header_class'), ENT_QUOTES, 'UTF-8') : 'pe-3';
 
 // Get the module icon
 $headerIcon = $params->get('header_icon') ? '<span class="' . htmlspecialchars($params->get('header_icon'), ENT_QUOTES, 'UTF-8') . '" aria-hidden="true"></span>' : '';
@@ -68,7 +68,7 @@ $headerIcon = $params->get('header_icon') ? '<span class="' . htmlspecialchars($
 				<?php endif; ?>
 
 				<?php if ($module->showtitle) : ?>
-					<<?php echo $headerTag; ?><?php echo $headerClass; ?>>
+					<<?php echo $headerTag; ?> class="<?php echo $headerClass; ?>">
 						<?php echo $headerIcon; ?>
 						<?php echo htmlspecialchars($module->title, ENT_QUOTES, 'UTF-8'); ?>
 					</<?php echo $headerTag; ?>>


### PR DESCRIPTION
Pull Request for Issue #33566

### Summary of Changes
This PR adds padding to the header to ensure that the cog icon which has been styled with position: absolute does not overlay on top of the header text. If a custom header_class param is set then this will not override its padding.


### Testing Instructions
1. Visit Backend
2. Refer to the gif below: Shrink your screen width to reach a breakpoint where the Module Header text is long enough to cover the full width of the card OR you can use inspect element to rewrite the header text such that it covers full width or the card.

Before the PR, the cog would overlay on top of the text because of its absolute position and higher z-index.
After the PR, the padding creates a gap that separates the cog icon from the text by wrapping the text to the next line.


### Actual result BEFORE applying this Pull Request
![padding_before](https://user-images.githubusercontent.com/53610833/117257716-d39ccd80-ae69-11eb-91c3-bf024f032a65.gif)


### Expected result AFTER applying this Pull Request
![padding_after](https://user-images.githubusercontent.com/53610833/117257739-d8fa1800-ae69-11eb-8e1e-d4b7df4d361a.gif)


### Documentation Changes Required
None
