### PR TITLE
[4][Atum] Remove bold from sidebar

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -46,10 +46,6 @@
       }
     }
 
-    &-level-1 > a {
-      font-weight: bold;
-    }
-
     &-level-2 > a {
       padding-inline-start: 3rem;
     }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/33573 and https://github.com/joomla/joomla-cms/pull/33100#issuecomment-832570594

### Summary of Changes

Removal of the bold white on the top level sidebar menu

### Testing Instructions

`npm run build:css`

### Actual result BEFORE applying this Pull Request

<img width="302" alt="Screenshot 2021-05-06 at 17 39 30" src="https://user-images.githubusercontent.com/400092/117334545-06f35280-ae92-11eb-9c4c-f19d02fd94d7.png">


### Expected result AFTER applying this Pull Request

<img width="297" alt="Screenshot 2021-05-06 at 17 38 30" src="https://user-images.githubusercontent.com/400092/117334517-fe028100-ae91-11eb-9a00-fe056ec87ac9.png">


### Documentation Changes Required

