### PR TITLE
[4] Post installation messages s/generic icon/bell icon

### DIFF
--- a/administrator/components/com_postinstall/src/View/Messages/HtmlView.php
+++ b/administrator/components/com_postinstall/src/View/Messages/HtmlView.php
@@ -54,7 +54,7 @@ class HtmlView extends BaseHtmlView
 		$this->token = Factory::getSession()->getFormToken();
 		$this->extension_options = $model->getComponentOptions();
 
-		ToolbarHelper::title(Text::sprintf('COM_POSTINSTALL_MESSAGES_TITLE', $model->getExtensionName($this->eid)));
+		ToolbarHelper::title(Text::sprintf('COM_POSTINSTALL_MESSAGES_TITLE', $model->getExtensionName($this->eid)), 'bell');
 
 		return parent::display($tpl);
 	}

--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -27,7 +27,7 @@ $adminFormClass = count($this->extension_options) > 1 ? 'form-inline mb-3' : 'vi
 
 <?php if (empty($this->items)) : ?>
 	<div class="py-5 text-center">
-		<span class="fa-8x icon-generic mb-4" aria-hidden="true"></span>
+		<span class="fa-8x icon-bell mb-4" aria-hidden="true"></span>
 		<h1 class="display-5 fw-bold"><?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?></h1>
 		<div>
 			<p class="lead mb-4">


### PR DESCRIPTION
### Summary of Changes

Change the generic dot-circle to be a bell in line with the icon used in the tool bar for this feature. 

### Testing Instructions

Apply PR - Click Post installation messages toolbar in the header of the page - see bells. 

### Actual result BEFORE applying this Pull Request

Inconsistent icons - a generic circle (used as the generic icon in Joomla when it doesn't know what to use) 

<img width="1108" alt="Screenshot 2021-05-06 at 20 31 09" src="https://user-images.githubusercontent.com/400092/117355080-01a20200-aeaa-11eb-8f18-616131dca1a8.png">


### Expected result AFTER applying this Pull Request

<img width="964" alt="Screenshot 2021-05-06 at 20 24 49" src="https://user-images.githubusercontent.com/400092/117355006-ee8f3200-aea9-11eb-8ea0-50a8a3778f39.png">

-- 

<img width="1296" alt="Screenshot 2021-05-06 at 20 24 43" src="https://user-images.githubusercontent.com/400092/117355025-f4851300-aea9-11eb-9203-cb76b1b717e0.png">



### Documentation Changes Required

