### PR TITLE
[4][Banners] Remove zip file when downloading tracks

### DIFF
--- a/administrator/components/com_banners/src/Model/TracksModel.php
+++ b/administrator/components/com_banners/src/Model/TracksModel.php
@@ -541,7 +541,7 @@ class TracksModel extends ListModel
 
 				$this->content = file_get_contents($ziproot);
 
-				// Remove file
+				// Remove tmp zip file, its no longer needed.
 				File::delete($ziproot);
 			}
 		}

--- a/administrator/components/com_banners/src/Model/TracksModel.php
+++ b/administrator/components/com_banners/src/Model/TracksModel.php
@@ -540,6 +540,9 @@ class TracksModel extends ListModel
 				}
 
 				$this->content = file_get_contents($ziproot);
+
+				// Remove file
+				File::delete($ziproot);
 			}
 		}
 

--- a/administrator/components/com_banners/src/Model/TracksModel.php
+++ b/administrator/components/com_banners/src/Model/TracksModel.php
@@ -541,7 +541,7 @@ class TracksModel extends ListModel
 
 				$this->content = file_get_contents($ziproot);
 
-				// Remove tmp zip file, its no longer needed.
+				// Remove tmp zip file, it's no longer needed.
 				File::delete($ziproot);
 			}
 		}


### PR DESCRIPTION
### Summary of Changes

Trying to find the most useless PR of the decade on a feature that no one ever uses... I thought FTP Layer was it, but this might well take the crown.

When you export Banner Tracks to a CSV file, Joomla first (by default) creates a zip file in the TMP folder. It then serves you the Zip content as a download but leaves the Zip file in the TMP folder with a semi unique file name like 

```
banners_tracks_6094508e34f0b.zip
```

This file is left in the TMP folder forever and not cleaned up.

### Testing Instructions

Grab a coffee. 
Create a banner client 
Create a banner - ensure track impressions/clicks is enabled
Edit the banner options - ensure track impressions/clicks is enabled
Create a Site Module for banners, put it in a position in your template, load your frontend to "make tracks"
revisit the admin, Components -> Banners -> Tracks
Click Export 
Leave Compressed  = YES
Click Export
Note you are served a ZIP file to download

CHECK TMP FOLDER see file like `banners_tracks_6094508e34f0b.zip` left in the TMP folder
delete that file

APPLY PR 

Click Export 
Leave Compressed  = YES
Click Export
Note you are served a ZIP file to download

CHECK TMP FOLDER see no left over ZIP file. 


### Actual result BEFORE applying this Pull Request

Zip file like `banners_tracks_6094508e34f0b.zip` left in the TMP folder

### Expected result AFTER applying this Pull Request

Zip file is cleaned up and not left on the server. 

### Documentation Changes Required
