### PR TITLE
Styling user profile page

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -5,7 +5,6 @@
   min-height: calc(100vh - 69px);
   background-color: var(--atum-sidebar-bg);
   box-shadow: 0 0 20px -10px var(--atum-bg-dark-50);
-  overflow-x: hidden;
 
   .sidebar-sticky {
     position: sticky;

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -5,6 +5,7 @@
   min-height: calc(100vh - 69px);
   background-color: var(--atum-sidebar-bg);
   box-shadow: 0 0 20px -10px var(--atum-bg-dark-50);
+  overflow-x: hidden;
 
   .sidebar-sticky {
     position: sticky;

--- a/components/com_users/tmpl/profile/default.php
+++ b/components/com_users/tmpl/profile/default.php
@@ -26,8 +26,8 @@ use Joomla\CMS\Router\Route;
 	<?php if (Factory::getUser()->id == $this->data->id) : ?>
 		<ul class="com-users-profile__edit btn-toolbar float-end">
 			<li class="btn-group">
-				<a class="btn" href="<?php echo Route::_('index.php?option=com_users&task=profile.edit&user_id=' . (int) $this->data->id); ?>">
-					<span class="icon-user" aria-hidden="true"></span> <?php echo Text::_('COM_USERS_EDIT_PROFILE'); ?>
+				<a class="btn btn-primary" href="<?php echo Route::_('index.php?option=com_users&task=profile.edit&user_id=' . (int) $this->data->id); ?>">
+					<span class="icon-user-edit" aria-hidden="true"></span> <?php echo Text::_('COM_USERS_EDIT_PROFILE'); ?>
 				</a>
 			</li>
 		</ul>

--- a/components/com_users/tmpl/profile/default_core.php
+++ b/components/com_users/tmpl/profile/default_core.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 ?>
-<fieldset id="com-users-profile__core users-profile-core">
+<fieldset id="users-profile-core" class="com-users-profile__core">
 	<legend>
 		<?php echo Text::_('COM_USERS_PROFILE_CORE_LEGEND'); ?>
 	</legend>

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -143,6 +143,20 @@ th dd {
   font-weight: var(--cassiopeia-font-weight-normal, $font-weight-normal);
 }
 
+.dl-horizontal {
+  display: grid;
+  grid-template-columns: auto;
+  dd {
+    padding: 0;
+  }
+  [dir="rtl"] dd {
+    padding: 0;
+  }
+  @include media-breakpoint-up(xl) {
+    grid-template-columns: 200px auto;
+  }
+}
+
 figure {
   margin: 0 0 ($cassiopeia-grid-gutter*2);
   &.float-start {


### PR DESCRIPTION
Pull Request for Issue #32561

Due to problems with my branch I created this new version of my previous PR #33514

### Summary of Changes
This PR addresses some issues mentioned in the issue above.

- Styling the lists on the user profile page
- Styling "Edit Profile" button and icon

### Testing Instructions

1. Login in the frontend of the website.
2. Go to the user profile page
3. Take a look at the user profile page before and after this fix.

![styling-user-profile-page](https://user-images.githubusercontent.com/5610413/117365934-594b6800-aec0-11eb-88f6-09be22a151f2.jpg)

### Actual result BEFORE applying this Pull Request
The styling of the user profile page is not structured

### Expected result AFTER applying this Pull Request
The styling is fixed

### Documentation Changes Required

