### PR TITLE
[4.0] Dashboard add color

### DIFF
--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -115,7 +115,7 @@
 
       > * {
         margin-bottom: 10px;
-        color: #30517b;
+        color: hsl(var(--hue), 30%, 40%);
       }
 
       &:hover,


### PR DESCRIPTION
Pull Request for Issue ##33605 .
The add icon will now be the same color as the icon because it is using the variable and not a hard coded color. You can test/experiment by changing the hue in the atum template style.

Dont forget to npm run build:css

## Examples

![image](https://user-images.githubusercontent.com/1296369/117369942-8ea28680-aebd-11eb-9d84-203b52079d19.png)

![image](https://user-images.githubusercontent.com/1296369/117370000-9eba6600-aebd-11eb-8ee6-9b24f9f4efb0.png)

![image](https://user-images.githubusercontent.com/1296369/117370029-b09c0900-aebd-11eb-9e8d-38384d11a45c.png)
