### PR TITLE
[4] JSON_PRETTY_PRINT the System Info Json Export

### DIFF
--- a/administrator/components/com_admin/src/View/Sysinfo/JsonView.php
+++ b/administrator/components/com_admin/src/View/Sysinfo/JsonView.php
@@ -50,7 +50,7 @@ class JsonView extends AbstractView
 
 		$data = $this->getLayoutData();
 
-		echo json_encode($data);
+		echo json_encode($data, JSON_PRETTY_PRINT);
 
 		Factory::getApplication()->close();
 	}


### PR DESCRIPTION
### Summary of Changes

add `JSON_PRETTY_PRINT` to `json_encode` to get human readable JSON output when exporting System Information. 

### Testing Instructions

Joomla 4 admin -> System -> System Information -> Download as JSON

### Actual result BEFORE applying this Pull Request

Export is a single VERY long line unreadable by average humans.

```json
{"info":{"php":"Linux ec6b3406c377 5.10.25-linuxkit #1 SMP Tue Mar 23 09:27:39 UTC 2021 x86_64","dbserver":"mysql","dbversion":"8.0.22","dbcollation":"utf8mb4_unicode_ci","dbconnectioncoll<snip>
```

### Expected result AFTER applying this Pull Request

Prettier output still useable by machines, but readable by humans, cats and printable on cups of coffee... 

```json
{
    "info": {
        "php": "Linux ec6b3406c377 5.10.25-linuxkit #1 SMP Tue Mar 23 09:27:39 UTC 2021 x86_64",
        "dbserver": "mysql",
        "dbversion": "8.0.22",
        "dbcollation": "utf8mb4_unicode_ci",
        "dbconnectioncollation": "utf8mb4_0900_ai_ci",
        "dbconnectionencryption": "",
        "dbconnencryptsupported": true,
        "phpversion": "7.4.18",
        "server": "nginx\/1.19.4",
        "sapi_name": "fpm-fcgi",
        "version": "Joomla! 4.0.0-beta8-dev Development [ Ma\u00f1ana ] 2-February-2021 20:02 GMT",
        "useragent": "Mozilla\/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit\/605.1.15 (KHTML, like Gecko) Version\/14.1.1 Safari\/605.1.15"
    },
<snip>
```

### Documentation Changes Required

none