### PR TITLE
[4.0] ] fix color selector box too big issue

### DIFF
--- a/build/media_source/system/scss/_jquery-minicolors.scss
+++ b/build/media_source/system/scss/_jquery-minicolors.scss
@@ -1,8 +1,8 @@
 // Overrides for jQuery Minicolors
 
 .minicolors-theme-bootstrap .minicolors-swatch {
-  width: 40px;
-  height: 40px;
+  width: 36px;
+  height: 36px;
   > .minicolors-sprite {
     top: 50%;
     left: 8px;


### PR DESCRIPTION
I am not 100% convinced this is the correct solution but based on the accepted code in #30585 it is a working solution

npm run build:css

Pull Request for Issue #33596 

After applying PR etc
![image](https://user-images.githubusercontent.com/1296369/117373876-ff4ca180-aec3-11eb-84b5-1cc31d2a1908.png)

