### PR TITLE
[4.0] version history toolbar

### DIFF
--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -52,7 +52,7 @@ $wa->useScript('com_contenthistory.admin-history-modal');
 					<span class="icon-upload" aria-hidden="true"></span>
 					<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_LOAD'); ?></span>
 				</button>
-				<button id="toolbar-preview" type="button" class="btn btn-primary" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>" data-url="<?php echo Route::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . Session::getFormToken() . '=1'); ?>">
+				<button id="toolbar-preview" type="button" class="btn btn-secondary" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>" data-url="<?php echo Route::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . Session::getFormToken() . '=1'); ?>">
 					<span class="icon-search" aria-hidden="true"></span>
 					<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></span>
 				</button>
@@ -60,11 +60,11 @@ $wa->useScript('com_contenthistory.admin-history-modal');
 					<span class="icon-search-plus" aria-hidden="true"></span>
 					<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></span>
 				</button>
-				<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.keep')}" class="btn btn-success pointer" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">
+				<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.keep')}" class="btn btn-secondary pointer" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">
 					<span class="icon-lock" aria-hidden="true"></span>
 					<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></span>
 				</button>
-				<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.delete')}" class="btn btn-danger pointer" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>">
+				<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.delete')}" class="btn btn-secondary pointer" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>">
 					<span class="icon-times" aria-hidden="true"></span>
 					<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_DELETE'); ?></span>
 				</button>


### PR DESCRIPTION
removes the multcolor rainbow buttons. All buttons on the toolbar are now the same black text
this partially reverts the changes in #33532 which should not have been merged

Pull Request for Issue #33585 

### before
![image](https://user-images.githubusercontent.com/1296369/117410073-d8b15980-af09-11eb-9dd9-fbf983c5ed02.png)

### after
![image](https://user-images.githubusercontent.com/1296369/117410080-dbac4a00-af09-11eb-8e26-4382a542016a.png)
