### PR TITLE
[4.0] icon before link

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -159,7 +159,6 @@ body:not(.contentpane) .main-card {
 
 // external links with icons
 a[target="_blank"]::before {
-  display: inline-block;
   padding-inline-end: 3px;
   font-family: "Font Awesome 5 Free";
   font-size: 14px;


### PR DESCRIPTION
Pull Request for Issue #33595.

This ensures that the icon link and the text of the link do not get separated. 

## before
![before](https://user-images.githubusercontent.com/1296369/117422938-0ef5d580-af18-11eb-8fd4-e7814e1e4145.gif)

### after
![after](https://user-images.githubusercontent.com/1296369/117422923-0bfae500-af18-11eb-8dab-a7faf8753320.gif)
