### PR TITLE
[4.0] Status icons with count

### DIFF
--- a/administrator/modules/mod_messages/tmpl/default.php
+++ b/administrator/modules/mod_messages/tmpl/default.php
@@ -24,7 +24,7 @@ $route = 'index.php?option=com_messages&view=messages';
 <a class="header-item-content" href="<?php echo Route::_($route); ?>" title="<?php echo Text::_('MOD_MESSAGES_PRIVATE_MESSAGES'); ?>">
 	<div class="header-item-icon">
 	<div class="w-auto">
-		<span class="icon-envelope" aria-hidden="true"></span>
+		<span class="fa-fw icon-envelope" aria-hidden="true"></span>
 			<?php if ($countUnread > 0) : ?>
 				<small class="header-item-count"><?php echo $countUnread; ?></small>
 			<?php endif; ?>

--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -25,7 +25,7 @@ if ($hideLinks)
 		 title="<?php echo Text::_('MOD_POST_INSTALLATION_MESSAGES'); ?>">
 		<div class="header-item-icon">
 			<div class="w-auto">
-				<span class="icon-bell" aria-hidden="true"></span>
+				<span class="fa-fw icon-bell" aria-hidden="true"></span>
 				<?php if (count($messages) > 0) : ?>
 					<small class="header-item-count"><?php echo count($messages); ?></small>
 				<?php endif; ?>


### PR DESCRIPTION
Because the icons are different widths the padding looks a little off. By using the fixed width version of the icons its much better.

### Before
![image](https://user-images.githubusercontent.com/1296369/117425426-ae1bcc80-af1a-11eb-8a29-fb42cdbdbbfd.png)

### After
![image](https://user-images.githubusercontent.com/1296369/117425159-73b22f80-af1a-11eb-86b3-5030f8402154.png)

Pull Request for Issue #33591
