### PR TITLE
[4.0] Cassiopeia - Add selector to list overflow style

### DIFF
--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -119,6 +119,13 @@ a {
   }
 }
 
+.com-content-article {
+  ol,
+  ul {
+    overflow: hidden;
+  }
+}
+
 .com-content-category__pagination {
   margin-bottom: $cassiopeia-grid-gutter;
 }
@@ -234,9 +241,4 @@ meter {
 // Bootstrap 4 b/c
 .sr-only {
   @extend .visually-hidden;
-}
-
-ol,
-ul {
-  overflow: hidden;
 }


### PR DESCRIPTION
Pull Request for Issue #33617

### Summary of Changes
The `overflow: hidden` style applied to `ul` and `ol` in #33560 affected the navbar dropdowns which I hadn't tested properly. To rectify my mistake, I've added a selector that only applies the style to lists that are inside the article component


### Testing Instructions
1. `npm run build:css`
2. Check that all dropdowns are functional in the frontend
3. Visit 'Your Modules' blog in frontend and ensure that the lists are  properly indented


### Actual result BEFORE applying this Pull Request
Dropdowns don't work


### Expected result AFTER applying this Pull Request
Dropdowns work

![image](https://user-images.githubusercontent.com/53610833/117429107-53976600-af44-11eb-9f60-97c9e383c386.png)



### Documentation Changes Required
None
