### PR TITLE
[4.0] Fix Sidebar "sub items" overflow when expanding/toggle menu

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -5,10 +5,10 @@
   min-height: calc(100vh - 69px);
   background-color: var(--atum-sidebar-bg);
   box-shadow: 0 0 20px -10px var(--atum-bg-dark-50);
+  overflow: hidden;
 
   .sidebar-sticky {
     position: sticky;
-    overflow: hidden;
     top: 0;
   }
 
@@ -198,6 +198,7 @@
   .sidebar-wrapper {
     flex: 1 0 $sidebar-width-closed;
     max-width: $sidebar-width-closed;
+    overflow: visible;
   }
 
   .sidebar-item-title,

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -4,8 +4,8 @@
   z-index: $zindex-sidebar;
   min-height: calc(100vh - 69px);
   background-color: var(--atum-sidebar-bg);
-  box-shadow: 0 0 20px -10px var(--atum-bg-dark-50);
   overflow: hidden;
+  box-shadow: 0 0 20px -10px var(--atum-bg-dark-50);
 
   .sidebar-sticky {
     position: sticky;

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -3,8 +3,8 @@
 .sidebar-wrapper {
   z-index: $zindex-sidebar;
   min-height: calc(100vh - 69px);
-  background-color: var(--atum-sidebar-bg);
   overflow: hidden;
+  background-color: var(--atum-sidebar-bg);
   box-shadow: 0 0 20px -10px var(--atum-bg-dark-50);
 
   .sidebar-sticky {

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -8,6 +8,7 @@
 
   .sidebar-sticky {
     position: sticky;
+    overflow: hidden;
     top: 0;
   }
 


### PR DESCRIPTION
Pull Request for Issue #33627  .

### Summary of Changes
Added an **overflow: hidden** to the **.sidebar-wrapper .sidebar-sticky** class in /administrator/templates/atum/scss/blocks/_sidebar.scss


### Testing Instructions
Try to Toggle sidebar menu in Joomla 4 backend.
You see the "submenu" rendered before the full sidebar.
With this patch it is rendered correctly.


### Actual result BEFORE applying this Pull Request
![issue-joomla](https://user-images.githubusercontent.com/1375730/117433556-e37ce600-af2b-11eb-8e7f-bac5f101b156.gif)


### Expected result AFTER applying this Pull Request
![issue-solved-joomla](https://user-images.githubusercontent.com/1375730/117433543-de1f9b80-af2b-11eb-9256-278e22196b5e.gif)


### Documentation Changes Required
None.