### PR TITLE
[4.0] Add module to dashboard - save and close button

### DIFF
--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -43,7 +43,7 @@ echo HTMLHelper::_(
 		'modalWidth'  => '80',
 		'footer'      => '<button type="button" class="button-cancel btn btn-danger" data-bs-dismiss="modal" data-bs-target="#closeBtn">'
 			. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-			. '<button type="button" class="button-save btn btn-success hidden" id="btnModalSaveAndClose" data-bs-target="#saveBtn">'
+			. '<button type="button" id="btnModalSaveAndClose" class="button-save btn btn-success hidden" data-bs-target="#saveBtn">'
 			. Text::_('JSAVE') . '</button>',
 	)
 );

--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -43,7 +43,7 @@ echo HTMLHelper::_(
 		'modalWidth'  => '80',
 		'footer'      => '<button type="button" class="button-cancel btn btn-danger" data-bs-dismiss="modal" data-bs-target="#closeBtn">'
 			. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-			. '<button type="button" class="button-save btn btn-success hidden" data-bs-target="#saveBtn">'
+			. '<button type="button" class="button-save btn btn-success" data-bs-target="#saveBtn">'
 			. Text::_('JSAVE') . '</button>',
 	)
 );

--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -43,7 +43,7 @@ echo HTMLHelper::_(
 		'modalWidth'  => '80',
 		'footer'      => '<button type="button" class="button-cancel btn btn-danger" data-bs-dismiss="modal" data-bs-target="#closeBtn">'
 			. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-			. '<button type="button" class="button-save btn btn-success hidden" data-bs-target="#saveBtn">'
+			. '<button type="button" class="button-save btn btn-success hidden" id="btnModalSaveAndClose" data-bs-target="#saveBtn">'
 			. Text::_('JSAVE') . '</button>',
 	)
 );

--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -43,7 +43,7 @@ echo HTMLHelper::_(
 		'modalWidth'  => '80',
 		'footer'      => '<button type="button" class="button-cancel btn btn-danger" data-bs-dismiss="modal" data-bs-target="#closeBtn">'
 			. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-			. '<button type="button" class="button-save btn btn-success" data-bs-target="#saveBtn">'
+			. '<button type="button" class="button-save btn btn-success hidden" data-bs-target="#saveBtn">'
 			. Text::_('JSAVE') . '</button>',
 	)
 );

--- a/administrator/components/com_modules/tmpl/module/modal.php
+++ b/administrator/components/com_modules/tmpl/module/modal.php
@@ -9,12 +9,6 @@
 
 defined('_JEXEC') or die;
 
-?>
-<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.apply');"></button>
-<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.save');"></button>
-<button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.cancel');"></button>
-
-<?php
 use Joomla\CMS\Factory;
 
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
@@ -25,7 +19,11 @@ $wa->addInlineScript('
         saveCloseButton.classList.remove("hidden");
     });
 ');
+
 ?>
+<button id="applyBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.apply');"></button>
+<button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.save');"></button>
+<button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.cancel');"></button>
 
 <div class="container-popup">
 	<?php $this->setLayout('edit'); ?>

--- a/administrator/components/com_modules/tmpl/module/modal.php
+++ b/administrator/components/com_modules/tmpl/module/modal.php
@@ -15,8 +15,10 @@ use Joomla\CMS\Factory;
 $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->addInlineScript('
     document.addEventListener("DOMContentLoaded", function() {
-        saveCloseButton = window.parent.document.getElementById("btnModalSaveAndClose");
-        saveCloseButton.classList.remove("hidden");
+        const saveCloseButton = window.parent.document.getElementById("btnModalSaveAndClose");
+        if (saveCloseButton) {
+          saveCloseButton.classList.remove("hidden");
+        }
     });
 ');
 

--- a/administrator/components/com_modules/tmpl/module/modal.php
+++ b/administrator/components/com_modules/tmpl/module/modal.php
@@ -14,6 +14,19 @@ defined('_JEXEC') or die;
 <button id="saveBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.save');"></button>
 <button id="closeBtn" type="button" class="hidden" onclick="Joomla.submitbutton('module.cancel');"></button>
 
+<?php
+use Joomla\CMS\Factory;
+
+/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->addInlineScript('
+    document.addEventListener("DOMContentLoaded", function() {
+        saveCloseButton = window.parent.document.getElementById("btnModalSaveAndClose");
+        saveCloseButton.classList.remove("hidden");
+    });
+');
+?>
+
 <div class="container-popup">
 	<?php $this->setLayout('edit'); ?>
 	<?php echo $this->loadTemplate(); ?>


### PR DESCRIPTION
Pull Request for Issue #33630 .

### Summary of Changes
https://github.com/joomla/joomla-cms/issues/33630#issuecomment-835691242

### Testing Instructions
Go to a dashboard, click "add a module".
Select a module, for example, logged-users
A Modal opens for module settings

### Actual result BEFORE applying this Pull Request
![before-module](https://user-images.githubusercontent.com/61203226/117443993-7d598880-af56-11eb-9d46-a85c6009881a.JPG)

### Expected result AFTER applying this Pull Request
![after-module](https://user-images.githubusercontent.com/61203226/117444001-7fbbe280-af56-11eb-9d5d-4acd13a29af8.JPG)


### Documentation Changes Required
None
