### PR TITLE
[4] Correctly implement Joomla toolbar in Versions popup

### DIFF
--- a/administrator/components/com_contenthistory/src/View/History/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/History/HtmlView.php
@@ -96,10 +96,10 @@ class HtmlView extends BaseHtmlView
 			? 'com_categories&amp;extension=' . implode('.', array_slice($aliasArray, 0, count($aliasArray) - 2))
 			: $aliasArray[0];
 		$filter         = InputFilter::getInstance();
-		$task           = $filter->clean($aliasArray[1]) . '.loadhistory';
+		$task           = $filter->clean($aliasArray[1], 'cmd') . '.loadhistory';
 
 		// Build the final urls.
-		$loadUrl        = Route::_('index.php?option=' . $filter->clean($option) . '&amp;task=' . $task . '&amp;' . $token . '=1');
+		$loadUrl        = Route::_('index.php?option=' . $filter->clean($option, 'cmd') . '&amp;task=' . $task . '&amp;' . $token . '=1');
 		$previewUrl     = Route::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . $token . '=1');
 		$compareUrl     = Route::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . $token . '=1');
 

--- a/administrator/components/com_contenthistory/src/View/History/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/History/HtmlView.php
@@ -91,17 +91,17 @@ class HtmlView extends BaseHtmlView
 		$token = Session::getFormToken();
 
 		// Clean up input to ensure a clean url.
-		$aliasArray     = explode('.', $this->state->item_id);
-		$option         = ($aliasArray[1] == 'category')
+		$aliasArray = explode('.', $this->state->item_id);
+		$option     = $aliasArray[1] == 'category'
 			? 'com_categories&amp;extension=' . implode('.', array_slice($aliasArray, 0, count($aliasArray) - 2))
 			: $aliasArray[0];
-		$filter         = InputFilter::getInstance();
-		$task           = $filter->clean($aliasArray[1]) . '.loadhistory';
+		$filter     = InputFilter::getInstance();
+		$task       = $filter->clean($aliasArray[1]) . '.loadhistory';
 
 		// Build the final urls.
-		$loadUrl        = Route::_('index.php?option=' . $filter->clean($option) . '&amp;task=' . $task . '&amp;' . $token . '=1');
-		$previewUrl     = Route::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . $token . '=1');
-		$compareUrl     = Route::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . $token . '=1');
+		$loadUrl    = Route::_('index.php?option=' . $filter->clean($option) . '&amp;task=' . $task . '&amp;' . $token . '=1');
+		$previewUrl = Route::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . $token . '=1');
+		$compareUrl = Route::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . $token . '=1');
 
 		$toolbar->basicButton('load')
 			->attributes(['data-url' => $loadUrl])

--- a/administrator/components/com_contenthistory/src/View/History/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/History/HtmlView.php
@@ -11,8 +11,15 @@ namespace Joomla\Component\Contenthistory\Administrator\View\History;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Pagination\Pagination;
+use Joomla\CMS\Router\Route;
+use Joomla\CMS\Session\Session;
+use Joomla\CMS\Toolbar\Toolbar;
+use Joomla\CMS\Toolbar\ToolbarFactoryInterface;
 
 /**
  * View class for a list of contenthistory.
@@ -31,7 +38,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \Joomla\CMS\Pagination\Pagination
+	 * @var  Pagination
 	 */
 	protected $pagination;
 
@@ -63,6 +70,72 @@ class HtmlView extends BaseHtmlView
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
+		$this->toolbar = $this->addToolbar();
+
 		return parent::display($tpl);
+	}
+
+	/**
+	 * Add the page toolbar.
+	 *
+	 * @return  Toolbar
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected function addToolbar(): Toolbar
+	{
+		/** @var Toolbar $toolbar */
+		$toolbar = Factory::getContainer()->get(ToolbarFactoryInterface::class)->createToolbar('toolbar');
+
+		// Cache a session token for reuse throughout.
+		$token = Session::getFormToken();
+
+		// Clean up input to ensure a clean url.
+		$aliasArray     = explode('.', $this->state->item_id);
+		$option         = ($aliasArray[1] == 'category')
+			? 'com_categories&amp;extension=' . implode('.', array_slice($aliasArray, 0, count($aliasArray) - 2))
+			: $aliasArray[0];
+		$filter         = InputFilter::getInstance();
+		$task           = $filter->clean($aliasArray[1]) . '.loadhistory';
+
+		// Build the final urls.
+		$loadUrl        = Route::_('index.php?option=' . $filter->clean($option) . '&amp;task=' . $task . '&amp;' . $token . '=1');
+		$previewUrl     = Route::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . $token . '=1');
+		$compareUrl     = Route::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . $token . '=1');
+
+		$toolbar->basicButton('load')
+			->attributes(['data-url' => $loadUrl])
+			->icon('icon-upload')
+			->buttonClass('btn btn-success')
+			->text('COM_CONTENTHISTORY_BUTTON_LOAD')
+			->listCheck(true);
+
+		$toolbar->basicButton('preview')
+			->attributes(['data-url' => $previewUrl])
+			->icon('icon-search')
+			->text('COM_CONTENTHISTORY_BUTTON_PREVIEW')
+			->listCheck(true);
+
+		$toolbar->basicButton('compare')
+			->attributes(['data-url' => $compareUrl])
+			->icon('icon-search-plus')
+			->text('COM_CONTENTHISTORY_BUTTON_COMPARE')
+			->listCheck(true);
+
+		$toolbar->basicButton('keep')
+			->task('history.keep')
+			->buttonClass('btn btn-inverse')
+			->icon('icon-lock')
+			->text('COM_CONTENTHISTORY_BUTTON_KEEP')
+			->listCheck(true);
+
+		$toolbar->basicButton('delete')
+			->task('history.delete')
+			->buttonClass('btn btn-danger')
+			->icon('icon-times')
+			->text('COM_CONTENTHISTORY_BUTTON_DELETE')
+			->listCheck(true);
+
+		return $toolbar;
 	}
 }

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -9,8 +9,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
-use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
@@ -20,18 +18,6 @@ Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 
 HTMLHelper::_('behavior.multiselect');
 
-$input          = Factory::getApplication()->input;
-$field          = $input->getCmd('field');
-$function       = 'jSelectContenthistory_' . $field;
-$listOrder      = $this->escape($this->state->get('list.ordering'));
-$listDirn       = $this->escape($this->state->get('list.direction'));
-$deleteMessage  = "alert(Joomla.Text._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));";
-$aliasArray     = explode('.', $this->state->item_id);
-$option         = ($aliasArray[1] == 'category') ? 'com_categories&amp;extension=' . implode('.', array_slice($aliasArray, 0, count($aliasArray) - 2)) : $aliasArray[0];
-$filter         = InputFilter::getInstance();
-$task           = $filter->clean($aliasArray[1]) . '.loadhistory';
-$loadUrl        = Route::_('index.php?option=' . $filter->clean($option) . '&amp;task=' . $task);
-$deleteUrl      = Route::_('index.php?option=com_contenthistory&task=history.delete');
 $hash           = $this->state->get('sha1_hash');
 $formUrl        = 'index.php?option=com_contenthistory&view=history&layout=modal&tmpl=component&item_id=' . $this->state->get('item_id') . '&' . Session::getFormToken() . '=1';
 
@@ -42,36 +28,15 @@ Text::script('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST');
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_contenthistory.admin-history-modal');
-
 ?>
 <div class="container-popup">
+	<div id="subhead" class="subhead mb-3">
 	<nav aria-label="toolbar">
-		<div class="float-end mb-3">
-			<div class="subhead noshadow">
-				<button id="toolbar-load" type="submit" class="btn btn-secondary" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_LOAD_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_LOAD_DESC'); ?>" data-url="<?php echo Route::_($loadUrl); ?>">
-					<span class="icon-upload" aria-hidden="true"></span>
-					<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_LOAD'); ?></span>
-				</button>
-				<button id="toolbar-preview" type="button" class="btn btn-primary" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW_DESC'); ?>" data-url="<?php echo Route::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . Session::getFormToken() . '=1'); ?>">
-					<span class="icon-search" aria-hidden="true"></span>
-					<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_PREVIEW'); ?></span>
-				</button>
-				<button id="toolbar-compare" type="button" class="btn btn-secondary" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_COMPARE_DESC'); ?>" data-url="<?php echo Route::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . Session::getFormToken() . '=1'); ?>">
-					<span class="icon-search-plus" aria-hidden="true"></span>
-					<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_COMPARE'); ?></span>
-				</button>
-				<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.keep')}" class="btn btn-success pointer" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_KEEP_DESC'); ?>">
-					<span class="icon-lock" aria-hidden="true"></span>
-					<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_KEEP'); ?></span>
-				</button>
-				<button onclick="if (document.adminForm.boxchecked.value==0){<?php echo $deleteMessage; ?>}else{ Joomla.submitbutton('history.delete')}" class="btn btn-danger pointer" aria-label="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>" title="<?php echo Text::_('COM_CONTENTHISTORY_BUTTON_DELETE_DESC'); ?>">
-					<span class="icon-times" aria-hidden="true"></span>
-					<span class="d-none d-md-inline"><?php echo Text::_('COM_CONTENTHISTORY_BUTTON_DELETE'); ?></span>
-				</button>
-			</div>
+		<div class="btn-toolbar d-flex" id="toolbar">
+			<?php echo $this->toolbar->render(); ?>
 		</div>
 	</nav>
-
+	</div>
 	<form action="<?php echo Route::_($formUrl); ?>" method="post" name="adminForm" id="adminForm">
 		<table class="table table-sm">
 			<caption class="visually-hidden">

--- a/build/media_source/com_contenthistory/js/admin-history-modal.es6.js
+++ b/build/media_source/com_contenthistory/js/admin-history-modal.es6.js
@@ -14,7 +14,7 @@
       const ids = document.querySelectorAll('input[id*="cb"]:checked');
       if (ids.length === 1) {
         // Add version item id to URL
-        const url = `${document.getElementById('toolbar-load').getAttribute('data-url')}&version_id=${ids[0].value}`;
+        const url = `${document.getElementById('toolbar-load').childNodes[1].getAttribute('data-url')}&version_id=${ids[0].value}`;
         if (window.parent && url) {
           window.parent.location = url;
         }
@@ -30,7 +30,7 @@
       const ids = document.querySelectorAll('input[id*="cb"]:checked');
       if (ids.length === 1) {
         // Add version item id to URL
-        const url = `${document.getElementById('toolbar-preview').getAttribute('data-url')}&version_id=${ids[0].value}`;
+        const url = `${document.getElementById('toolbar-preview').childNodes[1].getAttribute('data-url')}&version_id=${ids[0].value}`;
         if (window.parent && url) {
           window.open(url, '', windowSizeArray.toString());
         }
@@ -49,7 +49,7 @@
         alert(Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));
       } else if (ids.length === 2) {
         // Add version item ids to URL
-        const url = `${document.getElementById('toolbar-compare').getAttribute('data-url')}&id1=${ids[0].value}&id2=${ids[1].value}`;
+        const url = `${document.getElementById('toolbar-compare').childNodes[1].getAttribute('data-url')}&id1=${ids[0].value}&id2=${ids[1].value}`;
         if (window.parent && url) {
           window.open(url, '', windowSizeArray.toString());
         }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/33585 replacement for @brianteeman https://github.com/joomla/joomla-cms/pull/33616

### Summary of Changes

Correctly implement toolbar in the View of the MVC, and render it in the modal (slightly different to normal, but this is a modal) rather than hard coding the buttons in HTML in the layout. 

### Testing Instructions

After applying this PR you will need `npm run build:js` to rebuild your JS as changes have been made in the JS to target the `data-url` attribute. @dgrammatiko please review that change, happy to improve it if you think it needs it. 

Using Content and User Notes as a base, generate some content history (versions) of an item, and then use the Versions toolbar button when editing the article/user note to launch the modal - and test all the buttons in the modal work as expected, with correct JS validations and correct rendered look and feel consistent with all other toolbars in Joomla 4 admin. 

Yes, the buttons are meant to be LEFT aligned like all Joomla toolbars of actions. 

### Actual result BEFORE applying this Pull Request

Right aligned, hand coded, hard coded buttons in the layout without padding of icons and without the correct colours and hover state changes

<img width="662" alt="Screenshot 2021-05-07 at 13 25 32" src="https://user-images.githubusercontent.com/400092/117449370-cf3ee600-af37-11eb-8f9d-7b782e537e21.png">



### Expected result AFTER applying this Pull Request

Implementation of `Toolbar` compiled in the View and rendered in the layout. 

Buttons adhere to the List view, so grey out when they cannot be used. 

https://user-images.githubusercontent.com/400092/117449129-84bd6980-af37-11eb-990b-deedcfdec2ca.mp4



### Documentation Changes Required

None