### PR TITLE
[4.0] Ignore access level check while parsing SEF router

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -224,7 +224,7 @@ class SiteRouter extends Router
 		else
 		{
 			// Get menu items.
-			$items    = $this->menu->getItems('parent_id', 1);
+			$items    = $this->menu->getItems(['parent_id', 'access'], [1, null]);
 			$lang_tag = $this->app->getLanguage()->getTag();
 			$found   = null;
 


### PR DESCRIPTION
Pull Request for Issue #33500.

### Summary of Changes
Ignore menu items access level check while parsing sef router so that in case users access to a menu item which requires login, they will be redirected to login page instead of seeing 404 error (same behavior with Joomla! 3)


### Testing Instructions
1. Create  a menu item to link to an article, set **Access** to **Registered**. Set alias of that menu item to **test** or something you want. 
2. Access to frontend of your site, remember to log-out if you are logged in
3. Try to access to the the menu item which you created above. The link will have this format https://localhost/joomla4/index.php/test or  https://localhost/joomla4/test (depends on your site setting)
- Replace https://localhost/joomla4/ with URL of your site
- Replace test with Alias of the menu item which you created in step 1

4. Before patch: You get 404 error
5. After patch: You are being redirected to login page which allows you to login to access to that link