### PR TITLE
[4.0] fix first row on admin error page

### DIFF
--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -90,82 +90,79 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : '') . ($monochrome ? ' monochrome' : ''); ?>">
 
-<noscript>
-	<div class="alert alert-danger" role="alert">
-		<?php echo Text::_('JGLOBAL_WARNJAVASCRIPT'); ?>
+	<noscript>
+		<div class="alert alert-danger" role="alert">
+			<?php echo Text::_('JGLOBAL_WARNJAVASCRIPT'); ?>
+		</div>
+	</noscript>
+	<div class="ie11 alert alert-warning" role="alert">
+		<?php echo Text::_('JGLOBAL_WARNIE'); ?>
 	</div>
-</noscript>
 
-<header id="header" class="header">
-	<div class="d-flex">
-		<div class="header-title d-flex me-auto">
+	<header id="header" class="header">
+		<div class="header-title d-flex">
 			<div class="d-flex align-items-center">
 				<div class="logo">
 					<img src="<?php echo $logoBrandLarge; ?>" <?php echo $logoBrandLargeAlt; ?>>
 					<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" <?php echo $logoBrandSmallAlt; ?>>
 				</div>
 			</div>
-			<jdoc:include type="modules" name="title"/>
+			<jdoc:include type="modules" name="title" />
 		</div>
 		<?php echo $statusModules; ?>
-	</div>
-</header>
+	</header>
 
-<div id="wrapper" class="d-flex wrapper">
-
-	<?php // Sidebar ?>
-	<div id="sidebar-wrapper" class="sidebar-wrapper">
-		<div id="main-brand" class="main-brand">
-			<h2><?php echo $app->get('sitename'); ?></h2>
-			<a href="<?php echo Uri::root(); ?>"><?php echo Text::_('TPL_ATUM_LOGIN_SIDEBAR_VIEW_WEBSITE'); ?></a>
-		</div>
-		<div id="sidebar">
-			<jdoc:include type="modules" name="sidebar" style="body" />
-		</div>
-	</div>
-
-	<div class="container-fluid container-main">
-		<section id="content" class="content h-100">
-			<?php // Begin Content ?>
-			<main class="d-flex justify-content-center align-items-center h-100">
-				<div id="element-box" class="card">
-					<div class="card-body">
-						<div class="main-brand d-flex align-items-center justify-content-center">
-							<img src="<?php echo $loginLogo; ?>" <?php echo $loginLogoAlt; ?>>
-						</div>
-						<h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
-						<jdoc:include type="message" />
-						<blockquote class="blockquote">
-							<span class="badge bg-secondary"><?php echo $this->error->getCode(); ?></span>
-							<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
-						</blockquote>
-						<?php if ($this->debug) : ?>
-							<div>
-								<?php echo $this->renderBacktrace(); ?>
-								<?php // Check if there are more Exceptions and render their data as well ?>
-								<?php if ($this->error->getPrevious()) : ?>
-									<?php $loop = true; ?>
-									<?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly ?>
-									<?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions ?>
-									<?php $this->setError($this->_error->getPrevious()); ?>
-									<?php while ($loop === true) : ?>
-										<p><strong><?php echo Text::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
-										<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
-										<?php echo $this->renderBacktrace(); ?>
-										<?php $loop = $this->setError($this->_error->getPrevious()); ?>
-									<?php endwhile; ?>
-									<?php // Reset the main error object to the base error ?>
-									<?php $this->setError($this->error); ?>
-								<?php endif; ?>
+	<div id="wrapper" class="wrapper">
+		<div class="container-fluid container-main">
+			<section id="content" class="content h-100">
+				<main class="d-flex justify-content-center align-items-center h-100">
+					<div id="element-box" class="card">
+						<div class="card-body">
+							<div class="main-brand d-flex align-items-center justify-content-center">
+								<img src="<?php echo $loginLogo; ?>" <?php echo $loginLogoAlt; ?>>
 							</div>
-						<?php endif; ?>
+							<h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
+							<jdoc:include type="message" />
+							<blockquote class="blockquote">
+								<span class="badge bg-secondary"><?php echo $this->error->getCode(); ?></span>
+								<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+							</blockquote>
+							<?php if ($this->debug) : ?>
+								<div>
+									<?php echo $this->renderBacktrace(); ?>
+									<?php // Check if there are more Exceptions and render their data as well ?>
+									<?php if ($this->error->getPrevious()) : ?>
+										<?php $loop = true; ?>
+										<?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly ?>
+										<?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions ?>
+										<?php $this->setError($this->_error->getPrevious()); ?>
+										<?php while ($loop === true) : ?>
+											<p><strong><?php echo Text::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
+											<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+											<?php echo $this->renderBacktrace(); ?>
+											<?php $loop = $this->setError($this->_error->getPrevious()); ?>
+										<?php endwhile; ?>
+										<?php // Reset the main error object to the base error ?>
+										<?php $this->setError($this->error); ?>
+									<?php endif; ?>
+								</div>
+							<?php endif; ?>
+						</div>
 					</div>
-				</div>
-			</main>
-			<?php // End Content ?>
-		</section>
+				</main>
+			</section>
+		</div>
+
+		<div id="sidebar-wrapper" class="sidebar-wrapper px-3 pb-3">
+			<div id="main-brand" class="main-brand">
+				<h1><?php echo $app->get('sitename'); ?></h1>
+				<h2><a href="<?php echo Uri::root(); ?>"><?php echo Text::_('TPL_ATUM_LOGIN_SIDEBAR_VIEW_WEBSITE'); ?></a></h2>
+			</div>
+			<div id="sidebar">
+				<jdoc:include type="modules" name="sidebar" style="body" />
+			</div>
+		</div>
 	</div>
-</div>
-<jdoc:include type="modules" name="debug" style="none" />
+	<jdoc:include type="modules" name="debug" style="none" />
 </body>
 </html>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -95,6 +95,7 @@ HTMLHelper::_('bootstrap.dropdown');
 </head>
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : '') . ($monochrome ? ' monochrome' : ''); ?>">
+
 	<noscript>
 		<div class="alert alert-danger" role="alert">
 			<?php echo Text::_('JGLOBAL_WARNJAVASCRIPT'); ?>
@@ -134,7 +135,6 @@ HTMLHelper::_('bootstrap.dropdown');
 			</section>
 		</div>
 
-		<?php // Sidebar ?>
 		<div id="sidebar-wrapper" class="sidebar-wrapper px-3 pb-3">
 			<div id="main-brand" class="main-brand">
 				<h1><?php echo $app->get('sitename'); ?></h1>


### PR DESCRIPTION
Partial Pull Request for Issue #33599 .

### Summary of Changes

As mentioned in issue #33599 the colors of the error page seems to be broken.
Not only that... the first row of the error page is broken. 

This PR will fix the first row of the error page and adjusts the HTML in order to be in line with the login page. 
HTML for the sidebar placed after the HTML for the main part


another PR should fix the ability to get template params while on the error page. 

### Testing Instructions

as described in https://github.com/joomla/joomla-cms/issues/33599

### Actual result BEFORE applying this Pull Request

<img width="1636" alt="Schermafbeelding 2021-05-08 om 17 56 19" src="https://user-images.githubusercontent.com/639822/117545600-c8db6780-b026-11eb-8675-473d4358c4d3.png">


### Expected result AFTER applying this Pull Request

<img width="1635" alt="Schermafbeelding 2021-05-08 om 17 56 00" src="https://user-images.githubusercontent.com/639822/117545603-caa52b00-b026-11eb-904d-e3512e437ef5.png">


### Documentation Changes Required

