### PR TITLE
[4.0] Message and post-install hide

### DIFF
--- a/administrator/modules/mod_messages/tmpl/default.php
+++ b/administrator/modules/mod_messages/tmpl/default.php
@@ -23,11 +23,9 @@ $route = 'index.php?option=com_messages&view=messages';
 ?>
 <a class="header-item-content" href="<?php echo Route::_($route); ?>" title="<?php echo Text::_('MOD_MESSAGES_PRIVATE_MESSAGES'); ?>">
 	<div class="header-item-icon">
-	<div class="w-auto">
-		<span class="fa-fw icon-envelope" aria-hidden="true"></span>
-			<?php if ($countUnread > 0) : ?>
-				<small class="header-item-count"><?php echo $countUnread; ?></small>
-			<?php endif; ?>
+		<div class="w-auto">
+			<span class="fa-fw icon-envelope" aria-hidden="true"></span>
+			<small class="header-item-count"><?php echo $countUnread; ?></small>
 		</div>
 	</div>
 	<div class="header-item-text">

--- a/administrator/modules/mod_messages/tmpl/default.php
+++ b/administrator/modules/mod_messages/tmpl/default.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Router\Route;
 
 $hideLinks = $app->input->getBool('hidemainmenu');
 
-if ($hideLinks)
+if ($hideLinks || $countUnread < 1)
 {
 	return;
 }

--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Router\Route;
 
 $hideLinks = $app->input->getBool('hidemainmenu');
 
-if ($hideLinks)
+if ($hideLinks || count($messages) < 1)
 {
 	return;
 }

--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -26,9 +26,7 @@ if ($hideLinks || count($messages) < 1)
 		<div class="header-item-icon">
 			<div class="w-auto">
 				<span class="fa-fw icon-bell" aria-hidden="true"></span>
-				<?php if (count($messages) > 0) : ?>
-					<small class="header-item-count"><?php echo count($messages); ?></small>
-				<?php endif; ?>
+				<small class="header-item-count"><?php echo count($messages); ?></small>
 			</div>
 		</div>
 		<div class="header-item-text">


### PR DESCRIPTION
If there are no post-installation messages there is no point in displaying a button to them
If there are no private messages in your inbox there is no point in displaying a button to them

Just as the multilingual status button is not displayed if the site is not multilingual there is no point in displaying these buttons if there are no messages.
