### PR TITLE
[4.0] Fix console error

### DIFF
--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -154,7 +154,7 @@ Joomla = window.Joomla || {};
     });
 
     // eslint-disable-next-line no-undef
-    PreUpdateChecker.nonCoreCriticalPlugins = Joomla.getOptions('nonCoreCriticalPlugins');
+    PreUpdateChecker.nonCoreCriticalPlugins = Joomla.getOptions('nonCoreCriticalPlugins', []);
 
     // If there are no non Core Critical Plugins installed, and we are in the update view, then
     // disable the warnings upfront


### PR DESCRIPTION
Pull Request for Issue #33653 .

### Summary of Changes
-  add a default fallback (empty array) in `Joomla.getOptions()` for the `PreUpdateChecker.nonCoreCriticalPlugins`


### Testing Instructions
Visit administrator/index.php?option=com_joomlaupdate
Check the browser's console for errors


### Actual result BEFORE applying this Pull Request
Error logged


### Expected result AFTER applying this Pull Request
No Error

### Documentation Changes Required
Nooo
