### PR TITLE
[4.0] Remove - Use Default - for file selection dropdown in Mail Template attachment

### DIFF
--- a/administrator/components/com_mails/forms/template.xml
+++ b/administrator/components/com_mails/forms/template.xml
@@ -45,6 +45,7 @@
 			<field
 				name="file"
 				type="filelist"
+				hide_default="true"
 				label="COM_MAILS_FIELD_FILE_LABEL"
 			/>
 			<field


### PR DESCRIPTION
Part Of Pull Request for Issue #33655.

### Summary of Changes
**- Use Default -** in file selection dropdown in the Attachment of Mail Template does not make sense (It is not used and not needed). This PR just remove it
![Edit-Mail-Template-Joomla-4-Administration](https://user-images.githubusercontent.com/977664/117561781-faeed700-b0c3-11eb-8a6a-58dc7d712dbf.png)

### Testing Instructions
1. Access to System -> Mail Templates, click on Options button in the toolbar. Look for **Attachments Folder** config option, set it to `images/banners`
2. Now, access to **System -> Mail Templates** again, click on a mail template to edit. Look at the bottom, you will see Attachment section. Try to add file to it

- Before patch: You will use - Use Default - option from dropdown
- After patch: The option is not available anymore