### PR TITLE
[4.0] com_media drag and drop

### DIFF
--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -1,9 +1,9 @@
 // Media browser
 .media-browser {
   position: relative;
+  min-height: 70vh;
   border-left: 1px solid $border-color;
   transition: width .3s cubic-bezier(.4, 0, .2, 1);
-  min-height: 70vh;
 }
 
 // Grid View

--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -3,6 +3,7 @@
   position: relative;
   border-left: 1px solid $border-color;
   transition: width .3s cubic-bezier(.4, 0, .2, 1);
+  min-height: 70vh;
 }
 
 // Grid View


### PR DESCRIPTION
The dropzone is the height of the media-browser div. Before this PR that height was dependent on the height of the content. Now it is the full height of the div.

its a css change so npm i

## Test
The easiest way is to create a new folder in the media manager and try to upload a new file using dragdrop.

### Before
![before](https://user-images.githubusercontent.com/1296369/117569657-9da45700-b0be-11eb-9411-fbd399e92ca0.gif)

### After
![after](https://user-images.githubusercontent.com/1296369/117569662-a137de00-b0be-11eb-97d7-eeb3f7c7eead.gif)

Pull Request for Issue #33604