### PR TITLE
[4] Remove 2000ms delay in checking for Joomla updates

### DIFF
--- a/build/media_source/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
+++ b/build/media_source/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
@@ -2,37 +2,27 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-/**
- * Ajax call to get the update status of Joomla
- */
-((document, Joomla) => {
-  'use strict';
 
-  if (Joomla.getOptions('js-extensions-update')) {
-    const options = Joomla.getOptions('js-joomla-update');
+if (Joomla && Joomla.getOptions('js-extensions-update')) {
+  const options = Joomla.getOptions('js-joomla-update');
 
-    const update = (type, text) => {
-      const link = document.getElementById('plg_quickicon_joomlaupdate');
-      const linkSpans = [].slice.call(link.querySelectorAll('span.j-links-link'));
-      if (link) {
-        link.classList.add(type);
-      }
+  const update = (type, text) => {
+    const link = document.getElementById('plg_quickicon_joomlaupdate');
+    const linkSpans = [].slice.call(link.querySelectorAll('span.j-links-link'));
+    if (link) {
+      link.classList.add(type);
+    }
 
-      if (linkSpans.length) {
-        linkSpans.forEach((span) => {
-          span.innerHTML = text;
-        });
-      }
-    };
+    if (linkSpans.length) {
+      linkSpans.forEach((span) => {
+        span.innerHTML = text;
+      });
+    }
+  };
 
-    Joomla.request({
-      url: options.ajaxUrl,
-      method: 'GET',
-      data: '',
-      perform: true,
-      onSuccess: (response) => {
-        const updateInfoList = JSON.parse(response);
-
+  fetch(options.ajaxUrl, { method: 'GET' })
+    .then((response) => {
+      response.json().then((updateInfoList) => {
         if (Array.isArray(updateInfoList)) {
           if (updateInfoList.length === 0) {
             // No updates
@@ -50,11 +40,14 @@
           // An error occurred
           update('danger', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_ERROR'));
         }
-      },
-      onError: () => {
-        // An error occurred
-        update('danger', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_ERROR'));
-      },
+      })
+        .catch(() => {
+          // An error occurred
+          update('danger', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_ERROR'));
+        });
+    })
+    .catch(() => {
+      // An error occurred
+      update('danger', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_ERROR'));
     });
-  }
-})(document, Joomla);
+}

--- a/build/media_source/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
+++ b/build/media_source/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
@@ -8,71 +8,53 @@
 ((document, Joomla) => {
   'use strict';
 
-  const checkForJoomlaUpdates = () => {
-    if (Joomla.getOptions('js-extensions-update')) {
-      const options = Joomla.getOptions('js-joomla-update');
+  if (Joomla.getOptions('js-extensions-update')) {
+    const options = Joomla.getOptions('js-joomla-update');
 
-      const update = (type, text) => {
-        const link = document.getElementById('plg_quickicon_joomlaupdate');
-        const linkSpans = [].slice.call(link.querySelectorAll('span.j-links-link'));
-        if (link) {
-          link.classList.add(type);
-        }
+    const update = (type, text) => {
+      const link = document.getElementById('plg_quickicon_joomlaupdate');
+      const linkSpans = [].slice.call(link.querySelectorAll('span.j-links-link'));
+      if (link) {
+        link.classList.add(type);
+      }
 
-        if (linkSpans.length) {
-          linkSpans.forEach((span) => {
-            span.innerHTML = text;
-          });
-        }
-      };
+      if (linkSpans.length) {
+        linkSpans.forEach((span) => {
+          span.innerHTML = text;
+        });
+      }
+    };
 
-      Joomla.request({
-        url: options.ajaxUrl,
-        method: 'GET',
-        data: '',
-        perform: true,
-        onSuccess: (response) => {
-          const updateInfoList = JSON.parse(response);
+    Joomla.request({
+      url: options.ajaxUrl,
+      method: 'GET',
+      data: '',
+      perform: true,
+      onSuccess: (response) => {
+        const updateInfoList = JSON.parse(response);
 
-          if (Array.isArray(updateInfoList)) {
-            if (updateInfoList.length === 0) {
-              // No updates
-              update('success', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_UPTODATE'));
-            } else {
-              const updateInfo = updateInfoList.shift();
-
-              if (updateInfo.version !== options.version) {
-                update('danger', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND').replace('%s', `<span class="badge text-dark bg-light"> \u200E ${updateInfo.version}</span>`));
-              } else {
-                update('success', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_UPTODATE'));
-              }
-            }
+        if (Array.isArray(updateInfoList)) {
+          if (updateInfoList.length === 0) {
+            // No updates
+            update('success', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_UPTODATE'));
           } else {
-            // An error occurred
-            update('danger', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_ERROR'));
+            const updateInfo = updateInfoList.shift();
+
+            if (updateInfo.version !== options.version) {
+              update('danger', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_UPDATEFOUND').replace('%s', `<span class="badge text-dark bg-light"> \u200E ${updateInfo.version}</span>`));
+            } else {
+              update('success', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_UPTODATE'));
+            }
           }
-        },
-        onError: () => {
+        } else {
           // An error occurred
           update('danger', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_ERROR'));
-        },
-      });
-    }
-  };
-
-  const onBoot = () => {
-    if (!Joomla
-      || typeof Joomla.getOptions !== 'function'
-      || !Joomla.getOptions('js-joomla-update')) {
-      throw new Error('Script is not properly initialised');
-    }
-
-    setTimeout(checkForJoomlaUpdates, 2000);
-
-    // Cleanup
-    document.removeEventListener('DOMContentLoaded', onBoot);
-  };
-
-  // Initialize
-  document.addEventListener('DOMContentLoaded', onBoot);
+        }
+      },
+      onError: () => {
+        // An error occurred
+        update('danger', Joomla.Text._('PLG_QUICKICON_JOOMLAUPDATE_ERROR'));
+      },
+    });
+  }
 })(document, Joomla);


### PR DESCRIPTION

### Summary of Changes

@dgrammatiko 3 years ago in https://github.com/joomla/joomla-cms/pull/21421 you continued added a 2000ms delay in checking for Joomla updates when you refactored. Can you remember why waiting that long? 

It now "feels" that its slow checking for updates now, when sat along side the other boxes in Joomla 4 admin that are also running an ajax call checking for udpates - its not slow, because its not actually checking until 2000ms after page load, and then returns very fast once the ajax call is finally made. 

This PR is me pretending to be a javascript developer so if its wrong I'll happily let you do it, I compared it to the other boxes checking for updates and they dont have a `setTimeout`

### Testing Instructions

Load home dashboard - watch the four green boxes for updates.

### Actual result BEFORE applying this Pull Request

https://user-images.githubusercontent.com/400092/117572257-f9c0a880-b0c9-11eb-98c5-2b12f26846b3.mp4

### Expected result AFTER applying this Pull Request

same as before, just much (2000ms) faster.


https://user-images.githubusercontent.com/400092/117572643-b109ef00-b0cb-11eb-903b-9214d51c4647.mp4



### Documentation Changes Required

