### PR TITLE
[4.0] Backend - Add style to Privacy Quickicon badge

### DIFF
--- a/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
+++ b/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
@@ -28,7 +28,7 @@
             const countBadge = document.createElement('span');
             countBadge.classList.add('badge', 'text-dark', 'bg-light');
             countBadge.textContent = request.data.number_urgent_requests;
-            link.textContent = text.REQUESTFOUND + ' ';
+            link.textContent = text.REQUESTFOUND.concat(' ');
             link.appendChild(countBadge);
 
             // Quickicon becomes red

--- a/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
+++ b/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
@@ -28,7 +28,7 @@
             const countBadge = document.createElement('span');
             countBadge.classList.add('badge', 'text-dark', 'bg-light');
             countBadge.textContent = request.data.number_urgent_requests;
-            link.textContent = text.REQUESTFOUND.concat(' ');
+            link.textContent = `${text.REQUESTFOUND} `;
             link.appendChild(countBadge);
 
             // Quickicon becomes red

--- a/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
+++ b/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
@@ -25,7 +25,12 @@
 
           if (request.data.number_urgent_requests) {
             // Quickicon on dashboard shows message
-            link.textContent = `${text.REQUESTFOUND} ${request.data.number_urgent_requests}`;
+            const countBadge = document.createElement("span");
+            countBadge.classList.add("badge", "text-dark", "bg-light");
+            countBadge.textContent = request.data.number_urgent_requests;
+            link.textContent = text.REQUESTFOUND + " ";
+            link.appendChild(countBadge);
+
             // Quickicon becomes red
             quickicon.classList.add('danger');
 

--- a/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
+++ b/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js
@@ -25,10 +25,10 @@
 
           if (request.data.number_urgent_requests) {
             // Quickicon on dashboard shows message
-            const countBadge = document.createElement("span");
-            countBadge.classList.add("badge", "text-dark", "bg-light");
+            const countBadge = document.createElement('span');
+            countBadge.classList.add('badge', 'text-dark', 'bg-light');
             countBadge.textContent = request.data.number_urgent_requests;
-            link.textContent = text.REQUESTFOUND + " ";
+            link.textContent = text.REQUESTFOUND + ' ';
             link.appendChild(countBadge);
 
             // Quickicon becomes red


### PR DESCRIPTION
Pull Request for Issue #33695
Replacement for Closed PRs #33709 and #33711 

### Summary of Changes
Added a span to display the count. The classes applied to this span are identical to the other quickicon span badges


### Testing Instructions

1. Run this SQL to give you the same thing:
```sql
INSERT INTO `jos_privacy_requests` (`id`, `email`, `requested_at`, `status`, `request_type`, `confirm_token`, `confirm_token_created_at`)
VALUES
	(1, 'asdfasd@asdas', '2011-05-09 12:53:18', 0, 'export', '$2y$10$XfdBZSSZMDuhyvHFhJq7e.AUXMtrPOojvcNDEPVWZnOQjKBJfOkum', '2021-05-09 12:53:18'),
	(2, 'asdfasd@asdas', '2011-05-09 12:53:18', 1, 'export', '', '2021-05-09 12:53:53'),
	(3, 'asdfasd@asdas', '2011-05-09 12:53:18', 1, 'remove', '', '2021-05-09 12:53:58');
```
Alternatively, here's a trick I used:
Change the following line
https://github.com/joomla/joomla-cms/blob/d49c77fb80c3cfeb68cec44b014bee863eb57143/build/media_source/plg_quickicon_privacycheck/js/privacycheck.es6.js#L26
to : 
```js
if (!request.data.number_urgent_requests) {
```

2. `npm run build:js`

**Note:** You might observe a message like below on the admin dashboard: 
![image](https://user-images.githubusercontent.com/53610833/117581739-ff46de80-b11b-11eb-8317-df3f761c561f.png)
This is a different issue which has been reported and is not fixed by this PR

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/117580255-cc4d1c80-b114-11eb-8a7f-0c11b832afda.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/53610833/117580128-0833b200-b114-11eb-85b7-07aad0d880e2.png)



### Documentation Changes Required
None