### PR TITLE
[4.0] sidebar-toggle color

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -69,7 +69,7 @@
   }
 
   .sidebar-toggle {
-    background: var(--atum-link-color);
+    background: var(--atum-bg-dark-60);
 
     a {
       color: $white;


### PR DESCRIPTION
This PR change the color of the sidebar toggle from the link color to the same color as used on the status buttons so we dont have so many shades of blue. This also means that it will be styled consistently when the template hue is changed

Pull Request for Issue #33601 .

It's a css change so dont forget to rebuild the css

### Before
![image](https://user-images.githubusercontent.com/1296369/117582918-50df7100-b0fc-11eb-97fe-9e594fd3276f.png)

![image](https://user-images.githubusercontent.com/1296369/117582920-52a93480-b0fc-11eb-8ccb-7814213a3e57.png)

### After
![image](https://user-images.githubusercontent.com/1296369/117582923-563cbb80-b0fc-11eb-91e0-49446e29ad0d.png)

![image](https://user-images.githubusercontent.com/1296369/117582924-58067f00-b0fc-11eb-80d7-651a7ce212a0.png)
