### PR TITLE
[4.0] content maps

### DIFF
--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -121,7 +121,7 @@ $wa->useScript('com_finder.maps');
 							<?php endif; ?>
 							<td class="text-center btns itemnumber">
 							<?php if ($item->level > 1) : ?>
-								<a class="btn <?php if ((int) $item->count_published > 0) echo 'btn-success'; ?>" title="<?php echo Text::_('COM_FINDER_MAPS_COUNT_PUBLISHED_ITEMS'); ?>" href="<?php echo Route::_('index.php?option=com_finder&view=index&filter[state]=1&filter[content_map]=' . $item->id); ?>">
+								<a class="btn <?php echo ((int) $item->count_published > 0) ? 'btn-success' : 'btn-secondary'; ?>" title="<?php echo Text::_('COM_FINDER_MAPS_COUNT_PUBLISHED_ITEMS'); ?>" href="<?php echo Route::_('index.php?option=com_finder&view=index&filter[state]=1&filter[content_map]=' . $item->id); ?>">
 								<?php echo (int) $item->count_published; ?></a>
 							<?php else : ?>
 								-


### PR DESCRIPTION
Smart search content maps has a column for published and unpublished indexed content

Before this PR a content map with no published items displayed a zero with no styling

### Before
![image](https://user-images.githubusercontent.com/1296369/117583645-36a79200-b100-11eb-9101-ce8610b4e7c7.png)

### After
![image](https://user-images.githubusercontent.com/1296369/117583628-1c6db400-b100-11eb-9765-266e7a2ac4a9.png)
