### PR TITLE
[4.0] make Atum error page use template params

### DIFF
--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -28,6 +28,7 @@ $layout     = $input->get('layout', 'default');
 $task       = $input->get('task', 'display');
 $cpanel     = $option === 'com_cpanel';
 $hiddenMenu = $app->input->get('hidemainmenu');
+$params     = $app->getTemplate(true)->params;
 
 // Browsers support SVG favicons
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon.svg', '', [], true, 1), 'icon', 'rel', ['type' => 'image/svg+xml']);

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -50,21 +50,21 @@ $logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($th
 	? 'alt=""'
 	: 'alt="' . htmlspecialchars($this->params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8') . '"';
 
-	// Get the hue value
-	preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
+// Get the hue value
+preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
 
-	// Enable assets
-	$wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
-		->useStyle('template.active.language')
-		->useStyle('template.user')
-		->addInlineStyle(':root {
-			--hue: ' . $matches[1] . ';
-			--atum-bg-light: ' . $this->params->get('bg-light', '#f0f4fb') . ';
-			--atum-text-dark: ' . $this->params->get('text-dark', '#495057') . ';
-			--atum-text-light: ' . $this->params->get('text-light', '#ffffff') . ';
-			--atum-link-color: ' . $this->params->get('link-color', '#2a69b8') . ';
-			--atum-special-color: ' . $this->params->get('special-color', '#001B4C') . ';
-		}');
+// Enable assets
+$wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
+	->useStyle('template.active.language')
+	->useStyle('template.user')
+	->addInlineStyle(':root {
+		--hue: ' . $matches[1] . ';
+		--atum-bg-light: ' . $this->params->get('bg-light', '#f0f4fb') . ';
+		--atum-text-dark: ' . $this->params->get('text-dark', '#495057') . ';
+		--atum-text-light: ' . $this->params->get('text-light', '#ffffff') . ';
+		--atum-link-color: ' . $this->params->get('link-color', '#2a69b8') . ';
+		--atum-special-color: ' . $this->params->get('special-color', '#001B4C') . ';
+	}');
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
 $wa->registerStyle('template.active', '', [], [], ['template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -36,22 +36,22 @@ $this->addHeadLink(HTMLHelper::_('image', 'favicon.ico', '', [], true, 1), 'alte
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon-pinned.svg', '', [], true, 1), 'mask-icon', 'rel', ['color' => '#000']);
 
 // Template params
-$logoBrandLarge  = $this->params->get('logoBrandLarge')
-	? Uri::root() . htmlspecialchars($this->params->get('logoBrandLarge'), ENT_QUOTES)
+$logoBrandLarge  = $params->get('logoBrandLarge')
+	? Uri::root() . htmlspecialchars($params->get('logoBrandLarge'), ENT_QUOTES)
 	: $this->baseurl . '/templates/' . $this->template . '/images/logos/brand-large.svg';
-$logoBrandSmall = $this->params->get('logoBrandSmall')
-	? Uri::root() . htmlspecialchars($this->params->get('logoBrandSmall'), ENT_QUOTES)
+$logoBrandSmall = $params->get('logoBrandSmall')
+	? Uri::root() . htmlspecialchars($params->get('logoBrandSmall'), ENT_QUOTES)
 	: $this->baseurl . '/templates/' . $this->template . '/images/logos/brand-small.svg';
 
-$logoBrandLargeAlt = empty($this->params->get('logoBrandLargeAlt')) && empty($this->params->get('emptyLogoBrandLargeAlt'))
+$logoBrandLargeAlt = empty($params->get('logoBrandLargeAlt')) && empty($params->get('emptyLogoBrandLargeAlt'))
 	? 'alt=""'
-	: 'alt="' . htmlspecialchars($this->params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8') . '"';
-$logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($this->params->get('emptyLogoBrandSmallAlt'))
+	: 'alt="' . htmlspecialchars($params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8') . '"';
+$logoBrandSmallAlt = empty($params->get('logoBrandSmallAlt')) && empty($params->get('emptyLogoBrandSmallAlt'))
 	? 'alt=""'
-	: 'alt="' . htmlspecialchars($this->params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8') . '"';
+	: 'alt="' . htmlspecialchars($params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8') . '"';
 
 // Get the hue value
-preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
+preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
 
 // Enable assets
 $wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
@@ -59,11 +59,11 @@ $wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
 	->useStyle('template.user')
 	->addInlineStyle(':root {
 		--hue: ' . $matches[1] . ';
-		--atum-bg-light: ' . $this->params->get('bg-light', '#f0f4fb') . ';
-		--atum-text-dark: ' . $this->params->get('text-dark', '#495057') . ';
-		--atum-text-light: ' . $this->params->get('text-light', '#ffffff') . ';
-		--atum-link-color: ' . $this->params->get('link-color', '#2a69b8') . ';
-		--atum-special-color: ' . $this->params->get('special-color', '#001B4C') . ';
+		--atum-bg-light: ' . $params->get('bg-light', '#f0f4fb') . ';
+		--atum-text-dark: ' . $params->get('text-dark', '#495057') . ';
+		--atum-text-light: ' . $params->get('text-light', '#ffffff') . ';
+		--atum-link-color: ' . $params->get('link-color', '#2a69b8') . ';
+		--atum-special-color: ' . $params->get('special-color', '#001B4C') . ';
 	}');
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
@@ -72,7 +72,7 @@ $wa->registerStyle('template.active', '', [], [], ['template.atum.' . ($this->di
 // Set some meta data
 $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 
-$monochrome = (bool) $this->params->get('monochrome');
+$monochrome = (bool) $params->get('monochrome');
 
 // @see administrator/templates/atum/html/layouts/status.php
 $statusModules = LayoutHelper::render('status', ['modules' => 'status']);

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -13,7 +13,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
 /** @var \Joomla\CMS\Document\ErrorDocument $this */

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -53,7 +53,7 @@ $loginLogoAlt = empty($this->params->get('loginLogoAlt')) && empty($this->params
 	? 'alt=""'
 	: 'alt="' . htmlspecialchars($this->params->get('loginLogoAlt'), ENT_COMPAT, 'UTF-8') . '"';
 
-	// Get the hue value
+// Get the hue value
 preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
 
 // Enable assets

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -34,28 +34,28 @@ $this->addHeadLink(HTMLHelper::_('image', 'favicon.ico', '', [], true, 1), 'alte
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon-pinned.svg', '', [], true, 1), 'mask-icon', 'rel', ['color' => '#000']);
 
 // Template params
-$logoBrandLarge  = $this->params->get('logoBrandLarge')
-	? Uri::root() . htmlspecialchars($this->params->get('logoBrandLarge'), ENT_QUOTES)
+$logoBrandLarge  = $params->get('logoBrandLarge')
+	? Uri::root() . htmlspecialchars($params->get('logoBrandLarge'), ENT_QUOTES)
 	: $this->baseurl . '/templates/' . $this->template . '/images/logos/brand-large.svg';
-$loginLogo = $this->params->get('loginLogo')
-	? Uri::root() . $this->params->get('loginLogo')
+$loginLogo = $params->get('loginLogo')
+	? Uri::root() . $params->get('loginLogo')
 	: $this->baseurl . '/templates/' . $this->template . '/images/logos/login.svg';
-$logoBrandSmall = $this->params->get('logoBrandSmall')
-	? Uri::root() . htmlspecialchars($this->params->get('logoBrandSmall'), ENT_QUOTES)
+$logoBrandSmall = $params->get('logoBrandSmall')
+	? Uri::root() . htmlspecialchars($params->get('logoBrandSmall'), ENT_QUOTES)
 	: $this->baseurl . '/templates/' . $this->template . '/images/logos/brand-small.svg';
 
-$logoBrandLargeAlt = empty($this->params->get('logoBrandLargeAlt')) && empty($this->params->get('emptyLogoBrandLargeAlt'))
+$logoBrandLargeAlt = empty($params->get('logoBrandLargeAlt')) && empty($params->get('emptyLogoBrandLargeAlt'))
 	? 'alt=""'
-	: 'alt="' . htmlspecialchars($this->params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8') . '"';
-$logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($this->params->get('emptyLogoBrandSmallAlt'))
+	: 'alt="' . htmlspecialchars($params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8') . '"';
+$logoBrandSmallAlt = empty($params->get('logoBrandSmallAlt')) && empty($params->get('emptyLogoBrandSmallAlt'))
 	? 'alt=""'
-	: 'alt="' . htmlspecialchars($this->params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8') . '"';
-$loginLogoAlt = empty($this->params->get('loginLogoAlt')) && empty($this->params->get('emptyLoginLogoAlt'))
+	: 'alt="' . htmlspecialchars($params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8') . '"';
+$loginLogoAlt = empty($params->get('loginLogoAlt')) && empty($params->get('emptyLoginLogoAlt'))
 	? 'alt=""'
-	: 'alt="' . htmlspecialchars($this->params->get('loginLogoAlt'), ENT_COMPAT, 'UTF-8') . '"';
+	: 'alt="' . htmlspecialchars($params->get('loginLogoAlt'), ENT_COMPAT, 'UTF-8') . '"';
 
 // Get the hue value
-preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
+preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
 
 // Enable assets
 $wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
@@ -63,11 +63,11 @@ $wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
 	->useStyle('template.user')
 	->addInlineStyle(':root {
 		--hue: ' . $matches[1] . ';
-		--atum-bg-light: ' . $this->params->get('bg-light', '#f0f4fb') . ';
-		--atum-text-dark: ' . $this->params->get('text-dark', '#495057') . ';
-		--atum-text-light: ' . $this->params->get('text-light', '#ffffff') . ';
-		--atum-link-color: ' . $this->params->get('link-color', '#2a69b8') . ';
-		--atum-special-color: ' . $this->params->get('special-color', '#001B4C') . ';
+		--atum-bg-light: ' . $params->get('bg-light', '#f0f4fb') . ';
+		--atum-text-dark: ' . $params->get('text-dark', '#495057') . ';
+		--atum-text-light: ' . $params->get('text-light', '#ffffff') . ';
+		--atum-link-color: ' . $params->get('link-color', '#2a69b8') . ';
+		--atum-special-color: ' . $params->get('special-color', '#001B4C') . ';
 	}');
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
@@ -76,7 +76,7 @@ $wa->registerStyle('template.active', '', [], [], ['template.atum.' . ($this->di
 // Set some meta data
 $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 
-$monochrome = (bool) $this->params->get('monochrome');
+$monochrome = (bool) $params->get('monochrome');
 
 // @see administrator/templates/atum/html/layouts/status.php
 $statusModules = LayoutHelper::render('status', ['modules' => 'status']);

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -26,6 +26,7 @@ $option = $input->get('option', '');
 $view   = $input->get('view', '');
 $layout = $input->get('layout', 'default');
 $task   = $input->get('task', 'display');
+$params = $app->getTemplate(true)->params;
 
 // Browsers support SVG favicons
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon.svg', '', [], true, 1), 'icon', 'rel', ['type' => 'image/svg+xml']);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This PR will make it possible to use the Admin template params on an admin error page. 
@richard67 thank you for the suggestion how it is implemented in Cassiopeia. 
Good or bad... it works. 

### Testing Instructions

Login Joomla 4 admin
Go to Atum template and change a color. 
Logout of Joomla 4 admin
Go to a URL that generates a 403 Forbidden message - here is a quick example:

http://example.com/administrator/index.php?option=com_banners&task=tracks.display&format=raw

### Actual result BEFORE applying this Pull Request
<img width="1176" alt="Schermafbeelding 2021-05-09 om 21 57 28" src="https://user-images.githubusercontent.com/639822/117585276-cf92d900-b111-11eb-9af1-d3ba26447bb0.png">


### Expected result AFTER applying this Pull Request


<img width="1176" alt="Schermafbeelding 2021-05-09 om 21 59 04" src="https://user-images.githubusercontent.com/639822/117585273-cd307f00-b111-11eb-8f8a-5187fcefa455.png">



### Documentation Changes Required

