### PR TITLE
[4.0] fix position of Joomla button in Atum header

### DIFF
--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -93,7 +93,6 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 		</div>
 	</noscript>
 
-	<?php // Header ?>
 	<header id="header" class="header">
 		<div class="header-inside">
 			<div class="header-title d-flex">
@@ -109,10 +108,8 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 		</div>
 	</header>
 
-	<?php // Wrapper ?>
 	<div id="wrapper" class="d-flex wrapper<?php echo $hiddenMenu ? '0' : ''; ?>">
 
-		<?php // Sidebar ?>
 		<?php if (!$hiddenMenu) : ?>
 			<button class="navbar-toggler toggler-burger collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar-wrapper" aria-controls="sidebar-wrapper" aria-expanded="false" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
 				<span class="navbar-toggler-icon"></span>
@@ -131,10 +128,8 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 			</div>
 		<?php endif; ?>
 
-		<?php // container-fluid ?>
 		<div class="container-fluid container-main">
 			<?php if (!$cpanel) : ?>
-				<?php // Subheader ?>
 				<a class="btn btn-subhead d-md-none d-lg-none d-xl-none" data-bs-toggle="collapse"
 				   data-bs-target=".subhead-collapse"><?php echo Text::_('TPL_ATUM_TOOLBAR'); ?>
 					<span class="icon-wrench"></span></a>
@@ -148,7 +143,6 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 				</div>
 			<?php endif; ?>
 			<section id="content" class="content">
-				<?php // Begin Content ?>
 				<jdoc:include type="message" />
 				<jdoc:include type="modules" name="top" style="xhtml" />
 				<div class="row">
@@ -189,7 +183,6 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 						<jdoc:include type="modules" name="bottom" style="xhtml" />
 					<?php endif; ?>
 				</div>
-				<?php // End Content ?>
 			</section>
 		</div>
 	</div>

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -94,18 +94,16 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 	</noscript>
 
 	<header id="header" class="header">
-		<div class="header-inside">
-			<div class="header-title d-flex">
-				<div class="d-flex align-items-center">
-					<div class="logo">
-						<img src="<?php echo $logoBrandLarge; ?>" <?php echo $logoBrandLargeAlt; ?>>
-						<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" <?php echo $logoBrandSmallAlt; ?>>
-					</div>
+		<div class="header-title d-flex">
+			<div class="d-flex align-items-center">
+				<div class="logo">
+					<img src="<?php echo $logoBrandLarge; ?>" <?php echo $logoBrandLargeAlt; ?>>
+					<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" <?php echo $logoBrandSmallAlt; ?>>
 				</div>
-				<jdoc:include type="modules" name="title" />
 			</div>
-			<?php echo $statusModules; ?>
+			<jdoc:include type="modules" name="title" />
 		</div>
+		<?php echo $statusModules; ?>
 	</header>
 
 	<div id="wrapper" class="d-flex wrapper<?php echo $hiddenMenu ? '0' : ''; ?>">

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -93,7 +93,7 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 		</div>
 	</noscript>
 
-	<header id="header" class="header">
+	<header id="header" class="header d-flex">
 		<div class="header-title d-flex">
 			<div class="d-flex align-items-center">
 				<div class="logo">

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -109,25 +109,6 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 	</header>
 
 	<div id="wrapper" class="d-flex wrapper<?php echo $hiddenMenu ? '0' : ''; ?>">
-
-		<?php if (!$hiddenMenu) : ?>
-			<button class="navbar-toggler toggler-burger collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar-wrapper" aria-controls="sidebar-wrapper" aria-expanded="false" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
-				<span class="navbar-toggler-icon"></span>
-			</button>
-
-			<div id="sidebar-wrapper" class="sidebar-wrapper sidebar-menu" <?php echo $hiddenMenu ? 'data-hidden="' . $hiddenMenu . '"' : ''; ?>>
-				<div id="sidebarmenu">
-					<div class="sidebar-toggle item item-level-1">
-						<a id="menu-collapse" href="#" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
-							<span id="menu-collapse-icon" class="icon-toggle-off icon-fw" aria-hidden="true"></span>
-							<span class="sidebar-item-title"><?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?></span>
-						</a>
-					</div>
-					<jdoc:include type="modules" name="menu" style="none" />
-				</div>
-			</div>
-		<?php endif; ?>
-
 		<div class="container-fluid container-main">
 			<?php if (!$cpanel) : ?>
 				<a class="btn btn-subhead d-md-none d-lg-none d-xl-none" data-bs-toggle="collapse"
@@ -185,6 +166,24 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 				</div>
 			</section>
 		</div>
+
+		<?php if (!$hiddenMenu) : ?>
+			<button class="navbar-toggler toggler-burger collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar-wrapper" aria-controls="sidebar-wrapper" aria-expanded="false" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
+				<span class="navbar-toggler-icon"></span>
+			</button>
+
+			<div id="sidebar-wrapper" class="sidebar-wrapper sidebar-menu" <?php echo $hiddenMenu ? 'data-hidden="' . $hiddenMenu . '"' : ''; ?>>
+				<div id="sidebarmenu">
+					<div class="sidebar-toggle item item-level-1">
+						<a id="menu-collapse" href="#" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
+							<span id="menu-collapse-icon" class="icon-toggle-off icon-fw" aria-hidden="true"></span>
+							<span class="sidebar-item-title"><?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?></span>
+						</a>
+					</div>
+					<jdoc:include type="modules" name="menu" style="none" />
+				</div>
+			</div>
+		<?php endif; ?>
 	</div>
 	<jdoc:include type="modules" name="debug" style="none" />
 </body>

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -87,112 +87,112 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : '') . ($monochrome ? ' monochrome' : ''); ?>">
 
-<noscript>
-	<div class="alert alert-danger" role="alert">
-		<?php echo Text::_('JGLOBAL_WARNJAVASCRIPT'); ?>
-	</div>
-</noscript>
-
-<?php // Header ?>
-<header id="header" class="header">
-	<div class="header-inside">
-		<div class="header-title d-flex">
-			<div class="d-flex align-items-center">
-				<div class="logo">
-					<img src="<?php echo $logoBrandLarge; ?>" <?php echo $logoBrandLargeAlt; ?>>
-					<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" <?php echo $logoBrandSmallAlt; ?>>
-				</div>
-			</div>
-			<jdoc:include type="modules" name="title" />
+	<noscript>
+		<div class="alert alert-danger" role="alert">
+			<?php echo Text::_('JGLOBAL_WARNJAVASCRIPT'); ?>
 		</div>
-		<?php echo $statusModules; ?>
-	</div>
-</header>
+	</noscript>
 
-<?php // Wrapper ?>
-<div id="wrapper" class="d-flex wrapper<?php echo $hiddenMenu ? '0' : ''; ?>">
-
-	<?php // Sidebar ?>
-	<?php if (!$hiddenMenu) : ?>
-		<button class="navbar-toggler toggler-burger collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar-wrapper" aria-controls="sidebar-wrapper" aria-expanded="false" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
-			<span class="navbar-toggler-icon"></span>
-		</button>
-
-		<div id="sidebar-wrapper" class="sidebar-wrapper sidebar-menu" <?php echo $hiddenMenu ? 'data-hidden="' . $hiddenMenu . '"' : ''; ?>>
-			<div id="sidebarmenu">
-				<div class="sidebar-toggle item item-level-1">
-					<a id="menu-collapse" href="#" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
-						<span id="menu-collapse-icon" class="icon-toggle-off icon-fw" aria-hidden="true"></span>
-						<span class="sidebar-item-title"><?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?></span>
-					</a>
-				</div>
-				<jdoc:include type="modules" name="menu" style="none" />
-			</div>
-		</div>
-	<?php endif; ?>
-
-	<?php // container-fluid ?>
-	<div class="container-fluid container-main">
-		<?php if (!$cpanel) : ?>
-			<?php // Subheader ?>
-			<a class="btn btn-subhead d-md-none d-lg-none d-xl-none" data-bs-toggle="collapse"
-			   data-bs-target=".subhead-collapse"><?php echo Text::_('TPL_ATUM_TOOLBAR'); ?>
-				<span class="icon-wrench"></span></a>
-			<div id="subhead" class="subhead mb-3">
-				<div id="container-collapse" class="container-collapse"></div>
-				<div class="row">
-					<div class="col-md-12">
-						<jdoc:include type="modules" name="toolbar" style="none" />
+	<?php // Header ?>
+	<header id="header" class="header">
+		<div class="header-inside">
+			<div class="header-title d-flex">
+				<div class="d-flex align-items-center">
+					<div class="logo">
+						<img src="<?php echo $logoBrandLarge; ?>" <?php echo $logoBrandLargeAlt; ?>>
+						<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" <?php echo $logoBrandSmallAlt; ?>>
 					</div>
+				</div>
+				<jdoc:include type="modules" name="title" />
+			</div>
+			<?php echo $statusModules; ?>
+		</div>
+	</header>
+
+	<?php // Wrapper ?>
+	<div id="wrapper" class="d-flex wrapper<?php echo $hiddenMenu ? '0' : ''; ?>">
+
+		<?php // Sidebar ?>
+		<?php if (!$hiddenMenu) : ?>
+			<button class="navbar-toggler toggler-burger collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#sidebar-wrapper" aria-controls="sidebar-wrapper" aria-expanded="false" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
+				<span class="navbar-toggler-icon"></span>
+			</button>
+
+			<div id="sidebar-wrapper" class="sidebar-wrapper sidebar-menu" <?php echo $hiddenMenu ? 'data-hidden="' . $hiddenMenu . '"' : ''; ?>>
+				<div id="sidebarmenu">
+					<div class="sidebar-toggle item item-level-1">
+						<a id="menu-collapse" href="#" aria-label="<?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?>">
+							<span id="menu-collapse-icon" class="icon-toggle-off icon-fw" aria-hidden="true"></span>
+							<span class="sidebar-item-title"><?php echo Text::_('JTOGGLE_SIDEBAR_MENU'); ?></span>
+						</a>
+					</div>
+					<jdoc:include type="modules" name="menu" style="none" />
 				</div>
 			</div>
 		<?php endif; ?>
-		<section id="content" class="content">
-			<?php // Begin Content ?>
-			<jdoc:include type="message" />
-			<jdoc:include type="modules" name="top" style="xhtml" />
-			<div class="row">
-				<div class="col-md-12">
-					<h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
-					<blockquote class="blockquote">
-						<span class="badge bg-secondary"><?php echo $this->error->getCode(); ?></span>
-						<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
-					</blockquote>
-					<?php if ($this->debug) : ?>
-						<div>
-							<?php echo $this->renderBacktrace(); ?>
-							<?php // Check if there are more Exceptions and render their data as well ?>
-							<?php if ($this->error->getPrevious()) : ?>
-								<?php $loop = true; ?>
-								<?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly ?>
-								<?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions ?>
-								<?php $this->setError($this->_error->getPrevious()); ?>
-								<?php while ($loop === true) : ?>
-									<p><strong><?php echo Text::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
-									<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
-									<?php echo $this->renderBacktrace(); ?>
-									<?php $loop = $this->setError($this->_error->getPrevious()); ?>
-								<?php endwhile; ?>
-								<?php // Reset the main error object to the base error ?>
-								<?php $this->setError($this->error); ?>
-							<?php endif; ?>
-						</div>
-					<?php endif; ?>
-					<p>
-						<a href="<?php echo $this->baseurl; ?>" class="btn btn-secondary">
-							<span class="icon-dashboard" aria-hidden="true"></span>
-							<?php echo Text::_('JGLOBAL_TPL_CPANEL_LINK_TEXT'); ?></a>
-					</p>
-				</div>
 
-				<?php if ($this->countModules('bottom')) : ?>
-					<jdoc:include type="modules" name="bottom" style="xhtml" />
-				<?php endif; ?>
-			</div>
-			<?php // End Content ?>
-		</section>
+		<?php // container-fluid ?>
+		<div class="container-fluid container-main">
+			<?php if (!$cpanel) : ?>
+				<?php // Subheader ?>
+				<a class="btn btn-subhead d-md-none d-lg-none d-xl-none" data-bs-toggle="collapse"
+				   data-bs-target=".subhead-collapse"><?php echo Text::_('TPL_ATUM_TOOLBAR'); ?>
+					<span class="icon-wrench"></span></a>
+				<div id="subhead" class="subhead mb-3">
+					<div id="container-collapse" class="container-collapse"></div>
+					<div class="row">
+						<div class="col-md-12">
+							<jdoc:include type="modules" name="toolbar" style="none" />
+						</div>
+					</div>
+				</div>
+			<?php endif; ?>
+			<section id="content" class="content">
+				<?php // Begin Content ?>
+				<jdoc:include type="message" />
+				<jdoc:include type="modules" name="top" style="xhtml" />
+				<div class="row">
+					<div class="col-md-12">
+						<h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
+						<blockquote class="blockquote">
+							<span class="badge bg-secondary"><?php echo $this->error->getCode(); ?></span>
+							<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+						</blockquote>
+						<?php if ($this->debug) : ?>
+							<div>
+								<?php echo $this->renderBacktrace(); ?>
+								<?php // Check if there are more Exceptions and render their data as well ?>
+								<?php if ($this->error->getPrevious()) : ?>
+									<?php $loop = true; ?>
+									<?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly ?>
+									<?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions ?>
+									<?php $this->setError($this->_error->getPrevious()); ?>
+									<?php while ($loop === true) : ?>
+										<p><strong><?php echo Text::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
+										<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+										<?php echo $this->renderBacktrace(); ?>
+										<?php $loop = $this->setError($this->_error->getPrevious()); ?>
+									<?php endwhile; ?>
+									<?php // Reset the main error object to the base error ?>
+									<?php $this->setError($this->error); ?>
+								<?php endif; ?>
+							</div>
+						<?php endif; ?>
+						<p>
+							<a href="<?php echo $this->baseurl; ?>" class="btn btn-secondary">
+								<span class="icon-dashboard" aria-hidden="true"></span>
+								<?php echo Text::_('JGLOBAL_TPL_CPANEL_LINK_TEXT'); ?></a>
+						</p>
+					</div>
+
+					<?php if ($this->countModules('bottom')) : ?>
+						<jdoc:include type="modules" name="bottom" style="xhtml" />
+					<?php endif; ?>
+				</div>
+				<?php // End Content ?>
+			</section>
+		</div>
 	</div>
-</div>
-<jdoc:include type="modules" name="debug" style="none" />
+	<jdoc:include type="modules" name="debug" style="none" />
 </body>
 </html>

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -112,17 +112,6 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 	</header>
 
 	<div id="wrapper" class="d-flex wrapper">
-
-		<div id="sidebar-wrapper" class="sidebar-wrapper">
-			<div id="main-brand" class="main-brand">
-				<h1><?php echo $app->get('sitename'); ?></h1>
-				<a href="<?php echo Uri::root(); ?>"><?php echo Text::_('TPL_ATUM_LOGIN_SIDEBAR_VIEW_WEBSITE'); ?></a>
-			</div>
-			<div id="sidebar">
-				<jdoc:include type="modules" name="sidebar" style="body" />
-			</div>
-		</div>
-
 		<div class="container-fluid container-main">
 			<section id="content" class="content h-100">
 				<main class="d-flex justify-content-center align-items-center h-100">
@@ -161,6 +150,16 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 					</div>
 				</main>
 			</section>
+		</div>
+
+		<div id="sidebar-wrapper" class="sidebar-wrapper">
+			<div id="main-brand" class="main-brand">
+				<h1><?php echo $app->get('sitename'); ?></h1>
+				<a href="<?php echo Uri::root(); ?>"><?php echo Text::_('TPL_ATUM_LOGIN_SIDEBAR_VIEW_WEBSITE'); ?></a>
+			</div>
+			<div id="sidebar">
+				<jdoc:include type="modules" name="sidebar" style="body" />
+			</div>
 		</div>
 	</div>
 	<jdoc:include type="modules" name="debug" style="none" />

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -90,82 +90,82 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : '') . ($monochrome ? ' monochrome' : ''); ?>">
 
-<noscript>
-	<div class="alert alert-danger" role="alert">
-		<?php echo Text::_('JGLOBAL_WARNJAVASCRIPT'); ?>
-	</div>
-</noscript>
-
-<header id="header" class="header">
-	<div class="header-inside">
-		<div class="header-title d-flex">
-			<div class="d-flex align-items-center">
-				<div class="logo">
-					<img src="<?php echo $logoBrandLarge; ?>" <?php echo $logoBrandLargeAlt; ?>>
-					<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" <?php echo $logoBrandSmallAlt; ?>>
-				</div>
-			</div>
-			<jdoc:include type="modules" name="title" />
+	<noscript>
+		<div class="alert alert-danger" role="alert">
+			<?php echo Text::_('JGLOBAL_WARNJAVASCRIPT'); ?>
 		</div>
-		<?php echo $statusModules; ?>
-	</div>
-</header>
+	</noscript>
 
-<div id="wrapper" class="d-flex wrapper">
-
-	<?php // Sidebar ?>
-	<div id="sidebar-wrapper" class="sidebar-wrapper">
-		<div id="main-brand" class="main-brand">
-			<h1><?php echo $app->get('sitename'); ?></h1>
-			<a href="<?php echo Uri::root(); ?>"><?php echo Text::_('TPL_ATUM_LOGIN_SIDEBAR_VIEW_WEBSITE'); ?></a>
-		</div>
-		<div id="sidebar">
-			<jdoc:include type="modules" name="sidebar" style="body" />
-		</div>
-	</div>
-
-	<div class="container-fluid container-main">
-		<section id="content" class="content h-100">
-			<?php // Begin Content ?>
-			<main class="d-flex justify-content-center align-items-center h-100">
-				<div id="element-box" class="card">
-					<div class="card-body">
-						<div class="main-brand d-flex align-items-center justify-content-center">
-							<img src="<?php echo $loginLogo; ?>" <?php echo $loginLogoAlt; ?>>
-						</div>
-						<h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
-						<jdoc:include type="message" />
-						<blockquote class="blockquote">
-							<span class="badge bg-secondary"><?php echo $this->error->getCode(); ?></span>
-							<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
-						</blockquote>
-						<?php if ($this->debug) : ?>
-							<div>
-								<?php echo $this->renderBacktrace(); ?>
-								<?php // Check if there are more Exceptions and render their data as well ?>
-								<?php if ($this->error->getPrevious()) : ?>
-									<?php $loop = true; ?>
-									<?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly ?>
-									<?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions ?>
-									<?php $this->setError($this->_error->getPrevious()); ?>
-									<?php while ($loop === true) : ?>
-										<p><strong><?php echo Text::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
-										<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
-										<?php echo $this->renderBacktrace(); ?>
-										<?php $loop = $this->setError($this->_error->getPrevious()); ?>
-									<?php endwhile; ?>
-									<?php // Reset the main error object to the base error ?>
-									<?php $this->setError($this->error); ?>
-								<?php endif; ?>
-							</div>
-						<?php endif; ?>
+	<header id="header" class="header">
+		<div class="header-inside">
+			<div class="header-title d-flex">
+				<div class="d-flex align-items-center">
+					<div class="logo">
+						<img src="<?php echo $logoBrandLarge; ?>" <?php echo $logoBrandLargeAlt; ?>>
+						<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" <?php echo $logoBrandSmallAlt; ?>>
 					</div>
 				</div>
-			</main>
-			<?php // End Content ?>
-		</section>
+				<jdoc:include type="modules" name="title" />
+			</div>
+			<?php echo $statusModules; ?>
+		</div>
+	</header>
+
+	<div id="wrapper" class="d-flex wrapper">
+
+		<?php // Sidebar ?>
+		<div id="sidebar-wrapper" class="sidebar-wrapper">
+			<div id="main-brand" class="main-brand">
+				<h1><?php echo $app->get('sitename'); ?></h1>
+				<a href="<?php echo Uri::root(); ?>"><?php echo Text::_('TPL_ATUM_LOGIN_SIDEBAR_VIEW_WEBSITE'); ?></a>
+			</div>
+			<div id="sidebar">
+				<jdoc:include type="modules" name="sidebar" style="body" />
+			</div>
+		</div>
+
+		<div class="container-fluid container-main">
+			<section id="content" class="content h-100">
+				<?php // Begin Content ?>
+				<main class="d-flex justify-content-center align-items-center h-100">
+					<div id="element-box" class="card">
+						<div class="card-body">
+							<div class="main-brand d-flex align-items-center justify-content-center">
+								<img src="<?php echo $loginLogo; ?>" <?php echo $loginLogoAlt; ?>>
+							</div>
+							<h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
+							<jdoc:include type="message" />
+							<blockquote class="blockquote">
+								<span class="badge bg-secondary"><?php echo $this->error->getCode(); ?></span>
+								<?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
+							</blockquote>
+							<?php if ($this->debug) : ?>
+								<div>
+									<?php echo $this->renderBacktrace(); ?>
+									<?php // Check if there are more Exceptions and render their data as well ?>
+									<?php if ($this->error->getPrevious()) : ?>
+										<?php $loop = true; ?>
+										<?php // Reference $this->_error here and in the loop as setError() assigns errors to this property and we need this for the backtrace to work correctly ?>
+										<?php // Make the first assignment to setError() outside the loop so the loop does not skip Exceptions ?>
+										<?php $this->setError($this->_error->getPrevious()); ?>
+										<?php while ($loop === true) : ?>
+											<p><strong><?php echo Text::_('JERROR_LAYOUT_PREVIOUS_ERROR'); ?></strong></p>
+											<p><?php echo htmlspecialchars($this->_error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></p>
+											<?php echo $this->renderBacktrace(); ?>
+											<?php $loop = $this->setError($this->_error->getPrevious()); ?>
+										<?php endwhile; ?>
+										<?php // Reset the main error object to the base error ?>
+										<?php $this->setError($this->error); ?>
+									<?php endif; ?>
+								</div>
+							<?php endif; ?>
+						</div>
+					</div>
+				</main>
+				<?php // End Content ?>
+			</section>
+		</div>
 	</div>
-</div>
-<jdoc:include type="modules" name="debug" style="none" />
+	<jdoc:include type="modules" name="debug" style="none" />
 </body>
 </html>

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -97,18 +97,16 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 	</noscript>
 
 	<header id="header" class="header">
-		<div class="header-inside">
-			<div class="header-title d-flex">
-				<div class="d-flex align-items-center">
-					<div class="logo">
-						<img src="<?php echo $logoBrandLarge; ?>" <?php echo $logoBrandLargeAlt; ?>>
-						<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" <?php echo $logoBrandSmallAlt; ?>>
-					</div>
+		<div class="header-title d-flex">
+			<div class="d-flex align-items-center">
+				<div class="logo">
+					<img src="<?php echo $logoBrandLarge; ?>" <?php echo $logoBrandLargeAlt; ?>>
+					<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" <?php echo $logoBrandSmallAlt; ?>>
 				</div>
-				<jdoc:include type="modules" name="title" />
 			</div>
-			<?php echo $statusModules; ?>
+			<jdoc:include type="modules" name="title" />
 		</div>
+		<?php echo $statusModules; ?>
 	</header>
 
 	<div id="wrapper" class="d-flex wrapper">

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -96,7 +96,7 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 		</div>
 	</noscript>
 
-	<header id="header" class="header">
+	<header id="header" class="header d-flex">
 		<div class="header-title d-flex">
 			<div class="d-flex align-items-center">
 				<div class="logo">

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -113,7 +113,6 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 
 	<div id="wrapper" class="d-flex wrapper">
 
-		<?php // Sidebar ?>
 		<div id="sidebar-wrapper" class="sidebar-wrapper">
 			<div id="main-brand" class="main-brand">
 				<h1><?php echo $app->get('sitename'); ?></h1>
@@ -126,7 +125,6 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 
 		<div class="container-fluid container-main">
 			<section id="content" class="content h-100">
-				<?php // Begin Content ?>
 				<main class="d-flex justify-content-center align-items-center h-100">
 					<div id="element-box" class="card">
 						<div class="card-body">
@@ -162,7 +160,6 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 						</div>
 					</div>
 				</main>
-				<?php // End Content ?>
 			</section>
 		</div>
 	</div>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -105,7 +105,7 @@ HTMLHelper::_('bootstrap.dropdown');
 		<?php echo Text::_('JGLOBAL_WARNIE'); ?>
 	</div>
 
-	<header id="header" class="header">
+	<header id="header" class="header d-flex">
 		<div class="header-title d-flex">
 			<div class="d-flex align-items-center">
 				<div class="logo">

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -95,6 +95,7 @@ HTMLHelper::_('bootstrap.dropdown');
 </head>
 
 <body class="admin <?php echo $option . ' view-' . $view . ' layout-' . $layout . ($task ? ' task-' . $task : '') . ($monochrome ? ' monochrome' : ''); ?>">
+
 	<noscript>
 		<div class="alert alert-danger" role="alert">
 			<?php echo Text::_('JGLOBAL_WARNJAVASCRIPT'); ?>

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -135,7 +135,6 @@ HTMLHelper::_('bootstrap.dropdown');
 			</section>
 		</div>
 
-		<?php // Sidebar ?>
 		<div id="sidebar-wrapper" class="sidebar-wrapper px-3 pb-3">
 			<div id="main-brand" class="main-brand">
 				<h1><?php echo $app->get('sitename'); ?></h1>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

PR https://github.com/joomla/joomla-cms/pull/33654 fixed the placement of Joomla button on the first row.
Caused an unwanted styling bug on com_foo
PR https://github.com/joomla/joomla-cms/pull/33689 fixed the styling bug on com_foo
Caused the fix from the first PR

This PR also moves some php blocks to equalize the structure of error_login.php, error_full.php and login.php 

### Testing Instructions

- Navigate to http://example.com/administrator/index.php?option=com_foo where com_foo is not installed.
- Logout of Joomla 4 admin
- Go to a URL that generates a 403 Forbidden message - here is a quick example:
  http://example.com/administrator/index.php?option=com_banners&task=tracks.display&format=raw



### Actual result BEFORE applying this Pull Request

#### administrator/index.php?option=com_foo
<img width="1176" alt="Schermafbeelding 2021-05-09 om 22 29 55" src="https://user-images.githubusercontent.com/639822/117586058-1be01800-b116-11eb-846c-034f439932a8.png">

#### administrator/index.php?option=com_banners&task=tracks.display&format=raw
<img width="1176" alt="Schermafbeelding 2021-05-09 om 21 57 28" src="https://user-images.githubusercontent.com/639822/117586026-f81cd200-b115-11eb-9de8-414b620871fa.png">

### Expected result AFTER applying this Pull Request

#### administrator/index.php?option=com_foo
<img width="1176" alt="Schermafbeelding 2021-05-09 om 22 29 55" src="https://user-images.githubusercontent.com/639822/117586058-1be01800-b116-11eb-846c-034f439932a8.png">

#### administrator/index.php?option=com_banners&task=tracks.display&format=raw
<img width="1176" alt="Schermafbeelding 2021-05-09 om 22 06 45" src="https://user-images.githubusercontent.com/639822/117586075-28647080-b116-11eb-8152-f3a58e480344.png">


### Documentation Changes Required

