### PR TITLE
Fix UrlRule's phpDoc

### DIFF
--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -39,7 +39,7 @@ class UrlRule extends FormRule
 	 *
 	 * @since   1.7.0
 	 * @link    https://www.w3.org/Addressing/URL/url-spec.txt
-	 * @see	    JString
+	 * @see	    StringHelper
 	 */
 	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{

--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -39,7 +39,7 @@ class UrlRule extends FormRule
 	 *
 	 * @since   1.7.0
 	 * @link    https://www.w3.org/Addressing/URL/url-spec.txt
-	 * @see	    StringHelper
+	 * @see	    \Joomla\String\StringHelper
 	 */
 	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{


### PR DESCRIPTION
Fix Joomla\CMS\Form\Rule\UrlRule's phpDoc (JString is not part of Joomla!4, Joomla\String\StringHelper is used instead)

The code is not affected.