### PR TITLE
[4.0] Changed color of Joomlaversion

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -146,7 +146,7 @@
   &.joomlaversion {
     color: var(--bluegray);
     background-color: transparent;
-    
+
     .header-item-text {
       padding-inline-end: 12px;
     }

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -144,9 +144,9 @@
   }
 
   &.joomlaversion {
-    background-color: transparent;
     color: var(--bluegray);
-
+    background-color: transparent;
+    
     .header-item-text {
       padding-inline-end: 12px;
     }

--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -145,6 +145,7 @@
 
   &.joomlaversion {
     background-color: transparent;
+    color: var(--bluegray);
 
     .header-item-text {
       padding-inline-end: 12px;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
changed the color of joomlaversion on top. Earlier it had gray color,but not now


### Testing Instructions
apply this patch, build the CSS and observe the joomlaversion


### Actual result BEFORE applying this Pull Request
![old](https://user-images.githubusercontent.com/65963997/117635206-3a3d2680-b19d-11eb-9db6-dcb09922d24d.png)

### Expected result AFTER applying this Pull Request
![new](https://user-images.githubusercontent.com/65963997/117635217-3c9f8080-b19d-11eb-931d-7962b7444ed7.png)



### Documentation Changes Required

