### PR TITLE
[4.0] fieldset legend

### DIFF
--- a/administrator/templates/atum/scss/blocks/_layout.scss
+++ b/administrator/templates/atum/scss/blocks/_layout.scss
@@ -1,12 +1,14 @@
 .options-form {
   width: 100%;
+  padding: 1vw 2vw;
   margin-bottom: 1rem;
   color: var(--atum-text-dark);
+  border: 1px solid var(--bluegray);
 
   > legend {
     float: none;
     width: auto;
-    padding: 0;
+    padding: 0 1rem;
     font-weight: $font-weight-bold;
     color: var(--atum-text-dark);
     background-color: $white;

--- a/administrator/templates/atum/scss/blocks/_layout.scss
+++ b/administrator/templates/atum/scss/blocks/_layout.scss
@@ -3,7 +3,7 @@
   padding: 1vw 2vw;
   margin-bottom: 1rem;
   color: var(--atum-text-dark);
-  border: 1px solid var(--bluegray);
+  border: 1px solid var(--atum-bg-dark-20);
 
   > legend {
     float: none;


### PR DESCRIPTION
the repaint removed the lines around a fieldset. Unfortunately this makes it impossible to see which fields are in a fieldset and the legend is unclear what it is for. This pr puts the border back.

This is a css change so dont forget to rebuild the css

### Before
![image](https://user-images.githubusercontent.com/1296369/117645666-be35e500-b182-11eb-9acf-4a740747a6a7.png)

### After
![image](https://user-images.githubusercontent.com/1296369/117645482-8fb80a00-b182-11eb-98a4-36b0f48c4b2f.png)
