### PR TITLE
[4.0] Remove edit button in toolbar

### DIFF
--- a/administrator/components/com_installer/src/View/Updatesites/HtmlView.php
+++ b/administrator/components/com_installer/src/View/Updatesites/HtmlView.php
@@ -103,11 +103,6 @@ class HtmlView extends InstallerViewDefault
 		// Get the toolbar object instance
 		$toolbar = Toolbar::getInstance('toolbar');
 
-		if ($canDo->get('core.edit'))
-		{
-			ToolbarHelper::editList('updatesite.edit');
-		}
-
 		if ($canDo->get('core.edit.state'))
 		{
 			$dropdown = $toolbar->dropdownButton('status-group')


### PR DESCRIPTION
### Summary of Changes
The Edit button in the toolbar implies that multiple items can be edit. This is not the case so remove it. Also this is consistent with other views.


### Testing Instructions
System > Update > Update Sites
Select multiple items.
Click the Edit button.
Only the first selected item is editable.
Apply PR.
No Edit button.
Click on an item to edit.

