### PR TITLE
[4.0] Smart Search: Adding index to taxonomy table

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-05-10.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-05-10.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `#__finder_taxonomy`
+    ADD INDEX `idx_level` (`level`);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-05-10.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-05-10.sql
@@ -1,1 +1,1 @@
-CREATE INDEX "#__finder_taxonomy_idx_level" on "#__finder_taxonomy" ("level");
+CREATE INDEX "#__finder_taxonomy_level" on "#__finder_taxonomy" ("level");

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-05-10.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-05-10.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "#__finder_taxonomy_idx_level" on "#__finder_taxonomy" ("level");

--- a/installation/sql/mysql/extensions.sql
+++ b/installation/sql/mysql/extensions.sql
@@ -339,6 +339,7 @@ CREATE TABLE IF NOT EXISTS `#__finder_taxonomy` (
   INDEX `idx_state` (`state`),
   INDEX `idx_access` (`access`),
   INDEX `idx_path` (`path`(100)),
+  INDEX `idx_level` (`level`),
   INDEX `idx_left_right` (`lft`, `rgt`),
   INDEX `idx_alias` (`alias`(100)),
   INDEX `idx_language` (`language`),

--- a/installation/sql/postgresql/extensions.sql
+++ b/installation/sql/postgresql/extensions.sql
@@ -323,6 +323,7 @@ CREATE TABLE IF NOT EXISTS "#__finder_taxonomy" (
 CREATE INDEX "#__finder_taxonomy_state" on "#__finder_taxonomy" ("state");
 CREATE INDEX "#__finder_taxonomy_access" on "#__finder_taxonomy" ("access");
 CREATE INDEX "#__finder_taxonomy_path" on "#__finder_taxonomy" ("path");
+CREATE INDEX "#__finder_taxonomy_level" on "#__finder_taxonomy" ("level");
 CREATE INDEX "#__finder_taxonomy_lft_rgt" on "#__finder_taxonomy" ("lft", "rgt");
 CREATE INDEX "#__finder_taxonomy_alias" on "#__finder_taxonomy" ("alias");
 CREATE INDEX "#__finder_taxonomy_language" on "#__finder_taxonomy" ("language");


### PR DESCRIPTION
During some testing, the taxonomy table of the Smart Search component showed to be a performance problem, especially on sites with lots of taxonomies. The index being added in here improves this performance enormously. There isn't really any way to test this for the regular users. This needs a codereviews.