### PR TITLE
[4.0] Joomla style tooltip in com_redirect

### DIFF
--- a/administrator/components/com_redirect/src/Service/HTML/Redirect.php
+++ b/administrator/components/com_redirect/src/Service/HTML/Redirect.php
@@ -56,8 +56,9 @@ class Redirect
 		if ($canChange)
 		{
 			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon'
-				. ($value == 1 ? ' active' : '') . '" title="' . Text::_($state[3])
-				. '"><span class="icon-' . $icon . '" aria-hidden="true"></span></a>';
+				. ($value == 1 ? ' active' : '')
+				. '"><span class="icon-' . $icon . '" aria-hidden="true"></span></a>'
+				. '<div role="tooltip" id="cb' . $i. '">' . Text::_($state[3]) . '</div>';
 		}
 
 		return $html;

--- a/administrator/components/com_redirect/src/Service/HTML/Redirect.php
+++ b/administrator/components/com_redirect/src/Service/HTML/Redirect.php
@@ -56,7 +56,7 @@ class Redirect
 		if ($canChange)
 		{
 			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon' . ($value == 1 ? ' active' : '')
-				. '"><span class="icon-' . $icon . '" aria-hidden="true"></span></a>'
+				. '" aria-labelledby="cb' . $state[0] . $i . '-desc"><span class="icon-' . $icon . '" aria-hidden="true"></span></a>'
 				. '<div role="tooltip" id="cb' . $state[0] . $i . '-desc">' . Text::_($state[3]) . '</div>';
 		}
 

--- a/administrator/components/com_redirect/src/Service/HTML/Redirect.php
+++ b/administrator/components/com_redirect/src/Service/HTML/Redirect.php
@@ -57,7 +57,7 @@ class Redirect
 		{
 			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon' . ($value == 1 ? ' active' : '')
 				. '"><span class="icon-' . $icon . '" aria-hidden="true"></span></a>'
-				. '<div role="tooltip" id="cb' . $state[0] . $i . '">' . Text::_($state[3]) . '</div>';
+				. '<div role="tooltip" id="cb' . $state[0] . $i . '-desc' . '">' . Text::_($state[3]) . '</div>';
 		}
 
 		return $html;

--- a/administrator/components/com_redirect/src/Service/HTML/Redirect.php
+++ b/administrator/components/com_redirect/src/Service/HTML/Redirect.php
@@ -57,7 +57,7 @@ class Redirect
 		{
 			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon' . ($value == 1 ? ' active' : '')
 				. '"><span class="icon-' . $icon . '" aria-hidden="true"></span></a>'
-				. '<div role="tooltip" id="cb' . $state[0] . $i . '-desc' . '">' . Text::_($state[3]) . '</div>';
+				. '<div role="tooltip" id="cb' . $state[0] . $i . '-desc">' . Text::_($state[3]) . '</div>';
 		}
 
 		return $html;

--- a/administrator/components/com_redirect/src/Service/HTML/Redirect.php
+++ b/administrator/components/com_redirect/src/Service/HTML/Redirect.php
@@ -55,8 +55,7 @@ class Redirect
 
 		if ($canChange)
 		{
-			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon'
-				. ($value == 1 ? ' active' : '')
+			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon'.($value == 1 ? ' active' : '')
 				. '"><span class="icon-' . $icon . '" aria-hidden="true"></span></a>'
 				. '<div role="tooltip" id="cb' . $i. '">' . Text::_($state[3]) . '</div>';
 		}

--- a/administrator/components/com_redirect/src/Service/HTML/Redirect.php
+++ b/administrator/components/com_redirect/src/Service/HTML/Redirect.php
@@ -57,7 +57,7 @@ class Redirect
 		{
 			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon' . ($value == 1 ? ' active' : '')
 				. '"><span class="icon-' . $icon . '" aria-hidden="true"></span></a>'
-				. '<div role="tooltip" id="cb' . $i . '">' . Text::_($state[3]) . '</div>';
+				. '<div role="tooltip" id="cb' . $state[0] . $i . '">' . Text::_($state[3]) . '</div>';
 		}
 
 		return $html;

--- a/administrator/components/com_redirect/src/Service/HTML/Redirect.php
+++ b/administrator/components/com_redirect/src/Service/HTML/Redirect.php
@@ -55,9 +55,9 @@ class Redirect
 
 		if ($canChange)
 		{
-			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon'.($value == 1 ? ' active' : '')
+			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon' . ($value == 1 ? ' active' : '')
 				. '"><span class="icon-' . $icon . '" aria-hidden="true"></span></a>'
-				. '<div role="tooltip" id="cb' . $i. '">' . Text::_($state[3]) . '</div>';
+				. '<div role="tooltip" id="cb' . $i . '">' . Text::_($state[3]) . '</div>';
 		}
 
 		return $html;

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -104,9 +104,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php echo HTMLHelper::_('grid.id', $i, $item->id, false, 'cid', 'cb', $item->old_url); ?>
 						</td>
 						<td class="text-center">
-							<div class="btn-group">
-								<?php echo HTMLHelper::_('redirect.published', $item->published, $i); ?>
-							</div>
+							<?php echo HTMLHelper::_('redirect.published', $item->published, $i); ?>
 						</td>
 						<th scope="row" class="break-word">
 							<?php if ($canEdit) : ?>


### PR DESCRIPTION
Pull Request for Issue #.

### Summary of Changes
Remove `btn-group` because of no use here (IMO)
Add `div role="tooltip"`

### Testing Instructions
`Dashboard` > `System` > `Redirects under Manage` 

If your site doesn't have any redirects, please create some redirects using `New`

### Actual result BEFORE applying this Pull Request

https://user-images.githubusercontent.com/61203226/117690425-7772da00-b1d8-11eb-9247-8189f2b4bf0f.mp4

### Expected result AFTER applying this Pull Request

https://user-images.githubusercontent.com/61203226/117690440-7a6dca80-b1d8-11eb-9b27-21a83ae97b19.mp4

### Documentation Changes Required
No
