### PR TITLE
[4.0] Centrally aligned icons on dashboard

### DIFF
--- a/layouts/joomla/quickicons/icon.php
+++ b/layouts/joomla/quickicons/icon.php
@@ -41,7 +41,7 @@ $class = !empty($tmp) ? ' class="' . implode(' ', array_unique($tmp)) . '"' : ''
 	<?php endif; ?>
 
 		<a <?php echo $id . $class; ?> href="<?php echo $displayData['link']; ?>"<?php echo $target . $onclick . $title; ?>>
-			<div class="quickicon-info">
+			<div class="quickicon-info mx-auto" >
 				<?php if (isset($displayData['image'])): ?>
 					<div class="quickicon-icon">
 						<div class="<?php echo $displayData['image']; ?>" aria-hidden="true"></div>
@@ -56,13 +56,13 @@ $class = !empty($tmp) ? ' class="' . implode(' ', array_unique($tmp)) . '"' : ''
 			</div>
 			<?php // Name indicates the component
 			if (isset($displayData['name'])): ?>
-				<div class="quickicon-name d-flex align-items-end" <?php echo isset($displayData['ajaxurl']) ? ' aria-hidden="true"' : ''; ?>>
+				<div class="quickicon-name d-flex align-items-end mx-auto" <?php echo isset($displayData['ajaxurl']) ? ' aria-hidden="true"' : ''; ?>>
 					<?php echo Text::_($displayData['name']); ?>
 				</div>
 			<?php endif; ?>
 			<?php // Information or action from plugins
 			if (isset($displayData['text'])): ?>
-				<div class="quickicon-name d-flex align-items-center">
+				<div class="quickicon-name d-flex align-items-center mx-auto">
 					<?php echo $text; ?>
 				</div>
 			<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue  #
Icons are centered 

### Summary of Changes
Added bootstrap class mx-auto in the PHP file.


### Testing Instructions
Go to the dashboard
view the icons.
before the pr, the icons are at the bottom, after this pr the icons are centered in the div


### Actual result BEFORE applying this Pull Request
![icon1](https://user-images.githubusercontent.com/70388131/117691489-932ab000-b1d9-11eb-95c3-6a80d29694e6.jpeg)



### Expected result AFTER applying this Pull Request
![Screenshot (65)](https://user-images.githubusercontent.com/70388131/117692140-5ad7a180-b1da-11eb-80a0-91b055079f8c.png)


![icon](https://user-images.githubusercontent.com/70388131/117691938-1815c980-b1da-11eb-82ef-ad505b639109.gif)




