### PR TITLE
[4.0] Header height atum

### DIFF
--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -26,7 +26,7 @@ if ($hideLinks)
 HTMLHelper::_('bootstrap.dropdown', '.dropdown-toggle');
 ?>
 <div class="header-item-content dropdown header-profile">
-	<button class="dropdown-toggle d-flex align-items-center ps-0" data-bs-toggle="dropdown" type="button"
+	<button class="dropdown-toggle d-flex align-items-center ps-0 py-0" data-bs-toggle="dropdown" type="button"
 		title="<?php echo Text::_('MOD_USER_MENU'); ?>">
 		<div class="header-item-icon">
 			<span class="icon-user-circle" aria-hidden="true"></span>


### PR DESCRIPTION
Buttons have a padding of 1px defined in the browser unless it is specified in the css

On the toolbar they might all look like buttons but only the last one (user) is a button. Therefore that one is 68px and the others are 66px.

This results in a 2px difference in the height of the header as shown in the reported issue.

This PR removes the browser padding top and bottom and therefore the header is always 66px high.

Pull Request for Issue #33755.
