### PR TITLE
[4.0] Fix Modules Filter

### DIFF
--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -639,7 +639,8 @@ class ModuleModel extends AdminModel
 			// Pre-select some filters (Status, Module Position, Language, Access Level) in edit form if those have been selected in Module Manager
 			if (!$data->id)
 			{
-				$filters = (array) $app->getUserState('com_modules.modules.filter');
+				$clientId = $app->input->getInt('client_id', 0);
+				$filters  = (array) $app->getUserState('com_modules.modules.' . $clientId . '.filter');
 				$data->set('published', $app->input->getInt('published', ((isset($filters['state']) && $filters['state'] !== '') ? $filters['state'] : null)));
 				$data->set('position', $app->input->getInt('position', (!empty($filters['position']) ? $filters['position'] : null)));
 				$data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -87,7 +87,7 @@ class ModulesModel extends ListModel
 		{
 			$this->context .= '.' . $layout;
 		}
-		
+
 		// Make context client aware
 		$this->context .= '.' . $app->input->get->getInt('client_id', 0);
 
@@ -120,7 +120,7 @@ class ModulesModel extends ListModel
 		else
 		{
 			$clientId = (int) $this->getUserStateFromRequest($this->context . '.client_id', 'client_id', 0, 'int');
-			$clientId = (!in_array($clientId, array (0, 1))) ? 0 : $clientId;
+			$clientId = (!in_array($clientId, array(0, 1))) ? 0 : $clientId;
 			$this->setState('client_id', $clientId);
 		}
 

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -87,6 +87,29 @@ class ModulesModel extends ListModel
 		{
 			$this->context .= '.' . $layout;
 		}
+		
+		// Make context client aware
+		$this->context .= '.' . $app->input->get->getInt('client_id', 0);
+
+		// Load the filter state.
+		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+		$this->setState('filter.position', $this->getUserStateFromRequest($this->context . '.filter.position', 'filter_position', '', 'string'));
+		$this->setState('filter.module', $this->getUserStateFromRequest($this->context . '.filter.module', 'filter_module', '', 'string'));
+		$this->setState('filter.menuitem', $this->getUserStateFromRequest($this->context . '.filter.menuitem', 'filter_menuitem', '', 'cmd'));
+		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
+
+		// If in modal layout on the frontend, state and language are always forced.
+		if ($app->isClient('site') && $layout === 'modal')
+		{
+			$this->setState('filter.language', 'current');
+			$this->setState('filter.state', 1);
+		}
+		// If in backend (modal or not) we get the same fields from the user request.
+		else
+		{
+			$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'string'));
+			$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'string'));
+		}
 
 		// Special case for the client id.
 		if ($app->isClient('site') || $layout === 'modal')
@@ -105,26 +128,6 @@ class ModulesModel extends ListModel
 		if ($clientId == 1)
 		{
 			$this->filterFormName = 'filter_modulesadmin';
-		}
-
-		// Load the filter state.
-		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
-		$this->setState('filter.position', $this->getUserStateFromRequest($this->context . '.filter.position.' . $clientId, 'filter_position', '', 'string'));
-		$this->setState('filter.module', $this->getUserStateFromRequest($this->context . '.filter.module.' . $clientId, 'filter_module', '', 'string'));
-		$this->setState('filter.menuitem', $this->getUserStateFromRequest($this->context . '.filter.menuitem.' . $clientId, 'filter_menuitem', '', 'cmd'));
-		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
-
-		// If in modal layout on the frontend, state and language are always forced.
-		if ($app->isClient('site') && $layout === 'modal')
-		{
-			$this->setState('filter.language', 'current');
-			$this->setState('filter.state', 1);
-		}
-		// If in backend (modal or not) we get the same fields from the user request.
-		else
-		{
-			$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language.' . $clientId, 'filter_language', '', 'string'));
-			$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'string'));
 		}
 
 		// Load the parameters.

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -88,26 +88,6 @@ class ModulesModel extends ListModel
 			$this->context .= '.' . $layout;
 		}
 
-		// Load the filter state.
-		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
-		$this->setState('filter.position', $this->getUserStateFromRequest($this->context . '.filter.position', 'filter_position', '', 'string'));
-		$this->setState('filter.module', $this->getUserStateFromRequest($this->context . '.filter.module', 'filter_module', '', 'string'));
-		$this->setState('filter.menuitem', $this->getUserStateFromRequest($this->context . '.filter.menuitem', 'filter_menuitem', '', 'cmd'));
-		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
-
-		// If in modal layout on the frontend, state and language are always forced.
-		if ($app->isClient('site') && $layout === 'modal')
-		{
-			$this->setState('filter.language', 'current');
-			$this->setState('filter.state', 1);
-		}
-		// If in backend (modal or not) we get the same fields from the user request.
-		else
-		{
-			$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'string'));
-			$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'string'));
-		}
-
 		// Special case for the client id.
 		if ($app->isClient('site') || $layout === 'modal')
 		{
@@ -125,6 +105,26 @@ class ModulesModel extends ListModel
 		if ($clientId == 1)
 		{
 			$this->filterFormName = 'filter_modulesadmin';
+		}
+
+		// Load the filter state.
+		$this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+		$this->setState('filter.position', $this->getUserStateFromRequest($this->context . '.filter.position.' . $clientId, 'filter_position', '', 'string'));
+		$this->setState('filter.module', $this->getUserStateFromRequest($this->context . '.filter.module.' . $clientId, 'filter_module', '', 'string'));
+		$this->setState('filter.menuitem', $this->getUserStateFromRequest($this->context . '.filter.menuitem.' . $clientId, 'filter_menuitem', '', 'cmd'));
+		$this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
+
+		// If in modal layout on the frontend, state and language are always forced.
+		if ($app->isClient('site') && $layout === 'modal')
+		{
+			$this->setState('filter.language', 'current');
+			$this->setState('filter.state', 1);
+		}
+		// If in backend (modal or not) we get the same fields from the user request.
+		else
+		{
+			$this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language.' . $clientId, 'filter_language', '', 'string'));
+			$this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'string'));
 		}
 
 		// Load the parameters.

--- a/administrator/components/com_modules/src/Service/HTML/Modules.php
+++ b/administrator/components/com_modules/src/Service/HTML/Modules.php
@@ -187,7 +187,7 @@ class Modules
 
 		$app = Factory::getApplication();
 
-		$position = $app->getUserState('com_modules.' . $clientId . '.modules.filter.position');
+		$position = $app->getUserState('com_modules.modules' . $clientId . '.filter.position');
 
 		if ($position)
 		{

--- a/administrator/components/com_modules/src/Service/HTML/Modules.php
+++ b/administrator/components/com_modules/src/Service/HTML/Modules.php
@@ -187,7 +187,7 @@ class Modules
 
 		$app = Factory::getApplication();
 
-		$position = $app->getUserState('com_modules.modules.filter.position');
+		$position = $app->getUserState('com_modules.' . $clientId . '.modules.filter.position');
 
 		if ($position)
 		{

--- a/administrator/components/com_modules/src/Service/HTML/Modules.php
+++ b/administrator/components/com_modules/src/Service/HTML/Modules.php
@@ -187,7 +187,7 @@ class Modules
 
 		$app = Factory::getApplication();
 
-		$position = $app->getUserState('com_modules.modules' . $clientId . '.filter.position');
+		$position = $app->getUserState('com_modules.modules.' . $clientId . '.filter.position');
 
 		if ($position)
 		{


### PR DESCRIPTION
Pull Request for Issue #33692.

### Summary of Changes
Currently, we use same session key for Admin and Site modules filter options value, thus causes unexpected behavior. One of the issue is https://github.com/joomla/joomla-cms/issues/33692 

There are other issues, too. For example, if you are on Site Modules and select a module position filter, then switch to Administrator, you won't see any modules... (because the system remember that site position, but of course, backend modules have different positions list. Same for module filter and menu item filter.


### Testing Instructions
1. Look at the issue https://github.com/joomla/joomla-cms/issues/33692 , confirm that the issue happens (you would need to have a multilingual website to confirm the issue)
2. Apply patch, confirm that the issue sorted.
3. Try to filter modules by position, by module types and make sure it is still working as expected, nothing should be broken
4. From Modules Management screen, choose a module position. Then press New button in toolbar, confirm that that module position is pre-selected on New module screen.