### PR TITLE
Makes check for field type="Hidden" case-insensitive

### DIFF
--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -686,7 +686,7 @@ abstract class FormField
 		$this->repeat = ($repeat === 'true' || $repeat === 'multiple' || (!empty($this->form->repeat) && $this->form->repeat == 1));
 
 		// Set the visibility.
-		$this->hidden = ($this->hidden || (string) $element['type'] === 'hidden');
+		$this->hidden = ($this->hidden || strtolower((string) $this->element['type']) === 'hidden');
 
 		$this->layout = !empty($this->element['layout']) ? (string) $this->element['layout'] : $this->layout;
 


### PR DESCRIPTION
Fixes issue with field not being seen as hidden when using `type="Hidden"` instead of `type="hidden"`

You can test this by for instance - changing:
```
		<field
			name="update_site_id"
			type="hidden"
		/>
```
to:

```
		<field
			name="update_site_id"
			type="Hidden"
		/>
```
in administrator/components/com_installer/forms/updatesite.xml

Then go to administrator/index.php?option=com_installer&view=updatesites and click on one of the update sites.
Result is now:
![image](https://user-images.githubusercontent.com/13553242/117781572-12070380-b241-11eb-8efe-1c24d3490423.png)

After fix, that line is not visible (which is good).