### PR TITLE
[4.0] Fix Delete All for Content Map

### DIFF
--- a/administrator/components/com_finder/src/Model/MapsModel.php
+++ b/administrator/components/com_finder/src/Model/MapsModel.php
@@ -97,6 +97,18 @@ class MapsModel extends ListModel
 		// Include the content plugins for the on delete events.
 		PluginHelper::importPlugin('content');
 
+		// Iterate the items to check if all of them exists.
+		foreach ($pks as $i => $pk)
+		{
+			if (!$table->load($pk))
+			{
+				// Item is not in the table.
+				$this->setError($table->getError());
+
+				return false;
+			}
+		}
+
 		// Iterate the items to delete each one.
 		foreach ($pks as $i => $pk)
 		{
@@ -141,12 +153,6 @@ class MapsModel extends ListModel
 						$this->setError(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'));
 					}
 				}
-			}
-			else
-			{
-				$this->setError($table->getError());
-
-				return false;
 			}
 		}
 

--- a/administrator/components/com_finder/src/Model/MapsModel.php
+++ b/administrator/components/com_finder/src/Model/MapsModel.php
@@ -97,7 +97,7 @@ class MapsModel extends ListModel
 		// Include the content plugins for the on delete events.
 		PluginHelper::importPlugin('content');
 
-		// Iterate the items to check if all of them exists.
+		// Iterate the items to check if all of them exist.
 		foreach ($pks as $i => $pk)
 		{
 			if (!$table->load($pk))


### PR DESCRIPTION
Pull Request for Issue #33490

### Summary of Changes

<hr> 

#### Reason behind this issue

I debugged the array of id(s) which were queried for deletion and their query result:

```
Array of ids to be deleted: [5,4,10,14,13,12,11,15,7,6,9,8,3,2]
Status:
5 - done
4 - done
10 - failed
```

| id | Name | |
| --- | --- | --- |
| 5 | author/yatharthvyas | ✔️ Successfully deleted |
| 4 | author | ✔️ Successfully deleted but since it was a root level map, it also deleted all it's children along with it, so now id=10 was no longer present in the table |
| 10 | author/joomla | ❌ Failed because it was already deleted in the query of it's parent (id: 4).<br>This conditional block for key not in table returned false and ended the execution here skipping all remaining queries in the array. |

<hr> 

#### Changes Made:

The condition that checks if the key is in the table is now shifted outside the loop so when an element is deleted, that doesn't generate any error and return prematurely. Incase any key is not present, then it would be checked before deletion and the execution would stop then and there

<hr> 

### Testing Instructions

#### Before testing, Please take a backup of `#_finder_taxonomy` table to avoid the loss of any data
1. Visit Backend
2. Components -> Smart Search -> Content Map
3. Ensure that you have sufficient data in this table with multiple parent-level and child-level maps (Installting Blog Sample Data will also work)
4. Click on the select all checkbox and proceed to delete them.

Before the PR, only the first parent and its children would get deleted and then the function would return false skipping the remaining elements.
After the PR, you should see the Empty State, ie. All items deleted successfully.

<hr>

### Actual result BEFORE applying this Pull Request
Please refer to the video in #33490

<hr>

### Expected result AFTER applying this Pull Request
![content_map_fixed](https://user-images.githubusercontent.com/53610833/117789300-d2064780-b265-11eb-9425-74ed8870486d.gif)

<hr>

### Documentation Changes Required
None
