### PR TITLE
[4.0] Add class to CLOSE button

### DIFF
--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -40,7 +40,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					'closeButton' => false,
 					'backdrop'    => 'static',
 					'keyboard'    => false,
-					'footer'      => '<button type="button" class="btn" data-bs-dismiss="modal"'
+					'footer'      => '<button type="button" class="btn btn-danger" data-bs-dismiss="modal"'
 						. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#closeBtn\'})">'
 						. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
 						. '<button type="button" class="btn btn-primary" data-bs-dismiss="modal" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#saveBtn\'})">'


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Just add `btn-danger` class 

### Testing Instructions
* Disable System-Redirect plugin
* Go to System > Redirects
* Click on Redirect System Plugin
![system-redirect](https://user-images.githubusercontent.com/61203226/117811680-78f6dd80-b27e-11eb-86a0-873ff5427fbc.JPG)
* A model window appears, please hover on the `Close` button - Doesn't become `red` 
* Apply PR
* Refresh the page 
* Click on Redirect System Plugin
* Again hover on  the `Close` button - becomes `red` now

### Actual result BEFORE applying this Pull Request
Doesn't become 'red` on hover
![redirect](https://user-images.githubusercontent.com/61203226/117812165-15b97b00-b27f-11eb-9323-0f67bb20750a.JPG)

### Expected result AFTER applying this Pull Request
Becomes `red` on hover

### Documentation Changes Required
No
