### PR TITLE
[4.0] Add class to CLOSE button

### DIFF
--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -40,7 +40,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					'closeButton' => false,
 					'backdrop'    => 'static',
 					'keyboard'    => false,
-					'footer'      => '<button type="button" class="btn" data-bs-dismiss="modal"'
+					'footer'      => '<button type="button" class="btn btn-danger" data-bs-dismiss="modal"'
 						. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#closeBtn\'})">'
 						. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
 						. '<button type="button" class="btn btn-primary" data-bs-dismiss="modal" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#saveBtn\'})">'

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -40,7 +40,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					'closeButton' => false,
 					'backdrop'    => 'static',
 					'keyboard'    => false,
-					'footer'      => '<button type="button" class="btn btn-danger" data-bs-dismiss="modal"'
+					'footer'      => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal"'
 						. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#closeBtn\'})">'
 						. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
 						. '<button type="button" class="btn btn-primary" data-bs-dismiss="modal" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#saveBtn\'})">'

--- a/administrator/components/com_redirect/tmpl/links/emptystate.php
+++ b/administrator/components/com_redirect/tmpl/links/emptystate.php
@@ -58,7 +58,7 @@ if ($user->authorise('core.create', 'com_redirect')
 			'closeButton' => false,
 			'backdrop'    => 'static',
 			'keyboard'    => false,
-			'footer'      => '<button type="button" class="btn" data-bs-dismiss="modal"'
+			'footer'      => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal"'
 				. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#closeBtn\'})">'
 				. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
 				. '<button type="button" class="btn btn-primary" data-bs-dismiss="modal" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->redirectPluginId . 'Modal\', buttonSelector: \'#saveBtn\'})">'


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Just add `btn-secondary` class to CLOSE button. 
Why black https://github.com/joomla/joomla-cms/pull/33775#issuecomment-838428235

### Testing Instructions
* Disable System-Redirect plugin
* Go to System > Redirects
* Click on Redirect System Plugin
![system-redirect](https://user-images.githubusercontent.com/61203226/117811680-78f6dd80-b27e-11eb-86a0-873ff5427fbc.JPG)
* A model window appears, please hover on the `Close` button - Doesn't become `black` 
* Apply PR
* Refresh the page 
* Click on Redirect System Plugin
* Again hover on  the `Close` button - becomes `black` now

### Actual result BEFORE applying this Pull Request
Doesn't become `black` on hover
![redirect](https://user-images.githubusercontent.com/61203226/117812165-15b97b00-b27f-11eb-9323-0f67bb20750a.JPG)

### Expected result AFTER applying this Pull Request
Becomes `black` on hover

### Documentation Changes Required
No
