### PR TITLE
[4.0] Add Joomla style tooltip in com_messages

### DIFF
--- a/administrator/components/com_messages/src/Service/HTML/Messages.php
+++ b/administrator/components/com_messages/src/Service/HTML/Messages.php
@@ -47,9 +47,9 @@ class Messages
 		if ($canChange)
 		{
 			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon'
-					. ($value == 1 ? ' active' : '') . '" aria-labelledby="cb' . $state[0] . $i . '-desc"><span class="icon-'
-					. $icon . '" aria-hidden="true"></span></a><div role="tooltip" id="cb' . $state[0] . $i
-					. '-desc">' . Text::_($state[3]) . '</div>';
+				. ($value == 1 ? ' active' : '') . '" aria-labelledby="cb' . $state[0] . $i . '-desc"><span class="icon-'
+				. $icon . '" aria-hidden="true"></span></a><div role="tooltip" id="cb' . $state[0] . $i
+				. '-desc">' . Text::_($state[3]) . '</div>';
 		}
 
 		return $html;

--- a/administrator/components/com_messages/src/Service/HTML/Messages.php
+++ b/administrator/components/com_messages/src/Service/HTML/Messages.php
@@ -47,9 +47,9 @@ class Messages
 		if ($canChange)
 		{
 			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon'
-							. ($value == 1 ? ' active' : '') . '" aria-labelledby="cb' . $state[0] . $i . '-desc"><span class="icon-'
-							. $icon . '" aria-hidden="true"></span></a><div role="tooltip" id="cb' . $state[0] . $i
-							. '-desc">' . Text::_($state[3]) . '</div>';
+					. ($value == 1 ? ' active' : '') . '" aria-labelledby="cb' . $state[0] . $i . '-desc"><span class="icon-'
+					. $icon . '" aria-hidden="true"></span></a><div role="tooltip" id="cb' . $state[0] . $i
+					. '-desc">' . Text::_($state[3]) . '</div>';
 		}
 
 		return $html;

--- a/administrator/components/com_messages/src/Service/HTML/Messages.php
+++ b/administrator/components/com_messages/src/Service/HTML/Messages.php
@@ -46,9 +46,9 @@ class Messages
 
 		if ($canChange)
 		{
-			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon'
-				. ($value == 1 ? ' active' : '') . '" title="' . Text::_($state[3]) . '"><span class="icon-'
-				. $icon . '" aria-hidden="true"></span></a>';
+			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon' . ($value == 1 ? ' active' : '')
+							. '" aria-labelledby="cb' . $state[0] . $i . '-desc"><span class="icon-' . $icon . '" aria-hidden="true"></span></a>'
+							. '<div role="tooltip" id="cb' . $state[0] . $i . '-desc">' . Text::_($state[3]) . '</div>';
 		}
 
 		return $html;

--- a/administrator/components/com_messages/src/Service/HTML/Messages.php
+++ b/administrator/components/com_messages/src/Service/HTML/Messages.php
@@ -47,8 +47,9 @@ class Messages
 		if ($canChange)
 		{
 			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon'
-							. ($value == 1 ? ' active' : '') . '" aria-labelledby="cb' . $state[0] . $i . '-desc"><span class="icon-' . $icon
-							. '" aria-hidden="true"></span></a><div role="tooltip" id="cb' . $state[0] . $i . '-desc">' . Text::_($state[3]) . '</div>';
+							. ($value == 1 ? ' active' : '') . '" aria-labelledby="cb' . $state[0] . $i . '-desc"><span class="icon-'
+							. $icon . '" aria-hidden="true"></span></a><div role="tooltip" id="cb' . $state[0] . $i
+							. '-desc">' . Text::_($state[3]) . '</div>';
 		}
 
 		return $html;

--- a/administrator/components/com_messages/src/Service/HTML/Messages.php
+++ b/administrator/components/com_messages/src/Service/HTML/Messages.php
@@ -46,9 +46,9 @@ class Messages
 
 		if ($canChange)
 		{
-			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon' . ($value == 1 ? ' active' : '')
-							. '" aria-labelledby="cb' . $state[0] . $i . '-desc"><span class="icon-' . $icon . '" aria-hidden="true"></span></a>'
-							. '<div role="tooltip" id="cb' . $state[0] . $i . '-desc">' . Text::_($state[3]) . '</div>';
+			$html = '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $state[1] . '\')" class="tbody-icon'
+							. ($value == 1 ? ' active' : '') . '" aria-labelledby="cb' . $state[0] . $i . '-desc"><span class="icon-' . $icon
+							. '" aria-hidden="true"></span></a><div role="tooltip" id="cb' . $state[0] . $i . '-desc">' . Text::_($state[3]) . '</div>';
 		}
 
 		return $html;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Add `div role="tooltip"`

### Testing Instructions

Dashboard > Users > Messaging > Private Messages
If your site doesn't have any redirects, please create some redirects using New
![tooltip com message](https://user-images.githubusercontent.com/61203226/117816057-ba3dbc00-b283-11eb-8295-2ecf067834b1.JPG)
Hover on icons present in `Read` column
Apply PR
Again hover and see the difference

### Actual result BEFORE applying this Pull Request
Non-Joomla style tooltip

### Expected result AFTER applying this Pull Request
Joomla style tooltip

### Documentation Changes Required
No
