### PR TITLE
Update styling of the User Profile page and the Single Contact page

### DIFF
--- a/components/com_contact/tmpl/contact/default.php
+++ b/components/com_contact/tmpl/contact/default.php
@@ -91,35 +91,41 @@ $htag    = $tparams->get('show_page_heading') ? 'h2' : 'h1';
 	<?php echo $this->item->event->beforeDisplayContent; ?>
 
 	<?php if ($this->params->get('show_info', 1)) : ?>
-		<?php echo '<h3>' . Text::_('COM_CONTACT_DETAILS') . '</h3>'; ?>
 
-		<?php if ($this->item->image && $tparams->get('show_image')) : ?>
-			<div class="com-contact__thumbnail thumbnail float-end">
-				<?php echo HTMLHelper::_(
-					'image',
-					$this->item->image,
-					htmlspecialchars($this->item->name,  ENT_QUOTES, 'UTF-8'),
-					array('itemprop' => 'image')
-				); ?>
+		<div class="com-contact__container mb-4">
+			<?php echo '<h3>' . Text::_('COM_CONTACT_DETAILS') . '</h3>'; ?>
+
+			<?php if ($this->item->image && $tparams->get('show_image')) : ?>
+				<div class="com-contact__thumbnail thumbnail">
+					<?php echo HTMLHelper::_(
+						'image',
+						$this->item->image,
+						htmlspecialchars($this->item->name,  ENT_QUOTES, 'UTF-8'),
+						array('itemprop' => 'image')
+					); ?>
+				</div>
+			<?php endif; ?>
+
+			<?php if ($this->item->con_position && $tparams->get('show_position')) : ?>
+				<dl class="com-contact__position contact-position dl-horizontal">
+					<dt><?php echo Text::_('COM_CONTACT_POSITION'); ?>:</dt>
+					<dd itemprop="jobTitle">
+						<?php echo $this->item->con_position; ?>
+					</dd>
+				</dl>
+			<?php endif; ?>
+
+			<div class="com-contact__info">
+				<?php echo $this->loadTemplate('address'); ?>
+
+				<?php if ($tparams->get('allow_vcard')) : ?>
+					<?php echo Text::_('COM_CONTACT_DOWNLOAD_INFORMATION_AS'); ?>
+					<a href="<?php echo Route::_('index.php?option=com_contact&amp;view=contact&amp;id=' . $this->item->id . '&amp;format=vcf'); ?>">
+					<?php echo Text::_('COM_CONTACT_VCARD'); ?></a>
+				<?php endif; ?>
 			</div>
-		<?php endif; ?>
+		</div>
 
-		<?php if ($this->item->con_position && $tparams->get('show_position')) : ?>
-			<dl class="com-contact__position contact-position dl-horizontal">
-				<dt><?php echo Text::_('COM_CONTACT_POSITION'); ?>:</dt>
-				<dd itemprop="jobTitle">
-					<?php echo $this->item->con_position; ?>
-				</dd>
-			</dl>
-		<?php endif; ?>
-
-		<?php echo $this->loadTemplate('address'); ?>
-
-		<?php if ($tparams->get('allow_vcard')) : ?>
-			<?php echo Text::_('COM_CONTACT_DOWNLOAD_INFORMATION_AS'); ?>
-			<a href="<?php echo Route::_('index.php?option=com_contact&amp;view=contact&amp;id=' . $this->item->id . '&amp;format=vcf'); ?>">
-			<?php echo Text::_('COM_CONTACT_VCARD'); ?></a>
-		<?php endif; ?>
 	<?php endif; ?>
 
 	<?php if ($tparams->get('show_email_form') && ($this->item->email_to || $this->item->user_id)) : ?>

--- a/components/com_contact/tmpl/contact/default.php
+++ b/components/com_contact/tmpl/contact/default.php
@@ -92,7 +92,7 @@ $htag    = $tparams->get('show_page_heading') ? 'h2' : 'h1';
 
 	<?php if ($this->params->get('show_info', 1)) : ?>
 
-		<div class="com-contact__container mb-4">
+		<div class="com-contact__container">
 			<?php echo '<h3>' . Text::_('COM_CONTACT_DETAILS') . '</h3>'; ?>
 
 			<?php if ($this->item->image && $tparams->get('show_image')) : ?>

--- a/components/com_contact/tmpl/contact/default_form.php
+++ b/components/com_contact/tmpl/contact/default_form.php
@@ -25,7 +25,7 @@ HTMLHelper::_('behavior.formvalidator');
 			<?php endif; ?>
 			<?php $fields = $this->form->getFieldset($fieldset->name); ?>
 			<?php if (count($fields)) : ?>
-				<fieldset>
+				<fieldset class="m-0">
 					<?php if (isset($fieldset->label) && ($legend = trim(Text::_($fieldset->label))) !== '') : ?>
 						<legend><?php echo $legend; ?></legend>
 					<?php endif; ?>

--- a/components/com_users/tmpl/profile/default.php
+++ b/components/com_users/tmpl/profile/default.php
@@ -26,8 +26,8 @@ use Joomla\CMS\Router\Route;
 	<?php if (Factory::getUser()->id == $this->data->id) : ?>
 		<ul class="com-users-profile__edit btn-toolbar float-end">
 			<li class="btn-group">
-				<a class="btn" href="<?php echo Route::_('index.php?option=com_users&task=profile.edit&user_id=' . (int) $this->data->id); ?>">
-					<span class="icon-user" aria-hidden="true"></span> <?php echo Text::_('COM_USERS_EDIT_PROFILE'); ?>
+				<a class="btn btn-primary" href="<?php echo Route::_('index.php?option=com_users&task=profile.edit&user_id=' . (int) $this->data->id); ?>">
+					<span class="icon-user-edit" aria-hidden="true"></span> <?php echo Text::_('COM_USERS_EDIT_PROFILE'); ?>
 				</a>
 			</li>
 		</ul>

--- a/components/com_users/tmpl/profile/default_core.php
+++ b/components/com_users/tmpl/profile/default_core.php
@@ -13,7 +13,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 ?>
-<fieldset id="com-users-profile__core users-profile-core">
+<fieldset id="users-profile-core" class="com-users-profile__core">
 	<legend>
 		<?php echo Text::_('COM_USERS_PROFILE_CORE_LEGEND'); ?>
 	</legend>

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -151,6 +151,10 @@ th dd {
   font-weight: var(--cassiopeia-font-weight-normal, $font-weight-normal);
 }
 
+.com-contact__thumbnail {
+  text-align: left;
+}
+
 @include media-breakpoint-up(lg) {
 
   dl.dl-horizontal {
@@ -176,6 +180,7 @@ th dd {
     grid-template-columns: repeat(4, 1fr);
     grid-template-rows: repeat(4, auto);
     grid-gap: 1rem;
+    margin-bottom: $cassiopeia-grid-gutter;
 
     h3 {
         grid-column: 1 / 5;
@@ -184,6 +189,8 @@ th dd {
     .com-contact__thumbnail {
         grid-column: 3 / 5;
         grid-row: 2 / 5;
+        text-align: right;
+        margin-bottom: $cassiopeia-grid-gutter;
     }
 
     .com-contact__position {

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -135,19 +135,79 @@ small,
   font-size: $font-size-sm;
 }
 
-dd {
-  padding: 0 0 0 ($cassiopeia-grid-gutter*2);
-  margin-bottom: 0;
-}
-
 [dir="rtl"] dd {
-  padding: 0 ($cassiopeia-grid-gutter*2) 0 0;
   margin-right: 0;
   margin-left: auto;
+  padding: 0;
+  word-wrap: break-word;
+}
+
+dd {
+  padding: 0;
+  word-wrap: break-word;
 }
 
 th dd {
   font-weight: var(--cassiopeia-font-weight-normal, $font-weight-normal);
+}
+
+@include media-breakpoint-up(lg) {
+
+  dl.dl-horizontal {
+    display: grid;
+    grid-template-columns: auto 1fr;
+
+    dt {
+      grid-column-start: 1;
+      grid-column-end: 2;
+    }
+
+    dd {
+      grid-column-start: 2;
+      grid-column-end: 3;
+      padding: 0 0 0 $cassiopeia-grid-gutter;
+      margin-bottom: 0;
+    }
+  }
+
+  .com-contact__container {
+
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    grid-template-rows: repeat(4, auto);
+    grid-gap: 1rem;
+
+    h3 {
+        grid-column: 1 / 5;
+    }
+
+    .com-contact__thumbnail {
+        grid-column: 3 / 5;
+        grid-row: 2 / 5;
+    }
+
+    .com-contact__position {
+        grid-column: 1 / 3;
+        grid-row: 2 / 3;
+    }
+
+    .com-contact__info {
+        grid-column: 1 / 3;
+        grid-row: 3 / 4;
+    }
+  }
+
+  [dir="rtl"] dl.dl-horizontal {
+    dd {
+      padding: 0 $cassiopeia-grid-gutter 0 0;
+    }
+  }
+
+  .com-users-profile {
+    dt {
+      min-width: 180px;
+    }
+  }
 }
 
 figure {

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -135,16 +135,14 @@ small,
   font-size: $font-size-sm;
 }
 
-[dir="rtl"] dd {
-  margin-right: 0;
-  margin-left: auto;
+dd {
   padding: 0;
   word-wrap: break-word;
 }
 
-dd {
-  padding: 0;
-  word-wrap: break-word;
+[dir="rtl"] dd {
+  margin-right: 0;
+  margin-left: auto;
 }
 
 th dd {
@@ -156,7 +154,6 @@ th dd {
 }
 
 @include media-breakpoint-up(lg) {
-
   dl.dl-horizontal {
     display: grid;
     grid-template-columns: auto 1fr;
@@ -175,7 +172,6 @@ th dd {
   }
 
   .com-contact__container {
-
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     grid-template-rows: repeat(4, auto);

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -179,24 +179,24 @@ th dd {
     margin-bottom: $cassiopeia-grid-gutter;
 
     h3 {
-        grid-column: 1 / 5;
+      grid-column: 1 / 5;
     }
 
     .com-contact__thumbnail {
-        grid-column: 3 / 5;
-        grid-row: 2 / 5;
-        text-align: right;
-        margin-bottom: $cassiopeia-grid-gutter;
+      grid-column: 3 / 5;
+      grid-row: 2 / 5;
+      margin-bottom: $cassiopeia-grid-gutter;
+      text-align: right;
     }
 
     .com-contact__position {
-        grid-column: 1 / 3;
-        grid-row: 2 / 3;
+      grid-column: 1 / 3;
+      grid-row: 2 / 3;
     }
 
     .com-contact__info {
-        grid-column: 1 / 3;
-        grid-row: 3 / 4;
+      grid-column: 1 / 3;
+      grid-row: 3 / 4;
     }
   }
 


### PR DESCRIPTION
Pull Request for Issue #32561

Removed my previous PR #33603 and added the code from this PR and the missing styling for the contact page.

### Summary of Changes
There where some styling issues in both the user profile page and the single contact regarding the dl-horizontal class and the edit user profile button. This PR fixes the styling issues.

### Testing Instructions
Best way to test:

1. Enable the **User - Profile** plugin
2. Create a custom field in the Users Component
3. Fill all the fields in the extra tab "User Profile" now visible in the Users component under the account settings.Also fill the new custom field value
4. Enable as much options for the user account
5. Create a custom field for the Contacts component
6. Create a new contact in the Contacts component and Fill all the fields inducing the custom field
7. Enable as much options newly created contact
8. Link the Contact to the user profile under "Linked User"
9. Create a menu item of type "User Profile"
10. Create a menu item of type "Single Contact" and link this menu item to the created contact.
11. Login to the frontend of the site and visit both menu items.
12. Activate this PR and recreate the styling if necessary by running in the root of the site: **npm run build:css**
13. Visit the pages again and look at the results.

![com_users](https://user-images.githubusercontent.com/5610413/117830078-983c3d80-b273-11eb-8778-66829225fed7.jpg)

![com_contacts](https://user-images.githubusercontent.com/5610413/117830137-a25e3c00-b273-11eb-959c-1b0a3d146389.jpg)


### Actual result BEFORE applying this Pull Request
See the left site of the screenshots


### Expected result AFTER applying this Pull Request
See the right site of the screenshots


### Documentation Changes Required
No
