### PR TITLE
Fixed layout of extension name position in com_installer

### DIFF
--- a/administrator/components/com_installer/tmpl/install/default.php
+++ b/administrator/components/com_installer/tmpl/install/default.php
@@ -35,14 +35,14 @@ $tabs = $app->triggerEvent('onInstallerAddInstallationTab', []);
 <div id="installer-install" class="clearfix">
 
 	<form enctype="multipart/form-data" action="<?php echo Route::_('index.php?option=com_installer&view=install'); ?>" method="post" name="adminForm" id="adminForm">
+		<?php // Render messages set by extension install scripts here ?>
+		<?php if ($this->showMessage) : ?>
+			<?php echo $this->loadTemplate('message'); ?>
+		<?php endif; ?>
+
 		<div class="row">
 			<div class="col-md-12">
 				<div id="j-main-container" class="j-main-container main-card">
-					<?php // Render messages set by extension install scripts here ?>
-					<?php if ($this->showMessage) : ?>
-						<?php echo $this->loadTemplate('message'); ?>
-					<?php endif; ?>
-
 					<?php if (!$tabs) : ?>
 						<div class="alert alert-warning">
 							<span class="icon-exclamation-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('WARNING'); ?></span>

--- a/administrator/components/com_installer/tmpl/installer/default_message.php
+++ b/administrator/components/com_installer/tmpl/installer/default_message.php
@@ -15,12 +15,12 @@ $message2 = $state->get('extension_message');
 ?>
 
 <?php if ($message1) : ?>
-	<div class="my-3">
+	<div class="alert alert-info">
 		<strong><?php echo $message1; ?></strong>
 	</div>
 <?php endif; ?>
 <?php if ($message2) : ?>
-	<div class="my-3">
+	<div class="alert alert-info">
 		<?php echo $message2; ?>
 	</div>
 <?php endif; ?>

--- a/administrator/components/com_installer/tmpl/installer/default_message.php
+++ b/administrator/components/com_installer/tmpl/installer/default_message.php
@@ -15,12 +15,12 @@ $message2 = $state->get('extension_message');
 ?>
 
 <?php if ($message1) : ?>
-	<div class="installed-message">
+	<div class="my-3">
 		<strong><?php echo $message1; ?></strong>
 	</div>
 <?php endif; ?>
 <?php if ($message2) : ?>
-	<div class="installed-message">
+	<div class="my-3">
 		<?php echo $message2; ?>
 	</div>
 <?php endif; ?>

--- a/administrator/components/com_installer/tmpl/installer/default_message.php
+++ b/administrator/components/com_installer/tmpl/installer/default_message.php
@@ -15,16 +15,12 @@ $message2 = $state->get('extension_message');
 ?>
 
 <?php if ($message1) : ?>
-	<div class="container-fluid">
-		<div class="col-md-12">
-			<strong><?php echo $message1; ?></strong>
-		</div>
+	<div class="installed-message">
+		<strong><?php echo $message1; ?></strong>
 	</div>
 <?php endif; ?>
 <?php if ($message2) : ?>
-	<div class="container-fluid">
-		<div class="col-md-12">
-			<?php echo $message2; ?>
-		</div>
+	<div class="installed-message">
+		<?php echo $message2; ?>
 	</div>
 <?php endif; ?>

--- a/build/media_source/com_installer/css/installer.css
+++ b/build/media_source/com_installer/css/installer.css
@@ -82,3 +82,7 @@
 #dragarea[data-state=installing] .upload-actions {
 	display: none;
 }
+
+.installed-message {
+	min-height: 30px;
+}

--- a/build/media_source/com_installer/css/installer.css
+++ b/build/media_source/com_installer/css/installer.css
@@ -82,7 +82,3 @@
 #dragarea[data-state=installing] .upload-actions {
 	display: none;
 }
-
-.installed-message {
-	min-height: 30px;
-}


### PR DESCRIPTION
Pull Request for Issue #33697.

### Summary of Changes

Little changes in layout of installer component

### Testing Instructions

Go to administrator > com_installer and install any extension

### Actual result BEFORE applying this Pull Request

The name of just installed extension is overlay the add extension form, which looks bad
![before](https://user-images.githubusercontent.com/42320170/117831209-076a5f80-b27d-11eb-9d46-37d9f9ee058e.png)


### Expected result AFTER applying this Pull Request
The name of just installed extension is positioned like in Joomla! 3
![after](https://user-images.githubusercontent.com/42320170/117831461-439dc000-b27d-11eb-8db4-5eef75a38169.png)

