### PR TITLE
[4] Cast session_id to string before destroying it

### DIFF
--- a/libraries/src/Session/SessionManager.php
+++ b/libraries/src/Session/SessionManager.php
@@ -66,7 +66,7 @@ final class SessionManager
 
 		foreach ($sessionIds as $sessionId)
 		{
-			if (!$this->destroySession($sessionId))
+			if (!$this->destroySession((string) $sessionId))
 			{
 				$result = false;
 			}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/33740

### Summary of Changes

Cast session_id to a string before we use it 

### Testing Instructions

 https://github.com/joomla/joomla-cms/issues/33740

### Actual result BEFORE applying this Pull Request

Cant logout under some circumstances with pgsql

### Expected result AFTER applying this Pull Request

Can logout with no errors under some circumstances with pgsql

### Documentation Changes Required

