### PR TITLE
[4] Implement extra buttons to offline page

### DIFF
--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Uri\Uri;
 /** @var JDocumentHtml $this */
 
 $twofactormethods = AuthenticationHelper::getTwoFactorMethods();
+$extraButtons     = AuthenticationHelper::getLoginButtons('form-login');
 $app              = Factory::getApplication();
 $wa               = $this->getWebAssetManager();
 
@@ -129,6 +130,35 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
 						<label for="secretkey"><?php echo Text::_('JGLOBAL_SECRETKEY'); ?></label>
 						<input name="secretkey" autocomplete="one-time-code" class="form-control" id="secretkey" type="text">
 						<?php endif; ?>
+
+						<?php foreach($extraButtons as $button):
+							$dataAttributeKeys = array_filter(array_keys($button), function ($key) {
+								return substr($key, 0, 5) == 'data-';
+							});
+							?>
+							<div class="mod-login__submit form-group">
+								<button type="button"
+										class="btn btn-secondary w-100 mt-4 <?php echo $button['class'] ?? '' ?>"
+								<?php foreach ($dataAttributeKeys as $key): ?>
+									<?php echo $key ?>="<?php echo $button[$key] ?>"
+								<?php endforeach; ?>
+								<?php if ($button['onclick']): ?>
+									onclick="<?php echo $button['onclick'] ?>"
+								<?php endif; ?>
+								title="<?php echo Text::_($button['label']) ?>"
+								id="<?php echo $button['id'] ?>"
+								>
+								<?php if (!empty($button['icon'])): ?>
+									<span class="<?php echo $button['icon'] ?>"></span>
+								<?php elseif (!empty($button['image'])): ?>
+									<?php echo $button['image']; ?>
+								<?php elseif (!empty($button['svg'])): ?>
+									<?php echo $button['svg']; ?>
+								<?php endif; ?>
+								<?php echo Text::_($button['label']) ?>
+								</button>
+							</div>
+						<?php endforeach; ?>
 
 						<input type="submit" name="Submit" class="btn btn-primary" value="<?php echo Text::_('JLOGIN'); ?>">
 

--- a/templates/cassiopeia/scss/offline.scss
+++ b/templates/cassiopeia/scss/offline.scss
@@ -97,7 +97,7 @@ input {
   transform: translate(-50%, -50%);
 }
 
-svg {
+.logo-icon svg {
   display: block;
   width: 38px;
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/33779

### Summary of Changes

Joomla 4 has the concept of Extra Buttons for the login page. 

Joomla 4 also forgot to add this concept to the offline.php page for the default template. 


### Testing Instructions

1) Activate Webauthn (you need to be on https://)
2) Set the website into offline mode
3) Try to login with Webauthn on FRONTEND

### Actual result BEFORE applying this Pull Request

No extra buttons

### Expected result AFTER applying this Pull Request

Extra buttons that work

<img width="561" alt="Screenshot 2021-05-11 at 19 35 28" src="https://user-images.githubusercontent.com/400092/117867283-14dd1500-b290-11eb-9ac1-e5b2c085cbeb.png">

Errors in the process also render correctly

<img width="502" alt="Screenshot 2021-05-11 at 19 39 56" src="https://user-images.githubusercontent.com/400092/117867766-b8c6c080-b290-11eb-844f-b8f944f19756.png">


### Documentation Changes Required

None.