### PR TITLE
[4.0] atum Logo responsive

### DIFF
--- a/build/media_source/mod_menu/js/admin-menu.es6.js
+++ b/build/media_source/mod_menu/js/admin-menu.es6.js
@@ -66,6 +66,7 @@
     // Sidebar
     const menuToggle = document.getElementById('menu-collapse');
     const firsts = [].slice.call(sidebar.querySelectorAll('.collapse-level-1'));
+    const logo = document.getElementsByClassName('logo')[0];
 
     // Apply 2nd level collapse
     firsts.forEach((first) => {
@@ -88,6 +89,7 @@
       wrapper.classList.toggle('closed');
       menuToggleIcon.classList.toggle('icon-toggle-on');
       menuToggleIcon.classList.toggle('icon-toggle-off');
+      logo.classList.toggle('small');
 
       const listItems = [].slice.call(document.querySelectorAll('.main-nav > li'));
       listItems.forEach((item) => {


### PR DESCRIPTION
Pull Request for Issue #33660  .

### Summary of Changes
earlier, logo used to change immediately as sidemenu was toggled. It worked earlier, but changes in logo only showed up afetr refreshing the page. Now this is resolved.

### Testing Instructions
Apply the patch
build js  by running this command <code>npm run build:js</code>
observe the logo behavior on toggling sidemenu.

### Actual result BEFORE applying this Pull Request
![old](https://user-images.githubusercontent.com/65963997/117873320-44eedd00-b2bd-11eb-801f-41733b24bcee.gif)

### Expected result AFTER applying this Pull Request
![new](https://user-images.githubusercontent.com/65963997/117873345-4c15eb00-b2bd-11eb-870e-66567b846c05.gif)

### Documentation Changes Required

