### PR TITLE
[4] remove nested folder which is not needed

### DIFF
--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -18,7 +18,6 @@
 		<filename>template_thumbnail.png</filename>
 		<folder>css</folder>
 		<folder>html</folder>
-		<folder>html/tinymce</folder>
 		<folder>images</folder>
 		<folder>js</folder>
 		<folder>scss</folder>


### PR DESCRIPTION
revert part of #33130 to fix #33783

### Summary of Changes

remove subfolder from folder list, not needed as the folders are recursive anyway

### Testing Instructions

see  #33783

### Actual result BEFORE applying this Pull Request

can't copy template, tells you the folder/file already exists

### Expected result AFTER applying this Pull Request

can copy template

### Documentation Changes Required

//@chmst @brianteeman @richard67 @ChristineWk