### PR TITLE
[4.0] com_cpanel submenu

### DIFF
--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -51,7 +51,8 @@ use Joomla\CMS\Router\Route;
 						<?php // Only if Menu-show = true ?>
 						<?php if ($params->get('menu_show', 1)) : ?>
 							<li class="list-group-item d-flex align-items-center">
-								<a href="<?php echo $item->link; ?>"
+								<?php $class = $params->get('menu-quicktask') ? '' : 'class="flex-grow-1"'; ?>
+								<a <?php echo $class; ?> href="<?php echo $item->link; ?>"
 									<?php echo $item->target === '_blank' ? ' title="' . Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_($item->title)) . '"' : ''; ?>
 									<?php echo $item->target ? ' target="' . $item->target . '"' : ''; ?>>
 									<?php if (!empty($params->get('menu_image'))) : ?>

--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -51,7 +51,7 @@ use Joomla\CMS\Router\Route;
 						<?php // Only if Menu-show = true ?>
 						<?php if ($params->get('menu_show', 1)) : ?>
 							<li class="list-group-item d-flex align-items-center">
-								<a class="flex-grow-1" href="<?php echo $item->link; ?>"
+								<a href="<?php echo $item->link; ?>"
 									<?php echo $item->target === '_blank' ? ' title="' . Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_($item->title)) . '"' : ''; ?>
 									<?php echo $item->target ? ' target="' . $item->target . '"' : ''; ?>>
 									<?php if (!empty($params->get('menu_image'))) : ?>
@@ -88,7 +88,7 @@ use Joomla\CMS\Router\Route;
 											$sronly = Text::_($item->title) . ' - ' . $title;
 											?>
 											<a href="<?php echo $link; ?>">
-												<span class="icon-<?php echo $icon; ?> icon-xs" title="<?php echo htmlentities($title); ?>" aria-hidden="true"></span>
+												<span class="icon-<?php echo $icon; ?>" title="<?php echo htmlentities($title); ?>" aria-hidden="true"></span>
 												<span class="visually-hidden"><?php echo htmlentities($sronly); ?></span>
 											</a>
 										</span>

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -164,7 +164,6 @@
 .cpanel-modules {
   .list-group {
     border-top: 1px solid $list-group-border-color;
-
   }
 
   .list-group-item {

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -165,14 +165,16 @@
   .list-group {
     border-top: 1px solid $list-group-border-color;
 
-    &:not(.sample-data) {
-      font-size: .95rem;
-    }
   }
 
   .list-group-item {
     &:hover {
       background: var(--toolbar-bg);
+    }
+
+    a {
+      font-weight: 500;
+      text-decoration: underline;
     }
 
     .list-group-item a > span {


### PR DESCRIPTION
This PR corrects multiple issues with the menu links displayed in a card on a cpanel to make the styling match the other modules on the cpanel

1. Makes font the same size
2. Makes the font weight the same
3. Makes the link underlined
4. Makes the clickable area of the link just the text not the entire row
5. Slightly increase the size of the + button

Dont forget to rebuild the css

Thanks to @kostelano and @himanshu007

## before
![image](https://user-images.githubusercontent.com/1296369/117879997-807aae80-b29f-11eb-9c9f-8ef8b6a4a7d9.png)

## after
![image](https://user-images.githubusercontent.com/1296369/117879807-48736b80-b29f-11eb-8cb1-357e92541138.png)
