### PR TITLE
[4.0] Show Multilingual Associations menu for multilingual sites only

### DIFF
--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -13,6 +13,7 @@ namespace Joomla\Module\Menu\Administrator\Menu;
 
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\AdministratorMenuItem;
 use Joomla\CMS\Table\Table;
@@ -311,6 +312,17 @@ class CssMenu
 
 			// Exclude item if is not enabled
 			if ($item->element && !ComponentHelper::isEnabled($item->element))
+			{
+				$parent->removeChild($item);
+				continue;
+			}
+
+			/*
+			 * Multilingual Associations if the site is not set as multilingual and/or Associations is not enabled in
+			 * the Language Filter plugin
+			 */
+
+			if (!Associations::isEnabled() && $item->element === 'com_associations')
 			{
 				$parent->removeChild($item);
 				continue;


### PR DESCRIPTION
Pull Request for Issue #33784.

### Summary of Changes
The Multilingual Associations can only be used for multilingual website with Associations enabled in System - Language Filter plugin. This PRs modify code to only show **Multilingual Associations** menu item from Components menu backend if the conditions meet.

### Testing Instructions
1.  Install Joomla 4.0-dev
2. Access to Administrator area of your site, then access to Components menu item on the left sidebar
3. Before patch, you see Multilingual Associations menu item
4. Apply Patch:
- You see the menu item not being displayed
- Go to System -> Plugins, enable **System - Language Filter** and make sure **Item Associations** parameter set tot Yes. Then check it again, the menu item **Multilingual Associations** displayed.


### Actual result BEFORE applying this Pull Request
Multilingual Associations  menu item always displayed.

### Expected result AFTER applying this Pull Request
Multilingual Associations  menu item always displayed if conditions meet

