### PR TITLE
[4.0] Handle session ID being a stream to fix session manager problem on logout with PostgreSQL database

### DIFF
--- a/libraries/src/Session/SessionManager.php
+++ b/libraries/src/Session/SessionManager.php
@@ -66,6 +66,11 @@ final class SessionManager
 
 		foreach ($sessionIds as $sessionId)
 		{
+			if (is_resource($sessionId) && get_resource_type($sessionId) === 'stream')
+			{
+				$sessionId = stream_get_contents($sessionId);
+			}
+
 			if (!$this->destroySession($sessionId))
 			{
 				$result = false;


### PR DESCRIPTION
Pull Request for Issue #33740 .

Alternative to #33787 and #33817 .

### Summary of Changes

When reading the session id from the session table on a PostgreSQL database using loadColumn(), the result is an array of resources and not of strings.

This PR here adds a check in the destroySessions routine of the session manager if the session ID is of type `resource` and the resource type is a stream, and if that is the case, reads the stream and use the result string for the destroySession call.

### Testing Instructions

See issue #33740 .

### Actual result BEFORE applying this Pull Request

See issue #33740 .

### Expected result AFTER applying this Pull Request

No errors. Session destroyed correctly. Now back at the login screen.

### Documentation Changes Required

None.