### PR TITLE
Fix of vertical line not having height

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -301,5 +301,6 @@ joomla-tab {
 
   .main-card-columns > * > & {
     border-left: 1px solid var(--atum-bg-dark-10);
+    height: 100%;
   }
 }

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -300,7 +300,7 @@ joomla-tab {
   }
 
   .main-card-columns > * > & {
-    border-left: 1px solid var(--atum-bg-dark-10);
     height: 100%;
+    border-left: 1px solid var(--atum-bg-dark-10);
   }
 }


### PR DESCRIPTION
Pull Request for Issue #33809.

### Summary of Changes

Vertical line that separates sidebar from content is extended to bottom (see screenshots and issue)

### Testing Instructions

Go to Global Configuration > any component

### Actual result BEFORE applying this Pull Request
The vertical line lack of height
![image](https://user-images.githubusercontent.com/42320170/117974998-e1a19100-b336-11eb-8486-b6a460bd6790.png)

### Expected result AFTER applying this Pull Request
Everything is fine with height
![after](https://user-images.githubusercontent.com/42320170/117975682-976cdf80-b337-11eb-8870-9b1c422950c8.png)