### PR TITLE
fix: Convert session ids returned from PostgreSQL

### DIFF
--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -107,7 +107,7 @@ class PlgUserJoomla extends CMSPlugin
 			return;
 		}
 
-		$userid = (int) $user['id'];
+		$userId = (int) $user['id'];
 
 		// Only execute this if the session metadata is tracked
 		if ($this->app->get('session_metadata', true))
@@ -115,19 +115,19 @@ class PlgUserJoomla extends CMSPlugin
 			// Fetch all session IDs for the user account so they can be destroyed
 			try
 			{
-				$sessionIds = $this->getSessionIds($userid);
+				$sessionIds = $this->getSessionIds($userId);
+
+				/** @var SessionManager $sessionManager */
+				$sessionManager = Factory::getContainer()->get('session.manager');
+
+				if (!$sessionManager->destroySessions($sessionIds))
+				{
+					return;
+				}
 			}
 			catch (ExecutionFailureException $e)
 			{
 				// Continue.
-			}
-
-			/** @var SessionManager $sessionManager */
-			$sessionManager = Factory::getContainer()->get('session.manager');
-
-			if (!$sessionManager->destroySessions($sessionIds))
-			{
-				return;
 			}
 		}
 
@@ -136,8 +136,8 @@ class PlgUserJoomla extends CMSPlugin
 			$this->db->setQuery(
 				$this->db->getQuery(true)
 					->delete($this->db->quoteName('#__messages'))
-					->where($this->db->quoteName('user_id_from') . ' = :userid')
-					->bind(':userid', $userid, ParameterType::INTEGER)
+					->where($this->db->quoteName('user_id_from') . ' = :userId')
+					->bind(':userId', $userId, ParameterType::INTEGER)
 			)->execute();
 		}
 		catch (ExecutionFailureException $e)

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -396,7 +396,7 @@ class PlgUserJoomla extends CMSPlugin
 		{
 			try
 			{
-				$clientId = $sharedSessions ? null : (int)$options['clientid'];
+				$clientId = $sharedSessions ? null : (int) $options['clientid'];
 				$sessionIds = $this->getSessionIds($userid, $clientId);
 			}
 			catch (ExecutionFailureException $e)
@@ -490,20 +490,24 @@ class PlgUserJoomla extends CMSPlugin
 	 */
 	private function getSessionIds(int $userId, $clientId = null): array
 	{
-		$query = $this->db->getQuery(true)->select($this->db->quoteName('session_id'))->from(
-				$this->db->quoteName('#__session')
-			)->where($this->db->quoteName('userid') . ' = :userid')->bind(':userid', $userId, ParameterType::INTEGER)
-		;
+		$query = $this->db->getQuery(true)
+			->select($this->db->quoteName('session_id'))
+			->from($this->db->quoteName('#__session'))
+			->where($this->db->quoteName('userid') . ' = :userid')
+			->bind(':userid', $userId, ParameterType::INTEGER);
 
-		if ($clientId !== null) {
+		if ($clientId !== null)
+		{
 			$query->where($this->db->quoteName('client_id') . ' = :clientId')
-				  ->bind(':clientId', $clientId, ParameterType::INTEGER);
+				->bind(':clientId', $clientId, ParameterType::INTEGER);
 		}
 
 		$sessionIds = $this->db->setQuery($query)->loadColumn();
 
-		foreach ($sessionIds as &$sessionId) {
-			if (is_resource($sessionId) && get_resource_type($sessionId) === 'stream') {
+		foreach ($sessionIds as &$sessionId)
+		{
+			if (is_resource($sessionId) && get_resource_type($sessionId) === 'stream')
+			{
 				$sessionId = stream_get_contents($sessionId);
 			}
 		}

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -115,13 +115,7 @@ class PlgUserJoomla extends CMSPlugin
 			// Fetch all session IDs for the user account so they can be destroyed
 			try
 			{
-				$sessionIds = $this->db->setQuery(
-					$this->db->getQuery(true)
-						->select($this->db->quoteName('session_id'))
-						->from($this->db->quoteName('#__session'))
-						->where($this->db->quoteName('userid') . ' = :userid')
-						->bind(':userid', $userid, ParameterType::INTEGER)
-				)->loadColumn();
+				$sessionIds = $this->getSessionIds($userid);
 			}
 			catch (ExecutionFailureException $e)
 			{
@@ -400,24 +394,10 @@ class PlgUserJoomla extends CMSPlugin
 
 		if ($forceLogout)
 		{
-			// Fetch all session IDs for the user account so they can be destroyed
-			$query = $this->db->getQuery(true)
-				->select($this->db->quoteName('session_id'))
-				->from($this->db->quoteName('#__session'))
-				->where($this->db->quoteName('userid') . ' = :userid')
-				->bind(':userid', $userid, ParameterType::INTEGER);
-
-			if (!$sharedSessions)
-			{
-				$clientId = (int) $options['clientid'];
-
-				$query->where($this->db->quoteName('client_id') . ' = :clientId')
-					->bind(':clientId', $clientId, ParameterType::INTEGER);
-			}
-
 			try
 			{
-				$sessionIds = $this->db->setQuery($query)->loadColumn();
+				$clientId = $sharedSessions ? null : (int)$options['clientid'];
+				$sessionIds = $this->getSessionIds($userid, $clientId);
 			}
 			catch (ExecutionFailureException $e)
 			{
@@ -498,5 +478,36 @@ class PlgUserJoomla extends CMSPlugin
 		}
 
 		return $instance;
+	}
+
+	/**
+	 * Fetch all session IDs for the user account
+	 *
+	 * @param  int   $userId The User id
+	 * @param  int|null  $clientId The client id
+	 *
+	 * @return array
+	 */
+	private function getSessionIds(int $userId, $clientId = null): array
+	{
+		$query = $this->db->getQuery(true)->select($this->db->quoteName('session_id'))->from(
+				$this->db->quoteName('#__session')
+			)->where($this->db->quoteName('userid') . ' = :userid')->bind(':userid', $userid, ParameterType::INTEGER)
+		;
+
+		if ($clientId !== null) {
+			$query->where($this->db->quoteName('client_id') . ' = :clientId')
+				  ->bind(':clientId', $clientId, ParameterType::INTEGER);
+		}
+
+		$sessionIds = $this->db->setQuery($query)->loadColumn();
+
+		foreach ($sessionIds as &$sessionId) {
+			if (is_resource($sessionId) && get_resource_type($sessionId) === 'stream') {
+				$sessionId = stream_get_contents($sessionId);
+			}
+		}
+
+		return $sessionIds;
 	}
 }

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -492,7 +492,7 @@ class PlgUserJoomla extends CMSPlugin
 	{
 		$query = $this->db->getQuery(true)->select($this->db->quoteName('session_id'))->from(
 				$this->db->quoteName('#__session')
-			)->where($this->db->quoteName('userid') . ' = :userid')->bind(':userid', $userid, ParameterType::INTEGER)
+			)->where($this->db->quoteName('userid') . ' = :userid')->bind(':userid', $userId, ParameterType::INTEGER)
 		;
 
 		if ($clientId !== null) {


### PR DESCRIPTION
Pull Request for Issue #33740 . alternative to #33787, #33817, #33819

When reading the session id from the session table on a PostgreSQL database, the result is an array of streams and not of strings.

### Summary of Changes

If the session ids returned from the database are streams, they are converted into strings.
Additionally, duplicated code was reduced.

### Testing Instructions

see #33740

### Actual result BEFORE applying this Pull Request

see #33740

### Expected result AFTER applying this Pull Request

Successfull logout. Session destroyed correctly.

### Documentation Changes Required

None.