### PR TITLE
Difference in height of visibility button and password input #33823

### DIFF
--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -52,7 +52,7 @@ Text::script('JHIDEPASSWORD');
 				<div class="input-group">
 					<input id="modlgn-passwd-<?php echo $module->id; ?>" type="password" name="password" autocomplete="current-password" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>">
 					<label for="modlgn-passwd-<?php echo $module->id; ?>" class="visually-hidden"><?php echo Text::_('JGLOBAL_PASSWORD'); ?></label>
-					<button type="button" class="btn btn-secondary input-password-toggle">
+					<button type="button" class="btn btn-secondary mb-0 input-password-toggle">
 						<span class="icon-eye icon-fw" aria-hidden="true"></span>
 						<span class="visually-hidden"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
 					</button>


### PR DESCRIPTION
Pull Request for Issue #33823 

### Summary of Changes

Difference in the height of input and visibility button
Solved by adding a bootstrap bottom margin to 0.


### Testing Instructions

Go to the main joomla web page and view it on mobile view.

`<button type="button" class="btn btn-primary js-pstats-btn-allow-always m-1"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_SEND_ALWAYS'); ?></button> <button type="button" class="btn btn-primary js-pstats-btn-allow-once m-1"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_SEND_NOW'); ?></button> <button type="button" class="btn btn-primary js-pstats-btn-allow-never m-1" style="margin:0px"><?php echo Text::_('PLG_SYSTEM_STATS_BTN_NEVER_SEND'); ?></button>`

### Actual result BEFORE applying this Pull Request

![10 05 2021_20 55 28_REC](https://user-images.githubusercontent.com/63739986/118001860-bd5ca900-b364-11eb-8445-9e68e34553d8.png)


### Expected result AFTER applying this Pull Request

![11 05 2021_21 10 38_REC](https://user-images.githubusercontent.com/63739986/118001802-b170e700-b364-11eb-9c96-ca7610d1a2b3.png)


### Documentation Changes Required

No changes in the documentation.