### PR TITLE
[4.0] Click to check the checkbox in Languages - Overrides

### DIFF
--- a/administrator/components/com_languages/tmpl/overrides/default.php
+++ b/administrator/components/com_languages/tmpl/overrides/default.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+HTMLHelper::_('behavior.multiselect');
+
 $client    = $this->state->get('filter.client') == 'site' ? Text::_('JSITE') : Text::_('JADMINISTRATOR');
 $language  = $this->state->get('filter.language');
 $listOrder = $this->escape($this->state->get('list.ordering'));


### PR DESCRIPTION
Pull Request for Issue #33826.

### Summary of Changes
Add `HTMLHelper::_('behavior.multiselect');`

### Testing Instructions
System >  Languages Overrides under Manage > Create some Language Overrides 

### Actual result BEFORE applying this Pull Request
Click on table row doesn't check the checkbox

![com_language_before](https://user-images.githubusercontent.com/61203226/118019867-17ff0080-b377-11eb-88b4-9db74a5e2ca0.gif)

### Expected result AFTER applying this Pull Request
Click on table row checks the checkbox

![com_language_after](https://user-images.githubusercontent.com/61203226/118019888-1d5c4b00-b377-11eb-82b6-03c1fe6e8cfb.gif)

### Documentation Changes Required
No
