### PR TITLE
[4.0] Remove duplicate scss lines for form stylings

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -75,38 +75,6 @@ legend {
   margin-bottom: 1.1rem;
 }
 
-.checkboxes {
-  padding-top: 5px;
-
-  .checkbox input {
-    position: static;
-    margin-left: 0;
-  }
-}
-
-.form-check {
-  padding-top: 5px;
-  margin-bottom: 0;
-}
-
-.modal label {
-  width: 100%;
-}
-
-// Validation
-.invalid {
-  color: var(--danger);
-  border-color: var(--danger);
-}
-
-.valid {
-  border-color: var(--success);
-}
-
-.form-control-feedback {
-  display: block;
-}
-
 [aria-grabbed="true"] {
   box-shadow: $input-box-shadow;
 }


### PR DESCRIPTION
Pull Request for Issue #33829 .

### Intro
Hello, I'm one of the applicants for GSoC 2021 for the **Media Manager** project and I'm glad to start contributing to Joomla by creating a pull request for this small issue.

### Summary of Changes
Removed stylings from line 78-108 in /administrator/templates/atum/scss/blocks/_form.scss

### Testing Instructions
Go to any page that contains a form (for example Administrator > Articles > New > Images and Links) and everything will work normally.


### Actual result BEFORE applying this Pull Request
Duplicate scss code in /administrator/templates/atum/scss/vendor/bootstrap/_form.scss (from line 18-48) and in /administrator/templates/atum/scss/blocks/_form.scss (from line 78-108)


### Expected result AFTER applying this Pull Request
No duplicate stylings


### Documentation Changes Required

