### PR TITLE
[4.0] Remove obsolete table "#__csp" from support.sql so it's not created on new installations

### DIFF
--- a/installation/sql/mysql/supports.sql
+++ b/installation/sql/mysql/supports.sql
@@ -131,24 +131,6 @@ CREATE TABLE IF NOT EXISTS `#__contentitem_tag_map` (
 -- --------------------------------------------------------
 
 --
--- Table structure for table `#__csp`
---
-
-CREATE TABLE IF NOT EXISTS `#__csp` (
-  `id` int NOT NULL AUTO_INCREMENT,
-  `document_uri` varchar(500) NOT NULL DEFAULT '',
-  `blocked_uri` varchar(500) NOT NULL DEFAULT '',
-  `directive` varchar(500) NOT NULL DEFAULT '',
-  `client` varchar(500) NOT NULL DEFAULT '',
-  `created` datetime NOT NULL,
-  `modified` datetime NOT NULL,
-  `published` tinyint NOT NULL DEFAULT 0,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
-
--- --------------------------------------------------------
-
---
 -- Table structure for table `#__fields`
 --
 

--- a/installation/sql/postgresql/supports.sql
+++ b/installation/sql/postgresql/supports.sql
@@ -138,24 +138,6 @@ COMMENT ON COLUMN "#__contentitem_tag_map"."tag_id" IS 'PK from the tag table';
 COMMENT ON COLUMN "#__contentitem_tag_map"."tag_date" IS 'Date of most recent save for this tag-item';
 COMMENT ON COLUMN "#__contentitem_tag_map"."type_id" IS 'PK from the content_type table';
 
--- --------------------------------------------------------
-
---
--- Table structure for table `#__csp`
---
-
-CREATE TABLE IF NOT EXISTS "#__csp" (
-  "id" serial NOT NULL,
-  "document_uri" varchar(500) NOT NULL DEFAULT '',
-  "blocked_uri" varchar(500) NOT NULL DEFAULT '',
-  "directive" varchar(500) NOT NULL DEFAULT '',
-  "client" varchar(500) NOT NULL DEFAULT '',
-  "created" timestamp without time zone NOT NULL,
-  "modified"  timestamp without time zone NOT NULL,
-  "published" smallint DEFAULT 0 NOT NULL,
-  PRIMARY KEY ("id")
-);
-
 --
 -- Table structure for table `#__fields`
 --


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/33550#issuecomment-840468191 .

### Summary of Changes

See the title and the referred comment.

### Testing Instructions

1. Code review.
2. Check that all system tests have passed in drone, which means there were no SQL errors on installation with MySQL and PostgreSQL databases.

Or alternatively, make a new installation and check if table `#__csp` exists in database.

### Actual result BEFORE applying this Pull Request

Table `#__csp` exists in database after a new installation.

### Expected result AFTER applying this Pull Request

Table `#__csp` doesn't exist in database after a new installation.

### Additional information

For updates from 3.10 or from previous 4.0 Beta versions, everything is ok already, see #33820 .

### Documentation Changes Required

No.