### PR TITLE
[4.0] Change tooltip style in articles

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -257,8 +257,9 @@ $assoc = Associations::isEnabled();
 											<?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
 										<?php endif; ?>
 										<?php if ($canEdit || $canEditOwn) : ?>
-											<a href="<?php echo Route::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo $this->escape($item->title); ?>">
+											<a href="<?php echo Route::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" aria-labelledby="edit-<?php echo (int) $item->id; ?>">
 												<?php echo $this->escape($item->title); ?></a>
+											<div role="tooltip" id="edit-<?php echo (int) $item->id; ?>"><?php echo Text::_('JACTION_EDIT') . ' ' . $this->escape($item->title); ?></div>
 										<?php else : ?>
 											<span title="<?php echo Text::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
 										<?php endif; ?>
@@ -283,20 +284,16 @@ $assoc = Associations::isEnabled();
 												if (Factory::getLanguage()->isRtl())
 												{
 													if ($canEditCat || $canEditOwnCat) :
-														echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
-													endif;
-													echo $this->escape($item->category_title);
-													if ($canEditCat || $canEditOwnCat) :
-														echo '</a>';
+														echo '<a href="' . $CurrentCatUrl . '" aria-labelledby="edit-cat-' . (int) $item->id . '">';
+														echo $this->escape($item->category_title). '</a>';
+														echo '<div role="tooltip" id="edit-cat-' . (int) $item->id.'">' . $EditCatTxt . '</div>';
 													endif;
 													if ($item->category_level != '1') :
 														echo ' &#171; ';
 														if ($canEditParCat || $canEditOwnParCat) :
-															echo '<a href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
-														endif;
-														echo $this->escape($item->parent_category_title);
-														if ($canEditParCat || $canEditOwnParCat) :
-															echo '</a>';
+															echo '<a href="' . $ParentCatUrl . '" aria-labelledby="edit-cat-' . (int) $item->id . '">';
+															echo $this->escape($item->parent_category_title) . '</a>';
+															echo '<div role="tooltip" id="edit-cat-' . (int) $item->id.'">' . $EditCatTxt . '</div>';
 														endif;
 													endif;
 												}
@@ -304,20 +301,16 @@ $assoc = Associations::isEnabled();
 												{
 													if ($item->category_level != '1') :
 														if ($canEditParCat || $canEditOwnParCat) :
-															echo '<a href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
-														endif;
-														echo $this->escape($item->parent_category_title);
-														if ($canEditParCat || $canEditOwnParCat) :
-															echo '</a>';
+															echo '<a href="' . $ParentCatUrl . '" aria-labelledby="edit-cat-' . (int) $item->id . '">';
+															echo $this->escape($item->parent_category_title) . '</a>';
+															echo '<div role="tooltip" id="edit-cat-' . (int) $item->id.'">' . $EditCatTxt . '</div>';
 														endif;
 														echo ' &#187; ';
 													endif;
 													if ($canEditCat || $canEditOwnCat) :
-														echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
-													endif;
-													echo $this->escape($item->category_title);
-													if ($canEditCat || $canEditOwnCat) :
-														echo '</a>';
+														echo '<a href="' . $CurrentCatUrl . '" aria-labelledby="edit-cat-' . (int) $item->id . '">';
+														echo $this->escape($item->category_title) . '</a>';
+														echo '<div role="tooltip" id="edit-cat-' . (int) $item->id . '">' . $EditCatTxt . '</div>';
 													endif;
 												}
 												?>


### PR DESCRIPTION
### Summary of Changes
Change `title` to `tooltip`,
Add `aria-labelledby` in `a`

### Testing Instructions
Go to the articles page 

Please test with both RTL and LTR

### Actual result BEFORE applying this Pull Request

![articles-before](https://user-images.githubusercontent.com/61203226/118125385-847c0d00-b414-11eb-87ca-a9851a5b5a11.gif)

### Expected result AFTER applying this Pull Request

![articles-after](https://user-images.githubusercontent.com/61203226/118125412-8c3bb180-b414-11eb-8df7-00c293746472.gif)

### Documentation Changes Required
No

