### PR TITLE
[4.0] tooltip styling

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -18,7 +18,6 @@
   box-shadow: none;
 }
 
-
 .control-group {
   display: flex;
   flex-wrap: wrap;
@@ -125,7 +124,7 @@ legend {
   color: $white;
   text-align: start;
   background: $black;
-  border-radius: .2rem;
+  border-radius: .2rem !important;
 }
 
 // reveal associated tooltip on focus


### PR DESCRIPTION
The black tooltips are supposed to have rounded corners. However the search tooltips do not. This PR resolves that. There may be a better way than using !important but I couldn't find it.

Dont forget to rebuild the css

### Before
![image](https://user-images.githubusercontent.com/1296369/118166297-34ee0f00-b41d-11eb-931b-9903c79c7159.png)

### After
![image](https://user-images.githubusercontent.com/1296369/118166387-5222dd80-b41d-11eb-900b-4b9afe35e1a5.png)
