### PR TITLE
[4.0] Rename Check and Install button

### DIFF
--- a/administrator/language/en-GB/plg_installer_folderinstaller.ini
+++ b/administrator/language/en-GB/plg_installer_folderinstaller.ini
@@ -4,6 +4,6 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_INSTALLER_FOLDERINSTALLER_TEXT="Install from Folder"
-PLG_INSTALLER_FOLDERINSTALLER_BUTTON="Check and Install"
+PLG_INSTALLER_FOLDERINSTALLER_BUTTON="Check & Install"
 PLG_INSTALLER_FOLDERINSTALLER_NO_INSTALL_PATH="Please enter a Folder."
 PLG_INSTALLER_FOLDERINSTALLER_PLUGIN_XML_DESCRIPTION="This plugin allows you to install extensions from a folder on the web server."

--- a/administrator/language/en-GB/plg_installer_urlinstaller.ini
+++ b/administrator/language/en-GB/plg_installer_urlinstaller.ini
@@ -3,6 +3,6 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_INSTALLER_URLINSTALLER_BUTTON="Check and Install"
+PLG_INSTALLER_URLINSTALLER_BUTTON="Check & Install"
 PLG_INSTALLER_URLINSTALLER_PLUGIN_XML_DESCRIPTION="This plugin allows you to install extensions from a URL."
 PLG_INSTALLER_URLINSTALLER_TEXT="Install from URL"


### PR DESCRIPTION
### Summary of Changes
For consistency, the usage of `and` with `&` in `Upload & Install` and `Save & Close`, rename `Check and Install` to `Check & Install`.


### Testing Instructions
System > Install > Extensions
Click Install from Folder tab.
See `Check and Install` button.
Click Install from URL tab.
See `Check and Install` button.

System > Update >Joomla
Click Upload & Update tab.
See `Upload & Install` button.

Apply PR.

### Actual result BEFORE applying this Pull Request
> Check and Install


### Expected result AFTER applying this Pull Request
> Check & Install

