### PR TITLE
[4.0] Fix Module Positions Filter

### DIFF
--- a/administrator/components/com_modules/src/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Modules/HtmlView.php
@@ -97,6 +97,35 @@ class HtmlView extends BaseHtmlView
 			$this->setLayout('emptystate');
 		}
 
+		/**
+		 * The code below make sure the remembered position will be available from filter dropdown even if there are no
+		 * modules available for this position. This will make the UI less confusing for users in case there is only one
+		 * module in the selected position and user:
+		 * 1. Edit the module, change it to new position, save it and come back to Modules Management Screen
+		 * 2. Or move that module to new position using Batch action
+		 */
+		if (count($this->items) === 0 && $this->state->get('filter.position'))
+		{
+			$selectedPosition = $this->state->get('filter.position');
+			$positionField    = $this->filterForm->getField('position', 'filter');
+
+			$positionExists = false;
+
+			foreach ($positionField->getOptions() as $option)
+			{
+				if ($option->value === $selectedPosition)
+				{
+					$positionExists = true;
+					break;
+				}
+			}
+
+			if ($positionExists === false)
+			{
+				$positionField->addOption($selectedPosition, ['value' => $selectedPosition]);
+			}
+		}
+
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))
 		{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
See https://github.com/joomla/joomla-cms/pull/33763#issuecomment-838333863 to understand the issue which this PR tries to solve. Basically, on Modules management screen, if you filter module by certain position which **only has one module** and you:

- Move that module to new position using batch action
- Or edit the module, change it to a new position

After doing the action, you will be redirected back to Modules management screen with no modules displayed and also, no position selected in the filter. You would think that it is confusing because you do not have anything in the filter, why there are no modules at all?

This PR just tries to fix that special case by make sure the selected/remember position will be available and selected in the dropdown so that you know the reason why there is no modules being displayed.

### Testing Instructions
1. Access to Modules Management from backend
2. Try to select a position which only has one module (for example), banner position
3. Edit the module, change the position to a different position, save it
4. You will now being redirected to Modules Management screen
5. Before patch, you will see a screen like below (note that there is no position selected in the position filter)
6. After patch, the previous selected position will selected in the filter (so that you know why there is no modules - it is because you are filtering modules by that position)

### Actual result BEFORE applying this Pull Request

![no-modules_no_filter](https://user-images.githubusercontent.com/977664/118219873-90afab00-b4a4-11eb-8179-b6e000cf25ff.png)


### Expected result AFTER applying this Pull Request

![no_modules_filter_displayed](https://user-images.githubusercontent.com/977664/118219644-1b43da80-b4a4-11eb-991f-adbc97e708a6.png)


### Additional Comments
I'm unsure if it is really needed. But since it is reported and I see that the UI is confusing for this case, so I make a PR to address it anyway. I have no problem if this PR is rejected :)

