### PR TITLE
[4.0] Revert #33839 - accessibility break [a11y]

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -257,9 +257,8 @@ $assoc = Associations::isEnabled();
 											<?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
 										<?php endif; ?>
 										<?php if ($canEdit || $canEditOwn) : ?>
-											<a href="<?php echo Route::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" aria-labelledby="edit-<?php echo (int) $item->id; ?>">
+											<a href="<?php echo Route::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo $this->escape($item->title); ?>">
 												<?php echo $this->escape($item->title); ?></a>
-											<div role="tooltip" id="edit-<?php echo (int) $item->id; ?>"><?php echo Text::_('JACTION_EDIT') . ' ' . $this->escape($item->title); ?></div>
 										<?php else : ?>
 											<span title="<?php echo Text::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
 										<?php endif; ?>
@@ -284,16 +283,20 @@ $assoc = Associations::isEnabled();
 												if (Factory::getLanguage()->isRtl())
 												{
 													if ($canEditCat || $canEditOwnCat) :
-														echo '<a href="' . $CurrentCatUrl . '" aria-labelledby="edit-cat-' . (int) $item->id . '">';
-														echo $this->escape($item->category_title). '</a>';
-														echo '<div role="tooltip" id="edit-cat-' . (int) $item->id.'">' . $EditCatTxt . '</div>';
+														echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+													endif;
+													echo $this->escape($item->category_title);
+													if ($canEditCat || $canEditOwnCat) :
+														echo '</a>';
 													endif;
 													if ($item->category_level != '1') :
 														echo ' &#171; ';
 														if ($canEditParCat || $canEditOwnParCat) :
-															echo '<a href="' . $ParentCatUrl . '" aria-labelledby="edit-cat-' . (int) $item->id . '">';
-															echo $this->escape($item->parent_category_title) . '</a>';
-															echo '<div role="tooltip" id="edit-cat-' . (int) $item->id.'">' . $EditCatTxt . '</div>';
+															echo '<a href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
+														endif;
+														echo $this->escape($item->parent_category_title);
+														if ($canEditParCat || $canEditOwnParCat) :
+															echo '</a>';
 														endif;
 													endif;
 												}
@@ -301,16 +304,20 @@ $assoc = Associations::isEnabled();
 												{
 													if ($item->category_level != '1') :
 														if ($canEditParCat || $canEditOwnParCat) :
-															echo '<a href="' . $ParentCatUrl . '" aria-labelledby="edit-cat-' . (int) $item->id . '">';
-															echo $this->escape($item->parent_category_title) . '</a>';
-															echo '<div role="tooltip" id="edit-cat-' . (int) $item->id.'">' . $EditCatTxt . '</div>';
+															echo '<a href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
+														endif;
+														echo $this->escape($item->parent_category_title);
+														if ($canEditParCat || $canEditOwnParCat) :
+															echo '</a>';
 														endif;
 														echo ' &#187; ';
 													endif;
 													if ($canEditCat || $canEditOwnCat) :
-														echo '<a href="' . $CurrentCatUrl . '" aria-labelledby="edit-cat-' . (int) $item->id . '">';
-														echo $this->escape($item->category_title) . '</a>';
-														echo '<div role="tooltip" id="edit-cat-' . (int) $item->id . '">' . $EditCatTxt . '</div>';
+														echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+													endif;
+													echo $this->escape($item->category_title);
+													if ($canEditCat || $canEditOwnCat) :
+														echo '</a>';
 													endif;
 												}
 												?>


### PR DESCRIPTION
It is absolutely not necessary to change titles to tooltips. It is a pointless exercise with zero benefits that would need to be done in a gazillion places.

The only time we should be using the black tooltips is as a replacement for the bootstrap tooltips. They are NOT a replacement for titles.

In this specific case the category links now all have the exact same name "edit category" which is obviously an accessibility fail