### PR TITLE
[3.10] Fix folder deletion in script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2295,8 +2295,7 @@ class JoomlaInstallerScript
 			'/libraries/joomla/filesystem/wrapper',
 			'/libraries/joomla/filesystem',
 			// Joomla 3.10.0
-			'/libraries/joomla/base/adapter.php',
-			'/libraries/joomla/base/adapterinstance.php',
+			'/libraries/joomla/base',
 		);
 
 		jimport('joomla.filesystem.file');


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/28181#issuecomment-841204314 .

### Summary of Changes

Fix the removal of folder `libraries/joomla/base` on update.

With commit https://github.com/joomla/joomla-cms/commit/32006674e8af1feda8b10025e0db8826c7ace86d , the 2 files have been added to the folders list and not the folder.

### Testing Instructions

Code review:

1. On current 3.10-dev, verify that the two files are in the list of files to be deleted here:
https://github.com/joomla/joomla-cms/blob/3.10-dev/administrator/components/com_admin/script.php#L2055-L2056

2. On current 3.10-dev, verify that they appear again in the list of folders to be deleted here:
https://github.com/joomla/joomla-cms/blob/3.10-dev/administrator/components/com_admin/script.php#L2298-L2299

3. On current staging, verify that these 2 files are the only files in their parent folder, see here:
https://github.com/joomla/joomla-cms/tree/staging/libraries/joomla/base
So if the files are removed on update, the folder can be removed, too.

4. Verify here that the change of this PR fixes point 2, so the folder is in the list of folders and not the files.

### Actual result BEFORE applying this Pull Request

Wrong files `/libraries/joomla/base/adapter.php` and `/libraries/joomla/base/adapterinstance.php` in the list of folders to be deleted in script.php.

### Expected result AFTER applying this Pull Request

Right folder `/libraries/joomla/base` in the list of folders to be deleted in script.php.

### Documentation Changes Required

None.