### PR TITLE
[4] Fix redis socket connections

### DIFF
--- a/libraries/src/Session/SessionFactory.php
+++ b/libraries/src/Session/SessionFactory.php
@@ -106,7 +106,7 @@ class SessionFactory implements ContainerAwareInterface
 				$host  = $config->get('session_redis_server_host', '127.0.0.1');
 
 				// Use default port if connecting over a socket whatever the config value
-				$port = $host[0] === '/' ? $config->get('session_redis_server_port', 6379) : 6379;
+				$port = $host[0] === '/' ? 0 : $config->get('session_redis_server_port', 6379);
 
 				if ($config->get('session_redis_persist', true))
 				{


### PR DESCRIPTION
Closes #26269

### Summary of Changes

Fix blatantly wrong code.

If connecting to redis using a sock Eg: `/var/run/redis/redis.sock` then Joomla should be transparently setting the port to `0` before connecting to redis.

`$host[0] === '/'` is checking if the first char in the string `/var/run/redis/redis.sock` is a `/` and if so should be setting the port to `0` - someone got the `?:` wrong the wrong way and no one noticed :) 

### Testing Instructions

Provision a redis server correctly set up for socket connections though, say, `/var/run/redis/redis.sock`

Configure Joomla Global configuration to use Redis as a cache and session handler using the above sock (to match your server, not exactly the example `/var/run/redis/redis.sock`) 

### Actual result BEFORE applying this Pull Request

Joomla could not connect to redis over sock and would red screen of death or debugger message if debug mode on

<img width="1113" alt="Screenshot 2021-05-14 at 20 53 38" src="https://user-images.githubusercontent.com/400092/118322106-81594d80-b4f6-11eb-926b-10c31f4c4d0f.png">


### Expected result AFTER applying this Pull Request

Joomla can now connect. 

### Documentation Changes Required

Paging @simbus82 @csthomas 