### PR TITLE
[4.0] Fix Cassiopeia template style parameters in database on new installation and update from 3.10

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2016-10-02.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2016-10-02.sql
@@ -9,7 +9,7 @@ INSERT INTO `#__extensions` (`name`, `type`, `element`, `folder`, `client_id`, `
 
 INSERT INTO `#__template_styles` (`template`, `client_id`, `home`, `title`, `params`) VALUES
 ('atum', 1, (CASE WHEN (SELECT count FROM (SELECT count(`id`) AS count FROM `#__template_styles` WHERE home = '1' AND client_id = 1 AND `template` IN ('isis', 'hathor')) as c) = 0 THEN '0' ELSE '1' END), 'atum - Default', '{}'),
-('cassiopeia', 0, (CASE WHEN (SELECT count FROM (SELECT count(`id`) AS count FROM `#__template_styles` WHERE home = '1' AND client_id = 0 AND `template` IN ('protostar', 'beez3')) as c) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', '{}');
+('cassiopeia', 0, (CASE WHEN (SELECT count FROM (SELECT count(`id`) AS count FROM `#__template_styles` WHERE home = '1' AND client_id = 0 AND `template` IN ('protostar', 'beez3')) as c) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', '{"brand":"1","logoFile":"","siteTitle":"","siteDescription":"","useFontScheme":"0","colorName":"colors_standard","fluidContainer":"0","stickyHeader":0,"backTop":0}');
 
 --
 -- Move mod_version to the right position for the atum template

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2016-10-02.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2016-10-02.sql
@@ -9,7 +9,7 @@ INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "
 
 INSERT INTO "#__template_styles" ("template", "client_id", "home", "title", "params") VALUES
 ('atum', 1, (CASE WHEN (SELECT count FROM (SELECT count("id") AS count FROM "#__template_styles" WHERE home = '1' AND client_id = 1 AND "template" IN ('isis', 'hathor')) as c) = 0 THEN '0' ELSE '1' END), 'atum - Default', '{}'),
-('cassiopeia', 0, (CASE WHEN (SELECT count FROM (SELECT count("id") AS count FROM "#__template_styles" WHERE home = '1' AND client_id = 0 AND "template" IN ('protostar', 'beez3')) as c) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', '{}');
+('cassiopeia', 0, (CASE WHEN (SELECT count FROM (SELECT count("id") AS count FROM "#__template_styles" WHERE home = '1' AND client_id = 0 AND "template" IN ('protostar', 'beez3')) as c) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', '{"brand":"1","logoFile":"","siteTitle":"","siteDescription":"","useFontScheme":"0","colorName":"colors_standard","fluidContainer":"0","stickyHeader":0,"backTop":0}');
 
 --
 -- Move mod_version to the right position for the atum template

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -795,7 +795,7 @@ CREATE TABLE IF NOT EXISTS `#__template_styles` (
 
 INSERT INTO `#__template_styles` (`id`, `template`, `client_id`, `home`, `title`, `inheritable`, `parent`, `params`) VALUES
 (10, 'atum', 1, '1', 'atum - Default', 0, '', '{"hue":"hsl(214, 63%, 20%)","bg-light":"#f0f4fb","text-dark":"#495057","text-light":"#ffffff","link-color":"#2a69b8","special-color":"#001b4c","monochrome":"0","loginLogo":"","loginLogoAlt":"","logoBrandLarge":"","logoBrandLargeAlt":"","logoBrandSmall":"","logoBrandSmallAlt":""}'),
-(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', 0, '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
+(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', 0, '', '{"brand":"1","logoFile":"","siteTitle":"","siteDescription":"","useFontScheme":"0","colorName":"colors_standard","fluidContainer":"0","stickyHeader":0,"backTop":0}');
 
 -- --------------------------------------------------------
 

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -810,7 +810,7 @@ CREATE INDEX "#__template_styles_idx_client_id_home" ON "#__template_styles" ("c
 --
 INSERT INTO "#__template_styles" ("id", "template", "client_id", "home", "title", "inheritable", "parent", "params") VALUES
 (10, 'atum', 1, '1', 'atum - Default', 0, '', '{"hue":"hsl(214, 63%, 20%)","bg-light":"#f0f4fb","text-dark":"#495057","text-light":"#ffffff","link-color":"#2a69b8","special-color":"#001b4c","monochrome":"0","loginLogo":"","loginLogoAlt":"","logoBrandLarge":"","logoBrandLargeAlt":"","logoBrandSmall":"","logoBrandSmallAlt":""}'),
-(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', 0, '', '{"logoFile":"","fluidContainer":"0","sidebarLeftWidth":"3","sidebarRightWidth":"3"}');
+(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', 0, '', '{"brand":"1","logoFile":"","siteTitle":"","siteDescription":"","useFontScheme":"0","colorName":"colors_standard","fluidContainer":"0","stickyHeader":0,"backTop":0}');
 
 SELECT setval('#__template_styles_id_seq', 12, false);
 


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/33751#issuecomment-841432541 .

### Summary of Changes

1. Fix the outdated `params` values for the Cassiopeia template style in the base.sql files for new installation so they match to the default values in the XML file, including the changes from #33751 , #31520 and possibly others.
2. Create the template style in the update SQL `4.0.0-2016-10-02.sql` with the same `params` values when updating from 3.10.

### To be done

I have to check if it needs to do something for updates from previous J4 Beta versions. But this will be done with another PR, if necessary.

### Testing Instructions

**_Please wait with testing. I might replace this PR by another, new one with a slightly different solution._**

#### Test 1: New installation

Step 1: Use current 4.0-dev or the nightly build from tomorrow or later to make a new installation.

Step 2: After the installation has finished, do not do anything else in backend.

Step 3: In frontend, check if the blue header section is shown.

Result: No blue header section.

Step 4: Apply the changes from this PR.

Step 5: Remove configuration.php and delete all database tables.

Repeat steps 1 to 3.

Result: Blue header section with logo "Cassiopeia" and no site description is shown, like it was before PR #33751 was merged.

#### Test 2: Update from 3.10

Step 1: Update a current 3.10-dev or latest 3.10 nightly to the current 4.0-dev branch, which includes the merged PR #33751 .

Because there is no nightly build available with that yet, you have to use the following update package:

https://test5.richard-fath.de/Joomla_4.0.0-beta8-dev-Development-Update_Package_2021-05-14_20-22.zip

Step 2: After the update has finished, do not do anything else in backend.

Step 3: In frontend, check if the blue header section is shown.

Result: No blue header section.

Repeat steps 1 to 3, again starting with current 3.10-dev or latest 3.10 nightly, but this time update to the custom update URL or update package built by drone for this PR.

Result: Blue header section with logo "Cassiopeia" and no site description is shown, like it was before PR #33751 was merged.

### Actual result BEFORE applying this Pull Request

No blue header section with logo in frontend after a new installation or update from 3.10 without having saved template style settings.

See https://github.com/joomla/joomla-cms/pull/33751#issuecomment-841432541 .

### Expected result AFTER applying this Pull Request

Site shows the header with logo "Cassiopeia" on frontend after a new installation or update from 3.10 without having saved template style settings.

### Documentation Changes Required

None.