### PR TITLE
[4.0] responsive buttons

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_buttons.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_buttons.scss
@@ -2,6 +2,10 @@
 
 .btn {
   transition: none;
+
+  @include media-breakpoint-down(sm) {
+    margin-bottom: .25rem;
+  }
 }
 
 .btn-primary {


### PR DESCRIPTION
Adds margin-bottom to all buttons only when media-breakpoint-down(sm)

Fix it in one place instead of having to fix every existing button and remembering to fix every future button

![image](https://user-images.githubusercontent.com/1296369/118355435-edc06500-b567-11eb-87c1-340eddaf233d.png)

![image](https://user-images.githubusercontent.com/1296369/118355439-f022bf00-b567-11eb-8270-c444a943b2d1.png)

![image](https://user-images.githubusercontent.com/1296369/118355443-f1ec8280-b567-11eb-9a2f-244197e05888.png)
