### PR TITLE
[4.0] Hide Multilingual Associations from components dashboard

### DIFF
--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -13,6 +13,7 @@ namespace Joomla\Module\Submenu\Administrator\Menu;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\MenuItem;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
@@ -52,6 +53,17 @@ abstract class Menu
 		foreach ($children as $item)
 		{
 			if ($item->element && !ComponentHelper::isEnabled($item->element))
+			{
+				$parent->removeChild($item);
+				continue;
+			}
+
+			/*
+			 * Multilingual Associations if the site is not set as multilingual and/or Associations is not enabled in
+			 * the Language Filter plugin
+			 */
+
+			if ($item->element === 'com_associations' && !Associations::isEnabled())
 			{
 				$parent->removeChild($item);
 				continue;


### PR DESCRIPTION
Pull Request for Issue #33903.

### Summary of Changes
Similar to https://github.com/joomla/joomla-cms/pull/33815 , this PR for only show Multilingual Associations for multilingual website with Associations enabled in System - Language Filter plugin

### Testing Instructions
1. Access to Components dashboard (see https://github.com/joomla/joomla-cms/issues/33903#issuecomment-841641715 for instructions), confirm that **Multilingual Associations** component is displayed.
2. Apply patch, check it again. You should not see **Multilingual Associations** anymore
3. Go to System -> Plugins, enable System - Language Filter and make sure Item Associations parameter set tot Yes. Then check it again, you will now see Multilingual Associations displayed again.

![Components-Dashboard-Joomla-4-Administration](https://user-images.githubusercontent.com/977664/118359227-c0e27100-b5ac-11eb-936c-2acb21280b32.png)
