### PR TITLE
[4.0] Smart Search Taxonomy: Hiding authors for unpublished articles

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Taxonomy.php
+++ b/administrator/components/com_finder/src/Indexer/Taxonomy.php
@@ -206,7 +206,7 @@ class Taxonomy
 			// Prepare the node object.
 			$nodeTable->id = (int) $result->id;
 			$nodeTable->title = $result->title;
-			$nodeTable->state = (int) $result->title;
+			$nodeTable->state = (int) ($node->state > 0 ? $node->state : $result->state);
 			$nodeTable->access = (int) $result->access;
 			$nodeTable->language = $node->language;
 			$nodeTable->setLocation($result->parent_id, 'last-child');

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -314,7 +314,7 @@ class PlgFinderContent extends Adapter
 		// Add the author taxonomy data.
 		if (!empty($item->author) || !empty($item->created_by_alias))
 		{
-			$item->addTaxonomy('Author', !empty($item->created_by_alias) ? $item->created_by_alias : $item->author);
+			$item->addTaxonomy('Author', !empty($item->created_by_alias) ? $item->created_by_alias : $item->author, $item->state);
 		}
 
 		// Add the category taxonomy data.


### PR DESCRIPTION
Pull Request for Issue #32902.

### Summary of Changes
This hides the author from the taxonomies when the article itself is not published yet. This is a hack right now and will have to be further improve in Joomla 4.1.


### Testing Instructions
1. Create a new, unpublished article. Set a unique author alias in the article.
2. Save the article

### Actual result BEFORE applying this Pull Request
The author shows up in the filters in the frontend.


### Expected result AFTER applying this Pull Request
The author does not show up in the filters in the frontend.