### PR TITLE
[4.0] Smart Search: Only list entries in filters

### DIFF
--- a/administrator/components/com_finder/src/Service/HTML/Filter.php
+++ b/administrator/components/com_finder/src/Service/HTML/Filter.php
@@ -322,8 +322,8 @@ class Filter
 				$query->clear()
 					->select('t.*')
 					->from($db->quoteName('#__finder_taxonomy') . ' AS t')
-					->where('t.lft >= ' . (int) $bv->lft)
-					->where('t.rgt <= ' . (int) $bv->rgt)
+					->where('t.lft > ' . (int) $bv->lft)
+					->where('t.rgt < ' . (int) $bv->rgt)
 					->where('t.state = 1')
 					->where('t.access IN (' . $groups . ')')
 					->order('t.lft, t.title');


### PR DESCRIPTION
Pull Request for Issue #29988.

### Summary of Changes
When searching in Smart Search in the frontend and clicking on "Advanced Search", you can see the filters for the taxonomies. These currently not only show the available selections, but also the title of the taxonomies as well. These should not be there. Selecting them also results in an untranslated string. Thus this would fix both those issues.

### Testing Instructions
1. Install the sample data
2. In Frontend go to the Smart Search menu item
3. See that you can select "Types" as "Type" and do so. Also type in a searchword like "Joomla" and then search.

### Actual result BEFORE applying this Pull Request
You get an untranslated string PLG_FINDER_QUERY_FILTER_BRANCH_S_ROOT

### Expected result AFTER applying this Pull Request
You can't even select that entry from the "Types" filter anymore.