### PR TITLE
[4.0] Simplify populateState method for ActionLogs model

### DIFF
--- a/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
@@ -73,23 +73,6 @@ class ActionlogsModel extends ListModel
 	 */
 	protected function populateState($ordering = 'a.id', $direction = 'desc')
 	{
-		$app = Factory::getApplication();
-
-		$search = $app->getUserStateFromRequest($this->context . 'filter.search', 'filter_search', '', 'string');
-		$this->setState('filter.search', $search);
-
-		$user = $app->getUserStateFromRequest($this->context . 'filter.user', 'filter_user', '', 'string');
-		$this->setState('filter.user', $user);
-
-		$extension = $app->getUserStateFromRequest($this->context . 'filter.extension', 'filter_extension', '', 'string');
-		$this->setState('filter.extension', $extension);
-
-		$ip_address = $app->getUserStateFromRequest($this->context . 'filter.ip_address', 'filter_ip_address', '', 'string');
-		$this->setState('filter.ip_address', $ip_address);
-
-		$dateRange = $app->getUserStateFromRequest($this->context . 'filter.dateRange', 'filter_dateRange', '', 'string');
-		$this->setState('filter.dateRange', $dateRange);
-
 		parent::populateState($ordering, $direction);
 	}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Our ListModel is smart enough to populate model states automatically, so we do not have to write code to populate value for individual states anymore. From what I see, manual populating model states like this is only needed for Joomla 3 because we have to support Hathor, a template which does not use search tools for filtering data.

This PR is made to see if it could be accepted. If it is accepted, similar clean up code be made for some other model classes in our codebase


### Testing Instructions
1. Apply patch
2. Access to Users -> User Actions Log, try to filter action logs search by searching, filter by component, date range... and make sure it is still working as expected.