### PR TITLE
[4.0] breadcrumbs unused function

### DIFF
--- a/modules/mod_breadcrumbs/src/Helper/BreadcrumbsHelper.php
+++ b/modules/mod_breadcrumbs/src/Helper/BreadcrumbsHelper.php
@@ -12,8 +12,6 @@ namespace Joomla\Module\Breadcrumbs\Site\Helper;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\CMSApplication;
-use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\Registry\Registry;

--- a/modules/mod_breadcrumbs/src/Helper/BreadcrumbsHelper.php
+++ b/modules/mod_breadcrumbs/src/Helper/BreadcrumbsHelper.php
@@ -73,38 +73,4 @@ class BreadcrumbsHelper
 
 		return $crumbs;
 	}
-
-	/**
-	 * Set the breadcrumbs separator for the breadcrumbs display.
-	 *
-	 * @param   string  $custom  Custom xhtml compliant string to separate the items of the breadcrumbs
-	 *
-	 * @return  string	Separator string
-	 *
-	 * @since   1.5
-	 */
-	public static function setSeparator($custom = null)
-	{
-		$lang = Factory::getApplication()->getLanguage();
-
-		// If a custom separator has not been provided we try to load a template
-		// specific one first, and if that is not present we load the default separator
-		if ($custom === null)
-		{
-			if ($lang->isRtl())
-			{
-				$_separator = HTMLHelper::_('image', 'system/arrow_rtl.png', null, null, true);
-			}
-			else
-			{
-				$_separator = HTMLHelper::_('image', 'system/arrow.png', null, null, true);
-			}
-		}
-		else
-		{
-			$_separator = htmlspecialchars($custom, ENT_COMPAT, 'UTF-8');
-		}
-
-		return $_separator;
-	}
 }


### PR DESCRIPTION
This PR removes the function setSeparator that is not used in joomla 4

maintainers will need to decide if this is safe to delete or if it needs to be deprecated first.

Pull Request for Issue #33831