### PR TITLE
[4.0] Fix template params for ErrorDocument, revert #33718

### DIFF
--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
 /** @var \Joomla\CMS\Document\ErrorDocument $this */
@@ -28,7 +29,6 @@ $layout     = $input->get('layout', 'default');
 $task       = $input->get('task', 'display');
 $cpanel     = $option === 'com_cpanel';
 $hiddenMenu = $app->input->get('hidemainmenu');
-$params     = $app->getTemplate(true)->params;
 
 // Browsers support SVG favicons
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon.svg', '', [], true, 1), 'icon', 'rel', ['type' => 'image/svg+xml']);
@@ -36,35 +36,35 @@ $this->addHeadLink(HTMLHelper::_('image', 'favicon.ico', '', [], true, 1), 'alte
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon-pinned.svg', '', [], true, 1), 'mask-icon', 'rel', ['color' => '#000']);
 
 // Template params
-$logoBrandLarge  = $params->get('logoBrandLarge')
-	? Uri::root() . htmlspecialchars($params->get('logoBrandLarge'), ENT_QUOTES)
+$logoBrandLarge  = $this->params->get('logoBrandLarge')
+	? Uri::root() . htmlspecialchars($this->params->get('logoBrandLarge'), ENT_QUOTES)
 	: $this->baseurl . '/templates/' . $this->template . '/images/logos/brand-large.svg';
-$logoBrandSmall = $params->get('logoBrandSmall')
-	? Uri::root() . htmlspecialchars($params->get('logoBrandSmall'), ENT_QUOTES)
+$logoBrandSmall = $this->params->get('logoBrandSmall')
+	? Uri::root() . htmlspecialchars($this->params->get('logoBrandSmall'), ENT_QUOTES)
 	: $this->baseurl . '/templates/' . $this->template . '/images/logos/brand-small.svg';
 
-$logoBrandLargeAlt = empty($params->get('logoBrandLargeAlt')) && empty($params->get('emptyLogoBrandLargeAlt'))
+$logoBrandLargeAlt = empty($this->params->get('logoBrandLargeAlt')) && empty($this->params->get('emptyLogoBrandLargeAlt'))
 	? 'alt=""'
-	: 'alt="' . htmlspecialchars($params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8') . '"';
-$logoBrandSmallAlt = empty($params->get('logoBrandSmallAlt')) && empty($params->get('emptyLogoBrandSmallAlt'))
+	: 'alt="' . htmlspecialchars($this->params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8') . '"';
+$logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($this->params->get('emptyLogoBrandSmallAlt'))
 	? 'alt=""'
-	: 'alt="' . htmlspecialchars($params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8') . '"';
+	: 'alt="' . htmlspecialchars($this->params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8') . '"';
 
-// Get the hue value
-preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
+	// Get the hue value
+	preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
 
-// Enable assets
-$wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
-	->useStyle('template.active.language')
-	->useStyle('template.user')
-	->addInlineStyle(':root {
-		--hue: ' . $matches[1] . ';
-		--atum-bg-light: ' . $params->get('bg-light', '#f0f4fb') . ';
-		--atum-text-dark: ' . $params->get('text-dark', '#495057') . ';
-		--atum-text-light: ' . $params->get('text-light', '#ffffff') . ';
-		--atum-link-color: ' . $params->get('link-color', '#2a69b8') . ';
-		--atum-special-color: ' . $params->get('special-color', '#001B4C') . ';
-	}');
+	// Enable assets
+	$wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
+		->useStyle('template.active.language')
+		->useStyle('template.user')
+		->addInlineStyle(':root {
+			--hue: ' . $matches[1] . ';
+			--atum-bg-light: ' . $this->params->get('bg-light', '#f0f4fb') . ';
+			--atum-text-dark: ' . $this->params->get('text-dark', '#495057') . ';
+			--atum-text-light: ' . $this->params->get('text-light', '#ffffff') . ';
+			--atum-link-color: ' . $this->params->get('link-color', '#2a69b8') . ';
+			--atum-special-color: ' . $this->params->get('special-color', '#001B4C') . ';
+		}');
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
 $wa->registerStyle('template.active', '', [], [], ['template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);
@@ -72,7 +72,7 @@ $wa->registerStyle('template.active', '', [], [], ['template.atum.' . ($this->di
 // Set some meta data
 $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 
-$monochrome = (bool) $params->get('monochrome');
+$monochrome = (bool) $this->params->get('monochrome');
 
 // @see administrator/templates/atum/html/layouts/status.php
 $statusModules = LayoutHelper::render('status', ['modules' => 'status']);

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -26,7 +26,6 @@ $option = $input->get('option', '');
 $view   = $input->get('view', '');
 $layout = $input->get('layout', 'default');
 $task   = $input->get('task', 'display');
-$params = $app->getTemplate(true)->params;
 
 // Browsers support SVG favicons
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon.svg', '', [], true, 1), 'icon', 'rel', ['type' => 'image/svg+xml']);
@@ -34,28 +33,28 @@ $this->addHeadLink(HTMLHelper::_('image', 'favicon.ico', '', [], true, 1), 'alte
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon-pinned.svg', '', [], true, 1), 'mask-icon', 'rel', ['color' => '#000']);
 
 // Template params
-$logoBrandLarge  = $params->get('logoBrandLarge')
-	? Uri::root() . htmlspecialchars($params->get('logoBrandLarge'), ENT_QUOTES)
+$logoBrandLarge  = $this->params->get('logoBrandLarge')
+	? Uri::root() . htmlspecialchars($this->params->get('logoBrandLarge'), ENT_QUOTES)
 	: $this->baseurl . '/templates/' . $this->template . '/images/logos/brand-large.svg';
-$loginLogo = $params->get('loginLogo')
-	? Uri::root() . $params->get('loginLogo')
+$loginLogo = $this->params->get('loginLogo')
+	? Uri::root() . $this->params->get('loginLogo')
 	: $this->baseurl . '/templates/' . $this->template . '/images/logos/login.svg';
-$logoBrandSmall = $params->get('logoBrandSmall')
-	? Uri::root() . htmlspecialchars($params->get('logoBrandSmall'), ENT_QUOTES)
+$logoBrandSmall = $this->params->get('logoBrandSmall')
+	? Uri::root() . htmlspecialchars($this->params->get('logoBrandSmall'), ENT_QUOTES)
 	: $this->baseurl . '/templates/' . $this->template . '/images/logos/brand-small.svg';
 
-$logoBrandLargeAlt = empty($params->get('logoBrandLargeAlt')) && empty($params->get('emptyLogoBrandLargeAlt'))
+$logoBrandLargeAlt = empty($this->params->get('logoBrandLargeAlt')) && empty($this->params->get('emptyLogoBrandLargeAlt'))
 	? 'alt=""'
-	: 'alt="' . htmlspecialchars($params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8') . '"';
-$logoBrandSmallAlt = empty($params->get('logoBrandSmallAlt')) && empty($params->get('emptyLogoBrandSmallAlt'))
+	: 'alt="' . htmlspecialchars($this->params->get('logoBrandLargeAlt'), ENT_COMPAT, 'UTF-8') . '"';
+$logoBrandSmallAlt = empty($this->params->get('logoBrandSmallAlt')) && empty($this->params->get('emptyLogoBrandSmallAlt'))
 	? 'alt=""'
-	: 'alt="' . htmlspecialchars($params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8') . '"';
-$loginLogoAlt = empty($params->get('loginLogoAlt')) && empty($params->get('emptyLoginLogoAlt'))
+	: 'alt="' . htmlspecialchars($this->params->get('logoBrandSmallAlt'), ENT_COMPAT, 'UTF-8') . '"';
+$loginLogoAlt = empty($this->params->get('loginLogoAlt')) && empty($this->params->get('emptyLoginLogoAlt'))
 	? 'alt=""'
-	: 'alt="' . htmlspecialchars($params->get('loginLogoAlt'), ENT_COMPAT, 'UTF-8') . '"';
+	: 'alt="' . htmlspecialchars($this->params->get('loginLogoAlt'), ENT_COMPAT, 'UTF-8') . '"';
 
-// Get the hue value
-preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
+	// Get the hue value
+preg_match('#^hsla?\(([0-9]+)[\D]+([0-9]+)[\D]+([0-9]+)[\D]+([0-9](?:.\d+)?)?\)$#i', $this->params->get('hue', 'hsl(214, 63%, 20%)'), $matches);
 
 // Enable assets
 $wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
@@ -63,11 +62,11 @@ $wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
 	->useStyle('template.user')
 	->addInlineStyle(':root {
 		--hue: ' . $matches[1] . ';
-		--atum-bg-light: ' . $params->get('bg-light', '#f0f4fb') . ';
-		--atum-text-dark: ' . $params->get('text-dark', '#495057') . ';
-		--atum-text-light: ' . $params->get('text-light', '#ffffff') . ';
-		--atum-link-color: ' . $params->get('link-color', '#2a69b8') . ';
-		--atum-special-color: ' . $params->get('special-color', '#001B4C') . ';
+		--atum-bg-light: ' . $this->params->get('bg-light', '#f0f4fb') . ';
+		--atum-text-dark: ' . $this->params->get('text-dark', '#495057') . ';
+		--atum-text-light: ' . $this->params->get('text-light', '#ffffff') . ';
+		--atum-link-color: ' . $this->params->get('link-color', '#2a69b8') . ';
+		--atum-special-color: ' . $this->params->get('special-color', '#001B4C') . ';
 	}');
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
@@ -76,7 +75,7 @@ $wa->registerStyle('template.active', '', [], [], ['template.atum.' . ($this->di
 // Set some meta data
 $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 
-$monochrome = (bool) $params->get('monochrome');
+$monochrome = (bool) $this->params->get('monochrome');
 
 // @see administrator/templates/atum/html/layouts/status.php
 $statusModules = LayoutHelper::render('status', ['modules' => 'status']);

--- a/libraries/src/Error/Renderer/HtmlRenderer.php
+++ b/libraries/src/Error/Renderer/HtmlRenderer.php
@@ -73,7 +73,8 @@ class HtmlRenderer extends AbstractRenderer
 				'directory'        => JPATH_THEMES,
 				'debug'            => JDEBUG,
 				'csp_nonce'        => $app->get('csp_nonce'),
-				'templateInherits' => $template->parent
+				'templateInherits' => $template->parent,
+				'params'           => $template->params,
 			]
 		);
 	}

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -14,7 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
-/** @var JDocumentError $this */
+/** @var Joomla\CMS\Document\ErrorDocument $this */
 
 $app = Factory::getApplication();
 $wa  = $this->getWebAssetManager();
@@ -29,20 +29,17 @@ $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 $menu     = $app->getMenu()->getActive();
 $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 
-// Getting params from template
-$params = $app->getTemplate(true)->params;
-
 // Template path
 $templatePath = 'templates/' . $this->template;
 
 // Color Theme
-$paramsColorName = $params->get('colorName', 'colors_standard');
+$paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
 $wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $paramsColorName . '.css');
 $this->getPreloadManager()->prefetch($wa->getAsset('style', $assetColorName)->getUri(), ['as' => 'style']);
 
 // Use a font scheme if set in the template style options
-$paramsFontScheme = $params->get('useFontScheme', false);
+$paramsFontScheme = $this->params->get('useFontScheme', false);
 
 if ($paramsFontScheme)
 {
@@ -67,13 +64,13 @@ $this->addHeadLink(HTMLHelper::_('image', 'favicon.ico', '', [], true, 1), 'alte
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon-pinned.svg', '', [], true, 1), 'mask-icon', 'rel', ['color' => '#000']);
 
 // Logo file or site title param
-if ($params->get('logoFile'))
+if ($this->params->get('logoFile'))
 {
-	$logo = '<img src="' . htmlspecialchars(Uri::root() . $params->get('logoFile'), ENT_QUOTES, 'UTF-8') . '" alt="' . $sitename . '">';
+	$logo = '<img src="' . htmlspecialchars(Uri::root() . $this->params->get('logoFile'), ENT_QUOTES, 'UTF-8') . '" alt="' . $sitename . '">';
 }
-elseif ($params->get('siteTitle'))
+elseif ($this->params->get('siteTitle'))
 {
-	$logo = '<span title="' . $sitename . '">' . htmlspecialchars($params->get('siteTitle'), ENT_COMPAT, 'UTF-8') . '</span>';
+	$logo = '<span title="' . $sitename . '">' . htmlspecialchars($this->params->get('siteTitle'), ENT_COMPAT, 'UTF-8') . '</span>';
 }
 else
 {
@@ -81,7 +78,7 @@ else
 }
 
 // Container
-$wrapper = $params->get('fluidContainer') ? 'wrapper-fluid' : 'wrapper-static';
+$wrapper = $this->params->get('fluidContainer') ? 'wrapper-fluid' : 'wrapper-static';
 
 $this->setMetaData('viewport', 'width=device-width, initial-scale=1');
 
@@ -111,8 +108,8 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
 				<a class="brand-logo" href="<?php echo $this->baseurl; ?>/">
 					<?php echo $logo; ?>
 				</a>
-				<?php if ($params->get('siteDescription')) : ?>
-					<div class="site-description"><?php echo htmlspecialchars($params->get('siteDescription')); ?></div>
+				<?php if ($this->params->get('siteDescription')) : ?>
+					<div class="site-description"><?php echo htmlspecialchars($this->params->get('siteDescription')); ?></div>
 				<?php endif; ?>
 			</div>
 		</div>


### PR DESCRIPTION
### Summary of Changes

Assign the parameters to ErrorDocument to be available in error.php.
Reverts #33718.


### Testing Instructions
For backend follow #33718

For frontend:
- set a theme color to "Alternative", in Cassiopeia config.
- open non existing page to get 404 error
- make sure the template use "Alternative color"


