### PR TITLE
[4.0] Hide the empty div when no results match the Add Module search

### DIFF
--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -53,7 +53,7 @@ endif;
 			<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
 			<?php echo Text::_('COM_MODULES_MSG_MANAGE_NO_MODULES'); ?>
 		</div>
-		<h2 class="pb-3 ms-3" id="comModulesSelectHeader">
+		<h2 class="pb-3 ms-3" id="comModulesSelectTypeHeader">
 			<?php echo Text::_('COM_MODULES_TYPE_CHOOSE'); ?>
 		</h2>
 		<div class="main-card card-columns p-4" id="comModulesSelectResultsContainer">

--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -53,10 +53,10 @@ endif;
 			<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
 			<?php echo Text::_('COM_MODULES_MSG_MANAGE_NO_MODULES'); ?>
 		</div>
-		<h2 class="pb-3 ms-3">
+		<h2 class="pb-3 ms-3" id="comModulesSelectHeader">
 			<?php echo Text::_('COM_MODULES_TYPE_CHOOSE'); ?>
 		</h2>
-		<div class="main-card card-columns p-4">
+		<div class="main-card card-columns p-4" id="comModulesSelectResultsContainer">
 			<?php foreach ($this->items as &$item) : ?>
 				<?php // Prepare variables for the link. ?>
 					<?php $link = 'index.php?option=com_modules&task=module.add&client_id=' . $this->state->get('client_id', 0) . $this->modalLink . '&eid=' . $item->extension_id; ?>

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -36,7 +36,7 @@
 // Make sure the element exists i.e. a template override has not removed it.
 const elSearch = document.getElementById('comModulesSelectSearch');
 const elSearchContainer = document.getElementById('comModulesSelectSearchContainer');
-const elSearchHeader = document.getElementById('comModulesSelectHeader');
+const elSearchHeader = document.getElementById('comModulesSelectTypeHeader');
 const elSearchResults = document.getElementById('comModulesSelectResultsContainer');
 const alertElement = document.querySelector('.modules-alert');
 const elCards = [].slice.call(document.querySelectorAll('.comModulesSelectCard'));

--- a/build/media_source/com_modules/js/admin-module-search.es6.js
+++ b/build/media_source/com_modules/js/admin-module-search.es6.js
@@ -36,6 +36,8 @@
 // Make sure the element exists i.e. a template override has not removed it.
 const elSearch = document.getElementById('comModulesSelectSearch');
 const elSearchContainer = document.getElementById('comModulesSelectSearchContainer');
+const elSearchHeader = document.getElementById('comModulesSelectHeader');
+const elSearchResults = document.getElementById('comModulesSelectResultsContainer');
 const alertElement = document.querySelector('.modules-alert');
 const elCards = [].slice.call(document.querySelectorAll('.comModulesSelectCard'));
 
@@ -77,8 +79,12 @@ if (elSearch && elSearchContainer) {
 
     if (hasSearchResults || !partialSearch) {
       alertElement.classList.add('d-none');
+      elSearchHeader.classList.remove('d-none');
+      elSearchResults.classList.remove('d-none');
     } else {
       alertElement.classList.remove('d-none');
+      elSearchHeader.classList.add('d-none');
+      elSearchResults.classList.add('d-none');
     }
   });
 


### PR DESCRIPTION
Pull Request for Issue #33912

### Summary of Changes
- Added id to the h2 and div tags whose display is to be toggled
- Added JavaScript code to toggle class `d-none` based on the hasResults and partialSearch boolean


### Testing Instructions
Apply patch and `npm run build:js` to compile the JavaScript
For the following views, ensure that the div and h2 are not displayed when you enter a query that does not match any results:

1. Backend -> Content -> Site Modules -> Add
2. Backend -> Content -> Admin Modules -> Add
3. Backend's Home Dashboard -> Add Module to the Dashboard -> Modal

Also, ensure that the box stays hidden when you navigate outside and then back again to the same view (for persistent query).

### Actual result BEFORE applying this Pull Request

#### Add Module View
![image](https://user-images.githubusercontent.com/53610833/118399681-ebe7c600-b67b-11eb-81bd-8c85fba7774e.png)

#### Modal
![image](https://user-images.githubusercontent.com/53610833/118399873-d4f5a380-b67c-11eb-99d4-c2f1ddf69ec3.png)



### Expected result AFTER applying this Pull Request

#### Add Module View
![hideDiv](https://user-images.githubusercontent.com/53610833/118399723-1df92800-b67c-11eb-9d56-f885134b93e1.gif)

#### Modal
![hideDivModal](https://user-images.githubusercontent.com/53610833/118399852-ba232f00-b67c-11eb-8142-ea79ae07bd79.gif)



### Documentation Changes Required
None
