### PR TITLE
Fix Help & System Dashboards preset is not stylized

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -130,6 +130,7 @@ if ($icon == '' && $itemImage == '' && $current->level == 1 && $current->target 
 {
 	$itemImage = '<span class="m-3"></span>';
 }
+
 if ($link != '' && $current->target != '')
 {
 	echo "<a" . $linkClass . $dataToggle . " href=\"" . $link . "\" target=\"" . $current->target . "\">"

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -127,17 +127,7 @@ $itemImage = (empty($itemIconClass) && $itemImage) ? '&nbsp;<img src="' . Uri::r
 // If the item image is not set, set the default image.
 if ($icon == '' && $iconClass == '' && $current->level == 1 && $current->target == '')
 {
-	$lang = JFactory::getLanguage();
-	$isRtl = $lang->isRtl();
-
-	if ($isRtl)
-	{
-		$iconClass = '<span class="icon-angle-double-left icon-fw" aria-hidden="true"></span>';
-	}
-	else
-	{
-		$iconClass = '<span class="icon-angle-double-right icon-fw" aria-hidden="true"></span>';
-	}
+	$iconClass = '<span aria-hidden="true" class="icon-fw"></span>';
 }
 
 if ($link != '' && $current->target != '')

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -124,6 +124,12 @@ if ($iconImage)
 
 $itemImage = (empty($itemIconClass) && $itemImage) ? '&nbsp;<img src="' . Uri::root() . $itemImage . '" alt="">&nbsp;' : '';
 
+// if the item image is not set, than the item title would not have margin
+// here we add it
+if ($icon == '' && $itemImage == '' && $current->level == 1 && $current->target == '')
+{
+	$itemImage = '<span class="m-3"></span>';
+}
 if ($link != '' && $current->target != '')
 {
 	echo "<a" . $linkClass . $dataToggle . " href=\"" . $link . "\" target=\"" . $current->target . "\">"

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -124,8 +124,7 @@ if ($iconImage)
 
 $itemImage = (empty($itemIconClass) && $itemImage) ? '&nbsp;<img src="' . Uri::root() . $itemImage . '" alt="">&nbsp;' : '';
 
-// if the item image is not set, than the item title would not have margin
-// here we add it
+// If the item image is not set, the item title would not have margin. Here we add it.
 if ($icon == '' && $itemImage == '' && $current->level == 1 && $current->target == '')
 {
 	$itemImage = '<span class="m-3"></span>';

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -124,10 +124,20 @@ if ($iconImage)
 
 $itemImage = (empty($itemIconClass) && $itemImage) ? '&nbsp;<img src="' . Uri::root() . $itemImage . '" alt="">&nbsp;' : '';
 
-// If the item image is not set, the item title would not have margin. Here we add it.
-if ($icon == '' && $itemImage == '' && $current->level == 1 && $current->target == '')
+// If the item image is not set, set the default image.
+if ($icon == '' && $iconClass == '' && $current->level == 1 && $current->target == '')
 {
-	$itemImage = '<span class="m-3"></span>';
+	$lang = JFactory::getLanguage();
+	$isRtl = $lang->isRtl();
+
+	if ($isRtl)
+	{
+		$iconClass = '<span class="icon-angle-double-left icon-fw" aria-hidden="true"></span>';
+	}
+	else
+	{
+		$iconClass = '<span class="icon-angle-double-right icon-fw" aria-hidden="true"></span>';
+	}
 }
 
 if ($link != '' && $current->target != '')

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -124,7 +124,7 @@ if ($iconImage)
 
 $itemImage = (empty($itemIconClass) && $itemImage) ? '&nbsp;<img src="' . Uri::root() . $itemImage . '" alt="">&nbsp;' : '';
 
-// If the item image is not set, set the default image.
+// If the item image is not set, the item title would not have margin. Here we add it.
 if ($icon == '' && $iconClass == '' && $current->level == 1 && $current->target == '')
 {
 	$iconClass = '<span aria-hidden="true" class="icon-fw"></span>';


### PR DESCRIPTION
Pull Request for Issue #33898.

### Summary of Changes

Span added when image is not set in order to add margin.

### Testing Instructions

Go to the Admin Menu module (control panel), select the Help Dashboard preset in the settings and evaluate the main page of the control panel.

### Actual result BEFORE applying this Pull Request

The items in left menu have no left margin.

### Expected result AFTER applying this Pull Request

The items in left menu have margin.