### PR TITLE
[4.0] [a11y] Changes in mod_languages

### DIFF
--- a/build/media_source/mod_languages/css/template.css
+++ b/build/media_source/mod_languages/css/template.css
@@ -27,8 +27,12 @@ div.mod-languages img {
 }
 
 div.mod-languages a {
-  padding: .5rem 0;
+  padding: .5rem;
   text-decoration: none;
+}
+
+div.mod-languages a:focus {
+  outline: 1px solid #ddd;
 }
 
 div.mod-languages .btn-group {

--- a/build/media_source/mod_languages/css/template.css
+++ b/build/media_source/mod_languages/css/template.css
@@ -35,10 +35,6 @@ div.mod-languages a {
   text-decoration: none;
 }
 
-div.mod-languages a:focus {
-  outline: 1px solid #ddd;
-}
-
 div.mod-languages .btn-group {
   display: flex !important;
   margin: 0;

--- a/build/media_source/mod_languages/css/template.css
+++ b/build/media_source/mod_languages/css/template.css
@@ -17,6 +17,10 @@ div.mod-languages ul.lang-block li {
   padding: .5rem 0;
 }
 
+div.mod-languages ul li.lang-active {
+  background-color: #f0f0f0;
+}
+
 html[dir=rtl] div.mod-languages ul.lang-block li {
   text-align: right;
 }

--- a/build/media_source/mod_languages/css/template.css
+++ b/build/media_source/mod_languages/css/template.css
@@ -1,56 +1,41 @@
 div.mod-languages ul {
-	margin: 0;
-	padding: 0;
-	list-style:none;
+  padding: 0;
+  margin: 0;
+  list-style: none;
 }
 
 div.mod-languages li {
-	margin-left: .3em;
-	margin-right: .3em;
-}
-
-div.mod-languages li:last-of-type {
-	margin-bottom: .6em;
+  margin: 0 .5rem;
 }
 
 div.mod-languages ul.lang-inline li {
-	display:inline-block;
+  display: inline-block;
 }
 
 div.mod-languages ul.lang-block li {
-	display: block;
+  display: block;
+  padding: .5rem 0;
 }
 
 html[dir=rtl] div.mod-languages ul.lang-block li {
-	text-align: right;
+  text-align: right;
 }
 
 div.mod-languages img {
-	border: none;
-	display: inline-block;
+  display: inline-block;
+  border: none;
 }
 
 div.mod-languages a {
-	text-decoration: none;
+  padding: .5rem 0;
+  text-decoration: none;
 }
 
 div.mod-languages .btn-group {
-	display: flex !important;
+  display: flex !important;
+  margin: 0;
 }
 
 div.mod-languages .btn-group .btn {
-	flex: none;
-}
-
-div.mod-languages .dropdown-menu {
-	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.16), 0 2px 4px rgba(0, 0, 0, 0.23);
-}
-
-div.mod-languages .dropdown-menu::after {
-	 top: -1.4rem;
-}
-
-html[dir=rtl] div.mod-languages .dropdown-menu::after {
-	 left: auto;
-	 right: .9em;
+  flex: none;
 }

--- a/build/media_source/mod_languages/css/template.css
+++ b/build/media_source/mod_languages/css/template.css
@@ -12,6 +12,10 @@ div.mod-languages ul.lang-inline li {
   display: inline-block;
 }
 
+div.mod-languages .dropdown-menu {
+  padding: .5rem 0;
+}
+
 div.mod-languages ul.lang-block li {
   display: block;
   padding: .5rem 0;

--- a/language/en-GB/mod_languages.ini
+++ b/language/en-GB/mod_languages.ini
@@ -4,6 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 MOD_LANGUAGES="Language Switcher"
+MOD_LANGUAGES_DESC="Select your language"
 MOD_LANGUAGES_FIELD_ACTIVE_LABEL="Active Language"
 MOD_LANGUAGES_FIELD_DROPDOWN_IMAGE_LABEL="Use Flags For Dropdown"
 MOD_LANGUAGES_FIELD_DROPDOWN_LABEL="Use Dropdown"

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -29,7 +29,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 	<div class="mod-languages__select btn-group">
 		<?php foreach ($list as $language) : ?>
 			<?php if ($language->active) : ?>
-				<button href="#" data-bs-toggle="dropdown" class="btn dropdown-toggle" aria-expanded="false">
+				<button type ="button" data-bs-toggle="dropdown" class="btn dropdown-toggle" aria-expanded="false">
 					<?php if ($params->get('dropdownimage', 1)) : ?>
 						<?php if ($language->image) : ?>
 							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name', ) ? '' : $language->title_native, null, true); ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -78,7 +78,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 			$lbl = '';
 			if ((($params->get('full_name') === 0) && ($params->get('image') === 0)) || (!$language->image))
 			{
-				$lbl = 'aria-label= "' . $language->title_native . '"';
+				$lbl = 'aria-label="' . $language->title_native . '"';
 			}
 		?>
 		<?php if (!$language->active) : ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -29,7 +29,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 	<div class="mod-languages__select btn-group">
 		<?php foreach ($list as $language) : ?>
 			<?php if ($language->active) : ?>
-				<button id="language_btn" type ="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-labelledby="language_picker_des language_btn" aria-expanded="false">
+				<button id="language_btn" type ="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-haspopup="listbox" aria-labelledby="language_picker_des language_btn" aria-expanded="false">
 					<?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
 						<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 					<?php endif; ?>
@@ -40,9 +40,16 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 		<ul role="listbox" aria-labelledby="language_picker_des" class="lang-block dropdown-menu" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
 
 		<?php foreach ($list as $language) : ?>
+			<?php
+				$lbl = '';
+				if (($params->get('full_name') === 0))
+				{
+					$lbl = 'aria-label = "' . $language->title_native . '"';
+				}
+			?>
 			<?php if (!$language->active) : ?>
 				<li>
-					<a role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+					<a role="option" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 						<?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
 							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 						<?php endif; ?>
@@ -52,7 +59,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 			<?php elseif ($params->get('show_active', 1)) : ?>
 			<?php $base = Uri::getInstance(); ?>
 				<li class="lang-active">
-					<a aria-selected="true" role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+					<a aria-selected="true" role="option" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 						<?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
 							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 						<?php endif; ?>
@@ -67,9 +74,16 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 	<ul role="listbox" aria-labelledby="language_picker_des" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
 
 	<?php foreach ($list as $language) : ?>
+		<?php
+			$lbl = '';
+			if ((($params->get('full_name') === 0) && ($params->get('image') === 0)) || (!$language->image))
+			{
+				$lbl = 'aria-label = "' . $language->title_native . '"';
+			}
+		?>
 		<?php if (!$language->active) : ?>
 			<li>
-				<a role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+				<a role="option" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 					<?php if ($params->get('image', 1)) : ?>
 						<?php if ($language->image) : ?>
 							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
@@ -84,13 +98,13 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 		<?php elseif ($params->get('show_active', 1)) : ?>
 			<?php $base = Uri::getInstance(); ?>
 			<li class="lang-active">
-				<a aria-selected="true" role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+				<a aria-selected="true" role="option" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 
 				<?php if ($params->get('image', 1)) : ?>
 					<?php if ($language->image) : ?>
 						<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
 					<?php else : ?>
-						<span class="badge bg-secondary"><?php echo strtoupper($language->sef); ?></span>
+						<span class="badge bg-secondary" title="<?php echo $language->title_native; ?>"><?php echo strtoupper($language->sef); ?></span>
 					<?php endif; ?>
 				<?php else : ?>
 					<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -18,7 +18,7 @@ $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 ?>
 <div class="mod-languages">
-	<p class="visually-hidden" id="language_picker_des"><?php echo Text::_('MOD_LANGUAGES_DESC'); ?></p>
+	<p class="visually-hidden" id="language_picker_des_<?php echo $module->id; ?>"><?php echo Text::_('MOD_LANGUAGES_DESC'); ?></p>
 
 <?php if ($headerText) : ?>
 	<div class="mod-languages__pretext pretext"><p><?php echo $headerText; ?></p></div>
@@ -29,7 +29,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 	<div class="mod-languages__select btn-group">
 		<?php foreach ($list as $language) : ?>
 			<?php if ($language->active) : ?>
-				<button id="language_btn" type="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-haspopup="listbox" aria-labelledby="language_picker_des language_btn" aria-expanded="false">
+				<button id="language_btn_<?php echo $module->id; ?>" type="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-haspopup="listbox" aria-labelledby="language_picker_des_<?php echo $module->id; ?> language_btn_<?php echo $module->id; ?>" aria-expanded="false">
 					<?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
 						<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 					<?php endif; ?>
@@ -37,7 +37,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 				</button>
 			<?php endif; ?>
 		<?php endforeach; ?>
-		<ul role="listbox" aria-labelledby="language_picker_des" class="lang-block dropdown-menu">
+		<ul role="listbox" aria-labelledby="language_picker_des" class="lang-block dropdown-menu" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
 
 		<?php foreach ($list as $language) : ?>
 			<?php
@@ -71,7 +71,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 		</ul>
 	</div>
 <?php else : ?>
-	<ul role="listbox" aria-labelledby="language_picker_des" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>">
+	<ul role="listbox" aria-labelledby="language_picker_des" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
 
 	<?php foreach ($list as $language) : ?>
 		<?php

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -32,7 +32,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 				<button type ="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-expanded="false">
 					<?php if ($params->get('dropdownimage', 1)) : ?>
 						<?php if ($language->image) : ?>
-							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name', ) ? '' : $language->title_native, null, true); ?>
+							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 						<?php endif; ?>
 					<?php endif; ?>
 					<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
@@ -47,7 +47,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 					<a role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 						<?php if ($params->get('dropdownimage', 1)) : ?>
 							<?php if ($language->image) : ?>
-								<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name', ) ? '' : $language->title_native, null, true); ?>
+								<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 							<?php endif; ?>
 						<?php endif; ?>
 						<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
@@ -59,7 +59,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 					<a aria-selected="true" role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 						<?php if ($params->get('dropdownimage', 1)) : ?>
 							<?php if ($language->image) : ?>
-								<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name', ) ? '' : $language->title_native, null, true); ?>
+								<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 							<?php endif; ?>
 						<?php endif; ?>
 						<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -37,7 +37,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 				</button>
 			<?php endif; ?>
 		<?php endforeach; ?>
-		<ul role="listbox" aria-labelledby="language_picker_des" class="lang-block dropdown-menu" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
+		<ul role="listbox" aria-labelledby="language_picker_des" class="lang-block dropdown-menu">
 
 		<?php foreach ($list as $language) : ?>
 			<?php
@@ -59,7 +59,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 			<?php elseif ($params->get('show_active', 1)) : ?>
 			<?php $base = Uri::getInstance(); ?>
 				<li class="lang-active">
-					<a aria-selected="true" role="option" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+					<a aria-current="true" role="option" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 						<?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
 							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 						<?php endif; ?>
@@ -71,7 +71,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 		</ul>
 	</div>
 <?php else : ?>
-	<ul role="listbox" aria-labelledby="language_picker_des" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
+	<ul role="listbox" aria-labelledby="language_picker_des" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>">
 
 	<?php foreach ($list as $language) : ?>
 		<?php
@@ -98,7 +98,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 		<?php elseif ($params->get('show_active', 1)) : ?>
 			<?php $base = Uri::getInstance(); ?>
 			<li class="lang-active">
-				<a aria-selected="true" role="option" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+				<a aria-current="true" role="option" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 
 				<?php if ($params->get('image', 1)) : ?>
 					<?php if ($language->image) : ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -57,7 +57,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 					</a>
 				</li>
 			<?php elseif ($params->get('show_active', 1)) : ?>
-			<?php $base = Uri::getInstance(); ?>
+				<?php $base = Uri::getInstance(); ?>
 				<li class="lang-active">
 					<a aria-current="true" role="option" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 						<?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -17,8 +17,8 @@ use Joomla\CMS\Uri\Uri;
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 ?>
-<div class="mod-languages" aria-describedby="language_picker_des">
-	<p class="visually-hidden" id="language_picker_des"><?php echo Text::_('MOD_LANGUAGES_DESC'); ?></p>
+<div class="mod-languages">
+	<p class="visually-hidden"><?php echo Text::_('MOD_LANGUAGES_DESC'); ?></p>
 
 <?php if ($headerText) : ?>
 	<div class="mod-languages__pretext pretext"><p><?php echo $headerText; ?></p></div>
@@ -29,14 +29,14 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 	<div class="mod-languages__select btn-group">
 		<?php foreach ($list as $language) : ?>
 			<?php if ($language->active) : ?>
-				<a role="button" href="#" data-bs-toggle="dropdown" class="btn dropdown-toggle" aria-expanded="false">
+				<button href="#" data-bs-toggle="dropdown" class="btn dropdown-toggle" aria-expanded="false">
 					<?php if ($params->get('dropdownimage', 1)) : ?>
 						<?php if ($language->image) : ?>
 							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name', ) ? '' : $language->title_native, null, true); ?>
 						<?php endif; ?>
 					<?php endif; ?>
 					<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
-				</a>
+				</button>
 			<?php endif; ?>
 		<?php endforeach; ?>
 		<ul role="listbox" class="lang-block dropdown-menu" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -18,7 +18,7 @@ $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 ?>
 <div class="mod-languages">
-	<p class="visually-hidden"><?php echo Text::_('MOD_LANGUAGES_DESC'); ?></p>
+	<p class="visually-hidden" id="language_picker_des"><?php echo Text::_('MOD_LANGUAGES_DESC'); ?></p>
 
 <?php if ($headerText) : ?>
 	<div class="mod-languages__pretext pretext"><p><?php echo $headerText; ?></p></div>
@@ -29,7 +29,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 	<div class="mod-languages__select btn-group">
 		<?php foreach ($list as $language) : ?>
 			<?php if ($language->active) : ?>
-				<button type ="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-expanded="false">
+				<button id="language_btn" type ="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-labelledby="language_picker_des language_btn" aria-expanded="false">
 					<?php if ($params->get('dropdownimage', 1)) : ?>
 						<?php if ($language->image) : ?>
 							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -37,7 +37,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 				</button>
 			<?php endif; ?>
 		<?php endforeach; ?>
-		<ul role="listbox" aria-labelledby="language_picker_des" class="lang-block dropdown-menu" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
+		<ul role="listbox" aria-labelledby="language_picker_des" class="lang-block dropdown-menu">
 
 		<?php foreach ($list as $language) : ?>
 			<?php
@@ -71,7 +71,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 		</ul>
 	</div>
 <?php else : ?>
-	<ul role="listbox" aria-labelledby="language_picker_des" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
+	<ul role="listbox" aria-labelledby="language_picker_des" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>">
 
 	<?php foreach ($list as $language) : ?>
 		<?php

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -44,7 +44,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 				$lbl = '';
 				if ($params->get('full_name') === 0)
 				{
-					$lbl = 'aria-label= "' . $language->title_native . '"';
+					$lbl = 'aria-label="' . $language->title_native . '"';
 				}
 			?>
 			<?php if (!$language->active) : ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -29,7 +29,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 	<div class="mod-languages__select btn-group">
 		<?php foreach ($list as $language) : ?>
 			<?php if ($language->active) : ?>
-				<button id="language_btn" type ="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-haspopup="listbox" aria-labelledby="language_picker_des language_btn" aria-expanded="false">
+				<button id="language_btn" type="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-haspopup="listbox" aria-labelledby="language_picker_des language_btn" aria-expanded="false">
 					<?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
 						<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 					<?php endif; ?>
@@ -42,7 +42,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 		<?php foreach ($list as $language) : ?>
 			<?php
 				$lbl = '';
-				if (($params->get('full_name') === 0))
+				if ($params->get('full_name') === 0)
 				{
 					$lbl = 'aria-label = "' . $language->title_native . '"';
 				}

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -44,7 +44,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 				$lbl = '';
 				if ($params->get('full_name') === 0)
 				{
-					$lbl = 'aria-label = "' . $language->title_native . '"';
+					$lbl = 'aria-label= "' . $language->title_native . '"';
 				}
 			?>
 			<?php if (!$language->active) : ?>
@@ -78,7 +78,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 			$lbl = '';
 			if ((($params->get('full_name') === 0) && ($params->get('image') === 0)) || (!$language->image))
 			{
-				$lbl = 'aria-label = "' . $language->title_native . '"';
+				$lbl = 'aria-label= "' . $language->title_native . '"';
 			}
 		?>
 		<?php if (!$language->active) : ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -30,10 +30,8 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 		<?php foreach ($list as $language) : ?>
 			<?php if ($language->active) : ?>
 				<button id="language_btn" type ="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-labelledby="language_picker_des language_btn" aria-expanded="false">
-					<?php if ($params->get('dropdownimage', 1)) : ?>
-						<?php if ($language->image) : ?>
-							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
-						<?php endif; ?>
+					<?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
+						<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 					<?php endif; ?>
 					<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
 				</button>
@@ -45,10 +43,8 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 			<?php if (!$language->active) : ?>
 				<li>
 					<a role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
-						<?php if ($params->get('dropdownimage', 1)) : ?>
-							<?php if ($language->image) : ?>
-								<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
-							<?php endif; ?>
+						<?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
+							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 						<?php endif; ?>
 						<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
 					</a>
@@ -57,10 +53,8 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 			<?php $base = Uri::getInstance(); ?>
 				<li class="lang-active">
 					<a aria-selected="true" role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
-						<?php if ($params->get('dropdownimage', 1)) : ?>
-							<?php if ($language->image) : ?>
-								<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
-							<?php endif; ?>
+						<?php if ($params->get('dropdownimage', 1) && ($language->image)) : ?>
+							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name') ? '' : $language->title_native, null, true); ?>
 						<?php endif; ?>
 						<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
 					</a>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -29,7 +29,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 	<div class="mod-languages__select btn-group">
 		<?php foreach ($list as $language) : ?>
 			<?php if ($language->active) : ?>
-				<button type ="button" data-bs-toggle="dropdown" class="btn dropdown-toggle" aria-expanded="false">
+				<button type ="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown-toggle" aria-expanded="false">
 					<?php if ($params->get('dropdownimage', 1)) : ?>
 						<?php if ($language->image) : ?>
 							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name', ) ? '' : $language->title_native, null, true); ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -10,71 +10,72 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
-
 ?>
-<div class="mod-languages">
+<div class="mod-languages" aria-describedby="language_picker_des">
+	<p class="visually-hidden" id="language_picker_des"><?php echo Text::_('MOD_LANGUAGES_DESC'); ?></p>
+
 <?php if ($headerText) : ?>
 	<div class="mod-languages__pretext pretext"><p><?php echo $headerText; ?></p></div>
 <?php endif; ?>
 
-<?php if ($params->get('dropdown', 0) && !$params->get('dropdownimage', 1)) : ?>
-	<form name="lang" method="post" action="<?php echo htmlspecialchars_decode(htmlspecialchars(Uri::current(), ENT_COMPAT, 'UTF-8'), ENT_NOQUOTES); ?>">
-	<select class="inputbox form-select" onchange="document.location.replace(this.value);" >
-	<?php foreach ($list as $language) : ?>
-		<option dir=<?php echo $language->rtl ? '"rtl"' : '"ltr"'; ?> value="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>" <?php echo $language->active ? 'selected="selected"' : ''; ?>>
-		<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?></option>
-	<?php endforeach; ?>
-	</select>
-	</form>
-<?php elseif ($params->get('dropdown', 0) && $params->get('dropdownimage', 1)) : ?>
+<?php if ($params->get('dropdown', 0)) : ?>
 	<?php HTMLHelper::_('bootstrap.dropdown', '.dropdown-toggle'); ?>
 	<div class="mod-languages__select btn-group">
 		<?php foreach ($list as $language) : ?>
 			<?php if ($language->active) : ?>
-				<a href="#" data-bs-toggle="dropdown" class="btn dropdown-toggle">
-					<?php if ($language->image) : ?>
-						<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
+				<a role="button" href="#" data-bs-toggle="dropdown" class="btn dropdown-toggle" aria-expanded="false">
+					<?php if ($params->get('dropdownimage', 1)) : ?>
+						<?php if ($language->image) : ?>
+							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name', ) ? '' : $language->title_native, null, true); ?>
+						<?php endif; ?>
 					<?php endif; ?>
 					<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
 				</a>
 			<?php endif; ?>
 		<?php endforeach; ?>
-		<ul class="lang-block dropdown-menu" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
+		<ul role="listbox" class="lang-block dropdown-menu" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
+
 		<?php foreach ($list as $language) : ?>
 			<?php if (!$language->active) : ?>
 				<li>
-				<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
-					<?php if ($language->image) : ?>
-						<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
-					<?php endif; ?>
-					<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
-				</a>
+					<a role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+						<?php if ($params->get('dropdownimage', 1)) : ?>
+							<?php if ($language->image) : ?>
+								<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name', ) ? '' : $language->title_native, null, true); ?>
+							<?php endif; ?>
+						<?php endif; ?>
+						<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
+					</a>
 				</li>
 			<?php elseif ($params->get('show_active', 1)) : ?>
 			<?php $base = Uri::getInstance(); ?>
 				<li class="lang-active">
-				<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
-					<?php if ($language->image) : ?>
-						<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', '', null, true); ?>
-					<?php endif; ?>
-					<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
-				</a>
+					<a aria-selected="true" role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+						<?php if ($params->get('dropdownimage', 1)) : ?>
+							<?php if ($language->image) : ?>
+								<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $params->get('full_name', ) ? '' : $language->title_native, null, true); ?>
+							<?php endif; ?>
+						<?php endif; ?>
+						<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
+					</a>
 				</li>
 			<?php endif; ?>
 		<?php endforeach; ?>
 		</ul>
 	</div>
 <?php else : ?>
-	<ul class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
+	<ul role="listbox" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
+
 	<?php foreach ($list as $language) : ?>
 		<?php if (!$language->active) : ?>
 			<li>
-				<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+				<a role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($language->link, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 					<?php if ($params->get('image', 1)) : ?>
 						<?php if ($language->image) : ?>
 							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
@@ -89,18 +90,18 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 		<?php elseif ($params->get('show_active', 1)) : ?>
 			<?php $base = Uri::getInstance(); ?>
 			<li class="lang-active">
-			<a href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
+				<a aria-selected="true" role="option" href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
 
-			<?php if ($params->get('image', 1)) : ?>
-				<?php if ($language->image) : ?>
-					<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+				<?php if ($params->get('image', 1)) : ?>
+					<?php if ($language->image) : ?>
+						<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+					<?php else : ?>
+						<span class="badge bg-secondary"><?php echo strtoupper($language->sef); ?></span>
+					<?php endif; ?>
 				<?php else : ?>
-					<span class="badge bg-secondary"><?php echo strtoupper($language->sef); ?></span>
+					<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
 				<?php endif; ?>
-			<?php else : ?>
-				<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
-			<?php endif; ?>
-			</a>
+				</a>
 			</li>
 		<?php endif; ?>
 	<?php endforeach; ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -99,16 +99,15 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 			<?php $base = Uri::getInstance(); ?>
 			<li class="lang-active">
 				<a aria-current="true" role="option" <?php echo $lbl; ?> href="<?php echo htmlspecialchars_decode(htmlspecialchars($base, ENT_QUOTES, 'UTF-8'), ENT_NOQUOTES); ?>">
-
-				<?php if ($params->get('image', 1)) : ?>
-					<?php if ($language->image) : ?>
-						<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+					<?php if ($params->get('image', 1)) : ?>
+						<?php if ($language->image) : ?>
+							<?php echo HTMLHelper::_('image', 'mod_languages/' . $language->image . '.gif', $language->title_native, array('title' => $language->title_native), true); ?>
+						<?php else : ?>
+							<span class="badge bg-secondary" title="<?php echo $language->title_native; ?>"><?php echo strtoupper($language->sef); ?></span>
+						<?php endif; ?>
 					<?php else : ?>
-						<span class="badge bg-secondary" title="<?php echo $language->title_native; ?>"><?php echo strtoupper($language->sef); ?></span>
+						<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
 					<?php endif; ?>
-				<?php else : ?>
-					<?php echo $params->get('full_name', 1) ? $language->title_native : strtoupper($language->sef); ?>
-				<?php endif; ?>
 				</a>
 			</li>
 		<?php endif; ?>

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -37,7 +37,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 				</button>
 			<?php endif; ?>
 		<?php endforeach; ?>
-		<ul role="listbox" class="lang-block dropdown-menu" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
+		<ul role="listbox" aria-labelledby="language_picker_des" class="lang-block dropdown-menu" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
 
 		<?php foreach ($list as $language) : ?>
 			<?php if (!$language->active) : ?>
@@ -64,7 +64,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 		</ul>
 	</div>
 <?php else : ?>
-	<ul role="listbox" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
+	<ul role="listbox" aria-labelledby="language_picker_des" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>" dir="<?php echo $app->getLanguage()->isRtl() ? 'rtl' : 'ltr'; ?>">
 
 	<?php foreach ($list as $language) : ?>
 		<?php if (!$language->active) : ?>

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -240,10 +240,6 @@ figcaption {
   flex-direction: column;
 }
 
-.mod-languages__select {
-  background-color: $white;
-}
-
 // meter element
 meter {
   width: 100%;

--- a/templates/cassiopeia/scss/vendor/bootstrap/_dropdown.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_dropdown.scss
@@ -5,19 +5,6 @@
   margin-top: .5rem;
   background-color: $white;
   border-color: $cassiopeia-border-color;
-
-  &::after {
-    position: absolute;
-    top: -1.5rem;
-    left: .9rem;
-    font-family: "Font Awesome 5 Free";
-    font-size: 1.6rem;
-    font-weight: 900;
-    color: $white;
-    text-shadow: 0 -1px 0 hsla(0, 0%, 0%, .2);
-    content: "\f0d8";
-  }
-
 }
 
 .dropdown-item {


### PR DESCRIPTION
Replacing #31275.

### Summary of Changes
Several changes in the code of mod_languages, based on the comments here: https://github.com/joomla/joomla-cms/pull/31275#issuecomment-841653921

Also changes in the CSS of the module itself and in Cassiopeia


### Testing Instructions
You need a multilanguage Joomla installation. Create several language switcher modules using the different parameter combinations: with / without dropdown, with / without images... see https://github.com/joomla/joomla-cms/pull/31275#issuecomment-841788150

Install the patch and run npm ci


### Actual result BEFORE applying this Pull Request
Sometimes missing alt description for the flags
Different select list (select list or dropdown) if flags are present or not
Shadow and arrow in the dropdown menu

### Expected result AFTER applying this Pull Request

![grafik](https://user-images.githubusercontent.com/9153168/118658353-95e66000-b7ec-11eb-9ecd-9a7483f7d019.png)

![grafik](https://user-images.githubusercontent.com/9153168/118658376-9b43aa80-b7ec-11eb-9811-1653c21f6554.png)


### Documentation Changes Required

