### PR TITLE
[4.0] Fix menu item in recover mode

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -144,7 +144,7 @@ elseif ($link != '' && $current->type !== 'separator')
 }
 elseif ($current->title != '' && $current->type !== 'separator')
 {
-	echo "<a" . $linkClass . $dataToggle . ">"
+	echo "<a" . $linkClass . $dataToggle . " href=\"#\">"
 		. $iconClass
 		. '<span class="sidebar-item-title">'. $itemImage . Text::_($current->title) . '</span>' . $ajax . '</a>';
 }


### PR DESCRIPTION
### Summary of Changes

Fixed item in left menu has no changes in cursor on hover (in recover mode)

### Testing Instructions

Go to recover mode and hover on menu recovery
![img](https://user-images.githubusercontent.com/42320170/118542120-3e4be400-b75b-11eb-802a-b3699918c94d.png)


### Actual result BEFORE applying this Pull Request

The item has no changes in cursor on hover

### Expected result AFTER applying this Pull Request

The cursor becomes like CSS `cursor: pointer` property when it enters the menu item.