### PR TITLE
[4.0] Fix transitions display

### DIFF
--- a/administrator/components/com_workflow/tmpl/transition/edit.php
+++ b/administrator/components/com_workflow/tmpl/transition/edit.php
@@ -32,9 +32,7 @@ $tmpl    = $isModal || $this->input->get('tmpl', '', 'cmd') === 'component' ? '&
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_workflow&view=transition&workflow_id=' . $this->workflowID . '&extension=' . $this->input->getCmd('extension') . '&layout=' . $layout . $tmpl . '&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="workflow-form" aria-label="<?php echo Text::_('COM_WORKFLOW_TRANSITION_FORM_' . ( (int) $this->item->id === 0 ? 'NEW' : 'EDIT'), true); ?>" class="form-validate">
-
 	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
-
 	<div class="main-card">
 		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 

--- a/administrator/components/com_workflow/tmpl/transition/edit.php
+++ b/administrator/components/com_workflow/tmpl/transition/edit.php
@@ -32,9 +32,10 @@ $tmpl    = $isModal || $this->input->get('tmpl', '', 'cmd') === 'component' ? '&
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_workflow&view=transition&workflow_id=' . $this->workflowID . '&extension=' . $this->input->getCmd('extension') . '&layout=' . $layout . $tmpl . '&id=' . (int) $this->item->id); ?>" method="post" name="adminForm" id="workflow-form" aria-label="<?php echo Text::_('COM_WORKFLOW_TRANSITION_FORM_' . ( (int) $this->item->id === 0 ? 'NEW' : 'EDIT'), true); ?>" class="form-validate">
-	<div class="main-card">
-		<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
+	<?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
+
+	<div class="main-card">
 		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
 		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('COM_WORKFLOW_TRANSITION')); ?>


### PR DESCRIPTION
### Summary of Changes
Change markup to fix transitions display.


### Testing Instructions
Go to Global Configuration > Integration
Enable Workflows
Go to Content > Workflows
Under Transitions column, click badge.


### Actual result BEFORE applying this Pull Request
![transitions-before](https://user-images.githubusercontent.com/368084/118562357-6585bf80-b721-11eb-8e5c-a94d898d8363.jpg)



### Expected result AFTER applying this Pull Request
![transitions-after](https://user-images.githubusercontent.com/368084/118562372-6caccd80-b721-11eb-80d3-201b78702933.jpg)

