### PR TITLE
[4.0] Fix drag and drop ordering logic

### DIFF
--- a/build/media_source/system/js/draggable.es6.js
+++ b/build/media_source/system/js/draggable.es6.js
@@ -2,186 +2,182 @@
  * @copyright  (C) 2019 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
+// The container where the draggable will be enabled
+let url;
+let direction;
+let isNested;
+let dragElementIndex;
+let dropElementIndex;
+let container = document.querySelector('.js-draggable');
+const orderRows = container.querySelectorAll('[name="order[]"]');
 
-document.addEventListener('DOMContentLoaded', () => {
-  'use strict';
+if (container) {
+  /** The script expects a form with a class js-form
+   *  A table with the tbody with a class js-draggable
+   *                         with a data-url with the ajax request end point and
+   *                         with a data-direction for asc/desc
+   */
+  url = container.dataset.url;
+  direction = container.dataset.direction;
+  isNested = container.dataset.nested;
+} else if (Joomla.getOptions('draggable-list')) {
+  const options = Joomla.getOptions('draggable-list');
 
-  // The container where the draggable will be enabled
-  let url;
-  let direction;
-  let isNested;
-  let dragElementIndex;
-  let dropElementIndex;
-  let container = document.querySelector('.js-draggable');
-  const orderRows = container.querySelectorAll('[name="order[]"]');
-
-  if (container) {
-    /** The script expects a form with a class js-form
-     *  A table with the tbody with a class js-draggable
-     *                         with a data-url with the ajax request end point and
-     *                         with a data-direction for asc/desc
-     */
-    url = container.getAttribute('data-url');
-    direction = container.getAttribute('data-direction');
-    isNested = container.getAttribute('data-nested');
-  } else if (Joomla.getOptions('draggable-list')) {
-    const options = Joomla.getOptions('draggable-list');
-
-    container = document.querySelector(options.id);
-    /**
-     * This is here to make the transition to new forms easier.
-     */
-    if (!container.classList.contains('js-draggable')) {
-      container.classList.add('js-draggable');
-    }
-
-    ({ url } = options);
-    ({ direction } = options);
-    isNested = options.nested;
+  container = document.querySelector(options.id);
+  /**
+   * This is here to make the transition to new forms easier.
+   */
+  if (!container.classList.contains('js-draggable')) {
+    container.classList.add('js-draggable');
   }
 
-  if (container) {
-    // Add data order attribute for initial ordering
-    for (let i = 0, l = orderRows.length; l > i; i += 1) {
-      orderRows[i].setAttribute('data-order', i + 1);
-    }
+  ({ url } = options);
+  ({ direction } = options);
+  isNested = options.nested;
+}
 
-    // IOS 10 BUG
-    document.addEventListener('touchstart', () => {}, false);
+if (container) {
+  // Add data order attribute for initial ordering
+  for (let i = 0, l = orderRows.length; l > i; i += 1) {
+    orderRows[i].dataset.order = i + 1;
+  }
 
-    const getOrderData = (rows, inputRows, dragIndex, dropIndex) => {
-      let i;
-      const result = [];
+  // IOS 10 BUG
+  document.addEventListener('touchstart', () => {}, false);
 
-      // Element is moved down
-      if (dragIndex < dropIndex) {
-        rows[dropIndex].setAttribute('value', rows[dropIndex - 1].value);
+  const getOrderData = (rows, inputRows, dragIndex, dropIndex) => {
+    let i;
+    const result = [];
 
-        // Move down
-        for (i = dragIndex; i < dropIndex; i += 1) {
-          if (direction === 'asc') {
-            rows[i].setAttribute('value', parseInt(rows[i].value, 10) - 1);
-          } else {
-            rows[i].setAttribute('value', parseInt(rows[i].value, 10) + 1);
-          }
+    // Element is moved down
+    if (dragIndex < dropIndex) {
+      rows[dropIndex].setAttribute('value', rows[dropIndex - 1].value);
 
-          result.push(`order[]=${encodeURIComponent(rows[i].value)}`);
-          result.push(`cid[]=${encodeURIComponent(inputRows[i].value)}`);
+      // Move down
+      for (i = dragIndex; i < dropIndex; i += 1) {
+        if (direction === 'asc') {
+          rows[i].setAttribute('value', parseInt(rows[i].value, 10) - 1);
+        } else {
+          rows[i].setAttribute('value', parseInt(rows[i].value, 10) + 1);
         }
 
-        result.push(`order[]=${encodeURIComponent(rows[dropIndex].value)}`);
-        result.push(`cid[]=${encodeURIComponent(inputRows[dropIndex].value)}`);
-      } else {
-        // Element is moved up
-
-        rows[dropIndex].setAttribute('value', rows[dropIndex + 1].value);
-        rows[dropIndex].value = rows[dropIndex + 1].value;
-
-        result.push(`order[]=${encodeURIComponent(rows[dropIndex].value)}`);
-        result.push(`cid[]=${encodeURIComponent(inputRows[dropIndex].value)}`);
-
-        for (i = dropIndex + 1; i <= dragIndex; i += 1) {
-          if (direction === 'asc') {
-            rows[i].value = parseInt(rows[i].value, 10) + 1;
-          } else {
-            rows[i].value = parseInt(rows[i].value, 10) - 1;
-          }
-
-          result.push(`order[]=${encodeURIComponent(rows[i].value)}`);
-          result.push(`cid[]=${encodeURIComponent(inputRows[i].value)}`);
-        }
+        result.push(`order[]=${encodeURIComponent(rows[i].value)}`);
+        result.push(`cid[]=${encodeURIComponent(inputRows[i].value)}`);
       }
 
-      return result;
-    };
+      result.push(`order[]=${encodeURIComponent(rows[dropIndex].value)}`);
+      result.push(`cid[]=${encodeURIComponent(inputRows[dropIndex].value)}`);
+    } else {
+      // Element is moved up
 
-    // eslint-disable-next-line no-undef
-    dragula([container], {
-      // Y axis is considered when determining where an element would be dropped
-      direction: 'vertical',
-      // elements are moved by default, not copied
-      copy: false,
-      // elements in copy-source containers can be reordered
-      // copySortSource: true,
-      // spilling will put the element back where it was dragged from, if this is true
-      revertOnSpill: true,
-      // spilling will `.remove` the element, if this is true
-      // removeOnSpill: false,
+      rows[dropIndex].setAttribute('value', rows[dropIndex + 1].value);
+      rows[dropIndex].value = rows[dropIndex + 1].value;
 
-      accepts(el, target, source, sibling) {
-        if (isNested) {
-          if (sibling !== null) {
-            return sibling.getAttribute('data-draggable-group') && sibling.getAttribute('data-draggable-group') === el.getAttribute('data-draggable-group');
-          }
+      result.push(`order[]=${encodeURIComponent(rows[dropIndex].value)}`);
+      result.push(`cid[]=${encodeURIComponent(inputRows[dropIndex].value)}`);
 
-          return sibling === null || (sibling && sibling.tagName.toLowerCase() === 'tr');
+      for (i = dropIndex + 1; i <= dragIndex; i += 1) {
+        if (direction === 'asc') {
+          rows[i].value = parseInt(rows[i].value, 10) + 1;
+        } else {
+          rows[i].value = parseInt(rows[i].value, 10) - 1;
+        }
+
+        result.push(`order[]=${encodeURIComponent(rows[i].value)}`);
+        result.push(`cid[]=${encodeURIComponent(inputRows[i].value)}`);
+      }
+    }
+
+    return result;
+  };
+
+  // eslint-disable-next-line no-undef
+  dragula([container], {
+    // Y axis is considered when determining where an element would be dropped
+    direction: 'vertical',
+    // elements are moved by default, not copied
+    copy: false,
+    // elements in copy-source containers can be reordered
+    // copySortSource: true,
+    // spilling will put the element back where it was dragged from, if this is true
+    revertOnSpill: true,
+    // spilling will `.remove` the element, if this is true
+    // removeOnSpill: false,
+
+    accepts(el, target, source, sibling) {
+      if (isNested) {
+        if (sibling !== null) {
+          return sibling.dataset.draggableGroup
+            && sibling.dataset.draggableGroup === el.dataset.draggableGroup;
         }
 
         return sibling === null || (sibling && sibling.tagName.toLowerCase() === 'tr');
-      },
+      }
 
-      mirrorContainer: container,
+      return sibling === null || (sibling && sibling.tagName.toLowerCase() === 'tr');
+    },
+
+    mirrorContainer: container,
+  })
+    .on('drag', (el) => {
+      dragElementIndex = parseInt(el.querySelector('[name="order[]"]').dataset.order, 10) - 1;
     })
-      .on('drag', (el) => {
-        dragElementIndex = parseInt(el.querySelector('[name="order[]"]').getAttribute('data-order'), 10) - 1;
-      })
-      .on('cloned', () => {
+    .on('cloned', () => {
 
-      })
-      .on('drop', (el) => {
-        let orderSelector;
-        let inputSelector;
+    })
+    .on('drop', (el) => {
+      let orderSelector;
+      let inputSelector;
 
-        const groupId = el.getAttribute('data-draggable-group');
-        if (groupId) {
-          orderSelector = `[data-draggable-group="${groupId}"] [name="order[]"]`;
-          inputSelector = `[data-draggable-group="${groupId}"] [name="cid[]"]`;
-        } else {
-          orderSelector = '[name="order[]"]';
-          inputSelector = '[name="cid[]"]';
+      const groupId = el.dataset.draggableGroup;
+      if (groupId) {
+        orderSelector = `[data-draggable-group="${groupId}"] [name="order[]"]`;
+        inputSelector = `[data-draggable-group="${groupId}"] [name="cid[]"]`;
+      } else {
+        orderSelector = '[name="order[]"]';
+        inputSelector = '[name="cid[]"]';
+      }
+
+      const rows = [].slice.call(container.querySelectorAll(orderSelector));
+      const inputRows = [].slice.call(container.querySelectorAll(inputSelector));
+
+      for (let i = 0, l = rows.length - 1; l > i; i += 1) {
+        if (rows[i].dataset.order === el.querySelector('[name="order[]"]').dataset.order) {
+          dropElementIndex = i;
+          break;
         }
+      }
 
-        const rows = [].slice.call(container.querySelectorAll(orderSelector));
-        const inputRows = [].slice.call(container.querySelectorAll(inputSelector));
-
-        for (let i = 0, l = rows.length - 1; l > i; i += 1) {
-          if (rows[i].getAttribute('data-order') === el.querySelector('[name="order[]"]').getAttribute('data-order')) {
-            dropElementIndex = i;
-            break;
-          }
-        }
-
-        if (url) {
+      if (url) {
         // Detach task field if exists
-          const task = document.querySelector('[name="task"]');
+        const task = document.querySelector('[name="task"]');
 
-          // Detach task field if exists
-          if (task) {
-            task.setAttribute('name', 'some__Temporary__Name__');
-          }
-
-          // Prepare the options
-          const ajaxOptions = {
-            url,
-            method: 'POST',
-            data: getOrderData(rows, inputRows, dragElementIndex, dropElementIndex).join('&'),
-            perform: true,
-          };
-
-          Joomla.request(ajaxOptions);
-
-          // Re-Append original task field
-          if (task) {
-            task.setAttribute('name', 'task');
-          }
+        // Detach task field if exists
+        if (task) {
+          task.setAttribute('name', 'some__Temporary__Name__');
         }
-      })
-      .on('dragend', () => {
-        const elements = container.querySelectorAll('[name="order[]"]');
-        // Reset data order attribute for initial ordering
-        for (let i = 0, l = elements.length; l > i; i += 1) {
-          elements[i].setAttribute('data-order', i + 1);
+
+        // Prepare the options
+        const ajaxOptions = {
+          url,
+          method: 'POST',
+          data: getOrderData(rows, inputRows, dragElementIndex, dropElementIndex).join('&'),
+          perform: true,
+        };
+
+        Joomla.request(ajaxOptions);
+
+        // Re-Append original task field
+        if (task) {
+          task.setAttribute('name', 'task');
         }
-      });
-  }
-});
+      }
+    })
+    .on('dragend', () => {
+      const elements = container.querySelectorAll('[name="order[]"]');
+      // Reset data order attribute for initial ordering
+      for (let i = 0, l = elements.length; l > i; i += 1) {
+        elements[i].dataset.order = i + 1;
+      }
+    });
+}


### PR DESCRIPTION
Pull Request for Issue #33917

### Summary of Changes
My attempt to fix drag and drop re-ordering issue https://github.com/joomla/joomla-cms/issues/33917 . Ping everyone to review code, especial @dgrammatiko @Fedik @Ruud68 who understand the issue and discussed about it in https://github.com/joomla/joomla-cms/issues/33917

### Testing Instructions
1. Download update package for this PR at https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/33937/downloads/43843/Joomla_4.0.0-beta8-dev+pr.33937-Development-Update_Package.zip , go to System ->Update -> Joomla, upload and install that updated package

2. Go to Users -> Fields, create 7 or 8 user custom fields . (You just need to create 1 field, then use Save As Copy to create other fields to save time)

3. Click on Sort icon to sort fields by ordering, try to drag and drop to change of the field. Then re-fresh the page and make sure the ordering is sorted.
4. Choose 5 from Number records dropdown (so that the system will only display 5 records per page). Navigate to page 2 (that's the reason I asked you to create 7 or 8 fields). Then try to change ordering of items on that second page, refresh the page and make sure the ordering are kept (items ordering are saved properly)

### Actual result BEFORE applying this Pull Request
- ordering data of all items changed for each re-order action. Could cause performance issue
- ordering data of items always re-started from 1, which cause wrong ordering value, especially when we re-order items from page 2, page 3....

### Expected result AFTER applying this Pull Request
- only ordering data of the necessary items are changed. 
- ordering data of items in next page (page 2, page 3...) are calculated base on it's existing ordering data and the item which is re-ordered in the action