### PR TITLE
[4.0] metatitle in newsfeed display

### DIFF
--- a/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -308,11 +308,6 @@ class HtmlView extends BaseHtmlView
 			$this->document->setMetaData('robots', $this->params->get('robots'));
 		}
 
-		if ($app->get('MetaTitle') == '1')
-		{
-			$this->document->setMetaData('title', $this->item->name);
-		}
-
 		if ($app->get('MetaAuthor') == '1')
 		{
 			$this->document->setMetaData('author', $this->item->author);

--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -120,7 +120,6 @@ class JConfig
 
 	/* Meta Settings */
 	public $MetaDesc = 'Joomla! - the dynamic portal engine and content management system';
-	public $MetaTitle = true;
 	public $MetaAuthor = true;
 	public $MetaVersion = false;
 	public $MetaRights = '';

--- a/installation/src/Model/ConfigurationModel.php
+++ b/installation/src/Model/ConfigurationModel.php
@@ -453,7 +453,6 @@ class ConfigurationModel extends BaseInstallationModel
 
 		// Meta settings.
 		$registry->set('MetaDesc', '');
-		$registry->set('MetaTitle', true);
 		$registry->set('MetaAuthor', true);
 		$registry->set('MetaVersion', false);
 		$registry->set('robots', '');


### PR DESCRIPTION
@philetaylor spotted this ~#33879~ #33789 

Meta tags are for data that cannot be represented by html. [mdn](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta) specifically states that title is one of the things you do NOT need to set a meta tag for.

I am guessing that at some point over 10 years ago we mistakenly had this tag and it was removed but this one bit was left.

This PR stops the value being set in configuration.php on new installs
This PR stops a frontend display of a newsfeed adding meta name=title to the head
This PR will not remove the line from an existing configuration.php as its userdata we shouldnt touch. But as its no longer referenced anywhere there is no problem.
