### PR TITLE
[4.0] Fixing search suggestions for mixed-case searches

### DIFF
--- a/components/com_finder/src/Model/SuggestionsModel.php
+++ b/components/com_finder/src/Model/SuggestionsModel.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Component\Finder\Administrator\Indexer\Helper;
 use Joomla\Database\DatabaseQuery;
+use Joomla\String\StringHelper;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -76,7 +77,7 @@ class SuggestionsModel extends ListModel
 		// Limit term count to a reasonable number of results to reduce main query join size
 		$termIdQuery->select('ti.term_id')
 			->from($db->quoteName('#__finder_terms', 'ti'))
-			->where('ti.term LIKE ' . $db->quote($db->escape($this->getState('input'), true) . '%', false))
+			->where('ti.term LIKE ' . $db->quote($db->escape(StringHelper::strtolower($this->getState('input')), true) . '%', false))
 			->where('ti.common = 0')
 			->where('ti.language IN (' . $db->quote($lang) . ', ' . $db->quote('*') . ')')
 			->order('ti.links DESC')


### PR DESCRIPTION
### Summary of Changes
The search suggestions are not lowercasing the search term when searching for suggestions, thus having no result when the search term starts with an uppercase character. This should fix this.


### Testing Instructions
1. Setup Smart Search
2. Search for "Joomla" and see no suggestions
3. Apply patch
4. Type in "Joo" and see that you get suggestions with "joomla"