### PR TITLE
Fix PHP notice "Undefined variable: article" for action logs

### DIFF
--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -528,7 +528,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'id'             => $table->get($params->id_holder),
 			'title'          => $table->get($params->title_holder),
 			'extension_name' => $table->get($params->title_holder),
-			'itemlink'       => ActionlogsHelper::getContentTypeLink($option, $contentType, $table->get($params->id_holder), $params->id_holder, $article)
+			'itemlink'       => ActionlogsHelper::getContentTypeLink($option, $contentType, $table->get($params->id_holder), $params->id_holder, null)
 		);
 
 		$this->addLog(array($message), $messageLanguageKey, $context);


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/31836#discussion_r634316916 .

### Summary of Changes

Fix PHP notice caused by an undefined variable `$article` being used as function parameter where it should be null, see other places in that file using `ActionlogsHelper::getContentTypeLink` without a media object.

The notice is caused by PR #31836 which has impelemnted that code. It looks like a remainder from copy and paste.

### Testing Instructions

1. Set error reporting to maximum and log PHP errors into a file.

2. Upload an item into the media manager.

3. Check in the action log for the action from step 2 that the link on the uploaded file name is correct and leads to the folder of the uploaded item.

4. Change the options of an extension and check that the action is logged correctly.

5. Install or uninstall an extension and check that the action is logged correctly.

6. Check your PHP log if there are logged any PHP notices.

Result. The PHP error log shows PHP notice(s) "Undefined variable: article".

7. Apply the patch of this PR.

8. Repeat steps 2 to 6.

Result. No PHP notice(s) "Undefined variable: article".

### Actual result BEFORE applying this Pull Request

Action log works, but you get a PHP notice "Undefined variable: article"

### Expected result AFTER applying this Pull Request

Action log still works as before, but there is no PHP notice "Undefined variable: article".

### Documentation Changes Required

None.