### PR TITLE
[3] Fixing search suggestions for mixed-case searches

### DIFF
--- a/components/com_finder/models/suggestions.php
+++ b/components/com_finder/models/suggestions.php
@@ -94,7 +94,7 @@ class FinderModelSuggestions extends JModelList
 			->order('t.weight DESC');
 
 		// Determine the relevant mapping table suffix by inverting the logic from drivers
-		$mappingTableSuffix = StringHelper::substr(md5(StringHelper::substr($this->getState('input'), 0, 1)), 0, 1);
+		$mappingTableSuffix = StringHelper::substr(md5(StringHelper::substr(StringHelper::strtolower($this->getState('input')), 0, 1)), 0, 1);
 
 		// Join mapping table for term <-> link relation
 		$mappingTable = $db->quoteName('#__finder_links_terms' . $mappingTableSuffix);

--- a/components/com_finder/models/suggestions.php
+++ b/components/com_finder/models/suggestions.php
@@ -70,7 +70,7 @@ class FinderModelSuggestions extends JModelList
 		// Limit term count to a reasonable number of results to reduce main query join size
 		$termIdQuery->select('ti.term_id')
 			->from($db->quoteName('#__finder_terms', 'ti'))
-			->where('ti.term LIKE ' . $db->quote($db->escape($this->getState('input'), true) . '%', false))
+			->where('ti.term LIKE ' . $db->quote($db->escape(StringHelper::strtolower($this->getState('input')), true) . '%', false))
 			->where('ti.common = 0')
 			->where('ti.language IN (' . $db->quote($this->getState('language')) . ', ' . $db->quote('*') . ')')
 			->order('ti.links DESC')


### PR DESCRIPTION
### Summary of Changes
The search suggestions are not lowercasing the search term when searching for suggestions, thus having no result when the search term starts with an uppercase character. This should fix this.

### Testing Instructions
1. Setup Smart Search
2. Search for "Joomla" and see no suggestions
3. Apply patch
4. Type in "Joo" and see that you get suggestions with "joomla"
