### PR TITLE
[4.0] No quickicon if com_privacy is disabled

### DIFF
--- a/plugins/quickicon/privacycheck/privacycheck.php
+++ b/plugins/quickicon/privacycheck/privacycheck.php
@@ -9,6 +9,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
@@ -48,7 +49,9 @@ class PlgQuickiconPrivacyCheck extends CMSPlugin
 	 */
 	public function onGetIcons($context)
 	{
-		if ($context !== $this->params->get('context', 'update_quickicon') || !$this->app->getIdentity()->authorise('core.admin', 'com_privacy'))
+		if ($context !== $this->params->get('context', 'update_quickicon')
+			|| !$this->app->getIdentity()->authorise('core.admin', 'com_privacy')
+			|| !ComponentHelper::isEnabled('com_privacy'))
 		{
 			return array();
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Change
Don't show the quickicon for privacy if com_privacy is disabled.

### Testing Instructions
Disable com_privacy, go back to control panel
![grafik](https://user-images.githubusercontent.com/1035262/118676278-8e7a8300-b7fb-11eb-98a5-78af7fa81478.png)


### Actual result BEFORE applying this Pull Request
On the dashboard, the Quickicon button for privacy requests is red.
The link index.php?option=com_privacy&amp;view=request leads to the error "404 component not found"

![grafik](https://user-images.githubusercontent.com/1035262/118665683-c7622a00-b7f2-11eb-851a-c366e39e3ab9.png)


### Expected result AFTER applying this Pull Request
There is no button on the quickicons panel if the component is deactivated

![grafik](https://user-images.githubusercontent.com/1035262/118668599-507a6080-b7f5-11eb-8051-13342ea73e38.png)


### Documentation Changes Required
? 
