### PR TITLE
[4.0] Fix narrow column width in list view of media manager

### DIFF
--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -292,26 +292,26 @@
 
 .media-browser-table {
   .name {
-    width: calc(30% - 40px);
+    width: 40%;
     word-break: break-all;
   }
   .size {
-    width: 15%;
+    width: 10%;
     text-align: right;
   }
   .dimension {
     width: 15%;
   }
   .created {
-    width: 20%;
+    width: 15%;
   }
   .modified {
-    width: 20%;
+    width: 15%;
   }
   .type {
     position: relative;
     z-index: 0;
-    width: 50px;
+    width: 5%;
     padding: .6rem 0;
     font-size: $table-item-icon-size;
     line-height: $table-item-height;

--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -307,8 +307,8 @@
   .type {
     position: relative;
     z-index: 0;
-    min-width: 49px;
     width: 49px;
+    min-width: 49px;
     padding: .6rem 0;
     font-size: $table-item-icon-size;
     line-height: $table-item-height;

--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -293,6 +293,7 @@
 .media-browser-table {
   .name {
     width: calc(30% - 40px);
+    word-break: break-all;
   }
   .size {
     width: 15%;

--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -291,10 +291,6 @@
 }
 
 .media-browser-table {
-  .name {
-    width: 40%;
-    word-break: break-all;
-  }
   .size {
     width: 10%;
     text-align: right;
@@ -311,7 +307,8 @@
   .type {
     position: relative;
     z-index: 0;
-    width: 5%;
+    min-width: 49px;
+    width: 49px;
     padding: .6rem 0;
     font-size: $table-item-icon-size;
     line-height: $table-item-height;


### PR DESCRIPTION
Pull Request for Issue #33943.

### Summary of Changes

Fix of the narrow column width in media manager.

### Testing Instructions

Go to Content > Media
Click List icon.
Go to sampledata > parks > landscape

### Actual result BEFORE applying this Pull Request

Icons column has small width

### Expected result AFTER applying this Pull Request

Icons column has enough width