### PR TITLE
[4][Security] Do not allow command line to be called from the web

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -107,7 +107,7 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 		?OutputInterface $output = null
 	)
 	{
-		// Close the application if we are not executed from the command line.
+		// Close the application if it is not executed from the command line.
 		if (!\defined('STDOUT') || !\defined('STDIN') || !isset($_SERVER['argv']))
 		{
 			$this->close();

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -107,6 +107,12 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 		?OutputInterface $output = null
 	)
 	{
+		// Close the application if we are not executed from the command line.
+		if (!\defined('STDOUT') || !\defined('STDIN') || !isset($_SERVER['argv']))
+		{
+			$this->close();
+		}
+
 		// Set up a Input object for Controllers etc to use
 		$this->input    = new \Joomla\CMS\Input\Cli;
 		$this->language = $language;


### PR DESCRIPTION
### Summary of Changes

StackOverflow emailed me this https://joomla.stackexchange.com/questions/29123/cli-directory-is-publicly-accessible-is-it-supposed-to-be-is-that-safe/29181

They were correct, that Joomla 4 did not have any test for CLI use when the scripts were called from the web.  

The code proposed is back ported from the [Joomla-framework `Joomla\Console\Application` constructor](https://github.com/joomla-framework/console/blob/537038ea7eb67a807c1b502801441206a16c56f7/src/Application.php#L190
) and so should be "good enough"

### Testing Instructions

Go to http://example.com/cli/joomla.php in a web browser. 

### Actual result BEFORE applying this Pull Request

With debug on/error reporting = maximum 
<img width="1424" alt="Screenshot 2021-05-18 at 18 17 17" src="https://user-images.githubusercontent.com/400092/118695609-4b251200-b805-11eb-887a-6872a8bbfc57.png">

With debug off/error_reporting none

<img width="1294" alt="Screenshot 2021-05-18 at 18 18 00" src="https://user-images.githubusercontent.com/400092/118695745-6f80ee80-b805-11eb-9c61-1cd62fb42132.png">

### Expected result AFTER applying this Pull Request

White screen of death - which is a good thing.

### Documentation Changes Required

// @joomla/security @wilsonge 