### PR TITLE
[4.0] Solving the wrong method on button margin

### DIFF
--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -47,12 +47,12 @@ $adminFormClass = count($this->extension_options) > 1 ? 'form-inline mb-3' : 'vi
 			<div>
 				<?php echo Text::_($item->description_key); ?>
 				<?php if ($item->type !== 'message') : ?>
-				<a href="<?php echo Route::_('index.php?option=com_postinstall&view=messages&task=message.action&id=' . $item->postinstall_message_id . '&' . $this->token . '=1'); ?>" class="btn btn-primary my-1">
+				<a href="<?php echo Route::_('index.php?option=com_postinstall&view=messages&task=message.action&id=' . $item->postinstall_message_id . '&' . $this->token . '=1'); ?>" class="btn btn-primary">
 					<?php echo Text::_($item->action_key); ?>
 				</a>
 				<?php endif; ?>
 				<?php if (Factory::getApplication()->getIdentity()->authorise('core.edit.state', 'com_postinstall')) : ?>
-				<a href="<?php echo Route::_('index.php?option=com_postinstall&view=messages&task=message.unpublish&id=' . $item->postinstall_message_id . '&' . $this->token . '=1'); ?>" class="btn btn-danger btn-sm my-1">
+				<a href="<?php echo Route::_('index.php?option=com_postinstall&view=messages&task=message.unpublish&id=' . $item->postinstall_message_id . '&' . $this->token . '=1'); ?>" class="btn btn-danger btn-sm">
 					<?php echo Text::_('COM_POSTINSTALL_BTN_HIDE'); ?>
 				</a>
 				<?php endif; ?>

--- a/administrator/templates/atum/scss/vendor/bootstrap/_buttons.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_buttons.scss
@@ -33,3 +33,9 @@
   background-color: var(--atum-bg-dark);
   border-color: var(--atum-bg-dark);
 }
+
+@include media-breakpoint-down(md) {
+  .btn {
+    margin-bottom: .25rem;
+  }
+}


### PR DESCRIPTION
Pull Request for Issue #33717  .

### Summary of Changes

Earlier wrong method bootstrap margin was used individually on both the buttons

Solved it now using the SCSS margin.

`@include media-breakpoint-down(md) {
  .btn {
    margin-bottom: .25rem;
  }
}`

### Testing Instructions

In the dashboard go to the Post Installation Messages page.

### Actual result BEFORE applying this Pull Request

![13 05 2021_15 45 42_REC](https://user-images.githubusercontent.com/63739986/118708752-be487b80-b839-11eb-90bc-4a0203729cde.png)


### Expected result AFTER applying this Pull Request

![13 05 2021_20 50 17_REC](https://user-images.githubusercontent.com/63739986/118708774-c6a0b680-b839-11eb-8d58-7703ed4af833.png)


### Documentation Changes Required

No
