### PR TITLE
[4.0] Composer update phpmailer to version 6.4.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2306,16 +2306,16 @@
         },
         {
             "name": "phpmailer/phpmailer",
-            "version": "v6.4.0",
+            "version": "v6.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPMailer/PHPMailer.git",
-                "reference": "050d430203105c27c30efd1dce7aa421ad882d01"
+                "reference": "9256f12d8fb0cd0500f93b19e18c356906cbed3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/050d430203105c27c30efd1dce7aa421ad882d01",
-                "reference": "050d430203105c27c30efd1dce7aa421ad882d01",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/9256f12d8fb0cd0500f93b19e18c356906cbed3d",
+                "reference": "9256f12d8fb0cd0500f93b19e18c356906cbed3d",
                 "shasum": ""
             },
             "require": {
@@ -2368,13 +2368,7 @@
                 }
             ],
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
-            "funding": [
-                {
-                    "url": "https://github.com/Synchro",
-                    "type": "github"
-                }
-            ],
-            "time": "2021-03-31T20:06:42+00:00"
+            "time": "2021-04-29T12:25:04+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the PHP Mailer to version 6.4.1.

The reason for that is the reported security issue here: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36326 .

Joomla 3.x is not affected by this issue because in 3.x we use version 5.

### Testing Instructions

1. On a 4.0 site with current 4.0-dev branch where composer and npm have been run, configure mailing so that it works (SMTP, mail() or sendmail doesn't matter).

2. Check that mail works by sending the test mail from Global Configuration.

Result: The email is sent.

3. Apply the patch of this PR.

5. Run `composer install`.

Result: Only the `phpmailer/phpmailer` is updated, nothing else.

6. Repeat step 2.

Result: The email is sent.

### Actual result BEFORE applying this Pull Request

Mail works, phpmailer version is 6.4.0.

### Expected result AFTER applying this Pull Request

Mail works, phpmailer version is 6.4.1.

### Documentation Changes Required

None.