### PR TITLE
[4] parent::cleanCache only accepts one param, 2 provided

### DIFF
--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -1299,7 +1299,7 @@ class CategoryModel extends AdminModel
 	 * Custom clean the cache of com_content and content modules
 	 *
 	 * @param   string   $group     Cache group name.
-	 * @param   integer  $clientId  Application client id.
+	 * @param   integer  $clientId  @deprecated   5.0   No longer used.
 	 *
 	 * @return  void
 	 *

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -867,8 +867,7 @@ class ApplicationModel extends FormModel
 		$app->set('cors_allow_methods', $data['cors_allow_methods']);
 
 		// Clear cache of com_config component.
-		$this->cleanCache('_system', 0);
-		$this->cleanCache('_system', 1);
+		$this->cleanCache('_system');
 
 		$result = $app->triggerEvent('onApplicationBeforeSave', array($config));
 

--- a/administrator/components/com_config/src/Model/ComponentModel.php
+++ b/administrator/components/com_config/src/Model/ComponentModel.php
@@ -245,8 +245,7 @@ class ComponentModel extends FormModel
 		Factory::getApplication()->triggerEvent('onExtensionAfterSave', array($context, $table, false));
 
 		// Clean the component cache.
-		$this->cleanCache('_system', 0);
-		$this->cleanCache('_system', 1);
+		$this->cleanCache('_system');
 
 		return true;
 	}

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -1112,7 +1112,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 	 * Custom clean the cache of com_content and content modules
 	 *
 	 * @param   string   $group     The cache group
-	 * @param   integer  $clientId  The ID of the client
+	 * @param   integer  $clientId  @deprecated   5.0   No longer used.
 	 *
 	 * @return  void
 	 *

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -1123,7 +1123,7 @@ class FieldModel extends AdminModel
 	 * Clean the cache
 	 *
 	 * @param   string   $group     The cache group
-	 * @param   integer  $clientId  The ID of the client
+	 * @param   integer  $clientId  @deprecated   5.0   No longer used.
 	 *
 	 * @return  void
 	 *

--- a/administrator/components/com_fields/src/Model/GroupModel.php
+++ b/administrator/components/com_fields/src/Model/GroupModel.php
@@ -376,7 +376,7 @@ class GroupModel extends AdminModel
 	 * Clean the cache
 	 *
 	 * @param   string   $group     The cache group
-	 * @param   integer  $clientId  The ID of the client
+	 * @param   integer  $clientId  @deprecated   5.0   No longer used.
 	 *
 	 * @return  void
 	 *

--- a/administrator/components/com_finder/src/Model/FilterModel.php
+++ b/administrator/components/com_finder/src/Model/FilterModel.php
@@ -43,15 +43,15 @@ class FilterModel extends AdminModel
 	 * Custom clean cache method.
 	 *
 	 * @param   string   $group     The component name. [optional]
-	 * @param   integer  $clientId  The client ID. [optional]
+	 * @param   integer  $clientId  @deprecated   5.0   No longer used.
 	 *
 	 * @return  void
 	 *
 	 * @since   2.5
 	 */
-	protected function cleanCache($group = 'com_finder', $clientId = 1)
+	protected function cleanCache($group = 'com_finder', $clientId = 0)
 	{
-		parent::cleanCache($group, $clientId);
+		parent::cleanCache($group);
 	}
 
 	/**

--- a/administrator/components/com_installer/src/Model/InstallModel.php
+++ b/administrator/components/com_installer/src/Model/InstallModel.php
@@ -238,14 +238,10 @@ class InstallModel extends BaseDatabaseModel
 		InstallerHelper::cleanupInstall($package['packagefile'], $package['extractdir']);
 
 		// Clear the cached extension data and menu cache
-		$this->cleanCache('_system', 0);
-		$this->cleanCache('_system', 1);
-		$this->cleanCache('com_modules', 0);
-		$this->cleanCache('com_modules', 1);
-		$this->cleanCache('com_plugins', 0);
-		$this->cleanCache('com_plugins', 1);
-		$this->cleanCache('mod_menu', 0);
-		$this->cleanCache('mod_menu', 1);
+		$this->cleanCache('_system');
+		$this->cleanCache('com_modules');
+		$this->cleanCache('com_plugins');
+		$this->cleanCache('mod_menu');
 
 		return $result;
 	}

--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -168,12 +168,9 @@ class ManageModel extends InstallerModel
 		}
 
 		// Clear the cached extension data and menu cache
-		$this->cleanCache('_system', 0);
-		$this->cleanCache('_system', 1);
-		$this->cleanCache('com_modules', 0);
-		$this->cleanCache('com_modules', 1);
-		$this->cleanCache('mod_menu', 0);
-		$this->cleanCache('mod_menu', 1);
+		$this->cleanCache('_system');
+		$this->cleanCache('com_modules');
+		$this->cleanCache('mod_menu');
 
 		return $result;
 	}
@@ -299,14 +296,10 @@ class ManageModel extends InstallerModel
 		$app->setUserState('com_installer.extension_message', $installer->get('extension_message'));
 
 		// Clear the cached extension data and menu cache
-		$this->cleanCache('_system', 0);
-		$this->cleanCache('_system', 1);
-		$this->cleanCache('com_modules', 0);
-		$this->cleanCache('com_modules', 1);
-		$this->cleanCache('com_plugins', 0);
-		$this->cleanCache('com_plugins', 1);
-		$this->cleanCache('mod_menu', 0);
-		$this->cleanCache('mod_menu', 1);
+		$this->cleanCache('_system');
+		$this->cleanCache('com_modules');
+		$this->cleanCache('com_plugins');
+		$this->cleanCache('mod_menu');
 
 		return $result;
 	}

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -326,7 +326,7 @@ class UpdateModel extends ListModel
 		$db->execute();
 
 		// Clear the administrator cache
-		$this->cleanCache('_system', 1);
+		$this->cleanCache('_system');
 
 		$this->_message = Text::_('JLIB_INSTALLER_PURGED_UPDATES');
 
@@ -385,14 +385,10 @@ class UpdateModel extends ListModel
 		}
 
 		// Clear the cached extension data and menu cache
-		$this->cleanCache('_system', 0);
-		$this->cleanCache('_system', 1);
-		$this->cleanCache('com_modules', 0);
-		$this->cleanCache('com_modules', 1);
-		$this->cleanCache('com_plugins', 0);
-		$this->cleanCache('com_plugins', 1);
-		$this->cleanCache('mod_menu', 0);
-		$this->cleanCache('mod_menu', 1);
+		$this->cleanCache('_system');
+		$this->cleanCache('com_modules');
+		$this->cleanCache('com_plugins');
+		$this->cleanCache('mod_menu');
 
 		// Set the final state
 		$this->setState('result', $result);

--- a/administrator/components/com_installer/src/Model/UpdatesitesModel.php
+++ b/administrator/components/com_installer/src/Model/UpdatesitesModel.php
@@ -446,7 +446,7 @@ class UpdatesitesModel extends InstallerModel
 		}
 
 		// Flush the system cache to ensure extra_query is correctly loaded next time.
-		$this->cleanCache('_system', 1);
+		$this->cleanCache('_system');
 	}
 
 	/**

--- a/administrator/components/com_languages/src/Model/InstalledModel.php
+++ b/administrator/components/com_languages/src/Model/InstalledModel.php
@@ -338,8 +338,7 @@ class InstalledModel extends ListModel
 
 		// Clean the cache of com_languages and component cache.
 		$this->cleanCache();
-		$this->cleanCache('_system', 0);
-		$this->cleanCache('_system', 1);
+		$this->cleanCache('_system');
 
 		return true;
 	}

--- a/administrator/components/com_languages/src/Model/LanguageModel.php
+++ b/administrator/components/com_languages/src/Model/LanguageModel.php
@@ -275,7 +275,7 @@ class LanguageModel extends AdminModel
 	 * Custom clean cache method.
 	 *
 	 * @param   string   $group     Optional cache group name.
-	 * @param   integer  $clientId  Application client id.
+	 * @param   integer  $clientId  @deprecated   5.0   No longer used.
 	 *
 	 * @return  void
 	 *

--- a/administrator/components/com_languages/src/Model/LanguagesModel.php
+++ b/administrator/components/com_languages/src/Model/LanguagesModel.php
@@ -225,7 +225,7 @@ class LanguagesModel extends ListModel
 	 * Custom clean cache method, 2 places for 2 clients.
 	 *
 	 * @param   string   $group     Optional cache group name.
-	 * @param   integer  $clientId  Application client id.
+	 * @param   integer  $clientId  @deprecated   5.0   No longer used.
 	 *
 	 * @return  void
 	 *

--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -1904,7 +1904,7 @@ class ItemModel extends AdminModel
 	 * Custom clean the cache
 	 *
 	 * @param   string   $group     Cache group name.
-	 * @param   integer  $clientId  Application client id.
+	 * @param   integer  $clientId  @deprecated  5.0  No Longer Used.
 	 *
 	 * @return  void
 	 *
@@ -1912,9 +1912,8 @@ class ItemModel extends AdminModel
 	 */
 	protected function cleanCache($group = null, $clientId = 0)
 	{
-		parent::cleanCache('com_menus', 0);
+		parent::cleanCache('com_menus');
 		parent::cleanCache('com_modules');
-		parent::cleanCache('mod_menu', 0);
-		parent::cleanCache('mod_menu', 1);
+		parent::cleanCache('mod_menu');
 	}
 }

--- a/administrator/components/com_menus/src/Model/MenuModel.php
+++ b/administrator/components/com_menus/src/Model/MenuModel.php
@@ -395,7 +395,7 @@ class MenuModel extends FormModel
 	 * Custom clean the cache
 	 *
 	 * @param   string   $group     Cache group name.
-	 * @param   integer  $clientId  Application client id.
+	 * @param   integer  $clientId  @deprecated  5.0  No Longer used.
 	 *
 	 * @return  void
 	 *
@@ -403,9 +403,8 @@ class MenuModel extends FormModel
 	 */
 	protected function cleanCache($group = null, $clientId = 0)
 	{
-		parent::cleanCache('com_menus', 0);
+		parent::cleanCache('com_menus');
 		parent::cleanCache('com_modules');
-		parent::cleanCache('mod_menu', 0);
-		parent::cleanCache('mod_menu', 1);
+		parent::cleanCache('mod_menu');
 	}
 }

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -1153,7 +1153,7 @@ class ModuleModel extends AdminModel
 	 * Custom clean cache method for different clients
 	 *
 	 * @param   string   $group     The name of the plugin group to import (defaults to null).
-	 * @param   integer  $clientId  The client ID. [optional]
+	 * @param   integer  $clientId  @deprecated   5.0   No longer used.
 	 *
 	 * @return  void
 	 *

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -388,7 +388,7 @@ class ModuleModel extends AdminModel
 				}
 
 				// Clear module cache
-				parent::cleanCache($table->module, $table->client_id);
+				parent::cleanCache($table->module);
 			}
 			else
 			{
@@ -1127,7 +1127,7 @@ class ModuleModel extends AdminModel
 		$this->cleanCache();
 
 		// Clean module cache
-		parent::cleanCache($table->module, $table->client_id);
+		parent::cleanCache($table->module);
 
 		return true;
 	}
@@ -1161,6 +1161,6 @@ class ModuleModel extends AdminModel
 	 */
 	protected function cleanCache($group = null, $clientId = 0)
 	{
-		parent::cleanCache('com_modules', $this->getClient());
+		parent::cleanCache('com_modules');
 	}
 }

--- a/administrator/components/com_plugins/src/Model/PluginModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginModel.php
@@ -367,7 +367,7 @@ class PluginModel extends AdminModel
 	 * Custom clean cache method, plugins are cached in 2 places for different clients.
 	 *
 	 * @param   string   $group     Cache group name.
-	 * @param   integer  $clientId  Application client id.
+	 * @param   integer  $clientId  @deprecated   5.0   No longer used.
 	 *
 	 * @return  void
 	 *
@@ -375,7 +375,6 @@ class PluginModel extends AdminModel
 	 */
 	protected function cleanCache($group = null, $clientId = 0)
 	{
-		parent::cleanCache('com_plugins', 0);
-		parent::cleanCache('com_plugins', 1);
+		parent::cleanCache('com_plugins');
 	}
 }

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -737,7 +737,7 @@ class StyleModel extends AdminModel
 	 * Custom clean cache method
 	 *
 	 * @param   string   $group     The cache group
-	 * @param   integer  $clientId  The ID of the client
+	 * @param   integer  $clientId  @deprecated   5.0   No longer used.
 	 *
 	 * @return  void
 	 *

--- a/components/com_content/src/Model/ArticleModel.php
+++ b/components/com_content/src/Model/ArticleModel.php
@@ -454,7 +454,7 @@ class ArticleModel extends ItemModel
 	 * Cleans the cache of com_content and content modules
 	 *
 	 * @param   string   $group     The cache group
-	 * @param   integer  $clientId  The ID of the client
+	 * @param   integer  $clientId  @deprecated   5.0   No longer used.
 	 *
 	 * @return  void
 	 *


### PR DESCRIPTION
code review

Reference PR that removed the param: #14262