### PR TITLE
[4.0] replace module chrome

### DIFF
--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -123,7 +123,7 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 			<?php endif; ?>
 			<section id="content" class="content">
 				<jdoc:include type="message" />
-				<jdoc:include type="modules" name="top" style="xhtml" />
+				<jdoc:include type="modules" name="top" style="html5" />
 				<div class="row">
 					<div class="col-md-12">
 						<h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
@@ -159,7 +159,7 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 					</div>
 
 					<?php if ($this->countModules('bottom')) : ?>
-						<jdoc:include type="modules" name="bottom" style="xhtml" />
+						<jdoc:include type="modules" name="bottom" style="html5" />
 					<?php endif; ?>
 				</div>
 			</section>

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -169,7 +169,7 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 		<?php endif; ?>
 		<section id="content" class="content">
 			<?php // Begin Content ?>
-			<jdoc:include type="modules" name="top" style="xhtml" />
+			<jdoc:include type="modules" name="top" style="html5" />
 			<div class="row">
 				<div class="col-md-12">
 					<main>
@@ -178,7 +178,7 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 					</main>
 				</div>
 				<?php if ($this->countModules('bottom')) : ?>
-					<jdoc:include type="modules" name="bottom" style="xhtml" />
+					<jdoc:include type="modules" name="bottom" style="html5" />
 				<?php endif; ?>
 			</div>
 			<?php // End Content ?>


### PR DESCRIPTION
There are two positions in the atum template that use a non-existent module chrome of xhtml

This PR replaces that with the existing chrome of html5. This is the most basic module chrome that supports all the module params.

The module position is not used in core
