### PR TITLE
[4] remove redundant check

### DIFF
--- a/administrator/components/com_contact/src/View/Contact/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contact/HtmlView.php
@@ -112,7 +112,7 @@ class HtmlView extends BaseHtmlView
 		if ($isNew)
 		{
 			// For new records, check the create permission.
-			if ($isNew && (count($user->getAuthorisedCategories('com_contact', 'core.create')) > 0))
+			if (count($user->getAuthorisedCategories('com_contact', 'core.create')) > 0)
 			{
 				ToolbarHelper::apply('contact.apply');
 


### PR DESCRIPTION
Condition is always 'true' because '$isNew' is already 'true' at this point

code review