### PR TITLE
[4] Condition is always 'true' because '$onlyEnabled' is already 'true' at this point

### DIFF
--- a/administrator/components/com_installer/src/Helper/InstallerHelper.php
+++ b/administrator/components/com_installer/src/Helper/InstallerHelper.php
@@ -422,7 +422,7 @@ class InstallerHelper
 
 		if ($onlyEnabled)
 		{
-			$enabled = $onlyEnabled ? 1 : 0;
+			$enabled = 1;
 			$query->where($db->quoteName('s.enabled') . ' = :enabled')
 				->bind(':enabled', $enabled, ParameterType::INTEGER);
 		}


### PR DESCRIPTION
Condition is always 'true' because '$onlyEnabled' is already 'true' at this point

code review