### PR TITLE
[4.0] Change fa-fw to icon-fw

### DIFF
--- a/administrator/modules/mod_messages/tmpl/default.php
+++ b/administrator/modules/mod_messages/tmpl/default.php
@@ -24,7 +24,7 @@ $route = 'index.php?option=com_messages&view=messages';
 <a class="header-item-content" href="<?php echo Route::_($route); ?>" title="<?php echo Text::_('MOD_MESSAGES_PRIVATE_MESSAGES'); ?>">
 	<div class="header-item-icon">
 		<div class="w-auto">
-			<span class="fa-fw icon-envelope" aria-hidden="true"></span>
+			<span class="icon-envelope icon-fw" aria-hidden="true"></span>
 			<small class="header-item-count"><?php echo $countUnread; ?></small>
 		</div>
 	</div>

--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -25,7 +25,7 @@ if ($hideLinks || count($messages) < 1)
 		 title="<?php echo Text::_('MOD_POST_INSTALLATION_MESSAGES'); ?>">
 		<div class="header-item-icon">
 			<div class="w-auto">
-				<span class="fa-fw icon-bell" aria-hidden="true"></span>
+				<span class="icon-bell icon-fw" aria-hidden="true"></span>
 				<small class="header-item-count"><?php echo count($messages); ?></small>
 			</div>
 		</div>


### PR DESCRIPTION
### Summary of Changes
To remove references to FontAwesome, use generic icon class.
Change fa-fw to icon-fw.
Change order for consistency.


### Testing Instructions
Code review.

or

Log in to the administration area.
View Post Installation Messages/Private Messages buttons in the upper right corner.
Icons same before/after PR.

