### PR TITLE
[4] s/setMvcFactory/setMVCFactory

### DIFF
--- a/libraries/src/MVC/Factory/MVCFactoryServiceTrait.php
+++ b/libraries/src/MVC/Factory/MVCFactoryServiceTrait.php
@@ -51,7 +51,7 @@ trait MVCFactoryServiceTrait
 	 *
 	 * @since  4.0.0
 	 */
-	public function setMvcFactory(MVCFactoryInterface $mvcFactory)
+	public function setMVCFactory(MVCFactoryInterface $mvcFactory)
 	{
 		$this->mvcFactory = $mvcFactory;
 	}


### PR DESCRIPTION
Change case of method. Doesn't change the way its called, but is "more correct' that the 33+ instances that call this method, call it with the correct case

Note that `getMVCFactory` has MVC in all caps, and so rather than change33+ cases to be `setMvcFactory` it seems the right code change is to change as this PR is. 