### PR TITLE
[4] Make behindproxy_postinstall_action compatible with Joomla 4 and remove FTP layer

### DIFF
--- a/administrator/components/com_admin/postinstall/behindproxy.php
+++ b/administrator/components/com_admin/postinstall/behindproxy.php
@@ -9,7 +9,10 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Language\Text;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 
@@ -22,7 +25,7 @@ use Joomla\Utilities\ArrayHelper;
  */
 function admin_postinstall_behindproxy_condition()
 {
-	$app = JFactory::getApplication();
+	$app = Factory::getApplication();
 
 	if ($app->get('behind_loadbalancer', '0'))
 	{
@@ -57,19 +60,15 @@ function behindproxy_postinstall_action()
 
 	$config = new Registry($data);
 
-	jimport('joomla.filesystem.path');
-	jimport('joomla.filesystem.file');
-
 	// Set the configuration file path.
 	$file = JPATH_CONFIGURATION . '/configuration.php';
 
-	// Get the new FTP credentials.
-	$ftp = JClientHelper::getCredentials('ftp', true);
-
-	// Attempt to make the file writeable if using FTP.
-	if (!$ftp['enabled'] && JPath::isOwner($file) && !JPath::setPermissions($file, '0644'))
+	// Attempt to make the file writeable
+	if (Path::isOwner($file) && !Path::setPermissions($file, '0644'))
 	{
-		JError::raiseNotice(500, JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTWRITABLE'));
+		Factory::getApplication()->enqueueMessage(Text::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTWRITABLE'), 'error');
+
+		return;
 	}
 
 	// Attempt to write the configuration file as a PHP class named JConfig.
@@ -77,14 +76,14 @@ function behindproxy_postinstall_action()
 
 	if (!File::write($file, $configuration))
 	{
-		JFactory::getApplication()->enqueueMessage(JText::_('COM_CONFIG_ERROR_WRITE_FAILED'), 'error');
+		JFactory::getApplication()->enqueueMessage(Text::_('COM_CONFIG_ERROR_WRITE_FAILED'), 'error');
 
 		return;
 	}
 
-	// Attempt to make the file unwriteable if NOT using FTP.
-	if (!$ftp['enabled'] && JPath::isOwner($file) && !JPath::setPermissions($file, '0444'))
+	// Attempt to make the file unwriteable
+	if (Path::isOwner($file) && !Path::setPermissions($file, '0444'))
 	{
-		JError::raiseNotice(500, JText::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'));
+		Factory::getApplication()->enqueueMessage(Text::_('COM_CONFIG_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'), 'error');
 	}
 }

--- a/administrator/components/com_admin/postinstall/behindproxy.php
+++ b/administrator/components/com_admin/postinstall/behindproxy.php
@@ -76,7 +76,7 @@ function behindproxy_postinstall_action()
 
 	if (!File::write($file, $configuration))
 	{
-		JFactory::getApplication()->enqueueMessage(Text::_('COM_CONFIG_ERROR_WRITE_FAILED'), 'error');
+		Factory::getApplication()->enqueueMessage(Text::_('COM_CONFIG_ERROR_WRITE_FAILED'), 'error');
 
 		return;
 	}


### PR DESCRIPTION
Fixes merge forgetfulness, and refactors to make compatible with Joomla 4 class names and libs.

Also removes useless FTP checks now that the FTP layer has gone. 