### PR TITLE
[4.0] Fix wrong ordering value for articles

### DIFF
--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -273,7 +273,6 @@ class ArticlesModel extends ListModel
 				[
 					$db->quoteName('fp.featured_up'),
 					$db->quoteName('fp.featured_down'),
-					$db->quoteName('fp.ordering'),
 					$db->quoteName('l.title', 'language_title'),
 					$db->quoteName('l.image', 'language_image'),
 					$db->quoteName('uc.name', 'editor'),

--- a/administrator/components/com_content/src/Model/FeaturedModel.php
+++ b/administrator/components/com_content/src/Model/FeaturedModel.php
@@ -82,4 +82,20 @@ class FeaturedModel extends ArticlesModel
 		// Filter by featured articles.
 		$this->setState('filter.featured', 1);
 	}
+
+	/**
+	 * Build an SQL query to load the list data.
+	 *
+	 * @return  \Joomla\Database\DatabaseQuery
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getListQuery()
+	{
+		$query = parent::getListQuery();
+
+		$query->select($this->getDbo()->quoteName('fp.ordering'));
+
+		return $query;
+	}
 }


### PR DESCRIPTION
Pull Request for Issue #33936.

### Summary of Changes
As explained in https://github.com/joomla/joomla-cms/issues/33936 , the ordering value of each article record displayed in Articles management screen is having wrong value, thus it will make re-ordering articles not working as expected. This PR just fixes that issue

### Testing Instructions

1. Modify this line of code https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_content/tmpl/articles/default.php#L378 on your Joomla installation to:

```php
<?php echo (int) $item->id . ':' . $item->ordering; ?>
```

2. Access to Content -> Articles:

- Here is what is displayed before patch. You will see that there is no ordering value displayed (empty) unless the article is featured article.

![before_patch](https://user-images.githubusercontent.com/977664/118924337-23e65600-b967-11eb-8bdc-9116ba1c5f1e.png)

- After patch, the ordering value is displayed (next to article ID)

![after_patch](https://user-images.githubusercontent.com/977664/118924348-28ab0a00-b967-11eb-83dc-e126b13192fc.png)
