### PR TITLE
[4.0] List contacts in a category

### DIFF
--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -146,29 +146,29 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 								<?php echo Text::sprintf('COM_CONTACT_MOBILE_NUMBER', $item->mobile); ?><br>
 							<?php endif; ?>
 
-							<?php if ($this->params->get('show_fax_headings') && !empty($item->fax) ) : ?>
+							<?php if ($this->params->get('show_fax_headings') && !empty($item->fax)) : ?>
 								<?php echo Text::sprintf('COM_CONTACT_FAX_NUMBER', $item->fax); ?><br>
 							<?php endif; ?>
 
-							<?php if ($this->params->get('show_position_headings')) : ?>
+							<?php if ($this->params->get('show_position_headings') && !empty($item->con_position)) : ?>
 								<?php echo $item->con_position; ?><br>
 							<?php endif; ?>
 
-							<?php if ($this->params->get('show_email_headings')) : ?>
+							<?php if ($this->params->get('show_email_headings') && !empty($item->email_to)) : ?>
 								<?php echo $item->email_to; ?><br>
 							<?php endif; ?>
 
 							<?php $location = array(); ?>
 							<?php if ($this->params->get('show_suburb_headings') && !empty($item->suburb)) : ?>
-								<?php $location[] = $item->suburb; ?><br>
+								<?php $location[] = $item->suburb; ?>
 							<?php endif; ?>
 
 							<?php if ($this->params->get('show_state_headings') && !empty($item->state)) : ?>
-								<?php $location[] = $item->state; ?><br>
+								<?php $location[] = $item->state; ?>
 							<?php endif; ?>
 
 							<?php if ($this->params->get('show_country_headings') && !empty($item->country)) : ?>
-								<?php $location[] = $item->country; ?><br>
+								<?php $location[] = $item->country; ?>
 							<?php endif; ?>
 							<?php echo implode(', ', $location); ?>
 


### PR DESCRIPTION
This view was not checking correctly to see if it should output anything for a field. As a result there were a lot of empty rows

To test create a few contacts with various amounts of detail
Create a menu item of type List contacts in a category

When viewed on the frontend you will see numerous blank lines in the details

Apply the pr and those blank lines are removed.


_Actual details and fields in the screenshots will depend on the data and menu options_
### Before
![image](https://user-images.githubusercontent.com/1296369/118938495-a1e63500-b946-11eb-8cbe-93180eff6906.png)


### After
![image](https://user-images.githubusercontent.com/1296369/118938364-795e3b00-b946-11eb-994c-b4b0cb8531c5.png)
