### PR TITLE
[4.0] contact address

### DIFF
--- a/components/com_contact/tmpl/contact/default_address.php
+++ b/components/com_contact/tmpl/contact/default_address.php
@@ -34,7 +34,6 @@ use Joomla\CMS\String\PunycodeHelper;
 			<dd>
 				<span class="contact-street" itemprop="streetAddress">
 					<?php echo nl2br($this->item->address); ?>
-					<br>
 				</span>
 			</dd>
 		<?php endif; ?>
@@ -43,7 +42,6 @@ use Joomla\CMS\String\PunycodeHelper;
 			<dd>
 				<span class="contact-suburb" itemprop="addressLocality">
 					<?php echo $this->item->suburb; ?>
-					<br>
 				</span>
 			</dd>
 		<?php endif; ?>
@@ -51,7 +49,6 @@ use Joomla\CMS\String\PunycodeHelper;
 			<dd>
 				<span class="contact-state" itemprop="addressRegion">
 					<?php echo $this->item->state; ?>
-					<br>
 				</span>
 			</dd>
 		<?php endif; ?>
@@ -59,7 +56,6 @@ use Joomla\CMS\String\PunycodeHelper;
 			<dd>
 				<span class="contact-postcode" itemprop="postalCode">
 					<?php echo $this->item->postcode; ?>
-					<br>
 				</span>
 			</dd>
 		<?php endif; ?>
@@ -67,7 +63,6 @@ use Joomla\CMS\String\PunycodeHelper;
 			<dd>
 				<span class="contact-country" itemprop="addressCountry">
 					<?php echo $this->item->country; ?>
-					<br>
 				</span>
 			</dd>
 		<?php endif; ?>
@@ -135,7 +130,6 @@ use Joomla\CMS\String\PunycodeHelper;
 	<dd>
 		<span class="contact-mobile" itemprop="telephone">
 			<?php echo $this->item->mobile; ?>
-			<br>
 		</span>
 	</dd>
 <?php endif; ?>


### PR DESCRIPTION
`dd` is a block element so there is no need for a `br`

There is no visible difference in the output

![image](https://user-images.githubusercontent.com/1296369/118941812-08b91d80-b94a-11eb-8dea-a83899a64592.png)
