### PR TITLE
[4.0] Remove mt-4 class in users fieldset

### DIFF
--- a/administrator/components/com_users/tmpl/level/edit.php
+++ b/administrator/components/com_users/tmpl/level/edit.php
@@ -22,7 +22,7 @@ HTMLHelper::_('behavior.keepalive');
 	<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', array('active' => 'details')); ?>
 
 		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'details', Text::_('COM_USERS_LEVEL_DETAILS')); ?>
-			<fieldset class="options-form mt-4">
+			<fieldset class="options-form">
 				<legend><?php echo Text::_('COM_USERS_LEVEL_DETAILS'); ?></legend>
 				<div class="control-group">
 					<div class="control-label">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
There is an `mt-4` class in fieldset, I removed that class in this PR.
I don't think any reason of putting `mt-4` in fieldset here

### Testing Instructions
Dashboard > Users > Access Levels > click on any Level name > Go to Level Details tab

### Actual result BEFORE applying this Pull Request
![mt-4_before](https://user-images.githubusercontent.com/61203226/118944875-94df3b00-b972-11eb-9889-999f1d06428d.JPG)



### Expected result AFTER applying this Pull Request
![mt-4_after](https://user-images.githubusercontent.com/61203226/118944896-99a3ef00-b972-11eb-8cf3-ad42a1b4292d.JPG)



### Documentation Changes Required
No

