### PR TITLE
[4.0] com_finder advanced search [a11y]

### DIFF
--- a/components/com_finder/tmpl/search/default_form.php
+++ b/components/com_finder/tmpl/search/default_form.php
@@ -42,7 +42,7 @@ if ($this->params->get('show_autosuggest', 1))
 				</button>
 				<?php if ($this->params->get('show_advanced', 1)) : ?>
 					<?php HTMLHelper::_('bootstrap.collapse'); ?>
-					<button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#advancedSearch" aria-expanded="true">
+					<button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#advancedSearch" aria-expanded="<?php echo ($this->params->get('expand_advanced', 0) ? 'true' : 'false'); ?>">
 						<span class="icon-search-plus" aria-hidden="true"></span>
 						<?php echo Text::_('COM_FINDER_ADVANCED_SEARCH_TOGGLE'); ?></a>
 				<?php endif; ?>

--- a/components/com_finder/tmpl/search/default_form.php
+++ b/components/com_finder/tmpl/search/default_form.php
@@ -44,7 +44,7 @@ if ($this->params->get('show_autosuggest', 1))
 					<?php HTMLHelper::_('bootstrap.collapse'); ?>
 					<button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#advancedSearch" aria-expanded="<?php echo ($this->params->get('expand_advanced', 0) ? 'true' : 'false'); ?>">
 						<span class="icon-search-plus" aria-hidden="true"></span>
-						<?php echo Text::_('COM_FINDER_ADVANCED_SEARCH_TOGGLE'); ?></a>
+						<?php echo Text::_('COM_FINDER_ADVANCED_SEARCH_TOGGLE'); ?></button>
 				<?php endif; ?>
 			</div>
 		</div>

--- a/components/com_finder/tmpl/search/default_form.php
+++ b/components/com_finder/tmpl/search/default_form.php
@@ -42,7 +42,7 @@ if ($this->params->get('show_autosuggest', 1))
 				</button>
 				<?php if ($this->params->get('show_advanced', 1)) : ?>
 					<?php HTMLHelper::_('bootstrap.collapse'); ?>
-					<a href="#advancedSearch" data-bs-toggle="collapse" class="btn btn-secondary">
+					<button class="btn btn-secondary" type="button" data-bs-toggle="collapse" data-bs-target="#advancedSearch" aria-expanded="true">
 						<span class="icon-search-plus" aria-hidden="true"></span>
 						<?php echo Text::_('COM_FINDER_ADVANCED_SEARCH_TOGGLE'); ?></a>
 				<?php endif; ?>


### PR DESCRIPTION
This PR implements the advanced search button in com_finder the correct way. Its a button not a link so it should use the button element. It should also be using aria-expanded.

There is no visible change but it now works correctly.

Reference https://getbootstrap.com/docs/5.0/components/collapse/

![image](https://user-images.githubusercontent.com/1296369/118959685-75d4af00-b95a-11eb-9d63-b69748e836c2.png)

![image](https://user-images.githubusercontent.com/1296369/118959698-78370900-b95a-11eb-8775-168c8c0ad097.png)
