### PR TITLE
[4] Use RuntimeStorage on CLI

### DIFF
--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -222,7 +222,7 @@ class Session implements ServiceProviderInterface
 				}
 
 				return $this->buildSession(
-					new JoomlaStorage($app->input, $handler),
+					new RuntimeStorage,
 					$app,
 					$container->get(DispatcherInterface::class),
 					$options


### PR DESCRIPTION
After considerable debugging... like hours with xdebug and stepping through the code...

Rather than revert #33145 with PR #33993 for issue #32966 this PR will fix the already merged code so that `RuntimeStorage` is used (basically reverting PART of the PR), and along with the previous PR #33145 change to add the `session.handler` into the container, this fixes the issue reported in #32966 when deleting users. 

The `session.handler`  is needed because after deleting users using the CLI, plugins are triggered by the dispatcher, the `onUserAfterDelete` event is triggered in the `plgUserJoomla` class

In this class it attempts to "Fetch all session IDs for the user account so they can be destroyed". To do this it attempts to call the `session.manager` from the container, which doesnt exist ( issue #32966 )

#33145 has added a `session.manager` into the container, which the plugin needs to be there.

This PR simply changes the `JoomlaStorage` for the `RuntimeStorage`

@wilsonge 

### Testing Instructions

```
php cli/joomla.php  user:add
test
test
test@example.xom
6

php cli/joomla.php  user:delete
test
yes

```