### PR TITLE
[4.0] Remove hr in frontend edit module

### DIFF
--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -60,7 +60,6 @@ if (Multilanguage::isEnabled())
 
 			<div class="row mb-4">
 				<div class="col-md-12">
-
 					<div class="control-group">
 						<div class="control-label">
 							<?php echo $this->form->getLabel('title'); ?>
@@ -85,8 +84,6 @@ if (Multilanguage::isEnabled())
 							<?php echo $this->form->getInput('position'); ?>
 						</div>
 					</div>
-
-					<hr>
 
 					<?php if (Factory::getUser()->authorise('core.edit.state', 'com_modules.module.' . $this->item['id'])) : ?>
 					<div class="control-group">
@@ -152,8 +149,6 @@ if (Multilanguage::isEnabled())
 							<?php echo $this->form->getInput('note'); ?>
 						</div>
 					</div>
-
-					<hr>
 
 					<div id="options">
 						<?php echo $this->loadTemplate('options'); ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Remove `<hr>` in the frontend edit module

### Testing Instructions
Try to edit module in frontend
![edit](https://user-images.githubusercontent.com/61203226/119011136-5ec1ab80-b9b2-11eb-920f-35a5e3c9ba99.JPG)

### Actual result BEFORE applying this Pull Request
![hr-before](https://user-images.githubusercontent.com/61203226/119011153-63865f80-b9b2-11eb-92ab-fc5eee6a1988.JPG)

### Expected result AFTER applying this Pull Request
![hr-after](https://user-images.githubusercontent.com/61203226/119011161-66815000-b9b2-11eb-96e8-054dce89e834.JPG)

### Documentation Changes Required
No
