### PR TITLE
[4.0] Make padding/margin consistent in postinstall empty state

### DIFF
--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -26,7 +26,7 @@ $adminFormClass = count($this->extension_options) > 1 ? 'form-inline mb-3' : 'vi
 </form>
 
 <?php if (empty($this->items)) : ?>
-	<div class="py-5 text-center">
+	<div class="px-4 py-5 my-5 text-center">
 		<span class="fa-8x icon-bell mb-4" aria-hidden="true"></span>
 		<h1 class="display-5 fw-bold"><?php echo Text::_('COM_POSTINSTALL_LBL_NOMESSAGES_TITLE'); ?></h1>
 		<div>


### PR DESCRIPTION
### Summary of Changes
The margin/padding in the postinstall empty state is not the same with the other ones.

### Testing Instructions
Make sure there are no articles.
Go to Content > Articles
See position of article icon.

Click `Post Installation Messages` icon.
Click `Hide all messages` button.
See position of bell icon.

Apply PR.

Positions are consistent.

![articles-empty](https://user-images.githubusercontent.com/368084/119020419-0effc780-b953-11eb-8e51-adbc784ce4e4.jpg)

![postinstall-empty](https://user-images.githubusercontent.com/368084/119020430-11622180-b953-11eb-9eb9-8db1e5c26d98.jpg)



