### PR TITLE
[4.0] Dropdown border radius

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -70,7 +70,7 @@
     border-top-right-radius: 0;
   }
 
-  &:not(.first):not(.last) {
+  &:not(.first):not(.last):not(:only-of-type) {
     border-radius: 0;
   }
 }


### PR DESCRIPTION
Pull Request for Issue #33792

Go to Control Panel -- Menus -- Manage (panel on the right). Click on any of the modules. A drop-down item on hover has no rounding of its borders.

this is a css change so npm run build:css

### Before
![image](https://user-images.githubusercontent.com/1296369/119047163-777f9080-b9b5-11eb-9538-3dcdbac6a94f.png)

### After
![image](https://user-images.githubusercontent.com/1296369/119047090-5fa80c80-b9b5-11eb-89e5-78a9a99c0356.png)
