### PR TITLE
[4] Delete whole method from class as it contains calls to methods that dont exist.

### DIFF
--- a/components/com_content/src/Model/ArchiveModel.php
+++ b/components/com_content/src/Model/ArchiveModel.php
@@ -130,34 +130,6 @@ class ArchiveModel extends ArticlesModel
 	}
 
 	/**
-	 * Method to get the archived article list
-	 *
-	 * @access public
-	 * @return array
-	 */
-	public function getData()
-	{
-		$app = Factory::getApplication();
-
-		// Lets load the content if it doesn't already exist
-		if (empty($this->_data))
-		{
-			// Get the page/component configuration
-			$params = $app->getParams();
-
-			// Get the pagination request variables
-			$limit      = $app->input->get('limit', $params->get('display_num', 20), 'uint');
-			$limitstart = $app->input->get('limitstart', 0, 'uint');
-
-			$query = $this->_buildQuery();
-
-			$this->_data = $this->_getList($query, $limitstart, $limit);
-		}
-
-		return $this->_data;
-	}
-
-	/**
 	 * Model override to add alternating value for $odd
 	 *
 	 * @param   string   $query       The query.


### PR DESCRIPTION
Code review. 

Not a typo. 

This method cannot be used - as `_buildQuery` method doesnt even exist. 

I do not believe this method is ever called, and after considerable testing I cannot locate any code or gui interface that would call it.

Happy to be proved wrong, but even if something did call it, they would get a PHP error because `_buildQuery` method doesnt exist as a string in the whole of a Joomla 4 site. 

