### PR TITLE
[4] Correctly return from display method, correct the doc for that too - manually.

### DIFF
--- a/administrator/components/com_cache/src/View/Cache/HtmlView.php
+++ b/administrator/components/com_cache/src/View/Cache/HtmlView.php
@@ -83,11 +83,11 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   1.6
 	 *
-	 * @throws  Exception
+	 * @throws  GenericDataException
 	 */
 	public function display($tpl = null): void
 	{

--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -84,7 +84,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string|null  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -139,7 +139,7 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -84,6 +84,8 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string|null  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
+	 * @throws  GenericDataException
+	 *
 	 * @return  void
 	 */
 	public function display($tpl = null)

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -76,7 +76,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string|null  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -117,7 +117,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_checkin/src/View/Checkin/HtmlView.php
+++ b/administrator/components/com_checkin/src/View/Checkin/HtmlView.php
@@ -74,7 +74,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -99,7 +99,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_config/src/View/Application/HtmlView.php
+++ b/administrator/components/com_config/src/View/Application/HtmlView.php
@@ -54,7 +54,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @see     \JViewLegacy::loadTemplate()
 	 * @since   3.0
@@ -101,7 +101,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_config/src/View/Component/HtmlView.php
+++ b/administrator/components/com_config/src/View/Component/HtmlView.php
@@ -53,7 +53,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @see     \JViewLegacy::loadTemplate()
 	 * @since   3.2
@@ -102,7 +102,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_contact/src/View/Contact/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contact/HtmlView.php
@@ -53,7 +53,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -84,7 +84,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_contact/src/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contacts/HtmlView.php
@@ -75,7 +75,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -134,7 +134,7 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -70,7 +70,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @throws \Exception
 	 * @since   1.6
@@ -79,7 +79,9 @@ class HtmlView extends BaseHtmlView
 	{
 		if ($this->getLayout() == 'pagebreak')
 		{
-			return parent::display($tpl);
+			parent::display($tpl);
+
+			return;
 		}
 
 		$this->form  = $this->get('Form');
@@ -109,7 +111,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -85,7 +85,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -144,7 +144,7 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_content/src/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/src/View/Featured/HtmlView.php
@@ -85,7 +85,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -123,7 +123,7 @@ class HtmlView extends BaseHtmlView
 			$this->filterForm->removeField('language', 'filter');
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_contenthistory/src/View/Compare/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/Compare/HtmlView.php
@@ -40,7 +40,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
 	 *
-	 * @return  mixed  \Exception on failure, void on success.
+	 * @return  void
 	 *
 	 * @since   3.2
 	 */
@@ -55,6 +55,6 @@ class HtmlView extends BaseHtmlView
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 }

--- a/administrator/components/com_contenthistory/src/View/History/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/History/HtmlView.php
@@ -54,7 +54,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
 	 *
-	 * @return  mixed  \Exception on failure, void on success.
+	 * @return  void
 	 *
 	 * @since   3.2
 	 */
@@ -72,7 +72,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->toolbar = $this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_contenthistory/src/View/Preview/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/Preview/HtmlView.php
@@ -42,7 +42,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
 	 *
-	 * @return  mixed  \Exception on failure, void on success.
+	 * @return  void
 	 *
 	 * @since   3.2
 	 */
@@ -64,6 +64,6 @@ class HtmlView extends BaseHtmlView
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 }

--- a/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
+++ b/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
@@ -51,7 +51,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{

--- a/administrator/components/com_fields/src/View/Field/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Field/HtmlView.php
@@ -52,7 +52,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @see     HtmlView::loadTemplate()
 	 * @since   3.7.0
@@ -75,7 +75,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_fields/src/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Fields/HtmlView.php
@@ -71,7 +71,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @see     JViewLegacy::loadTemplate()
 	 * @since   3.7.0
@@ -110,7 +110,7 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_fields/src/View/Group/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Group/HtmlView.php
@@ -63,7 +63,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @see     JViewLegacy::loadTemplate()
 	 * @since   3.7.0
@@ -94,7 +94,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_fields/src/View/Groups/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Groups/HtmlView.php
@@ -71,7 +71,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @see     HtmlView::loadTemplate()
 	 * @since   3.7.0
@@ -106,7 +106,7 @@ class HtmlView extends BaseHtmlView
 			$this->filterForm->removeField('language', 'filter');
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_finder/src/View/Filter/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Filter/HtmlView.php
@@ -71,7 +71,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
 	 *
-	 * @return  mixed  A string if successful, otherwise an \Exception object.
+	 * @return  void
 	 *
 	 * @since   2.5
 	 */
@@ -93,7 +93,7 @@ class HtmlView extends BaseHtmlView
 		// Configure the toolbar.
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_finder/src/View/Filters/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Filters/HtmlView.php
@@ -89,7 +89,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
 	 *
-	 * @return  mixed  A string if successful, otherwise an \Exception object.
+	 * @return  void
 	 *
 	 * @since   2.5
 	 */
@@ -117,7 +117,7 @@ class HtmlView extends BaseHtmlView
 		// Configure the toolbar.
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_finder/src/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Index/HtmlView.php
@@ -103,7 +103,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
 	 *
-	 * @return  mixed  A string if successful, otherwise an \Exception object.
+	 * @return  void
 	 *
 	 * @since   2.5
 	 */
@@ -154,7 +154,7 @@ class HtmlView extends BaseHtmlView
 		// Configure the toolbar.
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_finder/src/View/Maps/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Maps/HtmlView.php
@@ -90,7 +90,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
 	 *
-	 * @return  mixed  A string if successful, otherwise an \Exception object.
+	 * @return  void
 	 *
 	 * @since   2.5
 	 */
@@ -121,7 +121,7 @@ class HtmlView extends BaseHtmlView
 		// Prepare the view.
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_finder/src/View/Searches/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Searches/HtmlView.php
@@ -93,7 +93,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -129,7 +129,7 @@ class HtmlView extends BaseHtmlView
 		// Prepare the view.
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_finder/src/View/Statistics/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Statistics/HtmlView.php
@@ -35,7 +35,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  A template file to load. [optional]
 	 *
-	 * @return  mixed  A string if successful, otherwise an \Exception object.
+	 * @return  void
 	 *
 	 * @since   2.5
 	 */
@@ -50,6 +50,6 @@ class HtmlView extends BaseHtmlView
 			throw new GenericDataException(implode("\n", $errors), 500);
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 }

--- a/administrator/components/com_languages/src/View/Languages/HtmlView.php
+++ b/administrator/components/com_languages/src/View/Languages/HtmlView.php
@@ -86,7 +86,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_media/src/View/File/HtmlView.php
+++ b/administrator/components/com_media/src/View/File/HtmlView.php
@@ -30,7 +30,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   4.0.0
 	 */
@@ -54,7 +54,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_media/src/View/Media/HtmlView.php
+++ b/administrator/components/com_media/src/View/Media/HtmlView.php
@@ -51,7 +51,7 @@ class HtmlView extends BaseHtmlView
 	 * @param   string  $tpl  The name of the template file to parse;
 	 *                        automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   4.0.0
 	 */

--- a/administrator/components/com_messages/src/View/Config/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Config/HtmlView.php
@@ -50,7 +50,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_messages/src/View/Messages/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Messages/HtmlView.php
@@ -75,7 +75,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_modules/src/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Modules/HtmlView.php
@@ -78,7 +78,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */
@@ -165,7 +165,7 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -56,7 +56,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
@@ -64,7 +64,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
@@ -51,7 +51,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{

--- a/administrator/components/com_plugins/src/View/Plugins/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugins/HtmlView.php
@@ -67,7 +67,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -85,7 +85,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_postinstall/src/View/Messages/HtmlView.php
+++ b/administrator/components/com_postinstall/src/View/Messages/HtmlView.php
@@ -30,7 +30,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  Subtemplate to use
 	 *
-	 * @return  boolean  Return true to allow rendering of the page
+	 * @return  void
 	 *
 	 * @since   3.2
 	 */
@@ -56,7 +56,7 @@ class HtmlView extends BaseHtmlView
 
 		ToolbarHelper::title(Text::sprintf('COM_POSTINSTALL_MESSAGES_TITLE', $model->getExtensionName($this->eid)), 'bell');
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_redirect/src/View/Links/HtmlView.php
+++ b/administrator/components/com_redirect/src/View/Links/HtmlView.php
@@ -107,7 +107,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  False if unsuccessful, otherwise void.
+	 * @return  void
 	 *
 	 * @throws  GenericDataException
 	 * @since   1.6
@@ -140,7 +140,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_tags/src/View/Tag/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tag/HtmlView.php
@@ -67,7 +67,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{

--- a/administrator/components/com_templates/src/View/Style/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Style/HtmlView.php
@@ -59,7 +59,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */
@@ -78,7 +78,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_templates/src/View/Styles/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Styles/HtmlView.php
@@ -75,7 +75,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -102,7 +102,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -142,7 +142,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void|boolean
 	 */
 	public function display($tpl = null)
 	{
@@ -217,7 +217,7 @@ class HtmlView extends BaseHtmlView
 			$this->setLayout('readonly');
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_templates/src/View/Templates/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Templates/HtmlView.php
@@ -94,7 +94,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */
@@ -118,7 +118,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_workflow/src/View/Stages/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Stages/HtmlView.php
@@ -112,7 +112,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since  4.0.0
 	 */
@@ -150,7 +150,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_workflow/src/View/Transitions/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Transitions/HtmlView.php
@@ -111,7 +111,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since  4.0.0
 	 */
@@ -143,7 +143,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/administrator/components/com_workflow/src/View/Workflows/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Workflows/HtmlView.php
@@ -94,7 +94,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since  4.0.0
 	 */
@@ -125,7 +125,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->addToolbar();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/components/com_config/src/View/Config/HtmlView.php
+++ b/components/com_config/src/View/Config/HtmlView.php
@@ -67,7 +67,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   3.2
 	 */

--- a/components/com_config/src/View/Modules/HtmlView.php
+++ b/components/com_config/src/View/Modules/HtmlView.php
@@ -45,7 +45,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   3.2
 	 */

--- a/components/com_config/src/View/Templates/HtmlView.php
+++ b/components/com_config/src/View/Templates/HtmlView.php
@@ -66,7 +66,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Method to render the view.
 	 *
-	 * @return  string  The rendered view.
+	 * @return  void
 	 *
 	 * @since   3.2
 	 */

--- a/components/com_contact/src/View/Category/HtmlView.php
+++ b/components/com_contact/src/View/Category/HtmlView.php
@@ -54,7 +54,7 @@ class HtmlView extends CategoryView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{

--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -107,7 +107,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void|boolean
 	 */
 	public function display($tpl = null)
 	{
@@ -401,7 +401,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->_prepareDocument();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/components/com_contact/src/View/Featured/HtmlView.php
+++ b/components/com_contact/src/View/Featured/HtmlView.php
@@ -70,7 +70,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  \Exception on failure, void on success.
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */
@@ -136,7 +136,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->_prepareDocument();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/components/com_contact/src/View/Form/HtmlView.php
+++ b/components/com_contact/src/View/Form/HtmlView.php
@@ -66,7 +66,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void|boolean
 	 *
 	 * @throws \Exception
 	 * @since  4.0.0

--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -88,13 +88,15 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
 		if ($this->getLayout() == 'pagebreak')
 		{
-			return parent::display($tpl);
+			parent::display($tpl);
+
+			return;
 		}
 
 		$app        = Factory::getApplication();

--- a/components/com_content/src/View/Category/HtmlView.php
+++ b/components/com_content/src/View/Category/HtmlView.php
@@ -65,7 +65,7 @@ class HtmlView extends CategoryView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -204,7 +204,7 @@ class HtmlView extends CategoryView
 			}
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -103,7 +103,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{

--- a/components/com_content/src/View/Form/HtmlView.php
+++ b/components/com_content/src/View/Form/HtmlView.php
@@ -91,7 +91,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void|boolean
 	 */
 	public function display($tpl = null)
 	{

--- a/components/com_newsfeeds/src/View/Category/HtmlView.php
+++ b/components/com_newsfeeds/src/View/Category/HtmlView.php
@@ -44,7 +44,7 @@ class HtmlView extends CategoryView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 */
 	public function display($tpl = null)
 	{
@@ -63,7 +63,7 @@ class HtmlView extends CategoryView
 			$item->params->merge($temp);
 		}
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -80,7 +80,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   1.6
 	 */
@@ -227,7 +227,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->_prepareDocument();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/components/com_privacy/src/View/Confirm/HtmlView.php
+++ b/components/com_privacy/src/View/Confirm/HtmlView.php
@@ -63,7 +63,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @see     BaseHtmlView::loadTemplate()
 	 * @since   3.9.0
@@ -87,7 +87,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->prepareDocument();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/components/com_privacy/src/View/Remind/HtmlView.php
+++ b/components/com_privacy/src/View/Remind/HtmlView.php
@@ -63,7 +63,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @see     BaseHtmlView::loadTemplate()
 	 * @since   3.9.0
@@ -87,7 +87,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->prepareDocument();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/components/com_privacy/src/View/Request/HtmlView.php
+++ b/components/com_privacy/src/View/Request/HtmlView.php
@@ -71,7 +71,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @see     BaseHtmlView::loadTemplate()
 	 * @since   3.9.0
@@ -96,7 +96,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->prepareDocument();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -111,7 +111,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   3.1
 	 */

--- a/components/com_users/src/View/Login/HtmlView.php
+++ b/components/com_users/src/View/Login/HtmlView.php
@@ -83,7 +83,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   1.5
 	 * @throws  \Exception

--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -102,7 +102,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed   A string if successful, otherwise an Error object.
+	 * @return  void|boolean
 	 *
 	 * @since   1.6
 	 * @throws  \Exception
@@ -166,7 +166,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->prepareDocument();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/components/com_users/src/View/Registration/HtmlView.php
+++ b/components/com_users/src/View/Registration/HtmlView.php
@@ -73,7 +73,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The template file to include
 	 *
-	 * @return  mixed
+	 * @return  void
 	 *
 	 * @since   1.6
 	 * @throws  \Exception
@@ -105,7 +105,7 @@ class HtmlView extends BaseHtmlView
 
 		$this->prepareDocument();
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 
 	/**

--- a/components/com_wrapper/src/View/Wrapper/HtmlView.php
+++ b/components/com_wrapper/src/View/Wrapper/HtmlView.php
@@ -51,7 +51,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   1.5
 	 */

--- a/installation/src/View/DefaultView.php
+++ b/installation/src/View/DefaultView.php
@@ -34,7 +34,7 @@ class DefaultView extends BaseHtmlView
 	 *
 	 * @param   string|null  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   4.0.0
 	 */
@@ -42,6 +42,6 @@ class DefaultView extends BaseHtmlView
 	{
 		$this->form = $this->get('Form');
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 }

--- a/installation/src/View/Preinstall/HtmlView.php
+++ b/installation/src/View/Preinstall/HtmlView.php
@@ -41,7 +41,7 @@ class HtmlView extends DefaultView
 	 *
 	 * @param   string|null  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   4.0.0
 	 */
@@ -49,6 +49,6 @@ class HtmlView extends DefaultView
 	{
 		$this->options = $this->get('PhpOptions');
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 }

--- a/installation/src/View/Remove/HtmlView.php
+++ b/installation/src/View/Remove/HtmlView.php
@@ -66,7 +66,7 @@ class HtmlView extends DefaultView
 	 *
 	 * @param   string|null  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void
 	 *
 	 * @since   4.0.0
 	 */
@@ -83,6 +83,6 @@ class HtmlView extends DefaultView
 		$this->phpoptions = $this->get('PhpOptions', 'Checks');
 		$this->phpsettings = $this->get('PhpSettings', 'Checks');
 
-		return parent::display($tpl);
+		parent::display($tpl);
 	}
 }

--- a/libraries/src/MVC/View/CategoriesView.php
+++ b/libraries/src/MVC/View/CategoriesView.php
@@ -49,7 +49,7 @@ class CategoriesView extends HtmlView
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
 	 *
-	 * @return  mixed  A string if successful, otherwise an Error object.
+	 * @return  void|boolean
 	 *
 	 * @since   3.2
 	 * @throws  \Exception


### PR DESCRIPTION
### Summary of Changes

Not a typo. 70 changed files with 128 additions and 124 deletions. 

Not a simple search and replace of everything. 

`parent::display()` in most extensions HtmlView.php files calls `\Joomla\CMS\MVC\View::display()` as `parent::display()`  which finally echo's a $result. 

An echo is not a return, so the second `parent::display()` returns `void` to the first, which then doesnt return anything (correctly returns void already) back to the HTMLView and so its plainly wrong to again then return the non-existing void back up the call stack. 

Therefore `return parent::display($tpl)` is simply wrong, proved by removing the return in this PR. 

This PR then updates the docblocks correctly. 

THERE ARE A COUPLE OF GOTCHAS, this is not a simple search and replace. 

### Testing Instructions

Code review

Apply PR - Joomla still works. 

### note...

This is different to the use of `return parent::display();` in Controllers which is correct, as that is returning an instance of `BaseController` to provide a fluid interface for chaining methods. Whereas this is not the case in the views. 