### PR TITLE
[4.0] template manager uppercase filenames

### DIFF
--- a/administrator/components/com_templates/src/Helper/TemplateHelper.php
+++ b/administrator/components/com_templates/src/Helper/TemplateHelper.php
@@ -83,7 +83,7 @@ abstract class TemplateHelper
 			}
 		}
 
-		if ($file['name'] !== File::makeSafe($file['name']) || preg_match('/\s/', File::makeSafe($file['name'])))
+		if (strtolower($file['name']) !== File::makeSafe($file['name']) || preg_match('/\s/', File::makeSafe($file['name'])))
 		{
 			$app = Factory::getApplication();
 			$app->enqueueMessage(Text::_('COM_TEMPLATES_ERROR_WARNFILENAME'), 'error');


### PR DESCRIPTION
All uploaded files are saved as lowercase.

Try to upload a file with an uppercase extension eg test.JPG

It fails

Apply PR

Try to upload a file with an uppercase extension eg test.JPG

Success - saved as test.jpg

Pull Request for Issue #33179 