### PR TITLE
[4.0] form-control-feedback

### DIFF
--- a/templates/cassiopeia/scss/blocks/_form.scss
+++ b/templates/cassiopeia/scss/blocks/_form.scss
@@ -66,7 +66,7 @@ td .form-control {
 }
 
 .form-control-feedback {
-  display: block;
+  display: inline-block;
 }
 
 // set up hidden tooltip


### PR DESCRIPTION
Changes to inline block so that the message if displayed does not cause the field to move. (which is an accessibility error and ugly)

Pull Request for Issue #32692 .

### before
![before](https://user-images.githubusercontent.com/1296369/119059745-d4d10d00-b9c8-11eb-9c85-b00b99d964e5.gif)

### after

![after](https://user-images.githubusercontent.com/1296369/119059806-ef0aeb00-b9c8-11eb-827f-016f1beb3349.gif)
