### PR TITLE
[4.0] site config items

### DIFF
--- a/components/com_config/src/View/Config/HtmlView.php
+++ b/components/com_config/src/View/Config/HtmlView.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Config\Site\View\Config;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\Component\Config\Administrator\Controller\RequestController;
 
@@ -94,6 +93,7 @@ class HtmlView extends BaseHtmlView
 		$this->data = $serviceData;
 
 		$this->_prepareDocument();
+
 		parent::display($tpl);
 	}
 
@@ -106,27 +106,12 @@ class HtmlView extends BaseHtmlView
 	 */
 	protected function _prepareDocument()
 	{
-		$app    = Factory::getApplication();
-		$params = $app->getParams();
+		$params = Factory::getApplication()->getParams();
 
 		// Because the application sets a default page title, we need to get it
 		// right from the menu item itself
-		$title = $params->get('page_title', '');
 
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		$this->setDocumentTitle($params->get('page_title', ''));
 
 		if ($params->get('menu-meta_description'))
 		{

--- a/components/com_config/src/View/Modules/HtmlView.php
+++ b/components/com_config/src/View/Modules/HtmlView.php
@@ -91,18 +91,7 @@ class HtmlView extends BaseHtmlView
 	 */
 	protected function _prepareDocument()
 	{
-		$app    = Factory::getApplication();
-
 		// There is no menu item for this so we have to use the title from the component
-		if ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), Text::_('COM_CONFIG_MODULES_SETTINGS_TITLE'));
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', Text::_('COM_CONFIG_MODULES_SETTINGS_TITLE'), $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		$this->setDocumentTitle(Text::_('COM_CONFIG_MODULES_SETTINGS_TITLE'));
 	}
 }

--- a/components/com_config/src/View/Modules/HtmlView.php
+++ b/components/com_config/src/View/Modules/HtmlView.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Config\Site\View\Modules;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Language\Text;
 
 /**
  * View to edit a module.
@@ -76,6 +77,31 @@ class HtmlView extends BaseHtmlView
 			$this->form->bind($moduleData);
 		}
 
-		return parent::display($tpl);
+		$this->_prepareDocument();
+		parent::display($tpl);
+	}
+
+	/**
+	 * Prepares the document.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function _prepareDocument()
+	{
+		$app    = Factory::getApplication();
+
+		// There is no menu item for this so we have to use the title from the component
+		if ($app->get('sitename_pagetitles', 0) == 1)
+		{
+			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), Text::_('COM_CONFIG_MODULES_SETTINGS_TITLE'));
+		}
+		elseif ($app->get('sitename_pagetitles', 0) == 2)
+		{
+			$title = Text::sprintf('JPAGETITLE', Text::_('COM_CONFIG_MODULES_SETTINGS_TITLE'), $app->get('sitename'));
+		}
+
+		$this->document->setTitle($title);
 	}
 }

--- a/components/com_config/src/View/Modules/HtmlView.php
+++ b/components/com_config/src/View/Modules/HtmlView.php
@@ -78,6 +78,7 @@ class HtmlView extends BaseHtmlView
 		}
 
 		$this->_prepareDocument();
+
 		parent::display($tpl);
 	}
 

--- a/components/com_config/src/View/Templates/HtmlView.php
+++ b/components/com_config/src/View/Templates/HtmlView.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Config\Site\View\Templates;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactory;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\Component\Config\Administrator\Controller\RequestController;
@@ -46,6 +47,22 @@ class HtmlView extends BaseHtmlView
 	 * @since 3.2
 	 */
 	protected $userIsSuperAdmin;
+
+	/**
+	 * The page class suffix
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $pageclass_sfx = '';
+
+	/**
+	 * The page parameters
+	 *
+	 * @var    \Joomla\Registry\Registry|null
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $params = null;
 
 	/**
 	 * Method to render the view.
@@ -96,6 +113,53 @@ class HtmlView extends BaseHtmlView
 
 		$this->data = $serviceData;
 
-		return parent::display($tpl);
+		$this->_prepareDocument();
+		parent::display($tpl);
+	}
+
+	/**
+	 * Prepares the document.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function _prepareDocument()
+	{
+		$app    = Factory::getApplication();
+		$params = $app->getParams();
+
+		// Because the application sets a default page title, we need to get it
+		// right from the menu item itself
+		$title = $params->get('page_title', '');
+
+		if (empty($title))
+		{
+			$title = $app->get('sitename');
+		}
+		elseif ($app->get('sitename_pagetitles', 0) == 1)
+		{
+			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
+		}
+		elseif ($app->get('sitename_pagetitles', 0) == 2)
+		{
+			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
+		}
+
+		$this->document->setTitle($title);
+
+		if ($params->get('menu-meta_description'))
+		{
+			$this->document->setDescription($params->get('menu-meta_description'));
+		}
+
+		if ($params->get('robots'))
+		{
+			$this->document->setMetaData('robots', $params->get('robots'));
+		}
+
+		// Escape strings for HTML output
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->params        = &$params;
 	}
 }

--- a/components/com_config/src/View/Templates/HtmlView.php
+++ b/components/com_config/src/View/Templates/HtmlView.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Config\Site\View\Templates;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactory;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\Component\Config\Administrator\Controller\RequestController;
@@ -127,27 +126,12 @@ class HtmlView extends BaseHtmlView
 	 */
 	protected function _prepareDocument()
 	{
-		$app    = Factory::getApplication();
-		$params = $app->getParams();
+		$params = Factory::getApplication()->getParams();
 
 		// Because the application sets a default page title, we need to get it
 		// right from the menu item itself
-		$title = $params->get('page_title', '');
 
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		$this->setDocumentTitle($params->get('page_title', ''));
 
 		if ($params->get('menu-meta_description'))
 		{

--- a/components/com_config/src/View/Templates/HtmlView.php
+++ b/components/com_config/src/View/Templates/HtmlView.php
@@ -114,6 +114,7 @@ class HtmlView extends BaseHtmlView
 		$this->data = $serviceData;
 
 		$this->_prepareDocument();
+
 		parent::display($tpl);
 	}
 

--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -20,7 +20,17 @@ $wa->useScript('keepalive')
 	->useScript('com_config.config');
 
 ?>
-
+<?php if ($this->params->get('show_page_heading')) : ?>
+	<div class="page-header">
+		<h1>
+			<?php if ($this->escape($this->params->get('page_heading'))) : ?>
+				<?php echo $this->escape($this->params->get('page_heading')); ?>
+			<?php else : ?>
+				<?php echo $this->escape($this->params->get('page_title')); ?>
+			<?php endif; ?>
+		</h1>
+	</div>
+<?php endif; ?>
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" id="application-form" method="post" name="adminForm" class="form-validate">
 
 	<?php echo $this->loadTemplate('site'); ?>

--- a/components/com_config/tmpl/templates/default.php
+++ b/components/com_config/tmpl/templates/default.php
@@ -23,7 +23,17 @@ $wa->useScript('keepalive')
 	->useScript('com_config.templates');
 
 ?>
-
+<?php if ($this->params->get('show_page_heading')) : ?>
+	<div class="page-header">
+		<h1>
+			<?php if ($this->escape($this->params->get('page_heading'))) : ?>
+				<?php echo $this->escape($this->params->get('page_heading')); ?>
+			<?php else : ?>
+				<?php echo $this->escape($this->params->get('page_title')); ?>
+			<?php endif; ?>
+		</h1>
+	</div>
+<?php endif; ?>
 <form action="<?php echo Route::_('index.php?option=com_config'); ?>" method="post" name="adminForm" id="templates-form" class="form-validate">
 
 	<div id="page-site" class="tab-pane active">


### PR DESCRIPTION
Pull Request for #29315

## Steps to reproduce the issue
install sample data
login to frontend as super admin
Click Site Settings
Set "Site Name in Page Titles" to After
Save

## Expected result
On every page, on the frontend, the site name should be appended to the page title.

## Actual result
The site name is missing from the following pages
Click Site Settings menu item
Click Template Settings menu item
Click to edit a module

In addition Site Settings and Template Settings ignore all the other menu settings such as show heading and pageclass
Edit a module doesnt have a menu item so that doesnt apply for this one

This PR should resolve all of this.

@PhilETaylor could you please check the docblocks - I didn't really know what I was supposed to be doing there.
