### PR TITLE
[4] Remove deprecated method __toString from CMSObject 

### DIFF
--- a/libraries/src/Object/CMSObject.php
+++ b/libraries/src/Object/CMSObject.php
@@ -47,19 +47,6 @@ class CMSObject
 	}
 
 	/**
-	 * Magic method to convert the object to a string gracefully.
-	 *
-	 * @return  string  The classname.
-	 *
-	 * @since   1.7.0
-	 * @deprecated 3.1.4  Classes should provide their own __toString() implementation.
-	 */
-	public function __toString()
-	{
-		return \get_class($this);
-	}
-
-	/**
 	 * Sets a default value if not already assigned
 	 *
 	 * @param   string  $property  The name of the property.


### PR DESCRIPTION
### Summary of Changes

Remove the deprecated __toString method from CMSObject

This was deprecated for removal in Joomla 3.1.4 and Joomla 4 doesnt rely on it, its well overdue for removal. 

### Testing Instructions

Apply PR - make sure Joomla still generically works... 

