### PR TITLE
[4] print_popup function missing, provide exception

### DIFF
--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -72,7 +72,7 @@ abstract class JHtmlIcon
 	 */
 	public static function print_popup($article, $params, $attribs = array(), $legacy = false)
 	{
-		return self::getIcon()->print_popup($article, $params, $attribs, $legacy);
+		throw new \Exception('Sorry, Joomla 4 no longer supports print_popup');
 	}
 
 	/**


### PR DESCRIPTION
code review.

This is not used by Joomla at all, it might be used by 3PD **BUT** it would never work and would generate a PHP Fatal error as the method doesnt exist in the class. 

Somewhere previously someone decided to deprecate the `print_popup` method for removal in Joomla 5. 

This method calls `\Joomla\Component\Content\Administrator\Service\HTML\Icon::print_popup` which doesnt exist. 

Rather than write that method from scratch, for an obviously deprecated future, I have taken the decision to throw an Exception, instead of a PHP Fatal error which seems to make more sense. 

Without this change, if a 3PD were to implement `JHtmlIcon::print_popup` static method, they would get a PHP Fatal error but now they will get accurate feedback 