### PR TITLE
[4] Push deprecation of CMSObject to 5.0.0 instead of 4.0.0

### DIFF
--- a/libraries/src/Object/CMSObject.php
+++ b/libraries/src/Object/CMSObject.php
@@ -17,7 +17,7 @@ namespace Joomla\CMS\Object;
  * and an internal error handler.
  *
  * @since       1.7.0
- * @deprecated  4.0.0
+ * @deprecated  5.0.0
  */
 class CMSObject
 {


### PR DESCRIPTION
Code review

It seems previously someone was optimistic that they could remove `CMSObject` in Joomla 4.0.0 

As this clearly has not happened, and Joomla 4.0.0 very much still depends on `CMSObject` I have updated the `@deprecated` tag to the next major series, which will be the next opportunity to remove this class. 