### PR TITLE
[4.0] Fix switcher label

### DIFF
--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -32,10 +32,12 @@ $switcher-height: 28px;
 }
 
 .switcher input:checked + label {
+  z-index: 0;
   opacity: 1;
 }
 
 .switcher input:not(:checked) + label {
+  z-index: 3;
   opacity: 0;
 }
 


### PR DESCRIPTION
Pull Request for Issue #34047.

### Summary of Changes

Added `z-index` properties to labels because of one label overlaps another and creates impossibility of using the second label

### Testing Instructions

Go to administrator > com_config and click on any input[type=radio]'s label.

### Actual result BEFORE applying this Pull Request

The input switches only when clicking on the "no" label.

### Expected result AFTER applying this Pull Request

Both of labels works