### PR TITLE
[4.0] Adapt blog sample data and dropdown menus on position "menu" to new collapsible menu layouts

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-05-21.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-05-21.sql
@@ -1,0 +1,20 @@
+UPDATE `#__modules`
+   SET `params` = REPLACE(`params`,'"layout":"cassiopeia:dropdown-metismenu"','"layout":"cassiopeia:collapse-metismenu"')
+ WHERE `client_id` = 0
+   AND `module` = 'mod_menu'
+   AND `position` = 'menu'
+   AND `params` LIKE '{%"layout":"cassiopeia:dropdown-metismenu"%}';
+
+UPDATE `#__modules`
+   SET `params` = REPLACE(`params`,'"layout":"_:default"','"layout":"_:collapse-default"')
+ WHERE `client_id` = 0
+   AND `module` = 'mod_menu'
+   AND `position` = 'menu'
+   AND `params` LIKE '{%"layout":"_:default"%}';
+
+UPDATE `#__modules`
+   SET `params` = REPLACE(`params`,'"layout":""','"layout":"_:collapse-default"')
+ WHERE `client_id` = 0
+   AND `module` = 'mod_menu'
+   AND `position` = 'menu'
+   AND `params` LIKE '{%"layout":""%}';

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-05-21.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-05-21.sql
@@ -4,17 +4,3 @@ UPDATE `#__modules`
    AND `module` = 'mod_menu'
    AND `position` = 'menu'
    AND `params` LIKE '{%"layout":"cassiopeia:dropdown-metismenu"%}';
-
-UPDATE `#__modules`
-   SET `params` = REPLACE(`params`,'"layout":"_:default"','"layout":"_:collapse-default"')
- WHERE `client_id` = 0
-   AND `module` = 'mod_menu'
-   AND `position` = 'menu'
-   AND `params` LIKE '{%"layout":"_:default"%}';
-
-UPDATE `#__modules`
-   SET `params` = REPLACE(`params`,'"layout":""','"layout":"_:collapse-default"')
- WHERE `client_id` = 0
-   AND `module` = 'mod_menu'
-   AND `position` = 'menu'
-   AND `params` LIKE '{%"layout":""%}';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-05-21.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-05-21.sql
@@ -4,17 +4,3 @@ UPDATE "#__modules"
    AND "module" = 'mod_menu'
    AND "position" = 'menu'
    AND "params" LIKE '{%"layout":"cassiopeia:dropdown-metismenu"%}';
-
-UPDATE "#__modules"
-   SET "params" = REPLACE("params",'"layout":"_:default"','"layout":"_:collapse-default"')
- WHERE "client_id" = 0
-   AND "module" = 'mod_menu'
-   AND "position" = 'menu'
-   AND "params" LIKE '{%"layout":"_:default"%}';
-
-UPDATE "#__modules"
-   SET "params" = REPLACE("params",'"layout":""','"layout":"_:collapse-default"')
- WHERE "client_id" = 0
-   AND "module" = 'mod_menu'
-   AND "position" = 'menu'
-   AND "params" LIKE '{%"layout":""%}';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-05-21.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-05-21.sql
@@ -1,0 +1,20 @@
+UPDATE "#__modules"
+   SET "params" = REPLACE("params",'"layout":"cassiopeia:dropdown-metismenu"','"layout":"cassiopeia:collapse-metismenu"')
+ WHERE "client_id" = 0
+   AND "module" = 'mod_menu'
+   AND "position" = 'menu'
+   AND "params" LIKE '{%"layout":"cassiopeia:dropdown-metismenu"%}';
+
+UPDATE "#__modules"
+   SET "params" = REPLACE("params",'"layout":"_:default"','"layout":"_:collapse-default"')
+ WHERE "client_id" = 0
+   AND "module" = 'mod_menu'
+   AND "position" = 'menu'
+   AND "params" LIKE '{%"layout":"_:default"%}';
+
+UPDATE "#__modules"
+   SET "params" = REPLACE("params",'"layout":""','"layout":"_:collapse-default"')
+ WHERE "client_id" = 0
+   AND "module" = 'mod_menu'
+   AND "position" = 'menu'
+   AND "params" LIKE '{%"layout":""%}';

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -574,7 +574,7 @@ CREATE TABLE IF NOT EXISTS `#__modules` (
 --
 
 INSERT INTO `#__modules` (`id`, `asset_id`, `title`, `note`, `content`, `ordering`, `position`, `publish_up`, `publish_down`, `published`, `module`, `access`, `showtitle`, `params`, `client_id`, `language`) VALUES
-(1, 39, 'Main Menu', '', '', 1, 'sidebar-right', NULL, NULL, 1, 'mod_menu', 1, 1, '{"menutype":"mainmenu","startLevel":"0","endLevel":"0","showAllChildren":"1","tag_id":"","class_sfx":"","window_open":"","layout":"","moduleclass_sfx":"","cache":"1","cache_time":"900","cachemode":"itemid"}', 0, '*'),
+(1, 39, 'Main Menu', '', '', 1, 'sidebar-right', NULL, NULL, 1, 'mod_menu', 1, 1, '{"menutype":"mainmenu","startLevel":"0","endLevel":"0","showAllChildren":"1","tag_id":"","class_sfx":"","window_open":"","layout":"_:default","moduleclass_sfx":"","cache":"1","cache_time":"900","cachemode":"itemid"}', 0, '*'),
 (2, 40, 'Login', '', '', 1, 'login', NULL, NULL, 1, 'mod_login', 1, 1, '', 1, '*'),
 (3, 41, 'Popular Articles', '', '', 3, 'cpanel', NULL, NULL, 1, 'mod_popular', 3, 1, '{"count":"5","catid":"","user_id":"0","layout":"_:default","moduleclass_sfx":"","cache":"0", "bootstrap_size": "12","header_tag":"h2"}', 1, '*'),
 (4, 42, 'Recently Added Articles', '', '', 4, 'cpanel', NULL, NULL, 1, 'mod_latest', 3, 1, '{"count":"5","ordering":"c_dsc","catid":"","user_id":"0","layout":"_:default","moduleclass_sfx":"","cache":"0", "bootstrap_size": "12","header_tag":"h2"}', 1, '*'),

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -598,7 +598,7 @@ CREATE INDEX "#__modules_idx_language" ON "#__modules" ("language");
 --
 
 INSERT INTO "#__modules" ("id", "asset_id", "title", "note", "content", "ordering", "position", "publish_up", "publish_down", "published", "module", "access", "showtitle", "params", "client_id", "language") VALUES
-(1, 39, 'Main Menu', '', '', 1, 'sidebar-right', NULL, NULL, 1, 'mod_menu', 1, 1, '{"menutype":"mainmenu","startLevel":"0","endLevel":"0","showAllChildren":"1","tag_id":"","class_sfx":"","window_open":"","layout":"","moduleclass_sfx":"","cache":"1","cache_time":"900","cachemode":"itemid"}', 0, '*'),
+(1, 39, 'Main Menu', '', '', 1, 'sidebar-right', NULL, NULL, 1, 'mod_menu', 1, 1, '{"menutype":"mainmenu","startLevel":"0","endLevel":"0","showAllChildren":"1","tag_id":"","class_sfx":"","window_open":"","layout":"_:default","moduleclass_sfx":"","cache":"1","cache_time":"900","cachemode":"itemid"}', 0, '*'),
 (2, 40, 'Login', '', '', 1, 'login', NULL, NULL, 1, 'mod_login', 1, 1, '', 1, '*'),
 (3, 41, 'Popular Articles', '', '', 3, 'cpanel', NULL, NULL, 1, 'mod_popular', 3, 1, '{"count":"5","catid":"","user_id":"0","layout":"_:default","moduleclass_sfx":"","cache":"0", "bootstrap_size": "12","header_tag":"h2"}', 1, '*'),
 (4, 42, 'Recently Added Articles', '', '', 4, 'cpanel', NULL, NULL, 1, 'mod_latest', 3, 1, '{"count":"5","ordering":"c_dsc","catid":"","user_id":"0","layout":"_:default","moduleclass_sfx":"","cache":"0", "bootstrap_size": "12","header_tag":"h2"}', 1, '*'),

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -1434,7 +1434,7 @@ class PlgSampledataBlog extends CMSPlugin
 				'showtitle' => 0,
 				'params'    => array(
 					'menutype'        => $menuTypes[0],
-					'layout'          => 'cassiopeia:dropdown-metismenu',
+					'layout'          => 'cassiopeia:collapse-metismenu',
 					'startLevel'      => 1,
 					'endLevel'        => 0,
 					'showAllChildren' => 1,


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/33978#issuecomment-845953092 .

### Summary of Changes

This pull request changes blog sample data so it uses for the "Main Menu Blog" the new "collapse-metismenu" layout of the Cassiopeia template which has been recently added by PR #33978. This makes this menu module collapsible and so behave like it was before that PR .

In addition, an update SQL script is added to update any menu module on module position "menu" which uses the "cassiopeia:dropdown-metismenu" layout to the new "collapse-metismenu" layout. Before PR #33978 , only menus on position "menu" were collapsible, therefore the limitation of this update SQL to modules on that position. Furthermore, the update is limited to modules using the "cassiopeia:dropdown-metismenu" layout in order not to risk updating menu modules with the default layout when other templates than Cassiopeia are used, i.e. any modules using the default layout will not be updated to the new "collapse-default" layout of the module.

Finally, the SQL statement in the "base.sql" script to insert the module for the main menu of the site is on new installation is changed to make sure that this module uses the non-collapsible default layout so that it behaves in the same way as before PR #33978 and because a collapsible menu on the right sidebar doesn't make much sense.

### Testing Instructions

Step 1: Make a new installation with the current 4.0-dev branch or a nightly build of today, May 22, or later.

Step 2: Install "Sample Data Blog".

Step 3: Check the horizontal menu in the header section of the frontend on mobile screen size.

Result: The menu is not collapsed and there is no "burger" button.

Step 4: Check which layout is used for the "Main Menu Blog" module.

Result: The non-collapsible "Dropdown" layout of the "Cassiopeia" template is used.

Step 5: Create a few copies of the "Main Menu Blog" module at different module positions.

Step 6: Update to the patched package for this PR using the package or the custom update URL created by drone.

Step 7: Check again the horizontal menu in the header section of the frontend on mobile screen size (if necessary reload the page).

Result: The menu is collapsed and there is a "burger" button.

Step 8: Check in backend which layout is used for the "Main Menu Blog" module.

Result: The "Collapsible Dropdown" layout of the "Cassiopeia" template is used.

Step 9: Check which layouts are used by the other frontend menu modules.

Result: For other modules nothing has changed, they still use non-collapsible layouts.

Step 12: Make again a new installation using the full package built by drone for this PR or by applying the patch of this PR to a clean 4.0-dev branch again. It will not work if you continue with the result from the previous steps because the installation folder either has been deleted at the end of step 1 or it will be without the changes of this PR because the update package doesn't update any installation folder.

Step 13: Install "Sample Data Blog".

Step 14: Check in backend which layout is used for the "Main Menu Blog" module.

Result: The "Collapsible Dropdown" layout of the "Cassiopeia" template is used.

### Actual result BEFORE applying this Pull Request

After the update e.g. from 4.0 Beta 7 or a nightly build from before May 22nd to the nightly of May 22 or later, a menu module with the "Dropdown" layout of the "Cassiopeia" template on module position "Menu" like e.g. the "Main Menu Blog" from a "Sample Data Blog" installation is not collapsible anymore like it was before that update, i.e. there is no "burger" button on mobile screens:

![pr-34086_02](https://user-images.githubusercontent.com/7413183/119226554-02719f80-bb0a-11eb-8bcd-80cd5cce7d99.png)

The same applies to a new installation of current 4.0-dev or a nightly of today (May 22) or later after installation of "Sample Data Blog".

### Expected result AFTER applying this Pull Request

After the update e.g. from 4.0 Beta 7 or a nightly build from before May 22nd or a current 4.0-dev branch to the patched package of this PR, a menu module with the "Dropdown" layout of the "Cassiopeia" template on module position "Menu" like e.g. the "Main Menu Blog" from a "Sample Data Blog" installation remains collapsible like it was before that update, i.e. there is still a "burger" button on mobile screens:

![pr-34086_01](https://user-images.githubusercontent.com/7413183/119226559-07365380-bb0a-11eb-8f75-48873aa1e1af.png)

The same applies to a new installation of current 4.0-dev or a nightly of today (May 22) or later after installation of "Sample Data Blog".

### Documentation Changes Required

None.