### PR TITLE
[4.0] Use setDocumentTitle to set page title for create contact form

### DIFF
--- a/components/com_contact/src/View/Form/HtmlView.php
+++ b/components/com_contact/src/View/Form/HtmlView.php
@@ -68,7 +68,7 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @return  mixed  A string if successful, otherwise an Error object.
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 * @since  4.0.0
 	 */
 	public function display($tpl = null)
@@ -142,19 +142,17 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @return  void
 	 *
-	 * @throws Exception
+	 * @throws \Exception
 	 *
 	 * @since  4.0.0
 	 */
 	protected function _prepareDocument()
 	{
-		$app   = Factory::getApplication();
-		$menus = $app->getMenu();
-		$title = null;
+		$app = Factory::getApplication();
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = $app->getMenu()->getActive();
 
 		if ($menu)
 		{
@@ -167,16 +165,7 @@ class HtmlView extends BaseHtmlView
 
 		$title = $this->params->def('page_title', Text::_('COM_CONTACT_FORM_EDIT_CONTACT'));
 
-		if ($app->get('sitename_pagetitles', 0) === 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		$this->setDocumentTitle($title);
 
 		$pathway = $app->getPathWay();
 		$pathway->addItem($title, '');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
A small code clean up to Form view of com_contact component. The parent class has method `setDocumentTitle` https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/src/MVC/View/HtmlView.php#L607  to calculate and set page title base on **Site Name in Page Titles** setting in Global Configuration already, so we do not have to write the same code again in the child class.

### Testing Instructions
1. Code review should be enough
2. Or :
- Create a menu item to link to **Create Contact** menu item type of **Contacts** component
- Login to frontend of the site using your super user account, access to that menu item and make sure browser page title is the same with before. 
- Go to System -> Global Configuration, navigate to Site tab, try to change the value of **Site Name in Page Titles** config option (see attached screenshot), then access to the menu item above again, confirm that browser page title is changed according to the value of that config option.

![sitename_in_page_title](https://user-images.githubusercontent.com/977664/119214396-c7af3d80-baf0-11eb-94e0-188865fc3275.png)
