### PR TITLE
[4.0] Use setDocumentTitle for com_wrapper

### DIFF
--- a/components/com_wrapper/src/View/Wrapper/HtmlView.php
+++ b/components/com_wrapper/src/View/Wrapper/HtmlView.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Wrapper\Site\View\Wrapper;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Uri\Uri;
 
@@ -58,27 +57,12 @@ class HtmlView extends BaseHtmlView
 	 */
 	public function display($tpl = null)
 	{
-		$app    = Factory::getApplication();
-		$params = $app->getParams();
+		$params = Factory::getApplication()->getParams();
 
 		// Because the application sets a default page title, we need to get it
 		// right from the menu item itself
-		$title = $params->get('page_title', '');
 
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		$this->setDocumentTitle($params->get('page_title', ''));
 
 		if ($params->get('menu-meta_description'))
 		{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
A small code clean up to Form view of com_wrapper component. The parent class has method `setDocumentTitle` https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/src/MVC/View/HtmlView.php#L607  to calculate and set page title base on **Site Name in Page Titles** setting in Global Configuration already, so we do not have to write the same code again in the child class.

### Testing Instructions
1. Code review should be enough
2. Or :
- Create a menu item to link to **Iframe Wrapper** menu item type of **Wrapper** component
- Go to frontend of your site, access to that menu item and make sure browser page title is the same with before. 
- Go to System -> Global Configuration, navigate to Site tab, try to change the value of **Site Name in Page Titles** config option (see attached screenshot), then access to the menu item above again, confirm that browser page title is changed according to the value of that config option.

![sitename_in_page_title](https://user-images.githubusercontent.com/977664/119214396-c7af3d80-baf0-11eb-94e0-188865fc3275.png)