### PR TITLE
[4.0] Use setDocumentTitle for com_finder

### DIFF
--- a/components/com_finder/src/View/Search/FeedView.php
+++ b/components/com_finder/src/View/Search/FeedView.php
@@ -14,7 +14,6 @@ namespace Joomla\Component\Finder\Site\View\Search;
 use Joomla\CMS\Document\Feed\FeedItem;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 
@@ -53,22 +52,7 @@ class FeedView extends BaseHtmlView
 		$explained = HTMLHelper::_('query.explained', $query);
 
 		// Set the document title.
-		$title = $params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		$this->setDocumentTitle($params->get('page_title', ''));
 
 		// Configure the document description.
 		if (!empty($explained))

--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -272,11 +272,10 @@ class HtmlView extends BaseHtmlView
 	protected function prepareDocument()
 	{
 		$app   = Factory::getApplication();
-		$menus = $app->getMenu();
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = $app->getMenu()->getActive();
 
 		if ($menu)
 		{
@@ -287,22 +286,7 @@ class HtmlView extends BaseHtmlView
 			$this->params->def('page_heading', Text::_('COM_FINDER_DEFAULT_PAGE_TITLE'));
 		}
 
-		$title = $this->params->get('page_title', '');
-
-		if (empty($title))
-		{
-			$title = $app->get('sitename');
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 1)
-		{
-			$title = Text::sprintf('JPAGETITLE', $app->get('sitename'), $title);
-		}
-		elseif ($app->get('sitename_pagetitles', 0) == 2)
-		{
-			$title = Text::sprintf('JPAGETITLE', $title, $app->get('sitename'));
-		}
-
-		$this->document->setTitle($title);
+		$this->setDocumentTitle($this->params->get('page_title', ''));
 
 		if ($layout = $this->params->get('article_layout'))
 		{
@@ -329,7 +313,7 @@ class HtmlView extends BaseHtmlView
 		if ($this->params->get('opensearch', 1))
 		{
 			$ostitle = $this->params->get('opensearch_name',
-				Text::_('COM_FINDER_OPENSEARCH_NAME') . ' ' . Factory::getApplication()->get('sitename')
+				Text::_('COM_FINDER_OPENSEARCH_NAME') . ' ' . $app->get('sitename')
 			);
 			$this->document->addHeadLink(
 				Uri::getInstance()->toString(array('scheme', 'host', 'port')) . Route::_('index.php?option=com_finder&view=search&format=opensearch'),


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
A small code clean up to Form view of com_contact component. The parent class has method `setDocumentTitle` https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/src/MVC/View/HtmlView.php#L607  to calculate and set page title base on **Site Name in Page Titles** setting in Global Configuration already, so we do not have to write the same code again in the child class.

### Testing Instructions
1. Code review should be enough
2. Or :
- Create a menu item to link to **Search** menu item type of **Smart Search** component
- Go to frontend of the site using, access to that menu item and make sure browser page title is the same with before. 
- Go to System -> Global Configuration, navigate to Site tab, try to change the value of **Site Name in Page Titles** config option (see attached screenshot), then access to the menu item above again, confirm that browser page title is changed according to the value of that config option.

![sitename_in_page_title](https://user-images.githubusercontent.com/977664/119214396-c7af3d80-baf0-11eb-94e0-188865fc3275.png)
