### PR TITLE
[4.0] Layout for GroupedlistField

### DIFF
--- a/layouts/joomla/form/field/groupedlist-fancy-select.php
+++ b/layouts/joomla/form/field/groupedlist-fancy-select.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  Layout
  *
- * @copyright   (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
@@ -125,4 +125,4 @@ Factory::getApplication()->getDocument()->getWebAssetManager()
 
 ?>
 
-<joomla-field-fancy-select <?php echo $attr2; ?>><?php	echo implode($html); ?></joomla-field-fancy-select>
+<joomla-field-fancy-select <?php echo $attr2; ?>><?php echo implode($html); ?></joomla-field-fancy-select>

--- a/layouts/joomla/form/field/groupedlist-fancy-select.php
+++ b/layouts/joomla/form/field/groupedlist-fancy-select.php
@@ -9,7 +9,9 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Language\Text;
 
 extract($displayData);
 
@@ -39,7 +41,7 @@ extract($displayData);
  * @var   boolean  $spellcheck      Spellcheck state for the form field.
  * @var   string   $validate        Validation rules to apply.
  * @var   string   $value           Value attribute of the field.
- * @var   array    $options         Options available for this field.
+ * @var   array    $groups          Groups of options available for this field.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*
  */
@@ -47,31 +49,46 @@ extract($displayData);
 $html = array();
 $attr = '';
 
-// Initialize the field attributes.
-$attr .= !empty($class) ? ' class="form-select ' . $class . '"' : ' class="form-select"';
+// Initialize some field attributes.
 $attr .= !empty($size) ? ' size="' . $size . '"' : '';
 $attr .= $multiple ? ' multiple' : '';
-$attr .= $required ? ' required' : '';
 $attr .= $autofocus ? ' autofocus' : '';
-$attr .= $onchange ? ' onchange="' . $onchange . '"' : '';
-$attr .= !empty($description) ? ' aria-describedby="' . $name . '-desc"' : '';
 $attr .= $dataAttribute;
 
-// To avoid user's confusion, readonly="readonly" should imply disabled="disabled".
+// To avoid user's confusion, readonly="true" should imply disabled="true".
 if ($readonly || $disabled)
 {
 	$attr .= ' disabled="disabled"';
 }
 
-// Create a read-only list (no name) with hidden input(s) to store the value(s).
+// Initialize JavaScript field attributes.
+$attr .= !empty($onchange) ? ' onchange="' . $onchange . '"' : '';
+
+$attr2  = '';
+$attr2 .= !empty($class) ? ' class="' . $class . '"' : '';
+$attr2 .= ' placeholder="' . $this->escape($hint ?: Text::_('JGLOBAL_TYPE_OR_SELECT_SOME_OPTIONS')) . '" ';
+
+if ($required)
+{
+	$attr  .= ' required class="required"';
+	$attr2 .= ' required';
+}
+
+// Create a read-only list (no name) with a hidden input to store the value.
 if ($readonly)
 {
-	$html[] = HTMLHelper::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $value, $id);
+	$html[] = HTMLHelper::_(
+		'select.groupedlist', $groups, null,
+		array(
+			'list.attr' => $attr, 'id' => $id, 'list.select' => $value, 'group.items' => null, 'option.key.toHtml' => false,
+			'option.text.toHtml' => false,
+		)
+	);
 
 	// E.g. form field type tag sends $this->value as array
-	if ($multiple && is_array($value))
+	if ($multiple && \is_array($value))
 	{
-		if (!count($value))
+		if (!\count($value))
 		{
 			$value[] = '';
 		}
@@ -86,18 +103,26 @@ if ($readonly)
 		$html[] = '<input type="hidden" name="' . $name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '">';
 	}
 }
+
+// Create a regular list.
 else
-// Create a regular list passing the arguments in an array.
 {
-	$listoptions = array();
-	$listoptions['option.key'] = 'value';
-	$listoptions['option.text'] = 'text';
-	$listoptions['list.select'] = $value;
-	$listoptions['id'] = $id;
-	$listoptions['list.translate'] = false;
-	$listoptions['option.attr'] = 'optionattr';
-	$listoptions['list.attr'] = trim($attr);
-	$html[] = HTMLHelper::_('select.genericlist', $options, $name, $listoptions);
+	$html[] = HTMLHelper::_(
+		'select.groupedlist', $groups, $name,
+		array(
+			'list.attr' => $attr, 'id' => $id, 'list.select' => $value, 'group.items' => null, 'option.key.toHtml' => false,
+			'option.text.toHtml' => false,
+		)
+	);
 }
 
-echo implode($html);
+Text::script('JGLOBAL_SELECT_NO_RESULTS_MATCH');
+Text::script('JGLOBAL_SELECT_PRESS_TO_SELECT');
+
+Factory::getApplication()->getDocument()->getWebAssetManager()
+	->usePreset('choicesjs')
+	->useScript('webcomponent.field-fancy-select');
+
+?>
+
+<joomla-field-fancy-select <?php echo $attr2; ?>><?php	echo implode($html); ?></joomla-field-fancy-select>

--- a/layouts/joomla/form/field/groupedlist.php
+++ b/layouts/joomla/form/field/groupedlist.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  Layout
  *
- * @copyright   (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/layouts/joomla/form/field/groupedlist.php
+++ b/layouts/joomla/form/field/groupedlist.php
@@ -39,7 +39,7 @@ extract($displayData);
  * @var   boolean  $spellcheck      Spellcheck state for the form field.
  * @var   string   $validate        Validation rules to apply.
  * @var   string   $value           Value attribute of the field.
- * @var   array    $options         Options available for this field.
+ * @var   array    $groups          Groups of options available for this field.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*
  */
@@ -47,31 +47,38 @@ extract($displayData);
 $html = array();
 $attr = '';
 
-// Initialize the field attributes.
+// Initialize some field attributes.
 $attr .= !empty($class) ? ' class="form-select ' . $class . '"' : ' class="form-select"';
 $attr .= !empty($size) ? ' size="' . $size . '"' : '';
 $attr .= $multiple ? ' multiple' : '';
 $attr .= $required ? ' required' : '';
 $attr .= $autofocus ? ' autofocus' : '';
-$attr .= $onchange ? ' onchange="' . $onchange . '"' : '';
-$attr .= !empty($description) ? ' aria-describedby="' . $name . '-desc"' : '';
 $attr .= $dataAttribute;
 
-// To avoid user's confusion, readonly="readonly" should imply disabled="disabled".
+// To avoid user's confusion, readonly="true" should imply disabled="true".
 if ($readonly || $disabled)
 {
 	$attr .= ' disabled="disabled"';
 }
 
-// Create a read-only list (no name) with hidden input(s) to store the value(s).
+// Initialize JavaScript field attributes.
+$attr .= !empty($onchange) ? ' onchange="' . $onchange . '"' : '';
+
+// Create a read-only list (no name) with a hidden input to store the value.
 if ($readonly)
 {
-	$html[] = HTMLHelper::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $value, $id);
+	$html[] = HTMLHelper::_(
+		'select.groupedlist', $groups, null,
+		array(
+			'list.attr' => $attr, 'id' => $id, 'list.select' => $value, 'group.items' => null, 'option.key.toHtml' => false,
+			'option.text.toHtml' => false,
+		)
+	);
 
 	// E.g. form field type tag sends $this->value as array
-	if ($multiple && is_array($value))
+	if ($multiple && \is_array($value))
 	{
-		if (!count($value))
+		if (!\count($value))
 		{
 			$value[] = '';
 		}
@@ -86,18 +93,17 @@ if ($readonly)
 		$html[] = '<input type="hidden" name="' . $name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '">';
 	}
 }
+
+// Create a regular list.
 else
-// Create a regular list passing the arguments in an array.
 {
-	$listoptions = array();
-	$listoptions['option.key'] = 'value';
-	$listoptions['option.text'] = 'text';
-	$listoptions['list.select'] = $value;
-	$listoptions['id'] = $id;
-	$listoptions['list.translate'] = false;
-	$listoptions['option.attr'] = 'optionattr';
-	$listoptions['list.attr'] = trim($attr);
-	$html[] = HTMLHelper::_('select.genericlist', $options, $name, $listoptions);
+	$html[] = HTMLHelper::_(
+		'select.groupedlist', $groups, $name,
+		array(
+			'list.attr' => $attr, 'id' => $id, 'list.select' => $value, 'group.items' => null, 'option.key.toHtml' => false,
+			'option.text.toHtml' => false,
+		)
+	);
 }
 
 echo implode($html);

--- a/layouts/joomla/form/field/list-fancy-select.php
+++ b/layouts/joomla/form/field/list-fancy-select.php
@@ -41,10 +41,7 @@ extract($displayData);
  * @var   boolean  $spellcheck      Spellcheck state for the form field.
  * @var   string   $validate        Validation rules to apply.
  * @var   string   $value           Value attribute of the field.
- * @var   array    $checkedOptions  Options that will be set as checked.
- * @var   boolean  $hasValue        Has this field a value assigned?
  * @var   array    $options         Options available for this field.
- * @var   array    $inputType       Options available for this field.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*
  */
@@ -107,7 +104,7 @@ else
 Text::script('JGLOBAL_SELECT_NO_RESULTS_MATCH');
 Text::script('JGLOBAL_SELECT_PRESS_TO_SELECT');
 
-Factory::getDocument()->getWebAssetManager()
+Factory::getApplication()->getDocument()->getWebAssetManager()
 	->usePreset('choicesjs')
 	->useScript('webcomponent.field-fancy-select');
 

--- a/libraries/src/Form/Field/GroupedlistField.php
+++ b/libraries/src/Form/Field/GroupedlistField.php
@@ -31,6 +31,14 @@ class GroupedlistField extends FormField
 	protected $type = 'Groupedlist';
 
 	/**
+	 * Name of the layout being used to render the field
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $layout = 'joomla.form.field.groupedlist';
+
+	/**
 	 * Method to get the field option groups.
 	 *
 	 * @return  array  The field option objects as a nested array in groups.
@@ -144,70 +152,11 @@ class GroupedlistField extends FormField
 	 */
 	protected function getInput()
 	{
-		$html = array();
-		$attr = '';
-
-		// Initialize some field attributes.
-		$attr .= !empty($this->class) ? ' class="form-select ' . $this->class . '"' : ' class="form-select"';
-		$attr .= !empty($this->size) ? ' size="' . $this->size . '"' : '';
-		$attr .= $this->multiple ? ' multiple' : '';
-		$attr .= $this->required ? ' required' : '';
-		$attr .= $this->autofocus ? ' autofocus' : '';
-
-		// To avoid user's confusion, readonly="true" should imply disabled="true".
-		if ($this->readonly || $this->disabled)
-		{
-			$attr .= ' disabled="disabled"';
-		}
-
-		// Initialize JavaScript field attributes.
-		$attr .= !empty($this->onchange) ? ' onchange="' . $this->onchange . '"' : '';
+		$data = $this->getLayoutData();
 
 		// Get the field groups.
-		$groups = (array) $this->getGroups();
+		$data['groups'] = (array) $this->getGroups();
 
-		// Create a read-only list (no name) with a hidden input to store the value.
-		if ($this->readonly)
-		{
-			$html[] = HTMLHelper::_(
-				'select.groupedlist', $groups, null,
-				array(
-					'list.attr' => $attr, 'id' => $this->id, 'list.select' => $this->value, 'group.items' => null, 'option.key.toHtml' => false,
-					'option.text.toHtml' => false,
-				)
-			);
-
-			// E.g. form field type tag sends $this->value as array
-			if ($this->multiple && \is_array($this->value))
-			{
-				if (!\count($this->value))
-				{
-					$this->value[] = '';
-				}
-
-				foreach ($this->value as $value)
-				{
-					$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($value, ENT_COMPAT, 'UTF-8') . '">';
-				}
-			}
-			else
-			{
-				$html[] = '<input type="hidden" name="' . $this->name . '" value="' . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '">';
-			}
-		}
-
-		// Create a regular list.
-		else
-		{
-			$html[] = HTMLHelper::_(
-				'select.groupedlist', $groups, $this->name,
-				array(
-					'list.attr' => $attr, 'id' => $this->id, 'list.select' => $this->value, 'group.items' => null, 'option.key.toHtml' => false,
-					'option.text.toHtml' => false,
-				)
-			);
-		}
-
-		return implode($html);
+		return $this->getRenderer($this->layout)->render($data);
 	}
 }

--- a/plugins/system/cache/cache.xml
+++ b/plugins/system/cache/cache.xml
@@ -37,6 +37,7 @@
 					label="PLG_CACHE_FIELD_EXCLUDE_MENU_ITEMS_LABEL"
 					multiple="multiple"
 					filter="intarray"
+					layout="joomla.form.field.groupedlist-fancy-select"
 				/>
 
 			</fieldset>


### PR DESCRIPTION
Pull Request for Issue #31249 and #33183 .

### Summary of Changes

Move GroupedlistField::getInput() to the layout.
Available 2 layout:

`joomla.form.field.groupedlist` - default, a regular select input
`joomla.form.field.groupedlist-fancy-select` - optional, fancy select


### Testing Instructions

Create 2 field, with different layout, somewhere:

```xml
<field
  name="field0" type="templatestyle" label="Field 0"
  multiple="multiple"
/>

<field
  name="field1" type="menuitem" label="Field 1"
  multiple="multiple"
  layout="joomla.form.field.groupedlist-fancy-select"
/>
```



### Actual result BEFORE applying this Pull Request
Both fields will show default `<select>` input


### Expected result AFTER applying this Pull Request
First field will be default `<select>` input
Second field will be "fancy select"


### Documentation Changes Required
Yes, update doc about Groupedlist field.
