### PR TITLE
[4.0] Use MVCFactory to create model

### DIFF
--- a/administrator/components/com_actionlogs/src/Plugin/ActionLogPlugin.php
+++ b/administrator/components/com_actionlogs/src/Plugin/ActionLogPlugin.php
@@ -13,7 +13,6 @@ namespace Joomla\Component\Actionlogs\Administrator\Plugin;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\CMSPlugin;
-use Joomla\Component\Actionlogs\Administrator\Model\ActionlogModel;
 
 /**
  * Abstract Action Log Plugin
@@ -94,8 +93,10 @@ abstract class ActionLogPlugin extends CMSPlugin
 			$messages[$index] = $message;
 		}
 
-		/** @var ActionlogModel $model */
-		$model = new ActionlogModel;
+		/** @var \Joomla\Component\Actionlogs\Administrator\Model\ActionlogModel $model */
+		$model = $this->app->bootComponent('com_actionlogs')
+			->getMVCFactory()->createModel('Actionlog', 'Administrator', ['ignore_request' => true]);
+
 		$model->addLog($messages, strtoupper($messageLanguageKey), $context, $userId);
 	}
 }

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7231,7 +7231,8 @@ class JoomlaInstallerScript
 	 */
 	private function cleanJoomlaCache()
 	{
-		$model = new \Joomla\Component\Cache\Administrator\Model\CacheModel;
+		/* @var \Joomla\Component\Cache\Administrator\Model\CacheModel $model */
+		$model = Factory::getApplication()->bootComponent('com_cache')->getMVCFactory()->createModel('Cache', 'Administrator', ['ignore_request' => true]);
 
 		// Clean frontend cache
 		$model->clean();

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7231,8 +7231,9 @@ class JoomlaInstallerScript
 	 */
 	private function cleanJoomlaCache()
 	{
-		/* @var \Joomla\Component\Cache\Administrator\Model\CacheModel $model */
-		$model = Factory::getApplication()->bootComponent('com_cache')->getMVCFactory()->createModel('Cache', 'Administrator', ['ignore_request' => true]);
+		/** @var \Joomla\Component\Cache\Administrator\Model\CacheModel $model */
+		$model = Factory::getApplication()->bootComponent('com_cache')->getMVCFactory()
+			->createModel('Cache', 'Administrator', ['ignore_request' => true]);
 
 		// Clean frontend cache
 		$model->clean();

--- a/administrator/modules/mod_latestactions/src/Helper/LatestActionsHelper.php
+++ b/administrator/modules/mod_latestactions/src/Helper/LatestActionsHelper.php
@@ -11,9 +11,9 @@ namespace Joomla\Module\LatestActions\Administrator\Helper;
 
 \defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Component\Actionlogs\Administrator\Helper\ActionlogsHelper;
-use Joomla\Component\Actionlogs\Administrator\Model\ActionlogsModel;
 use Joomla\Registry\Registry;
 
 /**
@@ -36,8 +36,8 @@ abstract class LatestActionsHelper
 	 */
 	public static function getList(&$params)
 	{
-		/** @var ActionlogsModel $model */
-		$model = new ActionlogsModel(['ignore_request' => true]);
+		/** @var \Joomla\Component\Actionlogs\Administrator\Model\ActionlogsModel $model */
+		$model = Factory::getApplication()->bootComponent('com_actionlogs')->getMVCFactory()->createModel('Actionlogs', 'Administrator', ['ignore_request' => true]);
 
 		// Set the Start and Limit
 		$model->setState('list.start', 0);

--- a/administrator/modules/mod_latestactions/src/Helper/LatestActionsHelper.php
+++ b/administrator/modules/mod_latestactions/src/Helper/LatestActionsHelper.php
@@ -37,7 +37,8 @@ abstract class LatestActionsHelper
 	public static function getList(&$params)
 	{
 		/** @var \Joomla\Component\Actionlogs\Administrator\Model\ActionlogsModel $model */
-		$model = Factory::getApplication()->bootComponent('com_actionlogs')->getMVCFactory()->createModel('Actionlogs', 'Administrator', ['ignore_request' => true]);
+		$model = Factory::getApplication()->bootComponent('com_actionlogs')->getMVCFactory()
+			->createModel('Actionlogs', 'Administrator', ['ignore_request' => true]);
 
 		// Set the Start and Limit
 		$model->setState('list.start', 0);

--- a/administrator/modules/mod_messages/mod_messages.php
+++ b/administrator/modules/mod_messages/mod_messages.php
@@ -20,8 +20,9 @@ if (!$app->getIdentity()->authorise('core.login.admin') || !$app->getIdentity()-
 // Try to get the items from the messages model
 try
 {
-	/* @var \Joomla\Component\Messages\Administrator\Model\MessagesModel $messagesModel */
-	$messagesModel = $app->bootComponent('com_messages')->getMVCFactory()->createModel('Messages', 'Administrator', ['ignore_request' => true]);
+	/** @var \Joomla\Component\Messages\Administrator\Model\MessagesModel $messagesModel */
+	$messagesModel = $app->bootComponent('com_messages')->getMVCFactory()
+		->createModel('Messages', 'Administrator', ['ignore_request' => true]);
 	$messagesModel->setState('filter.state', 0);
 	$messages = $messagesModel->getItems();
 }

--- a/administrator/modules/mod_messages/mod_messages.php
+++ b/administrator/modules/mod_messages/mod_messages.php
@@ -20,9 +20,10 @@ if (!$app->getIdentity()->authorise('core.login.admin') || !$app->getIdentity()-
 // Try to get the items from the messages model
 try
 {
-	$messagesModel = new \Joomla\Component\Messages\Administrator\Model\MessagesModel(['ignore_request' => true]);
+	/* @var \Joomla\Component\Messages\Administrator\Model\MessagesModel $messagesModel */
+	$messagesModel = $app->bootComponent('com_messages')->getMVCFactory()->createModel('Messages', 'Administrator', ['ignore_request' => true]);
 	$messagesModel->setState('filter.state', 0);
-	$messages      = $messagesModel->getItems();
+	$messages = $messagesModel->getItems();
 }
 catch (RuntimeException $e)
 {

--- a/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php
+++ b/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php
@@ -15,8 +15,9 @@ use Joomla\CMS\Helper\ModuleHelper;
 // Try to get the items from the post-installation model
 try
 {
-	/* @var \Joomla\Component\Postinstall\Administrator\Model\MessagesModel $messagesModel */
-	$messagesModel = $app->bootComponent('com_postinstall')->getMVCFactory()->createModel('Messages', 'Administrator', ['ignore_request' => true]);
+	/** @var \Joomla\Component\Postinstall\Administrator\Model\MessagesModel $messagesModel */
+	$messagesModel = $app->bootComponent('com_postinstall')->getMVCFactory()
+		->createModel('Messages', 'Administrator', ['ignore_request' => true]);
 	$messages      = $messagesModel->getItems();
 }
 catch (RuntimeException $e)

--- a/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php
+++ b/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php
@@ -15,7 +15,8 @@ use Joomla\CMS\Helper\ModuleHelper;
 // Try to get the items from the post-installation model
 try
 {
-	$messagesModel = new \Joomla\Component\Postinstall\Administrator\Model\MessagesModel(['ignore_request' => true]);
+	/* @var \Joomla\Component\Postinstall\Administrator\Model\MessagesModel $messagesModel */
+	$messagesModel = $app->bootComponent('com_postinstall')->getMVCFactory()->createModel('Messages', 'Administrator', ['ignore_request' => true]);
 	$messages      = $messagesModel->getItems();
 }
 catch (RuntimeException $e)

--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -159,7 +159,8 @@ class HtmlView extends BaseHtmlView
 		if ($item && $item->params->get('show_contact_list'))
 		{
 			// Get Category Model data
-			$categoryModel = new \Joomla\Component\Contact\Site\Model\CategoryModel(array('ignore_request' => true));
+			/* @var \Joomla\Component\Contact\Site\Model\CategoryModel $categoryModel */
+			$categoryModel = $app->bootComponent('com_contact')->getMVCFactory()->createModel('Category', 'Site', ['ignore_request' => true]);
 
 			$categoryModel->setState('category.id', $item->catid);
 			$categoryModel->setState('list.ordering', 'a.name');

--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -159,8 +159,9 @@ class HtmlView extends BaseHtmlView
 		if ($item && $item->params->get('show_contact_list'))
 		{
 			// Get Category Model data
-			/* @var \Joomla\Component\Contact\Site\Model\CategoryModel $categoryModel */
-			$categoryModel = $app->bootComponent('com_contact')->getMVCFactory()->createModel('Category', 'Site', ['ignore_request' => true]);
+			/** @var \Joomla\Component\Contact\Site\Model\CategoryModel $categoryModel */
+			$categoryModel = $app->bootComponent('com_contact')->getMVCFactory()
+				->createModel('Category', 'Site', ['ignore_request' => true]);
 
 			$categoryModel->setState('category.id', $item->catid);
 			$categoryModel->setState('list.ordering', 'a.name');

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Table\CoreContent;
 use Joomla\CMS\User\User;
 use Joomla\CMS\Workflow\WorkflowServiceInterface;
-use Joomla\Component\Workflow\Administrator\Model\StagesModel;
 use Joomla\Component\Workflow\Administrator\Table\StageTable;
 use Joomla\Component\Workflow\Administrator\Table\WorkflowTable;
 use Joomla\Database\DatabaseDriver;
@@ -351,7 +350,9 @@ class PlgContentJoomla extends CMSPlugin
 			return true;
 		}
 
-		$model = new StagesModel(['ignore_request' => true]);
+		/* @var \Joomla\Component\Workflow\Administrator\Model\StagesModel $model */
+		$model = $this->app->bootComponent('com_workflow')->getMVCFactory()
+			->createModel('Stages', 'Administrator', ['ignore_request' => true]);
 
 		$model->setState('filter.workflow_id', $pk);
 		$model->setState('filter.extension', $table->extension);

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -350,7 +350,7 @@ class PlgContentJoomla extends CMSPlugin
 			return true;
 		}
 
-		/* @var \Joomla\Component\Workflow\Administrator\Model\StagesModel $model */
+		/** @var \Joomla\Component\Workflow\Administrator\Model\StagesModel $model */
 		$model = $this->app->bootComponent('com_workflow')->getMVCFactory()
 			->createModel('Stages', 'Administrator', ['ignore_request' => true]);
 

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -19,7 +19,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Session\Session;
-use Joomla\Component\Menus\Administrator\Model\ItemModel;
 use Joomla\Database\ParameterType;
 
 /**
@@ -59,7 +58,7 @@ class PlgSampledataBlog extends CMSPlugin
 	/**
 	 * Holds the menuitem model
 	 *
-	 * @var    ItemModel
+	 * @var    \Joomla\Component\Menus\Administrator\Model\ItemModel
 	 *
 	 * @since  3.8.0
 	 */
@@ -884,7 +883,7 @@ class PlgSampledataBlog extends CMSPlugin
 		$articleIds = $this->app->getUserState('sampledata.blog.articles');
 
 		// Get MenuItemModel.
-		$this->menuItemModel = new ItemModel;
+		$this->menuItemModel = $this->app->bootComponent('com_menus')->getMVCFactory()->createModel('Item', 'Administrator', ['ignore_request' => true]);
 
 		// Get previously entered categories ids
 		$catIds = $this->app->getUserState('sampledata.blog.articles.catIds');
@@ -1410,7 +1409,8 @@ class PlgSampledataBlog extends CMSPlugin
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
 		// Add Include Paths.
-		$model  = new \Joomla\Component\Modules\Administrator\Model\ModuleModel;
+		/* @var \Joomla\Component\Modules\Administrator\Model\ModuleModel $model */
+		$model = $this->app->bootComponent('com_modules')->getMVCFactory()->createModel('Module', 'Administrator', ['ignore_request' => true]);
 		$access = (int) $this->app->get('access', 1);
 
 		// Get previously entered Data from UserStates.

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -883,7 +883,8 @@ class PlgSampledataBlog extends CMSPlugin
 		$articleIds = $this->app->getUserState('sampledata.blog.articles');
 
 		// Get MenuItemModel.
-		$this->menuItemModel = $this->app->bootComponent('com_menus')->getMVCFactory()->createModel('Item', 'Administrator', ['ignore_request' => true]);
+		$this->menuItemModel = $this->app->bootComponent('com_menus')->getMVCFactory()
+			->createModel('Item', 'Administrator', ['ignore_request' => true]);
 
 		// Get previously entered categories ids
 		$catIds = $this->app->getUserState('sampledata.blog.articles.catIds');
@@ -1409,8 +1410,9 @@ class PlgSampledataBlog extends CMSPlugin
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
 		// Add Include Paths.
-		/* @var \Joomla\Component\Modules\Administrator\Model\ModuleModel $model */
-		$model = $this->app->bootComponent('com_modules')->getMVCFactory()->createModel('Module', 'Administrator', ['ignore_request' => true]);
+		/** @var \Joomla\Component\Modules\Administrator\Model\ModuleModel $model */
+		$model = $this->app->bootComponent('com_modules')->getMVCFactory()
+			->createModel('Module', 'Administrator', ['ignore_request' => true]);
 		$access = (int) $this->app->get('access', 1);
 
 		// Get previously entered Data from UserStates.

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -131,8 +131,9 @@ class PlgSystemFields extends CMSPlugin
 
 		// Loading the model
 
-		/* @var \Joomla\Component\Fields\Administrator\Model\FieldModel $model */
-		$model = Factory::getApplication()->bootComponent('com_fields')->getMVCFactory()->createModel('Field', 'Administrator', ['ignore_request' => true]);
+		/** @var \Joomla\Component\Fields\Administrator\Model\FieldModel $model */
+		$model = Factory::getApplication()->bootComponent('com_fields')->getMVCFactory()
+			->createModel('Field', 'Administrator', ['ignore_request' => true]);
 
 		// Loop over the fields
 		foreach ($fields as $field)
@@ -221,8 +222,9 @@ class PlgSystemFields extends CMSPlugin
 
 		$context = $parts[0] . '.' . $parts[1];
 
-		/* @var \Joomla\Component\Fields\Administrator\Model\FieldModel $model */
-		$model = Factory::getApplication()->bootComponent('com_fields')->getMVCFactory()->createModel('Field', 'Administrator', ['ignore_request' => true]);
+		/** @var \Joomla\Component\Fields\Administrator\Model\FieldModel $model */
+		$model = Factory::getApplication()->bootComponent('com_fields')->getMVCFactory()
+			->createModel('Field', 'Administrator', ['ignore_request' => true]);
 		$model->cleanupValues($context, $item->id);
 	}
 

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -130,7 +130,9 @@ class PlgSystemFields extends CMSPlugin
 		}
 
 		// Loading the model
-		$model = new \Joomla\Component\Fields\Administrator\Model\FieldModel(array('ignore_request' => true));
+
+		/* @var \Joomla\Component\Fields\Administrator\Model\FieldModel $model */
+		$model = Factory::getApplication()->bootComponent('com_fields')->getMVCFactory()->createModel('Field', 'Administrator', ['ignore_request' => true]);
 
 		// Loop over the fields
 		foreach ($fields as $field)
@@ -219,7 +221,8 @@ class PlgSystemFields extends CMSPlugin
 
 		$context = $parts[0] . '.' . $parts[1];
 
-		$model = new \Joomla\Component\Fields\Administrator\Model\FieldModel(array('ignore_request' => true));
+		/* @var \Joomla\Component\Fields\Administrator\Model\FieldModel $model */
+		$model = Factory::getApplication()->bootComponent('com_fields')->getMVCFactory()->createModel('Field', 'Administrator', ['ignore_request' => true]);
 		$model->cleanupValues($context, $item->id);
 	}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
In Joomla 4, the right way to create a model object is use `MVCFactory` after `bootComponent`. For example https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_categories/src/Helper/CategoriesHelper.php#L99

However, there are still some places in our code use old method (create model class directly using `new ModelClassName` syntax). This PR improves code to make it consistent in our whole codebase.

### Testing Instructions
The modified code is random in our CMS, so I think the best way is someone with code review skill to review the code and make sure it is all correct. Or maybe @wilsonge will need to review and merge base on code review.