### PR TITLE
[4] webservices consistency

### DIFF
--- a/api/components/com_content/src/Serializer/ContentSerializer.php
+++ b/api/components/com_content/src/Serializer/ContentSerializer.php
@@ -43,7 +43,7 @@ class ContentSerializer extends JoomlaSerializer
 		foreach ($model->associations as $association)
 		{
 			$resources[] = (new Resource($association, $serializer))
-				->addLink('self', Route::link('site', Uri::root() . 'api/index.php/v1/content/article/' . $association->id));
+				->addLink('self', Route::link('site', Uri::root() . 'api/index.php/v1/content/articles/' . $association->id));
 		}
 
 		$collection = new Collection($resources, $serializer);

--- a/plugins/webservices/contact/contact.php
+++ b/plugins/webservices/contact/contact.php
@@ -41,7 +41,7 @@ class PlgWebservicesContact extends CMSPlugin
 	{
 		$route = new Route(
 			['POST'],
-			'v1/contact/form/:id',
+			'v1/contacts/form/:id',
 			'contact.submitForm',
 			['id' => '(\d+)'],
 			['component' => 'com_contact']
@@ -50,13 +50,13 @@ class PlgWebservicesContact extends CMSPlugin
 		$router->addRoute($route);
 
 		$router->createCRUDRoutes(
-			'v1/contact',
+			'v1/contacts',
 			'contact',
 			['component' => 'com_contact']
 		);
 
 		$router->createCRUDRoutes(
-			'v1/contact/categories',
+			'v1/contacts/categories',
 			'categories',
 			['component' => 'com_categories', 'extension' => 'com_contact']
 		);
@@ -78,37 +78,37 @@ class PlgWebservicesContact extends CMSPlugin
 	private function createFieldsRoutes(&$router)
 	{
 		$router->createCRUDRoutes(
-			'v1/fields/contact/contact',
+			'v1/fields/contacts/contact',
 			'fields',
 			['component' => 'com_fields', 'context' => 'com_contact.contact']
 		);
 
 		$router->createCRUDRoutes(
-			'v1/fields/contact/mail',
+			'v1/fields/contacts/mail',
 			'fields',
 			['component' => 'com_fields', 'context' => 'com_contact.mail']
 		);
 
 		$router->createCRUDRoutes(
-			'v1/fields/contact/categories',
+			'v1/fields/contacts/categories',
 			'fields',
 			['component' => 'com_fields', 'context' => 'com_contact.categories']
 		);
 
 		$router->createCRUDRoutes(
-			'v1/fields/groups/contact/contact',
+			'v1/fields/groups/contacts/contact',
 			'groups',
 			['component' => 'com_fields', 'context' => 'com_contact.contact']
 		);
 
 		$router->createCRUDRoutes(
-			'v1/fields/groups/contact/mail',
+			'v1/fields/groups/contacts/mail',
 			'groups',
 			['component' => 'com_fields', 'context' => 'com_contact.mail']
 		);
 
 		$router->createCRUDRoutes(
-			'v1/fields/groups/contact/categories',
+			'v1/fields/groups/contacts/categories',
 			'groups',
 			['component' => 'com_fields', 'context' => 'com_contact.categories']
 		);
@@ -133,9 +133,9 @@ class PlgWebservicesContact extends CMSPlugin
 		$getDefaults = array_merge(['public' => false], $defaults);
 
 		$routes = [
-			new Route(['GET'], 'v1/contact/contenthistory/:id', 'history.displayList', ['id' => '(\d+)'], $getDefaults),
-			new Route(['PATCH'], 'v1/contact/contenthistory/keep/:id', 'history.keep', ['id' => '(\d+)'], $defaults),
-			new Route(['DELETE'], 'v1/contact/contenthistory/:id', 'history.delete', ['id' => '(\d+)'], $defaults),
+			new Route(['GET'], 'v1/contacts/contenthistory/:id', 'history.displayList', ['id' => '(\d+)'], $getDefaults),
+			new Route(['PATCH'], 'v1/contacts/contenthistory/keep/:id', 'history.keep', ['id' => '(\d+)'], $defaults),
+			new Route(['DELETE'], 'v1/contacts/contenthistory/:id', 'history.delete', ['id' => '(\d+)'], $defaults),
 		];
 
 		$router->addRoutes($routes);

--- a/plugins/webservices/content/content.php
+++ b/plugins/webservices/content/content.php
@@ -40,7 +40,7 @@ class PlgWebservicesContent extends CMSPlugin
 	public function onBeforeApiRoute(&$router)
 	{
 		$router->createCRUDRoutes(
-			'v1/content/article',
+			'v1/content/articles',
 			'articles',
 			['component' => 'com_content']
 		);
@@ -111,9 +111,9 @@ class PlgWebservicesContent extends CMSPlugin
 		$getDefaults = array_merge(['public' => false], $defaults);
 
 		$routes = [
-			new Route(['GET'], 'v1/content/article/contenthistory/:id', 'history.displayList', ['id' => '(\d+)'], $getDefaults),
-			new Route(['PATCH'], 'v1/content/article/contenthistory/keep/:id', 'history.keep', ['id' => '(\d+)'], $defaults),
-			new Route(['DELETE'], 'v1/content/article/contenthistory/:id', 'history.delete', ['id' => '(\d+)'], $defaults),
+			new Route(['GET'], 'v1/content/articles/contenthistory/:id', 'history.displayList', ['id' => '(\d+)'], $getDefaults),
+			new Route(['PATCH'], 'v1/content/articles/contenthistory/keep/:id', 'history.keep', ['id' => '(\d+)'], $defaults),
+			new Route(['DELETE'], 'v1/content/articles/contenthistory/:id', 'history.delete', ['id' => '(\d+)'], $defaults),
 		];
 
 		$router->addRoutes($routes);

--- a/plugins/webservices/privacy/privacy.php
+++ b/plugins/webservices/privacy/privacy.php
@@ -43,18 +43,18 @@ class PlgWebservicesPrivacy extends CMSPlugin
 		$getDefaults = array_merge(['public' => false], $defaults);
 
 		$routes = [
-			new Route(['GET'], 'v1/privacy/request', 'requests.displayList', [], $getDefaults),
-			new Route(['GET'], 'v1/privacy/request/:id', 'requests.displayItem', ['id' => '(\d+)'], $getDefaults),
-			new Route(['GET'], 'v1/privacy/request/export/:id', 'requests.export', ['id' => '(\d+)'], $getDefaults),
-			new Route(['POST'], 'v1/privacy/request', 'requests.add', [], $defaults),
+			new Route(['GET'], 'v1/privacy/requests', 'requests.displayList', [], $getDefaults),
+			new Route(['GET'], 'v1/privacy/requests/:id', 'requests.displayItem', ['id' => '(\d+)'], $getDefaults),
+			new Route(['GET'], 'v1/privacy/requests/export/:id', 'requests.export', ['id' => '(\d+)'], $getDefaults),
+			new Route(['POST'], 'v1/privacy/requests', 'requests.add', [], $defaults),
 		];
 
 		$router->addRoutes($routes);
 
 		$routes = [
-			new Route(['GET'], 'v1/privacy/consent', 'consents.displayList', [], $getDefaults),
-			new Route(['GET'], 'v1/privacy/consent/:id', 'consents.displayItem', ['id' => '(\d+)'], $getDefaults),
-			new Route(['DELETE'], 'v1/privacy/consent/:id', 'consents.delete', ['id' => '(\d+)'], $defaults),
+			new Route(['GET'], 'v1/privacy/consents', 'consents.displayList', [], $getDefaults),
+			new Route(['GET'], 'v1/privacy/consents/:id', 'consents.displayItem', ['id' => '(\d+)'], $getDefaults),
+			new Route(['DELETE'], 'v1/privacy/consents/:id', 'consents.delete', ['id' => '(\d+)'], $defaults),
 		];
 
 		$router->addRoutes($routes);

--- a/plugins/webservices/redirect/redirect.php
+++ b/plugins/webservices/redirect/redirect.php
@@ -39,7 +39,7 @@ class PlgWebservicesRedirect extends CMSPlugin
 	public function onBeforeApiRoute(&$router)
 	{
 		$router->createCRUDRoutes(
-			'v1/redirect',
+			'v1/redirects',
 			'redirect',
 			['component' => 'com_redirect']
 		);

--- a/tests/Codeception/api/BasicCest.php
+++ b/tests/Codeception/api/BasicCest.php
@@ -63,7 +63,7 @@ class BasicCest
 	{
 		$I->amBearerAuthenticated('BADTOKEN');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/content/article/1');
+		$I->sendGET('/content/articles/1');
 		$I->seeResponseCodeIs(Codeception\Util\HttpCode::UNAUTHORIZED);
 	}
 
@@ -80,7 +80,7 @@ class BasicCest
 	{
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'text/xml');
-		$I->sendGET('/content/article/1');
+		$I->sendGET('/content/articles/1');
 		$I->seeResponseCodeIs(Codeception\Util\HttpCode::NOT_ACCEPTABLE);
 	}
 

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -76,7 +76,7 @@ class ContactCest
 			'name' => 'Francine Blogs'
 		];
 
-		$I->sendPOST('/contact', $testarticle);
+		$I->sendPOST('/contacts', $testarticle);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
 

--- a/tests/Codeception/api/com_contact/ContactCest.php
+++ b/tests/Codeception/api/com_contact/ContactCest.php
@@ -82,7 +82,7 @@ class ContactCest
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/contact/1');
+		$I->sendGET('/contacts/1');
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
@@ -90,12 +90,12 @@ class ContactCest
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
 
 		// Category is a required field for this patch request for now TODO: Remove this dependency
-		$I->sendPATCH('/contact/1', ['name' => 'Frankie Blogs', 'catid' => 4, 'published' => -2]);
+		$I->sendPATCH('/contacts/1', ['name' => 'Frankie Blogs', 'catid' => 4, 'published' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendDELETE('/contact/1');
+		$I->sendDELETE('/contacts/1');
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 
@@ -124,25 +124,25 @@ class ContactCest
 			]
 		];
 
-		$I->sendPOST('/contact/categories', $testContact);
+		$I->sendPOST('/contacts/categories', $testContact);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
 		$categoryId = $I->grabDataFromResponseByJsonPath('$.data.id')[0];
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/contact/categories/' . $categoryId);
+		$I->sendGET('/contacts/categories/' . $categoryId);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/contact/categories/' . $categoryId, ['title' => 'Another Title', 'published' => -2]);
+		$I->sendPATCH('/contacts/categories/' . $categoryId, ['title' => 'Another Title', 'published' => -2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendDELETE('/contact/categories/' . $categoryId);
+		$I->sendDELETE('/contacts/categories/' . $categoryId);
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 }

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -77,7 +77,7 @@ class ContentCest
 			'alias' => 'tobias'
 		];
 
-		$I->sendPOST('/content/article', $testarticle);
+		$I->sendPOST('/content/articles', $testarticle);
 
 		$I->seeResponseCodeIs(HttpCode::OK);
 
@@ -89,12 +89,12 @@ class ContentCest
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Content-Type', 'application/json');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendPATCH('/content/article/1', ['title' => 'Another Title', 'state' => -2, 'catid' => 2]);
+		$I->sendPATCH('/content/articles/1', ['title' => 'Another Title', 'state' => -2, 'catid' => 2]);
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendDELETE('/content/article/1');
+		$I->sendDELETE('/content/articles/1');
 		$I->seeResponseCodeIs(HttpCode::NO_CONTENT);
 	}
 

--- a/tests/Codeception/api/com_content/ContentCest.php
+++ b/tests/Codeception/api/com_content/ContentCest.php
@@ -83,7 +83,7 @@ class ContentCest
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');
 		$I->haveHttpHeader('Accept', 'application/vnd.api+json');
-		$I->sendGET('/content/article/1');
+		$I->sendGET('/content/articles/1');
 		$I->seeResponseCodeIs(HttpCode::OK);
 
 		$I->amBearerAuthenticated('c2hhMjU2OjM6ZTJmMjJlYTNlNTU0NmM1MDJhYTIzYzMwN2MxYzAwZTQ5NzJhMWRmOTUyNjY5MTk2YjE5ODJmZWMwZTcxNzgwMQ==');


### PR DESCRIPTION
Pull Request for discussion https://github.com/joomla/joomla-cms/discussions/34080#discussioncomment-770977

### Summary of Changes
so 
`v1/content/article` became `v1/content/articles` 

`v1/content/article/contenthistory/`         became `v1/content/articles/contenthistory/`
`v1/content/article/contenthistory/keep` became `v1/content/articles/contenthistory/keep`

`v1/contact/form/:id`      became  `v1/contacts/form/:id`
`v1/contact`                    became  `v1/contacts`
`v1/contact/categories`  became  `v1/contacts/categories`

`v1/fields/contact/contact`   became  `v1/fields/contacts/contact`
`v1/fields/contact/mail`   became `v1/fields/contacts/mail`
`v1/fields/groups/contact/contact` became  `v1/fields/groups/contacts/contact`
`v1/fields/groups/contact/mail`   became `v1/fields/groups/contacts/mail`
`v1/fields/groups/contact/categories`   became `v1/fields/groups/contacts/categories`

`v1/contact/contenthistory/:id`  became `v1/contacts/contenthistory/:id`
`v1/contact/contenthistory/keep/:id`  became `v1/contacts/contenthistory/keep/:id`

`v1/redirect`  became  `v1/redirects`

`v1/privacy/request` became  `v1/privacy/requests`
`v1/privacy/request/export/:id` became `v1/privacy/requests/export/:id`

`v1/privacy/consent`  became `v1/privacy/consents`


### Testing Instructions
call the all the above  endpoints




### Documentation Changes Required
yes
