### PR TITLE
[4.0] User Groups - Check before Deleting Groups

### DIFF
--- a/administrator/components/com_users/src/Model/GroupModel.php
+++ b/administrator/components/com_users/src/Model/GroupModel.php
@@ -271,6 +271,18 @@ class GroupModel extends AdminModel
 			}
 		}
 
+		// Iterate the items to check if all of them exist.
+		foreach ($pks as $i => $pk)
+		{
+			if (!$table->load($pk))
+			{
+				// Item is not in the table.
+				$this->setError($table->getError());
+
+				return false;
+			}
+		}
+
 		// Iterate the items to delete each one.
 		foreach ($pks as $i => $pk)
 		{
@@ -305,12 +317,6 @@ class GroupModel extends AdminModel
 					unset($pks[$i]);
 					Factory::getApplication()->enqueueMessage(Text::_('JERROR_CORE_DELETE_NOT_PERMITTED'), 'error');
 				}
-			}
-			else
-			{
-				$this->setError($table->getError());
-
-				return false;
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes
The `$table->load` check for deleting group rows has been moved above the loop that deletes them.
Please refer to #33771 for the reason behind this.
This PR mimics what was done for Content Map's Delete All Bug (#33771) to User Groups where a similar bug was left un-noticed


### Testing Instructions
1. Visit Backend -> Users -> User Groups
2. Add 4 new groups where 2 groups are the parent and 2 are their child:

```
- B
:  - B1
- C
:  - C1
```
3. Select all of these items as shown in the gif below. Order is Important: Parent (B) -> It's Child (B1) -> Parent (C) -> It's Child (C1)
4. Proceed to Delete them

**Before the PR:** only the first Parent-Child pair would be deleted and the 2nd Parent-Child was skipped. This happened because the B1 was deleted with B (it's parent) and the loop returned false when it iterated over B1 as it was no longer present in the table.
**After the PR:** all selected groups will be deleted.

### Actual result BEFORE applying this Pull Request
![delGroupsBefore](https://user-images.githubusercontent.com/53610833/119219167-b7538e80-bb01-11eb-81a9-40da1b1a8bbe.gif)



### Expected result AFTER applying this Pull Request
![delGroupsAfter](https://user-images.githubusercontent.com/53610833/119219168-ba4e7f00-bb01-11eb-85c6-cfd0d50980b4.gif)



### Documentation Changes Required
None
