### PR TITLE
[4.0] Make file extension case insensitive in Template Manager

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1980,8 +1980,9 @@ class TemplateModel extends FormModel
 			$archiveTypes = explode(',', $params->get('compressed_formats'));
 
 			$this->allowedFormats = array_merge($imageTypes, $sourceTypes, $fontTypes, $archiveTypes);
+			$this->allowedFormats = array_map('strtolower', $this->allowedFormats);
 		}
 
-		return in_array($ext, $this->allowedFormats);
+		return in_array(strtolower($ext), $this->allowedFormats);
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #33179.

### Summary of Changes
This PR address the issue https://github.com/joomla/joomla-cms/issues/33179 . So please see https://github.com/joomla/joomla-cms/issues/33179 to understand the issue which this PR tries to solves


### Testing Instructions
1. Prepare an image with file extension in filename in upper case. For example **sample.PNG**
2. Copy that file to templates/cassiopeia folder
3. Go to System -> Site Templates -> Cassiopeia Details and Files to see files/folder from that template
4. Before patch: You won't see the file  **sample.PNG**
5. After patch, you will see the file
