### PR TITLE
Webservice filters

### DIFF
--- a/libraries/src/MVC/View/JsonApiView.php
+++ b/libraries/src/MVC/View/JsonApiView.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\MVC\View;
 
 use Joomla\CMS\Document\JsonapiDocument;
 use Joomla\CMS\Factory;
+use Joomla\CMS\MVC\Model\BaseModel;
 use Joomla\CMS\MVC\View\Event\OnGetApiFields;
 use Joomla\CMS\Router\Exception\RouteNotFoundException;
 use Joomla\CMS\Serializer\JoomlaSerializer;
@@ -118,6 +119,12 @@ abstract class JsonApiView extends JsonView
 		$currentUrl = Uri::getInstance();
 		$currentPageDefaultInformation = ['offset' => 0, 'limit' => 20];
 		$currentPageQuery = $currentUrl->getVar('page', $currentPageDefaultInformation);
+
+		// Set any filters passed in the query as model state.
+		foreach ($currentUrl->getVar('filter', []) as $name => $value)
+		{
+			$model->setState('filter.' . $name, $value);
+		}
 
 		if ($items === null)
 		{


### PR DESCRIPTION
Pull Request for Issue #34100 

### Summary of Changes

Allow filtering of data sets by passing `filter[name]` parameters in the request query, similar to the `page[]` parameters to set `offset` and `limit`. Parameters passed in this manner are set in the model state before the query is executed. This allows for simple, straight forward filtering on parameters accessed by any specific `ListModel::getListQuery()` implementation.

### Testing Instructions

Call any known list endpoint with an appropriate filter parameter. For example:

{{base_path}}/api/index.php/v1/content/article?filter[category_id]=10
{{base_path}}/api/index.php/v1/content/categories?filter[extension]=com_content
etc.

### Documentation Changes Required

yes
