### PR TITLE
Fix patterns field check when field empty and not required

### DIFF
--- a/build/media_source/system/js/fields/validate.es6.js
+++ b/build/media_source/system/js/fields/validate.es6.js
@@ -223,7 +223,7 @@ class JFormValidator {
       }
 
       this.handleResponse(true, element);
-      return false;
+      return true;
     }
 
     if (handler === '') {


### PR DESCRIPTION
Pull Request for Issue #34102  .

### Summary of Changes
validating pattern fails when field is not required and empty, this is not correct. This PR fixes this (in line with J3 validation)
pinging @dgrammatiko 


### Testing Instructions
see #34102


### Actual result BEFORE applying this Pull Request
saving form with empty field is not possible


### Expected result AFTER applying this Pull Request
saving form with empty field works correct


### Documentation Changes Required
no