### PR TITLE
[3] Fix Delete Batch For User Groups

### DIFF
--- a/administrator/components/com_finder/models/maps.php
+++ b/administrator/components/com_finder/models/maps.php
@@ -86,17 +86,6 @@ class FinderModelMaps extends JModelList
 		// Include the content plugins for the on delete events.
 		JPluginHelper::importPlugin('content');
 
-		// Iterate the items to check if all of them exist.
-		foreach ($pks as $i => $pk)
-		{
-			if (!$table->load($pk))
-			{
-				$this->setError($table->getError());
-
-				return false;
-			}
-		}
-
 		// Iterate the items to delete each one.
 		foreach ($pks as $i => $pk)
 		{
@@ -141,6 +130,12 @@ class FinderModelMaps extends JModelList
 						$this->setError(JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'));
 					}
 				}
+			}
+			else
+			{
+				$this->setError($table->getError());
+
+				return false;
 			}
 		}
 

--- a/administrator/components/com_finder/models/maps.php
+++ b/administrator/components/com_finder/models/maps.php
@@ -86,6 +86,17 @@ class FinderModelMaps extends JModelList
 		// Include the content plugins for the on delete events.
 		JPluginHelper::importPlugin('content');
 
+		// Iterate the items to check if all of them exist.
+		foreach ($pks as $i => $pk)
+		{
+			if (!$table->load($pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+		}
+
 		// Iterate the items to delete each one.
 		foreach ($pks as $i => $pk)
 		{
@@ -130,12 +141,6 @@ class FinderModelMaps extends JModelList
 						$this->setError(JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'));
 					}
 				}
-			}
-			else
-			{
-				$this->setError($table->getError());
-
-				return false;
 			}
 		}
 

--- a/administrator/components/com_users/models/group.php
+++ b/administrator/components/com_users/models/group.php
@@ -245,12 +245,19 @@ class UsersModelGroup extends JModelAdmin
 		// Check if I am a Super Admin
 		$iAmSuperAdmin = $user->authorise('core.admin');
 
-		// Do not allow to delete groups to which the current user belongs
 		foreach ($pks as $pk)
 		{
+			// Do not allow to delete groups to which the current user belongs
 			if (in_array($pk, $groups))
 			{
 				JError::raiseWarning(403, JText::_('COM_USERS_DELETE_ERROR_INVALID_GROUP'));
+
+				return false;
+			}
+			// Check if the item exists.
+			elseif (!$table->load($pk))
+			{
+				$this->setError($table->getError());
 
 				return false;
 			}
@@ -290,12 +297,6 @@ class UsersModelGroup extends JModelAdmin
 					unset($pks[$i]);
 					JError::raiseWarning(403, JText::_('JERROR_CORE_DELETE_NOT_PERMITTED'));
 				}
-			}
-			else
-			{
-				$this->setError($table->getError());
-
-				return false;
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue #19346
Thanks @Quy https://github.com/joomla/joomla-cms/pull/34094#issuecomment-846561950

### Summary of Changes
Redo of PR #34094 for J3


### Testing Instructions

1. Visit Backend -> Users -> User Groups
2. Add 4 new groups where 2 groups are the parent and 2 are their child:

```
- A
:  - A1
- B
:  - B1
```
3. Select all of these items as shown in the gif below. Order is Important: Parent (A) -> It's Child (A1) -> Parent (B) -> It's Child (B1)
4. Proceed to Delete them

**Before the PR:** only the first Parent-Child pair would be deleted and the 2nd Parent-Child was skipped. This happened because the A1 was deleted with A (it's parent) and the loop returned false when it iterated over A1 as it was no longer present in the table.
**After the PR:** all selected groups will be deleted.

### Actual result BEFORE applying this Pull Request
![groupsj3_before](https://user-images.githubusercontent.com/53610833/119264102-61651080-bbff-11eb-8d93-b6b0885a1102.gif)



### Expected result AFTER applying this Pull Request
![groupsj3_after](https://user-images.githubusercontent.com/53610833/119264108-64f89780-bbff-11eb-8c8c-b9bfe717686c.gif)



### Documentation Changes Required
None
