### PR TITLE
[4] add autocomplete and required attributes to username/password fields

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/update/finaliseconfirm.php
+++ b/administrator/components/com_joomlaupdate/tmpl/update/finaliseconfirm.php
@@ -38,7 +38,7 @@ $twofactormethods = AuthenticationHelper::getTwoFactorMethods();
 		<div class="control-group">
 			<div class="controls">
 				<div class="input-group">
-					<input name="username" id="mod-login-username" type="text" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_USERNAME'); ?>" size="15" autofocus="true">
+					<input name="username" id="mod-login-username" type="text" class="form-control" required="required" autocomplete="username" placeholder="<?php echo Text::_('JGLOBAL_USERNAME'); ?>" size="15" autofocus="true">
 					<span class="input-group-text">
 						<span class="icon-user" aria-hidden="true"></span>
 						<label for="mod-login-username" class="visually-hidden">
@@ -51,7 +51,7 @@ $twofactormethods = AuthenticationHelper::getTwoFactorMethods();
 		<div class="control-group">
 			<div class="controls">
 				<div class="input-group">
-					<input name="passwd" id="mod-login-password" type="password" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>" size="15">
+					<input name="passwd" id="mod-login-password" type="password" class="form-control" required="required" autocomplete="current-password" placeholder="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>" size="15">
 					<span class="input-group-text">
 						<span class="icon-lock" aria-hidden="true"></span>
 						<label for="mod-login-password" class="visually-hidden">

--- a/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
+++ b/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
@@ -46,7 +46,7 @@ Text::script('JHIDEPASSWORD');
 		<div class="control-group">
 			<div class="controls">
 				<div class="input-group">
-					<input name="username" id="mod-login-username" type="text" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_USERNAME'); ?>" size="15" autofocus="true">
+					<input name="username" id="mod-login-username" type="text" class="form-control" required="required" autocomplete="username" placeholder="<?php echo Text::_('JGLOBAL_USERNAME'); ?>" size="15" autofocus="true">
 					<span class="input-group-text">
 						<span class="icon-user icon-fw" aria-hidden="true"></span>
 						<label for="mod-login-username" class="visually-hidden">
@@ -59,7 +59,7 @@ Text::script('JHIDEPASSWORD');
 		<div class="control-group">
 			<div class="controls">
 				<div class="input-group">
-					<input name="passwd" id="mod-login-password" type="password" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>" size="15">
+					<input name="passwd" id="mod-login-password" type="password" class="form-control" required="required" autocomplete="current-password" placeholder="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>" size="15">
 					<button type="button" class="btn btn-secondary input-password-toggle">
 						<span class="icon-eye icon-fw" aria-hidden="true"></span>
 						<span class="visually-hidden"><?php echo Text::_('JSHOWPASSWORD'); ?></span>


### PR DESCRIPTION
### Summary of Changes

add autocomplete and required attributes to username/password fields in the Joomla update process 

### Testing Instructions

Upgrade Joomla, checking the username and password fields before/after in the captive pages. 

### Actual result BEFORE applying this Pull Request

No required and autocomplete attributes.

### Expected result AFTER applying this Pull Request

Required and autocomplete attributes applied to fields. 

### Documentation Changes Required

none