### PR TITLE
[4.0] atum Remove underline from badges

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -173,6 +173,10 @@
 
     a {
       font-weight: 500;
+      text-decoration: underline;
+    }
+    
+    .btn{
       text-decoration: none;
     }
 

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -173,7 +173,7 @@
 
     a {
       font-weight: 500;
-      text-decoration: underline;
+      text-decoration: none;
     }
 
     .list-group-item a > span {

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -175,8 +175,8 @@
       font-weight: 500;
       text-decoration: underline;
     }
-    
-    .btn{
+
+    .btn {
       text-decoration: none;
     }
 


### PR DESCRIPTION
Pull Request for Issue #34137 .

### Summary of Changes

Removed underline style from Badge

### Testing Instructions
- Apply patch 
- Build css <code>npm run build:css</code>
- Navigate to <code>Home Dashboard</code>
- notice the badges in site information

 ADDITIONAL checks
 go to <code>User Menu>Accesssibility> Highlight Links</code> , enable it and notice the badges again. Having highlight links enables, text now is underligned.

### Actual result BEFORE applying this Pull Request
text in Badges were underlined 

### Expected result AFTER applying this Pull Request
Underline style is removed

### Documentation Changes Required
none