### PR TITLE
[4.0] rework language handling in module emptystate

### DIFF
--- a/layouts/joomla/content/emptystate_module.php
+++ b/layouts/joomla/content/emptystate_module.php
@@ -18,7 +18,7 @@ $componentLangString = $textPrefix . '_EMPTYSTATE_TITLE';
 $moduleLangString = $textPrefix . '_EMPTYSTATE_MODULE_TITLE' . (array_key_exists('textSuffix', $displayData) ? $displayData['textSuffix'] : '');
 
 // Did we have a definitive title provided to the view?
-if ($displayData['title'])
+if (isset($displayData['title']))
 {
 	$title = $displayData['title'];
 }

--- a/layouts/joomla/content/emptystate_module.php
+++ b/layouts/joomla/content/emptystate_module.php
@@ -9,18 +9,29 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
 $textPrefix = $displayData['textPrefix'];
 $icon = $displayData['icon'] ?? 'icon-copy article';
 $componentLangString = $textPrefix . '_EMPTYSTATE_TITLE';
 $moduleLangString = $textPrefix . '_EMPTYSTATE_MODULE_TITLE' . (array_key_exists('textSuffix', $displayData) ? $displayData['textSuffix'] : '');
-$moduleTitle = Text::_($moduleLangString);
 
-$title = $displayData['title']
-	?? ($moduleTitle != $moduleLangString
-		? Text::_($moduleTitle)
-		: Text::_($componentLangString));
+// Did we have a definitive title provided to the view?
+if ($displayData['title'])
+{
+	$title = $displayData['title'];
+}
+// Can we find a *_EMPTYSTATE_MODULE_TITLE translation?
+elseif (Factory::getApplication()->getLanguage()->hasKey($moduleLangString))
+{
+	$title = Text::_($moduleLangString);
+}
+// Else use the components *_EMPTYSTATE_TITLE string.
+else
+{
+	$title = Text::_($componentLangString);
+}
 ?>
 <div class="mb-4">
 	<p class="fw-bold text-center text-muted">


### PR DESCRIPTION

### Summary of Changes

When enabling language debug mode in Joomla 4.0, the new Module Empty State would display untranslated strings as it was doing a comparison incorrectly 

### Testing Instructions

Load home dashboard - view empty states in modules
enable language debug in joomla global config. 
Load home dashboard - view empty states in modules

### Actual result BEFORE applying this Pull Request

<img width="643" alt="Screenshot 2021-05-23 at 16 56 38" src="https://user-images.githubusercontent.com/400092/119268383-9d41ab00-bbea-11eb-822f-9236a46e4bbd.png">


### Expected result AFTER applying this Pull Request

<img width="642" alt="Screenshot 2021-05-23 at 17 12 33" src="https://user-images.githubusercontent.com/400092/119268381-9b77e780-bbea-11eb-9df3-0fed0ebc6b33.png">


### Documentation Changes Required

