### PR TITLE
[4.0] atum Toolbar items sizing issue

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -52,7 +52,7 @@ body {
 
     .joomlaversion {
       padding: 0;
-      text-decoration: none;
+      text-decoration: none !important;
       border: none;
     }
   }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -48,6 +48,11 @@ body {
       text-decoration: underline !important;
       border: #f00 dotted 1px;
     }
+
+    a.header-item-content {
+      padding:0px !important;
+    }
+
   }
 }
 

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -49,10 +49,17 @@ body {
       border: #f00 dotted 1px;
     }
 
-    a.header-item-content {
-      padding: 0 !important; /* no unit */
+    .header-item-content {
+      padding: 3px;
+      text-decoration: underline;
+      border: #f00 dotted 1px;
     }
 
+    .joomlaversion {
+      padding: 0;
+      text-decoration: none;
+      border: none;
+    }
   }
 }
 

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -43,7 +43,8 @@ body {
   }
 
   &.a11y_highlight {
-    a, .header-item-content {
+    a,
+    .header-item-content {
       padding: 3px;
       text-decoration: underline !important;
       border: #f00 dotted 1px;

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -43,15 +43,9 @@ body {
   }
 
   &.a11y_highlight {
-    a {
+    a, .header-item-content {
       padding: 3px;
       text-decoration: underline !important;
-      border: #f00 dotted 1px;
-    }
-
-    .header-item-content {
-      padding: 3px;
-      text-decoration: underline;
       border: #f00 dotted 1px;
     }
 

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -50,7 +50,7 @@ body {
     }
 
     a.header-item-content {
-      padding:0px !important;
+      --padding: 0px !important;
     }
 
   }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -50,7 +50,7 @@ body {
     }
 
     a.header-item-content {
-      --padding: 0px !important;
+      padding: 0 !important; /* no unit */
     }
 
   }


### PR DESCRIPTION
Pull Request for Issue #34109 .

### Summary of Changes
On enabling Highlight Links in accessibility, there was mismatch in size of toolbar items because of additional padding.
But keeping accessibility in mind, other things should be left unchanged, therefore just removed the padding.


### Testing Instructions
- apply the patch and rebuild css <code>npm run build:css</code>
- turn highlight links on from accessibility and note, size doesnt change

### Actual result BEFORE applying this Pull Request
<img width="711" alt="old" src="https://user-images.githubusercontent.com/65963997/119274356-19f57900-bc2d-11eb-8a44-dc867eff3443.png">

### Expected result AFTER applying this Pull Request
![ssss](https://user-images.githubusercontent.com/65963997/119296017-cbb89800-bc75-11eb-83f1-5a34f5ba5bda.gif)




### Documentation Changes Required

