### PR TITLE
[4.0.0] Deprecate mcrypt use in decrypting settings for 2fa

### DIFF
--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -1043,7 +1043,7 @@ class UserModel extends AdminModel
 			// Attempt to decrypt using the mcrypt adapter, under normal circumstances this should fail (We no longer use mcrypt adapter to encrypt).
 			$decryptedConfig = $mcrypt->decryptString($config);
 
-			// If we were able to decrypt correctly, { will be in the config (JSON String), so lets update to openssl adapter use.
+			// If we were able to decrypt using the mcrypt adapter, { will be in the config (JSON String), so lets update to openssl adapter use.
 			if (strpos($decryptedConfig, '{') !== false)
 			{
 				// Data encrypted with mcrypt, decrypt it, and then convert to openssl.

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -1040,7 +1040,7 @@ class UserModel extends AdminModel
 
 			$decryptedConfig = $mcrypt->decryptString($config);
 
-			// If we were able to decrypt correctly, { will be in the config, so lets get rid of mcrypt and update to openssl encryption.
+			// If we were able to decrypt correctly, { will be in the config, so lets get rid of mcrypt and update to openssl adapter use.
 			if (strpos($decryptedConfig, '{') !== false)
 			{
 				// Data encrypted with mcrypt, decrypt it, and then convert to openssl.
@@ -1049,7 +1049,7 @@ class UserModel extends AdminModel
 			}
 			else
 			{
-				// Config data seems to be save encrypted, this can happen with 3.6.3 and openssl, lets get the data
+				// Config data seems to be save encrypted, this can happen with 3.6.3 and openssl, lets get the data.
 				$decryptedConfig = $openssl->decryptString($config);
 			}
 

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -1031,16 +1031,19 @@ class UserModel extends AdminModel
 		// Get the secret key, yes the thing that is saved in the configuration file
 		$key = $this->getOtpConfigEncryptionKey();
 
+		// Cleanup old encryption methods, and convert to using openssl as the adapter to use.
 		if (strpos($config, '{') === false)
 		{
-			$openssl         = new Aes($key, 256);
+			// We use the openssl adapter by default now.
+			$openssl = new Aes($key, 256);
 
-			// Deal with legacy mcrypt encrypted data, and convert it to openssl encrypted data.
-			$mcrypt          = new Aes($key, 256, 'cbc', 'mcrypt');
+			// Deal with legacy mcrypt encrypted data.
+			$mcrypt = new Aes($key, 256, 'cbc', 'mcrypt');
 
+			// Attempt to decrypt using the mcrypt adapter, under normal circumstances this should fail (We no longer use mcrypt adapter to encrypt).
 			$decryptedConfig = $mcrypt->decryptString($config);
 
-			// If we were able to decrypt correctly, { will be in the config, so lets get rid of mcrypt and update to openssl adapter use.
+			// If we were able to decrypt correctly, { will be in the config (JSON String), so lets update to openssl adapter use.
 			if (strpos($decryptedConfig, '{') !== false)
 			{
 				// Data encrypted with mcrypt, decrypt it, and then convert to openssl.

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -1034,13 +1034,16 @@ class UserModel extends AdminModel
 		if (strpos($config, '{') === false)
 		{
 			$openssl         = new Aes($key, 256);
-			$mcrypt          = new Aes($key, 256, 'cbc', null, 'mcrypt');
+
+			// Deal with legacy mcrypt encrypted data, and convert it to openssl encrypted data.
+			$mcrypt          = new Aes($key, 256, 'cbc', 'mcrypt');
 
 			$decryptedConfig = $mcrypt->decryptString($config);
 
+			// If we were able to decrypt correctly, { will be in the config, so lets get rid of mcrypt and update to openssl encryption.
 			if (strpos($decryptedConfig, '{') !== false)
 			{
-				// Data encrypted with mcrypt
+				// Data encrypted with mcrypt, decrypt it, and then convert to openssl.
 				$decryptedOtep = $mcrypt->decryptString($encryptedOtep);
 				$encryptedOtep = $openssl->encryptString($decryptedOtep);
 			}

--- a/libraries/src/Encrypt/AES/Mcrypt.php
+++ b/libraries/src/Encrypt/AES/Mcrypt.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Encrypt\Randval;
  * Mcrypt implementation
  *
  * @since    4.0.0
+ *
+ * @deprecated 4.0.0 will be removed in 5.0.0
  */
 class Mcrypt extends AbstractAES implements AesInterface
 {


### PR DESCRIPTION
### Summary of Changes

The mcrypt extension has been abandonware for over a decade now, and was also fairly complex to use. It has therefore been deprecated in favour of OpenSSL, where it will be removed from the core and into PECL in PHP 7.2. It was deprecated in PHP 7.1

There is one use in Joomla 4 that can still be triggered, and that is to decrypt the configuration and OTEP values from the database, if previously encrypted with mcrypt. 

If this case is triggered then Joomla decrypts using mcrypt and re-encrypts using openssl using the AES Class. 

**THIS CODE HAS NEVER WORKED ANYWAY SINCE BEING ADDED** due to a typo in the constructor arguments  when setting up the `$mcrypt` instance. The number of params provided meant that the `mcrypt' value last in the params list was never used, meaning that `$mcrypt` was always an instance using the openssl adapter. 

As Joomla 4.0.0 is about to be released (cough, maybe some time, but the RC will be) we need to slip these deprecated tags in else it will be another decade before we can remove this code. 

@wilsonge urgent review please :) :) :)

### Testing Instructions

Code review. 


// cc @nikosdion @joomdonation 
// replacement for https://github.com/joomla/joomla-cms/pull/33954