### PR TITLE
[4] filter to bool the cache_platformprefix and debug_lang_const on save

### DIFF
--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -32,7 +32,7 @@
 			layout="joomla.form.field.radio.switcher"
 			default="0"
 			label="COM_CONFIG_FIELD_CACHE_PLATFORMPREFIX_LABEL"
-			filter="integer"
+			filter="boolean"
 			showon="caching:1,2"
 			>
 			<option value="0">JNO</option>
@@ -319,7 +319,7 @@
 			description="COM_CONFIG_FIELD_DEBUG_CONST_LANG_DESC"
 			layout="joomla.form.field.radio.switcher"
 			default="1"
-			filter="integer"
+			filter="boolean"
 			showon="debug_lang:1"
 			>
 			<option value="0">COM_CONFIG_FIELD_DEBUG_CONST</option>

--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -116,7 +116,7 @@ class JConfig
 	/* Debug Settings */
 	public $debug = true;
 	public $debug_lang = false;
-	public $debug_lang_const = 1;
+	public $debug_lang_const = true;
 
 	/* Meta Settings */
 	public $MetaDesc = 'Joomla! - the dynamic portal engine and content management system';

--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -811,7 +811,7 @@ class Cache
 	public static function getPlatformPrefix()
 	{
 		// No prefix when Global Config is set to no platform specific prefix
-		if (!Factory::getApplication()->get('cache_platformprefix', '0'))
+		if (!Factory::getApplication()->get('cache_platformprefix', false))
 		{
 			return '';
 		}

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -324,7 +324,7 @@ class Language
 			// Store debug information
 			if ($this->debug)
 			{
-				$value = Factory::getApplication()->get('debug_lang_const', 1) == 0 ? $key : $string;
+				$value = Factory::getApplication()->get('debug_lang_const', true) == false ? $key : $string;
 				$string = '**' . $value . '**';
 
 				$caller = $this->getCallerInfo();

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -324,7 +324,7 @@ class Language
 			// Store debug information
 			if ($this->debug)
 			{
-				$value = Factory::getApplication()->get('debug_lang_const', true) == false ? $key : $string;
+				$value = Factory::getApplication()->get('debug_lang_const', true) ? $string : $key;
 				$string = '**' . $value . '**';
 
 				$caller = $this->getCallerInfo();


### PR DESCRIPTION
### Summary of Changes

Pull Request for Issue https://github.com/joomla/joomla-cms/issues/34134

### Testing Instructions

Install joomla 4
View configuration.php
Login to admin
save global configuration with no changes

see the https://gist.github.com/PhilETaylor/95609cc3d716e985aa348da5b839cced/revisions

as you can see debug_lang_const and cache_platformprefix on clean installation are booleans

After saving Joomla global configuration, they are converted and stored as integers.

### Actual result BEFORE applying this Pull Request

```php
public $debug_lang_const = 1;
public $cache_platformprefix = 1;
```

### Expected result AFTER applying this Pull Request

```php
public $debug_lang_const = true;
public $cache_platformprefix = true;
```

### Documentation Changes Required

none