### PR TITLE
[3] Fix Delete Batch for Content Maps

### DIFF
--- a/administrator/components/com_finder/models/maps.php
+++ b/administrator/components/com_finder/models/maps.php
@@ -86,6 +86,17 @@ class FinderModelMaps extends JModelList
 		// Include the content plugins for the on delete events.
 		JPluginHelper::importPlugin('content');
 
+		// Iterate the items to check if all of them exist.
+		foreach ($pks as $i => $pk)
+		{
+			if (!$table->load($pk))
+			{
+				$this->setError($table->getError());
+
+				return false;
+			}
+		}
+
 		// Iterate the items to delete each one.
 		foreach ($pks as $i => $pk)
 		{
@@ -130,12 +141,6 @@ class FinderModelMaps extends JModelList
 						$this->setError(JText::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'));
 					}
 				}
-			}
-			else
-			{
-				$this->setError($table->getError());
-
-				return false;
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes
Redo of PR #33771 for J3


### Testing Instructions

#### Before testing, Please take a backup of `#_finder_taxonomy` table to avoid the loss of any data

1. Visit Control Panel (Backend)
2. Top Navbar -> Extensions -> Plugins -> Search 'Content - Smart Search' -> Enable the plugin
3. Components -> Smart Search -> Content Map
4. Ensure that you have sufficient data in this table with multiple parent-level and child-level maps (Installting Blog Sample Data will also work)
5. Click on the select all checkbox and proceed to delete them.

Before the PR, only the first parent and its children would get deleted and then the function would return false skipping the remaining elements.
After the PR, you should see the Empty State, ie. All items deleted successfully.

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request
![maps_after](https://user-images.githubusercontent.com/53610833/119316097-2b25a080-bc94-11eb-967b-a5a04a4ba2bb.gif)



### Documentation Changes Required
None
