### PR TITLE
[4.0] Hide unassigned modules

### DIFF
--- a/administrator/components/com_menus/layouts/joomla/menu/edit_modules.php
+++ b/administrator/components/com_menus/layouts/joomla/menu/edit_modules.php
@@ -47,7 +47,7 @@ if (!$saveHistory)
 }
 
 $html   = array();
-$html[] = '<fieldset><ul class="horizontal-buttons list-unstyled">';
+$html[] = '<fieldset><ul class="list-unstyled">';
 
 foreach ($fields as $field)
 {


### PR DESCRIPTION
This is a visual change as shown in the screenshots. For me the current horizontal layout of the two radio is confusing as it appears that they are part of the table below.

### before
![image](https://user-images.githubusercontent.com/1296369/119314843-1c77c300-bc6d-11eb-97c4-56e5cf064944.png)

### After
![image](https://user-images.githubusercontent.com/1296369/119314907-2b5e7580-bc6d-11eb-8658-665ce39391ed.png)
