### PR TITLE
[4.0] gray-600 [a11y]

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -7,7 +7,7 @@ $gray-200:                         #e8e8e8;
 $gray-300:                         #dee2e6; //used for toolbar and badges
 $gray-400:                         #cdcdcd; //used for border-bottom sidebar-nav and toolbar normal border
 $gray-500:                         #adb5bd; //used in toolbar and buttons for border
-//$gray-600:                         #6f7780; //used for atum-text-dark and $secondary
+$gray-600:                         #666e76; //used for atum-text-dark and $secondary
 $gray-700:                         #495057; //used for atum-text-dark, secondary
 $gray-800:                         #343a40;
 $gray-900:                         #212529; //used for tree header


### PR DESCRIPTION
Anything using $gray-600 is getting the color from the bs5 variables.scss

```
$text-muted:   $gray-600 !default;
$form-text-color:  $text-muted !default;
```

This is not a contrast problem when the background color is white but if the background is the blue pattern then the color ratio fails

One place where this is used is the alias description
![image](https://user-images.githubusercontent.com/1296369/117322163-aa8a3600-ae85-11eb-905c-bdea1602477d.png)

I am not sure why but we are overriding the bs5 default colors for the $gray-* variables nor why the $gray-600 was commented out

This PR uncomments the gray-600 variable and changes it slightly so that the contrast is valid on both the white and blue backgrounds

Pull Request for Issue #33580 

this is a scss change so dont forget to rebuild the css