### PR TITLE
[4.0] Sidebar badge contrast [a11y]

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -185,7 +185,7 @@
   .badge {
     align-self: center;
     margin: 0 .3rem .25rem;
-    background-color: var(--atum-bg-dark-50);
+    background-color: var(--atum-bg-dark-60);
   }
 }
 


### PR DESCRIPTION
On a multilingual site there is a badge for the default language menu item. This is failing the contrast checks.

this is an scss change so dont forget to rebuild the css for testing

![image](https://user-images.githubusercontent.com/1296369/119318133-d58bcc80-bc70-11eb-82b7-910f09d59264.png)
