### PR TITLE
[4.0] Sidebar collapse toggle incorrectly initialized for smaller screens

### DIFF
--- a/build/media_source/templates/administrator/atum/js/template.es6.js
+++ b/build/media_source/templates/administrator/atum/js/template.es6.js
@@ -149,14 +149,19 @@ function setMobile() {
   }
 
   if (small.matches) {
-    if (sidebarNav) sidebarNav.classList.add('collapse');
     if (subhead) subhead.classList.add('collapse');
     if (sidebarWrapper) sidebarWrapper.classList.add('collapse');
   } else {
-    if (sidebarNav) sidebarNav.classList.remove('collapse');
     if (subhead) subhead.classList.remove('collapse');
     if (sidebarWrapper) sidebarWrapper.classList.remove('collapse');
   }
+
+  if (mobile.matches) {
+    if (sidebarNav) sidebarNav.classList.add('collapse');
+  } else {
+    if (sidebarNav) sidebarNav.classList.remove('collapse');
+  }
+
   changeLogo('closed');
 }
 
@@ -180,20 +185,27 @@ function setDesktop() {
 }
 
 /**
+ * Do resize depending on current screen
+ * 
+ * @since 4.0.0
+ */
+function resizeAction() {
+  if (mobile.matches) {
+    setMobile();
+  } else {
+    setDesktop();
+  }
+
+  headerItemsInDropdown();
+}
+
+/**
  * React on resizing window
  *
  * @since   4.0.0
  */
 function reactToResize() {
-  window.addEventListener('resize', () => {
-    if (mobile.matches) {
-      setMobile();
-    } else {
-      setDesktop();
-    }
-
-    headerItemsInDropdown();
-  });
+  window.addEventListener('resize', resizeAction);
 }
 
 /**
@@ -217,6 +229,7 @@ function subheadScrolling() {
 headerItemsInDropdown();
 reactToResize();
 subheadScrolling();
+resizeAction();
 if (!navigator.cookieEnabled) {
   Joomla.renderMessages({ error: [Joomla.Text._('JGLOBAL_WARNCOOKIES')] }, undefined, false, 6000);
 }


### PR DESCRIPTION
Pull Request for Issue #34117.

### Summary of Changes

Page resize logic updated. Now the resize function called when page loaded in order to solve whether the menu should be collapsed or not (according to `aria-expanded="false"` on mobile the menu should be collapsed initially).

### Testing Instructions

1. Visit the Global Configuration page in the Backend.
2. Switch to the mobile view using Devtools.
3. Refresh the page while being in the mobile view or navigate outside and back to this page to imitate how a mobile user would enter this page.
4. Notice that the sidebar dropdown is initially collapsed (Contrary to the previous behaviour) and when you press the toggle button animation is ok contrary to the previous behaviour.

### Actual result BEFORE applying this Pull Request

![test](https://user-images.githubusercontent.com/42320170/119324838-efd1a480-bc88-11eb-961a-b06a1ae033f6.gif)


### Expected result AFTER applying this Pull Request

![after](https://user-images.githubusercontent.com/42320170/119325003-1c85bc00-bc89-11eb-8d00-9335119a6361.gif)


### Documentation Changes Required

Added the `resizeAction` function and a comment to it. Please comment if documentation is incorrect (e.g. english grammar)