### PR TITLE
[4] Remove non existing class import

### DIFF
--- a/libraries/src/Application/CliApplication.php
+++ b/libraries/src/Application/CliApplication.php
@@ -22,7 +22,6 @@ use Joomla\DI\ContainerAwareTrait;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
-use Joomla\Input\Cli;
 use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 use Joomla\Session\SessionInterface;


### PR DESCRIPTION
Code review

This class doesnt exist, and is not used in the file anyway as the only one that is, is `\Joomla\CMS\Input\Cli` which itself is deprecated with a note to use this non existing class `\Joomla\Input\Cli` /facepalm

Related to https://github.com/joomla/joomla-cms/issues/34162