### PR TITLE
[4] Fix fatal error due to Undefined Class not imported 

### DIFF
--- a/libraries/src/Versioning/VersionableModelTrait.php
+++ b/libraries/src/Versioning/VersionableModelTrait.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Versioning;
 
 \defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Table\Table;
 use Joomla\Utilities\ArrayHelper;
 


### PR DESCRIPTION
Code review

`use Joomla\CMS\Language\Text;` is missing which is used on line 61 when setting the error text message.