### PR TITLE
[4] remove undefined call to parent::loadConfiguration that would cause fatal error

### DIFF
--- a/libraries/src/Application/DaemonApplication.php
+++ b/libraries/src/Application/DaemonApplication.php
@@ -265,9 +265,6 @@ abstract class DaemonApplication extends CliApplication
 	 */
 	public function loadConfiguration($data)
 	{
-		// Execute the parent load method.
-		parent::loadConfiguration($data);
-
 		/*
 		 * Setup some application metadata options.  This is useful if we ever want to write out startup scripts
 		 * or just have some sort of information available to share about things.


### PR DESCRIPTION
Code review.

There is no such method called `loadConfiguration` in the parent class.

In fact there is no such method called `loadConfiguration` in the whole of Joomla including its installed vendors, apart from this method that being called. 

If this method were to be called ever, it would result in a fatal error