### PR TITLE
[4] move RFC3339 to DateTimeInterface

### DIFF
--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -429,7 +429,7 @@ class Date extends \DateTime
 	 */
 	public function toISO8601($local = false)
 	{
-		return $this->format(\DateTime::RFC3339, $local, false);
+		return $this->format(\DateTimeInterface::RFC3339, $local, false);
 	}
 
 	/**


### PR DESCRIPTION
Code review

`RFC3339` has been moved from `DateTime` to `DateTimeInterface` in PHP 7.something. 