### PR TITLE
[4] Cleanup response from deleting /installation folder

### DIFF
--- a/installation/src/Controller/InstallationController.php
+++ b/installation/src/Controller/InstallationController.php
@@ -256,24 +256,10 @@ class InstallationController extends JSONController
 
 		/** @var \Joomla\CMS\Installation\Model\CleanupModel $model */
 		$model = $this->getModel('Cleanup');
-		$success = $model->deleteInstallationFolder();
-
-		// If an error was encountered return an error.
-		if (!$success)
-		{
-			$this->app->enqueueMessage(Text::sprintf('INSTL_COMPLETE_ERROR_FOLDER_DELETE', 'installation'), 'warning');
-		}
+		$model->deleteInstallationFolder();
 
 		$this->app->getSession()->destroy();
 
-		$r = new \stdClass;
-		$r->view = 'remove';
-
-		/**
-		 * TODO: We can't send a response this way because our installation classes no longer
-		 *       exist. We probably need to hardcode a json response here
-		 *
-		 * $this->sendJsonResponse($r);
-		 */
+		echo json_encode(['error' => false]);
 	}
 }

--- a/installation/src/Controller/InstallationController.php
+++ b/installation/src/Controller/InstallationController.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\CMS\Session\Session;
 use Joomla\Utilities\ArrayHelper;
 
 /**
@@ -256,10 +257,31 @@ class InstallationController extends JSONController
 
 		/** @var \Joomla\CMS\Installation\Model\CleanupModel $model */
 		$model = $this->getModel('Cleanup');
-		$model->deleteInstallationFolder();
+
+		if (!$model->deleteInstallationFolder())
+		{
+			// We can't send a response with sendJsonResponse because our installation classes might not now exist
+			$error = [
+				'token' => Session::getFormToken(true),
+				'error' => true,
+				'data' => [
+					'view' => 'remove'
+				],
+				'messages' => [
+					'warning' => [
+						Text::sprintf('INSTL_COMPLETE_ERROR_FOLDER_DELETE', 'installation')
+					]
+				]
+			];
+
+			echo json_encode($error);
+
+			return;
+		}
 
 		$this->app->getSession()->destroy();
 
+		// We can't send a response with sendJsonResponse because our installation classes now do not exist
 		echo json_encode(['error' => false]);
 	}
 }

--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -44,9 +44,11 @@ if (document.getElementById('removeInstallationFolder')) {
 					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
 					onSuccess: function (response) {
             const successresponse = JSON.parse(response);
-            if (successresponse.messages) {
-              Joomla.renderMessages(successresponse.messages, '#system-message-container');
-              Joomla.loadOptions({'csrf.token': successresponse.token});
+            if (successresponse.error === true) {
+              if (successresponse.messages) {
+                Joomla.renderMessages(successresponse.messages, '#system-message-container');
+                Joomla.loadOptions({'csrf.token': successresponse.token});
+              }
             } else {
               const customInstallation = document.getElementById('customInstallation');
               customInstallation.parentNode.removeChild(customInstallation);

--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -42,11 +42,17 @@ if (document.getElementById('removeInstallationFolder')) {
 					perform: true,
 					token: true,
 					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-					onSuccess: function () {
-						const customInstallation = document.getElementById('customInstallation');
-						customInstallation.parentNode.removeChild(customInstallation);
-						const removeInstallationTab = document.getElementById('removeInstallationTab');
-						removeInstallationTab.parentNode.removeChild(removeInstallationTab);
+					onSuccess: function (response) {
+            const successresponse = JSON.parse(response);
+            if (successresponse.messages) {
+              Joomla.renderMessages(successresponse.messages, '#system-message-container');
+              Joomla.loadOptions({'csrf.token': successresponse.token});
+            } else {
+              const customInstallation = document.getElementById('customInstallation');
+              customInstallation.parentNode.removeChild(customInstallation);
+              const removeInstallationTab = document.getElementById('removeInstallationTab');
+              removeInstallationTab.parentNode.removeChild(removeInstallationTab);
+            }
 					},
 					onError: function (xhr) {
             Joomla.renderMessages({ error: [xhr] }, '#system-message-container');

--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -48,6 +48,9 @@ if (document.getElementById('removeInstallationFolder')) {
               if (successresponse.messages) {
                 Joomla.renderMessages(successresponse.messages, '#system-message-container');
                 Joomla.loadOptions({'csrf.token': successresponse.token});
+              } else {
+                // Stuff went wrong. No error messages. Just panic bail!
+                Joomla.renderMessages('Unknown error deleting the installation folder.', '#system-message-container');
               }
             } else {
               const customInstallation = document.getElementById('customInstallation');


### PR DESCRIPTION

### Summary of Changes

Clean up a TODO left in the installation process on the task of deleting the /installation folder. 

Note that there is no point enqueuing a message, because when you destroy a session, you destroy that messageQueue ! 

### Testing Instructions

Install Joomla 4 taking notice of the ajax response when deleting the installation folder on the last step

### Actual result BEFORE applying this Pull Request

A full HTML page is returned from the delete installation folder ajax

### Expected result AFTER applying this Pull Request

A simple JSON page is returned from the delete installation folder ajax

### Documentation Changes Required

none