### PR TITLE
[4.0] Correct a typo: "intl" not "instl"

### DIFF
--- a/installation/src/Model/ChecksModel.php
+++ b/installation/src/Model/ChecksModel.php
@@ -220,7 +220,7 @@ class ChecksModel extends BaseInstallationModel
 
 		// Check for intl support
 		$setting = new \stdClass;
-		$setting->label = Text::sprintf('INSTL_EXTENSION_AVAILABLE', 'instl');
+		$setting->label = Text::sprintf('INSTL_EXTENSION_AVAILABLE', 'intl');
 		$setting->state = function_exists('transliterator_transliterate');
 		$setting->recommended = true;
 		$settings[] = $setting;


### PR DESCRIPTION
### Summary of Changes
Found a little typo in $setting->label (row 223) for the new check about **intl**.

Probably the little mistake was introduced with this PR #33977





