### PR TITLE
[4.0] media action plugins border

### DIFF
--- a/build/media_source/com_media/scss/components/_media-edit.scss
+++ b/build/media_source/com_media/scss/components/_media-edit.scss
@@ -12,6 +12,9 @@
 
     > fieldset {
       padding: 2rem;
+      &.options-form {
+        border: none;
+      }
 
       legend {
         float: left;


### PR DESCRIPTION
Removes the fieldset border on the crop/resize/rotate plugins

Pull Request for Issue #34184 
This is an scss change so dont forget to rebuild 

### Before
![image](https://user-images.githubusercontent.com/1296369/119404286-82009980-bcd7-11eb-9eff-bb97044b0bfa.png)

### After
![image](https://user-images.githubusercontent.com/1296369/119404235-6dbc9c80-bcd7-11eb-807e-b4fa1ff3d009.png)
