### PR TITLE
[4.0] user note status

### DIFF
--- a/administrator/components/com_users/forms/note.xml
+++ b/administrator/components/com_users/forms/note.xml
@@ -52,6 +52,7 @@
 			name="state"
 			type="list"
 			label="JSTATUS"
+			class="form-select-color-state"
 			size="1"
 			default="1"
 			validate="options"


### PR DESCRIPTION
Make sure that the status field has the correct class. ie green when published and red when unpublished

Pull Request for Issue #34193

