### PR TITLE
[4.0] module form status

### DIFF
--- a/components/com_config/forms/modules.xml
+++ b/components/com_config/forms/modules.xml
@@ -50,6 +50,7 @@
 			name="published"
 			type="list"
 			label="JSTATUS"
+			class="form-select-color-state"
 			default="1"
 			size="1"
 			validate="options"


### PR DESCRIPTION
When editing a module on the frontend the status field should be using the green/red etc colourscheme. Before this PR there is no change in colour when the status changes. After this PR the colour changes as expected
![image](https://user-images.githubusercontent.com/1296369/119478091-6d5bea00-bd47-11eb-967c-fffe480f80c9.png)
