### PR TITLE
[4.0] Revert parentclass in template.xml

### DIFF
--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -90,7 +90,6 @@
 					type="groupedlist"
 					label="TPL_CASSIOPEIA_FONT_LABEL"
 					default="0"
-					parentclass="span-3"
 					>
 					<option value="0">JNONE</option>
 					<group label="TPL_CASSIOPEIA_FONT_GROUP_LOCAL">
@@ -107,7 +106,6 @@
 					type="note"
 					description="TPL_CASSIOPEIA_FONT_NOTE_TEXT"
 					class="alert alert-warning"
-					parentclass="span-3-inline"
 				/>
 
 				<field
@@ -115,7 +113,6 @@
 					type="list"
 					default="colors_standard"
 					label="TPL_CASSIOPEIA_COLOR_NAME_LABEL"
-					parentclass="span-3"
 					>
 					<option value="colors_standard">TPL_CASSIOPEIA_COLOR_NAME_STANDARD</option>
 					<option value="colors_alternative">TPL_CASSIOPEIA_COLOR_NAME_ALTERNATIVE</option>


### PR DESCRIPTION
Pull Request for Issue #34181 .

### Summary of Changes
Reverted the usage of parentclass in templateDetails.xml


### Testing Instructions
Applay the patch and check that all fields again have full width. 


### Actual result BEFORE applying this Pull Request
The note field for fonts is on the same level as the font face field.


### Expected result AFTER applying this Pull Request
The note field for fonts is below the font face field

