### PR TITLE
[4.0] Clean up contact view

### DIFF
--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -103,6 +103,13 @@ class HtmlView extends BaseHtmlView
 	protected $pageclass_sfx = '';
 
 	/**
+	 * The flag to mark if the active menu item is linked to the being displayed contact
+	 *
+	 * @var boolean
+	 */
+	protected $menuItemMatchContact = false;
+
+	/**
 	 * Execute and display a template script.
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
@@ -131,28 +138,38 @@ class HtmlView extends BaseHtmlView
 
 		$app->setUserState('com_contact.contact.data', $data);
 
-		if ($active)
+		// If the current view is the active item and a contact view for this contact, then the menu item params take priority
+		if ($active
+			&& $active->component == 'com_contact'
+			&& isset($active->query['view'], $active->query['id'])
+			&& $active->query['view'] == 'contact'
+			&& $active->query['id'] == $item->id)
 		{
-			// If the current view is the active item and a contact view for this contact, then the menu item params take priority
-			if (strpos($active->link, 'view=contact') && strpos($active->link, '&id=' . (int) $item->id))
+			$this->menuItemMatchContact = true;
+
+			// Load layout from active query (in case it is an alternative menu item)
+			if (isset($active->query['layout']))
 			{
-				// $item->params are the contact params, $temp are the menu item params
-				// Merge so that the menu item params take priority
-				$item->params->merge($temp);
+				$this->setLayout($active->query['layout']);
 			}
-			else
+			// Check for alternative layout of contact
+			elseif ($layout = $item->params->get('contact_layout'))
 			{
-				// Current view is not a single contact, so the contact params take priority here
-				// Merge the menu item params with the contact params so that the contact params take priority
-				$temp->merge($item->params);
-				$item->params = $temp;
+				$this->setLayout($layout);
 			}
+
+			$item->params->merge($temp);
 		}
 		else
 		{
 			// Merge so that contact params take priority
 			$temp->merge($item->params);
 			$item->params = $temp;
+
+			if ($layout = $item->params->get('contact_layout'))
+			{
+				$this->setLayout($layout);
+			}
 		}
 
 		// Collect extra contact information when this information is required
@@ -178,7 +195,7 @@ class HtmlView extends BaseHtmlView
 		// Check if access is not public
 		$groups = $user->getAuthorisedViewLevels();
 
-		if ((!in_array($item->access, $groups)) || (!in_array($item->category_access, $groups)))
+		if (!in_array($item->access, $groups) || !in_array($item->category_access, $groups))
 		{
 			$app->enqueueMessage(Text::_('JERROR_ALERTNOAUTHOR'), 'error');
 			$app->setHeader('status', 403, true);
@@ -370,21 +387,6 @@ class HtmlView extends BaseHtmlView
 		$item->tags = new TagsHelper;
 		$item->tags->getItemTags('com_contact.contact', $this->item->id);
 
-		// Override the layout only if this is not the active menu item
-		// If it is the active menu item, then the view and item id will match
-		if ((!$active) || ((strpos($active->link, 'view=contact') === false) || (strpos($active->link, '&id=' . (string) $this->item->id) === false)))
-		{
-			if (($layout = $item->params->get('contact_layout')))
-			{
-				$this->setLayout($layout);
-			}
-		}
-		elseif (isset($active->query['layout']))
-		{
-			// We need to set the layout in case this is an alternative menu item (with an alternative layout)
-			$this->setLayout($active->query['layout']);
-		}
-
 		$model = $this->getModel();
 		$model->hit();
 
@@ -414,12 +416,11 @@ class HtmlView extends BaseHtmlView
 	protected function _prepareDocument()
 	{
 		$app     = Factory::getApplication();
-		$menus   = $app->getMenu();
 		$pathway = $app->getPathway();
 
 		// Because the application sets a default page title,
 		// we need to get it from the menu item itself
-		$menu = $menus->getActive();
+		$menu = $app->getMenu()->getActive();
 
 		if ($menu)
 		{
@@ -432,11 +433,8 @@ class HtmlView extends BaseHtmlView
 
 		$title = $this->params->get('page_title', '');
 
-		$id = (int) @$menu->query['id'];
-
 		// If the menu item does not concern this contact
-		if ($menu && (!isset($menu->query['option']) || $menu->query['option'] !== 'com_contact' || $menu->query['view'] !== 'contact'
-			|| $id != $this->item->id))
+		if (!$this->menuItemMatchContact)
 		{
 			// If this is not a single contact menu item, set the page title to the contact title
 			if ($this->item->name)
@@ -444,11 +442,21 @@ class HtmlView extends BaseHtmlView
 				$title = $this->item->name;
 			}
 
+			// Get ID of the category from active menu item
+			if ($menu && $menu->component == 'com_contact' && isset($menu->query['view'])
+				&& in_array($menu->query['view'], ['categories', 'category']))
+			{
+				$id = $menu->query['id'];
+			}
+			else
+			{
+				$id = 0;
+			}
+
 			$path = array(array('title' => $this->item->name, 'link' => ''));
 			$category = Categories::getInstance('Contact')->get($this->item->catid);
 
-			while ($category && (!isset($menu->query['option']) || $menu->query['option'] !== 'com_contact' || $menu->query['view'] === 'contact'
-				|| $id != $category->id) && $category->id > 1)
+			while ($category !== null && $category->id != $id && $category->id !== 'root')
 			{
 				$path[] = array('title' => $category->title, 'link' => RouteHelper::getCategoryRoute($category->id, $category->language));
 				$category = $category->getParent();

--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -105,7 +105,8 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The flag to mark if the active menu item is linked to the contact being displayed
 	 *
-	 * @var boolean
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $menuItemMatchContact = false;
 

--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -103,7 +103,7 @@ class HtmlView extends BaseHtmlView
 	protected $pageclass_sfx = '';
 
 	/**
-	 * The flag to mark if the active menu item is linked to the being displayed contact
+	 * The flag to mark if the active menu item is linked to the contact being displayed
 	 *
 	 * @var boolean
 	 */


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR improves the code of contact view of com_contact component (mostly relate to handle breadcrumb). The code which we are having right now is a mess, hard to understand and difficult to maintain:

- We are using string comparison to check if the current active menu item is linked to com_contact
- Duplicate to calculate params for the contact item
- Bad code to handle breadcrumb

The new code is base on the current code which we are having in view article in com_content. It is much easier to understand compare to the original code.

### Testing Instructions
1. Create two contact categories. Add 2 or 3 contacts to each category (You can use Save As Copy button to save time for creating multiple contacts)
2. Create menu items to the following menu item types of Contacts component:
- List All Categories in a Contact Category Tree							
- List Contacts in a Category			
- Single Contact
3. Apply patch
4. Access to above menu items, then try to access to contact, make sure breadcrumb is handled properly

- For contact accessed base on the first two menu item types, the breadcrumb displayed in the breadcrumb has this format:
**Home / Active Menu Item / [Sub Category] / Contact Name**

- For contact accessed from Single Contact menu item type, the breadcrumb should have this format:
**Home / Active Menu Item**


### Actual result BEFORE applying this Pull Request
Works but code looks bad.

### Expected result AFTER applying this Pull Request
Works and code is cleaner, easier to understand.