### PR TITLE
[4.0] Remove Fieldsets from Two Factor Authentication Steps

### DIFF
--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -65,19 +65,16 @@ $this->useCoreUI = true;
 
 		<?php if (!empty($this->tfaform) && $this->item->id) : ?>
 		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'twofactorauth', Text::_('COM_USERS_USER_TWO_FACTOR_AUTH')); ?>
-			<fieldset class="options-form">
-				<legend><?php echo Text::_('COM_USERS_USER_TWO_FACTOR_AUTH'); ?></legend>
-				<div class="control-group">
-					<div class="control-label">
-						<label id="jform_twofactor_method-lbl" for="jform_twofactor_method">
-							<?php echo Text::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
-						</label>
-					</div>
-					<div class="controls">
-						<?php echo HTMLHelper::_('select.genericlist', UsersHelper::getTwoFactorMethods(), 'jform[twofactor][method]', array('onchange' => 'Joomla.twoFactorMethodChange();', 'class' => 'form-select'), 'value', 'text', $this->otpConfig->method, 'jform_twofactor_method', false); ?>
-					</div>
+			<div class="control-group">
+				<div class="control-label">
+					<label id="jform_twofactor_method-lbl" for="jform_twofactor_method">
+						<?php echo Text::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
+					</label>
 				</div>
-			</fieldset>
+				<div class="controls">
+					<?php echo HTMLHelper::_('select.genericlist', UsersHelper::getTwoFactorMethods(), 'jform[twofactor][method]', array('onchange' => 'Joomla.twoFactorMethodChange();', 'class' => 'form-select'), 'value', 'text', $this->otpConfig->method, 'jform_twofactor_method', false); ?>
+				</div>
+			</div>
 			<div id="com_users_twofactor_forms_container">
 				<?php foreach ($this->tfaform as $form) : ?>
 					<?php $class = $form['method'] == $this->otpConfig->method ? '' : ' class="hidden"'; ?>

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -65,24 +65,27 @@ $this->useCoreUI = true;
 
 		<?php if (!empty($this->tfaform) && $this->item->id) : ?>
 		<?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'twofactorauth', Text::_('COM_USERS_USER_TWO_FACTOR_AUTH')); ?>
-			<div class="control-group">
-				<div class="control-label">
-					<label id="jform_twofactor_method-lbl" for="jform_twofactor_method">
-						<?php echo Text::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
-					</label>
-				</div>
-				<div class="controls">
-					<?php echo HTMLHelper::_('select.genericlist', UsersHelper::getTwoFactorMethods(), 'jform[twofactor][method]', array('onchange' => 'Joomla.twoFactorMethodChange();', 'class' => 'form-select'), 'value', 'text', $this->otpConfig->method, 'jform_twofactor_method', false); ?>
-				</div>
-			</div>
-			<div id="com_users_twofactor_forms_container">
-				<?php foreach ($this->tfaform as $form) : ?>
-					<?php $class = $form['method'] == $this->otpConfig->method ? '' : ' class="hidden"'; ?>
-					<div id="com_users_twofactor_<?php echo $form['method'] ?>"<?php echo $class; ?>>
-						<?php echo $form['form'] ?>
+			<fieldset class="options-form">
+				<legend><?php echo Text::_('COM_USERS_USER_TWO_FACTOR_AUTH'); ?></legend>
+				<div class="control-group">
+					<div class="control-label">
+						<label id="jform_twofactor_method-lbl" for="jform_twofactor_method">
+							<?php echo Text::_('COM_USERS_USER_FIELD_TWOFACTOR_LABEL'); ?>
+						</label>
 					</div>
-				<?php endforeach; ?>
-			</div>
+					<div class="controls">
+						<?php echo HTMLHelper::_('select.genericlist', UsersHelper::getTwoFactorMethods(), 'jform[twofactor][method]', array('onchange' => 'Joomla.twoFactorMethodChange();', 'class' => 'form-select'), 'value', 'text', $this->otpConfig->method, 'jform_twofactor_method', false); ?>
+					</div>
+				</div>
+				<div id="com_users_twofactor_forms_container">
+					<?php foreach ($this->tfaform as $form) : ?>
+						<?php $class = $form['method'] == $this->otpConfig->method ? '' : ' class="hidden"'; ?>
+						<div id="com_users_twofactor_<?php echo $form['method'] ?>"<?php echo $class; ?>>
+							<?php echo $form['form'] ?>
+						</div>
+					<?php endforeach; ?>
+				</div>
+			</fieldset>
 
 			<h3 class="mt-4">
 				<?php echo Text::_('COM_USERS_USER_OTEPS'); ?>

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -77,15 +77,15 @@ $this->useCoreUI = true;
 						<?php echo HTMLHelper::_('select.genericlist', UsersHelper::getTwoFactorMethods(), 'jform[twofactor][method]', array('onchange' => 'Joomla.twoFactorMethodChange();', 'class' => 'form-select'), 'value', 'text', $this->otpConfig->method, 'jform_twofactor_method', false); ?>
 					</div>
 				</div>
-				<div id="com_users_twofactor_forms_container">
-					<?php foreach ($this->tfaform as $form) : ?>
-						<?php $class = $form['method'] == $this->otpConfig->method ? '' : ' class="hidden"'; ?>
-						<div id="com_users_twofactor_<?php echo $form['method'] ?>"<?php echo $class; ?>>
-							<?php echo $form['form'] ?>
-						</div>
-					<?php endforeach; ?>
-				</div>
 			</fieldset>
+			<div id="com_users_twofactor_forms_container">
+				<?php foreach ($this->tfaform as $form) : ?>
+					<?php $class = $form['method'] == $this->otpConfig->method ? '' : ' class="hidden"'; ?>
+					<div id="com_users_twofactor_<?php echo $form['method'] ?>"<?php echo $class; ?>>
+						<?php echo $form['form'] ?>
+					</div>
+				<?php endforeach; ?>
+			</div>
 
 			<h3 class="mt-4">
 				<?php echo Text::_('COM_USERS_USER_OTEPS'); ?>

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -86,11 +86,11 @@ $this->useCoreUI = true;
 					<?php endforeach; ?>
 				</div>
 			</fieldset>
+			<hr>
 
-			<h3 class="mt-4">
+			<h3>
 				<?php echo Text::_('COM_USERS_USER_OTEPS'); ?>
 			</h3>
-			<hr>
 
 			<div class="alert alert-info">
 				<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -85,29 +85,29 @@ $this->useCoreUI = true;
 						</div>
 					<?php endforeach; ?>
 				</div>
-
-				<fieldset>
-					<legend>
-						<?php echo Text::_('COM_USERS_USER_OTEPS'); ?>
-					</legend>
-					<div class="alert alert-info">
-						<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
-						<?php echo Text::_('COM_USERS_USER_OTEPS_DESC'); ?>
-					</div>
-					<?php if (empty($this->otpConfig->otep)) : ?>
-						<div class="alert alert-warning">
-							<span class="icon-exclamation-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('WARNING'); ?></span>
-							<?php echo Text::_('COM_USERS_USER_OTEPS_WAIT_DESC'); ?>
-						</div>
-					<?php else : ?>
-						<?php foreach ($this->otpConfig->otep as $otep) : ?>
-							<span class="col-lg-3">
-								<?php echo substr($otep, 0, 4); ?>-<?php echo substr($otep, 4, 4); ?>-<?php echo substr($otep, 8, 4); ?>-<?php echo substr($otep, 12, 4); ?>
-							</span>
-						<?php endforeach; ?>
-					<?php endif; ?>
-				</fieldset>
 			</fieldset>
+
+			<h3 class="mt-4">
+				<?php echo Text::_('COM_USERS_USER_OTEPS'); ?>
+			</h3>
+			<hr>
+
+			<div class="alert alert-info">
+				<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+				<?php echo Text::_('COM_USERS_USER_OTEPS_DESC'); ?>
+			</div>
+			<?php if (empty($this->otpConfig->otep)) : ?>
+				<div class="alert alert-warning">
+					<span class="icon-exclamation-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('WARNING'); ?></span>
+					<?php echo Text::_('COM_USERS_USER_OTEPS_WAIT_DESC'); ?>
+				</div>
+			<?php else : ?>
+				<?php foreach ($this->otpConfig->otep as $otep) : ?>
+					<span class="col-lg-3">
+						<?php echo substr($otep, 0, 4); ?>-<?php echo substr($otep, 4, 4); ?>-<?php echo substr($otep, 8, 4); ?>-<?php echo substr($otep, 12, 4); ?>
+					</span>
+				<?php endforeach; ?>
+			<?php endif; ?>
 			
 		<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>

--- a/plugins/twofactorauth/totp/tmpl/form.php
+++ b/plugins/twofactorauth/totp/tmpl/form.php
@@ -43,79 +43,79 @@ Factory::getDocument()->addScriptDeclaration($js);
 	</div>
 </div>
 
-<fieldset>
-	<legend>
-		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_HEAD') ?>
-	</legend>
+<h3 class="mt-4">
+	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_HEAD') ?>
+</h3>
+<hr>
+
+<p>
+	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_TEXT') ?>
+</p>
+<ul>
+	<li>
+		<a href="<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1_LINK') ?>" target="_blank" rel="noopener noreferrer">
+			<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1') ?>
+		</a>
+	</li>
+	<li>
+		<a href="<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2_LINK') ?>" target="_blank" rel="noopener noreferrer">
+			<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2') ?>
+		</a>
+	</li>
+</ul>
+<div class="alert alert-warning">
+	<span class="icon-exclamation-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('WARNING'); ?></span>
+	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_WARN'); ?>
+</div>
+
+<h3 class="mt-4">
+	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_HEAD') ?>
+</h3>
+<hr>
+
+<div class="col-md-6">
 	<p>
-		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_TEXT') ?>
+		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_TEXT') ?>
 	</p>
-	<ul>
-		<li>
-			<a href="<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1_LINK') ?>" target="_blank" rel="noopener noreferrer">
-				<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM1') ?>
-			</a>
-		</li>
-		<li>
-			<a href="<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2_LINK') ?>" target="_blank" rel="noopener noreferrer">
-				<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_ITEM2') ?>
-			</a>
-		</li>
-	</ul>
-	<div class="alert alert-warning">
-		<span class="icon-exclamation-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('WARNING'); ?></span>
-		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_WARN'); ?>
-	</div>
-</fieldset>
+	<table class="table">
+		<tr>
+			<td>
+				<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_ACCOUNT') ?>
+			</td>
+			<td>
+				<?php echo $sitename ?>/<?php echo $username ?>
+			</td>
+		</tr>
+		<tr>
+			<td>
+				<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_KEY') ?>
+			</td>
+			<td>
+				<?php echo $secret ?>
+			</td>
+		</tr>
+	</table>
+</div>
 
-<fieldset>
-	<legend>
-		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_HEAD') ?>
-	</legend>
+<div class="col-md-6">
+	<p>
+		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_ALTTEXT') ?>
+		<br>
+		<div id="totp-qrcode"></div>
+	</p>
+</div>
 
-	<div class="col-md-6">
-		<p>
-			<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_TEXT') ?>
-		</p>
-		<table class="table">
-			<tr>
-				<td>
-					<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_ACCOUNT') ?>
-				</td>
-				<td>
-					<?php echo $sitename ?>/<?php echo $username ?>
-				</td>
-			</tr>
-			<tr>
-				<td>
-					<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_KEY') ?>
-				</td>
-				<td>
-					<?php echo $secret ?>
-				</td>
-			</tr>
-		</table>
-	</div>
-
-	<div class="col-md-6">
-		<p>
-			<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_ALTTEXT') ?>
-			<br>
-			<div id="totp-qrcode"></div>
-		</p>
-	</div>
-
-	<div class="alert alert-info">
-		<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
-		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_RESET'); ?>
-	</div>
-</fieldset>
+<div class="alert alert-info">
+	<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_RESET'); ?>
+</div>
 
 <?php if ($new_totp): ?>
-<fieldset>
-	<legend>
+	<h3 class="mt-4">
 		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP3_HEAD') ?>
-	</legend>
+	</h3>
+	<hr>
+
 	<p>
 		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP3_TEXT') ?>
 	</p>
@@ -127,5 +127,4 @@ Factory::getDocument()->addScriptDeclaration($js);
 			<input type="text" class="form-control" name="jform[twofactor][totp][securitycode]" id="totpsecuritycode" autocomplete="0">
 		</div>
 	</div>
-</fieldset>
 <?php endif; ?>

--- a/plugins/twofactorauth/totp/tmpl/form.php
+++ b/plugins/twofactorauth/totp/tmpl/form.php
@@ -42,11 +42,11 @@ Factory::getDocument()->addScriptDeclaration($js);
 		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_INTRO') ?>
 	</div>
 </div>
+<hr>
 
-<h3 class="mt-4">
+<h3>
 	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_HEAD') ?>
 </h3>
-<hr>
 
 <p>
 	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_TEXT') ?>
@@ -67,11 +67,11 @@ Factory::getDocument()->addScriptDeclaration($js);
 	<span class="icon-exclamation-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('WARNING'); ?></span>
 	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP1_WARN'); ?>
 </div>
+<hr>
 
-<h3 class="mt-4">
+<h3>
 	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP2_HEAD') ?>
 </h3>
-<hr>
 
 <div class="col-md-6">
 	<p>
@@ -111,10 +111,10 @@ Factory::getDocument()->addScriptDeclaration($js);
 </div>
 
 <?php if ($new_totp): ?>
-<h3 class="mt-4">
+<hr>
+<h3>
 	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP3_HEAD') ?>
 </h3>
-<hr>
 
 <p>
 	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP3_TEXT') ?>

--- a/plugins/twofactorauth/totp/tmpl/form.php
+++ b/plugins/twofactorauth/totp/tmpl/form.php
@@ -111,20 +111,20 @@ Factory::getDocument()->addScriptDeclaration($js);
 </div>
 
 <?php if ($new_totp): ?>
-	<h3 class="mt-4">
-		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP3_HEAD') ?>
-	</h3>
-	<hr>
+<h3 class="mt-4">
+	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP3_HEAD') ?>
+</h3>
+<hr>
 
-	<p>
-		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP3_TEXT') ?>
-	</p>
-	<div class="control-group">
-		<label class="control-label" for="totpsecuritycode">
-			<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP3_SECURITYCODE') ?>
-		</label>
-		<div class="controls">
-			<input type="text" class="form-control" name="jform[twofactor][totp][securitycode]" id="totpsecuritycode" autocomplete="0">
-		</div>
+<p>
+	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP3_TEXT') ?>
+</p>
+<div class="control-group">
+	<label class="control-label" for="totpsecuritycode">
+		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_STEP3_SECURITYCODE') ?>
+	</label>
+	<div class="controls">
+		<input type="text" class="form-control" name="jform[twofactor][totp][securitycode]" id="totpsecuritycode" autocomplete="0">
 	</div>
+</div>
 <?php endif; ?>

--- a/plugins/twofactorauth/yubikey/tmpl/form.php
+++ b/plugins/twofactorauth/yubikey/tmpl/form.php
@@ -17,12 +17,12 @@ use Joomla\CMS\Language\Text;
 		<?php echo Text::_('PLG_TWOFACTORAUTH_YUBIKEY_INTRO') ?>
 	</div>
 </div>
+<hr>
 
 <?php if ($new_totp): ?>
-<h3 class="mt-4">
-		<?php echo Text::_('PLG_TWOFACTORAUTH_YUBIKEY_STEP1_HEAD') ?>
+<h3>
+	<?php echo Text::_('PLG_TWOFACTORAUTH_YUBIKEY_STEP1_HEAD') ?>
 </h3>
-<hr>
 
 <p>
 	<?php echo Text::_('PLG_TWOFACTORAUTH_YUBIKEY_STEP1_TEXT') ?>
@@ -37,10 +37,9 @@ use Joomla\CMS\Language\Text;
 	</div>
 </div>
 <?php else: ?>
-<h3 class="mt-4">
+<h3>
 	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_RESET_HEAD') ?>
 </h3>
-<hr>
 
 <p>
 	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_RESET_TEXT') ?>

--- a/plugins/twofactorauth/yubikey/tmpl/form.php
+++ b/plugins/twofactorauth/yubikey/tmpl/form.php
@@ -19,32 +19,30 @@ use Joomla\CMS\Language\Text;
 </div>
 
 <?php if ($new_totp): ?>
-<fieldset>
-	<legend>
+<h3 class="mt-4">
 		<?php echo Text::_('PLG_TWOFACTORAUTH_YUBIKEY_STEP1_HEAD') ?>
-	</legend>
+</h3>
+<hr>
 
-	<p>
-		<?php echo Text::_('PLG_TWOFACTORAUTH_YUBIKEY_STEP1_TEXT') ?>
-	</p>
+<p>
+	<?php echo Text::_('PLG_TWOFACTORAUTH_YUBIKEY_STEP1_TEXT') ?>
+</p>
 
-	<div class="control-group">
-		<label class="control-label" for="yubikeysecuritycode">
-			<?php echo Text::_('PLG_TWOFACTORAUTH_YUBIKEY_SECURITYCODE') ?>
-		</label>
-		<div class="controls">
-			<input type="text" class="form-control" name="jform[twofactor][yubikey][securitycode]" id="yubikeysecuritycode" autocomplete="0">
-		</div>
+<div class="control-group">
+	<label class="control-label" for="yubikeysecuritycode">
+		<?php echo Text::_('PLG_TWOFACTORAUTH_YUBIKEY_SECURITYCODE') ?>
+	</label>
+	<div class="controls">
+		<input type="text" class="form-control" name="jform[twofactor][yubikey][securitycode]" id="yubikeysecuritycode" autocomplete="0">
 	</div>
-</fieldset>
+</div>
 <?php else: ?>
-<fieldset>
-	<legend>
-		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_RESET_HEAD') ?>
-	</legend>
+<h3 class="mt-4">
+	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_RESET_HEAD') ?>
+</h3>
+<hr>
 
-	<p>
-		<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_RESET_TEXT') ?>
-	</p>
-</fieldset>
+<p>
+	<?php echo Text::_('PLG_TWOFACTORAUTH_TOTP_RESET_TEXT') ?>
+</p>
 <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #34187

### Summary of Changes
Removes fieldset from 'Steps' and the parent fieldset now only encloses the authentication method dropdown and the security code field. ie. Everything except for One time emergency passwords

Changed
```html
<fieldset>
    <legend> LEGEND_TEXT </legend>
    ...
</fieldset>
```
to
```html
<hr>
<h3> 
    LEGEND_TEXT 
</h3>
...
```

### Testing Instructions

1. Make sure the Yubikey and Google Two Factor Authentication Plugins are Enabled
2. Backend -> Users -> Manage -> Select any User to Edit -> Visit the Two Factor Authentication Tab\
3. Try all options for the Authentication Method Dropdown and ensure that the headings are corrected formatted.


### Actual result BEFORE applying this Pull Request
The Steps displayed on selecting each 2FA method are displayed as fieldsets. See https://github.com/joomla/joomla-cms/issues/34187#issuecomment-847507971

![image](https://user-images.githubusercontent.com/53610833/119502687-cf3c4400-bd87-11eb-8eff-115ff9a281c4.png)



### Expected result AFTER applying this Pull Request
The Steps look similar to how they did in Joomla 3

![image](https://user-images.githubusercontent.com/53610833/119704361-2ff57a80-be75-11eb-81e1-a877dad81c64.png)




### Documentation Changes Required
None
