### PR TITLE
[4.0] Subcategories heading

### DIFF
--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -489,17 +489,6 @@
 		/>
 
 		<field
-			name="show_category_heading_title_text"
-			type="radio"
-			label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-			layout="joomla.form.field.radio.switcher"
-			default="1"
-			>
-			<option value="0">JHIDE</option>
-			<option value="1">JSHOW</option>
-		</field>
-
-		<field
 			name="show_category_title"
 			type="radio"
 			layout="joomla.form.field.radio.switcher"
@@ -552,6 +541,17 @@
 			name="show_no_contacts"
 			type="radio"
 			label="COM_CONTACT_NO_CONTACTS_LABEL"
+			layout="joomla.form.field.radio.switcher"
+			default="1"
+			>
+			<option value="0">JHIDE</option>
+			<option value="1">JSHOW</option>
+		</field>
+
+		<field
+			name="show_category_heading_title_text"
+			type="radio"
+			label="JGLOBAL_SHOW_SUBCATEGORY_HEADING"
 			layout="joomla.form.field.radio.switcher"
 			default="1"
 			>

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -532,17 +532,6 @@
 		/>
 
 		<field
-			name="show_category_heading_title_text"
-			type="radio"
-			label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-			layout="joomla.form.field.radio.switcher"
-			default="1"
-			>
-			<option value="0">JHIDE</option>
-			<option value="1">JSHOW</option>
-		</field>
-
-		<field
 			name="show_category_title"
 			type="radio"
 			label="JGLOBAL_SHOW_CATEGORY_TITLE"
@@ -606,6 +595,17 @@
 			name="show_no_articles"
 			type="radio"
 			label="COM_CONTENT_NO_ARTICLES_LABEL"
+			layout="joomla.form.field.radio.switcher"
+			default="1"
+			>
+			<option value="0">JHIDE</option>
+			<option value="1">JSHOW</option>
+		</field>
+
+		<field
+			name="show_category_heading_title_text"
+			type="radio"
+			label="JGLOBAL_SHOW_SUBCATEGORY_HEADING"
 			layout="joomla.form.field.radio.switcher"
 			default="1"
 			>

--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -638,6 +638,7 @@ JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC="Show or hide the subcategories desc
 JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL="Subcategories Descriptions"
 JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC="If None, only articles from this category will show. If a number, all articles from the category and the subcategories up to and including that level will show in the blog."
 JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL="Include Subcategories"
+JGLOBAL_SHOW_SUBCATEGORY_HEADING="Subcategories Heading"
 JGLOBAL_SHOW_TAGS_DESC="Show the tags for this link."
 JGLOBAL_SHOW_TAGS_LABEL="Tags"
 JGLOBAL_SHOW_TITLE_DESC="If set to Show, the article title is shown."

--- a/api/language/en-GB/joomla.ini
+++ b/api/language/en-GB/joomla.ini
@@ -633,6 +633,7 @@ JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_DESC="Show or hide the subcategories desc
 JGLOBAL_SHOW_SUBCATEGORIES_DESCRIPTION_LABEL="Subcategories Descriptions"
 JGLOBAL_SHOW_SUBCATEGORY_CONTENT_DESC="If None, only articles from this category will show. If a number, all articles from the category and the subcategories up to and including that level will show in the blog."
 JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL="Include Subcategories"
+JGLOBAL_SHOW_SUBCATEGORY_HEADING="Subcategories Heading"
 JGLOBAL_SHOW_TAGS_DESC="Show the tags for this link."
 JGLOBAL_SHOW_TAGS_LABEL="Tags"
 JGLOBAL_SHOW_TITLE_DESC="If set to Show, the article title is shown."

--- a/components/com_contact/tmpl/categories/default.xml
+++ b/components/com_contact/tmpl/categories/default.xml
@@ -99,18 +99,6 @@
 		<fieldset name="category" label="JGLOBAL_CATEGORY_OPTIONS" description="JGLOBAL_SUBSLIDER_DRILL_CATEGORIES_LABEL">
 
 			<field
-				name="show_category_heading_title_text"
-				type="list"
-				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-				useglobal="true"
-				class="custom-select-color-state"
-				validate="options"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
 				name="show_category_title"
 				type="list"
 				label="JGLOBAL_SHOW_CATEGORY_TITLE"
@@ -178,6 +166,18 @@
 				name="show_no_contacts"
 				type="list"
 				label="COM_CONTACT_NO_CONTACTS_LABEL"
+				useglobal="true"
+				class="custom-select-color-state"
+				validate="options"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_category_heading_title_text"
+				type="list"
+				label="JGLOBAL_SHOW_SUBCATEGORY_HEADING"
 				useglobal="true"
 				class="custom-select-color-state"
 				validate="options"

--- a/components/com_contact/tmpl/category/default.xml
+++ b/components/com_contact/tmpl/category/default.xml
@@ -38,18 +38,6 @@
 			>
 
 			<field
-				name="show_category_heading_title_text"
-				type="list"
-				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-				useglobal="true"
-				class="custom-select-color-state"
-				validate="options"
-				>
-				<option value="0">JHIDE</option>
-				<option value="1">JSHOW</option>
-			</field>
-
-			<field
 				name="show_category_title"
 				type="list"
 				label="JGLOBAL_SHOW_CATEGORY_TITLE"
@@ -117,6 +105,18 @@
 				name="show_no_contacts"
 				type="list"
 				label="COM_CONTACT_NO_CONTACTS_LABEL"
+				useglobal="true"
+				class="custom-select-color-state"
+				validate="options"
+				>
+				<option value="0">JHIDE</option>
+				<option value="1">JSHOW</option>
+			</field>
+
+			<field
+				name="show_category_heading_title_text"
+				type="list"
+				label="JGLOBAL_SHOW_SUBCATEGORY_HEADING"
 				useglobal="true"
 				class="custom-select-color-state"
 				validate="options"

--- a/components/com_content/tmpl/category/blog.xml
+++ b/components/com_content/tmpl/category/blog.xml
@@ -44,18 +44,6 @@
 				/>
 
 				<field
-					name="show_category_heading_title_text"
-					type="list"
-	 				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
-					useglobal="true"
-					class="form-select-color-state"
-					validate="options"
-					>
-					<option value="0">JHIDE</option>
-					<option value="1">JSHOW</option>
-				</field>
-
-				<field
 					name="show_category_title"
 					type="list"
 					label="JGLOBAL_SHOW_CATEGORY_TITLE"
@@ -124,6 +112,18 @@
 					name="show_no_articles"
 					type="list"
 					label="COM_CONTENT_NO_ARTICLES_LABEL"
+					useglobal="true"
+					class="form-select-color-state"
+					validate="options"
+					>
+					<option value="0">JHIDE</option>
+					<option value="1">JSHOW</option>
+				</field>
+
+				<field
+					name="show_category_heading_title_text"
+					type="list"
+	 				label="JGLOBAL_SHOW_SUBCATEGORY_HEADING"
 					useglobal="true"
 					class="form-select-color-state"
 					validate="options"

--- a/components/com_content/tmpl/category/default.xml
+++ b/components/com_content/tmpl/category/default.xml
@@ -119,7 +119,7 @@
 			<field
 				name="show_category_heading_title_text"
 				type="list"
-				label="JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL"
+				label="JGLOBAL_SHOW_SUBCATEGORY_HEADING"
 				useglobal="true"
 				class="form-select-color-state"
 				validate="options"


### PR DESCRIPTION
Content and Contacts have an option labeled "Subcategories Text"

What it does is to add the h3 heading "Subcategories" above the list of subcategories

This PR changes the text to be "Subcategories Heading" which I believe is a more accurate description.

Because the key for the language string is a global string and misnamed as JGLOBAL_SHOW_CATEGORY_HEADING_TITLE_TEXT_LABEL and not SUBcategory I added a new string.

The name of the field, also misnamed as show_category_heading_title_text, has not been changed as that would break b/c for no good reason.

Finally, I suspect because of the incorrect name, the option was not being displayed in the correct, and consistent, place in the form and this PR fixes that as well.

There is no change to anything on the frontend

