### PR TITLE
[4.0] Hide hits column/sort options in admin

### DIFF
--- a/administrator/components/com_content/forms/filter_articles.xml
+++ b/administrator/components/com_content/forms/filter_articles.xml
@@ -149,8 +149,8 @@
 			<option value="a.publish_up DESC">COM_CONTENT_PUBLISH_UP_DESC</option>
 			<option value="a.publish_down ASC">COM_CONTENT_PUBLISH_DOWN_ASC</option>
 			<option value="a.publish_down DESC">COM_CONTENT_PUBLISH_DOWN_DESC</option>
-			<option value="a.hits ASC">JGLOBAL_HITS_ASC</option>
-			<option value="a.hits DESC">JGLOBAL_HITS_DESC</option>
+			<option value="a.hits ASC" requires="hits">JGLOBAL_HITS_ASC</option>
+			<option value="a.hits DESC" requires="hits">JGLOBAL_HITS_DESC</option>
 			<option value="rating_count ASC" requires="vote">JGLOBAL_VOTES_ASC</option>
 			<option value="rating_count DESC" requires="vote">JGLOBAL_VOTES_DESC</option>
 			<option value="rating ASC" requires="vote">JGLOBAL_RATINGS_ASC</option>

--- a/administrator/components/com_content/forms/filter_featured.xml
+++ b/administrator/components/com_content/forms/filter_featured.xml
@@ -129,8 +129,8 @@
 			<option value="language DESC" requires="multilanguage">JGRID_HEADING_LANGUAGE_DESC</option>
 			<option value="a.created ASC">JDATE_ASC</option>
 			<option value="a.created DESC">JDATE_DESC</option>
-			<option value="a.hits ASC">JGLOBAL_HITS_ASC</option>
-			<option value="a.hits DESC">JGLOBAL_HITS_DESC</option>
+			<option value="a.hits ASC" requires="hits">JGLOBAL_HITS_ASC</option>
+			<option value="a.hits DESC" requires="hits">JGLOBAL_HITS_DESC</option>
 			<option value="rating_count ASC" requires="vote">JGLOBAL_VOTES_ASC</option>
 			<option value="rating_count DESC" requires="vote">JGLOBAL_VOTES_DESC</option>
 			<option value="rating ASC" requires="vote">JGLOBAL_RATINGS_ASC</option>

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -95,6 +95,7 @@ class HtmlView extends BaseHtmlView
 		$this->filterForm    = $this->get('FilterForm');
 		$this->activeFilters = $this->get('ActiveFilters');
 		$this->vote          = PluginHelper::isEnabled('content', 'vote');
+		$this->hits          = ComponentHelper::getParams('com_content')->get('record_hits');
 
 		if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState'))
 		{

--- a/administrator/components/com_content/src/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/src/View/Featured/HtmlView.php
@@ -95,6 +95,7 @@ class HtmlView extends BaseHtmlView
 		$this->filterForm    = $this->get('FilterForm');
 		$this->activeFilters = $this->get('ActiveFilters');
 		$this->vote          = PluginHelper::isEnabled('content', 'vote');
+		$this->hits          = ComponentHelper::getParams('com_content')->get('record_hits');
 
 		if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState'))
 		{

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -153,9 +153,11 @@ $assoc = Associations::isEnabled();
 								<th scope="col" class="w-10 d-none d-md-table-cell text-center">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_CONTENT_HEADING_DATE_' . strtoupper($orderingColumn), 'a.' . $orderingColumn, $listDirn, $listOrder); ?>
 								</th>
-								<th scope="col" class="w-3 d-none d-lg-table-cell text-center">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
-								</th>
+								<?php if ($this->hits) : ?>
+									<th scope="col" class="w-3 d-none d-lg-table-cell text-center">
+										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<?php if ($this->vote) : ?>
 									<th scope="col" class="w-3 d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_VOTES', 'rating_count', $listDirn, $listOrder); ?>
@@ -356,11 +358,13 @@ $assoc = Associations::isEnabled();
 									echo $date > 0 ? HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC4')) : '-';
 									?>
 								</td>
-								<td class="d-none d-lg-table-cell text-center">
-									<span class="badge bg-info">
-										<?php echo (int) $item->hits; ?>
-									</span>
-								</td>
+								<?php if ($this->hits) : ?>
+									<td class="d-none d-lg-table-cell text-center">
+										<span class="badge bg-info">
+											<?php echo (int) $item->hits; ?>
+										</span>
+									</td>
+								<?php endif; ?>
 								<?php if ($this->vote) : ?>
 									<td class="d-none d-md-table-cell text-center">
 										<span class="badge bg-success">

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -155,9 +155,11 @@ $assoc = Associations::isEnabled();
 								<th scope="col" class="w-10 d-none d-md-table-cell text-center">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_CONTENT_HEADING_DATE_' . strtoupper($orderingColumn), 'a.' . $orderingColumn, $listDirn, $listOrder); ?>
 								</th>
-								<th scope="col" class="w-3 d-none d-lg-table-cell text-center">
-									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
-								</th>
+								<?php if ($this->hits) : ?>
+									<th scope="col" class="w-3 d-none d-lg-table-cell text-center">
+										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_HITS', 'a.hits', $listDirn, $listOrder); ?>
+									</th>
+								<?php endif; ?>
 								<?php if ($this->vote) : ?>
 									<th scope="col" class="w-3 d-none d-md-table-cell text-center">
 										<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_VOTES', 'rating_count', $listDirn, $listOrder); ?>
@@ -362,11 +364,13 @@ $assoc = Associations::isEnabled();
 									echo $date > 0 ? HTMLHelper::_('date', $date, Text::_('DATE_FORMAT_LC4')) : '-';
 									?>
 								</td>
-								<td class="d-none d-lg-table-cell text-center">
-									<span class="badge bg-info">
-										<?php echo (int) $item->hits; ?>
-									</span>
-								</td>
+								<?php if ($this->hits) : ?>
+									<td class="d-none d-lg-table-cell text-center">
+										<span class="badge bg-info">
+											<?php echo (int) $item->hits; ?>
+										</span>
+									</td>
+								<?php endif; ?>
 								<?php if ($this->vote) : ?>
 									<td class="d-none d-md-table-cell text-center">
 										<span class="badge bg-success">

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -102,6 +102,12 @@ class ListField extends FormField
 				{
 					continue;
 				}
+
+				// Requires record hits
+				if (\in_array('hits', $requires) && !ComponentHelper::getParams('com_content')->get('record_hits'))
+				{
+					continue;
+				}
 			}
 
 			$value = (string) $option['value'];


### PR DESCRIPTION
### Summary of Changes
Hide hits column/sort options under Articles/Featured Articles in admin when `Record Hits` is `No`.

Intentionally, leave Popular module as it because without the Hits column it does not make sense.

### Testing Instructions
Go to Content > Articles.
See `Hits` column.
See `Hits ascending/descending` options in `Sort Table By` dropdown.
Go to Content > Features.
See `Hits` column.
See `Hits ascending/descending` options in `Sort Table By` dropdown.

Apply PR.

Go to Global Configuration > Articles
Click `Record Hits` to `No`.
Click `Save & Close`  button.

Repeat above steps.
See no `Hits` column and Hits options in dropdown.


