### PR TITLE
[4.0] Checkboxes in Site Template Styles

### DIFF
--- a/administrator/components/com_templates/tmpl/style/edit_assignment.php
+++ b/administrator/components/com_templates/tmpl/style/edit_assignment.php
@@ -42,7 +42,7 @@ $wa->useScript('com_templates.admin-template-toggle-assignment');
 
 					<?php foreach ($type->links as $link) : ?>
 						<label class="checkbox small" for="link<?php echo (int) $link->value; ?>" >
-						<input type="checkbox" name="jform[assigned][]" value="<?php echo (int) $link->value; ?>" id="link<?php echo (int) $link->value; ?>"<?php if ($link->template_style_id == $this->item->id) : ?> checked="checked"<?php endif; ?><?php if ($link->checked_out && $link->checked_out != $user->id) : ?> disabled="disabled"<?php else : ?> class="chk-menulink menutype-<?php echo $type->menutype; ?>"<?php endif; ?> />
+						<input type="checkbox" name="jform[assigned][]" value="<?php echo (int) $link->value; ?>" id="link<?php echo (int) $link->value; ?>"<?php if ($link->template_style_id == $this->item->id) : ?> checked="checked"<?php endif; ?><?php if ($link->checked_out && $link->checked_out != $user->id) : ?> disabled="disabled"<?php else : ?> class="form-check-input chk-menulink menutype-<?php echo $type->menutype; ?>"<?php endif; ?> />
 						<?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $link->level)) . $link->text; ?>
 						</label>
 					<?php endforeach; ?>


### PR DESCRIPTION
Pull Request for Issue #34183 .

### Summary of Changes
Add class `form-check-input`


### Testing Instructions
System > Site Template Styles > cassiopeia - Default > Go to Menu Assignment tab


### Actual result BEFORE applying this Pull Request ( In firefox )
![form-check-before](https://user-images.githubusercontent.com/61203226/119546764-e8f28100-bdb1-11eb-990e-6a20365c8edc.JPG)



### Expected result AFTER applying this Pull Request  ( In firefox )
![form-check-after](https://user-images.githubusercontent.com/61203226/119546773-eb54db00-bdb1-11eb-8379-ec12eeacb0cd.JPG)



### Documentation Changes Required
No
