### PR TITLE
[4.0] tinyMCE 5.8.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9168,9 +9168,9 @@
       "dev": true
     },
     "node_modules/tinymce": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.8.0.tgz",
-      "integrity": "sha512-1bOI3k+1D76rVjAJC3XkHezXJVghurnKBDREF1STHBLTQUY17XTbaDNJUxNgJqJHa2xg1udd5I1bzdfSd77DGw=="
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.8.1.tgz",
+      "integrity": "sha512-1zGXdZplWQafstlC7sri0ttCgMagsiXDc9N3I8JNrPOsWAeTfq4AAJWZoxsQBYn8gYcuPu/WzMKG5SoJjxI1VA=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -17785,9 +17785,9 @@
       "dev": true
     },
     "tinymce": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.8.0.tgz",
-      "integrity": "sha512-1bOI3k+1D76rVjAJC3XkHezXJVghurnKBDREF1STHBLTQUY17XTbaDNJUxNgJqJHa2xg1udd5I1bzdfSd77DGw=="
+      "version": "5.8.1",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.8.1.tgz",
+      "integrity": "sha512-1zGXdZplWQafstlC7sri0ttCgMagsiXDc9N3I8JNrPOsWAeTfq4AAJWZoxsQBYn8gYcuPu/WzMKG5SoJjxI1VA=="
     },
     "tmp": {
       "version": "0.2.1",

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_tinymce</name>
-	<version>5.8.0</version>
-	<creationDate>2005-2019</creationDate>
+	<version>5.8.1</version>
+	<creationDate>2005-2021</creationDate>
 	<author>Tiny Technologies, Inc</author>
 	<authorEmail>N/A</authorEmail>
 	<authorUrl>https://www.tiny.cloud</authorUrl>


### PR DESCRIPTION
Version 5.8.1 - May 20, 2021
Fixed
An unexpected exception was thrown when switching to readonly mode and adjusting the editor width.
Content could be lost when the pagebreak_split_block setting was enabled.
The list-style-type: none; style on nested list items was incorrectly removed when clearing formatting.
URLs were not always detected when pasting over a selection. Patch contributed by jwcooper.
Properties on the OpenNotification event were incorrectly namespaced.
