### PR TITLE
[4.0] editor margin

### DIFF
--- a/templates/cassiopeia/scss/editor.scss
+++ b/templates/cassiopeia/scss/editor.scss
@@ -1,6 +1,6 @@
 /* STYLES FOR JOOMLA! EDITOR */
 body {
-  margin: 0;
+  margin: 1rem;
   font-size: 1rem;
   font-weight: 400;
   line-height: 1.5;


### PR DESCRIPTION
I made a mistake when creating the editor.scss #33112 and I set the margins to 0 - really surprised no one spotted it either then or now.

This PR puts the margin back as TinyMCE intended it to be

### Before
![image](https://user-images.githubusercontent.com/1296369/119569398-99f31e80-bda6-11eb-9191-74c4379546bf.png)

### After
![image](https://user-images.githubusercontent.com/1296369/119569407-9bbce200-bda6-11eb-8bfc-604a5c558280.png)
