### PR TITLE
[4.0] Update required colors

### DIFF
--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -82,9 +82,9 @@
 
       &.warning,
       &.danger {
-        --text-color: var(--white);
-        --bg-color: var(--danger);
-        --icon-color: var(--white);
+        --text-color: var(--danger);
+        --bg-color: #f4f0f0;
+        --icon-color: #ce8484;
         --bg-color-hvr: var(--danger);
       }
 


### PR DESCRIPTION
Before this PR the red color was solid and with no transition on hover unlike the other quickions.

After the PR the red color is pale with a transition to solid dark red on hover etc

This is a css change so dont forget to reubuild the css

If your site doesnt have any updates and you want to test this then the easiest way is to inspectthe souce and change the class on the link from success to danger

PS I have no idea if the success colours were calculated or not so I created the reds by eye

### before
![before](https://user-images.githubusercontent.com/1296369/119577002-bea0c380-bdb1-11eb-9a80-0f91d369fe37.gif)


### after
![after](https://user-images.githubusercontent.com/1296369/119576952-a8930300-bdb1-11eb-8f08-053068c7cdd7.gif)
