### PR TITLE
Switch favicon lookup to prefer the icon in Joomla root

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -670,24 +670,17 @@ class HtmlDocument extends Document
 			ob_end_clean();
 		}
 
-		// Try to find a favicon by checking the root then the template folder
-		$icon = 'favicon.ico';
+		// Try to find a favicon by checking the root and then the template folder
+		$icon = '/favicon.ico';
 
-		if (file_exists($icon))
+		foreach (array(JPATH_BASE, $directory) as $dir)
 		{
-			$this->addFavicon($icon);
-		}
-		else
-		{
-			foreach (array($directory, JPATH_BASE) as $dir)
+			if (file_exists($dir . $icon))
 			{
-    			if (file_exists($dir . '/' . $icon))
-				{
-					$path = str_replace(JPATH_BASE, '', $dir);
-					$path = str_replace('\\', '/', $path);
-					$this->addFavicon(Uri::base(true) . $path . '/' . $icon);
-						break;
-				}
+				$path = str_replace(JPATH_BASE, '', $dir);
+				$path = str_replace('\\', '/', $path);
+				$this->addFavicon(Uri::base(true) . $path . $icon);
+				break;
 			}
 		}
 

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -670,17 +670,24 @@ class HtmlDocument extends Document
 			ob_end_clean();
 		}
 
-		// Try to find a favicon by checking the template and root folder
-		$icon = '/favicon.ico';
+		// Try to find a favicon by checking the root then the template folder
+		$icon = 'favicon.ico';
 
-		foreach (array($directory, JPATH_BASE) as $dir)
+		if (file_exists($icon))
 		{
-			if (file_exists($dir . $icon))
+			$this->addFavicon($icon);
+		}
+		else
+		{
+			foreach (array($directory, JPATH_BASE) as $dir)
 			{
-				$path = str_replace(JPATH_BASE, '', $dir);
-				$path = str_replace('\\', '/', $path);
-				$this->addFavicon(Uri::base(true) . $path . $icon);
-				break;
+    			if (file_exists($dir . '/' . $icon))
+				{
+					$path = str_replace(JPATH_BASE, '', $dir);
+					$path = str_replace('\\', '/', $path);
+					$this->addFavicon(Uri::base(true) . $path . '/' . $icon);
+						break;
+				}
 			}
 		}
 


### PR DESCRIPTION
Change favicon lookup order to check Joomla root folder before the template folder.

### Summary of Changes
Currently by default the favicon is chosen from the default template folder.  If a site replaces the icon in the same folder, the new icon is gone after the template is updated.  On the other hand, if the site puts the custom icon in the Joomla root, the current lookup order doesn't pick the icon because the template folder is considered first.

This PR switches the favicon lookup order to pick the icon in the Joomla root first if one exists.  This addresses the Joomla forum comment [here](https://forum.joomla.org/viewtopic.php?t=937844#p3551480).

### Testing Instructions
If we have two different favicons in Joomla root folder and in the template folder, this change will pick the one in Joomla root.

### Actual result BEFORE applying this Pull Request
The favicon in the template folder is shown on the published site.

### Expected result AFTER applying this Pull Request
The favicon in the Joomla root folder is shown on the published site.

### Documentation Changes Required
Not sure if favicon lookup order is documented somewhere or not.