### PR TITLE
[4.0] Finish transition from CSS classes "label-" to "alert-" for the pre-update check

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -187,8 +187,8 @@ $compatibilityTypes = array(
 				<?php $compatibilityDisplayNotes = $compatibilityData['notes']; ?>
 				<?php $compatibilityTypeGroup    = $compatibilityData['group']; ?>
 				<fieldset id="compatibilitytype<?php echo $compatibilityTypeGroup;?>" class="col-md-12 compatibilitytypes">
-					<legend class="alert <?php echo $compatibilityDisplayClass;?>">
-						<h3>
+					<legend>
+						<h3 class="alert <?php echo $compatibilityDisplayClass;?>">
 							<?php if ($compatibilityType !== "COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_RUNNING_PRE_UPDATE_CHECKS") : ?>
 								<div class="compatibilitytoggle" data-state="closed"><?php echo Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_SHOW_MORE_COMPATIBILITY_INFORMATION', '<span class="icon-chevron-right"></span>'); ?></div>
 							<?php endif; ?>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -188,7 +188,7 @@ $compatibilityTypes = array(
 				<?php $compatibilityTypeGroup    = $compatibilityData['group']; ?>
 				<fieldset id="compatibilitytype<?php echo $compatibilityTypeGroup;?>" class="col-md-12 compatibilitytypes">
 					<legend>
-						<h3 class="alert <?php echo $compatibilityDisplayClass;?>">
+						<h3 class="alert <?php echo $compatibilityDisplayClass; ?>">
 							<?php if ($compatibilityType !== "COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_RUNNING_PRE_UPDATE_CHECKS") : ?>
 								<div class="compatibilitytoggle" data-state="closed"><?php echo Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_SHOW_MORE_COMPATIBILITY_INFORMATION', '<span class="icon-chevron-right"></span>'); ?></div>
 							<?php endif; ?>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -70,8 +70,8 @@ $compatibilityTypes = array(
 				}
 			endforeach;
 			?>
-			<legend class="alert alert-<?php echo $labelClass;?>">
-				<h3>
+			<legend>
+				<h3 class="alert alert-<?php echo $labelClass; ?>">```
 					<?php
 					echo $labelClass === 'danger' ? Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_REQUIRED_SETTINGS_WARNING') : Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_REQUIRED_SETTINGS_PASSED');
 					?>
@@ -128,8 +128,8 @@ $compatibilityTypes = array(
 			endforeach;
 			?>
 
-			<legend class="alert alert-<?php echo $labelClass;?>">
-				<h3>
+			<legend>
+				<h3 class="alert alert-<?php echo $labelClass; ?>">
 					<?php
 					echo $labelClass === 'warning' ? Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_RECOMMENDED_SETTINGS_WARNING') : Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_RECOMMENDED_SETTINGS_PASSED');
 					?>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -71,7 +71,7 @@ $compatibilityTypes = array(
 			endforeach;
 			?>
 			<legend>
-				<h3 class="alert alert-<?php echo $labelClass; ?>">```
+				<h3 class="alert alert-<?php echo $labelClass; ?>">
 					<?php
 					echo $labelClass === 'danger' ? Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_REQUIRED_SETTINGS_WARNING') : Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_REQUIRED_SETTINGS_PASSED');
 					?>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -28,7 +28,7 @@ $compatibilityTypes = array(
 		'group' => 0,
 	),
 	'COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_PRE_UPDATE_CHECKS_FAILED' => array(
-		'class' => 'label-important',
+		'class' => 'alert-danger',
 		'notes' => 'COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_PRE_UPDATE_CHECKS_FAILED_NOTES',
 		'group' => 4,
 	),
@@ -65,15 +65,15 @@ $compatibilityTypes = array(
 			foreach ($this->phpOptions as $option) :
 				if (!$option->state)
 				{
-					$labelClass = 'important';
+					$labelClass = 'danger';
 					break;
 				}
 			endforeach;
 			?>
-			<legend class="label label-<?php echo $labelClass;?>">
+			<legend class="alert alert-<?php echo $labelClass;?>">
 				<h3>
 					<?php
-					echo $labelClass === 'important' ? Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_REQUIRED_SETTINGS_WARNING') : Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_REQUIRED_SETTINGS_PASSED');
+					echo $labelClass === 'danger' ? Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_REQUIRED_SETTINGS_WARNING') : Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_REQUIRED_SETTINGS_PASSED');
 					?>
 					<div class="settingstoggle ms-1" data-state="closed"><?php echo Text::sprintf('COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_SHOW_MORE_COMPATIBILITY_INFORMATION', '<span class="icon-chevron-right"></span>'); ?></div>
 				</h3>
@@ -128,7 +128,7 @@ $compatibilityTypes = array(
 			endforeach;
 			?>
 
-			<legend class="label label-<?php echo $labelClass;?>">
+			<legend class="alert alert-<?php echo $labelClass;?>">
 				<h3>
 					<?php
 					echo $labelClass === 'warning' ? Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_RECOMMENDED_SETTINGS_WARNING') : Text::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_RECOMMENDED_SETTINGS_PASSED');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With pull request (PR) #33393 , the CSS classes used for colouring the legends of the different fieldsets of the extensions compatibility checks depending on the checks' results have been adapted to Boostrap 5.

This PR here completes that by applying the same changes to the legends of the two PHP checks, "Required PHP & Database Settings" and "Recommended PHP Settings" and by changing the CSS class at one place (line 31) where it was forgotten with PR #33393 .

In addition, it moves the alert CSS classes from the legend to the h3 element so the colours are applied by the (existing and not changed) CSS.

### Testing Instructions

1. Code review.

2. Check if the legends "Required PHP & Database Settings" and "Recommended PHP Settings" are coloured according to the status of the checks.

The easiest way to get an error in the "Required PHP & Database Settings" is to create an empty SQL update script with a higher schema version than the database schema, e.g. "4.0.0-2021-05-26.sql" in the update SQL script folder for your database type, so the database schema checker will show an error.

### Actual result BEFORE applying this Pull Request

The legends "Required PHP & Database Settings" and "Recommended PHP Settings" have old BS 2 CSS classes "legend-..." and so are not coloured depending on the check result:

![pr-34227_before-with-php-req-error](https://user-images.githubusercontent.com/7413183/119640095-8c767c80-be18-11eb-86df-0188b7807eb8.png)

### Expected result AFTER applying this Pull Request

The legends "Required PHP & Database Settings" and "Recommended PHP Settings" have BS 5 CSS classes "alert-..." and so are coloured depending on the check result:

- "Required PHP & Database Settings" has "alert-success" if all checks have passed and "alert-danger" if not.
- "Recommended PHP Settings" has "alert-success" if all checks have passed and "alert-warning" if not.

![pr-34227_after-with-php-req-ok](https://user-images.githubusercontent.com/7413183/119692484-beed9d00-be4b-11eb-9b65-6d27a10f764e.png)

![pr-34227_after-with-php-req-error](https://user-images.githubusercontent.com/7413183/119692544-c6ad4180-be4b-11eb-9da5-e2c250291ebc.png)

### Documentation Changes Required

None.