### PR TITLE
[4.0] Make sending attachments with the Mail Templates component more secure

### DIFF
--- a/administrator/components/com_mails/config.xml
+++ b/administrator/components/com_mails/config.xml
@@ -45,7 +45,7 @@
 			description="COM_MAILS_CONFIG_FIELD_ATTACHMENT_FOLDER_DESC"
 			size="40"
 			validate="filePath"
-			exclude="administrator|api|bin|cache|cli|components|includes|language|layouts|libraries|modules|plugins|templates|tmp"
+			exclude="administrator|api|cache|cli|components|includes|language|layouts|libraries|modules|plugins|templates|tmp"
 		/>
 
 	</fieldset>

--- a/administrator/components/com_mails/config.xml
+++ b/administrator/components/com_mails/config.xml
@@ -44,6 +44,8 @@
 			label="COM_MAILS_CONFIG_FIELD_ATTACHMENT_FOLDER_LABEL"
 			description="COM_MAILS_CONFIG_FIELD_ATTACHMENT_FOLDER_DESC"
 			size="40"
+			validate="filePath"
+			exclude="administrator|api|bin|cache|cli|components|includes|language|layouts|libraries|modules|plugins|templates|tmp"
 		/>
 
 	</fieldset>

--- a/administrator/components/com_mails/config.xml
+++ b/administrator/components/com_mails/config.xml
@@ -43,6 +43,7 @@
 			type="text"
 			label="COM_MAILS_CONFIG_FIELD_ATTACHMENT_FOLDER_LABEL"
 			description="COM_MAILS_CONFIG_FIELD_ATTACHMENT_FOLDER_DESC"
+			filter="path"
 			size="40"
 			validate="filePath"
 			exclude="administrator|api|bin|cache|cli|components|includes|language|layouts|libraries|modules|plugins|templates|tmp"

--- a/administrator/components/com_mails/config.xml
+++ b/administrator/components/com_mails/config.xml
@@ -43,7 +43,6 @@
 			type="text"
 			label="COM_MAILS_CONFIG_FIELD_ATTACHMENT_FOLDER_LABEL"
 			description="COM_MAILS_CONFIG_FIELD_ATTACHMENT_FOLDER_DESC"
-			filter="path"
 			size="40"
 			validate="filePath"
 			exclude="administrator|api|bin|cache|cli|components|includes|language|layouts|libraries|modules|plugins|templates|tmp"

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Mails\Administrator\Model;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
@@ -113,7 +114,16 @@ class TemplateModel extends AdminModel
 			$form->removeField('copyto', 'params');
 		}
 
-		if (!$params->get('attachment_folder') || !is_dir(JPATH_ROOT . '/' . $params->get('attachment_folder')))
+		try
+		{
+			$attachmentPath = Path::check(JPATH_ROOT . '/' . $params->get('attachment_folder'));
+		}
+		catch (\Exception $e)
+		{
+			$attachmentPath = '';
+		}
+
+		if (!$attachmentPath || !is_dir($attachmentPath))
 		{
 			$form->removeField('attachments');
 		}
@@ -122,7 +132,7 @@ class TemplateModel extends AdminModel
 			$field = $form->getField('attachments');
 			$subform = new \SimpleXMLElement($field->formsource);
 			$files = $subform->xpath('field[@name="file"]');
-			$files[0]->addAttribute('directory', JPATH_ROOT . '/' . $params->get('attachment_folder'));
+			$files[0]->addAttribute('directory', $attachmentPath);
 			$form->load('<form><field name="attachments" type="subform" '
 				. 'label="COM_MAILS_FIELD_ATTACHMENTS_LABEL" multiple="true" '
 				. 'layout="joomla.form.field.subform.repeatable-table">'

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -130,7 +130,7 @@ class TemplateModel extends AdminModel
 			$attachmentPath = '';
 		}
 
-		if (!$attachmentPath || $attachmentPath === JPATH_ROOT || !is_dir($attachmentPath))
+		if (!$attachmentPath || $attachmentPath === Path::clean(JPATH_ROOT) || !is_dir($attachmentPath))
 		{
 			$form->removeField('attachments');
 

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -114,7 +114,7 @@ class TemplateModel extends AdminModel
 			$form->removeField('copyto', 'params');
 		}
 
-		if (!$params->get('attachment_folder'))
+		if (!trim($params->get('attachment_folder')))
 		{
 			$form->removeField('attachments');
 

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -123,7 +123,7 @@ class TemplateModel extends AdminModel
 
 		try
 		{
-			$attachmentPath = rtrim(Path::check(JPATH_ROOT . '/' . $params->get('attachment_folder')), '/');
+			$attachmentPath = rtrim(Path::check(JPATH_ROOT . '/' . $params->get('attachment_folder')), \DIRECTORY_SEPARATOR);
 		}
 		catch (\Exception $e)
 		{

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -114,32 +114,39 @@ class TemplateModel extends AdminModel
 			$form->removeField('copyto', 'params');
 		}
 
+		if (!$params->get('attachment_folder'))
+		{
+			$form->removeField('attachments');
+
+			return $form;
+		}
+
 		try
 		{
-			$attachmentPath = Path::check(JPATH_ROOT . '/' . $params->get('attachment_folder'));
+			$attachmentPath = rtrim(Path::check(JPATH_ROOT . '/' . $params->get('attachment_folder')), '/');
 		}
 		catch (\Exception $e)
 		{
 			$attachmentPath = '';
 		}
 
-		if (!$attachmentPath || !is_dir($attachmentPath))
+		if (!$attachmentPath || $attachmentPath === JPATH_ROOT || !is_dir($attachmentPath))
 		{
 			$form->removeField('attachments');
+
+			return $form;
 		}
-		else
-		{
-			$field = $form->getField('attachments');
-			$subform = new \SimpleXMLElement($field->formsource);
-			$files = $subform->xpath('field[@name="file"]');
-			$files[0]->addAttribute('directory', $attachmentPath);
-			$form->load('<form><field name="attachments" type="subform" '
-				. 'label="COM_MAILS_FIELD_ATTACHMENTS_LABEL" multiple="true" '
-				. 'layout="joomla.form.field.subform.repeatable-table">'
-				. str_replace('<?xml version="1.0"?>', '', $subform->asXML())
-				. '</field></form>'
-			);
-		}
+
+		$field = $form->getField('attachments');
+		$subform = new \SimpleXMLElement($field->formsource);
+		$files = $subform->xpath('field[@name="file"]');
+		$files[0]->addAttribute('directory', $attachmentPath);
+		$form->load('<form><field name="attachments" type="subform" '
+			. 'label="COM_MAILS_FIELD_ATTACHMENTS_LABEL" multiple="true" '
+			. 'layout="joomla.form.field.subform.repeatable-table">'
+			. str_replace('<?xml version="1.0"?>', '', $subform->asXML())
+			. '</field></form>'
+		);
 
 		return $form;
 	}

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -477,7 +477,8 @@ class MailTemplate
 	}
 
 	/**
-	 * Check and if necessary fix the file name of an attachment so that the attached file has the same extension as the source file, and not a different file extension
+	 * Check and if necessary fix the file name of an attachment so that the attached file
+	 * has the same extension as the source file, and not a different file extension
 	 *
 	 * @param   string  $file  Path to the file to be attached
 	 * @param   string  $name  The file name to be used for the attachment

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -287,7 +287,7 @@ class MailTemplate
 
 		$folderPath = rtrim(Path::check(JPATH_ROOT . '/' . $config->get('attachment_folder')), '/');
 
-		if ($folderPath && $folderPath !== JPATH_ROOT && is_dir($folderPath))
+		if ($folderPath && $folderPath !== Path::clean(JPATH_ROOT) && is_dir($folderPath))
 		{
 			$attachments = (array) json_decode($mail->attachments);
 		}

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -285,7 +285,7 @@ class MailTemplate
 			$this->mailer->addReplyTo($this->replyto->mail, $this->replyto->name);
 		}
 
-		$folderPath = rtrim(Path::check($config->get('attachment_folder')), '/');
+		$folderPath = rtrim(Path::check(JPATH_ROOT . '/' . $config->get('attachment_folder')), '/');
 
 		if ($folderPath && $folderPath !== JPATH_ROOT && is_dir($folderPath))
 		{

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\Mail;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
@@ -297,7 +298,7 @@ class MailTemplate
 
 					if (is_file($filePath))
 					{
-						$this->mailer->addAttachment($filePath, $this->setAttachmentName($filePath, $attachment->name ?? $attachment->file));
+						$this->mailer->addAttachment($filePath, $this->getAttachmentName($filePath, $attachment->name));
 					}
 				}
 			}
@@ -307,7 +308,7 @@ class MailTemplate
 		{
 			if (is_file($attachment->file))
 			{
-				$this->mailer->addAttachment($attachment->file, $this->setAttachmentName($attachment->file, $attachment->name));
+				$this->mailer->addAttachment($attachment->file, $this->getAttachmentName($attachment->file, $attachment->name));
 			}
 			else
 			{
@@ -485,29 +486,17 @@ class MailTemplate
 	 *
 	 * @since   4.0.0
 	 */
-	protected function setAttachmentName($file, $name)
+	protected function getAttachmentName($file, $name)
 	{
-		// If no name is given use the basename of the file to be attached
+		// If no name is given, do not process it further
 		if (!trim($name))
 		{
-			return basename($file);
+			return '';
 		}
 
-		// Get file extension of the file to be attached
-		$extensionFile = pathinfo($file, PATHINFO_EXTENSION);
+		$ext = File::getExt($file);
 
-		// If the file has no extension there is nothing to do with the name
-		if (!$extensionFile)
-		{
-			return $name;
-		}
-
-		// Make sure to attach the file with the same extension as the attached file has (case-insensitive)
-		if (strtolower(pathinfo($name, PATHINFO_EXTENSION)) !== strtolower($extensionFile))
-		{
-			return $name . '.' . $extensionFile;
-		}
-
-		return $name;
+		// Strip off extension from $name and append extension of $file, if any
+		return File::stripExt($name) . ($ext ? '.' . $ext : '');;
 	}
 }

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -285,25 +285,21 @@ class MailTemplate
 			$this->mailer->addReplyTo($this->replyto->mail, $this->replyto->name);
 		}
 
-		$attachments = array();
-
-		if ($config->get('attachment_folder'))
+		if (trim($config->get('attachment_folder')))
 		{
 			$folderPath = rtrim(Path::check(JPATH_ROOT . '/' . $config->get('attachment_folder')), \DIRECTORY_SEPARATOR);
 
 			if ($folderPath && $folderPath !== Path::clean(JPATH_ROOT) && is_dir($folderPath))
 			{
-				$attachments = (array) json_decode($mail->attachments);
-			}
-		}
+				foreach ((array) json_decode($mail->attachments) as $attachment)
+				{
+					$filePath = Path::check($folderPath . '/' . $attachment->file);
 
-		foreach ($attachments as $attachment)
-		{
-			$filePath = Path::check($folderPath . '/' . $attachment->file);
-
-			if (is_file($filePath))
-			{
-				$this->mailer->addAttachment($filePath, $this->setAttachmentName($filePath, $attachment->name ?? $attachment->file));
+					if (is_file($filePath))
+					{
+						$this->mailer->addAttachment($filePath, $this->setAttachmentName($filePath, $attachment->name ?? $attachment->file));
+					}
+				}
 			}
 		}
 

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -285,7 +285,7 @@ class MailTemplate
 			$this->mailer->addReplyTo($this->replyto->mail, $this->replyto->name);
 		}
 
-		$attachments = array()
+		$attachments = array();
 
 		if ($config->get('attachment_folder'))
 		{

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -285,13 +285,24 @@ class MailTemplate
 			$this->mailer->addReplyTo($this->replyto->mail, $this->replyto->name);
 		}
 
-		$path = Path::check(JPATH_ROOT . '/' . $config->get('attachment_folder') . '/');
+		$folderPath = rtrim(Path::check($config->get('attachment_folder')), '/');
 
-		foreach ((array) json_decode($mail->attachments)  as $attachment)
+		if ($folderPath && $folderPath !== JPATH_ROOT && is_dir($folderPath))
 		{
-			if (is_file($path . $attachment->file))
+			$attachments = (array) json_decode($mail->attachments);
+		}
+		else
+		{
+			$attachments = array();
+		}
+
+		foreach ($attachments as $attachment)
+		{
+			$filePath = Path::check($folderPath . '/' . $attachment->file);
+
+			if (is_file($filePath))
 			{
-				$this->mailer->addAttachment($path . $attachment->file, $attachment->name ?? $attachment->file);
+				$this->mailer->addAttachment($filePath, $attachment->name ?? $attachment->file);
 			}
 		}
 

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -507,7 +507,7 @@ class MailTemplate
 		}
 
 		// Make sure to attach the file with the same extension as the attached file has (case-insensitive)
-		if (strtolower(pathinfo($name, PATHINFO_EXTENSION)) !== $extensionFile)
+		if (strtolower(pathinfo($name, PATHINFO_EXTENSION)) !== strtolower($extensionFile))
 		{
 			return $name . '.' . $extensionFile;
 		}

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -303,7 +303,7 @@ class MailTemplate
 
 			if (is_file($filePath))
 			{
-				$this->mailer->addAttachment($filePath, $attachment->name ?? $attachment->file);
+				$this->mailer->addAttachment($filePath, $this->setAttachmentName($filePath, $attachment->name ?? $attachment->file));
 			}
 		}
 
@@ -311,7 +311,7 @@ class MailTemplate
 		{
 			if (is_file($attachment->file))
 			{
-				$this->mailer->addAttachment($attachment->file, $attachment->name);
+				$this->mailer->addAttachment($attachment->file, $this->setAttachmentName($attachment->file, $attachment->name));
 			}
 			else
 			{
@@ -477,5 +477,41 @@ class MailTemplate
 		$db->setQuery($query);
 
 		return $db->execute();
+	}
+
+	/**
+	 * Check and if necessary fix the file name of an attachment
+	 *
+	 * @param   string  $file  Path to the file to be attached
+	 * @param   string  $name  The file name to be used for the attachment
+	 *
+	 * @return  string  The corrected file name for the attachment
+	 *
+	 * @since   4.0.0
+	 */
+	protected function setAttachmentName($file, $name)
+	{
+		// If no name is given use the basename of the file to be attached
+		if (!trim($name))
+		{
+			return basename($file);
+		}
+
+		// Get file extension of the file to be attached
+		$extensionFile = pathinfo($file, PATHINFO_EXTENSION);
+
+		// If the file has no extension there is nothing to do with the name
+		if (!$extensionFile)
+		{
+			return $name;
+		}
+
+		// Make sure to attach the file with the same extension as the attached file has (case-insensitive)
+		if (strtolower(pathinfo($name, PATHINFO_EXTENSION)) !== $extensionFile)
+		{
+			return $name . '.' . $extensionFile;
+		}
+
+		return $name;
 	}
 }

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -497,6 +497,6 @@ class MailTemplate
 		$ext = File::getExt($file);
 
 		// Strip off extension from $name and append extension of $file, if any
-		return File::stripExt($name) . ($ext ? '.' . $ext : '');;
+		return File::stripExt($name) . ($ext ? '.' . $ext : '');
 	}
 }

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\Mail;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\Database\ParameterType;
@@ -178,6 +179,7 @@ class MailTemplate
 	 * @return  boolean  True on success
 	 *
 	 * @since   4.0.0
+	 * @throws  \Exception
 	 * @throws  MailDisabledException
 	 * @throws  phpmailerException
 	 */
@@ -283,7 +285,7 @@ class MailTemplate
 			$this->mailer->addReplyTo($this->replyto->mail, $this->replyto->name);
 		}
 
-		$path = JPATH_ROOT . '/' . $config->get('attachment_folder') . '/';
+		$path = Path::check(JPATH_ROOT . '/' . $config->get('attachment_folder') . '/');
 
 		foreach ((array) json_decode($mail->attachments)  as $attachment)
 		{

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -289,7 +289,7 @@ class MailTemplate
 
 		if ($config->get('attachment_folder'))
 		{
-			$folderPath = rtrim(Path::check(JPATH_ROOT . '/' . $config->get('attachment_folder')), '/');
+			$folderPath = rtrim(Path::check(JPATH_ROOT . '/' . $config->get('attachment_folder')), \DIRECTORY_SEPARATOR);
 
 			if ($folderPath && $folderPath !== Path::clean(JPATH_ROOT) && is_dir($folderPath))
 			{

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -477,7 +477,7 @@ class MailTemplate
 	}
 
 	/**
-	 * Check and if necessary fix the file name of an attachment
+	 * Check and if necessary fix the file name of an attachment so that the attached file has the same extension as the source file, and not a different file extension
 	 *
 	 * @param   string  $file  Path to the file to be attached
 	 * @param   string  $name  The file name to be used for the attachment
@@ -486,7 +486,7 @@ class MailTemplate
 	 *
 	 * @since   4.0.0
 	 */
-	protected function getAttachmentName($file, $name)
+	protected function getAttachmentName(string $file, string $name): string
 	{
 		// If no name is given, do not process it further
 		if (!trim($name))

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -285,15 +285,16 @@ class MailTemplate
 			$this->mailer->addReplyTo($this->replyto->mail, $this->replyto->name);
 		}
 
-		$folderPath = rtrim(Path::check(JPATH_ROOT . '/' . $config->get('attachment_folder')), '/');
+		$attachments = array()
 
-		if ($folderPath && $folderPath !== Path::clean(JPATH_ROOT) && is_dir($folderPath))
+		if ($config->get('attachment_folder'))
 		{
-			$attachments = (array) json_decode($mail->attachments);
-		}
-		else
-		{
-			$attachments = array();
+			$folderPath = rtrim(Path::check(JPATH_ROOT . '/' . $config->get('attachment_folder')), '/');
+
+			if ($folderPath && $folderPath !== Path::clean(JPATH_ROOT) && is_dir($folderPath))
+			{
+				$attachments = (array) json_decode($mail->attachments);
+			}
 		}
 
 		foreach ($attachments as $attachment)


### PR DESCRIPTION
Pull Request for Issue #34185 .

### Summary of Changes

This pull request (PR) adds validation to the "Attachments Folder" option of the Mail Templates (com_mails) component so it falls under the same restrictions like the "Path to Images Folder" option of the Media Manager, i.e.
- The attachments folder has to be below the Joomla root folder.
- Certain system folders like "administrator", "api", "cache", and so on are not allowed.

In addition, it adds checks for the parameter from database in case if a path to the "Attachments Folder" has been saved in database which is not valid, which can happen before the patch of this PR is applied, or after that if someone hacks your database. These checks are added at two places:
- When loading the form to edit mail templates, the fields for adding attachments are not included in the form if the "Attachments Folder" is not valid or equal to the Joomla root.
- Sending email will be rejected with an exception if the "Attachments Folder" is not valid or equal to the Joomla root or if the full path to the attachment file is not valid or the file doesn't exist.

Finally, it makes sure that the file name used for the email attachment (Field "File Name" of an attachment in the mail template form), which can be different to the real name of the file on the server, doesn't use a different file name extension than the real file, by stripping off any extension from the attachment name and appending the extension of the real file.

What this PR does not fix:
- You can save the options form with "Attachments Folder" which doesn't exist.
- You can enter a "File Name" for an attachment which is not a valid file name on any client OS and so might make problems when the email receiver wants to save the attachment with that suggested name.

### Testing Instructions

The test starts on an installation of current 4.0-dev branch or latest 4.0 nightly build _without_ the patch of this PR applied which has mailing configured so that it works.

All actions are performed in backend or your local email client.

1. Go to "System -> Templates -> Mail Templates" and edit the options.

2. In field Attachments Folder, enter a valid folder below the Joomla root, e.g. "images", and save and close.

3. Make sure that the previously entered folder contains some files which can be attached to email, e.g some images.

4. Edit one of the mail templates, e.g. "Global Configuration: Test Mail".

5. At the bottom in section "Attachments", use the "File" field to select a file which has a file name extension, e.g. ".jpg" for an image.

6. In field "Filename" enter a file name using a different extension. E.g. if the attachment has extension ".jpg", use ".txt".

7. Save the changes.

8. Cause sending an email to an address of which you can receive email and read it in an email client.

9. When having received the email, open it in your email client and check the name of the attachment.
Result: The attachment has the name and extension as entered in step 3 in field "Filename".
This can be used to send files like "virus.exe" as an attachment "nice-image.jpg".
It can also cause problems when saving the file locally and then trying to open it on an OS (Windows) which uses the extension to determine the file type and to decide what to do with it, i.e. which program to use to open that file.

10. Go back to "System -> Templates -> Mail Templates" and edit again the component's options.

11. In field "Attachments Folder, enter a relative path to a folder which exists and is accessible for the webserver and PHP but outside the Joomla root, using "../" to break out the Joomla root, like it is described in issue #34185.

12. Save the changes.
Result: You can save the options.

13. Edit a mail template, e.g. "Global Configuration: Test Mail", and check if you can chose attachments from the folder specified in step 11.
Result: You can chose attachments from that folder.

14. Select an attachment and save the changes.

15. Cause a mail to be sent with that mail template.
Result: The mail is sent with the attachment specified in step 14.

16. Apply the patch of this PR.

17. Cause again a mail to be sent with that mail template.
Result: The mail is not sent. You see an error alert.

18. Edit again the mail template chosen in step 13 and check if you can chose attachments.
Result: The fields for choosing attachments are not shown.

19. Go back to "System -> Templates -> Mail Templates" , open again the component's options and try to save.
Result: You can't save the options due to invalid "Attachments Folder".

20. Try to use one of the system folders which are in the exclude list here: https://github.com/joomla/joomla-cms/pull/34233/files#diff-2792d8a5dc948a15bef321b2d150882221ceeb12488953ed502422a601235bd6R48
Result: You can't save the options due to invalid "Attachments Folder".

21. Change the "Path to Images Folder" to a valid path inside the Joomla root which contains files, and save the options.
Result: You can save the options.

22. Edit one of the mail templates, e.g. "Global Configuration: Test Mail".

23. At the bottom in section "Attachments", use the "File" field to select a file which has a file name extension, e.g. ".jpg" for an image.

24. In field "Filename" enter a file name using a different extension. E.g. if the attachment has extension ".jpg", use ".txt".

25. Save the changes.

26. Cause sending an email to an address of which you can receive email and read it in an email client.

27. When having received the email, open it in your email client and check the name of the attachment.
Result: The attachment has the name as entered in step 24 in field "Filename" but without the extension plus the extension of the real file appended. E.g. if the real file on the server was "joomla_black.png" and you have entered "blabla.txt" in field "Filename", the attachment will be named "blabla.png".

28. Edit again one of the mail templates, e.g. "Global Configuration: Test Mail".

29. At the bottom in section "Attachments", use the "File" field to select a file which has a file name extension, e.g. ".jpg" for an image.

30. In field "Filename" enter a file name using no extension.

31. Save the changes.

32. Cause sending an email to an address of which you can receive email and read it in an email client.

33. When having received the email, open it in your email client and check the name of the attachment.
Result: The attachment has the name as entered in step 30 in field "Filename" plus the extension of the real file appended. E.g. if the real file on the server was "joomla_black.png" and you have entered "blabla" in field "Filename", the attachment will be named "blabla.png".

### Actual result BEFORE applying this Pull Request

Any folder can be specified as attachment folder in mail template options. This includes the possibility to break outside the Joomla root.

Files can be attached to email with a different file name extension than the attached file has on the server, e.g. you can attach a file "virus.exe" with name "funny-image.jpg".

### Expected result AFTER applying this Pull Request

The attachment folder parameter for mail templates is validated in the same way as it is for the "images" folder in the media manager options, i.e. it has to be in the Joomla root or below, and it excludes system folders like "administrator", "api", "cache", and so on.

If for some reason an invalid attachment folder parameter has been saved in database, e.g. on a previous 4.0 Beta version or a current 4.0-dev or nightly build which doesn't include the patch from this PR someone has used such a bad path, or someone hacked it in your database, then it is checked in the mail template's templates model and cleared if invalid.

Finally the path is checked when attaching files to mails on sending. If there for some reason the path is not valid, an exception is raised, so sending the mail is aborted.

When files are attached to mail, the file name extension of the real file on server side is appended to the (possibly different) file name of the attachment, if necessary, so it's not possible anymore that the attachment has a different extension than the file being attached.

### Documentation Changes Required

Possibly there is already documentation for the mail templates, and it tells that you can use any folder, also outside the Joomla root. If this is the case: It needs to be updated.