### PR TITLE
[4.0] Add search module types label

### DIFF
--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -32,7 +32,7 @@ endif;
 	<div class="d-flex mt-2">
 		<div class="ms-auto me-auto">
 			<label class="visually-hidden" for="comModulesSelectSearch">
-				<?php echo Text::_('COM_MODULES_TYPE_CHOOSE'); ?>
+				<?php echo Text::_('COM_MODULES_TYPE_FILTER_SEARCH_LABEL'); ?>
 			</label>
 			<div class="input-group mb-3 me-sm-2">
 				<input type="text" value=""

--- a/administrator/language/en-GB/com_modules.ini
+++ b/administrator/language/en-GB/com_modules.ini
@@ -189,6 +189,7 @@ COM_MODULES_SELECT_MODULE="Select module, %s"
 COM_MODULES_SUBITEMS="Sub-items"
 COM_MODULES_TABLE_CAPTION="Table of Modules"
 COM_MODULES_TYPE_CHOOSE="Select a Module Type"
+COM_MODULES_TYPE_FILTER_SEARCH_LABEL="Search Module Types"
 COM_MODULES_TYPE_OR_SELECT_POSITION="Type or Select a Position"
 COM_MODULES_XML_DESCRIPTION="Component for module management in the Administrator Backend."
 


### PR DESCRIPTION
### Summary of Changes
The label for the search field is the same as the heading. 

Adds a new label for the search field.

### Testing Instructions
Code review.

or

Click the `Add module to the dashboard` box at the bottom of the page to display a modal.
View page source or use browser's developer tool to inspect label markup before the search field..


### Actual result BEFORE applying this Pull Request
![select-module-type](https://user-images.githubusercontent.com/368084/119706668-220d0e80-be0f-11eb-96c5-e8478211e650.jpg)



### Expected result AFTER applying this Pull Request
![search-module-types](https://user-images.githubusercontent.com/368084/119706680-246f6880-be0f-11eb-868d-b16f6fe49e09.jpg)
