### PR TITLE
[4.0] pre-update check [a11y] [ui]

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -98,13 +98,15 @@ $compatibilityTypes = array(
 						<tr>
 							<th scope="row">
 								<?php echo $option->label; ?>
+								<?php if ($option->notice) : ?>
+								<div class="small">
+									<?php echo $option->notice; ?>
+								</div>
+								<?php endif; ?>
 							</th>
 							<td>
 								<span class="badge bg-<?php echo $option->state ? 'success' : 'danger'; ?>">
 									<?php echo Text::_($option->state ? 'JYES' : 'JNO'); ?>
-									<?php if ($option->notice) : ?>
-										<span class="icon-info-circle icon-white" title="<?php echo $option->notice; ?>"></span>
-									<?php endif; ?>
 								</span>
 							</td>
 						</tr>


### PR DESCRIPTION
In the required section of the pre-update check there are three requirements that have some extra information available if the requirement is not met.

Currently they are completely inaccessible as they are a title on a non-focusable element which is only the tiny icon and not the entire badge. There really isnt a good reason for this information not to be visible by default when it should be displayed. 

It also would allow links to be placed in the information if desired and suggested by @infograf768 

### Before
![before](https://user-images.githubusercontent.com/1296369/119815118-20147f80-bee3-11eb-8c6e-c1c85f68ddde.gif)


### After with all three notices displayed
![image](https://user-images.githubusercontent.com/1296369/119814666-94025800-bee2-11eb-8445-98953198aec3.png)
