### PR TITLE
[4.0] pre-update check link

### DIFF
--- a/administrator/language/en-GB/com_joomlaupdate.ini
+++ b/administrator/language/en-GB/com_joomlaupdate.ini
@@ -57,7 +57,7 @@ COM_JOOMLAUPDATE_VIEW_DEFAULT_DESCRIPTION_MISSING_TAG="Extensions marked with <s
 COM_JOOMLAUPDATE_VIEW_DEFAULT_DESCRIPTION_UPDATE_REQUIRED="Extensions marked with <span class='badge bg-warning text-dark'>Yes (X.X.X)</span> might require an update."
 COM_JOOMLAUPDATE_VIEW_DEFAULT_DIRECTIVE="Directive"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_DOWNLOAD_IN_PROGRESS="Downloading update file. Please wait ..."
-COM_JOOMLAUPDATE_VIEW_DEFAULT_EXPLANATION_AND_LINK_TO_DOCS="The pre-update check provides you with information about the readiness of your server, settings and installed extensions for the update.<br>You can find more information about this page and how to prepare for updating Joomla in the <a class='pre-update-docs' href='https://docs.joomla.org/Pre-Update_Check'>pre-update check documentation</a>."
+COM_JOOMLAUPDATE_VIEW_DEFAULT_EXPLANATION_AND_LINK_TO_DOCS="The pre-update check provides you with information about the readiness of your server, settings and installed extensions for the update.<br>You can find more information about this page and how to prepare for updating Joomla in the <a class='pre-update-docs' href='https://docs.joomla.org/Pre-Update_Check' target='_blank' rel='noopener noreferrer'>pre-update check documentation</a>."
 COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_RUNNING_PRE_UPDATE_CHECKS="Running Pre-Update Checks"
 COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_RUNNING_PRE_UPDATE_CHECKS_NOTES="Please be patient whilst we run the pre-update checks on your extensions."
 COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_PRE_UPDATE_CHECKS_FAILED="Pre-Update Checks Failed"


### PR DESCRIPTION
This pr adds the rel=noopener noreferrer to the link and makes the link open in a new tab. This is perfectly valid as you are opening information that is intended to be read accompanying the current page.

![image](https://user-images.githubusercontent.com/1296369/119815979-0e7fa780-bee4-11eb-983b-a2e3a4404421.png)
