### PR TITLE
[4.0] Dashboard menu language

### DIFF
--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -63,13 +63,14 @@ use Joomla\CMS\Router\Route;
 										?>
 										<?php echo HTMLHelper::_('image', $image, $alt, 'class="' . $class . '"'); ?>
 									<?php endif; ?>
-									<?php echo ($params->get('menu_text', 1)) ? htmlspecialchars(Text::_($item->title), ENT_QUOTES, 'UTF-8') . $item->iconImage : ''; ?>
+									<?php echo ($params->get('menu_text', 1)) ? htmlspecialchars(Text::_($item->title), ENT_QUOTES, 'UTF-8') : ''; ?>
 									<?php if ($item->ajaxbadge) : ?>
 										<span class="menu-badge">
 											<span class="icon-spin icon-spinner mt-1 system-counter float-end" data-url="<?php echo $item->ajaxbadge; ?>"></span>
 										</span>
 									<?php endif; ?>
 								</a>
+								<?php echo $item->iconImage; ?>
 								<?php if ($params->get('menu-quicktask')) : ?>
 									<?php $permission = $params->get('menu-quicktask-permission'); ?>
 									<?php $scope = $item->scope !== 'default' ? $item->scope : null; ?>


### PR DESCRIPTION
On a multilingual website on the menu dashboard each of the default menus for a language has the language code displayed after the Menu name.

This PR moves the language out of the link to avoid the ugly underline between the menu name and the language code

### Before
![image](https://user-images.githubusercontent.com/1296369/119838883-accb3780-befb-11eb-9443-c800423fb66a.png)

### After
![image](https://user-images.githubusercontent.com/1296369/119838675-81e0e380-befb-11eb-972f-ae0b7f44d39e.png)
