### PR TITLE
[4.0] alert-warning colors fix

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -191,9 +191,9 @@ $state-info-text:                  var(--atum-bg-dark-70);
 $state-info-bg:                    var(--white);
 $state-info-border:                var(--atum-bg-dark-70);
 
-$state-warning-text:               darken($warning, 24%);
+$state-warning-text:               $warning;
 $state-warning-bg:                 lighten($warning, 44%);
-$state-warning-border:             darken($warning, 24%);
+$state-warning-border:             $warning;
 
 $state-danger-text:                $danger;
 $state-danger-bg:                  lighten($danger, 52%);

--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -192,6 +192,7 @@ $state-info-bg:                    var(--white);
 $state-info-border:                var(--atum-bg-dark-70);
 
 $state-warning-text:               $warning;
+$state-warning-custom-text:        darken($warning, 24%);
 $state-warning-bg:                 lighten($warning, 44%);
 $state-warning-border:             $warning;
 

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -87,6 +87,7 @@
   }
 
   &[type="warning"] {
+    color: #996900 !important;
     --alert-accent-color: #{$state-warning-text};
     --alert-bg-color: #{$state-warning-bg};
   }

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -87,7 +87,7 @@
   }
 
   &[type="warning"] {
-    & .joomla-alert--close {
+    .joomla-alert--close {
       color: #{$state-warning-custom-text};
     }
 

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -87,6 +87,10 @@
   }
 
   &[type="warning"] {
+    & .joomla-alert--close {
+      color: #{$state-warning-custom-text};
+    }
+
     color: #{$state-warning-custom-text};
     --alert-accent-color: #{$state-warning-text};
     --alert-bg-color: #{$state-warning-bg};

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -87,7 +87,7 @@
   }
 
   &[type="warning"] {
-    color: #996900 !important;
+    color: #996900;
     --alert-accent-color: #{$state-warning-text};
     --alert-bg-color: #{$state-warning-bg};
   }

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -87,7 +87,7 @@
   }
 
   &[type="warning"] {
-    color: #996900;
+    color: #{$state-warning-custom-text};
     --alert-accent-color: #{$state-warning-text};
     --alert-bg-color: #{$state-warning-bg};
   }


### PR DESCRIPTION
Pull Request for Issue #34174.

### Summary of Changes
As discussed <a href="https://github.com/joomla/joomla-cms/issues/34174#issuecomment-849442618">here</a>
Changed the warning accent color to yellow and text color to mud yellow.

### Testing Instructions
- build css <code>npm run build:css</code>
- check the warning alert   ( you can try to login to backend with wrong credetials for example)
- notice the colors of warning alert

### Actual result BEFORE applying this Pull Request
 
A mud(ish) yellow color accent color  (#996900)

### Expected result AFTER applying this Pull Request

Yellow color in general and <code>text color + dismiss button</code> to mud(ish) yellow (#996900)
![ss](https://user-images.githubusercontent.com/65963997/120112782-f2eef800-c194-11eb-9ee3-00fdaa325578.gif)

### Documentation Changes Required
_none_
