### PR TITLE
Make sure the status is always 0

### DIFF
--- a/administrator/components/com_privacy/models/request.php
+++ b/administrator/components/com_privacy/models/request.php
@@ -427,6 +427,9 @@ class PrivacyModelRequest extends JModelAdmin
 			return false;
 		}
 
+		// Make sure the status is always 0
+		$validatedData['status'] = 0;
+
 		// The user cannot create a request for their own account
 		if (strtolower(JFactory::getUser()->email) === strtolower($validatedData['email']))
 		{


### PR DESCRIPTION
Pull Request for an issue reported to the JSST by DangKhai

### Summary of Changes

Make sure super users can not bypass the inital status of an privacy request.

### Testing Instructions

- install staging
- create an privacy request
- apply this PR
- create another privacy requst 

### Actual result BEFORE applying this Pull Request

A super user could modify the request and set the intial state of the privacy request to something else than "0".

### Expected result AFTER applying this Pull Request

We force any privacy request's inital status to be 0

### Documentation Changes Required

None.

cc @richard67 @HLeithner @SniperSister 