### PR TITLE
Added more context to Filesystem::delete exception

### DIFF
--- a/libraries/vendor/joomla/filesystem/src/File.php
+++ b/libraries/vendor/joomla/filesystem/src/File.php
@@ -123,7 +123,7 @@ class File
 
 			if (!Path::canChmod($file))
 			{
-				throw new FilesystemException(__METHOD__ . ': Failed deleting inaccessible file ' . $filename);
+				throw new FilesystemException(__METHOD__ . ': Failed deleting inaccessible file ' . ( defined('JDEBUG') && JDEBUG ? $file : $filename) );
 			}
 
 			// Try making the file writable first. If it's read-only, it can't be deleted
@@ -134,7 +134,7 @@ class File
 			// as long as the owner is either the webserver or the ftp
 			if (!@ unlink($file))
 			{
-				throw new FilesystemException(__METHOD__ . ': Failed deleting ' . $filename);
+				throw new FilesystemException(__METHOD__ . ': Failed deleting ' . ( defined('JDEBUG') && JDEBUG ? $file : $filename) );
 			}
 		}
 


### PR DESCRIPTION
I would prefer to know where a problematic file is located during a failed update.

Pull Request for Issue # .

### Summary of Changes

Added a check for JDEBUG and present a full path of the undeletable file to the user in case the system runs in debug mode.

### Testing Instructions

Make a core file inaccessible to the web server and run a core refresh or update. In case it can't delete a file, it will raise an error with just the file name or in debug mode with the full path name.

### Actual result BEFORE applying this Pull Request

Just a filename without any information where to find that file.

### Expected result AFTER applying this Pull Request

A full path to the file...

### Documentation Changes Required

