### PR TITLE
[4.0] Improve FilePathRule

### DIFF
--- a/libraries/src/Form/Rule/FilePathRule.php
+++ b/libraries/src/Form/Rule/FilePathRule.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Form\Rule;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormRule;
@@ -74,6 +75,12 @@ class FilePathRule extends FormRule
 		catch (\Exception $e)
 		{
 			// When there is an exception in the check path this is not valid
+			return false;
+		}
+
+		// Check to make sure $value is an existing directory
+		if (!Folder::exists($value))
+		{
 			return false;
 		}
 


### PR DESCRIPTION
Pull Request for Issue #34236.

### Summary of Changes
This PR makes small improvement to `FilePathRule` so that the entered path not only must be an internal path but also needs to be a valid/existing folder.

### Testing Instructions
1. Access to Content -> Media, click on Options button in the toolbar
2. Change **Path to Files Folder** from images to a random string like aaa (a none existing folder)
3. Before patch: The change is saved
4. After patch: The change is not saved, there is an error message displayed **Invalid field: Path to Files Folder**