### PR TITLE
[4.0] Fix row selecting, when module is disabled

### DIFF
--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -94,9 +94,7 @@ if ($saveOrder && !empty($this->items))
 				?>
 					<tr class="row<?php echo $i % 2; ?>" data-draggable-group="<?php echo $item->position ?: 'none'; ?>">
 						<td class="text-center">
-							<?php if ($item->enabled > 0) : ?>
-								<?php echo HTMLHelper::_('grid.id', $i, $item->id, false, 'cid', 'cb', $item->title); ?>
-							<?php endif; ?>
+							<?php echo HTMLHelper::_('grid.id', $i, $item->id, false, 'cid', 'cb', $item->title); ?>
 						</td>
 						<td class="text-center d-none d-md-table-cell">
 							<?php


### PR DESCRIPTION
Fix for #30798

### Summary of Changes
Fixing incorrect selection when clicking on the row with disabled module.
This enable check box for disabled module, the same behavior as for Menu item when component is disabled.


### Testing Instructions

Create Custom HTML Module. (or any other unlocked module)
Go to extension manager and disable "Custom Module".
Go back to module overview, and try select this module.


### Actual result BEFORE applying this Pull Request

The next row will be selected. You cannot delete "disabled" record.


### Expected result AFTER applying this Pull Request

A correct row will be selected. You able to delete "disabled" record.


### Documentation Changes Required
nope
