### PR TITLE
[4.0] New form field validation rules for paths to existing folders or files

### DIFF
--- a/administrator/components/com_mails/config.xml
+++ b/administrator/components/com_mails/config.xml
@@ -44,6 +44,8 @@
 			label="COM_MAILS_CONFIG_FIELD_ATTACHMENT_FOLDER_LABEL"
 			description="COM_MAILS_CONFIG_FIELD_ATTACHMENT_FOLDER_DESC"
 			size="40"
+			validate="folderPathExists"
+			exclude="administrator|api|bin|cache|cli|components|includes|language|layouts|libraries|modules|plugins|templates|tmp"
 		/>
 
 	</fieldset>

--- a/administrator/components/com_mails/forms/template.xml
+++ b/administrator/components/com_mails/forms/template.xml
@@ -47,6 +47,7 @@
 				type="filelist"
 				hide_default="true"
 				label="COM_MAILS_FIELD_FILE_LABEL"
+				validate="filePathExists"
 			/>
 			<field
 				name="name"

--- a/administrator/components/com_media/config.xml
+++ b/administrator/components/com_media/config.xml
@@ -29,7 +29,7 @@
 			description="COM_MEDIA_FIELD_PATH_FILE_FOLDER_DESC"
 			size="50"
 			default="images"
-			validate="filePath"
+			validate="folderPathExists"
 			exclude="administrator|api|bin|cache|cli|components|includes|language|layouts|libraries|media|modules|plugins|templates|tmp"
 		/>
 
@@ -40,7 +40,7 @@
 			description="COM_MEDIA_FIELD_PATH_IMAGE_FOLDER_DESC"
 			size="50"
 			default="images"
-			validate="filePath"
+			validate="folderPathExists"
 			exclude="administrator|api|bin|cache|cli|components|includes|language|layouts|libraries|modules|plugins|templates|tmp"
 		/>
 

--- a/libraries/src/Form/Rule/FilePathExistsRule.php
+++ b/libraries/src/Form/Rule/FilePathExistsRule.php
@@ -10,6 +10,8 @@ namespace Joomla\CMS\Form\Rule;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\Rule\FilePathRule;
 use Joomla\Registry\Registry;
@@ -52,8 +54,20 @@ class FilePathExistsRule extends FilePathRule
 		}
 
 		// In case of a file list field we might have a directory, otherwise it's Joomla root
-		$parentPath = $element['directory'] ?? JPATH_ROOT;
+		if (isset($element['directory']) && trim((string) $element['directory']))
+		{
+			$parentPath = Path::clean((string) $element['directory']);
 
-		return is_file($parentPath . '/' . $value);
+			if (strpos($parentPath, Path::clean(JPATH_ROOT)) !== 0)
+			{
+				$parentPath = JPATH_ROOT . '/' . $parentPath;
+			}
+		}
+		else
+		{
+			$parentPath = JPATH_ROOT;
+		}
+
+		return File::exists($parentPath . '/' . $value);
 	}
 }

--- a/libraries/src/Form/Rule/FilePathExistsRule.php
+++ b/libraries/src/Form/Rule/FilePathExistsRule.php
@@ -43,6 +43,14 @@ class FilePathExistsRule extends FilePathRule
 			return false;
 		}
 
+		// If the field is empty and not required, the field is valid.
+		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+
+		if (!$required && empty($value))
+		{
+			return true;
+		}
+
 		// In case of a file list field we might have a directory, otherwise it's Joomla root
 		$parentPath = $element['directory'] ?? JPATH_ROOT;
 

--- a/libraries/src/Form/Rule/FilePathExistsRule.php
+++ b/libraries/src/Form/Rule/FilePathExistsRule.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Form\Rule;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\Rule\FilePathRule;
+use Joomla\Registry\Registry;
+
+/**
+ * Form Rule class for the Joomla Platform.
+ *
+ * @since  4.0.0
+ */
+class FilePathExistsRule extends FilePathRule
+{
+	/**
+	 * Method to test if the file path is valid and points to an existing file in or below the Joomla root or a directory
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
+	 *
+	 * @return  boolean  True if the value is valid and points to an existing file in or below the Joomla root, false otherwise.
+	 *
+	 * @since   4.0.0
+	 */
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	{
+		if (!parent::test($element, $value, $group, $input, $form))
+		{
+			return false;
+		}
+
+		// In case of a file list field we might have a directory, otherwise it's Joomla root
+		$parentPath = $element['directory'] ?? JPATH_ROOT;
+
+		return is_file($parentPath . '/' . $value);
+	}
+}

--- a/libraries/src/Form/Rule/FilePathExistsRule.php
+++ b/libraries/src/Form/Rule/FilePathExistsRule.php
@@ -17,7 +17,7 @@ use Joomla\Registry\Registry;
 /**
  * Form Rule class for the Joomla Platform.
  *
- * @since  4.0.0
+ * @since  __DEPLOY_VERSION__
  */
 class FilePathExistsRule extends FilePathRule
 {
@@ -34,7 +34,7 @@ class FilePathExistsRule extends FilePathRule
 	 *
 	 * @return  boolean  True if the value is valid and points to an existing file in or below the Joomla root, false otherwise.
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{

--- a/libraries/src/Form/Rule/FilePathExistsRule.php
+++ b/libraries/src/Form/Rule/FilePathExistsRule.php
@@ -2,7 +2,7 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/libraries/src/Form/Rule/FolderPathExistsRule.php
+++ b/libraries/src/Form/Rule/FolderPathExistsRule.php
@@ -10,6 +10,8 @@ namespace Joomla\CMS\Form\Rule;
 
 defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Filesystem\Folder;
+use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\Rule\FilePathRule;
 use Joomla\Registry\Registry;
@@ -52,8 +54,20 @@ class FolderPathExistsRule extends FilePathRule
 		}
 
 		// In case of a folder list field we might have a directory, otherwise it's Joomla root
-		$parentPath = $element['directory'] ?? JPATH_ROOT;
+		if (isset($element['directory']) && trim((string) $element['directory']))
+		{
+			$parentPath = Path::clean((string) $element['directory']);
 
-		return is_dir($parentPath . '/' . $value);
+			if (strpos($parentPath, Path::clean(JPATH_ROOT)) !== 0)
+			{
+				$parentPath = JPATH_ROOT . '/' . $parentPath;
+			}
+		}
+		else
+		{
+			$parentPath = JPATH_ROOT;
+		}
+
+		return Folder::exists($parentPath . '/' . $value);
 	}
 }

--- a/libraries/src/Form/Rule/FolderPathExistsRule.php
+++ b/libraries/src/Form/Rule/FolderPathExistsRule.php
@@ -24,7 +24,7 @@ use Joomla\Registry\Registry;
 class FolderPathExistsRule extends FilePathRule
 {
 	/**
-	 * Method to test if the folder path is valid and points to an existing folder (directory) in or below the Joomla root
+	 * Method to test if the folder path is valid and points to an existing folder (directory) below the Joomla root
 	 *
 	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed              $value    The form field value to validate.
@@ -34,7 +34,7 @@ class FolderPathExistsRule extends FilePathRule
 	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
 	 * @param   Form               $form     The form object for which the field is being tested.
 	 *
-	 * @return  boolean  True if the value is valid and points to an existing folder in or below the Joomla root, false otherwise.
+	 * @return  boolean  True if the value is valid and points to an existing folder below the Joomla root, false otherwise.
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
@@ -53,12 +53,14 @@ class FolderPathExistsRule extends FilePathRule
 			return true;
 		}
 
+		$rootCleaned = rtrim(Path::clean(JPATH_ROOT), \DIRECTORY_SEPARATOR);
+
 		// In case of a folder list field we might have a directory, otherwise it's Joomla root
 		if (isset($element['directory']) && trim((string) $element['directory']))
 		{
 			$parentPath = Path::clean((string) $element['directory']);
 
-			if (strpos($parentPath, Path::clean(JPATH_ROOT)) !== 0)
+			if (strpos($parentPath, $rootCleaned) !== 0)
 			{
 				$parentPath = JPATH_ROOT . '/' . $parentPath;
 			}
@@ -68,6 +70,14 @@ class FolderPathExistsRule extends FilePathRule
 			$parentPath = JPATH_ROOT;
 		}
 
-		return Folder::exists($parentPath . '/' . $value);
+		$pathCleaned = rtrim(Path::clean($parentPath . '/' . $value), \DIRECTORY_SEPARATOR);
+
+		// Joomla root is not allowed
+		if ($pathCleaned === $rootCleaned)
+		{
+			return false;
+		}
+
+		return Folder::exists($pathCleaned);
 	}
 }

--- a/libraries/src/Form/Rule/FolderPathExistsRule.php
+++ b/libraries/src/Form/Rule/FolderPathExistsRule.php
@@ -24,7 +24,7 @@ use Joomla\Registry\Registry;
 class FolderPathExistsRule extends FilePathRule
 {
 	/**
-	 * Method to test if the file path is valid and points to an existing folder (directory) in or below the Joomla root
+	 * Method to test if the folder path is valid and points to an existing folder (directory) in or below the Joomla root
 	 *
 	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
 	 * @param   mixed              $value    The form field value to validate.

--- a/libraries/src/Form/Rule/FolderPathExistsRule.php
+++ b/libraries/src/Form/Rule/FolderPathExistsRule.php
@@ -2,7 +2,7 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/libraries/src/Form/Rule/FolderPathExistsRule.php
+++ b/libraries/src/Form/Rule/FolderPathExistsRule.php
@@ -17,7 +17,7 @@ use Joomla\Registry\Registry;
 /**
  * Form Rule class for the Joomla Platform.
  *
- * @since  4.0.0
+ * @since  __DEPLOY_VERSION__
  */
 class FolderPathExistsRule extends FilePathRule
 {
@@ -34,7 +34,7 @@ class FolderPathExistsRule extends FilePathRule
 	 *
 	 * @return  boolean  True if the value is valid and points to an existing folder in or below the Joomla root, false otherwise.
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
 	{

--- a/libraries/src/Form/Rule/FolderPathExistsRule.php
+++ b/libraries/src/Form/Rule/FolderPathExistsRule.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  Copyright (C) 2005 - 2020 Open Source Matters, Inc. All rights reserved.
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Form\Rule;
+
+defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\Rule\FilePathRule;
+use Joomla\Registry\Registry;
+
+/**
+ * Form Rule class for the Joomla Platform.
+ *
+ * @since  4.0.0
+ */
+class FolderPathExistsRule extends FilePathRule
+{
+	/**
+	 * Method to test if the file path is valid and points to an existing folder (directory) in or below the Joomla root
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
+	 *
+	 * @return  boolean  True if the value is valid and points to an existing folder in or below the Joomla root, false otherwise.
+	 *
+	 * @since   4.0.0
+	 */
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	{
+		if (!parent::test($element, $value, $group, $input, $form))
+		{
+			return false;
+		}
+
+		// In case of a folder list field we might have a directory, otherwise it's Joomla root
+		$parentPath = $element['directory'] ?? JPATH_ROOT;
+
+		return is_dir($parentPath . '/' . $value);
+	}
+}

--- a/libraries/src/Form/Rule/FolderPathExistsRule.php
+++ b/libraries/src/Form/Rule/FolderPathExistsRule.php
@@ -43,6 +43,14 @@ class FolderPathExistsRule extends FilePathRule
 			return false;
 		}
 
+		// If the field is empty and not required, the field is valid.
+		$required = ((string) $element['required'] == 'true' || (string) $element['required'] == 'required');
+
+		if (!$required && empty($value))
+		{
+			return true;
+		}
+
 		// In case of a folder list field we might have a directory, otherwise it's Joomla root
 		$parentPath = $element['directory'] ?? JPATH_ROOT;
 

--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathExistsRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathExistsRuleTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.UnitTest
- * @subpackage  HTML
+ * @subpackage  Rule
  *
  * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathExistsRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathExistsRuleTest.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  HTML
+ *
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\FilePathExistsRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for FilePathExistsRule.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ * @since       4.0.0
+ */
+class FilePathExistsRuleTest extends UnitTestCase
+{
+	/**
+	 * Test data for the testRule method
+	 *
+	 * @return  array
+	 *
+	 * @since   4.0.0
+	 */
+	public function dataTest(): array
+	{
+		$xml = new \SimpleXMLElement('<field
+			name="file_path"
+			type="text"
+			label="COM_MEDIA_FIELD_PATH_FILE_FOLDER_LABEL"
+			description="COM_MEDIA_FIELD_PATH_FILE_FOLDER_DESC"
+			size="50"
+			default="images"
+			validate="filePathExists"
+			exclude="administrator|media"
+		/>'
+		);
+
+		return [
+			[true, $xml, ''],
+			[false, $xml, 'images'],
+			[true, $xml, 'images/index.html'],
+			[false, $xml, 'images/banners'],
+			[true, $xml, 'images/banners/banner.jpg'],
+			[false, $xml, 'images/notexisting.html'],
+			[false, $xml, '.images'],
+			[false, $xml, './images'],
+			[false, $xml, '.\images'],
+			[false, $xml, '../images'],
+			[false, $xml, '.../images'],
+			[false, $xml, 'c:\images'],
+			[false, $xml, '\\images'], // Means \images
+			[false, $xml, 'ftp://images'],
+			[false, $xml, 'http://images'],
+			[false, $xml, 'media'],
+			[false, $xml, 'administrator'],
+			[false, $xml, '/4711images'],
+			[false, $xml, '4711images'],
+			[false, $xml, '1'],
+			[false, $xml, '_'],
+			[false, $xml, '*'],
+			[false, $xml, '%'],
+			[false, $xml, '://foo'],
+			[false, $xml, '/4711i/images'],
+			[false, $xml, '../4711i/images'],
+			[false, $xml, 'Εικόνες'],
+			[false, $xml, 'Изображений'],
+		];
+	}
+
+	/**
+	 * Tests the FilePathExistsRule::test method.
+	 *
+	 * @param   string             $expected  The expected test result
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 * @dataProvider dataTest
+	 */
+	public function testRule($expected, $element, $value)
+	{
+		$this->assertEquals($expected, (new FilePathExistsRule)->test($element, $value));
+	}
+}

--- a/tests/Unit/Libraries/Cms/Form/Rule/FilePathExistsRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FilePathExistsRuleTest.php
@@ -17,7 +17,7 @@ use Joomla\Tests\Unit\UnitTestCase;
  *
  * @package     Joomla.UnitTest
  * @subpackage  Form
- * @since       4.0.0
+ * @since       __DEPLOY_VERSION__
  */
 class FilePathExistsRuleTest extends UnitTestCase
 {
@@ -26,7 +26,7 @@ class FilePathExistsRuleTest extends UnitTestCase
 	 *
 	 * @return  array
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function dataTest(): array
 	{
@@ -83,7 +83,7 @@ class FilePathExistsRuleTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 * @dataProvider dataTest
 	 */
 	public function testRule($expected, $element, $value)

--- a/tests/Unit/Libraries/Cms/Form/Rule/FolderPathExistsRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FolderPathExistsRuleTest.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * @package     Joomla.UnitTest
- * @subpackage  HTML
+ * @subpackage  Rule
  *
  * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt

--- a/tests/Unit/Libraries/Cms/Form/Rule/FolderPathExistsRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FolderPathExistsRuleTest.php
@@ -17,7 +17,7 @@ use Joomla\Tests\Unit\UnitTestCase;
  *
  * @package     Joomla.UnitTest
  * @subpackage  Form
- * @since       4.0.0
+ * @since       __DEPLOY_VERSION__
  */
 class FolderPathExistsRuleTest extends UnitTestCase
 {
@@ -26,7 +26,7 @@ class FolderPathExistsRuleTest extends UnitTestCase
 	 *
 	 * @return  array
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function dataTest(): array
 	{
@@ -81,7 +81,7 @@ class FolderPathExistsRuleTest extends UnitTestCase
 	 *
 	 * @return  void
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 * @dataProvider dataTest
 	 */
 	public function testRule($expected, $element, $value)

--- a/tests/Unit/Libraries/Cms/Form/Rule/FolderPathExistsRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FolderPathExistsRuleTest.php
@@ -37,7 +37,7 @@ class FolderPathExistsRuleTest extends UnitTestCase
 			description="COM_MEDIA_FIELD_PATH_FILE_FOLDER_DESC"
 			size="50"
 			default="images"
-			validate="filePathExists"
+			validate="folderPathExists"
 			exclude="administrator|media"
 		/>'
 		);

--- a/tests/Unit/Libraries/Cms/Form/Rule/FolderPathExistsRuleTest.php
+++ b/tests/Unit/Libraries/Cms/Form/Rule/FolderPathExistsRuleTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  HTML
+ *
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Libraries\Cms\Form\Rule;
+
+use Joomla\CMS\Form\Rule\FolderPathExistsRule;
+use Joomla\Tests\Unit\UnitTestCase;
+
+/**
+ * Test class for FolderPathExistsRule.
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Form
+ * @since       4.0.0
+ */
+class FolderPathExistsRuleTest extends UnitTestCase
+{
+	/**
+	 * Test data for the testRule method
+	 *
+	 * @return  array
+	 *
+	 * @since   4.0.0
+	 */
+	public function dataTest(): array
+	{
+		$xml = new \SimpleXMLElement('<field
+			name="file_path"
+			type="text"
+			label="COM_MEDIA_FIELD_PATH_FILE_FOLDER_LABEL"
+			description="COM_MEDIA_FIELD_PATH_FILE_FOLDER_DESC"
+			size="50"
+			default="images"
+			validate="filePathExists"
+			exclude="administrator|media"
+		/>'
+		);
+
+		return [
+			[true, $xml, ''],
+			[true, $xml, 'images'],
+			[true, $xml, 'images/headers'],
+			[false, $xml, 'images/notexisting'],
+			[false, $xml, '.images'],
+			[false, $xml, './images'],
+			[false, $xml, '.\images'],
+			[false, $xml, '../images'],
+			[false, $xml, '.../images'],
+			[false, $xml, 'c:\images'],
+			[false, $xml, '\\images'], // Means \images
+			[false, $xml, 'ftp://images'],
+			[false, $xml, 'http://images'],
+			[false, $xml, 'media'],
+			[false, $xml, 'administrator'],
+			[false, $xml, '/4711images'],
+			[false, $xml, '4711images'],
+			[false, $xml, '1'],
+			[false, $xml, '_'],
+			[false, $xml, '*'],
+			[false, $xml, '%'],
+			[false, $xml, '://foo'],
+			[false, $xml, '/4711i/images'],
+			[false, $xml, '../4711i/images'],
+			[false, $xml, 'Εικόνες'],
+			[false, $xml, 'Изображений'],
+		];
+	}
+
+	/**
+	 * Tests the FolderPathExistsRule::test method.
+	 *
+	 * @param   string             $expected  The expected test result
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 *
+	 * @return  void
+	 *
+	 * @since   4.0.0
+	 * @dataProvider dataTest
+	 */
+	public function testRule($expected, $element, $value)
+	{
+		$this->assertEquals($expected, (new FolderPathExistsRule)->test($element, $value));
+	}
+}


### PR DESCRIPTION
Pull Request for Issue #34262 and possibly others.

### Summary of Changes

Currently, when you enter a valid path to a not existing file or folder, e.g. the path to files and images in the com_media options or the attachment selection in com_mails, you can save the form without any notice that the file or folder doesn't exist.

See issue #34262 for the filelist field or the discussion in PR #34233 for the attachment folder field in com_mails options, the discussions or issues related to com_media folders I have to search for, but I'm sure there are some.

This pull request (PR) fixes that by adding two new validation rules, which can be used with text fields or filelist fields or folderlist fields.
- "FilePathExistsRule" for paths to files
- "FolderPathExistsRule" for paths to folders

Both rules extend from rule "FilePathRule" and first call the check method of this parent.

After that, the file or folder is checked for existence if the field is required.

This PR adds use of these rules at following places, other places can be done in later PR's:

- "Path to Files Folder" and "Path to Images Folder" text fields in Media Manager (com_media) options
- "Attachments Folder" text field in Mail Templates (com_mails) options
- "File" filelist field for an attachment in a Mail Template

### Testing Instructions

The test starts on an installation of current 4.0-dev branch or latest 4.0 nightly build without the patch of this PR applied.

All actions are performed in backend.

1. Go to media manager options.

2. In one or both of the fields "Path to Files Folder" and "Path to Images Folder", enter a path which is valid e.g. regarding forbidden characters but which doesn't exist below the Joomla root, e.g. "gaga" or "images/gaga".

3. Save and close.
Result: Changes are saved, green success message shown.

4. Go to "System -> Templates -> Mail Templates" and edit the options.

5. In field "Attachments Folder", enter a path which is valid e.g. regarding forbidden characters but which doesn't exist below the Joomla root, e.g. "gaga" or "images/gaga".

6. Save the change.
Result: Changes are saved, green success message shown.

7. Change field "Attachments Folder" back to a path which is valid and exists and which contains files which can be attached to email, e.g. "images", and save and close.

8. Go to "System -> Templates -> Mail Templates" and edit one of the mail templates, e.g. "Global Configuration: Test Mail".

9. At the bottom in section "Attachments", add an attachment but don't select a file, or select a file and modify the value to an invalid one in the DOM using your browser's developer tools like it is described in issue #34262 .

10. Save the change.
Result: Changes are saved, green success message shown.

11. Apply the patch of this PR.

12. Go to media manager options which have still the path to not existing folder(s) from step 2.

13. Without making any changes, use the "Save" button.
Result: The form is not saved, you get an alert about invalid field.

14. Change the path(s) so they are valid and point to existing folder(s), and save and close.

15. Edit again the mail template you have edited in step 8 but don't make changes.

16. Use the "Save" button.
Result: The form is not saved, you get an alert about invalid field.

17. Select a file for the attachment, and use again the "Save" button.
Result: The form is saved.

### Actual result BEFORE applying this Pull Request

- "File" filelist field for an attachment in a Mail Template: See issue #34262 .
- "Path to Files Folder" and "Path to Images Folder" text fields in Media Manager (com_media) options and "Attachments Folder" text field in Mail Templates (com_mails) options: See section "What this PR does not fix" in PR #34233 .

### Expected result AFTER applying this Pull Request

Will be added soon.

### Other information

The "FilePathExistsRule" doesn't work with fields of type "filelist" if the "stripext" element of that field is set to "true".

### Documentation Changes Required

Documentation of form field validation rules in J4 needs to be extended by the two new rules, including what's mentioned in the previous section "Other information".