### PR TITLE
[4.0] Make tags api components use the preprocessData function

### DIFF
--- a/api/components/com_contact/src/Controller/ContactController.php
+++ b/api/components/com_contact/src/Controller/ContactController.php
@@ -55,18 +55,16 @@ class ContactController extends ApiController
 	protected $default_view = 'contacts';
 
 	/**
-	 * Method to save a record.
+	 * Method to allow extended classes to manipulate the data to be saved for an extension.
 	 *
-	 * @param   integer  $recordKey  The primary key of the item (if exists)
+	 * @param   array  $data  An array of input data.
 	 *
-	 * @return  integer  The record ID on success, false on failure
+	 * @return  array
 	 *
 	 * @since   4.0.0
 	 */
-	protected function save($recordKey = null)
+	protected function preprocessSaveData(array $data): array
 	{
-		$data = (array) json_decode($this->input->json->getRaw(), true);
-
 		foreach (FieldsHelper::getFields('com_contact.contact') as $field)
 		{
 			if (isset($data[$field->name]))
@@ -78,9 +76,7 @@ class ContactController extends ApiController
 			}
 		}
 
-		$this->input->set('data', $data);
-
-		return parent::save($recordKey);
+		return $data;
 	}
 
 	/**

--- a/api/components/com_content/src/Controller/ArticlesController.php
+++ b/api/components/com_content/src/Controller/ArticlesController.php
@@ -79,18 +79,16 @@ class ArticlesController extends ApiController
 	}
 
 	/**
-	 * Method to save a record.
+	 * Method to allow extended classes to manipulate the data to be saved for an extension.
 	 *
-	 * @param   integer  $recordKey  The primary key of the item (if exists)
+	 * @param   array  $data  An array of input data.
 	 *
-	 * @return  integer  The record ID on success, false on failure
+	 * @return  array
 	 *
 	 * @since   4.0.0
 	 */
-	protected function save($recordKey = null)
+	protected function preprocessSaveData(array $data): array
 	{
-		$data = (array) json_decode($this->input->json->getRaw(), true);
-
 		foreach (FieldsHelper::getFields('com_content.article') as $field)
 		{
 			if (isset($data[$field->name]))
@@ -102,8 +100,6 @@ class ArticlesController extends ApiController
 			}
 		}
 
-		$this->input->set('data', $data);
-
-		return parent::save($recordKey);
+		return $data;
 	}
 }

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -42,18 +42,16 @@ class UsersController extends ApiController
 	protected $default_view = 'users';
 
 	/**
-	 * Method to save a record.
+	 * Method to allow extended classes to manipulate the data to be saved for an extension.
 	 *
-	 * @param   integer  $recordKey  The primary key of the item (if exists)
+	 * @param   array  $data  An array of input data.
 	 *
-	 * @return  integer  The record ID on success, false on failure
+	 * @return  array
 	 *
 	 * @since   4.0.0
 	 */
-	protected function save($recordKey = null)
+	protected function preprocessSaveData(array $data): array
 	{
-		$data = (array) json_decode($this->input->json->getRaw(), true);
-
 		foreach (FieldsHelper::getFields('com_users.user') as $field)
 		{
 			if (isset($data[$field->name]))
@@ -65,9 +63,7 @@ class UsersController extends ApiController
 			}
 		}
 
-		$this->input->set('data', $data);
-
-		return parent::save($recordKey);
+		return $data;
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
As noted in https://github.com/joomla/joomla-cms/pull/34274 several components override the save method to reformat tags data when `preprocessSaveData` would do just fine (this is just because when we did the GSOC project originally `preprocessSaveData` didn't exist :) )

### Testing Instructions
Ensure tags can still be attached to an article with no changes in functionality

### Documentation Changes Required
None
