### PR TITLE
[4.0] Missing plugins from the ApiModel.php

### DIFF
--- a/administrator/components/com_media/src/Model/ApiModel.php
+++ b/administrator/components/com_media/src/Model/ApiModel.php
@@ -394,6 +394,9 @@ class ApiModel extends BaseDatabaseModel
 		$object->path      = $path;
 
 		PluginHelper::importPlugin('content');
+		
+		// Also include the filesystem plugins, perhaps they support batch processing too
+ 		PluginHelper::importPlugin('media-action');
 
 		$result = $app->triggerEvent('onContentBeforeDelete', ['com_media.' . $type, $object]);
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fixes the file deletion that doesn't fire all the related plugins.

### Testing Instructions
This PR really can go with a review:
- check the `createFile` https://github.com/joomla/joomla-cms/blob/0268268d88ef27b9a20ee10686f965c902f4f922/administrator/components/com_media/src/Model/ApiModel.php#L302-L303
- check the `updateFile` https://github.com/joomla/joomla-cms/blob/0268268d88ef27b9a20ee10686f965c902f4f922/administrator/components/com_media/src/Model/ApiModel.php#L352-L353

The lines above are replicated also for the `deleteFile`

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

No, the Events should fire the same plugins

@wilsonge committing by review is a no-go let me know and I'll create a small plugin here