### PR TITLE
[4.0] Use validate="options" for filelist and folderlist fields

### DIFF
--- a/administrator/components/com_languages/forms/language.xml
+++ b/administrator/components/com_languages/forms/language.xml
@@ -57,6 +57,7 @@
 			hide_none="1"
 			hide_default="1"
 			fileFilter="\.gif$"
+			validate="options"
 			>
 			<option value="">JNONE</option>
 		</field>

--- a/administrator/components/com_mails/forms/template.xml
+++ b/administrator/components/com_mails/forms/template.xml
@@ -47,6 +47,7 @@
 				type="filelist"
 				hide_default="true"
 				label="COM_MAILS_FIELD_FILE_LABEL"
+				validate="options"
 			/>
 			<field
 				name="name"

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -207,6 +207,7 @@
 					hide_none="true"
 					hide_default="false"
 					directory="media/vendor/codemirror/theme"
+					validate="options"
 				/>
 
 				<field

--- a/plugins/editors/tinymce/forms/setoptions.xml
+++ b/plugins/editors/tinymce/forms/setoptions.xml
@@ -26,6 +26,7 @@
 			directory="media/vendor/tinymce/skins/ui"
 			recursive="false"
 			hide_none="true"
+			validate="options"
 		/>
 
 		<field
@@ -35,6 +36,7 @@
 			directory="media/vendor/tinymce/skins/ui"
 			recursive="false"
 			hide_none="true"
+			validate="options"
 		/>
 
 		<field
@@ -79,6 +81,7 @@
 			exclude="system"
 			default=""
 			folderFilter="^tinymce"
+			validate="options"
 		/>
 
 		<field
@@ -115,6 +118,7 @@
 			hide_default="1"
 			fileFilter="\.js$"
 			showon="lang_mode:0"
+			validate="options"
 		/>
 
 		<field

--- a/plugins/fields/imagelist/imagelist.xml
+++ b/plugins/fields/imagelist/imagelist.xml
@@ -31,6 +31,7 @@
 					hide_default="true"
 					recursive="true"
 					default="/"
+					validate="options"
 					>
 					<option value="/">/</option>
 				</field>

--- a/plugins/fields/imagelist/params/imagelist.xml
+++ b/plugins/fields/imagelist/params/imagelist.xml
@@ -11,6 +11,7 @@
 				hide_none="true"
 				hide_default="true"
 				recursive="true"
+				validate="options"
 				>
 				<option value="">COM_FIELDS_FIELD_USE_GLOBAL</option>
 				<option value="/">/</option>

--- a/plugins/fields/media/params/media.xml
+++ b/plugins/fields/media/params/media.xml
@@ -9,6 +9,7 @@
 				directory="images"
 				hide_none="true"
 				recursive="true"
+				validate="options"
 			/>
 
 			<field

--- a/plugins/filesystem/local/local.xml
+++ b/plugins/filesystem/local/local.xml
@@ -42,6 +42,7 @@
 							exclude=""
 							stripext=""
 							hide_none="true"
+							validate="options"
 						/>
 					</form>
 				</field>


### PR DESCRIPTION
Pull Request for Issue #34262 .

### Summary of Changes

This pull request (PR) adds `validate="options"` to all fields of type "filelist" or "folderlist" in forms XML files to ensure server-side validation of the submitted values.

### Testing Instructions

See issue #34262 : Edit one of the forms modified by this PR, select a value for a field modified by this PR, then inspect that field with the developer tools of your browser, modify the value to something not existing or bad in the DOM, like described in the issue, and save.

Without the PR you can save, with the PR you can't and get an invalid field validation message.

With the PR applied, verify in addition that selecting values and submitting the form without hacking the value in the DOM still works the same as without the PR.

Following fields in following forms are modified with this PR:

- System -> Manage -> Content languages, edit a language, field "Image"
- System -> Templates -> Mail Templates, edit a template -> Add attachment at the bottom, field "File" for that attachment
- System -> Plugins, edit the "Editor - CodeMirror" plugin, field "Theme" in tab "Appearance Options"
- System -> Plugins, edit the "Editor - TinyMCE" plugin, fields "Site Skin", "Administrator Skin", "Content Template Directory" and "Language Code" (only shown if "Automatic Language Selection" is "Off").
- System -> Plugins, edit the "Fields - Imagelist" plugin, field "Directory".
- System -> Plugins, edit the "Fields - Media" plugin, field "Directory".
- System -> Plugins, edit the "FileSystem - Local" plugin, dropdown field for each folder.

### Actual result BEFORE applying this Pull Request

Values of fields of type "filelist" or "imagelist" are not validated against the available options on server side when submitting the form.

### Expected result AFTER applying this Pull Request

Values of fields of type "filelist" or "imagelist" are validated against the available options on server side when submitting the form.

Selecting and submitting valid values works as well as without this PR.

### Documentation Changes Required

None.