### PR TITLE
Apply PHPCS to the build tools and remove unused md5/sha1 hashes

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -28,7 +28,7 @@ function usage($command)
 {
 	echo PHP_EOL;
 	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
-	echo PHP_TAB . '[options]:'.PHP_EOL;
+	echo PHP_TAB . '[options]:' . PHP_EOL;
 	echo PHP_TAB . PHP_TAB . '--remote <remote>:' . PHP_TAB . 'The git remote reference to build from (ex: `tags/3.8.6`, `4.0-dev`), defaults to the most recent tag for the repository' . PHP_EOL;
 	echo PHP_TAB . PHP_TAB . '--exclude-zip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .zip packages' . PHP_EOL;
 	echo PHP_TAB . PHP_TAB . '--exclude-gzip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .tar.gz packages' . PHP_EOL;
@@ -466,7 +466,7 @@ foreach ($checksums as $packageName => $packageHashes)
 	$githubContent[$type][] = '[' . substr($packageName, strpos($packageName, 'Package') + 7) . '](' . $githubLink . $packageName . ')';
 }
 
-foreach($releaseText as $type => $text)
+foreach ($releaseText as $type => $text)
 {
 	if (empty($githubContent[$type]))
 	{

--- a/build/build.php
+++ b/build/build.php
@@ -228,18 +228,21 @@ for ($num = $release - 1; $num >= 0; $num--)
 	// Loop through and add all files except: tests, installation, build, .git, .travis, travis, phpunit, .md, or images
 	foreach ($files as $file)
 	{
-		if (substr($file, 0, 1) === 'R') {
-			$fileName   = substr($file, strrpos($file, "\t") + 1);
-		} else {
-			$fileName   = substr($file, 2);
+		if (substr($file, 0, 1) === 'R')
+		{
+			$fileName = substr($file, strrpos($file, "\t") + 1);
 		}
-		$folderPath = explode('/', $fileName);
-		$baseFolderName = $folderPath[0];
+		else
+		{
+			$fileName = substr($file, 2);
+		}
 
-		$doNotPackageFile = in_array(trim($fileName), $doNotPackage);
-		$doNotPatchFile = in_array(trim($fileName), $doNotPatch);
+		$folderPath             = explode('/', $fileName);
+		$baseFolderName         = $folderPath[0];
+		$doNotPackageFile       = in_array(trim($fileName), $doNotPackage);
+		$doNotPatchFile         = in_array(trim($fileName), $doNotPatch);
 		$doNotPackageBaseFolder = in_array($baseFolderName, $doNotPackage);
-		$doNotPatchBaseFolder = in_array($baseFolderName, $doNotPatch);
+		$doNotPatchBaseFolder   = in_array($baseFolderName, $doNotPatch);
 
 		if ($doNotPackageFile || $doNotPatchFile || $doNotPackageBaseFolder || $doNotPatchBaseFolder)
 		{
@@ -393,7 +396,7 @@ foreach (array_keys($checksums) as $packageName)
 {
 	echo "Generating checksums for $packageName\n";
 
-	foreach (array('md5', 'sha1', 'sha256', 'sha384', 'sha512') as $hash)
+	foreach (array('sha256', 'sha384', 'sha512') as $hash)
 	{
 		if (file_exists('packages/' . $packageName))
 		{
@@ -439,16 +442,24 @@ $githubLink = 'https://github.com/joomla/joomla-cms/releases/download/' . $tagVe
 foreach ($checksums as $packageName => $packageHashes)
 {
 	$type = '';
+
 	if (strpos($packageName, 'Full_Package') !== false)
 	{
 		$type = 'FULL';
-	} elseif (strpos($packageName, 'Patch_Package') !== false) {
-		if (strpos($packageName, '.x_to') !== false) {
+	}
+	elseif (strpos($packageName, 'Patch_Package') !== false)
+	{
+		if (strpos($packageName, '.x_to') !== false)
+		{
 			$type = 'MINOR';
-		} else {
+		}
+		else
+		{
 			$type = 'POINT';
 		}
-	} elseif (strpos($packageName, 'Update_Package') !== false) {
+	}
+	elseif (strpos($packageName, 'Update_Package') !== false)
+	{
 		$type = 'UPGRADE';
 	}
 
@@ -457,7 +468,8 @@ foreach ($checksums as $packageName => $packageHashes)
 
 foreach($releaseText as $type => $text)
 {
-	if (empty($githubContent[$type])) {
+	if (empty($githubContent[$type]))
+	{
 		continue;
 	}
 

--- a/build/bump.php
+++ b/build/bump.php
@@ -180,16 +180,16 @@ if (!empty($opts['c']))
 
 // Prints version information.
 echo PHP_EOL;
-echo 'Version data:'. PHP_EOL;
+echo 'Version data:' . PHP_EOL;
 echo '- Main:' . PHP_TAB . PHP_TAB . PHP_TAB . $version['main'] . PHP_EOL;
 echo '- Release:' . PHP_TAB . PHP_TAB . $version['release'] . PHP_EOL;
-echo '- Full:'  . PHP_TAB . PHP_TAB . PHP_TAB . $version['main'] . '.' . $version['dev_devel'] . PHP_EOL;
+echo '- Full:' . PHP_TAB . PHP_TAB . PHP_TAB . $version['main'] . '.' . $version['dev_devel'] . PHP_EOL;
 echo '- Build:' . PHP_TAB . PHP_TAB . $version['build'] . PHP_EOL;
 echo '- Dev Level:' . PHP_TAB . PHP_TAB . $version['dev_devel'] . PHP_EOL;
 echo '- Dev Status:' . PHP_TAB . PHP_TAB . $version['dev_status'] . PHP_EOL;
 echo '- Release date:' . PHP_TAB . PHP_TAB . $version['reldate'] . PHP_EOL;
 echo '- Release time:' . PHP_TAB . PHP_TAB . $version['reltime'] . PHP_EOL;
-echo '- Release timezone:'  . PHP_TAB . $version['reltz'] . PHP_EOL;
+echo '- Release timezone:' . PHP_TAB . $version['reltz'] . PHP_EOL;
 echo '- Creation date:' . PHP_TAB . $version['credate'] . PHP_EOL;
 
 if (!empty($version['codename']))
@@ -282,8 +282,8 @@ foreach ($readMeFiles as $readMeFile)
 $changedFilesCopyrightDate = 0;
 $changedFilesSinceVersion  = 0;
 $year                      = date('Y');
-$directory                 = new \RecursiveDirectoryIterator($rootPath);
-$iterator                  = new \RecursiveIteratorIterator($directory, RecursiveIteratorIterator::SELF_FIRST);
+$directory                 = new RecursiveDirectoryIterator($rootPath);
+$iterator                  = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::SELF_FIRST);
 
 foreach ($iterator as $file)
 {

--- a/build/bump.php
+++ b/build/bump.php
@@ -36,49 +36,49 @@ function usage($command)
 const PHP_TAB = "\t";
 
 // File paths.
-$versionFile      = '/libraries/src/Version.php';
+$versionFile = '/libraries/src/Version.php';
 
-$coreXmlFiles     = array(
-			'/administrator/manifests/files/joomla.xml',
-			);
+$coreXmlFiles = array(
+	'/administrator/manifests/files/joomla.xml',
+);
 
 $languageXmlFiles = array(
-			'/language/en-GB/en-GB.xml',
-			'/language/en-GB/install.xml',
-			'/administrator/language/en-GB/en-GB.xml',
-			'/administrator/language/en-GB/install.xml',
-			'/installation/language/en-GB/en-GB.xml',
-			);
+	'/language/en-GB/en-GB.xml',
+	'/language/en-GB/install.xml',
+	'/administrator/language/en-GB/en-GB.xml',
+	'/administrator/language/en-GB/install.xml',
+	'/installation/language/en-GB/en-GB.xml',
+);
 
 $languagePackXmlFile = '/administrator/manifests/packages/pkg_en-GB.xml';
 
 $antJobFile = '/build.xml';
 
 $readMeFiles = array(
-			'/README.md',
-			'/README.txt',
-			);
+	'/README.md',
+	'/README.txt',
+);
 
 /*
  * Change copyright date exclusions.
  * Some systems may try to scan the .git directory, exclude it.
- * Also exclude build resources such as the packaging space or the API documentation build.
+ * Also exclude build resources such as the packaging space or the API documentation build
+ * as well as external libraries.
  */
 $directoryLoopExcludeDirectories = array(
-			'/.git',
-			'/build/api/',
-			'/build/coverage/',
-			'/build/tmp/',
-			'/libraries/vendor/',
-			'/libraries/phputf8/',
-			'/libraries/php-encryption/',
-			'/libraries/phpass/',
-			'/libraries/idna_convert/',
-			'/libraries/fof/',
-			);
+	'/.git',
+	'/build/api/',
+	'/build/coverage/',
+	'/build/tmp/',
+	'/libraries/vendor/',
+	'/libraries/phputf8/',
+	'/libraries/php-encryption/',
+	'/libraries/phpass/',
+	'/libraries/idna_convert/',
+	'/libraries/fof/',
+);
 
-$directoryLoopExcludeFiles = array(
-			);
+$directoryLoopExcludeFiles = array();
 
 // Check arguments (exit if incorrect cli arguments).
 $opts = getopt("v:c:");
@@ -157,20 +157,20 @@ else
 $versionSubParts = explode('.', $versionParts[0]);
 
 $version = array(
-		'main'       => $versionSubParts[0] . '.' . $versionSubParts[1],
-		'major'      => $versionSubParts[0],
-		'minor'      => $versionSubParts[1],
-		'patch'      => $versionSubParts[2],
-		'extra'      => (!empty($versionParts[1]) ? $versionParts[1] : '') . (!empty($versionParts[2]) ? (!empty($versionParts[1]) ? '-' : '') . $versionParts[2] : ''),
-		'release'    => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
-		'dev_devel'  => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : '') . (!empty($versionParts[2]) ? '-' . $versionParts[2] : ''),
-		'dev_status' => $dev_status,
-		'build'      => '',
-		'reldate'    => date('j-F-Y'),
-		'reltime'    => date('H:i'),
-		'reltz'      => 'GMT',
-		'credate'    => date('F Y'),
-		);
+	'main'       => $versionSubParts[0] . '.' . $versionSubParts[1],
+	'major'      => $versionSubParts[0],
+	'minor'      => $versionSubParts[1],
+	'patch'      => $versionSubParts[2],
+	'extra'      => (!empty($versionParts[1]) ? $versionParts[1] : '') . (!empty($versionParts[2]) ? (!empty($versionParts[1]) ? '-' : '') . $versionParts[2] : ''),
+	'release'    => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
+	'dev_devel'  => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : '') . (!empty($versionParts[2]) ? '-' . $versionParts[2] : ''),
+	'dev_status' => $dev_status,
+	'build'      => '',
+	'reldate'    => date('j-F-Y'),
+	'reltime'    => date('H:i'),
+	'reltz'      => 'GMT',
+	'credate'    => date('F Y'),
+);
 
 // Version Codename.
 if (!empty($opts['c']))
@@ -191,10 +191,12 @@ echo '- Release date:' . PHP_TAB . PHP_TAB . $version['reldate'] . PHP_EOL;
 echo '- Release time:' . PHP_TAB . PHP_TAB . $version['reltime'] . PHP_EOL;
 echo '- Release timezone:'  . PHP_TAB . $version['reltz'] . PHP_EOL;
 echo '- Creation date:' . PHP_TAB . $version['credate'] . PHP_EOL;
+
 if (!empty($version['codename']))
 {
 	echo '- Codename:' . PHP_TAB . PHP_TAB . $version['codename'] . PHP_EOL;
 }
+
 echo PHP_EOL;
 
 $rootPath = dirname(__DIR__);
@@ -214,10 +216,12 @@ if (file_exists($rootPath . $versionFile))
 	$fileContents = preg_replace("#RELDATE\s*=\s*'[^\']*'#", "RELDATE = '" . $version['reldate'] . "'", $fileContents);
 	$fileContents = preg_replace("#RELTIME\s*=\s*'[^\']*'#", "RELTIME = '" . $version['reltime'] . "'", $fileContents);
 	$fileContents = preg_replace("#RELTZ\s*=\s*'[^\']*'#", "RELTZ = '" . $version['reltz'] . "'", $fileContents);
+
 	if (!empty($version['codename']))
 	{
 		$fileContents = preg_replace("#CODENAME\s*=\s*'[^\']*'#", "CODENAME = '" . $version['codename'] . "'", $fileContents);
 	}
+
 	file_put_contents($rootPath . $versionFile, $fileContents);
 }
 
@@ -343,10 +347,12 @@ if ($changedFilesCopyrightDate > 0 || $changedFilesSinceVersion > 0)
 	{
 		echo '- Copyright Date changed in ' . $changedFilesCopyrightDate . ' files.' . PHP_EOL;
 	}
+
 	if ($changedFilesSinceVersion > 0)
 	{
 		echo '- Since Version changed in ' . $changedFilesSinceVersion . ' files.' . PHP_EOL;
 	}
+
 	echo PHP_EOL;
 }
 

--- a/build/stubGenerator.php
+++ b/build/stubGenerator.php
@@ -84,7 +84,6 @@ class StubGenerator extends CliApplication
  */
 
 PHP;
-
 			}
 
 			$file .= "$modifier$type $oldName extends $newName {}\n\n";

--- a/build/stubGenerator.php
+++ b/build/stubGenerator.php
@@ -39,13 +39,13 @@ ini_set('display_errors', 1);
  *
  * As Joomla transitions its core classes from residing in the global PHP namespace to using namespaced PHP classes, it will be a common
  * occurrence for developers to work in an environment where their code is still using the old class names which may not exist in newer
- * Joomla releases except for in PHP's autoloader as a class alias.  This script therefore allows developers to generate a mapping
+ * Joomla releases except for in PHP's autoloader as a class alias. This script therefore allows developers to generate a mapping
  * file they can use in their local environment which will create "real" classes for the aliased class names and allow things like
  * IDE auto completion to work normally.
  *
  * When this script is run, a `stubs.php` file will be generated at the root of your Joomla installation holding all of the mapping
- * information.  Note that this file will raise some IDE errors as it will generate stub classes extending a final class (something
- * not allowed in PHP).  Therefore it is suggested that inspections on this file are disabled.
+ * information. Note that this file will raise some IDE errors as it will generate stub classes extending a final class (something
+ * not allowed in PHP). Therefore it is suggested that inspections on this file are disabled.
  *
  * @since  3.0
  */


### PR DESCRIPTION
### Summary of Changes

Apply PHPCS to the build tools and remove unused md5/sha1 hashes

### Testing Instructions

- make sure the builds (below this page) still works.
- code review

### Actual result BEFORE applying this Pull Request

Some phpcs issues as well as the generation of the not used md5 & sha1 hashes

### Expected result AFTER applying this Pull Request

Lesser phpcs issues as well as no md5 nor sha1 hashes anymore

### Documentation Changes Required

none