### PR TITLE
[4] Dont allow replying to yourself in messages

### DIFF
--- a/administrator/components/com_messages/src/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Message/HtmlView.php
@@ -99,8 +99,7 @@ class HtmlView extends BaseHtmlView
 			ToolbarHelper::title(Text::_('COM_MESSAGES_VIEW_PRIVATE_MESSAGE'), 'envelope inbox');
 			$sender = User::getInstance($this->item->user_id_from);
 
-			if ($sender->id !== $app->getIdentity()->get('id')
-				&& ($sender->authorise('core.admin')
+			if ($sender->id !== $app->getIdentity()->get('id') && ($sender->authorise('core.admin')
 				|| $sender->authorise('core.manage', 'com_messages') && $sender->authorise('core.login.admin'))
 			)
 			{

--- a/administrator/components/com_messages/src/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Message/HtmlView.php
@@ -84,9 +84,11 @@ class HtmlView extends BaseHtmlView
 	 */
 	protected function addToolbar()
 	{
+		$app = Factory::getApplication();
+
 		if ($this->getLayout() == 'edit')
 		{
-			Factory::getApplication()->input->set('hidemainmenu', true);
+			$app->input->set('hidemainmenu', true);
 			ToolbarHelper::title(Text::_('COM_MESSAGES_WRITE_PRIVATE_MESSAGE'), 'envelope-open-text new-privatemessage');
 			ToolbarHelper::custom('message.save', 'envelope', '', 'COM_MESSAGES_TOOLBAR_SEND', false);
 			ToolbarHelper::cancel('message.cancel');
@@ -97,7 +99,10 @@ class HtmlView extends BaseHtmlView
 			ToolbarHelper::title(Text::_('COM_MESSAGES_VIEW_PRIVATE_MESSAGE'), 'envelope inbox');
 			$sender = User::getInstance($this->item->user_id_from);
 
-			if ($sender->authorise('core.admin') || $sender->authorise('core.manage', 'com_messages') && $sender->authorise('core.login.admin'))
+			if ($sender->id !== $app->getIdentity()->get('id')
+				&& ($sender->authorise('core.admin')
+				|| $sender->authorise('core.manage', 'com_messages') && $sender->authorise('core.login.admin'))
+			)
 			{
 				ToolbarHelper::custom('message.reply', 'redo', '', 'COM_MESSAGES_TOOLBAR_REPLY', false);
 			}


### PR DESCRIPTION
### Summary of Changes

Been this way for a while, but came across this again today 

Its not possible to write to yourself a new message in messages, therefore it should also be impossible to reply to yourself. 

### Testing Instructions

As a super admin generate some fake privacy requests - this will send you some private messages 

View the private message - see that it comes from you... 

### Actual result BEFORE applying this Pull Request

There is a reply button

<img width="610" alt="Screenshot 2021-05-30 at 18 30 42" src="https://user-images.githubusercontent.com/400092/120114023-29b51600-c175-11eb-9e5a-d4d7395c1ca8.png">


### Expected result AFTER applying this Pull Request

There is no reply button

<img width="661" alt="Screenshot 2021-05-30 at 18 31 06" src="https://user-images.githubusercontent.com/400092/120114038-36d20500-c175-11eb-89be-199ccaf37851.png">


### Documentation Changes Required

