### PR TITLE
[4] use  and not  when using nl2br

### DIFF
--- a/administrator/components/com_mails/src/View/Template/HtmlView.php
+++ b/administrator/components/com_mails/src/View/Template/HtmlView.php
@@ -99,7 +99,7 @@ class HtmlView extends BaseHtmlView
 		}
 		else
 		{
-			$this->master->htmlbody = nl2br($this->master->body);
+			$this->master->htmlbody = nl2br($this->master->body, false);
 		}
 
 		$this->templateData = [

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -176,7 +176,7 @@ $tfa        = PluginHelper::isEnabled('twofactorauth');
 											<ul><li><?php echo str_replace("\n", '</li><li>', $item->group_names); ?></li></ul>
 										</div>
 									<?php else : ?>
-										<?php echo nl2br($item->group_names); ?>
+										<?php echo nl2br($item->group_names, false); ?>
 									<?php endif; ?>
 								</td>
 								<td class="d-none d-xl-table-cell break-word">

--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -94,7 +94,7 @@ $onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.g
 							</span>
 						</td>
 						<td>
-							<?php echo nl2br($item->group_names); ?>
+							<?php echo nl2br($item->group_names, false); ?>
 						</td>
 						<td>
 							<?php echo (int) $item->id; ?>

--- a/components/com_contact/tmpl/contact/default_address.php
+++ b/components/com_contact/tmpl/contact/default_address.php
@@ -33,7 +33,7 @@ use Joomla\CMS\String\PunycodeHelper;
 		<?php if ($this->item->address && $this->params->get('show_street_address')) : ?>
 			<dd>
 				<span class="contact-street" itemprop="streetAddress">
-					<?php echo nl2br($this->item->address); ?>
+					<?php echo nl2br($this->item->address, false); ?>
 				</span>
 			</dd>
 		<?php endif; ?>

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -251,7 +251,7 @@ class MailTemplate
 			// If HTML body is empty try to convert the Plain template to html
 			if (!$htmlBody)
 			{
-				$htmlBody = nl2br($plainBody);
+				$htmlBody = nl2br($plainBody, false);
 			}
 
 			$this->mailer->setBody($htmlBody);


### PR DESCRIPTION
### Summary of Changes

Joomla 4 should use `<br>` throughout apparently. 

In several places, including the new Mail Templates, we use `nl2br` which has a second parameter called `use_xhtml` which by default is set to true - docs: https://www.php.net/manual/en/function.nl2br.php

This pr sets all instances to not use xhtml and thus generate `<br>` and not `<br />` tags

### Testing Instructions

Code review is easiest

For Mail Templates, edit options and set Mail Format = HTML, but dont edit any of the templates to provide a HTML version, letting Joomla convert the language string (which is plain text) into "magic" HTML - send an email and inspect its source

### Actual result BEFORE applying this Pull Request

Example

<img width="837" alt="Screenshot 2021-05-30 at 18 43 34" src="https://user-images.githubusercontent.com/400092/120114400-f4112c80-c176-11eb-91bb-9db8fe4992e8.png">


### Expected result AFTER applying this Pull Request

Any use of `nl2br` in Joomla 4 renders  `<br>` and not `<br />` tags


<img width="877" alt="Screenshot 2021-05-30 at 18 44 31" src="https://user-images.githubusercontent.com/400092/120114433-199e3600-c177-11eb-96bc-60b27b49997a.png">


### Documentation Changes Required

