### PR TITLE
[4] update deprecated replacement message in CLI to point to joomla/console

### DIFF
--- a/libraries/src/Input/Cli.php
+++ b/libraries/src/Input/Cli.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Filter\InputFilter;
  * Joomla! Input CLI Class
  *
  * @since       1.7.0
- * @deprecated  5.0  Use Joomla\Input\Cli instead
+ * @deprecated  5.0  Use the `joomla/console` package instead
  */
 class Cli extends Input
 {
@@ -25,7 +25,7 @@ class Cli extends Input
 	 *
 	 * @var    string
 	 * @since  1.7.0
-	 * @deprecated  5.0  Use Joomla\Input\Cli instead
+	 * @deprecated  5.0  Use the `joomla/console` package instead
 	 */
 	public $executable;
 
@@ -35,7 +35,7 @@ class Cli extends Input
 	 *
 	 * @var    array
 	 * @since  1.7.0
-	 * @deprecated  5.0  Use Joomla\Input\Cli instead
+	 * @deprecated  5.0  Use the `joomla/console` package instead
 	 */
 	public $args = array();
 
@@ -46,7 +46,7 @@ class Cli extends Input
 	 * @param   array  $options  Array of configuration parameters (Optional)
 	 *
 	 * @since   1.7.0
-	 * @deprecated  5.0  Use Joomla\Input\Cli instead
+	 * @deprecated  5.0  Use the `joomla/console` package instead
 	 */
 	public function __construct(array $source = null, array $options = array())
 	{
@@ -72,7 +72,7 @@ class Cli extends Input
 	 * @return  string  The serialized input.
 	 *
 	 * @since   3.0.0
-	 * @deprecated  5.0  Use Joomla\Input\Cli instead
+	 * @deprecated  5.0  Use the `joomla/console` package instead
 	 */
 	public function serialize()
 	{
@@ -96,7 +96,7 @@ class Cli extends Input
 	 * @return  Input  The input object.
 	 *
 	 * @since   3.0.0
-	 * @deprecated  5.0  Use Joomla\Input\Cli instead
+	 * @deprecated  5.0  Use the `joomla/console` package instead
 	 */
 	public function unserialize($input)
 	{
@@ -122,7 +122,7 @@ class Cli extends Input
 	 * @return  void
 	 *
 	 * @since   1.7.0
-	 * @deprecated  5.0  Use Joomla\Input\Cli instead
+	 * @deprecated  5.0  Use the `joomla/console` package instead
 	 */
 	protected function parseArguments()
 	{


### PR DESCRIPTION
Code review 

The deprecated hint is to "Use Joomla\Input\Cli instead"

"Joomla\Input\Cli" doesnt exist at all

"Joomla\CMS\Input\Cli" exists, but that itself is deprecated and says to use `Joomla\Input\Cli` so in a catch 22

This PR updates "Joomla\CMS\Input\Cli" with a new deprecated message telling people to "Use the `joomla/console` package instead" which is the same message elsewhere in deprecated statements to do with CLI in Joomla 4