### PR TITLE
[4.0] Modules Article Category hits

### DIFF
--- a/modules/mod_articles_category/mod_articles_category.xml
+++ b/modules/mod_articles_category/mod_articles_category.xml
@@ -292,7 +292,7 @@
 					>
 					<option value="a.ordering">MOD_ARTICLES_CATEGORY_OPTION_ORDERING_VALUE</option>
 					<option value="fp.ordering">MOD_ARTICLES_CATEGORY_OPTION_ORDERINGFEATURED_VALUE</option>
-					<option value="a.hits">MOD_ARTICLES_CATEGORY_OPTION_HITS_VALUE</option>
+					<option value="a.hits" requires="hits">MOD_ARTICLES_CATEGORY_OPTION_HITS_VALUE</option>
 					<option value="a.title">JGLOBAL_TITLE</option>
 					<option value="a.id">MOD_ARTICLES_CATEGORY_OPTION_ID_VALUE</option>
 					<option value="a.alias">JFIELD_ALIAS_LABEL</option>


### PR DESCRIPTION
Disable the ordering by hits option when the article option record hits is disabled

![image](https://user-images.githubusercontent.com/1296369/120195178-5b31ee00-c216-11eb-84a5-33d508caa236.png)
