### PR TITLE
[4.0] quickicon class

### DIFF
--- a/layouts/joomla/quickicons/icon.php
+++ b/layouts/joomla/quickicons/icon.php
@@ -28,7 +28,7 @@ $title = empty($displayData['title']) ? '' : (' title="' . $this->escape($displa
 $text = empty($displayData['text']) ? '' : ('<span class="j-links-link">' . $displayData['text'] . '</span>');
 
 // Make the class string
-$class = !empty($tmp) ? ' class="' . implode(' ', array_unique($tmp)) . '"' : '';
+$class = empty($displayData['class']) ? '' : (' class="' . $this->escape($displayData['class']) . '"');
 
 ?>
 <?php // If it is a button with two links: make it a list


### PR DESCRIPTION
Use the class if it is defined in the plugin. Before this PR the download key icon is always blue. now it is green or red

Pull request for #33698 
![image](https://user-images.githubusercontent.com/1296369/120221947-22eed780-c237-11eb-889a-a22ca67b8915.png)
