### PR TITLE
[4] The Download Key is missing color

### DIFF
--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -100,7 +100,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										</div>
 										<?php if($item->isMissingDownloadKey): ?>
 										<?php HTMLHelper::_('bootstrap.popover', 'span.hasPopover', ['trigger' => 'hover focus']); ?>
-										<span class="badge bg-danger text-white">
+										<span class="badge bg-danger">
 											<span class="hasPopover"
 												  title="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL') ?>"
 												  data-bs-content="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_TIP') ?>"

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -100,7 +100,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										</div>
 										<?php if($item->isMissingDownloadKey): ?>
 										<?php HTMLHelper::_('bootstrap.popover', 'span.hasPopover', ['trigger' => 'hover focus']); ?>
-										<span class="badge bg-warning text-dark">
+										<span class="badge bg-danger text-white">
 											<span class="hasPopover"
 												  title="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL') ?>"
 												  data-bs-content="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_TIP') ?>"

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -114,7 +114,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										</span>
 										<code><?php echo $item->downloadKey['value']; ?></code>
 										<?php elseif ($item->downloadKey['supported']) : ?>
-										<span class="badge bg-warning text-dark">
+										<span class="badge bg-danger text-white">
 											<span class="hasPopover"
 													title="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL') ?>"
 													data-bs-content="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_TIP') ?>"

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -114,7 +114,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										</span>
 										<code><?php echo $item->downloadKey['value']; ?></code>
 										<?php elseif ($item->downloadKey['supported']) : ?>
-										<span class="badge bg-danger text-white">
+										<span class="badge bg-danger">
 											<span class="hasPopover"
 													title="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL') ?>"
 													data-bs-content="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_TIP') ?>"


### PR DESCRIPTION
forked from https://github.com/joomla/joomla-cms/pull/34312#issuecomment-851640188

### Summary of Changes

If the quick icon is going to be red/danger and a missing download key is "that level" of feedback, then it should be consistently used "at that level" = E.g Danger/Error/Red level

### Testing Instructions

Install a 3PD that needs a download key 

Visit update sites 

### Actual result BEFORE applying this Pull Request

<img width="566" alt="Screenshot 2021-05-31 at 20 05 49" src="https://user-images.githubusercontent.com/400092/120233593-1cb82580-c24e-11eb-94d0-baf61389567e.png">


### Expected result AFTER applying this Pull Request

<img width="541" alt="Screenshot 2021-05-31 at 20 24 34" src="https://user-images.githubusercontent.com/400092/120233652-3bb6b780-c24e-11eb-97c5-93d6fff46f35.png">


### Documentation Changes Required

