### PR TITLE
[4] Replace placeholders in file names of attachments in Mail Templates

### DIFF
--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -502,8 +502,6 @@ class MailTemplate
 		$ext = File::getExt($file);
 
 		// Strip off extension from $name and append extension of $file, if any
-		$name = File::stripExt($name) . ($ext ? '.' . $ext : '');
-
-		return $name;
+		return File::stripExt($name) . ($ext ? '.' . $ext : '');
 	}
 }

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -495,13 +495,14 @@ class MailTemplate
 			return '';
 		}
 
+		// Replace any placeholders.
+		$name = $this->replaceTags($name, $this->data);
+
+		// Get the file extension.
 		$ext = File::getExt($file);
 
 		// Strip off extension from $name and append extension of $file, if any
 		$name = File::stripExt($name) . ($ext ? '.' . $ext : '');
-
-		// Replace any placeholders.
-		$name = $this->replaceTags($name, $this->data);
 
 		return $name;
 	}

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -498,6 +498,11 @@ class MailTemplate
 		$ext = File::getExt($file);
 
 		// Strip off extension from $name and append extension of $file, if any
-		return File::stripExt($name) . ($ext ? '.' . $ext : '');
+		$name = File::stripExt($name) . ($ext ? '.' . $ext : '');
+
+		// Replace any placeholders.
+		$name = $this->replaceTags($name, $this->data);
+
+		return $name;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #34287

### Summary of Changes

Allows the use of place holders in the custom file name of an attachment for mail templates. 

### Testing Instructions

Install a fresh Joomla 4 - set up your mail settings correctly and test them. 

(Tip: Learn what [MailHog](https://github.com/mailhog/MailHog) is if you dont already use it!) 

- Login to Joomla Admin 
- System -> Mail Templates -> Options
- set Attachment Folder = images 
- Save and close
- System -> Mail Templates -> Edit Global Configuration: Test Mail
- Click + to add a new file
- Select `joomla_blank.png`
- Type `{METHOD}_test.png` as the name of the file
- Save and close
- System -> Global Configuration -> Server Tab -> Test Mail button... 
- Check your mail. 

### Actual result BEFORE applying this Pull Request

`{METHOD}_test.png` would be the name of the file attached to your email

### Expected result AFTER applying this Pull Request

`{METHOD}` will get replaced with your mail method (Mine is SMTP) 

Mine therefore is `SMTP_test.png` when attached. 

<img width="701" alt="Screenshot 2021-05-31 at 22 38 49" src="https://user-images.githubusercontent.com/400092/120244021-fea7f080-c260-11eb-8d22-4d97beebcb17.png">


### Documentation Changes Required

None - its a secret. 

### Commentry

Thinking how this feature might be used, the 3pd might want to add dynamic detail to the file name. E.g Joe Blogs buys an ebook, and so the filename becomes Order123_Bloggs_book.pdf dynamically using the placeholders.

### Security 

I cannot see a way that this can be used to spoof anything, happy to be proved wrong. The same checks on file extensions will still apply, and phpMailer restrictions on the files name will also apply still as they did before this PR. 