### PR TITLE
[4] Change notefield form field to display better

### DIFF
--- a/libraries/src/Form/Field/NoteField.php
+++ b/libraries/src/Form/Field/NoteField.php
@@ -74,13 +74,7 @@ class NoteField extends FormField
 			$html[] = '<button type="button" class="btn-close" data-dismiss="' . $close . '">&times;</button>';
 		}
 
-		$html[] = !empty($title)
-			? ($heading ? '<' . $heading . '>' : '')
-			. '<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden">' . Text::_('INFO') . '</span> '
-			. Text::_($title)
-			. ($heading ? '</' . $heading . '>' : '')
-			: '';
-
+		$html[] = !empty($title) ? '<' . $heading . '>' . Text::_($title) . '</' . $heading . '>' : '';
 		$html[] = !empty($description) ? Text::_($description) : '';
 
 		return '</div><div ' . $class . '>' . implode('', $html);

--- a/libraries/src/Form/Field/NoteField.php
+++ b/libraries/src/Form/Field/NoteField.php
@@ -74,7 +74,13 @@ class NoteField extends FormField
 			$html[] = '<button type="button" class="btn-close" data-dismiss="' . $close . '">&times;</button>';
 		}
 
-		$html[] = !empty($title) ? ($heading ? '<' . $heading . '>' : '') . '<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden">Info</span> ' . Text::_($title) . ($heading ? '</' . $heading . '>' : '') : '';
+		$html[] = !empty($title)
+			? ($heading ? '<' . $heading . '>' : '')
+			. '<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden">' . Text::_('INFO') . '</span> '
+			. Text::_($title)
+			. ($heading ? '</' . $heading . '>' : '')
+			: '';
+
 		$html[] = !empty($description) ? Text::_($description) : '';
 
 		return '</div><div ' . $class . '>' . implode('', $html);

--- a/libraries/src/Form/Field/NoteField.php
+++ b/libraries/src/Form/Field/NoteField.php
@@ -74,7 +74,7 @@ class NoteField extends FormField
 			$html[] = '<button type="button" class="btn-close" data-dismiss="' . $close . '">&times;</button>';
 		}
 
-		$html[] = !empty($title) ? '<' . $heading . '>' . Text::_($title) . '</' . $heading . '>' : '';
+		$html[] = !empty($title) ? ($heading ? '<' . $heading . '>' : '') . '<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden">Info</span> ' . Text::_($title) . ($heading ? '</' . $heading . '>' : '') : '';
 		$html[] = !empty($description) ? Text::_($description) : '';
 
 		return '</div><div ' . $class . '>' . implode('', $html);

--- a/plugins/user/token/forms/token.xml
+++ b/plugins/user/token/forms/token.xml
@@ -10,7 +10,7 @@
 				name="saveme"
 				type="note"
 				label="PLG_USER_TOKEN_SAVEME_DESC"
-				heading="p"
+				heading=""
 				class="alert alert-warning"
 			/>
 
@@ -18,7 +18,7 @@
 				name="notokenforotherpeople"
 				type="note"
 				label="PLG_USER_TOKEN_NOTOKENFOROTHERPEOPLE_DESC"
-				heading="p"
+				heading=""
 				class="alert alert-warning"
 			/>
 
@@ -26,7 +26,7 @@
 				name="savemeforotherpeople"
 				type="note"
 				label="PLG_USER_TOKEN_SAVEMEFOROTHERPEOPLE_DESC"
-				heading="p"
+				heading=""
 				class="alert alert-warning"
 			/>
 

--- a/plugins/user/token/forms/token.xml
+++ b/plugins/user/token/forms/token.xml
@@ -9,24 +9,21 @@
 			<field
 				name="saveme"
 				type="note"
-				label="PLG_USER_TOKEN_SAVEME_DESC"
-				heading=""
+				description="PLG_USER_TOKEN_SAVEME_DESC"
 				class="alert alert-warning"
 			/>
 
 			<field
 				name="notokenforotherpeople"
 				type="note"
-				label="PLG_USER_TOKEN_NOTOKENFOROTHERPEOPLE_DESC"
-				heading=""
+				description="PLG_USER_TOKEN_NOTOKENFOROTHERPEOPLE_DESC"
 				class="alert alert-warning"
 			/>
 
 			<field
 				name="savemeforotherpeople"
 				type="note"
-				label="PLG_USER_TOKEN_SAVEMEFOROTHERPEOPLE_DESC"
-				heading=""
+				description="PLG_USER_TOKEN_SAVEMEFOROTHERPEOPLE_DESC"
 				class="alert alert-warning"
 			/>
 


### PR DESCRIPTION
Pull Request for Issue #34247

### Summary of Changes

correct rendering of alerts

### Testing Instructions

Visit Joomla API Token tab in Edit User and look at the alert blocks which are yellow - these are built by a "note" field in a form. 

### Actual result BEFORE applying this Pull Request

<img width="1140" alt="Screenshot 2021-05-31 at 23 26 16" src="https://user-images.githubusercontent.com/400092/120246256-9e687d00-c267-11eb-928a-16e957e51be0.png">


### Expected result AFTER applying this Pull Request

<img width="1140" alt="Screenshot 2021-06-01 at 11 24 50" src="https://user-images.githubusercontent.com/400092/120308422-fe910a80-c2cb-11eb-9017-2463521b18a5.png">

Text color is addressed in https://github.com/joomla/joomla-cms/pull/34328

### Documentation Changes Required

