### PR TITLE
[4] Fix default state of toggle for behind_loadbalancer

### DIFF
--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -386,8 +386,8 @@
 			default="0"
 			filter="boolean"
 			>
-			<option value="1">JYES</option>
 			<option value="0">JNO</option>
+			<option value="1">JYES</option>
 		</field>
 
 		<field


### PR DESCRIPTION
Pull Request for Issue #34324

### Summary of Changes

Set the order of the options correctly so Joomla paints them correctly

### Testing Instructions

Visit Joomla Global Config. 

### Actual result BEFORE applying this Pull Request

<img width="891" alt="Screenshot 2021-05-31 at 23 43 34" src="https://user-images.githubusercontent.com/400092/120247432-4fbce200-c26b-11eb-983a-6d82d4a8aa6d.png">


### Expected result AFTER applying this Pull Request

<img width="891" alt="Screenshot 2021-05-31 at 23 51 46" src="https://user-images.githubusercontent.com/400092/120247436-52b7d280-c26b-11eb-9cde-1599234b2f0e.png">


### Documentation Changes Required

