### PR TITLE
[4] Correct warning alerts colours and joomla-alert custom element css

### DIFF
--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -191,8 +191,7 @@ $state-info-text:                  var(--atum-bg-dark-70);
 $state-info-bg:                    var(--white);
 $state-info-border:                var(--atum-bg-dark-70);
 
-$state-warning-text:               $warning;
-$state-warning-custom-text:        darken($warning, 24%);
+$state-warning-text:               darken($warning, 24%);
 $state-warning-bg:                 lighten($warning, 44%);
 $state-warning-border:             $warning;
 

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -88,11 +88,11 @@
 
   &[type="warning"] {
     .joomla-alert--close {
-      color: #{$state-warning-custom-text};
+      color: #{$state-warning-text};
     }
 
-    color: #{$state-warning-custom-text};
-    --alert-accent-color: #{$state-warning-text};
+    color: #{$state-warning-text};
+    --alert-accent-color: #{$warning};
     --alert-bg-color: #{$state-warning-bg};
   }
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/34322 reverts and improves on https://github.com/joomla/joomla-cms/pull/34246

### Summary of Changes

In Joomla 4 we have two types of Warning Alert rendering. 

We have bootstrap with standard `alert alert-warning` classes (An example: Field notes. Login to Joomla admin and then go to User Menu -> Edit account -> Joomla API Token)

We also have `joomla-alert` custom element. (An example: Login to Joomla admin with a wrong user and pass and see the warning)

After the changes in https://github.com/joomla/joomla-cms/pull/34246 the custom element looked good, but the bootstrap element looked "too yellow"

*"looked good". = Bright yellow border and optional left panel and "muddy" text
*"too yellow" = Bright yellow text and bright yellow border and optional left panel

### Testing Instructions

Using the two example above - check them before and after applying this PR

Remember to rebuild your CSS with `npm run build:css` after applying the PR, and remember browsers aggressively cache css files. 

### Actual result BEFORE applying this Pull Request

Custom Elements:

<img width="1181" alt="Screenshot 2021-06-01 at 11 08 07" src="https://user-images.githubusercontent.com/400092/120306339-a9ec9000-c2c9-11eb-908f-9eee58b6618b.png">

Bootstrap Elements:

<img width="1111" alt="Screenshot 2021-06-01 at 11 09 38" src="https://user-images.githubusercontent.com/400092/120306558-e15b3c80-c2c9-11eb-8211-4dcf5f3030db.png">


### Expected result AFTER applying this Pull Request

Custom Elements:

<img width="1181" alt="Screenshot 2021-06-01 at 11 08 07" src="https://user-images.githubusercontent.com/400092/120306339-a9ec9000-c2c9-11eb-908f-9eee58b6618b.png">


Bootstrap Elements:

<img width="1142" alt="Screenshot 2021-06-01 at 11 07 43" src="https://user-images.githubusercontent.com/400092/120306295-9e996480-c2c9-11eb-9876-49fc01be966f.png">


### Contrast

The muddy color on the yellow background gives a contrast ratio of 4.68 which is good enough for AA but not the 7.0 needed for AAA which would require the muddy cooler to be `#745000`

<img width="158" alt="Screenshot 2021-06-01 at 11 17 47" src="https://user-images.githubusercontent.com/400092/120307641-20d65880-c2cb-11eb-8bab-120e449cf2b1.png">
