### PR TITLE
[3] Fix Undefined class RuntimeException

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -692,7 +692,7 @@ class CMSApplication extends WebApplication
 				'deprecated'
 			);
 		}
-		catch (RuntimeException $exception)
+		catch (\RuntimeException $exception)
 		{
 			// Informational log only
 		}
@@ -718,7 +718,7 @@ class CMSApplication extends WebApplication
 				'deprecated'
 			);
 		}
-		catch (RuntimeException $exception)
+		catch (\RuntimeException $exception)
 		{
 			// Informational log only
 		}


### PR DESCRIPTION
Code review.

This is a namespaced file, and therefore any reference to `RuntimeException` needs to be namespaced back to the root. 

