### PR TITLE
[4] Fix fatal error by calling correct class name

### DIFF
--- a/components/com_newsfeeds/src/Helper/AssociationHelper.php
+++ b/components/com_newsfeeds/src/Helper/AssociationHelper.php
@@ -48,7 +48,7 @@ abstract class AssociationHelper extends CategoryAssociationHelper
 
 				foreach ($associations as $tag => $item)
 				{
-					$return[$tag] = Route::getNewsfeedRoute($item->id, (int) $item->catid, $item->language);
+					$return[$tag] = RouteHelper::getNewsfeedRoute($item->id, (int) $item->catid, $item->language);
 				}
 
 				return $return;


### PR DESCRIPTION
Code review. 

`Route::getNewsfeedRoute` is invalid 

The method `getNewsfeedRoute` is in the `RouteHelper.php` file in the same namespace