### PR TITLE
[4] Prevent fatal error by importing \Exception

### DIFF
--- a/components/com_contact/src/Model/FormModel.php
+++ b/components/com_contact/src/Model/FormModel.php
@@ -11,6 +11,7 @@ namespace Joomla\Component\Contact\Site\Model;
 
 \defined('_JEXEC') or die;
 
+use Exception;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Helper\TagsHelper;


### PR DESCRIPTION
Code review

`Exception` is used 4 times in this file, but its undefined. 

three in docblocks, no worries, but undefined as not in the same namespace. 

One of those uses is in a try/catch block on line 102, therefore to prevent that not working we need the class imported. 