### PR TITLE
[4] Prevent fatal error by importing use CategoryFactoryInterface

### DIFF
--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Tags\Site\Service;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\SiteApplication;
+use Joomla\CMS\Categories\CategoryFactoryInterface;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Component\Router\RouterBase;
 use Joomla\CMS\Menu\AbstractMenu;


### PR DESCRIPTION
Code review

`CategoryFactoryInterface` is used in the constructor however that class is not defined as this file is in the namespace `Joomla\Component\Tags\Site\Service` and `CategoryFactoryInterface` is in the namespace `Joomla\CMS\Categories`

So we need to import the class to prevent fatal errors if someone ever used the constructor and provided a valid value for `$categoryFactory`