### PR TITLE
[4] When using path::clean, a security method, correctly throw a useable exception. 

### DIFF
--- a/libraries/src/Filesystem/Path.php
+++ b/libraries/src/Filesystem/Path.php
@@ -212,8 +212,7 @@ class Path
 				sprintf(
 					'%s() - $path is not a string',
 					__METHOD__
-				),
-				20
+				)
 			);
 		}
 

--- a/libraries/src/Filesystem/Path.php
+++ b/libraries/src/Filesystem/Path.php
@@ -173,8 +173,7 @@ class Path
 				sprintf(
 					'%s() - Use of relative paths not permitted',
 					__METHOD__
-				),
-				20
+				)
 			);
 		}
 
@@ -187,8 +186,7 @@ class Path
 					'%1$s() - Snooping out of bounds @ %2$s',
 					__METHOD__,
 					$path
-				),
-				20
+				)
 			);
 		}
 


### PR DESCRIPTION
Pull Request for Issue #34263

### Summary of Changes

When using `Path::clean()` method, with an invalid path (Like `../../../../../../`) it is designed to throw an exception. 

The problem is that someone used code = 20 in the exception.

If your code calls the code below, and doesnt catch the exception then your website will not show an error message, it will show a 502 Bad Gateway (on nginx)

```php
Path::clean('../../../../../../');
```


When you have a php-fpm set up, where the web server passes the request "upstream" to the "gateway" (i.e php-fpm running somewhere, or somehow else) then PHP-FPM will return error code `20` when this exception is thrown causing an error like:

```
webserver_1  | 2021/06/01 15:10:43 [error] 31#31: *109 upstream sent invalid status "20" while reading response header from upstream, client: 172.19.0.1, server: , request: "GET /administrator/index.php HTTP/1.1", upstream: "fastcgi://172.19.0.6:9000", host: "127.0.0.1:4444"
```

### Testing Instructions

If your code calls the code below, and doesnt catch the exception then your website will not show an error message, it will show a 502 Bad Gateway (on nginx)

```php
Path::clean('../../../../../../');
```

### Actual result BEFORE applying this Pull Request

 502 Bad Gateway 

### Expected result AFTER applying this Pull Request

 Correctly displayed Exception that can be handled 

### Documentation Changes Required

// @Fedik @dgrammatiko 