### PR TITLE
Make sure the text files are only generated when needed

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -71,6 +71,9 @@ $excludeGzip  = isset($options['exclude-gzip']);
 $excludeBzip2 = isset($options['exclude-bzip2']);
 $showHelp     = isset($options['help']);
 
+// Disable the generation of extra text files
+$includeExtraTextfiles = false;
+
 if ($showHelp)
 {
 	usage($argv[0]);
@@ -84,6 +87,9 @@ if (!$remote)
 	$tagVersion = system($systemGit . ' describe --tags `' . $systemGit . ' rev-list --tags --max-count=1`', $tagVersion);
 	$remote = 'tags/' . $tagVersion;
 	chdir($here);
+
+	// We in release mode so we need the extra text files
+	$includeExtraTextfiles = true;
 }
 
 echo "Start build for remote $remote.\n";
@@ -409,76 +415,80 @@ foreach (array_keys($checksums) as $packageName)
 	}
 }
 
-echo "Generating checksums.txt file\n";
-
-$checksumsContent = '';
-
-foreach ($checksums as $packageName => $packageHashes)
+// Thats only needed when we release a version
+if ($includeExtraTextfiles)
 {
-	$checksumsContent .= "Filename: $packageName\n";
+	echo "Generating checksums.txt file\n";
 
-	foreach ($packageHashes as $hashType => $hash)
+	$checksumsContent = '';
+
+	foreach ($checksums as $packageName => $packageHashes)
 	{
-		$checksumsContent .= "$hashType: $hash\n";
-	}
+		$checksumsContent .= "Filename: $packageName\n";
 
-	$checksumsContent .= "\n";
-}
-
-file_put_contents('checksums.txt', $checksumsContent);
-
-echo "Generating github_release.txt file\n";
-
-$githubContent = array();
-$githubText = '';
-$releaseText = array(
-	'FULL' => 'New Joomla! Installations ',
-	'POINT' => 'Update from Joomla! ' . $version . '.' . $previousRelease . ' ',
-	'MINOR' => 'Update from Joomla! ' . $version . '.x ',
-	'UPGRADE' => 'Update from Joomla! 2.5 or previous 3.x releases ',
-);
-$githubLink = 'https://github.com/joomla/joomla-cms/releases/download/' . $tagVersion . '/';
-
-foreach ($checksums as $packageName => $packageHashes)
-{
-	$type = '';
-
-	if (strpos($packageName, 'Full_Package') !== false)
-	{
-		$type = 'FULL';
-	}
-	elseif (strpos($packageName, 'Patch_Package') !== false)
-	{
-		if (strpos($packageName, '.x_to') !== false)
+		foreach ($packageHashes as $hashType => $hash)
 		{
-			$type = 'MINOR';
+			$checksumsContent .= "$hashType: $hash\n";
 		}
-		else
+
+		$checksumsContent .= "\n";
+	}
+
+	file_put_contents('checksums.txt', $checksumsContent);
+
+	echo "Generating github_release.txt file\n";
+
+	$githubContent = array();
+	$githubText    = '';
+	$releaseText   = array(
+		'FULL'    => 'New Joomla! Installations ',
+		'POINT'   => 'Update from Joomla! ' . $version . '.' . $previousRelease . ' ',
+		'MINOR'   => 'Update from Joomla! ' . $version . '.x ',
+		'UPGRADE' => 'Update from Joomla! 2.5 or previous 3.x releases ',
+	);
+	$githubLink = 'https://github.com/joomla/joomla-cms/releases/download/' . $tagVersion . '/';
+
+	foreach ($checksums as $packageName => $packageHashes)
+	{
+		$type = '';
+
+		if (strpos($packageName, 'Full_Package') !== false)
 		{
-			$type = 'POINT';
+			$type = 'FULL';
 		}
+		elseif (strpos($packageName, 'Patch_Package') !== false)
+		{
+			if (strpos($packageName, '.x_to') !== false)
+			{
+				$type = 'MINOR';
+			}
+			else
+			{
+				$type = 'POINT';
+			}
+		}
+		elseif (strpos($packageName, 'Update_Package') !== false)
+		{
+			$type = 'UPGRADE';
+		}
+
+		$githubContent[$type][] = '[' . substr($packageName, strpos($packageName, 'Package') + 7) . '](' . $githubLink . $packageName . ')';
 	}
-	elseif (strpos($packageName, 'Update_Package') !== false)
+
+	foreach ($releaseText as $type => $text)
 	{
-		$type = 'UPGRADE';
+		if (empty($githubContent[$type]))
+		{
+			continue;
+		}
+
+		$githubText .= $text;
+		$githubText .= implode(" | ", $githubContent[$type]);
+
+		$githubText .= "\n";
 	}
 
-	$githubContent[$type][] = '[' . substr($packageName, strpos($packageName, 'Package') + 7) . '](' . $githubLink . $packageName . ')';
+	file_put_contents('github_release.txt', $githubText);
 }
-
-foreach ($releaseText as $type => $text)
-{
-	if (empty($githubContent[$type]))
-	{
-		continue;
-	}
-
-	$githubText .= $text;
-	$githubText .= implode(" | ", $githubContent[$type]);
-
-	$githubText .= "\n";
-}
-
-file_put_contents('github_release.txt', $githubText);
 
 echo "Build of version $fullVersion complete!\n";

--- a/build/build.php
+++ b/build/build.php
@@ -398,26 +398,27 @@ if (!$excludeZip)
 
 chdir('..');
 
-foreach (array_keys($checksums) as $packageName)
-{
-	echo "Generating checksums for $packageName\n";
-
-	foreach (array('sha256', 'sha384', 'sha512') as $hash)
-	{
-		if (file_exists('packages/' . $packageName))
-		{
-			$checksums[$packageName][$hash] = hash_file($hash, 'packages/' . $packageName);
-		}
-		else
-		{
-			echo "Package $packageName not found in build directories\n";
-		}
-	}
-}
-
 // Thats only needed when we release a version
 if ($includeExtraTextfiles)
 {
+
+	foreach (array_keys($checksums) as $packageName)
+	{
+		echo "Generating checksums for $packageName\n";
+
+		foreach (array('sha256', 'sha384', 'sha512') as $hash)
+		{
+			if (file_exists('packages/' . $packageName))
+			{
+				$checksums[$packageName][$hash] = hash_file($hash, 'packages/' . $packageName);
+			}
+			else
+			{
+				echo "Package $packageName not found in build directories\n";
+			}
+		}
+	}
+
 	echo "Generating checksums.txt file\n";
 
 	$checksumsContent = '';

--- a/build/build.php
+++ b/build/build.php
@@ -88,7 +88,7 @@ if (!$remote)
 	$remote = 'tags/' . $tagVersion;
 	chdir($here);
 
-	// We in release mode so we need the extra text files
+	// We are in release mode so we need the extra text files
 	$includeExtraTextfiles = true;
 }
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/34188

### Summary of Changes

Make sure the text files (checksums.txt and github_release.txt) are only generated when needed

### Testing Instructions

run a build on the current branch with the remote command so without a tag.
`php build.php --remote=origin/staging`

### Actual result BEFORE applying this Pull Request

PHP Warning: Of an `Undefined variable $tagVersion`

### Expected result AFTER applying this Pull Request

No php warning and no generation of files we don't need on none-release builds.

### Documentation Changes Required

None

cc @HLeithner @wilsonge 