### PR TITLE
[4] fix undefined namespace autocompletion in IDEs

### DIFF
--- a/components/com_users/src/Controller/DisplayController.php
+++ b/components/com_users/src/Controller/DisplayController.php
@@ -28,7 +28,7 @@ class DisplayController extends BaseController
 	 *
 	 * @param   boolean        $cachable   If true, the view output will be cached
 	 * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types,
-	 *                                     for valid values see {@link Joomla\CMS\Filter\InputFilter::clean()}.
+	 *                                     for valid values see {@link \Joomla\CMS\Filter\InputFilter::clean()}.
 	 *
 	 * @return  static  This object to support chaining.
 	 *

--- a/libraries/src/Event/GenericEvent.php
+++ b/libraries/src/Event/GenericEvent.php
@@ -13,7 +13,7 @@ namespace Joomla\CMS\Event;
 /**
  * This class gives a concrete implementation of the AbstractEvent class.
  *
- * @see    Joomla\CMS\Event\AbstractEvent
+ * @see    \Joomla\CMS\Event\AbstractEvent
  * @since  4.0.0
  */
 class GenericEvent extends AbstractEvent

--- a/plugins/system/debug/src/DataCollector/InfoCollector.php
+++ b/plugins/system/debug/src/DataCollector/InfoCollector.php
@@ -70,7 +70,7 @@ class InfoCollector extends AbstractDataCollector implements AssetProvider
 
 	/**
 	 * Returns a hash where keys are control names and their values
-	 * an array of options as defined in {@see DebugBar\JavascriptRenderer::addControl()}
+	 * an array of options as defined in {@see \DebugBar\JavascriptRenderer::addControl()}
 	 *
 	 * @since  4.0.0
 	 * @return array

--- a/plugins/system/debug/src/DataCollector/LanguageErrorsCollector.php
+++ b/plugins/system/debug/src/DataCollector/LanguageErrorsCollector.php
@@ -70,7 +70,7 @@ class LanguageErrorsCollector extends AbstractDataCollector implements AssetProv
 
 	/**
 	 * Returns a hash where keys are control names and their values
-	 * an array of options as defined in {@see DebugBar\JavascriptRenderer::addControl()}
+	 * an array of options as defined in {@see \DebugBar\JavascriptRenderer::addControl()}
 	 *
 	 * @since  4.0.0
 	 *

--- a/plugins/system/debug/src/DataCollector/LanguageFilesCollector.php
+++ b/plugins/system/debug/src/DataCollector/LanguageFilesCollector.php
@@ -86,7 +86,7 @@ class LanguageFilesCollector extends AbstractDataCollector implements AssetProvi
 
 	/**
 	 * Returns a hash where keys are control names and their values
-	 * an array of options as defined in {@see DebugBar\JavascriptRenderer::addControl()}
+	 * an array of options as defined in {@see \DebugBar\JavascriptRenderer::addControl()}
 	 *
 	 * @since  4.0.0
 	 *

--- a/plugins/system/debug/src/DataCollector/LanguageStringsCollector.php
+++ b/plugins/system/debug/src/DataCollector/LanguageStringsCollector.php
@@ -59,7 +59,7 @@ class LanguageStringsCollector extends AbstractDataCollector implements AssetPro
 
 	/**
 	 * Returns a hash where keys are control names and their values
-	 * an array of options as defined in {@see DebugBar\JavascriptRenderer::addControl()}
+	 * an array of options as defined in {@see \DebugBar\JavascriptRenderer::addControl()}
 	 *
 	 * @since  4.0.0
 	 *

--- a/plugins/system/debug/src/DataCollector/ProfileCollector.php
+++ b/plugins/system/debug/src/DataCollector/ProfileCollector.php
@@ -298,7 +298,7 @@ class ProfileCollector extends AbstractDataCollector
 
 	/**
 	 * Returns a hash where keys are control names and their values
-	 * an array of options as defined in {@see DebugBar\JavascriptRenderer::addControl()}
+	 * an array of options as defined in {@see \DebugBar\JavascriptRenderer::addControl()}
 	 *
 	 * @since  4.0.0
 	 * @return array

--- a/plugins/system/debug/src/DataCollector/SessionCollector.php
+++ b/plugins/system/debug/src/DataCollector/SessionCollector.php
@@ -60,7 +60,7 @@ class SessionCollector  extends AbstractDataCollector
 
 	/**
 	 * Returns a hash where keys are control names and their values
-	 * an array of options as defined in {@see DebugBar\JavascriptRenderer::addControl()}
+	 * an array of options as defined in {@see \DebugBar\JavascriptRenderer::addControl()}
 	 *
 	 * @since  4.0.0
 	 *


### PR DESCRIPTION
Code review

A bunch of classes in comments that are not correctly namespace and so generate warnings/errors in IDE's and other tools about the namespaces and classes not existing. 