### PR TITLE
[4.0] - LDAP Plugin - fix typo on getAttribute

### DIFF
--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -179,7 +179,7 @@ class PlgAuthenticationLdap extends CMSPlugin
 		// Grab some details from LDAP and return them
 		$response->username = $entry->getAttribute($ldap_uid)[0] ?? false;
 		$response->email    = $entry->getAttribute($ldap_email)[0] ?? false;
-		$response->fullname = $entry->getAttribute($ldap_fullname)[0] ?? trim($entry->geAttribute($ldap_fullname)[0]) ?: $credentials['username'];
+		$response->fullname = $entry->getAttribute($ldap_fullname)[0] ?? trim($entry->getAttribute($ldap_fullname)[0]) ?: $credentials['username'];
 
 		// Were good - So say so.
 		$response->status        = Authentication::STATUS_SUCCESS;


### PR DESCRIPTION
Fixes a typo on `getAttribute`