### PR TITLE
[4.0] Fix MediaField with custom directory

### DIFF
--- a/libraries/src/Form/Field/MediaField.php
+++ b/libraries/src/Form/Field/MediaField.php
@@ -306,7 +306,7 @@ class MediaField extends FormField
 			if (MediaHelper::isValidLocalDirectory($paths[0]))
 			{
 				$adapterName  = array_shift($paths);
-				$this->folder = 'local-' . $adapterName . '/' . implode('/', $paths);
+				$this->folder = 'local-' . $adapterName . ':/' . implode('/', $paths);
 			}
 		}
 		elseif ($this->directory && strpos(':', $this->directory))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
There is a small bug for MediaField when a custom directory is set via directory attribute like https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_banners/forms/banner.xml#L315 . This PR just fixes that bug.


### Testing Instructions
1. Use Joomla 4 nightly build
2. Create a banner, select an Image for that banner
3. Before patch, you would get an error **The account was not found** in the popup.
4. After patch, no error anymore