### PR TITLE
[4.0] Tags Service Router clean up

### DIFF
--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -31,7 +31,7 @@ class Router extends RouterBase
 	 *
 	 * @var DatabaseInterface
 	 *
-	 * @since  4.0.0
+	 * @since  __DEPLOY_VERSION__
 	 */
 	private $db;
 

--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -27,6 +27,15 @@ use Joomla\Utilities\ArrayHelper;
 class Router extends RouterBase
 {
 	/**
+	 * The db
+	 *
+	 * @var DatabaseInterface
+	 *
+	 * @since  4.0.0
+	 */
+	private $db;
+
+	/**
 	 * Tags Component router constructor
 	 *
 	 * @param   SiteApplication           $app              The application object
@@ -36,7 +45,7 @@ class Router extends RouterBase
 	 *
 	 * @since  4.0.0
 	 */
-	public function __construct(SiteApplication $app, AbstractMenu $menu, CategoryFactoryInterface $categoryFactory = null, DatabaseInterface $db)
+	public function __construct(SiteApplication $app, AbstractMenu $menu, ?CategoryFactoryInterface $categoryFactory, DatabaseInterface $db)
 	{
 		$this->db = $db;
 
@@ -57,7 +66,6 @@ class Router extends RouterBase
 		$segments = array();
 
 		// Get a menu item based on Itemid or currently active
-		$params = ComponentHelper::getParams('com_tags');
 
 		// We need a menu item.  Either the one specified in the query, or the current active one if none specified
 		if (empty($query['Itemid']))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Small clean up to com_tags Router  to make IDE happy:

1. Added $db property to the class
2. Change __construct method to solve warning Optional parameter before required parameter
3. Remove un-used variable


### Testing Instructions
1. Use Joomla 4 nightly build
2. Install Blog Sample Data
3. Access to Blog menu item, make sure tags are still being displayed in article
4. Click on a tag and make sure that the link you are being redirected to still work


Or code review should be enough, too
![tags](https://user-images.githubusercontent.com/977664/120435538-0cb45900-c3a8-11eb-9ce9-77c455754a88.png)

