### PR TITLE
Joomla Update pre-update checks for third party extensions are wrong

### DIFF
--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -302,8 +302,8 @@ Joomla = window.Joomla || {};
     Joomla.request({
       url: `${PreUpdateChecker.config.serverUrl
       }&joomla-target-version=${encodeURIComponent(PreUpdateChecker.joomlaTargetVersion)
-      }joomla-current-version=${PreUpdateChecker.joomlaCurrentVersion
-      }extension-version=${node.getAttribute('data-extension-current-version')
+      }&joomla-current-version=${PreUpdateChecker.joomlaCurrentVersion
+      }&extension-version=${node.getAttribute('data-extension-current-version')
       }&extension-id=${encodeURIComponent(node.getAttribute('data-extension-id'))}`,
       onSuccess(data) {
         const response = JSON.parse(data);


### PR DESCRIPTION
Pull Request for Issue #34351 .

### Summary of Changes

Added the missing ampersands in the Joomla Update Javascript, fixing the Pre-update checks for third party extensions.

### Testing Instructions

* Install any extension compatible with Joomla 4, such as the latest versions of JCE or Akeeba Backup.
* Edit libraries/src/Version.php to fake the current Joomla version as 4.0.0-beta8 (which will allow Joomla Update to find an update to the CMS version 4.0.0-rc1, the current version at the time of this writing).
* Go to System, Update, Extensions and click on Check for Updates to verify Joomla has the latest extension update information.
* Go to System, Update, Joomla.
* Look at the Pre-update Check results.

### Actual result BEFORE applying this Pull Request

You are told that the third party extension you installed needs to be updated because it's not compatible with Joomla 4. When you click More Detail you see that the latest version and the currently installed one are the same but there is "no compatibility information" which is obviously wrong.

### Expected result AFTER applying this Pull Request

Make sure to Follow the **last three steps** of the instructions.

Now you see that the third party extension is listed as No Update Required. Woo-hoo!

### Documentation Changes Required

None required.