### PR TITLE
Update Sites filtering breaks when changing the "Select Download Key"

### DIFF
--- a/administrator/components/com_installer/src/Model/UpdatesitesModel.php
+++ b/administrator/components/com_installer/src/Model/UpdatesitesModel.php
@@ -491,7 +491,7 @@ class UpdatesitesModel extends InstallerModel
 			'enabled'   => 'string',
 			'type'      => 'string',
 			'folder'    => 'string',
-			'supported' => 'bool',
+			'supported' => 'int',
 		];
 
 		foreach ($stateKeys as $key => $filterType)
@@ -518,6 +518,18 @@ class UpdatesitesModel extends InstallerModel
 		}
 
 		parent::populateState($ordering, $direction);
+	}
+
+	protected function getStoreId($id = '')
+	{
+		$id .= ':' . $this->getState('search');
+		$id .= ':' . $this->getState('client_id');
+		$id .= ':' . $this->getState('enabled');
+		$id .= ':' . $this->getState('type');
+		$id .= ':' . $this->getState('folder');
+		$id .= ':' . $this->getState('supported');
+
+		return parent::getStoreId($id);
 	}
 
 	/**
@@ -635,7 +647,7 @@ class UpdatesitesModel extends InstallerModel
 				->bind(':siteId', $uid, ParameterType::INTEGER);
 		}
 
-		if ($supported != 0)
+		if (is_numeric($supported))
 		{
 			switch ($supported)
 			{


### PR DESCRIPTION
Pull Request for Issue #34353 .

### Summary of Changes

Fixed the UpdatesitesModel in `com_installer` to reset the view when you deselect the Select Download Key filter.

I also added the missing `getStoreId` method to properly support sites with caching enabled.

### Testing Instructions

* Go to System, Update Sites
* Click the “- Select Download Key -” dropdown and select “Download Key Supported”.
* After the page reloads click the same dropdown and select “- Select Download Key -”.

### Actual result BEFORE applying this Pull Request

You see no entries.

### Expected result AFTER applying this Pull Request

You see all entries, as expected.

Please note that if you are using caching on your site you need to go to System, Clear Cache and click on Delete All _before_ retrying the testing instructions after applying the Pull Request.

### Documentation Changes Required

None.