### PR TITLE
[4.0] Composer update joomla/utilities

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1721,21 +1721,21 @@
         },
         {
             "name": "joomla/utilities",
-            "version": "2.0.0-beta",
+            "version": "2.0.0-beta2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/utilities.git",
-                "reference": "e15b14b060e524ab869504942440e14473dfb3de"
+                "reference": "30aaf824c9e6702c92c0463246b237276aa02cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/utilities/zipball/e15b14b060e524ab869504942440e14473dfb3de",
-                "reference": "e15b14b060e524ab869504942440e14473dfb3de",
+                "url": "https://api.github.com/repos/joomla-framework/utilities/zipball/30aaf824c9e6702c92c0463246b237276aa02cae",
+                "reference": "30aaf824c9e6702c92c0463246b237276aa02cae",
                 "shasum": ""
             },
             "require": {
                 "joomla/string": "^1.3|^2.0",
-                "php": "^7.2.5"
+                "php": "^7.2.5|^8.0"
             },
             "require-dev": {
                 "joomla/coding-standards": "^2.0@alpha",
@@ -1763,7 +1763,7 @@
                 "joomla",
                 "utilities"
             ],
-            "time": "2020-06-05T11:26:55+00:00"
+            "time": "2021-06-03T11:06:46+00:00"
         },
         {
             "name": "laminas/laminas-diactoros",


### PR DESCRIPTION
Pull Request for Issue #34365 .

### Summary of Changes

Update composer dependency "joomla/utilities" to latest version "2.0.0-beta2" which contains the fix for issue 34365 .

### Testing Instructions

Code review.

Or apply the patch to a clean, current 4.0-dev branch where "composer install" and "npm ci" have been run before, and then run "composer install" again.
Result: "joomla/utilities" is updated from "2.0.0-beta" to "2.0.0-beta2". Nothing else is updated, added or removed by composer.

### Actual result BEFORE applying this Pull Request

Version "2.0.0-beta" of the composer dependency "joomla/utilities" is used.

### Expected result AFTER applying this Pull Request

Version "2.0.0-beta2" of the composer dependency "joomla/utilities" is used.

The new version uses `array_shift` and not `array_pop` in file `libraries/vendor/joomla/utilities/src/IpHelper.php`, line 450, as you can see it here in the framework repository for the dependency's source:

https://github.com/joomla-framework/utilities/blob/2.0-dev/src/IpHelper.php#L450 .

### Documentation Changes Required

None.