### PR TITLE
[4.0] Dialoges Should be labeled

### DIFF
--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -24,7 +24,7 @@ Text::script('JHIDEPASSWORD');
 ?>
 <form class="form-validate" action="<?php echo Route::_('index.php', true); ?>" method="post" id="form-login">
 	<fieldset>
-	<legend class="visually-hidden"> <?php echo Text::_('COM_LOGIN'); ?></legend>
+	<legend class="visually-hidden"> <?php echo Text::_('MOD_LOGIN'); ?></legend>
 		<div class="form-group">
 			<label for="mod-login-username">
 				<?php echo Text::_('JGLOBAL_USERNAME'); ?>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -24,7 +24,7 @@ Text::script('JHIDEPASSWORD');
 ?>
 <form class="form-validate" action="<?php echo Route::_('index.php', true); ?>" method="post" id="form-login">
 	<fieldset>
-	<legend> <?php echo Text::_('COM_LOGIN'); ?></legend>
+	<legend class="visually-hidden"> <?php echo Text::_('COM_LOGIN'); ?></legend>
 		<div class="form-group">
 			<label for="mod-login-username">
 				<?php echo Text::_('JGLOBAL_USERNAME'); ?>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -37,9 +37,8 @@ Text::script('JHIDEPASSWORD');
 					type="text"
 					class="form-control"
 					required="required"
-					autofocus=""
+					autofocus
 					autocomplete="username"
-				
 				>
 			</div>
 		</div>
@@ -55,8 +54,7 @@ Text::script('JHIDEPASSWORD');
 					type="password"
 					class="form-control input-full"
 					required="required"
-					autocomplete="current-password"
-					
+					autocomplete="current-password"	
 				>
 				<button type="button" class="btn btn-secondary input-password-toggle">
 					<span class="icon-eye icon-fw" aria-hidden="true"></span>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -24,6 +24,7 @@ Text::script('JHIDEPASSWORD');
 ?>
 <form class="form-validate" action="<?php echo Route::_('index.php', true); ?>" method="post" id="form-login">
 	<fieldset>
+	<legend> </legend>
 		<div class="form-group">
 			<label for="mod-login-username">
 				<?php echo Text::_('JGLOBAL_USERNAME'); ?>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -24,7 +24,7 @@ Text::script('JHIDEPASSWORD');
 ?>
 <form class="form-validate" action="<?php echo Route::_('index.php', true); ?>" method="post" id="form-login">
 	<fieldset>
-	<legend> </legend>
+	
 		<div class="form-group">
 			<label for="mod-login-username">
 				<?php echo Text::_('JGLOBAL_USERNAME'); ?>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -39,7 +39,7 @@ Text::script('JHIDEPASSWORD');
 					required="required"
 					autofocus=""
 					autocomplete="username"
-					aria-required = "true"
+				
 				>
 			</div>
 		</div>
@@ -56,7 +56,7 @@ Text::script('JHIDEPASSWORD');
 					class="form-control input-full"
 					required="required"
 					autocomplete="current-password"
-					aria-required = "true"
+					
 				>
 				<button type="button" class="btn btn-secondary input-password-toggle">
 					<span class="icon-eye icon-fw" aria-hidden="true"></span>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -24,7 +24,7 @@ Text::script('JHIDEPASSWORD');
 ?>
 <form class="form-validate" action="<?php echo Route::_('index.php', true); ?>" method="post" id="form-login">
 	<fieldset>
-	
+	<legend> <?php echo Text::_('COM_LOGIN'); ?></legend>
 		<div class="form-group">
 			<label for="mod-login-username">
 				<?php echo Text::_('JGLOBAL_USERNAME'); ?>
@@ -37,8 +37,9 @@ Text::script('JHIDEPASSWORD');
 					type="text"
 					class="form-control"
 					required="required"
-					autofocus
+					autofocus=""
 					autocomplete="username"
+					aria-required = "true"
 				>
 			</div>
 		</div>
@@ -55,6 +56,7 @@ Text::script('JHIDEPASSWORD');
 					class="form-control input-full"
 					required="required"
 					autocomplete="current-password"
+					aria-required = "true"
 				>
 				<button type="button" class="btn btn-secondary input-password-toggle">
 					<span class="icon-eye icon-fw" aria-hidden="true"></span>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -24,7 +24,6 @@ Text::script('JHIDEPASSWORD');
 ?>
 <form class="form-validate" action="<?php echo Route::_('index.php', true); ?>" method="post" id="form-login">
 	<fieldset>
-	<legend class="visually-hidden"> <?php echo Text::_('MOD_LOGIN'); ?></legend>
 		<div class="form-group">
 			<label for="mod-login-username">
 				<?php echo Text::_('JGLOBAL_USERNAME'); ?>

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -54,7 +54,7 @@ Text::script('JHIDEPASSWORD');
 					type="password"
 					class="form-control input-full"
 					required="required"
-					autocomplete="current-password"	
+					autocomplete="current-password"
 				>
 				<button type="button" class="btn btn-secondary input-password-toggle">
 					<span class="icon-eye icon-fw" aria-hidden="true"></span>

--- a/plugins/system/stats/layouts/message.php
+++ b/plugins/system/stats/layouts/message.php
@@ -23,7 +23,8 @@ extract($displayData);
  */
 ?>
 
-<joomla-alert type="info" dismiss="true" class="js-pstats-alert hidden" role="alertdialog" aria-label="<?php echo Text::_('PLG_SYSTEM_STATS_LABEL_MESSAGE_TITLE'); ?>">
+<joomla-alert type="info" dismiss="true" class="js-pstats-alert hidden" role="alertdialog" aria-labelledby="alert-stats-heading">
+	<div id="alert-stats-heading" class="alert-heading"><?php echo Text::_('PLG_SYSTEM_STATS_LABEL_MESSAGE_TITLE'); ?></div>
 	<div class="alert-heading"><?php echo Text::_('PLG_SYSTEM_STATS_LABEL_MESSAGE_TITLE'); ?></div>
 	<div>
 		<div class="alert-message">

--- a/plugins/system/stats/layouts/message.php
+++ b/plugins/system/stats/layouts/message.php
@@ -25,7 +25,6 @@ extract($displayData);
 
 <joomla-alert type="info" dismiss="true" class="js-pstats-alert hidden" role="alertdialog" aria-labelledby="alert-stats-heading">
 	<div id="alert-stats-heading" class="alert-heading"><?php echo Text::_('PLG_SYSTEM_STATS_LABEL_MESSAGE_TITLE'); ?></div>
-	<div class="alert-heading"><?php echo Text::_('PLG_SYSTEM_STATS_LABEL_MESSAGE_TITLE'); ?></div>
 	<div>
 		<div class="alert-message">
 			<p>

--- a/plugins/system/stats/layouts/message.php
+++ b/plugins/system/stats/layouts/message.php
@@ -23,7 +23,7 @@ extract($displayData);
  */
 ?>
 
-<joomla-alert type="info" dismiss="true" class="js-pstats-alert hidden" role="alertdialog">
+<joomla-alert type="info" dismiss="true" class="js-pstats-alert hidden" role="alertdialog" aria-label="<?php echo Text::_('PLG_SYSTEM_STATS_LABEL_MESSAGE_TITLE'); ?>">
 	<div class="alert-heading"><?php echo Text::_('PLG_SYSTEM_STATS_LABEL_MESSAGE_TITLE'); ?></div>
 	<div>
 		<div class="alert-message">


### PR DESCRIPTION
For any container whose contents act as a dialog box (for example, a modal dialog asking the user to make a choice or respond to an action being taken), give it a descriptive label or name, so that assistive technology users can easily discover what its purpose is.

Testing Instructions : 
![Screenshot (269)](https://user-images.githubusercontent.com/49578630/121037379-091c3a00-c7cd-11eb-9d58-9b7d7512da4c.png)
 # Arrow Indicating Dialog box .

Improvement: Dialog was not accessible before. Whenever we are adding a dialog role we must provide an accessible name for a dialog, which can be done with the aria-label or aria-labelledby attribute.