### PR TITLE
[4.0] Hide save buttons when no download key field in Update Sites

### DIFF
--- a/administrator/components/com_installer/src/View/Updatesite/HtmlView.php
+++ b/administrator/components/com_installer/src/View/Updatesite/HtmlView.php
@@ -110,7 +110,7 @@ class HtmlView extends InstallerViewDefault
 		$toolbarButtons = [];
 
 		// Can't save the record if it's checked out and editable
-		if (!$checkedOut && $itemEditable)
+		if (!$checkedOut && $itemEditable && $this->form->getField('extra_query'))
 		{
 			$toolbarButtons[] = ['apply', 'updatesite.apply'];
 			$toolbarButtons[] = ['save', 'updatesite.save'];


### PR DESCRIPTION
### Summary of Changes
Only display the Save/Save & Close buttons when editing an Update Site that has the Download Key field, 

### Testing Instructions
Install this fake "paid download" extension [Null file](http://updates.myoldsite.com/file_null-1.0.zip). Thanks nikosdion for the file.

Apply PR.

Go to System > Update > Update Sites

Edit Null Files.
Save/Save & Close buttons available.

Edit Joomla! Core.
No Save/Save & Close buttons.

