### PR TITLE
[3.9] Custom Fields : missing value class rendering

### DIFF
--- a/components/com_fields/layouts/field/render.php
+++ b/components/com_fields/layouts/field/render.php
@@ -18,6 +18,7 @@ $label = JText::_($field->label);
 $value = $field->value;
 $showLabel = $field->params->get('showlabel');
 $labelClass = $field->params->get('label_render_class');
+$renderClass = $field->params->get('render_class');
 
 if ($value == '')
 {
@@ -28,4 +29,4 @@ if ($value == '')
 <?php if ($showLabel == 1) : ?>
 	<span class="field-label <?php echo $labelClass; ?>"><?php echo htmlentities($label, ENT_QUOTES | ENT_IGNORE, 'UTF-8'); ?>: </span>
 <?php endif; ?>
-<span class="field-value"><?php echo $value; ?></span>
+<span class="field-value <?php echo $renderClass; ?>"><?php echo $value; ?></span>


### PR DESCRIPTION
when displaying a custom field, render class parameter is missing.

### Testing Instructions

Add a render class in a custom field. 

![def](https://user-images.githubusercontent.com/19435246/120758985-c8919780-c512-11eb-8917-7e69a4fd4369.jpg)

### Actual result BEFORE applying this Pull Request

![before](https://user-images.githubusercontent.com/19435246/120759858-bfed9100-c513-11eb-9613-4c60a1e1d299.jpg)

### Expected result AFTER applying this Pull Request

![after](https://user-images.githubusercontent.com/19435246/120759740-9c2a4b00-c513-11eb-9baf-d86d0a5e098c.jpg)

