### PR TITLE
[4.0] Restore pagination padding with highlighted links

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -55,6 +55,10 @@ body {
       text-decoration: none !important;
       border: none;
     }
+
+    a.page-link {
+      padding: $pagination-padding-y $pagination-padding-x;
+    }
   }
 }
 


### PR DESCRIPTION
Pull Request for Issue #34363 .

### Summary of Changes
Changed padding for `page-link` when highlight links is active


### Testing Instructions
See issue
Run `npm ci` or `npm run build:css`


### Actual result BEFORE applying this Pull Request
Wrong padding
![grafik](https://user-images.githubusercontent.com/9153168/120780380-59bf3900-c528-11eb-8f83-9e584bdb6c73.png)



### Expected result AFTER applying this Pull Request
Padding is correct
![grafik](https://user-images.githubusercontent.com/9153168/120780343-4dd37700-c528-11eb-833e-569d970a30d6.png)



### Documentation Changes Required

