### PR TITLE
[4.0] capitalisation of styles

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-06-04.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-06-04.sql
@@ -4,5 +4,5 @@ UPDATE `#__template_styles`
  WHERE `title` = 'atum - Default';
 
 UPDATE `#__template_styles`
-   SET `title` = 'Cassopeia - Default'
+   SET `title` = 'Cassiopeia - Default'
  WHERE `title` = 'cassiopeia - Default';

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-06-04.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-06-04.sql
@@ -1,0 +1,8 @@
+-- after 4.0.0 RC1
+UPDATE `#__template_styles`
+   SET `title` = 'Atum - Default'
+ WHERE `title` = 'atum - Default';
+
+UPDATE `#__template_styles`
+   SET `title` = 'Cassopeia - Default'
+ WHERE `title` = 'cassiopeia - Default';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-06-04.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-06-04.sql
@@ -4,5 +4,5 @@ UPDATE "#__template_styles"
  WHERE "title" = 'atum - Default';
 
 UPDATE "#__template_styles"
-   SET "title" = 'Cassopeia - Default'
+   SET "title" = 'Cassiopeia - Default'
  WHERE "title" = 'cassiopeia - Default';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-06-04.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-06-04.sql
@@ -1,0 +1,8 @@
+-- after 4.0.0 RC1
+UPDATE "#__template_styles"
+   SET "title" = 'Atum - Default'
+ WHERE "title" = 'atum - Default';
+
+UPDATE "#__template_styles"
+   SET "title" = 'Cassopeia - Default'
+ WHERE "title" = 'cassiopeia - Default';

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -799,8 +799,8 @@ CREATE TABLE IF NOT EXISTS `#__template_styles` (
 --
 
 INSERT INTO `#__template_styles` (`id`, `template`, `client_id`, `home`, `title`, `inheritable`, `parent`, `params`) VALUES
-(10, 'atum', 1, '1', 'atum - Default', 0, '', '{"hue":"hsl(214, 63%, 20%)","bg-light":"#f0f4fb","text-dark":"#495057","text-light":"#ffffff","link-color":"#2a69b8","special-color":"#001b4c","monochrome":"0","loginLogo":"","loginLogoAlt":"","logoBrandLarge":"","logoBrandLargeAlt":"","logoBrandSmall":"","logoBrandSmallAlt":""}'),
-(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', 0, '', '{"brand":"1","logoFile":"","siteTitle":"","siteDescription":"","useFontScheme":"0","colorName":"colors_standard","fluidContainer":"0","stickyHeader":0,"backTop":0}');
+(10, 'atum', 1, '1', 'Atum - Default', 0, '', '{"hue":"hsl(214, 63%, 20%)","bg-light":"#f0f4fb","text-dark":"#495057","text-light":"#ffffff","link-color":"#2a69b8","special-color":"#001b4c","monochrome":"0","loginLogo":"","loginLogoAlt":"","logoBrandLarge":"","logoBrandLargeAlt":"","logoBrandSmall":"","logoBrandSmallAlt":""}'),
+(11, 'cassiopeia', 0, '1', 'Cassiopeia - Default', 0, '', '{"brand":"1","logoFile":"","siteTitle":"","siteDescription":"","useFontScheme":"0","colorName":"colors_standard","fluidContainer":"0","stickyHeader":0,"backTop":0}');
 
 -- --------------------------------------------------------
 

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -814,8 +814,8 @@ CREATE INDEX "#__template_styles_idx_client_id_home" ON "#__template_styles" ("c
 -- Dumping data for table `#__template_styles`
 --
 INSERT INTO "#__template_styles" ("id", "template", "client_id", "home", "title", "inheritable", "parent", "params") VALUES
-(10, 'atum', 1, '1', 'atum - Default', 0, '', '{"hue":"hsl(214, 63%, 20%)","bg-light":"#f0f4fb","text-dark":"#495057","text-light":"#ffffff","link-color":"#2a69b8","special-color":"#001b4c","monochrome":"0","loginLogo":"","loginLogoAlt":"","logoBrandLarge":"","logoBrandLargeAlt":"","logoBrandSmall":"","logoBrandSmallAlt":""}'),
-(11, 'cassiopeia', 0, '1', 'cassiopeia - Default', 0, '', '{"brand":"1","logoFile":"","siteTitle":"","siteDescription":"","useFontScheme":"0","colorName":"colors_standard","fluidContainer":"0","stickyHeader":0,"backTop":0}');
+(10, 'atum', 1, '1', 'Atum - Default', 0, '', '{"hue":"hsl(214, 63%, 20%)","bg-light":"#f0f4fb","text-dark":"#495057","text-light":"#ffffff","link-color":"#2a69b8","special-color":"#001b4c","monochrome":"0","loginLogo":"","loginLogoAlt":"","logoBrandLarge":"","logoBrandLargeAlt":"","logoBrandSmall":"","logoBrandSmallAlt":""}'),
+(11, 'cassiopeia', 0, '1', 'Cassiopeia - Default', 0, '', '{"brand":"1","logoFile":"","siteTitle":"","siteDescription":"","useFontScheme":"0","colorName":"colors_standard","fluidContainer":"0","stickyHeader":0,"backTop":0}');
 
 SELECT setval('#__template_styles_id_seq', 12, false);
 


### PR DESCRIPTION
Nothing major but it bugs me that the template styles are "atum - Default" and "cassiopeia - Default" with the template name being all lower case.

This PR will change that for new installations
`
@richard67  For upgrades from J3 do I edit `administrator\components\com_admin\sql\updates\mysql\4.0.0-2018-03-05.sql` or create a new sql file
