### PR TITLE
[4.0] remove com_admin scss

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_admin.scss
+++ b/administrator/templates/atum/scss/pages/_com_admin.scss
@@ -1,9 +1,0 @@
-// com_admin
-
-.sysinfo {
-  .table {
-    th {
-      font-weight: $font-weight-bold;
-    }
-  }
-}

--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -58,7 +58,6 @@
 
 // Also these DO NOT BELONG HERE!!!
 // Page specifics
-@import "pages/com_admin";
 @import "pages/com_config";
 @import "pages/com_content";
 @import "pages/com_cpanel";


### PR DESCRIPTION
When this css was added the table headers of the template were not bold. Since they are now we don't need this extra css file.

Note that th in the header is still font-weight: 700 but the th in the body will be 500 - this is consistent with all other tables now.

