### PR TITLE
[4.0] remove com_joomlaupdate scss

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_joomlaupdate.scss
+++ b/administrator/templates/atum/scss/pages/_com_joomlaupdate.scss
@@ -1,7 +1,0 @@
-// com_joomlaupdate
-
-.com_joomlaupdate {
-  caption {
-    caption-side: top;
-  }
-}

--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -63,7 +63,6 @@
 @import "pages/com_content";
 @import "pages/com_cpanel";
 @import "pages/com_finder";
-@import "pages/com_joomlaupdate";
 @import "pages/com_modules";
 @import "pages/com_tags";
 @import "pages/com_privacy";


### PR DESCRIPTION
This scss file only had one class and as the exact same class is already in BS5 (_tables.scss) there is no need for it
