### PR TITLE
[4.0] legend css

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -70,10 +70,6 @@ td .form-control {
   width: auto;
 }
 
-legend {
-  margin-bottom: 1.1rem;
-}
-
 .checkboxes {
   padding-top: 5px;
 


### PR DESCRIPTION
Remove rule from the override in atum blocks/_forms.scss as its identical to the rule in vendor/bootstrap/_forms.scss
