### PR TITLE
[4.0] missing string

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
@@ -42,7 +42,7 @@
           try {
             response = JSON.parse(resp);
           } catch (e) {
-            editor.windowManager.alert(Joomla.Text._('JERROR') + ": {e}");
+            editor.windowManager.alert(Joomla.Text._('ERROR') + ": {e}");
           }
 
           if (response.data && response.data.path) {

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -532,7 +532,7 @@ class PlgEditorTinymce extends CMSPlugin
 			}
 
 			Text::script('PLG_TINY_ERR_UNSUPPORTEDBROWSER');
-			Text::script('JERROR');
+			Text::script('ERROR');
 			Text::script('PLG_TINY_DND_ADDITIONALDATA');
 			Text::script('PLG_TINY_DND_ALTTEXT');
 			Text::script('PLG_TINY_DND_LAZYLOADED');


### PR DESCRIPTION
The drag and drop plugin for tinymce uses anon-existent language constant (JERROR)  it should be ERROR

To test enable the language debug in global configuration and navigate to any page that uses tinymce. In the list of untranslated strings you will see JERROR

Apply the PR and run npm ci
the error has gone
