### PR TITLE
[4.0] Dont try to translate missing label

### DIFF
--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1312,7 +1312,7 @@ abstract class FormField
 	{
 		// Label preprocess
 		$label = !empty($this->element['label']) ? (string) $this->element['label'] : null;
-		$label = !empty($this->translateLabel) ? Text::_($label) : $label;
+		$label = $label && $this->translateLabel ? Text::_($label) : $label;
 
 		// Description preprocess
 		$description = !empty($this->description) ? $this->description : null;

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1311,7 +1311,7 @@ abstract class FormField
 	protected function getLayoutData()
 	{
 		// Label preprocess
-		$label = $this->element['label'] ? (string) $this->element['label'] : (string) $this->element['name'];
+		$label = $this->element['label'] ? (string) $this->element['label'] : null;
 		$label = $this->translateLabel ? Text::_($label) : $label;
 
 		// Description preprocess

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1311,8 +1311,8 @@ abstract class FormField
 	protected function getLayoutData()
 	{
 		// Label preprocess
-		$label = $this->element['label'] ? (string) $this->element['label'] : null;
-		$label = $this->translateLabel ? Text::_($label) : $label;
+		$label = !empty($this->element['label']) ? (string) $this->element['label'] : null;
+		$label = !empty($this->translateLabel) ? Text::_($label) : $label;
 
 		// Description preprocess
 		$description = !empty($this->description) ? $this->description : null;


### PR DESCRIPTION
There are several fields that are hidden and they do not have a label. Before this PR Joomla would use the field name as a label in this instance and then try to run it through JTEXT to translate it.

However the label is never rendered for these hidden fields so it is a pointless exercise AND it results in the language debugger reporting a missing language string.

To test open a custom field (or create a new one) with language debug on
You will see in the debug that there is a missing translation (CONTEXT)
View the source of the page and you will see the field

`<input
	type="hidden"
	name="jform[context]"
	id="jform_context"
	value="com_users.user"
	>`

Apply this PR
the language debug doesnt report any missing translations and if you view the source for this input nothing has changed
