### PR TITLE
[4.0] plg installer non-existent string

### DIFF
--- a/plugins/installer/urlinstaller/tmpl/default.php
+++ b/plugins/installer/urlinstaller/tmpl/default.php
@@ -13,8 +13,6 @@ use Joomla\CMS\Language\Text;
 
 /** @var PlgInstallerUrlInstaller $this */
 
-Text::script('PLG_INSTALLER_URLINSTALLER_NO_URL');
-
 $this->app->getDocument()->getWebAssetManager()
 	->registerAndUseScript('plg_installer_urlinstaller.urlinstaller', 'plg_installer_urlinstaller/urlinstaller.js', [], ['defer' => true], ['core']);
 


### PR DESCRIPTION
A string is attempted to be loaded to be used in the javascript of the plg_installer_urlinstaller

The string does not exist in the language file
The string is not called in the javascript

This PR removes the reference to the string
