### PR TITLE
[4.0] download key tip

### DIFF
--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -101,12 +101,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										<?php if($item->isMissingDownloadKey): ?>
 										<?php HTMLHelper::_('bootstrap.popover', 'span.hasPopover', ['trigger' => 'hover focus']); ?>
 										<span class="badge bg-danger">
-											<span class="hasPopover"
-												  title="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL') ?>"
-												  data-bs-content="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_TIP') ?>"
-											>
-												<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?>
-												</span>
+											<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?>
 										</span>
 										<?php endif; ?>
 									</th>

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -103,7 +103,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 												<?php $url = 'index.php?option=com_installer&view=updatesite&layout=edit&update_site_id=' . $item->update_site_id; ?>
 											<?php } ?>
 											<span class="badge bg-danger">
-													<a href="<?php echo $url; ?>"><?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?></a>
+													<a class="text-decoration-none text-white" href="<?php echo $url; ?>"><?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?></a>
 											</span>
 										<?php endif; ?>
 									</th>

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -99,12 +99,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 											<?php endif; ?>
 										</div>
 										<?php if($item->isMissingDownloadKey): ?>
-											<?php { ?>
-												<?php $url = 'index.php?option=com_installer&view=updatesite&layout=edit&update_site_id=' . $item->update_site_id; ?>
-											<?php } ?>
-											<span class="badge bg-danger">
-													<a class="text-decoration-none text-white" href="<?php echo $url; ?>"><?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?></a>
-											</span>
+											<?php $url = 'index.php?option=com_installer&task=updatesite.edit&update_site_id=' . (int) $item->update_site_id; ?>
+											<a class="btn btn-danger btn-sm text-decoration-none" href="<?php echo $url; ?>"><?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?></a>
 										<?php endif; ?>
 									</th>
 									<td class="d-none d-md-table-cell">

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -100,8 +100,8 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										</div>
 										<?php if($item->isMissingDownloadKey): ?>
 											<?php $url = 'index.php?option=com_installer&task=updatesite.edit&update_site_id=' . (int) $item->update_site_id; ?>
-											<a class="btn btn-danger btn-sm text-decoration-none" href="<?php echo $url; ?>"><?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?></a>
-										<?php endif; ?>
+											<a class="btn btn-danger btn-sm text-decoration-none" href="<?php echo Route::_($url); ?>"><?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?></a>
+											<?php endif; ?>
 									</th>
 									<td class="d-none d-md-table-cell">
 										<?php echo $item->client_translated; ?>

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -99,7 +99,6 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 											<?php endif; ?>
 										</div>
 										<?php if($item->isMissingDownloadKey): ?>
-										<?php print_r($item); ?>
 											<?php { ?>
 												<?php $url = 'index.php?option=com_installer&view=updatesite&layout=edit&update_site_id=' . $item->update_site_id; ?>
 											<?php } ?>

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -99,10 +99,13 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 											<?php endif; ?>
 										</div>
 										<?php if($item->isMissingDownloadKey): ?>
-										<?php HTMLHelper::_('bootstrap.popover', 'span.hasPopover', ['trigger' => 'hover focus']); ?>
-										<span class="badge bg-danger">
-											<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?>
-										</span>
+										<?php print_r($item); ?>
+											<?php { ?>
+												<?php $url = 'index.php?option=com_installer&view=updatesite&layout=edit&update_site_id=' . $item->update_site_id; ?>
+											<?php } ?>
+											<span class="badge bg-danger">
+													<a href="<?php echo $url; ?>"><?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?></a>
+											</span>
 										<?php endif; ?>
 									</th>
 									<td class="d-none d-md-table-cell">

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -117,7 +117,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										<span class="badge bg-danger" tabindex="0">
 											<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?>
 										</span>
-										<div role="tooltip" id="tip<?php echo $i; ?>">
+										<div role="tooltip" id="tip-missing<?php echo $i; ?>">
 											<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_TIP'); ?>
 										</div>
 										<?php endif; ?>

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -114,14 +114,12 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 										</span>
 										<code><?php echo $item->downloadKey['value']; ?></code>
 										<?php elseif ($item->downloadKey['supported']) : ?>
-										<span class="badge bg-danger">
-											<span class="hasPopover"
-													title="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL') ?>"
-													data-bs-content="<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_TIP') ?>"
-											>
+										<span class="badge bg-danger" tabindex="0">
 											<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_LABEL'); ?>
-											</span>
 										</span>
+										<div role="tooltip" id="tip<?php echo $i; ?>">
+											<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_MISSING_TIP'); ?>
+										</div>
 										<?php endif; ?>
 									</span>
 								</th>


### PR DESCRIPTION
A tooltip is displayed for a missing download key that is not correct.

### Testing Instructions
Install this fake [ "paid download" ](http://updates.myoldsite.com/file_null-1.0.zip)extension Null file. Thanks @nikosdion for the file.

Go to System > Update > Extensions

Observe the alert and the tooltip

![image](https://user-images.githubusercontent.com/1296369/120894928-b4cd5a80-c612-11eb-92b8-8a13abac695d.png)

The tooltip should not be displayed here as its the tooltip for the update sites view and the instructions will not work on this page.

~This PR removes the tooltip from this page. I chose not to add a new tooltip with the correct information as it would just be a duplicate of the alert.~

Update
replaced the tooltip with a direct link to the extension update site page

Update 2
On the page Extensions: Update Sites the tooltip has been converted from a bootstrap tooltip
![image](https://user-images.githubusercontent.com/1296369/123240434-37418f80-d4d8-11eb-9adf-9ff2f69d0ffe.png)
