### PR TITLE
[4.0] Messaging : options missing string

### DIFF
--- a/administrator/language/en-GB/com_messages.ini
+++ b/administrator/language/en-GB/com_messages.ini
@@ -5,6 +5,7 @@
 
 COM_MESSAGES="Messaging"
 COM_MESSAGES_ADD="New Private Message"
+COM_MESSAGES_CONFIGURATION="Messages: Options"
 COM_MESSAGES_CONFIG_FORM="My Settings"
 COM_MESSAGES_CONFIG_SAVED="Configuration saved."
 COM_MESSAGES_EMPTYSTATE_BUTTON_ADD="Send a message"


### PR DESCRIPTION
Go to the options for the messaging component and you will see the title is missing

![image](https://user-images.githubusercontent.com/1296369/120895396-ada74c00-c614-11eb-8271-34021e2b94ae.png)
