### PR TITLE
[4.0] Home icon on dashboard

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -110,9 +110,6 @@
 
   .card-body {
     padding: 0;
-    overflow: hidden;
-    border-bottom-right-radius: $border-radius;
-    border-bottom-left-radius: $border-radius;
   }
 
   .module-actions {
@@ -196,17 +193,19 @@
     }
   }
 
-  .list-group-item a > span.home-image {
+  .list-group-item span.home-image {
     &[class^="#{$jicon-css-prefix}-"],
     &[class*=" #{$jicon-css-prefix}-"],
     &[class^="#{$fa-css-prefix}-"],
     &[class*=" #{$fa-css-prefix}-"] {
       display: inline-block;
       padding: 0;
+      margin: 0 .85rem;
       font-size: .9rem;
       color: rgba(1, 1, 1, 1);
       background: var(--white-offset);
       box-shadow: none;
+      transform: scale(1.2);
     }
   }
 

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -110,6 +110,9 @@
 
   .card-body {
     padding: 0;
+    overflow: hidden;
+    border-bottom-right-radius: $border-radius;
+    border-bottom-left-radius: $border-radius;
   }
 
   .module-actions {


### PR DESCRIPTION
In the menu-sideboard the space between text and home-symbol is different to the menu-dashboard:

![image](https://user-images.githubusercontent.com/1296369/120916570-489a3780-c6a2-11eb-9163-9b4203ae09fd.png)

Pull request for #34427 