### PR TITLE
[4.0] Reinitialise the installer's cached extensions table's properties after a core update.

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -91,6 +91,9 @@ class JoomlaInstallerScript
 			// Informational log only
 		}
 
+		// Reinitialise the installer's extensions table's properties.
+		$installer->extension->getFields(true);
+
 		// Ensure we delete the repeatable fields plugin before we remove its files
 		$this->uninstallRepeatableFieldsPlugin();
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -91,9 +91,6 @@ class JoomlaInstallerScript
 			// Informational log only
 		}
 
-		// Reinitialise the installer's extensions table's properties.
-		$installer->extension->getFields(true);
-
 		// Ensure we delete the repeatable fields plugin before we remove its files
 		$this->uninstallRepeatableFieldsPlugin();
 

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -715,6 +715,9 @@ ENDDATA;
 			return false;
 		}
 
+		// Reinitialise the installer's extensions table's properties.
+		$installer->extension->getFields(true);
+
 		// Start Joomla! 1.6.
 		ob_start();
 		ob_implicit_flush(false);


### PR DESCRIPTION
Pull Request for Issue #34362 .

### Summary of Changes

At the end of a core update, especially to a new major version, it may happen that there are structural changes on columns of the extensions table applied by the update SQL scripts, e.g. like real NULL values and no default value for the `checked_out_time` column.

But the installer object still uses old, cached information about these columns even if you create a new installer object, and so uses the old default values for such columns when loading the extensions table in its constructor.

When after running the update SQL scripts the manifest cache of all core extensions is updated, this results in the old default values being written for columns like e.g. the `checked_out_time` column, where the old zero date '0000-00-00 00:00:00' on MySQL and MariaDB or '1970-01-01 00:00:00' on PostgreSQL are used when storing the table.

This result in issue #34362 .

This pull request (PR) fixes that by calling the `getFields` method of the installer's extensions table object with the `$reload` parameter set to `true` just after the schema updates have run, so the table columns properties are read again from database with the new table structure.

That `getFields` is the one of the parent class here: https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/src/Table/Table.php#L242

### Testing Instructions

1. Update a clean 3.10 Alpha 6 or latest 3.10- nightly or a current 3.10-dev branch to 4.0 RC 1 or latest 4.0 nightly.

2. After the update has finished, go to "System -> Maintenance -> Global Check-in".
Result: See section "Actual result BEFORE applying this Pull Request" below.

3. Update a clean 3.10 Alpha 6 or latest 3.10- nightly or a current 3.10-dev branch to the patched package built buy drone for this PR using either the custom update URL or the zip package.

4. After the update has finished, go to "System -> Maintenance -> Global Check-in".
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

A lot of items (215 on a clean and empty installation) are shown to be checked it for the the `#___extensions` table.

In fact these are all records of that table.

If you go to "System -> Manage -> Extensions", everything looks ok, nothing is checked out.

If you check in database you will see that the `checked_out` column is zero for all extensions, but the `checked_out_time` column doesn't have value NULL but has the old style (peudo) null dates ('0000-00-00 00:00:00' on MySQL or MariaDB and '1970-01-01 00:00:00' on PostgreSQL databases).

Checking in the items in Global Check-In works, i.e. after that they are not shown as checked out anymore.

### Expected result AFTER applying this Pull Request

Nothing to be checked in which was not to be checked in before the update (which should be nothing when updating from a clean 3.10).

### Documentation Changes Required

None.