### PR TITLE
[4.0] double translate extension name

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_preupdatecheck.php
@@ -226,7 +226,7 @@ $compatibilityTypes = array(
 							<?php foreach ($this->nonCoreExtensions as $extension) : ?>
 								<tr>
 									<td class="exname col-md-8">
-										<?php echo Text::_($extension->name); ?>
+										<?php echo $extension->name; ?>
 									</td>
 									<td class="extype col-md-4">
 										<?php echo Text::_('COM_INSTALLER_TYPE_' . strtoupper($extension->type)); ?>


### PR DESCRIPTION
In the pre-update check list of installed components it is being translated twice which obviously will not work.

This PR removes the second pass through JText

The first instance is in the model

Either code review or install some extensions and enable language debug and go to the pre-update check and you will see either
**??extension name??**
or
????extension name????

After this PR it will be
**extension name**
or
??extension name??
