### PR TITLE
[4.0] admin module descriptions

### DIFF
--- a/administrator/language/en-GB/mod_messages.ini
+++ b/administrator/language/en-GB/mod_messages.ini
@@ -5,4 +5,4 @@
 
 MOD_MESSAGES="Messages"
 MOD_MESSAGES_PRIVATE_MESSAGES="Private Messages"
-MOD_MESSAGES_XML_DESCRIPTION="This module shows the count of private messages and is intended to be displayed in the 'status' position."
+MOD_MESSAGES_XML_DESCRIPTION="This module shows the count of private messages and is intended to be displayed in the 'status' position. It is only displayed when there are messages to read."

--- a/administrator/language/en-GB/mod_messages.sys.ini
+++ b/administrator/language/en-GB/mod_messages.sys.ini
@@ -5,4 +5,4 @@
 
 MOD_MESSAGES="Messages"
 MOD_MESSAGES_LAYOUT_DEFAULT="Default"
-MOD_MESSAGES_XML_DESCRIPTION="This module shows the count of private messages and is intended to be displayed in the 'status' position."
+MOD_MESSAGES_XML_DESCRIPTION="This module shows the count of private messages and is intended to be displayed in the 'status' position. It is only displayed when there are messages to read."

--- a/administrator/language/en-GB/mod_post_installation_messages.ini
+++ b/administrator/language/en-GB/mod_post_installation_messages.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 MOD_POST_INSTALLATION_MESSAGES="Post Installation Messages"
-MOD_POST_INSTALLATION_MESSAGES_XML_DESCRIPTION="This module shows a counter and a link to the latest post installation messages."
+MOD_POST_INSTALLATION_MESSAGES_XML_DESCRIPTION="This module shows a counter and a link to the latest post installation messages. It is only displayed when there are messages to read."

--- a/administrator/language/en-GB/mod_post_installation_messages.sys.ini
+++ b/administrator/language/en-GB/mod_post_installation_messages.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 MOD_POST_INSTALLATION_MESSAGES="Post Installation Messages"
-MOD_POST_INSTALLATION_MESSAGES_XML_DESCRIPTION="This module shows a counter and a link to the latest post installation messages."
+MOD_POST_INSTALLATION_MESSAGES_XML_DESCRIPTION="This module shows a counter and a link to the latest post installation messages. It is only displayed when there are messages to read."


### PR DESCRIPTION
As the private messages and post-install messages modules are not displayed (even if published) unless there are messages to read this could confuse some users so the description of the modules is updated for clarity
