### PR TITLE
[4.0] Multilingual sample data cleanup

### DIFF
--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -57,16 +57,7 @@ class PlgSampledataMultilang extends CMSPlugin
 	 * @since   4.0.0
 	 */
 	protected $autoloadLanguage = true;
-
-	/**
-	 * Holds the menuitem model
-	 *
-	 * @var     MenusModelItem
-	 *
-	 * @since   4.0.0
-	 */
-	private $menuItemModel;
-
+	
 	/**
 	 * @var     string language path
 	 *
@@ -75,7 +66,7 @@ class PlgSampledataMultilang extends CMSPlugin
 	protected $path = null;
 
 	/**
-	 * @var    Admin Id, author of all generated content.
+	 * @var    integer Id, author of all generated content.
 	 *
 	 * @since   4.0.0
 	 */
@@ -84,13 +75,13 @@ class PlgSampledataMultilang extends CMSPlugin
 	/**
 	 * Get an overview of the proposed sampledata.
 	 *
-	 * @return  boolean  True on success.
+	 * @return  stdClass|void  Will be converted into the JSON response to the module.
 	 *
 	 * @since   4.0.0
 	 */
 	public function onSampledataGetOverview()
 	{
-		if (!Factory::getUser()->authorise('core.create', 'com_content'))
+		if (!$this->app->getIdentity()->authorise('core.create', 'com_content'))
 		{
 			return;
 		}
@@ -135,7 +126,7 @@ class PlgSampledataMultilang extends CMSPlugin
 			$response            = array();
 			$response['success'] = false;
 
-			$lang = Factory::getLanguage()->getTag();
+			$lang = $this->app->getLanguage();
 			$lang->load('plg_system_languagefilter', JPATH_ADMINISTRATOR);
 			$message = $lang->_('PLG_SYSTEM_LANGUAGEFILTER');
 
@@ -144,9 +135,9 @@ class PlgSampledataMultilang extends CMSPlugin
 			return $response;
 		}
 
-		$response          = new stdClass;
-		$response->success = true;
-		$response->message = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP1_SUCCESS');
+		$response            = [];
+		$response['success'] = true;
+		$response['message'] = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP1_SUCCESS');
 
 		return $response;
 	}
@@ -165,7 +156,7 @@ class PlgSampledataMultilang extends CMSPlugin
 			return;
 		}
 
-		if (!ComponentHelper::isEnabled('com_modules') || !Factory::getUser()->authorise('core.create', 'com_modules'))
+		if (!ComponentHelper::isEnabled('com_modules') || !$this->app->getIdentity()->authorise('core.create', 'com_modules'))
 		{
 			$response            = array();
 			$response['success'] = true;
@@ -179,7 +170,7 @@ class PlgSampledataMultilang extends CMSPlugin
 			$response            = array();
 			$response['success'] = false;
 
-			$lang = Factory::getLanguage()->getTag();
+			$lang = $this->app->getLanguage();
 			$lang->load('mod_languages', JPATH_SITE);
 			$message = $lang->_('MOD_LANGUAGES');
 
@@ -188,9 +179,9 @@ class PlgSampledataMultilang extends CMSPlugin
 			return $response;
 		}
 
-		$response          = new stdClass;
-		$response->success = true;
-		$response->message = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP2_SUCCESS');
+		$response            = [];
+		$response['success'] = true;
+		$response['message'] = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP2_SUCCESS');
 
 		return $response;
 	}
@@ -227,9 +218,9 @@ class PlgSampledataMultilang extends CMSPlugin
 			return $response;
 		}
 
-		$response          = new stdClass;
-		$response->success = true;
-		$response->message = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP3_SUCCESS');
+		$response            = [];
+		$response['success'] = true;
+		$response['message'] = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP3_SUCCESS');
 
 		return $response;
 	}
@@ -248,7 +239,7 @@ class PlgSampledataMultilang extends CMSPlugin
 			return;
 		}
 
-		if (!ComponentHelper::isEnabled('com_menus') || !Factory::getUser()->authorise('core.create', 'com_menus'))
+		if (!ComponentHelper::isEnabled('com_menus') || !$this->app->getIdentity()->authorise('core.create', 'com_menus'))
 		{
 			$response            = array();
 			$response['success'] = true;
@@ -291,9 +282,9 @@ class PlgSampledataMultilang extends CMSPlugin
 			return $response;
 		}
 
-		$response          = new stdClass;
-		$response->success = true;
-		$response->message = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP4_SUCCESS');
+		$response            = [];
+		$response['success'] = true;
+		$response['message'] = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP4_SUCCESS');
 
 		return $response;
 	}
@@ -312,7 +303,7 @@ class PlgSampledataMultilang extends CMSPlugin
 			return;
 		}
 
-		if (!ComponentHelper::isEnabled('com_modules') || !Factory::getUser()->authorise('core.create', 'com_modules'))
+		if (!ComponentHelper::isEnabled('com_modules') || !$this->app->getIdentity()->authorise('core.create', 'com_modules'))
 		{
 			$response            = array();
 			$response['success'] = true;
@@ -335,9 +326,9 @@ class PlgSampledataMultilang extends CMSPlugin
 			}
 		}
 
-		$response          = new stdClass;
-		$response->success = true;
-		$response->message = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP5_SUCCESS');
+		$response            = [];
+		$response['success'] = true;
+		$response['message'] = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP5_SUCCESS');
 
 		return $response;
 	}
@@ -356,7 +347,7 @@ class PlgSampledataMultilang extends CMSPlugin
 			return;
 		}
 
-		if (!ComponentHelper::isEnabled('com_content') || !Factory::getUser()->authorise('core.create', 'com_content'))
+		if (!ComponentHelper::isEnabled('com_content') || !$this->app->getIdentity()->authorise('core.create', 'com_content'))
 		{
 			$response            = array();
 			$response['success'] = true;
@@ -365,7 +356,7 @@ class PlgSampledataMultilang extends CMSPlugin
 			return $response;
 		}
 
-		if (!ComponentHelper::isEnabled('com_categories') || !Factory::getUser()->authorise('core.create', 'com_content.category'))
+		if (!ComponentHelper::isEnabled('com_categories') || !$this->app->getIdentity()->authorise('core.create', 'com_content.category'))
 		{
 			$response            = array();
 			$response['success'] = true;
@@ -423,9 +414,9 @@ class PlgSampledataMultilang extends CMSPlugin
 			return $response;
 		}
 
-		$response          = new stdClass;
-		$response->success = true;
-		$response->message = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP6_SUCCESS');
+		$response            = [];
+		$response['success'] = true;
+		$response['message'] = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP6_SUCCESS');
 
 		return $response;
 	}
@@ -462,9 +453,9 @@ class PlgSampledataMultilang extends CMSPlugin
 			return $response;
 		}
 
-		$response          = new stdClass;
-		$response->success = true;
-		$response->message = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP7_SUCCESS');
+		$response            = [];
+		$response['success'] = true;
+		$response['message'] = Text::_('PLG_SAMPLEDATA_MULTILANG_STEP7_SUCCESS');
 
 		return $response;
 	}
@@ -472,7 +463,7 @@ class PlgSampledataMultilang extends CMSPlugin
 	/**
 	 * Final step to show completion of sampledata.
 	 *
-	 * @return  array or void  Will be converted into the JSON response to the module.
+	 * @return  array|void  Will be converted into the JSON response to the module.
 	 *
 	 * @since  4.0.0
 	 */

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -57,7 +57,7 @@ class PlgSampledataMultilang extends CMSPlugin
 	 * @since   4.0.0
 	 */
 	protected $autoloadLanguage = true;
-	
+
 	/**
 	 * @var     string language path
 	 *


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR makes some cleanup to Multilingual Sample Data plugin:

1. Remove un-used class property
2. Correct return data type of some methods in docblock
3. Unify return data type of some method to array. In some methods, we return both `array` and `stdClass`, it works because at the end, the return data will be json encoded, but we should choose to use one type only.
4. Replace deprecated method class:
- `Factory::getLanguage()` with `$this->app->getLanguage()`
- `Factory::getUser()` with `$this->app->getIdentity()`
5. Fixes potential fatal error

We have code `$lang = Factory::getLanguage()->getTag();`, then `$lang->load` and it will cause fatal error (because the $lang is a string, not object). This PR fixes this error, too

### Testing Instructions
1. Code review
2. Or install latest Joomla 4.0-dev, then install Multilingual Sample Data and make sure sample data is still being installed properly.