### PR TITLE
[4.0] Cleanup Blog Sample Data Plugin

### DIFF
--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -785,7 +785,7 @@ class PlgSampledataBlog extends CMSPlugin
 				if (!empty($article['authorValue']))
 				{
 					// Store a field value
-					
+
 					$valueAuthor = (object) [
 						'item_id'  => $articleModel->getItem()->id,
 						'field_id' => $fieldIds[0],

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -67,13 +67,13 @@ class PlgSampledataBlog extends CMSPlugin
 	/**
 	 * Get an overview of the proposed sampledata.
 	 *
-	 * @return  boolean  True on success.
+	 * @return  stdClass|void  Will be converted into the JSON response to the module.
 	 *
 	 * @since  3.8.0
 	 */
 	public function onSampledataGetOverview()
 	{
-		if (!Factory::getUser()->authorise('core.create', 'com_content'))
+		if (!$this->app->getIdentity()->authorise('core.create', 'com_content'))
 		{
 			return;
 		}
@@ -91,7 +91,7 @@ class PlgSampledataBlog extends CMSPlugin
 	/**
 	 * First step to enter the sampledata. Content.
 	 *
-	 * @return  array or void  Will be converted into the JSON response to the module.
+	 * @return  array|void  Will be converted into the JSON response to the module.
 	 *
 	 * @since  3.8.0
 	 */
@@ -113,14 +113,15 @@ class PlgSampledataBlog extends CMSPlugin
 
 		// Get some metadata.
 		$access = (int) $this->app->get('access', 1);
-		$user   = Factory::getUser();
+		$user   = $this->app->getIdentity();
 
 		// Detect language to be used.
-		$language   = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : '*';
+		$language   = Multilanguage::isEnabled() ? $this->app->getLanguage()->getTag() : '*';
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
 		/** @var \Joomla\Component\Tags\Administrator\Model\TagModel $model */
-		$modelTag = $this->app->bootComponent('com_tags')->getMVCFactory()->createModel('Tag', 'Administrator', ['ignore_request' => true]);
+		$modelTag = $this->app->bootComponent('com_tags')->getMVCFactory()
+			->createModel('Tag', 'Administrator', ['ignore_request' => true]);
 
 		$tagIds = array();
 
@@ -146,7 +147,7 @@ class PlgSampledataBlog extends CMSPlugin
 			{
 				if (!$modelTag->save($tag))
 				{
-					Factory::getLanguage()->load('com_tags');
+					$this->app->getLanguage()->load('com_tags');
 					throw new Exception(Text::_($modelTag->getError()));
 				}
 			}
@@ -162,7 +163,7 @@ class PlgSampledataBlog extends CMSPlugin
 			$tagIds[] = $modelTag->getItem()->id;
 		}
 
-		if (!ComponentHelper::isEnabled('com_content') || !Factory::getUser()->authorise('core.create', 'com_content'))
+		if (!ComponentHelper::isEnabled('com_content') || !$this->app->getIdentity()->authorise('core.create', 'com_content'))
 		{
 			$response            = array();
 			$response['success'] = true;
@@ -173,7 +174,7 @@ class PlgSampledataBlog extends CMSPlugin
 
 		if (ComponentHelper::isEnabled('com_fields') && $user->authorise('core.create', 'com_fields'))
 		{
-			Factory::getLanguage()->load('com_fields');
+			$this->app->getLanguage()->load('com_fields');
 
 			$mvcFactory = $this->app->bootComponent('com_fields')->getMVCFactory();
 
@@ -283,7 +284,7 @@ class PlgSampledataBlog extends CMSPlugin
 			}
 		}
 
-		if (ComponentHelper::isEnabled('com_workflow') && Factory::getUser()->authorise('core.create', 'com_workflow'))
+		if (ComponentHelper::isEnabled('com_workflow') && $this->app->getIdentity()->authorise('core.create', 'com_workflow'))
 		{
 			$this->app->bootComponent('com_workflow');
 
@@ -531,7 +532,7 @@ class PlgSampledataBlog extends CMSPlugin
 			{
 				if (!$categoryModel->save($category))
 				{
-					Factory::getLanguage()->load('com_categories');
+					$this->app->getLanguage()->load('com_categories');
 					throw new Exception($categoryModel->getError());
 				}
 			}
@@ -779,13 +780,12 @@ class PlgSampledataBlog extends CMSPlugin
 			}
 
 			// Add a value to the custom field if a value is given
-			if (ComponentHelper::isEnabled('com_fields') && Factory::getUser()->authorise('core.create', 'com_fields'))
+			if (ComponentHelper::isEnabled('com_fields') && $this->app->getIdentity()->authorise('core.create', 'com_fields'))
 			{
 				if (!empty($article['authorValue']))
 				{
 					// Store a field value
-					$query = $this->db->getQuery(true);
-
+					
 					$valueAuthor = (object) [
 						'item_id'  => $articleModel->getItem()->id,
 						'field_id' => $fieldIds[0],
@@ -800,9 +800,9 @@ class PlgSampledataBlog extends CMSPlugin
 		$this->app->setUserState('sampledata.blog.articles', $ids);
 		$this->app->setUserState('sampledata.blog.articles.catIds', $catIds);
 
-		$response          = new stdClass;
-		$response->success = true;
-		$response->message = Text::_('PLG_SAMPLEDATA_BLOG_STEP1_SUCCESS');
+		$response            = [];
+		$response['success'] = true;
+		$response['message'] = Text::_('PLG_SAMPLEDATA_BLOG_STEP1_SUCCESS');
 
 		return $response;
 	}
@@ -810,7 +810,7 @@ class PlgSampledataBlog extends CMSPlugin
 	/**
 	 * Second step to enter the sampledata. Menus.
 	 *
-	 * @return  array or void  Will be converted into the JSON response to the module.
+	 * @return  array|void  Will be converted into the JSON response to the module.
 	 *
 	 * @since  3.8.0
 	 */
@@ -821,7 +821,7 @@ class PlgSampledataBlog extends CMSPlugin
 			return;
 		}
 
-		if (!ComponentHelper::isEnabled('com_menus') || !Factory::getUser()->authorise('core.create', 'com_menus'))
+		if (!ComponentHelper::isEnabled('com_menus') || !$this->app->getIdentity()->authorise('core.create', 'com_menus'))
 		{
 			$response            = array();
 			$response['success'] = true;
@@ -831,7 +831,7 @@ class PlgSampledataBlog extends CMSPlugin
 		}
 
 		// Detect language to be used.
-		$language   = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : '*';
+		$language   = Multilanguage::isEnabled() ? $this->app->getLanguage()->getTag() : '*';
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
 		// Create the menu types.
@@ -858,7 +858,7 @@ class PlgSampledataBlog extends CMSPlugin
 
 				if (!$menuTable->check())
 				{
-					Factory::getLanguage()->load('com_menu');
+					$this->app->getLanguage()->load('com_menu');
 					throw new Exception($menuTable->getError());
 				}
 
@@ -1378,25 +1378,20 @@ class PlgSampledataBlog extends CMSPlugin
 	/**
 	 * Third step to enter the sampledata. Modules.
 	 *
-	 * @return  array or void  Will be converted into the JSON response to the module.
+	 * @return  array|void  Will be converted into the JSON response to the module.
 	 *
 	 * @since  3.8.0
 	 */
 	public function onAjaxSampledataApplyStep3()
 	{
-		$app = Factory::getApplication();
-
-		// Get previously entered categories ids
-		$catIds = $this->app->getUserState('sampledata.blog.articles.catIds');
-
 		if (!Session::checkToken('get') || $this->app->input->get('type') != $this->_name)
 		{
 			return;
 		}
 
-		Factory::getLanguage()->load('com_modules');
+		$this->app->getLanguage()->load('com_modules');
 
-		if (!ComponentHelper::isEnabled('com_modules') || !Factory::getUser()->authorise('core.create', 'com_modules'))
+		if (!ComponentHelper::isEnabled('com_modules') || !$this->app->getIdentity()->authorise('core.create', 'com_modules'))
 		{
 			$response            = array();
 			$response['success'] = true;
@@ -1406,7 +1401,7 @@ class PlgSampledataBlog extends CMSPlugin
 		}
 
 		// Detect language to be used.
-		$language   = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : '*';
+		$language   = Multilanguage::isEnabled() ? $this->app->getLanguage()->getTag() : '*';
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
 		// Add Include Paths.
@@ -1421,6 +1416,7 @@ class PlgSampledataBlog extends CMSPlugin
 		// Get previously entered Data from UserStates
 		$menuTypes = $this->app->getUserState('sampledata.blog.menutypes');
 
+		// Get previously entered categories ids
 		$catIds = $this->app->getUserState('sampledata.blog.articles.catIds');
 
 		// Link to article "typography" in banner module
@@ -1735,7 +1731,7 @@ class PlgSampledataBlog extends CMSPlugin
 
 		if (!isset($home))
 		{
-			$home = $app->getMenu('site')->getDefault()->id;
+			$home = $this->app->getMenu('site')->getDefault()->id;
 		}
 
 		foreach ($modules as $module)
@@ -1835,7 +1831,7 @@ class PlgSampledataBlog extends CMSPlugin
 	/**
 	 * Final step to show completion of sampledata.
 	 *
-	 * @return  array or void  Will be converted into the JSON response to the module.
+	 * @return  array|void  Will be converted into the JSON response to the module.
 	 *
 	 * @since  4.0.0
 	 */
@@ -1868,11 +1864,10 @@ class PlgSampledataBlog extends CMSPlugin
 	{
 		$itemIds = array();
 		$access  = (int) $this->app->get('access', 1);
-		$user    = Factory::getUser();
-		$app     = Factory::getApplication();
+		$user    = $this->app->getIdentity();
 
 		// Detect language to be used.
-		$language   = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : '*';
+		$language   = Multilanguage::isEnabled() ? $this->app->getLanguage()->getTag() : '*';
 		$langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
 		foreach ($menuItems as $menuItem)
@@ -1888,9 +1883,9 @@ class PlgSampledataBlog extends CMSPlugin
 			// Set unicodeslugs if alias is empty
 			if (trim(str_replace('-', '', $menuItem['alias']) == ''))
 			{
-				$unicode = $app->set('unicodeslugs', 1);
+				$unicode = $this->app->set('unicodeslugs', 1);
 				$menuItem['alias'] = ApplicationHelper::stringURLSafe($menuItem['title']);
-				$app->set('unicodeslugs', $unicode);
+				$this->app->set('unicodeslugs', $unicode);
 			}
 
 			// Append language suffix to title.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR makes some cleanup to Blog Sample Data plugin:

1. Correct return data type of some methods in docblock
3. Unify return data type of some method to array. In some methods, we return both `array` and `stdClass`, it works because at the end, the return data will be json encoded, but we should choose to use one type only.
4. Replace deprecated method class:
- `Factory::getLanguage()` with `$this->app->getLanguage()`
- `Factory::getUser()` with `$this->app->getIdentity()`
- Replace $app = Factory::getApplication(); with injected $this->app

### Testing Instructions
1. Code review
2. Or install latest Joomla 4.0-dev, then install Blog Sample Data and make sure sample data is still being installed properly.