### PR TITLE
[4.0] Active sidebar (menu collapsing)

### DIFF
--- a/build/media_source/mod_menu/js/admin-menu.es6.js
+++ b/build/media_source/mod_menu/js/admin-menu.es6.js
@@ -74,7 +74,7 @@ if (sidebar && !sidebar.getAttribute('data-hidden')) {
 
   // Set active class
   allLinks.forEach((link) => {
-    if (currentUrl === link.href) {
+    if (currentUrl.indexOf(link.href) === 0) {
       link.setAttribute('aria-current', 'page');
       link.classList.add('mm-active');
 


### PR DESCRIPTION
PR for #33590
**This does not fix all the issues but it fixes the majority**

For an analysis of why the sidebar is not always open and the active item not selected see #34067

To test
First make sure that you can replicate the problem by replicating the first few issues reported at #33590

Now apply the pr and rebuild the js
Now try to replicate the issues reported at #33590

This PR does NOT fix the links from a category which is a different issue
(I know what is needed to fix it I just dont know how to get the $default_view for a component when I am in com_categories)

This PR does NOT fix the context links for com_fields which is a different issue
( look at the url when you change the dropdown)