### PR TITLE
ARIA IDs are not unique when there are multiple menu's active

### DIFF
--- a/modules/mod_menu/tmpl/collapse-default.php
+++ b/modules/mod_menu/tmpl/collapse-default.php
@@ -16,10 +16,10 @@ HTMLHelper::_('bootstrap.collapse');
 ?>
 
 <nav class="navbar navbar-expand-md">
-	<button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="<?php echo Text::_('MOD_MENU_TOGGLE'); ?>">
+	<button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbar<?php echo $module->id; ?>" aria-controls="navbar<?php echo $module->id; ?>" aria-expanded="false" aria-label="<?php echo Text::_('MOD_MENU_TOGGLE'); ?>">
 		<span class="icon-menu" aria-hidden="true"></span>
 	</button>
-	<div class="collapse navbar-collapse" id="navbar">
+	<div class="collapse navbar-collapse" id="navbar<?php echo $module->id; ?>">
 		<?php require __DIR__ . '/default.php'; ?>
 	</div>
 </nav>

--- a/templates/cassiopeia/html/mod_menu/collapse-metismenu.php
+++ b/templates/cassiopeia/html/mod_menu/collapse-metismenu.php
@@ -16,10 +16,10 @@ HTMLHelper::_('bootstrap.collapse');
 ?>
 
 <nav class="navbar navbar-expand-md">
-	<button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="<?php echo Text::_('MOD_MENU_TOGGLE'); ?>">
+	<button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbar<?php echo $module->id; ?>" aria-controls="navbar<?php echo $module->id; ?>" aria-expanded="false" aria-label="<?php echo Text::_('MOD_MENU_TOGGLE'); ?>">
 		<span class="icon-menu" aria-hidden="true"></span>
 	</button>
-	<div class="collapse navbar-collapse" id="navbar">
+	<div class="collapse navbar-collapse" id="navbar<?php echo $module->id; ?>">
 		<?php require __DIR__ . '/dropdown-metismenu.php'; ?>
 	</div>
 </nav>


### PR DESCRIPTION
### Summary of Changes
When there are mut
The mod_menu layout collapse-default.php and the mod_menu collapse-metismenu.php layout override in the Cassiopeia all share the same ID (#navbar). When there are multiple menu's with these layouts, then this will result in accessibility problems because every menu must have an unique ID. Also for lot of other reasons it's not advisable to have multiple elements with the same ID in a website.

### Testing Instructions
1. Go to the modules and copy the Main Menu Module two times. Put one of them in the position "menu" and leave the other in the position "sidebar-right".
2. The two modules in the position "sidebar-right" must have the Layout set to: Collapsible Default Menu
3. The module in position "menu" must have the Layout set to: Collapsible Dropdown
4. Activate the menu modules.
5. Look at the code to verify that the modules with there layouts, all have the same ID.

### Actual result BEFORE applying this Pull Request
![Image-001](https://user-images.githubusercontent.com/5610413/121271737-9b533980-c8c4-11eb-8aca-d5aa2e708546.jpg)

### Expected result AFTER applying this Pull Request
![Image-002](https://user-images.githubusercontent.com/5610413/121271761-ab6b1900-c8c4-11eb-89ca-d1af99b28442.jpg)

### Documentation Changes Required
No
