### PR TITLE
[4.0] Change order of fields and add description in content global options

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -743,6 +743,14 @@
 		/>
 
 		<field
+			name="blog_class"
+			type="text"
+			label="JGLOBAL_BLOG_CLASS"
+			description="JGLOBAL_BLOG_CLASS_NOTE_DESC"
+			validate="CssIdentifier"
+		/>
+
+		<field
 			name="num_columns"
 			type="number"
 			label="JGLOBAL_NUM_COLUMNS_LABEL"
@@ -760,13 +768,6 @@
 			<option value="0">JGLOBAL_BLOG_DOWN_OPTION</option>
 			<option value="1">JGLOBAL_BLOG_ACROSS_OPTION</option>
 		</field>
-
-		<field
-			name="blog_class"
-			type="text"
-			label="JGLOBAL_BLOG_CLASS"
-			validate="CssIdentifier"
-		/>
 
 		<field
 			name="num_links"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Changed the order of the fields in content global config to match the order of the fields in menu. Added description for article class field.


### Testing Instructions
Go to Content > Options > Blog/Featured Layouts
(compare with the layout of a menu of type `Category Blog`)

### Actual result BEFORE applying this Pull Request
The field `Article Class` is after the columns fields, no description

![Screenshot 2021-06-09 at 08-38-27 Articles Options - Joomla 4 RC - Administration](https://user-images.githubusercontent.com/9153168/121306405-16394600-c8ff-11eb-8261-c090a410a993.png)


### Expected result AFTER applying this Pull Request
The field `Article Class` is directly after `# Articles` and has a description 

![Screenshot 2021-06-09 at 08-39-09 Articles Options - Joomla 4 RC - Administration](https://user-images.githubusercontent.com/9153168/121306423-1afdfa00-c8ff-11eb-98c8-222b4906dc0d.png)


### Documentation Changes Required

