### PR TITLE
[4.1]Add 2 new positions in Template Cassipeia

### DIFF
--- a/templates/cassiopeia/html/layouts/chromes/card.php
+++ b/templates/cassiopeia/html/layouts/chromes/card.php
@@ -22,7 +22,8 @@ if ($module->content === null || $module->content === '')
 
 $moduleTag              = $params->get('module_tag', 'div');
 $moduleAttribs          = [];
-$moduleAttribs['class'] = $module->position . ' card ' . htmlspecialchars($params->get('moduleclass_sfx'), ENT_QUOTES, 'UTF-8');
+$moduleAttribs['class'] = $module->position . ' card ' . ($params->get('moduleclass_sfx') ?
+			(htmlspecialchars($params->get('moduleclass_sfx'), ENT_QUOTES, 'UTF-8')) : $attribs['class']);
 $headerTag              = htmlspecialchars($params->get('header_tag', 'h3'), ENT_QUOTES, 'UTF-8');
 $headerClass            = htmlspecialchars($params->get('header_class', ''), ENT_QUOTES, 'UTF-8');
 $headerAttribs          = [];

--- a/templates/cassiopeia/html/layouts/chromes/noCard.php
+++ b/templates/cassiopeia/html/layouts/chromes/noCard.php
@@ -22,7 +22,8 @@ if ($module->content === null || $module->content === '')
 
 $moduleTag              = $params->get('module_tag', 'div');
 $moduleAttribs          = [];
-$moduleAttribs['class'] = $module->position . ' no-card ' . htmlspecialchars($params->get('moduleclass_sfx'), ENT_QUOTES, 'UTF-8');
+$moduleAttribs['class'] = $module->position . ' no-card ' . ($params->get('moduleclass_sfx') ?
+			(htmlspecialchars($params->get('moduleclass_sfx'), ENT_QUOTES, 'UTF-8')) : $attribs['class']);
 $headerTag              = htmlspecialchars($params->get('header_tag', 'h3'), ENT_QUOTES, 'UTF-8');
 $headerClass            = htmlspecialchars($params->get('header_class', ''), ENT_QUOTES, 'UTF-8');
 $headerAttribs          = [];

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -152,6 +152,8 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 			<jdoc:include type="modules" name="banner" style="none" />
 		</div>
 	<?php endif; ?>
+	
+	<jdoc:include type="modules" name="top" style="none" class="grid-child" />
 
 	<?php if ($this->countModules('top-a', true)) : ?>
 	<div class="grid-child container-top-a">
@@ -198,6 +200,8 @@ $stickyHeader = $this->params->get('stickyHeader') ? 'position-sticky sticky-top
 		<jdoc:include type="modules" name="bottom-b" style="card" />
 	</div>
 	<?php endif; ?>
+	
+	<jdoc:include type="modules" name="bottom" style="none" class="grid-child" />
 
 	<?php if ($this->countModules('footer', true)) : ?>
 	<footer class="container-footer footer full-width">

--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -5,6 +5,7 @@
     display: grid;
     grid-template-areas: ". head head head head ."
       ". banner banner banner banner ."
+      ". top top top top ."
       ". top-a top-a top-a top-a ."
       ". top-b top-b top-b top-b ."
       ". comp comp comp comp ."
@@ -12,6 +13,7 @@
       ". side-l side-l side-l side-l ."
       ". bot-a bot-a bot-a bot-a ."
       ". bot-b bot-b bot-b bot-b ."
+      ". bot bot bot bot ."
       ". footer footer footer footer ."
       ". debug debug debug debug .";
     grid-template-columns: [full-start] minmax(0, 1fr) [main-start] repeat(4, minmax(0, 19.875rem)) [main-end] minmax(0, 1fr) [full-end];
@@ -38,11 +40,13 @@
     @include media-breakpoint-up(md) {
       grid-template-areas: ". head head head head ."
         ". banner banner banner banner ."
+        ". top top top top ."
         ". top-a top-a top-a top-a ."
         ". top-b top-b top-b top-b ."
         ". side-l comp comp side-r ."
         ". bot-a bot-a bot-a bot-a ."
         ". bot-b bot-b bot-b bot-b ."
+        ". bot bot bot bot ."
         ". footer footer footer footer ."
         ". debug debug debug debug .";
     }
@@ -68,6 +72,10 @@
 
 .container-banner {
   grid-area: banner;
+}
+
+.container-top {
+  grid-area: top;
 }
 
 .container-top-a {
@@ -108,6 +116,10 @@
 
 .container-bottom-b {
   grid-area: bot-b;
+}
+
+.container-bottom {
+  grid-area: bot;
 }
 
 .container-footer {

--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -26,6 +26,7 @@
 		<position>menu</position>
 		<position>search</position>
 		<position>banner</position>
+		<position>top</position>
 		<position>top-a</position>
 		<position>top-b</position>
 		<position>main-top</position>
@@ -35,6 +36,7 @@
 		<position>sidebar-right</position>
 		<position>bottom-a</position>
 		<position>bottom-b</position>
+		<position>bottom</position>
 		<position>footer</position>
 		<position>debug</position>
 	</positions>


### PR DESCRIPTION
Dear colleagues. How many web designers create websites using the Cassiopeia template, redefining its blocks, creating a completely new design?
I do the same thing. The Cassiopeia template has accessibility, normalization, styles, and a framework. This template is ideal for starting even if you need to create a website with a completely different design.
But Cassiopeia is not adapted for use on a large scale with such capabilities.
Cassiopeia is used only with the design that is already laid down. This is bad. It can not be used as NORMALIZE.CSS is used.
We need to add this to the template:
//134 line
**`<jdoc:include type="modules" name="top" style="none" class="grid-child" />`**
//180 line
**`<jdoc:include type="modules" name="bottom" style="none" class="grid-child" />`**
**The important thing is that you need to add these positions without the** **`<DIV>`** **container**.
Using classes in a position
`  class="grid-child"`
we specify that the position will have the default grid width that all blocks on the site have.
Class processing should be added to
//25 line  \templates\cassiopeia\html\layouts\chromes\noCard.php
//25 line  \templates\cassiopeia\html\layouts\chromes\card.php
```
$moduleAttribs['class'] = $module->position . ' no-card ' . ($params->get('moduleclass_sfx') ?
			(htmlspecialchars($params->get('moduleclass_sfx'), ENT_QUOTES, 'UTF-8')) : $attribs['class']);
```
Add the GRID-ARIA grid position to the styles.
.
Dear colleagues, thanks to the change. You can create modules on the site that are the width of the entire site, this can be a map of the route map. It can be a carousel of products. Agree that the driving directions and carousel are convenient when they are the entire width of the site.
Let's make more features for Cassiopeia!
By default, this position has only the width of the content.
This is also convenient when placing just ordinary modules.
If desired, we can place the gallery in the entire width of the site between the blocks.
90% of sites have a gallery in the site header with a width of 100% without affecting the main menu.
For example, the Xiaomi website.
https://www.mi.com/global/
https://www.solus.com/
to make a wide module, you need to add a class suffix **`full-width`** in the module settings of the admin panel.