### PR TITLE
[4.0] Sanitize modals

### DIFF
--- a/build/media_source/vendor/bootstrap/js/modal.es6.js
+++ b/build/media_source/vendor/bootstrap/js/modal.es6.js
@@ -5,6 +5,10 @@ Joomla.Modal = Joomla.Modal || {};
 window.bootstrap = window.bootstrap || {};
 window.bootstrap.Modal = Modal;
 
+const allowed = {
+  iframe: ['src', 'name', 'width', 'height']
+};
+
 Joomla.initialiseModal = (modal, options) => {
   if (!(modal instanceof Element)) {
     return;
@@ -53,9 +57,9 @@ Joomla.initialiseModal = (modal, options) => {
           el = document.getElementById(idFieldArr[1]).value;
         }
 
-        modalBody.insertAdjacentHTML('afterbegin', `${iframeTextArr[0]}${el}${iframeTextArr[2]}`);
+        modalBody.insertAdjacentHTML('afterbegin', Joomla.sanitizeHtml(`${iframeTextArr[0]}${el}${iframeTextArr[2]}`, allowed));
       } else {
-        modalBody.insertAdjacentHTML('afterbegin', modal.dataset.iframe);
+        modalBody.insertAdjacentHTML('afterbegin', Joomla.sanitizeHtml(modal.dataset.iframe, allowed));
       }
     }
   });

--- a/build/media_source/vendor/bootstrap/js/modal.es6.js
+++ b/build/media_source/vendor/bootstrap/js/modal.es6.js
@@ -6,7 +6,7 @@ window.bootstrap = window.bootstrap || {};
 window.bootstrap.Modal = Modal;
 
 const allowed = {
-  iframe: ['src', 'name', 'width', 'height']
+  iframe: ['src', 'name', 'width', 'height'],
 };
 
 Joomla.initialiseModal = (modal, options) => {


### PR DESCRIPTION
Pull Request for Issue # .

# This is also a RELEASE BLOCKER

### Summary of Changes
- sanitize the iframe tag passed as a data attribute

### Testing Instructions
Apply the patch or download the installable package from the Github PR

Try to edit an article, select an image, select a user
Try to edit a menu item and create/edit an article
Modals should work fine

### Actual result BEFORE applying this Pull Request
The initialization of a modal could be compromised to run non verified code 


### Expected result AFTER applying this Pull Request
The iframe tag can not be compromised



### Documentation Changes Required

