### PR TITLE
[4.0] Sanitization for code using insertAdjacentHTML

### DIFF
--- a/build/media_source/com_finder/js/indexer.es6.js
+++ b/build/media_source/com_finder/js/indexer.es6.js
@@ -82,7 +82,7 @@
             Object.entries(json.pluginState).forEach((context) => {
               let item = `<dt class="col-sm-3">${context[0]}</dt>`;
               item += `<dd id="finder-${context[0].replace(/\s+/g, '-').toLowerCase()}" class="col-sm-9"></dd>`;
-              debuglist.insertAdjacentHTML('beforeend', item);
+              debuglist.insertAdjacentHTML('beforeend', Joomla.sanitizeHtml(item));
             });
           }
         }

--- a/build/media_source/plg_system_stats/js/stats-message.es6.js
+++ b/build/media_source/plg_system_stats/js/stats-message.es6.js
@@ -17,7 +17,7 @@ Joomla = window.Joomla || {};
     tbody: [],
     thead: [],
     caption: [],
-    th: [],
+    th: ['scope'],
     tr: [],
     td: [],
   };

--- a/build/media_source/plg_system_stats/js/stats-message.es6.js
+++ b/build/media_source/plg_system_stats/js/stats-message.es6.js
@@ -9,6 +9,10 @@ Joomla = window.Joomla || {};
 ((Joomla, document) => {
   'use strict';
 
+  const allowed = {
+    input: ['type', 'name', 'value'],
+  };
+
   const initStatsEvents = (callback) => {
     const messageContainer = document.getElementById('system-message-container');
     const joomlaAlert = messageContainer.querySelector('.js-pstats-alert');
@@ -71,7 +75,7 @@ Joomla = window.Joomla || {};
         try {
           const json = JSON.parse(response);
           if (json && json.html) {
-            messageContainer.insertAdjacentHTML('beforeend', Joomla.sanitizeHtml(json.html));
+            messageContainer.insertAdjacentHTML('beforeend', Joomla.sanitizeHtml(json.html, allowed));
             messageContainer.querySelector('.js-pstats-alert').classList.remove('hidden');
             initStatsEvents(getJson);
           }

--- a/build/media_source/plg_system_stats/js/stats-message.es6.js
+++ b/build/media_source/plg_system_stats/js/stats-message.es6.js
@@ -11,6 +11,15 @@ Joomla = window.Joomla || {};
 
   const allowed = {
     input: ['type', 'name', 'value'],
+    'joomla-alert': ['type', 'dismiss', 'role'],
+    button: ['type'],
+    table: [],
+    tbody: [],
+    thead: [],
+    caption: [],
+    th: [],
+    tr: [],
+    td: []
   };
 
   const initStatsEvents = (callback) => {

--- a/build/media_source/plg_system_stats/js/stats-message.es6.js
+++ b/build/media_source/plg_system_stats/js/stats-message.es6.js
@@ -71,7 +71,7 @@ Joomla = window.Joomla || {};
         try {
           const json = JSON.parse(response);
           if (json && json.html) {
-            messageContainer.insertAdjacentHTML('beforeend', json.html);
+            messageContainer.insertAdjacentHTML('beforeend', Joomla.sanitizeHtml(json.html));
             messageContainer.querySelector('.js-pstats-alert').classList.remove('hidden');
             initStatsEvents(getJson);
           }

--- a/build/media_source/plg_system_stats/js/stats-message.es6.js
+++ b/build/media_source/plg_system_stats/js/stats-message.es6.js
@@ -19,7 +19,7 @@ Joomla = window.Joomla || {};
     caption: [],
     th: [],
     tr: [],
-    td: []
+    td: [],
   };
 
   const initStatsEvents = (callback) => {

--- a/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
@@ -43,14 +43,14 @@
       container.insertAdjacentHTML('afterbegin', `
 <joomla-field-mediamore
   parent-id="${Joomla.sanitizeHtml(currentModal.id)}"
-  summary-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_SUMMARY_LABEL'))}"
-  lazy-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_LAZY_LABEL'))}"
-  alt-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_ALT_LABEL'))}"
-  alt-check-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_ALT_CHECK_LABEL'))}"
-  alt-check-desc-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_ALT_CHECK_DESC_LABEL'))}"
-  classes-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_CLASS_LABEL'))}"
-  figure-classes-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_FIGURE_CLASS_LABEL'))}"
-  figure-caption-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_FIGURE_CAPTION_LABEL'))}"
+  summary-label="${Joomla.Text._('JFIELD_MEDIA_SUMMARY_LABEL')}"
+  lazy-label="${Joomla.Text._('JFIELD_MEDIA_LAZY_LABEL')}"
+  alt-label="${Joomla.Text._('JFIELD_MEDIA_ALT_LABEL')}"
+  alt-check-label="${Joomla.Text._('JFIELD_MEDIA_ALT_CHECK_LABEL')}"
+  alt-check-desc-label="${Joomla.Text._('JFIELD_MEDIA_ALT_CHECK_DESC_LABEL')}"
+  classes-label="${Joomla.Text._('JFIELD_MEDIA_CLASS_LABEL')}"
+  figure-classes-label="${Joomla.Text._('JFIELD_MEDIA_FIGURE_CLASS_LABEL')}"
+  figure-caption-label="${Joomla.Text._('JFIELD_MEDIA_FIGURE_CAPTION_LABEL')}"
 ></joomla-field-mediamore>`);
     }
   });

--- a/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
@@ -40,7 +40,7 @@
     }
 
     if (Joomla.selectedMediaFile.path) {
-      container.insertAdjacentHTML('afterbegin', `
+      container.insertAdjacentHTML('afterbegin', Joomla.sanitizeHtml(`
 <joomla-field-mediamore
   parent-id="${currentModal.id}"
   summary-label="${Joomla.Text._('JFIELD_MEDIA_SUMMARY_LABEL')}"
@@ -52,7 +52,7 @@
   figure-classes-label="${Joomla.Text._('JFIELD_MEDIA_FIGURE_CLASS_LABEL')}"
   figure-caption-label="${Joomla.Text._('JFIELD_MEDIA_FIGURE_CAPTION_LABEL')}"
 ></joomla-field-mediamore>
-`);
+`));
     }
   });
 

--- a/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
@@ -42,7 +42,7 @@
     if (Joomla.selectedMediaFile.path) {
       container.insertAdjacentHTML('afterbegin', `
 <joomla-field-mediamore
-  parent-id="${Joomla.sanitizeHtml(currentModal.id)}"
+  parent-id="${currentModal.id}"
   summary-label="${Joomla.Text._('JFIELD_MEDIA_SUMMARY_LABEL')}"
   lazy-label="${Joomla.Text._('JFIELD_MEDIA_LAZY_LABEL')}"
   alt-label="${Joomla.Text._('JFIELD_MEDIA_ALT_LABEL')}"

--- a/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
@@ -40,19 +40,18 @@
     }
 
     if (Joomla.selectedMediaFile.path) {
-      container.insertAdjacentHTML('afterbegin', Joomla.sanitizeHtml(`
+      container.insertAdjacentHTML('afterbegin', `
 <joomla-field-mediamore
-  parent-id="${currentModal.id}"
-  summary-label="${Joomla.Text._('JFIELD_MEDIA_SUMMARY_LABEL')}"
-  lazy-label="${Joomla.Text._('JFIELD_MEDIA_LAZY_LABEL')}"
-  alt-label="${Joomla.Text._('JFIELD_MEDIA_ALT_LABEL')}"
-  alt-check-label="${Joomla.Text._('JFIELD_MEDIA_ALT_CHECK_LABEL')}"
-  alt-check-desc-label="${Joomla.Text._('JFIELD_MEDIA_ALT_CHECK_DESC_LABEL')}"
-  classes-label="${Joomla.Text._('JFIELD_MEDIA_CLASS_LABEL')}"
-  figure-classes-label="${Joomla.Text._('JFIELD_MEDIA_FIGURE_CLASS_LABEL')}"
-  figure-caption-label="${Joomla.Text._('JFIELD_MEDIA_FIGURE_CAPTION_LABEL')}"
-></joomla-field-mediamore>
-`));
+  parent-id="${Joomla.sanitizeHtml(currentModal.id)}"
+  summary-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_SUMMARY_LABEL'))}"
+  lazy-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_LAZY_LABEL'))}"
+  alt-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_ALT_LABEL'))}"
+  alt-check-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_ALT_CHECK_LABEL'))}"
+  alt-check-desc-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_ALT_CHECK_DESC_LABEL'))}"
+  classes-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_CLASS_LABEL'))}"
+  figure-classes-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_FIGURE_CLASS_LABEL'))}"
+  figure-caption-label="${Joomla.sanitizeHtml(Joomla.Text._('JFIELD_MEDIA_FIGURE_CAPTION_LABEL'))}"
+></joomla-field-mediamore>`);
     }
   });
 

--- a/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-image-select.w-c.es6.js
@@ -51,7 +51,8 @@
   classes-label="${Joomla.Text._('JFIELD_MEDIA_CLASS_LABEL')}"
   figure-classes-label="${Joomla.Text._('JFIELD_MEDIA_FIGURE_CLASS_LABEL')}"
   figure-caption-label="${Joomla.Text._('JFIELD_MEDIA_FIGURE_CAPTION_LABEL')}"
-></joomla-field-mediamore>`);
+></joomla-field-mediamore>
+`);
     }
   });
 


### PR DESCRIPTION
Pull Request for Issue # .

# this is also a RELEASE BLOCKER

### Summary of Changes
- Code that injects HTML using `insertAdjacentHTML` should first sanitize the string


### Testing Instructions
Apply the PR or download the installable package from the Github PR

- Check that the Stats plugin works correctly (eg the first notification when you log in for the first time in the admin)
- Check that you can select an image in the intro/fulltext position and also inside an editor

### Actual result BEFORE applying this Pull Request
Code vulnerable to XSS


### Expected result AFTER applying this Pull Request
Vulnerabilities mitigated 


### Documentation Changes Required

