### PR TITLE
[4.0] Fix searchtool JS error

### DIFF
--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -286,18 +286,16 @@ Joomla = window.Joomla || {};
 
     // eslint-disable-next-line class-methods-use-this
     checkActiveStatus(cont) {
-      const els = this.getFilterFields();
+      const els = [].slice.call(this.getFilterFields());
       let activeFilterCount = 0;
 
-      if (els) {
-        els.forEach((item) => {
-          if (item.classList.contains('active')) {
-            activeFilterCount += 1;
-            cont.filterButton.classList.remove('btn-secondary');
-            cont.filterButton.classList.add('btn-primary');
-          }
-        });
-      }
+      els.forEach((item) => {
+        if (item.classList.contains('active')) {
+          activeFilterCount += 1;
+          cont.filterButton.classList.remove('btn-secondary');
+          cont.filterButton.classList.add('btn-primary');
+        }
+      });
 
       // If there are no active filters - remove the filtered caption area from the table
       if (activeFilterCount === 0) {

--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -289,13 +289,15 @@ Joomla = window.Joomla || {};
       const els = this.getFilterFields();
       let activeFilterCount = 0;
 
-      els.forEach((item) => {
-        if (item.classList.contains('active')) {
-          activeFilterCount += 1;
-          cont.filterButton.classList.remove('btn-secondary');
-          cont.filterButton.classList.add('btn-primary');
-        }
-      });
+      if (els) {
+        els.forEach((item) => {
+          if (item.classList.contains('active')) {
+            activeFilterCount += 1;
+            cont.filterButton.classList.remove('btn-secondary');
+            cont.filterButton.classList.add('btn-primary');
+          }
+        });
+      }
 
       // If there are no active filters - remove the filtered caption area from the table
       if (activeFilterCount === 0) {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Currently, if we use searchtools script but there are no filter fields for some reasons (it could happen with third party extensions like mine), there could be javascript errors in browser console like this:

```javascript
Uncaught TypeError: Cannot read property 'forEach' of undefined
    at Searchtools.checkActiveStatus (searchtools.js?2de576a4eb7e64e845e8e1a5fafd9f831d1aec5c:264)
    at new Searchtools (searchtools.js?2de576a4eb7e64e845e8e1a5fafd9f831d1aec5c:194)
    at HTMLDocument.onBoot (searchtools.js?2de576a4eb7e64e845e8e1a5fafd9f831d1aec5c:504)
```

We have the code to check and make sure filter fields exist on other places like:

https://github.com/joomla/joomla-cms/blob/4.0-dev/build/media_source/system/js/searchtools.es6.js#L177
https://github.com/joomla/joomla-cms/blob/4.0-dev/build/media_source/system/js/searchtools.es6.js#L248
....

So I think it makes sense to have the same check in `checkActiveStatus` method, too.

### Testing Instructions
I think this issue only happens for third party extensions only, so there is nothing to check from core. So we will have to rely on code review here.

@dgrammatiko Could you please take a look at this to see if the change is OK ?