### PR TITLE
Fix W3C Warning role="navigation" is unnecessary for element nav

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/breadcrumb/breadcrumb.vue
+++ b/administrator/components/com_media/resources/scripts/components/breadcrumb/breadcrumb.vue
@@ -1,7 +1,6 @@
 <template>
   <nav
     class="media-breadcrumb"
-    role="navigation"
     :aria-label="translate('COM_MEDIA_BREADCRUMB_LABEL')"
   >
     <ol>

--- a/layouts/joomla/pagination/links.php
+++ b/layouts/joomla/pagination/links.php
@@ -53,7 +53,7 @@ if ($currentPage >= $step)
 
 
 <?php if (!empty($pages)) : ?>
-	<nav role="navigation" aria-label="<?php echo Text::_('JLIB_HTML_PAGINATION'); ?>">
+	<nav class="pagination__wrapper" aria-label="<?php echo Text::_('JLIB_HTML_PAGINATION'); ?>">
 		<div class="pagination pagination-toolbar text-center">
 
 			<?php if ($showLimitBox) : ?>

--- a/layouts/joomla/pagination/list.php
+++ b/layouts/joomla/pagination/list.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Language\Text;
 $list = $displayData['list'];
 
 ?>
-<nav role="navigation" aria-label="<?php echo Text::_('JLIB_HTML_PAGINATION'); ?>">
+<nav class="pagination__wrapper" aria-label="<?php echo Text::_('JLIB_HTML_PAGINATION'); ?>">
 	<ul class="pagination ms-0 mb-4">
 		<?php echo $list['start']['data']; ?>
 		<?php echo $list['previous']['data']; ?>

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -13,7 +13,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
 ?>
-<nav role="navigation" aria-label="<?php echo htmlspecialchars($module->title, ENT_QUOTES, 'UTF-8'); ?>">
+<nav class="mod-breadcrumbs__wrapper" aria-label="<?php echo htmlspecialchars($module->title, ENT_QUOTES, 'UTF-8'); ?>">
 	<ol itemscope itemtype="https://schema.org/BreadcrumbList" class="mod-breadcrumbs breadcrumb px-3 py-2">
 		<?php if ($params->get('showHere', 1)) : ?>
 			<li class="mod-breadcrumbs__here float-start">


### PR DESCRIPTION
### Summary of Changes
The breadcrumbs have the ARIA role="navigation", but this is unnecessary for nav elements. Also added a classes for easy styling.

### Testing Instructions
Look at the code of the breadcrumbs and the pagination and see if the the role element is there. Apply the patch and check if the role element is gone and the class added.

### Actual result BEFORE applying this Pull Request
 role="navigation" present

### Expected result AFTER applying this Pull Request
role="navigation" is removed and nav has a class

### Documentation Changes Required
No
