### PR TITLE
[4.0] content_history scope

### DIFF
--- a/administrator/components/com_contenthistory/tmpl/preview/preview.php
+++ b/administrator/components/com_contenthistory/tmpl/preview/preview.php
@@ -31,8 +31,8 @@ Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 		</caption>
 		<thead>
 			<tr>
-				<th class="w-25"><?php echo Text::_('COM_CONTENTHISTORY_PREVIEW_FIELD'); ?></th>
-				<th><?php echo Text::_('COM_CONTENTHISTORY_PREVIEW_VALUE'); ?></th>
+				<th class="w-25" scope="col"><?php echo Text::_('COM_CONTENTHISTORY_PREVIEW_FIELD'); ?></th>
+				<th scope="col"><?php echo Text::_('COM_CONTENTHISTORY_PREVIEW_VALUE'); ?></th>
 			</tr>
 		</thead>
 		<tbody>


### PR DESCRIPTION
adds scope=col to the column headers when using preview in content versions

code review
