### PR TITLE
[4.0] Hide up/down selector arrows for Hits readonly

### DIFF
--- a/administrator/components/com_categories/forms/category.xml
+++ b/administrator/components/com_categories/forms/category.xml
@@ -12,7 +12,7 @@
 
 	<field
 		name="hits"
-		type="number"
+		type="text"
 		label="JGLOBAL_HITS"
 		default="0"
 		class="readonly"

--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -814,7 +814,7 @@
 
 	<field
 		name="hits"
-		type="number"
+		type="text"
 		label="JGLOBAL_HITS"
 		class="readonly"
 		readonly="true"

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -233,7 +233,7 @@
 
 		<field
 			name="hits"
-			type="number"
+			type="text"
 			label="JGLOBAL_HITS"
 			class="readonly"
 			readonly="true"

--- a/administrator/components/com_newsfeeds/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/forms/newsfeed.xml
@@ -455,7 +455,7 @@
 
 			<field
 				name="hits"
-				type="number"
+				type="text"
 				label="JGLOBAL_HITS"
 				class="readonly"
 				readonly="true"

--- a/administrator/components/com_redirect/forms/link.xml
+++ b/administrator/components/com_redirect/forms/link.xml
@@ -78,7 +78,7 @@
 
 		<field
 			name="hits"
-			type="number"
+			type="text"
 			label="JGLOBAL_HITS"
 			class="readonly"
 			readonly="true"

--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -11,7 +11,7 @@
 
 	<field
 		name="hits"
-		type="number"
+		type="text"
 		label="JGLOBAL_HITS"
 		class="readonly"
 		default="0"


### PR DESCRIPTION
Pull Request for Issue #30885 (partial fix).

### Summary of Changes
Depending on the browser, the up/down arrows for number type may display when the field is readonly. 
This is the case with Firefox and Safari on Mac as reported in the issue.

This PR fixes the Hits readonly field by changing its `type` attribute from number to text.

The ID readonly field will be done in a separate PR.


### Testing Instructions
Go to the following to add/edit an item and go to the Publishing tab.

Content > Articles
Content > Categories
Components > Contacts
Components > News Feeds
Components > Tags

Make sure that add/edit can be saved successfully.


### Actual result BEFORE applying this Pull Request
![hits-arrows](https://user-images.githubusercontent.com/368084/121580844-0e060700-c9e2-11eb-8180-d7d83dfe44c7.jpg)



### Expected result AFTER applying this Pull Request
![hits-no-arrows](https://user-images.githubusercontent.com/368084/121580850-10686100-c9e2-11eb-800d-6fbf3c35077c.jpg)

