### PR TITLE
[4.0] Fix sorted by: table caption

### DIFF
--- a/layouts/joomla/searchtools/grid/sort.php
+++ b/layouts/joomla/searchtools/grid/sort.php
@@ -20,7 +20,7 @@ $id = '';
 
 if ($data->order === $data->selected) :
 	$icon = $data->orderIcon;
-	$sort = $data->direction === 'asc' ? 'ascending' : 'descending';
+	$sort = $data->direction === 'asc' ? 'descending' : 'ascending';
 	$caption = !empty($data->title) ? Text::_($data->title) . ' - ' . $sort : Text::_('JGRID_HEADING_ID');
 	$selected = ' selected';
 	$id = 'id="sorted"';

--- a/libraries/src/HTML/Helpers/SearchTools.php
+++ b/libraries/src/HTML/Helpers/SearchTools.php
@@ -113,7 +113,7 @@ abstract class SearchTools
 		}
 		else
 		{
-			$direction = $direction === 'desc' ? 'asc' : 'desc';
+			$direction = $direction === 'desc' ? 'desc' : 'asc';
 		}
 
 		// Create an object to pass it to the layouts

--- a/libraries/src/HTML/Helpers/SearchTools.php
+++ b/libraries/src/HTML/Helpers/SearchTools.php
@@ -113,7 +113,7 @@ abstract class SearchTools
 		}
 		else
 		{
-			$direction = $direction === 'desc' ? 'desc' : 'asc';
+			$direction = $direction === 'desc' ? 'asc' : 'desc';
 		}
 
 		// Create an object to pass it to the layouts


### PR DESCRIPTION
Pull Request for Issue #34476.

### Summary of Changes
correct ternary operator in $data->direction


### Testing Instructions
Visit the articles page in the backend
Sort the table, for example - by Status ascending
Just look at the table caption in the developer tools or just remove class="visually-hidden" from the code
https://github.com/joomla/joomla-cms/blob/44934f7863bc68ec09aa510a6cb890b16f98a51b/administrator/components/com_content/tmpl/articles/default.php#L110

### Actual result BEFORE applying this Pull Request
![sorted](https://user-images.githubusercontent.com/61203226/121654517-6e1cac00-cabb-11eb-84d2-48110d74502f.JPG)



### Expected result AFTER applying this Pull Request
![sorted-correct](https://user-images.githubusercontent.com/61203226/121654544-7543ba00-cabb-11eb-9183-ec035e45d9f6.JPG)



### Documentation Changes Required
No
