### PR TITLE
[4.0] sr-only

### DIFF
--- a/components/com_menus/layouts/joomla/searchtools/default.php
+++ b/components/com_menus/layouts/joomla/searchtools/default.php
@@ -95,7 +95,7 @@ HTMLHelper::_('searchtools.form', $data['options']['formSelector'], $data['optio
 		<?php $clientIdField = $data['view']->filterForm->getField('client_id'); ?>
 		<?php if ($clientIdField) : ?>
 		<div class="js-stools-container-selector">
-			<div class="sr-only">
+			<div class="visually-hidden">
 				<?php echo $clientIdField->label; ?>
 			</div>
 			<div class="js-stools-field-selector js-stools-client_id">


### PR DESCRIPTION
sr-only was a class used in previous versions of bootstrap. Although we have a class mapping in _global.scss for backwards compatibility there is no need for the core not to update its markup to visually-hidden
