### PR TITLE
[4.0] element-invisible

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_update.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/default_update.php
@@ -179,7 +179,7 @@ use Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView;
 								<a href="<?php echo $authorURL; ?>" target="_blank" >
 								<?php echo $authorURL; ?>
 								<span class="icon-out-2" aria-hidden="true"></span>
-								<span class="element-invisible"><?php echo Text::_('JBROWSERTARGET_NEW'); ?></span>
+								<span class="visually-hidden"><?php echo Text::_('JBROWSERTARGET_NEW'); ?></span>
 								</a>
 							<?php endif;?>
 						</td>


### PR DESCRIPTION
element-invisible was a class used in previous versions of bootstrap. Although we have a class  _utilities.scss for backwards compatibility there is no need for the core not to update its markup to visually-hidden
