### PR TITLE
[4.0] Remove arrows/spinners from ID readonly field

### DIFF
--- a/administrator/components/com_banners/forms/banner.xml
+++ b/administrator/components/com_banners/forms/banner.xml
@@ -4,7 +4,7 @@
 
 		<field
 			name="id"
-			type="number"
+			type="text"
 			label="JGLOBAL_FIELD_ID_LABEL"
 			default="0"
 			readonly="true"

--- a/administrator/components/com_categories/forms/category.xml
+++ b/administrator/components/com_categories/forms/category.xml
@@ -3,7 +3,7 @@
 
 	<field
 		name="id"
-		type="number"
+		type="text"
 		label="JGLOBAL_FIELD_ID_LABEL"
 		default="0"
 		class="readonly"

--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -3,7 +3,7 @@
 	<fieldset addfieldprefix="Joomla\Component\Contact\Administrator\Field">
 		<field
 			name="id"
-			type="number"
+			type="text"
 			label="JGLOBAL_FIELD_ID_LABEL"
 			default="0"
 			class="readonly"

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -3,7 +3,7 @@
 	<fieldset addfieldprefix="Joomla\Component\Content\Administrator\Field">
 		<field
 			name="id"
-			type="number"
+			type="text"
 			label="JGLOBAL_FIELD_ID_LABEL"
 			class="readonly"
 			default="0"

--- a/administrator/components/com_fields/forms/field.xml
+++ b/administrator/components/com_fields/forms/field.xml
@@ -3,7 +3,7 @@
 	<fieldset>
 		<field
 			name="id"
-			type="number"
+			type="text"
 			label="JGLOBAL_FIELD_ID_LABEL"
 			default="0"
 			class="readonly"

--- a/administrator/components/com_fields/forms/group.xml
+++ b/administrator/components/com_fields/forms/group.xml
@@ -3,7 +3,7 @@
 	<fieldset>
 		<field
 			name="id"
-			type="number"
+			type="text"
 			label="JGLOBAL_FIELD_ID_LABEL"
 			default="0"
 			class="readonly"

--- a/administrator/components/com_newsfeeds/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/forms/newsfeed.xml
@@ -5,7 +5,7 @@
 
 		<field
 			name="id"
-			type="number"
+			type="text"
 			label="JGLOBAL_FIELD_ID_LABEL"
 			default="0"
 			class="readonly"

--- a/administrator/components/com_redirect/forms/link.xml
+++ b/administrator/components/com_redirect/forms/link.xml
@@ -3,7 +3,7 @@
 	<fieldset addfieldprefix="Joomla\Component\Redirect\Administrator\Field">
 		<field
 			name="id"
-			type="number"
+			type="text"
 			label="JGLOBAL_FIELD_ID_LABEL"
 			default="0"
 			readonly="true"

--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -2,7 +2,7 @@
 <form>
 	<field
 		name="id"
-		type="number"
+		type="text"
 		label="JGLOBAL_FIELD_ID_LABEL"
 		default="0"
 		class="readonly"

--- a/administrator/components/com_users/forms/user.xml
+++ b/administrator/components/com_users/forms/user.xml
@@ -134,7 +134,7 @@
 
 		<field
 			name="id"
-			type="number"
+			type="text"
 			label="JGLOBAL_FIELD_ID_LABEL"
 			class="readonly"
 			default="0"


### PR DESCRIPTION
Pull Request for Issue #30885.

### Summary of Changes
Depending on the browser, the up/down arrows for number type may display when the field is readonly. 
This is the case with Firefox and Safari on Mac as reported in the issue.

This PR only fixes the ID readonly field that are visible by changing its `type` attribute from number to text.


### Testing Instructions
Go to the following to add/edit an item and see the ID field.

Content > Articles
Content > Categories
Content > Fields
Content > Field Groups
Components > Contacts
Components > News Feeds
Components > Tags
Users > Manage
System > Redirect

Make sure that add/edit can be saved successfully.


### Actual result BEFORE applying this Pull Request
![id-arrows](https://user-images.githubusercontent.com/368084/121714367-9ba12f80-ca92-11eb-80bf-c57ce6d722d8.jpg)


### Expected result AFTER applying this Pull Request
![id-no-arrows](https://user-images.githubusercontent.com/368084/121714382-9f34b680-ca92-11eb-9e5c-4860efff27b7.jpg)


