### PR TITLE
[3.x] Smart Search: Fix inserting tokens to DB

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -536,7 +536,7 @@ abstract class FinderIndexer
 					. $db->quote($token->stem) . ', '
 					. (int) $token->common . ', '
 					. (int) $token->phrase . ', '
-					. $db->quote($token->weight) . ', '
+					. $db->escape((float) $token->weight) . ', '
 					. (int) $context . ', '
 					. $db->quote($token->language)
 				);

--- a/administrator/components/com_finder/helpers/indexer/indexer.php
+++ b/administrator/components/com_finder/helpers/indexer/indexer.php
@@ -513,13 +513,20 @@ abstract class FinderIndexer
 		// Get the database object.
 		$db = $this->db;
 
+		$query = clone $this->addTokensToDbQueryTemplate;
+
+		// Check if a single FinderIndexerToken object was given and make it to be an array of FinderIndexerToken objects
+		$tokens = is_array($tokens) ? $tokens : array($tokens);
+
 		// Count the number of token values.
 		$values = 0;
 
-		if (($tokens instanceof FinderIndexerToken) === false)
+		// Break into chunks of no more than 1000 items
+		$chunks = array_chunk($tokens, 128);
+
+		foreach ($chunks as $tokens)
 		{
-			// Cloning a new query template is twice as fast as calling the clear function
-			$query = clone $this->addTokensToDbQueryTemplate;
+			$query->clear('values');
 
 			// Iterate through the tokens to create SQL value sets.
 			foreach ($tokens as $token)
@@ -529,41 +536,20 @@ abstract class FinderIndexer
 					. $db->quote($token->stem) . ', '
 					. (int) $token->common . ', '
 					. (int) $token->phrase . ', '
-					. $db->escape((float) $token->weight) . ', '
+					. $db->quote($token->weight) . ', '
 					. (int) $context . ', '
 					. $db->quote($token->language)
 				);
-				$values++;
-
-				if ($values > 0 && ($values % 128) == 0)
-				{
-					$db->setQuery($query)->execute();
-					$query->clear('values');
-
-					// Check if we're approaching the memory limit of the token table.
-					if ($values > static::$state->options->get('memory_table_limit', 10000))
-					{
-						$this->toggleTables(false);
-					}
-				}
+				++$values;
 			}
-		}
-		else
-		{
-			$query = clone $this->addTokensToDbQueryTemplate;
-
-			$query->values(
-				$db->quote($tokens->term) . ', '
-				. $db->quote($tokens->stem) . ', '
-				. (int) $tokens->common . ', '
-				. (int) $tokens->phrase . ', '
-				. $db->escape((float) $tokens->weight) . ', '
-				. (int) $context . ', '
-				. $db->quote($tokens->language)
-			);
-			++$values;
 
 			$db->setQuery($query)->execute();
+
+			// Check if we're approaching the memory limit of the token table.
+			if ($values > static::$state->options->get('memory_table_limit', 10000))
+			{
+				$this->toggleTables(false);
+			}
 		}
 
 		return $values;


### PR DESCRIPTION
Pull Request for Issue #34242  .

### Summary of Changes
When indexing, due to a logic error, the words of a text were only stored to the database in chunks of 128 at a time. If a chunk had less than 128 words, it wasn't saved to the database. This change fixes that.

### Testing Instructions
Have Smart Search be set up. Write a short article (less than 128 words) with a unique word and save it. Then go to the frontend and search for that unique word. You don't get a result.
Apply the patch, reindex the content and search for it again. Now you get the article as result.
