### PR TITLE
[4.0] Smart Search: Fix inserting tokens to DB

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -955,7 +955,6 @@ class Indexer
 				);
 				++$values;
 			}
-		
 			$db->setQuery($query)->execute();
 
 			// Check if we're approaching the memory limit of the token table.

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -919,12 +919,19 @@ class Indexer
 
 		$query = clone $this->addTokensToDbQueryTemplate;
 
+		// Check if a single FinderIndexerToken object was given and make it to be an array of FinderIndexerToken objects
+		$tokens = is_array($tokens) ? $tokens : array($tokens);
+
 		// Count the number of token values.
 		$values = 0;
 
-		// Iterate through the tokens to create SQL value sets.
-		if (!is_a($tokens, Token::class))
+		// Break into chunks of no more than 128 items
+		$chunks = array_chunk($tokens, 128);
+
+		foreach ($chunks as $tokens)
 		{
+			$query->clear('values');
+
 			foreach ($tokens as $token)
 			{
 				if ($filterCommon && $token->common)
@@ -946,38 +953,16 @@ class Indexer
 					. (int) $context . ', '
 					. $db->quote($token->language)
 				);
-				$values++;
-
-				if ($values > 0 && ($values % 128) == 0)
-				{
-					$db->setQuery($query)->execute();
-					$query->clear('values');
-
-					// Check if we're approaching the memory limit of the token table.
-					if ($values > static::$state->options->get('memory_table_limit', 10000))
-					{
-						$this->toggleTables(false);
-					}
-				}
+				++$values;
 			}
-		}
-		else
-		{
-			$query->values(
-				$db->quote($tokens->term) . ', '
-				. $db->quote($tokens->stem) . ', '
-				. (int) $tokens->common . ', '
-				. (int) $tokens->phrase . ', '
-				. $db->escape((float) $tokens->weight) . ', '
-				. (int) $context . ', '
-				. $db->quote($tokens->language)
-			);
-			$values++;
-		}
-
-		if ($query->values)
-		{
+		
 			$db->setQuery($query)->execute();
+
+			// Check if we're approaching the memory limit of the token table.
+			if ($values > static::$state->options->get('memory_table_limit', 10000))
+			{
+				$this->toggleTables(false);
+			}
 		}
 
 		return $values;

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -955,6 +955,7 @@ class Indexer
 				);
 				++$values;
 			}
+
 			$db->setQuery($query)->execute();
 
 			// Check if we're approaching the memory limit of the token table.


### PR DESCRIPTION
This is the Pull Request for the J3 Issue #34242 in 4.0.

### Summary of Changes
When indexing, due to a logic error, the words of a text were only stored to the database in chunks of 128 at a time. If a chunk had less than 128 words, it wasn't saved to the database. This change fixes that. However, in 4.0, the bug had been fixed in a different way. In order to keep the code in sync, the better and shorter solution of 3.9 is used here.

### Testing Instructions
Have Smart Search be set up. Write a short article (less than 128 words) with a unique word and save it. Then go to the frontend and search for that unique word. You don't get a result.
Apply the patch, reindex the content and search for it again. Now you get the article as result.