### PR TITLE
[4.0] Remove 3.9.27 update SQL scripts after upmerge from 3.10-dev

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/3.9.27-2021-04-20.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/3.9.27-2021-04-20.sql
@@ -1,3 +1,0 @@
-INSERT INTO `#__postinstall_messages` (`extension_id`, `title_key`, `description_key`, `language_extension`, `language_client_id`, `type`, `version_introduced`, `enabled`)
-VALUES
-(700, 'COM_ADMIN_POSTINSTALL_MSG_FLOC_BLOCKER_TITLE', 'COM_ADMIN_POSTINSTALL_MSG_FLOC_BLOCKER_DESCRIPTION', 'com_admin', 1, 'message', '3.9.27', 1);

--- a/administrator/components/com_admin/sql/updates/postgresql/3.9.27-2021-04-20.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/3.9.27-2021-04-20.sql
@@ -1,3 +1,0 @@
-INSERT INTO "#__postinstall_messages" ("extension_id", "title_key", "description_key", "language_extension", "language_client_id", "type", "version_introduced", "enabled")
-VALUES
-(700, 'COM_ADMIN_POSTINSTALL_MSG_FLOC_BLOCKER_TITLE', 'COM_ADMIN_POSTINSTALL_MSG_FLOC_BLOCKER_DESCRIPTION', 'com_admin', 1, 'message', '3.9.27', 1);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) removes the 2 `3.9.27-2021-04-20.sql` update SQL scripts for MySQL and PostgreSQL having been merged up from 3.10-dev last night with https://github.com/joomla/joomla-cms/commit/6274e5f1369eed4d407b971d266707b164c14f6c .

The 2 scripts and the one for sqlazure which hasn't been merged up have been added already to the files deletion on update in `script.php` with PR #34289 :
- https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/script.php#L749
- https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/script.php#L865
- https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/script.php#L984 

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

`3.9.27-2021-04-20.sql` update SQL scripts present in the 4.0-dev branch.

### Expected result AFTER applying this Pull Request

No Joomla 3 update SQL scripts present in the 4.0-dev branch.

### Documentation Changes Required

None.