### PR TITLE
[4.0] Fix form validation error

### DIFF
--- a/build/media_source/system/js/fields/validate.es6.js
+++ b/build/media_source/system/js/fields/validate.es6.js
@@ -117,11 +117,11 @@ class JFormValidator {
       const elMsg = document.createElement('span');
       elMsg.classList.add('form-control-feedback');
       if (empty && empty === 'checkbox') {
-        elMsg.innerHTML = (message !== null && Joomla.sanitizeHtml(message)) || Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_CHECK'));
+        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_CHECK');
       } else if (empty && empty === 'value') {
-        elMsg.innerHTML = (message !== null && Joomla.sanitizeHtml(message)) || Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_VALUE'));
+        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_VALUE');
       } else {
-        elMsg.innerHTML = (message !== null && Joomla.sanitizeHtml(message)) || Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_INVALID_VALUE'));
+        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_INVALID_VALUE');
       }
 
       if (label) {

--- a/build/media_source/system/js/fields/validate.es6.js
+++ b/build/media_source/system/js/fields/validate.es6.js
@@ -117,11 +117,11 @@ class JFormValidator {
       const elMsg = document.createElement('span');
       elMsg.classList.add('form-control-feedback');
       if (empty && empty === 'checkbox') {
-        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_CHECK');
+        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_CHECK'));
       } else if (empty && empty === 'value') {
-        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_VALUE');
+        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_VALUE'));
       } else {
-        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_INVALID_VALUE');
+        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_INVALID_VALUE'));
       }
 
       if (label) {

--- a/build/media_source/system/js/fields/validate.es6.js
+++ b/build/media_source/system/js/fields/validate.es6.js
@@ -117,11 +117,11 @@ class JFormValidator {
       const elMsg = document.createElement('span');
       elMsg.classList.add('form-control-feedback');
       if (empty && empty === 'checkbox') {
-        elMsg.innerHTML = Joomla.sanitizeHtml(message) || Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_CHECK'));
+        elMsg.innerHTML = (message !== null && Joomla.sanitizeHtml(message)) || Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_CHECK'));
       } else if (empty && empty === 'value') {
-        elMsg.innerHTML = Joomla.sanitizeHtml(message) || Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_VALUE'));
+        elMsg.innerHTML = (message !== null && Joomla.sanitizeHtml(message)) || Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_VALUE'));
       } else {
-        elMsg.innerHTML = Joomla.sanitizeHtml(message) || Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_INVALID_VALUE'));
+        elMsg.innerHTML = (message !== null && Joomla.sanitizeHtml(message)) || Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_INVALID_VALUE'));
       }
 
       if (label) {


### PR DESCRIPTION
Pull Request for Issue #34511.

### Summary of Changes
Added code to check and make sure message is not null before calling `Joomla.sanitizeHtml` to avoid javascript error. See the original issue for more details.


### Testing Instructions
1. See https://github.com/joomla/joomla-cms/issues/34511 to understand the issue.
2. Download update package for this PR at https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/34513/downloads/45176/Joomla_4.0.0-rc2-dev+pr.34513-Development-Update_Package.zip
, go to System -> Update -> Joomla, upload this package and run the update.
5. Check it again, confirm the original issue fixed.