### PR TITLE
[4.0] Fix com_joomlaupdate js error

### DIFF
--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -99,17 +99,17 @@ Joomla = window.Joomla || {};
     [].slice.call(document.querySelectorAll('.settingstoggle')).forEach((el) => {
       el.style.float = 'right';
       el.style.cursor = 'pointer';
-      el.addEventListener('click', (toggle) => {
+      el.addEventListener('click', () => {
         const settingsfieldset = el.closest('fieldset');
-        if (toggle.target.dataset.state === 'closed') {
-          toggle.target.dataset.state = 'open';
-          toggle.target.innerHTML = Joomla.sanitizeHtml(Joomla.getOptions('COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_SHOW_LESS_COMPATIBILITY_INFORMATION'));
+        if (el.dataset.state === 'closed') {
+          el.dataset.state = 'open';
+          el.innerHTML = Joomla.sanitizeHtml(Joomla.getOptions('COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_SHOW_LESS_COMPATIBILITY_INFORMATION'));
           settingsfieldset.querySelectorAll('.settingsInfo').forEach((fieldset) => {
             fieldset.classList.remove('hidden');
           });
         } else {
-          toggle.target.dataset.state = 'closed';
-          toggle.target.innerHTML = Joomla.sanitizeHtml(Joomla.getOptions('COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_SHOW_MORE_COMPATIBILITY_INFORMATION'));
+          el.dataset.state = 'closed';
+          el.innerHTML = Joomla.sanitizeHtml(Joomla.getOptions('COM_JOOMLAUPDATE_VIEW_DEFAULT_EXTENSIONS_SHOW_MORE_COMPATIBILITY_INFORMATION'));
           settingsfieldset.querySelectorAll('.settingsInfo').forEach((fieldset) => {
             fieldset.classList.add('hidden');
           });
@@ -417,7 +417,7 @@ Joomla = window.Joomla || {};
       PreUpdateChecker.nonCoreCriticalPlugins.forEach((plugin, cpi) => {
         if (plugin.package_id.toString() === extensionId
             || plugin.extension_id.toString() === extensionId) {
-          document.getElementById(`#plg_${plugin.extension_id}`).remove();
+          document.getElementById(`plg_${plugin.extension_id}`).remove();
           PreUpdateChecker.nonCoreCriticalPlugins.splice(cpi, 1);
         }
       });

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -417,7 +417,7 @@ Joomla = window.Joomla || {};
       PreUpdateChecker.nonCoreCriticalPlugins.forEach((plugin, cpi) => {
         if (plugin.package_id.toString() === extensionId
             || plugin.extension_id.toString() === extensionId) {
-          document.getElementById(`plg_${plugin.extension_id}`).remove();
+          document.getElementById(`#plg_${plugin.extension_id}`).remove();
           PreUpdateChecker.nonCoreCriticalPlugins.splice(cpi, 1);
         }
       });


### PR DESCRIPTION
Pull Request for Issue #34510.

### Summary of Changes
This PR fixes few js error for com_joomlaupdate. See https://github.com/joomla/joomla-cms/issues/34510 for more details. It also fixes an error in the console when the page is loaded (You need to install a third party extension like JCE to see this error - or code review)


### Testing Instructions
1. See https://github.com/joomla/joomla-cms/issues/34510 to understand the issue
2. Download update package for this PR, go to System -> Update -> Joomla to install the update package for this PR (or apply patch, and run npm command, sorry I don't remember the command to run)
3. Check and confirm the issue is gone.