### PR TITLE
[4.0] Add padding between button and Insert Tags

### DIFF
--- a/administrator/components/com_mails/tmpl/template/edit.php
+++ b/administrator/components/com_mails/tmpl/template/edit.php
@@ -65,7 +65,7 @@ $this->document->addScriptOptions('com_mails', ['templateData' => $this->templat
 			</div>
 			<div class="col-md-3">
 				<input type="button" id="btnResetBody" class="btn btn-secondary" value="<?php echo Text::_('COM_MAILS_RESET_TO_DEFAULT_BODY'); ?>" />
-				<div class="tags-container-body <?php echo $fieldBody->disabled ? 'hidden' : ''; ?>">
+				<div class="tags-container-body mt-3 <?php echo $fieldBody->disabled ? 'hidden' : ''; ?>">
 					<h2><?php echo Text::_('COM_MAILS_FIELDSET_TAGS_LABEL'); ?></h2>
 					<?php echo MailsHelper::mailtags($this->master, 'body'); ?>
 				</div>
@@ -80,7 +80,7 @@ $this->document->addScriptOptions('com_mails', ['templateData' => $this->templat
 			</div>
 			<div class="col-md-3">
 				<input type="button" id="btnResetHtmlBody" class="btn btn-secondary" value="<?php echo Text::_('COM_MAILS_RESET_TO_DEFAULT_HTML_BODY'); ?>" />
-				<div class="tags-container-htmlbody <?php echo $fieldHtmlBody->disabled ? 'hidden' : ''; ?>">
+				<div class="tags-container-htmlbody mt-3 <?php echo $fieldHtmlBody->disabled ? 'hidden' : ''; ?>">
 					<h2><?php echo Text::_('COM_MAILS_FIELDSET_TAGS_LABEL'); ?></h2>
 					<?php echo MailsHelper::mailtags($this->master, 'htmlbody'); ?>
 				</div>


### PR DESCRIPTION
Partial Pull Request for Issue #33655.

### Summary of Changes
Add padding between button and Insert Tags.


### Testing Instructions
Go to Global Configuration > Mail Templates
In Mail Format dropdown, select Both.
Go to System > Mail Templates
Edit a template.


### Actual result BEFORE applying this Pull Request
![33655](https://user-images.githubusercontent.com/368084/121936446-7ca6d580-ccfe-11eb-88d1-06af52cbb583.jpg)
