### PR TITLE
[4.0] Update deleted files in script.php to changes from PR #33864

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -5387,7 +5387,6 @@ class JoomlaInstallerScript
 			'/administrator/components/com_csp/tmpl/reports/default.php',
 			'/administrator/components/com_csp/tmpl/reports/default.xml',
 			'/administrator/components/com_fields/src/Field/SubfieldstypeField.php',
-			'/administrator/components/com_fields/tmpl/field/modal.php',
 			'/administrator/components/com_installer/tmpl/installer/default_ftp.php',
 			'/administrator/components/com_joomlaupdate/src/Helper/Select.php',
 			'/administrator/language/en-GB/com_csp.ini',
@@ -5848,11 +5847,18 @@ class JoomlaInstallerScript
 			'/templates/cassiopeia/scss/tools/mixins/_visually-hidden.scss',
 			'/templates/system/js/error-locales.js',
 			// 4.0 from RC 1 to RC 2
+			'/administrator/components/com_fields/tmpl/field/modal.php',
 			'/administrator/templates/atum/scss/pages/_com_admin.scss',
 			'/administrator/templates/atum/scss/pages/_com_finder.scss',
 			'/administrator/templates/atum/scss/pages/_com_joomlaupdate.scss',
 			'/libraries/src/Error/JsonApi/InstallLanguageExceptionHandler.php',
 			'/libraries/src/MVC/Controller/Exception/InstallLanguage.php',
+			'/media/com_fields/js/admin-field-edit-modal-es5.js',
+			'/media/com_fields/js/admin-field-edit-modal-es5.min.js',
+			'/media/com_fields/js/admin-field-edit-modal-es5.min.js.gz',
+			'/media/com_fields/js/admin-field-edit-modal.js',
+			'/media/com_fields/js/admin-field-edit-modal.min.js',
+			'/media/com_fields/js/admin-field-edit-modal.min.js.gz',
 		);
 
 		$folders = array(


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/33864#issuecomment-861363775 .

### Summary of Changes

- Move the deleted file "/administrator/components/com_fields/tmpl/field/modal.php" from section "// 4.0 from Beta 7 to Beta 8" to section "// 4.0 from RC 1 to RC 2".
- Add the compiled and minified and gzipped js of which the source has been removed with PR #33864 to the same section "// 4.0 from RC 1 to RC 2".

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

- Deleted file "/administrator/components/com_fields/tmpl/field/modal.php" is in section "// 4.0 from Beta 7 to Beta 8" of the removed files in "script.php".
- Files "/media/com_fields/js/admin-field-edit-modal*" will **not** be deleted when updating to current 4.0-dev.

### Expected result AFTER applying this Pull Request

- Deleted file "/administrator/components/com_fields/tmpl/field/modal.php" is in section "// 4.0 from RC 1 to RC 2" of the removed files in "script.php".
- Files "/media/com_fields/js/admin-field-edit-modal*" will be deleted when updating to a 4.0 version which includes this PR.

### Documentation Changes Required

None.