### PR TITLE
[4.0] Fix caption for the Ordering column and ascending/descending strings

### DIFF
--- a/layouts/joomla/searchtools/grid/sort.php
+++ b/layouts/joomla/searchtools/grid/sort.php
@@ -21,7 +21,7 @@ $id = '';
 if ($data->order === $data->selected) :
 	$icon = $data->orderIcon;
 	$sort = $data->direction === 'asc' ? 'descending' : 'ascending';
-	$caption = (!empty($data->title) ? Text::_($data->title) : Text::_('JGRID_HEADING_ORDERING')) . ' - ' . Text::_('JGLOBAL_ORDER_' . ($sort));
+	$caption = (!empty($data->title) ? Text::_($data->title) : Text::_('JGRID_HEADING_ORDERING')) . ' - ' . Text::_('JGLOBAL_ORDER_' . $sort);
 	$selected = ' selected';
 	$id = 'id="sorted"';
 endif;

--- a/layouts/joomla/searchtools/grid/sort.php
+++ b/layouts/joomla/searchtools/grid/sort.php
@@ -21,7 +21,7 @@ $id = '';
 if ($data->order === $data->selected) :
 	$icon = $data->orderIcon;
 	$sort = $data->direction === 'asc' ? 'descending' : 'ascending';
-	$caption = (!empty($data->title) ? Text::_($data->title) : Text::_('JGRID_HEADING_ORDERING')) . ' ' . Text::_('JGLOBAL_ORDER_' . ($sort));
+	$caption = (!empty($data->title) ? Text::_($data->title) : Text::_('JGRID_HEADING_ORDERING')) . ' - ' . Text::_('JGLOBAL_ORDER_' . ($sort));
 	$selected = ' selected';
 	$id = 'id="sorted"';
 endif;

--- a/layouts/joomla/searchtools/grid/sort.php
+++ b/layouts/joomla/searchtools/grid/sort.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 
 $data = $displayData;
-$icon = "icon-sort";
+$icon = 'icon-sort';
 $sort = '';
 $caption = '';
 $selected = '';
@@ -21,7 +21,7 @@ $id = '';
 if ($data->order === $data->selected) :
 	$icon = $data->orderIcon;
 	$sort = $data->direction === 'asc' ? 'descending' : 'ascending';
-	$caption = !empty($data->title) ? Text::_($data->title) . ' - ' . $sort : Text::_('JGRID_HEADING_ID');
+	$caption = (!empty($data->title) ? Text::_($data->title) : Text::_('JGRID_HEADING_ORDERING')) . ' ' . Text::_('JGLOBAL_ORDER_' . ($sort));
 	$selected = ' selected';
 	$id = 'id="sorted"';
 endif;


### PR DESCRIPTION
### Summary of Changes
In list view, the caption text is wrong for the Ordering column and ascending/descending are not translated.


### Testing Instructions
Go to Global Configuration > System
Enable Debug Language.

In https://github.com/Quy/joomla-cms/blob/30c1d8ce688c9e84e6f996bb1877a9fdec23fc94/administrator/components/com_content/tmpl/articles/default.php#L110
Change `<caption class="visually-hidden">` to `<caption class="caption-top">`.

Go to Content > Articles
In Sort Table By dropdown, select Ordering ascending/descending.
In Sort Table By dropdown, select Status ascending/descending.

Apply PR.

See captions for the above.


### Actual result BEFORE applying this Pull Request
```
**Table of Articles**, **Sorted by:** **ID**,
**Table of Articles**, **Sorted by:** **ID**,

**Table of Articles**, **Sorted by:** **Status** - ascending,
**Table of Articles**, **Sorted by:** **Status** - descending, 
```


### Expected result AFTER applying this Pull Request
```
**Table of Articles**, **Sorted by:** **Ordering** **Ascending**, 
**Table of Articles**, **Sorted by:** **Ordering** **Descending**, 

**Table of Articles**, **Sorted by:** **Status** - **Ascending**, 
**Table of Articles**, **Sorted by:** **Status** - **Descending**, 

```