### PR TITLE
[4.0] Reorder Featured in Sort Table By dropdown

### DIFF
--- a/administrator/components/com_contact/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/forms/filter_contacts.xml
@@ -103,10 +103,10 @@
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option value="a.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
 			<option value="a.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
-			<option value="a.published ASC">JSTATUS_ASC</option>
-			<option value="a.published DESC">JSTATUS_DESC</option>
 			<option value="a.featured ASC">JFEATURED_ASC</option>
 			<option value="a.featured DESC">JFEATURED_DESC</option>
+			<option value="a.published ASC">JSTATUS_ASC</option>
+			<option value="a.published DESC">JSTATUS_DESC</option>
 			<option value="a.name ASC">JGLOBAL_TITLE_ASC</option>
 			<option value="a.name DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="category_title ASC">JCATEGORY_ASC</option>

--- a/administrator/components/com_content/forms/filter_articles.xml
+++ b/administrator/components/com_content/forms/filter_articles.xml
@@ -125,10 +125,10 @@
 			<option value="">JGLOBAL_SORT_BY</option>
 			<option value="a.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
 			<option value="a.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
-			<option value="a.state ASC">JSTATUS_ASC</option>
-			<option value="a.state DESC">JSTATUS_DESC</option>
 			<option value="a.featured ASC">JFEATURED_ASC</option>
 			<option value="a.featured DESC">JFEATURED_DESC</option>
+			<option value="a.state ASC">JSTATUS_ASC</option>
+			<option value="a.state DESC">JSTATUS_DESC</option>
 			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
 			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
 			<option value="category_title ASC">JCATEGORY_ASC</option>


### PR DESCRIPTION
### Summary of Changes
Reorder Featured in Sort Table By dropdown to match columns order.


### Testing Instructions
Go to Content > Articles
View Sort Table By dropdown.
Go to Components > Contacts
View Sort Table By dropdown.

Featured ascending/descending should be before Status ascending/descending.

