### PR TITLE
Added urlencode to search word

### DIFF
--- a/components/com_search/controller.php
+++ b/components/com_search/controller.php
@@ -50,13 +50,10 @@ class SearchController extends JControllerLegacy
 		// If searchword enclosed in double quotes, strip quotes and do exact match
 		if (substr($searchword, 0, 1) === '"' && substr($searchword, -1) === '"')
 		{
-			$post['searchword'] = substr($searchword, 1, -1);
+			$searchword = substr($searchword, 1, -1);
 			$this->input->set('searchphrase', 'exact');
 		}
-		else
-		{
-			$post['searchword'] = $searchword;
-		}
+		$post['searchword'] = urlencode(urlencode($searchword));
 
 		$post['ordering']     = $this->input->post->getWord('ordering');
 		$post['searchphrase'] = $this->input->post->getWord('searchphrase', 'all');


### PR DESCRIPTION
The encoding of the search word prevent unexpected behavior with this user-dependent field (e.g. "word&with=special+characters" will be search literally rather than parsed in the URL), and fixes some bugs related to special characters such as accents (for example "café") in the "Location" response header, that are blocked by some security protection

Pull Request for Issue #34540.

### Summary of Changes

Added `urlencode` call (twice, because one wasn't enough) in `com_search/controller.php` around `$searchword`

### Testing Instructions

Perform a search using a special character (such as an ampersand, symbol used to separate URL parameters), and check the term effectively searched

### Actual result BEFORE applying this Pull Request

Search for `word&with=special+characters` and get a search result for `word`, with an extra URL parameter `with=special+characters`

### Expected result AFTER applying this Pull Request

Search for `word&with=special+characters` and get a search result for `word&with=special+characters`, without  any extra URL parameter

### Documentation Changes Required

No change would be required, as it fix an abnormal behavior of the `com_search` component