### PR TITLE
[4.0] table header font weight

### DIFF
--- a/templates/cassiopeia/scss/vendor/bootstrap/_table.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_table.scss
@@ -2,6 +2,10 @@
 
 .table {
 
+  th {
+    font-weight: 500;
+  }
+
   thead th {
     white-space: nowrap;
     border-bottom-width: 1px;


### PR DESCRIPTION
Use font-weight: 500 for table headers
Quick pull request for #34544 

I still prefer the approach in atum https://github.com/joomla/joomla-cms/issues/34544#issuecomment-863471589 but I guess thats a bigger task for another day