### PR TITLE
[4.0] com_content set default date field

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -957,7 +957,6 @@
 			name="order_date"
 			type="list"
 			label="JGLOBAL_ORDERING_DATE_LABEL"
-			showon="orderby_sec:rdate,date"
 			default="published"
 			validate="options"
 			>


### PR DESCRIPTION
This PR lets you set the default date field to be used in lists. eg published, created, modified

Before this PR you could only set the field if you had also set a default list order that was date based, which didnt actually make sense.

It was also confusing as the use of showon for this field was only in the global config for com_content and not at the menu level.

Pull Request for Issue #34553 
