### PR TITLE
[4.0] Don't trim trailing slash in SEF URL's of home menu items on multilingual sites

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -504,7 +504,7 @@ class SiteRouter extends Router
 		// Set path again in the URI
 		$uri->setPath(ltrim($route, '/'));
 
-		if (!$item->home)
+		if (!isset($item->home) || !$item->home)
 		{
 			$uri->setPath(rtrim($route, '/'));
 		}

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -496,7 +496,7 @@ class SiteRouter extends Router
 		$route = ltrim($uri->getPath() . '/' . $tmp, '/');
 
 		// Remove trailing slash if URL ends with 'index.php/' or is not a home menu item
-		if (substr($route, -10) === 'index.php/' || !isset($item->home) || !$item->home)
+		if (substr($route, -10) === 'index.php/' || $item === null || !$item->home)
 		{
 			$route = rtrim($route, '/');
 		}

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -492,9 +492,10 @@ class SiteRouter extends Router
 			$tmp = 'component/' . substr($query['option'], 4) . '/' . $tmp;
 		}
 
-		// Get the route
+		// Get the route without any leading slash
 		$route = ltrim($uri->getPath() . '/' . $tmp, '/');
 
+		// Remove trailing slash if URL ends with 'index.php/' or is not a home menu item
 		if (substr($route, -10) === 'index.php/' || !isset($item->home) || !$item->home)
 		{
 			$route = rtrim($route, '/');

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -500,7 +500,14 @@ class SiteRouter extends Router
 
 		// Set query again in the URI
 		$uri->setQuery($query);
-		$uri->setPath(trim($route, '/'));
+
+		// Set path again in the URI
+		$uri->setPath(ltrim($route, '/'));
+
+		if (!$item->home)
+		{
+			$uri->setPath(rtrim($route, '/'));
+		}
 	}
 
 	/**

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -482,7 +482,7 @@ class SiteRouter extends Router
 		{
 			if (!$item->home)
 			{
-				$tmp = $item->route . '/' . $tmp;
+				$tmp = $tmp ? $item->route . '/' . $tmp : $item->route;
 			}
 
 			unset($query['Itemid']);
@@ -492,13 +492,10 @@ class SiteRouter extends Router
 			$tmp = 'component/' . substr($query['option'], 4) . '/' . $tmp;
 		}
 
-		// Get the route without leading slash
-		$route = ltrim($uri->getPath() . '/' . $tmp, '/');
-
-		// Remove trailing slash if URL ends with 'index.php/' or is not a home menu item
-		if (substr($route, -10) === 'index.php/' || $item === null || !$item->home)
+		// Get the route
+		if ($tmp)
 		{
-			$route = rtrim($route, '/');
+			$uri->setPath($uri->getPath() . '/' . $tmp);
 		}
 
 		// Unset unneeded query information
@@ -506,7 +503,6 @@ class SiteRouter extends Router
 
 		// Set query again in the URI
 		$uri->setQuery($query);
-		$uri->setPath($route);
 	}
 
 	/**

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -495,7 +495,7 @@ class SiteRouter extends Router
 		// Get the route
 		$route = ltrim($uri->getPath() . '/' . $tmp, '/');
 
-		if (!isset($item->home) || !$item->home)
+		if (substr($route, -10) === 'index.php/' || !isset($item->home) || !$item->home)
 		{
 			$route = rtrim($route, '/');
 		}

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -492,7 +492,7 @@ class SiteRouter extends Router
 			$tmp = 'component/' . substr($query['option'], 4) . '/' . $tmp;
 		}
 
-		// Get the route without any leading slash
+		// Get the route without leading slash
 		$route = ltrim($uri->getPath() . '/' . $tmp, '/');
 
 		// Remove trailing slash if URL ends with 'index.php/' or is not a home menu item

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -493,21 +493,19 @@ class SiteRouter extends Router
 		}
 
 		// Get the route
-		$route = $uri->getPath() . '/' . $tmp;
+		$route = ltrim($uri->getPath() . '/' . $tmp, '/');
+
+		if (!isset($item->home) || !$item->home)
+		{
+			$route = rtrim($route, '/');
+		}
 
 		// Unset unneeded query information
 		unset($query['option']);
 
 		// Set query again in the URI
 		$uri->setQuery($query);
-
-		// Set path again in the URI
-		$uri->setPath(ltrim($route, '/'));
-
-		if (!isset($item->home) || !$item->home)
-		{
-			$uri->setPath(rtrim($route, '/'));
-		}
+		$uri->setPath($route);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #34523 .

### Summary of Changes

Don't strip off the trailing slash for home menu items when SEF URL's are switched on.

Thanks to @brianteeman who pointed me to the right place of code with his PR #34538 .

### Testing Instructions

Create a multlingual site and check that the URL's for
- home pages (item "Home" in "Main Menu" in the right sidebar when using Sample Data Blog)
- other pages one level below the home page (e.g. first item "Blog" in the "Main MenuBlog" in the header when using Sample Data Blog)
- other pages more than one level below the home page (e.g. "Help -> About your home page" in the "Main MenuBlog" in the header when using Sample Data Blog)

Test with different SEF settings in Global Configuration - Site.

Check also the `rel="alternate"` head links with your browser inspector.

Do the same checks for a monolingual site, except of the last one with the head links.

Test not only menu items belonging to com_content but also for other components, e.g. com_contact, or for some 3rd party extension.

### Actual result BEFORE applying this Pull Request

See issue #34523 (description and later comments).

### Expected result AFTER applying this Pull Request

#### Multilingual sites

Check of the head links: In all the below cases there should be `rel="alternate"` head links only for the other languages but not for the current one.

I. "Search Engine Friendly URLs" = "Yes", "Use URL Rewriting"= "Yes", "Add Suffix to URL" = "No":

Associations and links in mod_languages to the default (home) pages of different languages should be:
- https://www.example.com/en/
- https://www.example.com/es/
- https://www.example.com/nl/
...

No trailing slash should be appended to non default pages:
- https://www.example.com/en/my-article
- https://www.example.com/en/my-category-blog
- https://www.example.com/en/whatever/whatever-else
...

II. "Search Engine Friendly URLs" = "Yes", "Use URL Rewriting"= "No", "Add Suffix to URL" = "No":

Same as I. except of the `/index.php` being appended after the domain (or the subfolder if Jooma is installed in a subfolder).

III. "Search Engine Friendly URLs" = "Yes", "Use URL Rewriting"= "Yes", "Add Suffix to URL" = "Yes":

Associations and links in mod_languages to the default (home) pages of different languages should be same as I. and II. before.

The .html suffix should be appended to non default pages:
- https://www.example.com/en/my-article.html
- https://www.example.com/en/my-category-blog.html
- https://www.example.com/en/whatever/whatever-else.html
...

IV. "Search Engine Friendly URLs" = "Yes", "Use URL Rewriting"= "No", "Add Suffix to URL" = "Yes":

Same as III. except of the `/index.php` being appended after the domain (or the subfolder if Jooma is installed in a subfolder).

V. "Search Engine Friendly URLs" = "No"

There should not be any difference between with and without this PR.

#### Monolingual sites

There should not be any difference between with and without this PR.

### Documentation Changes Required

None.