### PR TITLE
[4.0] Add sticky information to banner

### DIFF
--- a/components/com_banners/src/Model/BannersModel.php
+++ b/components/com_banners/src/Model/BannersModel.php
@@ -77,6 +77,7 @@ class BannersModel extends ListModel
 				$db->quoteName('a.type'),
 				$db->quoteName('a.name'),
 				$db->quoteName('a.clickurl'),
+				$db->quoteName('a.sticky'),
 				$db->quoteName('a.cid'),
 				$db->quoteName('a.description'),
 				$db->quoteName('a.params'),


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Banners can be displayed in a frontend module. 
But the modules does not know which banners are pinned (sticky).
This PR adds the information to the itmes.


### Testing Instructions
Code review or debug mod_banners

