### PR TITLE
[4.0] Plural for password rules

### DIFF
--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -114,27 +114,27 @@ if ($rules)
 
 	if ($minLength)
 	{
-		$requirements[] = Text::sprintf('JFIELD_PASSWORD_RULES_CHARACTERS', $minLength);
+		$requirements[] = Text::plural('JFIELD_PASSWORD_RULES_CHARACTERS', $minLength);
 	}
 
 	if ($minIntegers)
 	{
-		$requirements[] = Text::sprintf('JFIELD_PASSWORD_RULES_DIGITS', $minIntegers);
+		$requirements[] = Text::plural('JFIELD_PASSWORD_RULES_DIGITS', $minIntegers);
 	}
 
 	if ($minSymbols)
 	{
-		$requirements[] = Text::sprintf('JFIELD_PASSWORD_RULES_SYMBOLS', $minSymbols);
+		$requirements[] = Text::plural('JFIELD_PASSWORD_RULES_SYMBOLS', $minSymbols);
 	}
 
 	if ($minUppercase)
 	{
-		$requirements[] = Text::sprintf('JFIELD_PASSWORD_RULES_UPPERCASE', $minUppercase);
+		$requirements[] = Text::plural('JFIELD_PASSWORD_RULES_UPPERCASE', $minUppercase);
 	}
 
 	if ($minLowercase)
 	{
-		$requirements[] = Text::sprintf('JFIELD_PASSWORD_RULES_LOWERCASE', $minLowercase);
+		$requirements[] = Text::plural('JFIELD_PASSWORD_RULES_LOWERCASE', $minLowercase);
 	}
 }
 ?>


### PR DESCRIPTION
### Summary of Changes
Make it possible to change the string of password parameters for each language separately.

For example, in Russian it will look much better if you change the wording to "N characters ...". Changes for a bunch of lines:

```
JFIELD_PASSWORD_RULES_CHARACTERS="Characters: %d"
JFIELD_PASSWORD_RULES_DIGITS="Numbers: %d"
JFIELD_PASSWORD_RULES_LOWERCASE="Lower Case: %d"
...
JFIELD_PASSWORD_RULES_SYMBOLS="Symbols: %d"
JFIELD_PASSWORD_RULES_UPPERCASE="Upper Case: %d"
```

How to check? Change the password requirements in the user settings - add required characters, numbers, upper / lower case, etc.

Break, for example, the line below (each in its own language) and apply the correct wording: 

`JFIELD_PASSWORD_RULES_CHARACTERS="Characters: %d"`

=>

```
JFIELD_PASSWORD_RULES_CHARACTERS_1="%d character"
JFIELD_PASSWORD_RULES_CHARACTERS_2="%d characters"
JFIELD_PASSWORD_RULES_CHARACTERS="%d characters"
```
Turn on registration on the site and try to register a new user. Pay attention to the password hints. 