### PR TITLE
[4.0] contact icons

### DIFF
--- a/build/media_source/system/scss/_icomoon.scss
+++ b/build/media_source/system/scss/_icomoon.scss
@@ -77,7 +77,7 @@ $jicons-special: (
 $jicons: (
   add : $fa-var-plus,
   address-book : $fa-var-address-book,
-  address : $fa-var-file-alt,
+  address : $fa-var-address-book,
   align-justify : $fa-var-align-justify,
   angle-double-left : $fa-var-angle-double-left,
   angle-double-right : $fa-var-angle-double-right,
@@ -442,7 +442,7 @@ $jicons: (
   user : $fa-var-user,
   users-cog : $fa-var-users-cog,
   users : $fa-var-users,
-  vcard : $fa-var-file-alt,
+  vcard : $fa-var-address-card,
   video-2 : $fa-var-play,
   video : $fa-var-video,
   wand : $fa-var-magic,


### PR DESCRIPTION
The entire point of the _icomoon.scss file is to map fontawesome icons to the icons used in joomla 3 from icomoon

Somehow the wrong icons were used for icon-address and icon-vcard

You can see the original icomoon icons here https://docs.joomla.org/J3.x:Joomla_Standard_Icomoon_Fonts
