### PR TITLE
[4.0] input border

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -12,12 +12,6 @@
   }
 }
 
-.form-control:disabled,
-.form-control[readonly] {
-  border: 0;
-  box-shadow: none;
-}
-
 .control-group {
   position: relative;
   display: flex;


### PR DESCRIPTION
#27918 set the border to none for  form-control:disabled and form-control:readonly in the admin

Amongst other things this made the image select box look odd as it only had a partial border

PR for #34572

For testing dont forget to rebuild the scss and then test readonly fields such as for an article with the hits, intro image fields
