### PR TITLE
[4.0] PlgSystemDebug fix: Deprecated usort() Returning bool.

### DIFF
--- a/plugins/system/debug/src/Storage/FileStorage.php
+++ b/plugins/system/debug/src/Storage/FileStorage.php
@@ -89,7 +89,12 @@ class FileStorage extends \DebugBar\Storage\FileStorage
 		usort(
 			$files,
 			function ($a, $b) {
-				return $a['time'] < $b['time'];
+				if ($a['time'] === $b['time'])
+				{
+					return 0;
+				}
+
+				return $a['time'] < $b['time'] ? 1 : -1;
 			}
 		);
 


### PR DESCRIPTION
### Summary of Changes
Fix for PHP 8
```
Deprecated: usort(): Returning bool from comparison function is deprecated, 
return an integer less than, equal to, or greater than zero in
```


### Testing Instructions
Code review.

Or:

Apply patch. Make sure your PHP shows deprecated messages.
Enable debug.
Navigate around site.
In debug bar click a "folder" icon to open debug history.



### Actual result BEFORE applying this Pull Request
The history popup is empty


### Expected result AFTER applying this Pull Request
The history popup not empty, and you can select previous debug.


### Documentation Changes Required
none
