### PR TITLE
[4.0] Fix Drag'n'Drop a parent-category show children-categories only after page-refresh

### DIFF
--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -158,7 +158,9 @@ if ($saveOrder && !empty($this->items))
 									$parentsStr = '';
 								}
 								?>
-								<tr class="row<?php echo $i % 2; ?>" data-draggable-group="<?php echo $item->parent_id; ?>" item-id="<?php echo $item->id ?>" parents="<?php echo $parentsStr ?>" level="<?php echo $item->level ?>">
+								<tr class="row<?php echo $i % 2; ?>" data-draggable-group="<?php echo $item->parent_id; ?>"
+									data-item-id="<?php echo $item->id ?>" data-parents="<?php echo $parentsStr ?>"
+									data-level="<?php echo $item->level ?>">
 									<td class="text-center">
 										<?php echo HTMLHelper::_('grid.id', $i, $item->id, false, 'cid', 'cb', $item->title); ?>
 									</td>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -134,8 +134,8 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 							}
 							?>
 							<tr class="row<?php echo $i % 2; ?>" data-draggable-group="<?php echo $item->parent_id; ?>"
-								item-id="<?php echo $item->id; ?>" parents="<?php echo $parentsStr; ?>"
-								level="<?php echo $item->level; ?>">
+								data-item-id="<?php echo $item->id; ?>" data-parents="<?php echo $parentsStr; ?>"
+								data-level="<?php echo $item->level; ?>">
 								<td class="text-center">
 									<?php echo HTMLHelper::_('grid.id', $i, $item->id, false, 'cid', 'cb', $item->title); ?>
 								</td>

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -161,7 +161,9 @@ if ($saveOrder && !empty($this->items))
 						$parentsStr = '';
 					}
 					?>
-						<tr class="row<?php echo $i % 2; ?>" data-draggable-group="<?php echo $item->parent_id; ?>" item-id="<?php echo $item->id; ?>" parents="<?php echo $parentsStr; ?>" level="<?php echo $item->level; ?>">
+						<tr class="row<?php echo $i % 2; ?>" data-draggable-group="<?php echo $item->parent_id; ?>"
+							data-item-id="<?php echo $item->id; ?>" data-parents="<?php echo $parentsStr; ?>"
+							data-level="<?php echo $item->level; ?>">
 							<td class="text-center">
 								<?php echo HTMLHelper::_('grid.id', $i, $item->id, false, 'cid', 'cb', $item->title); ?>
 							</td>

--- a/build/media_source/system/js/draggable.es6.js
+++ b/build/media_source/system/js/draggable.es6.js
@@ -140,10 +140,26 @@ if (container) {
       }
     }
 
+    // Update positions for a children of the moved item
+    rearrangeChildren(el);
+
     // Reset data order attribute for initial ordering
     const elements = container.querySelectorAll('[name="order[]"]');
     for (let i = 0, l = elements.length; l > i; i += 1) {
       elements[i].dataset.order = i + 1;
+    }
+  };
+
+  const rearrangeChildren = ($parent) => {
+    if (!$parent.dataset.itemId) {
+      return;
+    }
+    const parentId = $parent.dataset.itemId;
+    // Get children list. Each child row should have an attribute data-parents=" 1 2 3" where the number is id of parent
+    const $children = container.querySelectorAll(`tr[data-parents~="${parentId}"]`);
+
+    if ($children.length) {
+      $parent.after(...$children);
     }
   };
 

--- a/build/media_source/system/js/draggable.es6.js
+++ b/build/media_source/system/js/draggable.es6.js
@@ -92,6 +92,20 @@ if (container) {
     return result;
   };
 
+  const rearrangeChildren = ($parent) => {
+    if (!$parent.dataset.itemId) {
+      return;
+    }
+    const parentId = $parent.dataset.itemId;
+    // Get children list. Each child row should have
+    // an attribute data-parents=" 1 2 3" where the number is id of parent
+    const $children = container.querySelectorAll(`tr[data-parents~="${parentId}"]`);
+
+    if ($children.length) {
+      $parent.after(...$children);
+    }
+  };
+
   const saveTheOrder = (el) => {
     let orderSelector;
     let inputSelector;
@@ -147,19 +161,6 @@ if (container) {
     const elements = container.querySelectorAll('[name="order[]"]');
     for (let i = 0, l = elements.length; l > i; i += 1) {
       elements[i].dataset.order = i + 1;
-    }
-  };
-
-  const rearrangeChildren = ($parent) => {
-    if (!$parent.dataset.itemId) {
-      return;
-    }
-    const parentId = $parent.dataset.itemId;
-    // Get children list. Each child row should have an attribute data-parents=" 1 2 3" where the number is id of parent
-    const $children = container.querySelectorAll(`tr[data-parents~="${parentId}"]`);
-
-    if ($children.length) {
-      $parent.after(...$children);
     }
   };
 


### PR DESCRIPTION
Pull Request for Issue #34389 .

### Summary of Changes
Move the children after the order is changed


### Testing Instructions
Apply patch, run `npm install` and please follow #34389


### Documentation Changes Required
none
