### PR TITLE
Ignore null values in subform rule

### DIFF
--- a/libraries/src/Form/Rule/SubFormRule.php
+++ b/libraries/src/Form/Rule/SubFormRule.php
@@ -45,7 +45,12 @@ class SubformRule extends FormRule
 		{
 			throw new \UnexpectedValueException(sprintf('%s is no subform field.', $element['name']));
 		}
-
+		
+		if ($value === null)
+		{
+			return true;
+		}
+		
 		$subForm = $field->loadSubForm();
 
 		// Multiple values: Validate every row.


### PR DESCRIPTION
### Summary of Changes
The subform rule can get **null** as value to validate. This throws the following warning:
_Warning: foreach() argument must be of type array|object, null given in /var/www/html/j3/libraries/src/Form/Rule/SubFormRule.php on line 52_

~@Fedik can you help here with a test case in core?~


### Testing Instructions
- Add the following code to the file modules/mod_custom/mod_custom.xml after line 27:  
```
<field type="subform" name="subform" multiple="true" label="subform" 
  validate="subform" filter="unset">
  <form>
    <field type="text" name="text" label="text" />
  </form>
</field>
```
- Create a new custom module and save it

### Actual result BEFORE applying this Pull Request
The warning mentioned above is added to the logs of the server.

### Expected result AFTER applying this Pull Request
No Warning.