### PR TITLE
[4.0] Add support full typizations for base class Table.

### DIFF
--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -2281,7 +2281,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			return $value->toSql();
 		}
 
-		// Convert field with type \Joomla\CMS\Date\Date(and Others) to SQL format
+		// Convert field with type \Joomla\CMS\Date\Date (and others) to SQL format
 		if (is_object($value) && in_array($typeLower, ['tosql','string']) && method_exists($value, 'toSql'))
 		{
 			return $value->toSql();

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -247,7 +247,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 *
 	 * @param   string               $table       Name of the table to model.
 	 * @param   mixed                $key         Name of the primary key field in the table or array of field names that compose the primary key.
-	 * @param   DatabaseDriver       $db          DatabaseDriver object.
+	 * @param   DatabaseDriver|null  $db          DatabaseDriver object.
 	 * @param   DispatcherInterface  $dispatcher  Event dispatcher for this table
 	 *
 	 * @since  1.7.0

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -143,7 +143,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 * The \DateTimeZone object for usage in rending dates as strings.
 	 *
 	 * @var    \DateTimeZone
-	 * @since  4.0.0
+	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $_tz = null;
 

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -152,7 +152,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 * Only properties declared in table class
 	 *
 	 * @var    array
-	 * @since  4.0.0
+	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $_propertyTypes = [];
 

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -160,7 +160,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 * Array types convert type BD to type PHP
 	 *
 	 * @var array
-	 * @since  4.0.0
+	 * @since  __DEPLOY_VERSION__
 	 */
 	protected static $_typesVeluesProperty = [
 		// 'This type SQL' => 'This type PHP'

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -2242,8 +2242,10 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 * @param mixed $value Value converting in new type
 	 * @param string $type New type for value
 	 * @param  mixed  $tz  Time zone to be used for the date. Might be a string or a DateTimeZone object.
+	 *
 	 * @return mixed
-	 * @since  4.0.0
+	 *	 
+	 * @since  __DEPLOY_VERSION__
 	 */
 	public static function TypeConvert($value = null, $type = '', $tz = null)
 	{

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -248,7 +248,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 * @param   string               $table       Name of the table to model.
 	 * @param   mixed                $key         Name of the primary key field in the table or array of field names that compose the primary key.
 	 * @param   DatabaseDriver|null  $db          DatabaseDriver object.
-	 * @param   DispatcherInterface  $dispatcher  Event dispatcher for this table
+	 * @param   DispatcherInterface|null  $dispatcher  Event dispatcher for this table
 	 *
 	 * @since  1.7.0
 	 */

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -2201,8 +2201,9 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	/**
 	 * Convert(preparation) $this object to data array for save to BD.
 	 *
-	 * @return  stdClass
-	 * @since  4.0.0
+	 * @return  \stdClass
+	 *
+	 * @since  __DEPLOY_VERSION__
 	 */
 	public function toSqlData() : object
 	{

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -2175,7 +2175,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 *
 	 * @return  \DateTimeZone
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 * @note    This method can't be type hinted due to a PHP bug: https://bugs.php.net/bug.php?id=61483
 	 */
 	public function setTimezone($tz = null)

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -2330,8 +2330,10 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 * Get type PHP property from DB type column
 	 *
 	 * @param string $typeDB
+	 *	 
 	 * @return string
-	 * @since  4.0.0
+	 *	 
+	 * @since  __DEPLOY_VERSION__
 	 */
 	public static function getTypeProperty($typeDB)
 	{

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -223,7 +223,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 * Array default values for php simple types
 	 *
 	 * @var array
-	 * @since  4.0.0
+	 * @since  __DEPLOY_VERSION__
 	 */
 	protected static $_defaultValuesProperty = [
 		'bool' => false,

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -2190,6 +2190,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 
 	/**
 	 * Get list properties name and their types
+	 *
 	 * @return array
 	 */
 	public function getTypesProperties()

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -2256,7 +2256,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			return static::$_defaultValuesProperty[$typeLower];
 		}
-		
+
 		if (isset(static::$_typesVeluesProperty[$typeLower]))
 		{
 			$typeLower = static::$_typesVeluesProperty[$typeLower];

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -163,7 +163,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 * @since  4.0.0
 	 */
 	protected static $_typesVeluesProperty = [
-		//'This type SQL' => 'This type PHP'
+		// 'This type SQL' => 'This type PHP'
 		'bool' => 'bool',
 		'boolean' => 'bool',
 
@@ -285,7 +285,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		$this->_db = $db ?? Factory::getDbo();
 
 		// Initialise the table properties.
-		foreach ((new \ReflectionObject($this))->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop)// [0=>(name,class)... ]
+		foreach ((new \ReflectionObject($this))->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop)
 		{
 			if ('_' == substr($prop->name, 0, 1))
 			{
@@ -308,17 +308,14 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 
 			$this->{$prop->name} = static::TypeConvert('', $type);
 		}
-//if (!\in_array($k, $this->_tbl_keys) && (strpos($k, '_') !== 0))
+
 		// Convert types otherwise default value
 		foreach ($this->getFields() as $name => $field)
 		{
-			// Use type property if it is not already present.
-			if (isset($this->_propertyTypes[$field->Field]))
+			if (!\in_array($name, $this->_tbl_keys) && (strpos($name, '_') !== 0))
 			{
-				$field->TypeProperty = $this->_propertyTypes[$field->Field]; 
+				$this->$name = static::TypeConvert($field->Default, $field->TypeProperty, $this->_tz);
 			}
-
-			$this->$name = static::TypeConvert($field->Default, $field->TypeProperty, $this->_tz);
 		}
 
 		// If we are tracking assets, make sure an access field exists and initially set the default.
@@ -378,7 +375,8 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 
 			foreach ($fields as $field)
 			{
-				$field->TypeProperty = static::getTypeProperty($field->Type);
+				// Use type property if it is not already present.
+				$field->TypeProperty = $this->_propertyTypes[$field->Field] ?? static::getTypeProperty($field->Type);
 			}
 
 			$cache = $fields;

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -201,7 +201,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		'nvarchar' => 'string',
 		'nchar' => 'string',
 		'json' => 'string',
-		
+
 		'cidr' => 'string',
 		'macaddr' => 'string',
 		'macaddr8' => 'string',
@@ -2306,7 +2306,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 
 			return $value;
 		}
-		
+
 		// Convert field with type \Joomla\CMS\Date\Date(and Others) to SQL format
 		if (is_object($value) && in_array($type, ['tosql','string']) && method_exists($value, 'toSql'))
 		{

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -235,7 +235,6 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 */
 	public function __construct($table, $key, DatabaseDriver $db = null, DispatcherInterface $dispatcher = null)
 	{
-		
 		if (!isset($this->_tz))
 		{
 			$this->_tz = Factory::getUser()->getTimezone();
@@ -273,7 +272,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		// Initialise the table properties.
 		foreach ((new \ReflectionObject($this))->getProperties(\ReflectionProperty::IS_PUBLIC) as $prop)// [0=>(name,class)... ]
 		{
-			if('_' == substr($prop->name, 0, 1))
+			if ('_' == substr($prop->name, 0, 1))
 			{
 				continue;
 			}
@@ -281,12 +280,12 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			$type = (string)$prop->getType();//->getName()
 			$this->_propertyTypes[$prop->name] = $type;
 
-			if(isset($this->{$prop->name}))
+			if (isset($this->{$prop->name}))
 			{
 				continue;
 			}
 
-			if($type == '' || substr($type, 0, 1) == '?'){
+			if ($type == '' || substr($type, 0, 1) == '?'){
 				$this->{$prop->name} = null;
 				continue;
 			}
@@ -299,7 +298,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			// Add the field if it is not already present.
 			$type = $field->TypeProperty;
-			if(isset($this->_propertyTypes[$field->Field]))
+			if (isset($this->_propertyTypes[$field->Field]))
 			{
 				$field->TypeProperty = $this->_propertyTypes[$field->Field];
 				$type = $field->TypeProperty;
@@ -308,7 +307,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			{
 				//get type PHP from type DB without length
 				$field->TypeProperty = static::getTypeProperty($field->Type);
-				if(isset(static::$_typesVeluesProperty[$field->TypeProperty]))
+				if (isset(static::$_typesVeluesProperty[$field->TypeProperty]))
 				{
 					$type = static::$_typesVeluesProperty[$field->TypeProperty];
 				}
@@ -815,23 +814,23 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		foreach ($src as $k => $value)
 		{
 			// Only process fields not in the ignore array.
-			if(\in_array($k, $ignore))
+			if (\in_array($k, $ignore))
 			{
 				continue;
 			}
-			if(isset($fields[$k]))
+			if (isset($fields[$k]))
 			{
 				$type = $fields[$k]->TypeProperty;
 				$this->{$k} = static::TypeConvert($value,$type);
 				continue;
 			}
-			if(isset($this->_propertyTypes[$k]))
+			if (isset($this->_propertyTypes[$k]))
 			{
 				$type = $this->_propertyTypes[$k];
 				$this->{$k} = static::TypeConvert($value,$type);
 				continue;
 			}
-			if(isset($this->{$k}))
+			if (isset($this->{$k}))
 			{
 				$this->{$k} = $value;
 			}
@@ -2175,7 +2174,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 */
 	public function setTimezone($tz = null)
 	{
-		if($tz)
+		if ($tz)
 		{
 			$this->_tz = $tz;
 		}
@@ -2192,7 +2191,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	{
 		$objectSql = new \stdClass;
 		foreach ($this->getFields() as $name => $field){
-			if(!isset($this->{$name})){
+			if (!isset($this->{$name})){
 				$objectSql->{$name} = $field->DefaultProperty;
 				continue;
 			}
@@ -2245,7 +2244,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 */
 	protected static function TypeConvert($value = null, $type = '')
 	{
-		if($type == '')
+		if ($type == '')
 		{
 			return $value;
 		}
@@ -2253,67 +2252,67 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		$typeParam = $type;
 		$type  = strtolower($type);
 
-		if(empty($value) && isset(static::$_devaultValuesProperty[$type]))
+		if (empty($value) && isset(static::$_devaultValuesProperty[$type]))
 		{
 			return static::$_devaultValuesProperty[$type];
 		}
-		if(empty($value) && class_exists($type) && is_a($type, "Joomla\CMS\Table\TablePropertyInterface", true))
+		if (empty($value) && class_exists($type) && is_a($type, "Joomla\CMS\Table\TablePropertyInterface", true))
 		{
 			return new $type($value);
 		}
 
-		if(is_scalar($value) && $type =='tosql')
+		if (is_scalar($value) && $type =='tosql')
 		{
 			return $value;
 		}
-		if(is_scalar($value) && $type=='string')
+		if (is_scalar($value) && $type=='string')
 		{
 			return (string)$value;
 		}
 		// conditions for DateTime types
-		if(in_array($type, ['tosql','string']) && $value instanceof DateTimeInterface)
+		if (in_array($type, ['tosql','string']) && $value instanceof DateTimeInterface)
 		{
-			if( ! $value instanceof \Joomla\CMS\Date\Date)
+			if ( ! $value instanceof \Joomla\CMS\Date\Date)
 				$value = new \Joomla\CMS\Date\Date($value);
 			$value = $value->toSql();
 			return $value;
 		}
 		// convert field with type \Joomla\CMS\Date\Date(and Others) to SQL format
-		if(is_object($value) && in_array($type, ['tosql','string']) && method_exists($value, 'toSql'))
+		if (is_object($value) && in_array($type, ['tosql','string']) && method_exists($value, 'toSql'))
 		{
 			$value = $value->toSql();
 			return $value;
 		}
-		if(in_array($type, ['tostring','string']) && method_exists($value, '__toString'))
+		if (in_array($type, ['tostring','string']) && method_exists($value, '__toString'))
 		{
 			return $value->__toString();
 		}
-		if($type == 'datetime' || $type == strtolower('Joomla\CMS\Date\Date'))
+		if ($type == 'datetime' || $type == strtolower('Joomla\CMS\Date\Date'))
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;
 			$value = new \Joomla\CMS\Date\Date($value);
 			return $value;
 		}
-		if($type == 'timestamp')
+		if ($type == 'timestamp')
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;
 			$value = (new \Joomla\CMS\Date\Date($value))->toSql();
 			return $value;
 		}
-		if(in_array($typeParam, ['u']))
+		if (in_array($typeParam, ['u']))
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;
 			$value = date_format($value,'u');
 			return $value;
 		}
-		if(in_array($typeParam, ['U','Unix','toUnix',]))
+		if (in_array($typeParam, ['U','Unix','toUnix',]))
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;
 			$value = date_format($value,'U');
 			return $value;
 		}
 
-		if(isset(static::$_typesVeluesProperty[$type]))
+		if (isset(static::$_typesVeluesProperty[$type]))
 		{
 			$type = static::$_typesVeluesProperty[$type];
 			settype($value,$type);

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -246,7 +246,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 */
 	public function __construct($table, $key, DatabaseDriver $db = null, DispatcherInterface $dispatcher = null)
 	{
-		if (!isset($this->_tz))
+		if (!isset($this->_tz) && class_exists('Joomla\CMS\Factory'))
 		{
 			$this->_tz = Factory::getUser()->getTimezone();
 		}

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -178,11 +178,17 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		'tinyblob' => 'int',
 		'mediumblob' => 'int',
 		'largeblob' => 'int',
+		'serial' => 'int',
+		'smallserial' => 'int',
+		'bigserial' => 'int',
+		'numeric' => 'int',
+		'integer' => 'int',
 
 		'float' => 'float',
 		'double' => 'float',
 		'decimal' => 'float',
 		'real' => 'float',
+		'float8' => 'float',
 
 		'string' => 'string',
 		'text' => 'string',
@@ -195,6 +201,11 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		'nvarchar' => 'string',
 		'nchar' => 'string',
 		'json' => 'string',
+		
+		'cidr' => 'string',
+		'macaddr' => 'string',
+		'macaddr8' => 'string',
+		'xml' => 'string',
 
 		'enum' => '',
 		'set' => '',
@@ -2295,6 +2306,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 
 			return $value;
 		}
+		
 		// Convert field with type \Joomla\CMS\Date\Date(and Others) to SQL format
 		if (is_object($value) && in_array($type, ['tosql','string']) && method_exists($value, 'toSql'))
 		{

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -277,7 +277,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				continue;
 			}
 
-			$type = (string)$prop->getType();
+			$type = (string) $prop->getType();
 			$this->_propertyTypes[$prop->name] = $type;
 
 			if (isset($this->{$prop->name}))
@@ -291,14 +291,15 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				continue;
 			}
 
-			$this->{$prop->name} = static::TypeConvert('',$type);
+			$this->{$prop->name} = static::TypeConvert('', $type);
 		}
 
-		// convert types otherwise default value
+		// Convert types otherwise default value
 		foreach ($this->getFields() as $name => $field)
 		{
 			// Add the field if it is not already present.
 			$type = $field->TypeProperty;
+
 			if (isset($this->_propertyTypes[$field->Field]))
 			{
 				$field->TypeProperty = $this->_propertyTypes[$field->Field];
@@ -306,8 +307,9 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			}
 			else
 			{
-				//get type PHP from type DB without length
+				// Get type PHP from type DB without length
 				$field->TypeProperty = static::getTypeProperty($field->Type);
+
 				if (isset(static::$_typesVeluesProperty[$field->TypeProperty]))
 				{
 					$type = static::$_typesVeluesProperty[$field->TypeProperty];
@@ -317,7 +319,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 					$type = '';
 				}
 			}
-	
+
 			$field->DefaultProperty = static::TypeConvert($field->Default, $type);
 			$this->$name = $field->DefaultProperty;
 		}
@@ -382,7 +384,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				$field->TypeProperty = static::getTypeProperty($field->Type);
 				$field->DefaultProperty = static::TypeConvert($field->Default, $field->TypeProperty);
 			}
-			
+
 			$cache = $fields;
 		}
 
@@ -812,6 +814,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 
 		// Bind the source value, excluding the ignored fields.
 		$fields = $this->getFields();
+		
 		foreach ($src as $k => $value)
 		{
 			// Only process fields not in the ignore array.
@@ -823,14 +826,14 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			if (isset($fields[$k]))
 			{
 				$type = $fields[$k]->TypeProperty;
-				$this->{$k} = static::TypeConvert($value,$type);
+				$this->{$k} = static::TypeConvert($value, $type);
 				continue;
 			}
 
 			if (isset($this->_propertyTypes[$k]))
 			{
 				$type = $this->_propertyTypes[$k];
-				$this->{$k} = static::TypeConvert($value,$type);
+				$this->{$k} = static::TypeConvert($value, $type);
 				continue;
 			}
 
@@ -2241,12 +2244,12 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	}
 
 	/**
-	 * Convert type, 
+	 * Convert type.
 	 * if empty type then return value as exist.
 	 * if empty value then return default value for this type
 	 *
-	 * @param mixed $value 
-	 * @param string $type 
+	 * @param mixed $value
+	 * @param string $type
 	 * @return mixed
 	 * @since  4.0.0
 	 */
@@ -2264,6 +2267,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			return static::$_devaultValuesProperty[$type];
 		}
+
 		if (empty($value) && class_exists($type) && is_a($type, "Joomla\CMS\Table\TablePropertyInterface", true))
 		{
 			return new $type($value);
@@ -2273,64 +2277,67 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			return $value;
 		}
-		
+
 		if (is_scalar($value) && $type=='string')
 		{
 			return (string)$value;
 		}
-		
-		// conditions for DateTime types
+
+		// Conditions for DateTime types
 		if (in_array($type, ['tosql','string']) && $value instanceof DateTimeInterface)
 		{
 			if ( ! $value instanceof \Joomla\CMS\Date\Date)
+			{
 				$value = new \Joomla\CMS\Date\Date($value);
+			}
+
 			$value = $value->toSql();
 			return $value;
 		}
-		// convert field with type \Joomla\CMS\Date\Date(and Others) to SQL format
+		// Convert field with type \Joomla\CMS\Date\Date(and Others) to SQL format
 		if (is_object($value) && in_array($type, ['tosql','string']) && method_exists($value, 'toSql'))
 		{
 			$value = $value->toSql();
 			return $value;
 		}
-		
+
 		if (in_array($type, ['tostring','string']) && method_exists($value, '__toString'))
 		{
 			return $value->__toString();
 		}
-		
+
 		if ($type == 'datetime' || $type == strtolower('Joomla\CMS\Date\Date'))
 		{
-			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;
+			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
 			$value = new \Joomla\CMS\Date\Date($value);
 			return $value;
 		}
-		
+
 		if ($type == 'timestamp')
 		{
-			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;
+			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
 			$value = (new \Joomla\CMS\Date\Date($value))->toSql();
 			return $value;
 		}
-		
+
 		if (in_array($typeParam, ['u']))
 		{
-			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;
-			$value = date_format($value,'u');
+			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
+			$value = date_format($value, 'u');
 			return $value;
 		}
-		
+
 		if (in_array($typeParam, ['U','Unix','toUnix',]))
 		{
-			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;
-			$value = date_format($value,'U');
+			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
+			$value = date_format($value, 'U');
 			return $value;
 		}
 
 		if (isset(static::$_typesVeluesProperty[$type]))
 		{
 			$type = static::$_typesVeluesProperty[$type];
-			settype($value,$type);
+			settype($value, $type);
 		}
 
 		return $value;

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -289,7 +289,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				continue;
 			}
 
-			$type = (string) $prop->getType();
+			$type = (string) $prop->getType()->getName();
 			$this->_propertyTypes[$prop->name] = $type;
 
 			if (isset($this->{$prop->name}))

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -289,7 +289,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				continue;
 			}
 
-			$type = (string) $prop->getType()->getName();
+			$type = (string) $prop->getType();
 			$this->_propertyTypes[$prop->name] = $type;
 
 			if (isset($this->{$prop->name}))

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -331,7 +331,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				}
 			}
 
-			$field->DefaultProperty = static::TypeConvert($field->Default, $type);
+			$field->DefaultProperty = static::TypeConvert($field->Default, $type, $this->_tz);
 			$this->$name = $field->DefaultProperty;
 		}
 
@@ -393,7 +393,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			foreach ($fields as $field)
 			{
 				$field->TypeProperty = static::getTypeProperty($field->Type);
-				$field->DefaultProperty = static::TypeConvert($field->Default, $field->TypeProperty);
+				$field->DefaultProperty = static::TypeConvert($field->Default, $field->TypeProperty, $this->_tz);
 			}
 
 			$cache = $fields;
@@ -837,14 +837,14 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			if (isset($fields[$k]))
 			{
 				$type = $fields[$k]->TypeProperty;
-				$this->{$k} = static::TypeConvert($value, $type);
+				$this->{$k} = static::TypeConvert($value, $type, $this->_tz);
 				continue;
 			}
 
 			if (isset($this->_propertyTypes[$k]))
 			{
 				$type = $this->_propertyTypes[$k];
-				$this->{$k} = static::TypeConvert($value, $type);
+				$this->{$k} = static::TypeConvert($value, $type, $this->_tz);
 				continue;
 			}
 
@@ -2218,7 +2218,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				continue;
 			}
 
-			$objectSql->{$name} = static::TypeConvert($this->{$name}, $field->TypeProperty);
+			$objectSql->{$name} = static::TypeConvert($this->{$name}, $field->TypeProperty, $this->_tz);
 
 			// Pre-processing by observers
 			$event = \Joomla\CMS\Event\AbstractEvent::create(
@@ -2259,12 +2259,13 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 * if empty type then return value as exist.
 	 * if empty value then return default value for this type
 	 *
-	 * @param mixed $value
-	 * @param string $type
+	 * @param mixed $value Value converting in new type
+	 * @param string $type New type for value
+	 * @param  mixed  $tz  Time zone to be used for the date. Might be a string or a DateTimeZone object.
 	 * @return mixed
 	 * @since  4.0.0
 	 */
-	protected static function TypeConvert($value = null, $type = '')
+	protected static function TypeConvert($value = null, $type = '', $tz = null)
 	{
 		if ($type == '')
 		{
@@ -2299,7 +2300,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			if (!$value instanceof \Joomla\CMS\Date\Date)
 			{
-				$value = new \Joomla\CMS\Date\Date($value, $this->_tz);
+				$value = new \Joomla\CMS\Date\Date($value, $tz);
 			}
 
 			$value = $value->toSql();
@@ -2321,7 +2322,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		if ($type == 'datetime' || $type == strtolower('Joomla\CMS\Date\Date'))
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
-			$value = new \Joomla\CMS\Date\Date($value, $this->_tz);
+			$value = new \Joomla\CMS\Date\Date($value, $tz);
 
 			return $value;
 		}
@@ -2329,7 +2330,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		if ($type == 'timestamp')
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
-			$value = (new \Joomla\CMS\Date\Date($value, $this->_tz))->toSql();
+			$value = (new \Joomla\CMS\Date\Date($value, $tz))->toSql();
 
 			return $value;
 		}

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -2184,10 +2184,11 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	}
 
 	/**
-	 * Get list properties name and their types 
+	 * Get list properties name and their types
 	 * @return array
 	 */
-	public function getTypesProperties() {
+	public function getTypesProperties()
+	{
 		return $this->_propertyTypes;
 	}
 

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -145,7 +145,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 * @var    \DateTimeZone
 	 * @since  4.0.0
 	 */
-	protected $_tz;
+	protected $_tz = null;
 
 	/**
 	 * List public properties and this default types
@@ -2299,7 +2299,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			if (!$value instanceof \Joomla\CMS\Date\Date)
 			{
-				$value = new \Joomla\CMS\Date\Date($value);
+				$value = new \Joomla\CMS\Date\Date($value, $this->_tz);
 			}
 
 			$value = $value->toSql();
@@ -2321,7 +2321,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		if ($type == 'datetime' || $type == strtolower('Joomla\CMS\Date\Date'))
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
-			$value = new \Joomla\CMS\Date\Date($value);
+			$value = new \Joomla\CMS\Date\Date($value, $this->_tz);
 
 			return $value;
 		}
@@ -2329,7 +2329,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		if ($type == 'timestamp')
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
-			$value = (new \Joomla\CMS\Date\Date($value))->toSql();
+			$value = (new \Joomla\CMS\Date\Date($value, $this->_tz))->toSql();
 
 			return $value;
 		}

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -148,7 +148,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	protected $_tz;
 
 	/**
-	 * List public properties and this default types 
+	 * List public properties and this default types
 	 * Only properties declared in table class
 	 *
 	 * @var    array
@@ -158,7 +158,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 
 	/**
 	 * Array types convert type BD to type PHP
-	 * 
+	 *
 	 * @var array
 	 * @since  4.0.0
 	 */
@@ -202,7 +202,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 
 	/**
 	 * Array default values for php simple types
-	 * 
+	 *
 	 * @var array
 	 * @since  4.0.0
 	 */
@@ -213,12 +213,12 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		'string' => '',
 		'array' => [],
 		'iterable' => [],
-		'' => NULL,
-		'null' => NULL,
-		'object' => NULL,
-		'stdClass' => NULL,
-		'classes' => NULL,
-		'self' => NULL,
+		'' => null,
+		'null' => null,
+		'object' => null,
+		'stdClass' => null,
+		'classes' => null,
+		'self' => null,
 	];
 
 	/**
@@ -285,7 +285,8 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				continue;
 			}
 
-			if ($type == '' || substr($type, 0, 1) == '?'){
+			if ($type == '' || substr($type, 0, 1) == '?')
+			{
 				$this->{$prop->name} = null;
 				continue;
 			}
@@ -818,21 +819,21 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			{
 				continue;
 			}
-			
+
 			if (isset($fields[$k]))
 			{
 				$type = $fields[$k]->TypeProperty;
 				$this->{$k} = static::TypeConvert($value,$type);
 				continue;
 			}
-			
+
 			if (isset($this->_propertyTypes[$k]))
 			{
 				$type = $this->_propertyTypes[$k];
 				$this->{$k} = static::TypeConvert($value,$type);
 				continue;
 			}
-			
+
 			if (isset($this->{$k}))
 			{
 				$this->{$k} = $value;
@@ -2181,20 +2182,24 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			$this->_tz = $tz;
 		}
+
 		return $this->_tz;
 	}
 
 	/**
 	 * Convert(preparation) $this object to data array for save to BD.
-	 * 
+	 *
 	 * @return  stdClass
 	 * @since  4.0.0
 	 */
 	public function toSqlData() : object
 	{
 		$objectSql = new \stdClass;
-		foreach ($this->getFields() as $name => $field){
-			if (!isset($this->{$name})){
+
+		foreach ($this->getFields() as $name => $field)
+		{
+			if (!isset($this->{$name}))
+			{
 				$objectSql->{$name} = $field->DefaultProperty;
 				continue;
 			}
@@ -2217,7 +2222,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 
 	/**
 	 * Get type PHP property from DB type column
-	 * 
+	 *
 	 * @param string $typeDB
 	 * @return string
 	 * @since  4.0.0
@@ -2239,7 +2244,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 * Convert type, 
 	 * if empty type then return value as exist.
 	 * if empty value then return default value for this type
-	 * 
+	 *
 	 * @param mixed $value 
 	 * @param string $type 
 	 * @return mixed
@@ -2268,10 +2273,12 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			return $value;
 		}
+		
 		if (is_scalar($value) && $type=='string')
 		{
 			return (string)$value;
 		}
+		
 		// conditions for DateTime types
 		if (in_array($type, ['tosql','string']) && $value instanceof DateTimeInterface)
 		{
@@ -2286,28 +2293,33 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			$value = $value->toSql();
 			return $value;
 		}
+		
 		if (in_array($type, ['tostring','string']) && method_exists($value, '__toString'))
 		{
 			return $value->__toString();
 		}
+		
 		if ($type == 'datetime' || $type == strtolower('Joomla\CMS\Date\Date'))
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;
 			$value = new \Joomla\CMS\Date\Date($value);
 			return $value;
 		}
+		
 		if ($type == 'timestamp')
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;
 			$value = (new \Joomla\CMS\Date\Date($value))->toSql();
 			return $value;
 		}
+		
 		if (in_array($typeParam, ['u']))
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;
 			$value = date_format($value,'u');
 			return $value;
 		}
+		
 		if (in_array($typeParam, ['U','Unix','toUnix',]))
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP'])? 'now' : $value;

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -277,7 +277,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				continue;
 			}
 
-			$type = (string)$prop->getType();//->getName()
+			$type = (string)$prop->getType();
 			$this->_propertyTypes[$prop->name] = $type;
 
 			if (isset($this->{$prop->name}))
@@ -818,18 +818,21 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			{
 				continue;
 			}
+			
 			if (isset($fields[$k]))
 			{
 				$type = $fields[$k]->TypeProperty;
 				$this->{$k} = static::TypeConvert($value,$type);
 				continue;
 			}
+			
 			if (isset($this->_propertyTypes[$k]))
 			{
 				$type = $this->_propertyTypes[$k];
 				$this->{$k} = static::TypeConvert($value,$type);
 				continue;
 			}
+			
 			if (isset($this->{$k}))
 			{
 				$this->{$k} = $value;

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -246,9 +246,10 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 	 */
 	public function __construct($table, $key, DatabaseDriver $db = null, DispatcherInterface $dispatcher = null)
 	{
-		if (!isset($this->_tz) && class_exists('Joomla\CMS\Factory'))
+		if (!isset($this->_tz) && class_exists('Joomla\CMS\Factory') && Factory::$application)
 		{
-			$this->_tz = Factory::getUser()->getTimezone();
+			$user = Factory::getApplication()->getIdentity();
+			$this->_tz = $user ? $user->getTimezone() : null;
 		}
 
 		// Set internal variables.

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -209,9 +209,14 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		'xml' => 'string',
 
 		'datetime' => 'string',
+		'tosql' => 'string',
+		'tostring' => 'string',
 
 		'enum' => '',
 		'set' => '',
+
+		'object' => 'object',
+		'array' => 'array',
 	];
 
 	/**
@@ -2251,24 +2256,22 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			return static::$_defaultValuesProperty[$typeLower];
 		}
-
-		if (empty($value) && class_exists($typeLower) && is_a($typeLower, "Joomla\CMS\Table\TablePropertyInterface", true))
+		
+		if (isset(static::$_typesVeluesProperty[$typeLower]))
 		{
-			return new $typeLower($value);
-		}
+			$typeLower = static::$_typesVeluesProperty[$typeLower];
+			settype($value, $typeLower);
 
-		if (is_scalar($value) && $typeLower == 'tosql')
-		{
 			return $value;
 		}
 
-		if (is_scalar($value) && $typeLower == 'string')
+		if (class_exists($type) && is_a($type, "Joomla\CMS\Table\TablePropertyInterface", true))
 		{
-			return (string) $value;
+			return new $type($value);
 		}
 
 		// Conditions for DateTime types
-		if (($type == 'datetime' || in_array($typeLower, ['tosql','string'])) && $value instanceof DateTimeInterface)
+		if (($type == 'datetime' || in_array($typeLower, ['tosql'])) && $value instanceof DateTimeInterface)
 		{
 			if (!$value instanceof \Joomla\CMS\Date\Date)
 			{
@@ -2282,11 +2285,6 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		if (is_object($value) && in_array($typeLower, ['tosql','string']) && method_exists($value, 'toSql'))
 		{
 			return $value->toSql();
-		}
-
-		if (in_array($typeLower, ['tostring','string']) && method_exists($value, '__toString'))
-		{
-			return $value->__toString();
 		}
 
 		if ($type == 'DateTime' || is_a($type, 'Joomla\CMS\Date\Date', true))
@@ -2319,12 +2317,6 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			$value = date_format($value, 'U');
 
 			return $value;
-		}
-
-		if (isset(static::$_typesVeluesProperty[$typeLower]))
-		{
-			$typeLower = static::$_typesVeluesProperty[$typeLower];
-			settype($value, $typeLower);
 		}
 
 		return $value;

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -814,7 +814,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 
 		// Bind the source value, excluding the ignored fields.
 		$fields = $this->getFields();
-		
+
 		foreach ($src as $k => $value)
 		{
 			// Only process fields not in the ignore array.
@@ -2207,7 +2207,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 				continue;
 			}
 
-			$objectSql->{$name} = static::TypeConvert($this->{$name},$field->TypeProperty);
+			$objectSql->{$name} = static::TypeConvert($this->{$name}, $field->TypeProperty);
 
 			// Pre-processing by observers
 			$event = \Joomla\CMS\Event\AbstractEvent::create(
@@ -2273,32 +2273,32 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 			return new $type($value);
 		}
 
-		if (is_scalar($value) && $type =='tosql')
+		if (is_scalar($value) && $type == 'tosql')
 		{
 			return $value;
 		}
 
-		if (is_scalar($value) && $type=='string')
+		if (is_scalar($value) && $type == 'string')
 		{
-			return (string)$value;
+			return (string) $value;
 		}
 
 		// Conditions for DateTime types
 		if (in_array($type, ['tosql','string']) && $value instanceof DateTimeInterface)
 		{
-			if ( ! $value instanceof \Joomla\CMS\Date\Date)
+			if (!$value instanceof \Joomla\CMS\Date\Date)
 			{
 				$value = new \Joomla\CMS\Date\Date($value);
 			}
 
 			$value = $value->toSql();
+
 			return $value;
 		}
 		// Convert field with type \Joomla\CMS\Date\Date(and Others) to SQL format
 		if (is_object($value) && in_array($type, ['tosql','string']) && method_exists($value, 'toSql'))
 		{
-			$value = $value->toSql();
-			return $value;
+			return $value->toSql();
 		}
 
 		if (in_array($type, ['tostring','string']) && method_exists($value, '__toString'))
@@ -2310,6 +2310,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
 			$value = new \Joomla\CMS\Date\Date($value);
+
 			return $value;
 		}
 
@@ -2317,6 +2318,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
 			$value = (new \Joomla\CMS\Date\Date($value))->toSql();
+
 			return $value;
 		}
 
@@ -2324,6 +2326,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
 			$value = date_format($value, 'u');
+
 			return $value;
 		}
 
@@ -2331,6 +2334,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
 		{
 			$value = in_array($value, [null,'','CURRENT_TIMESTAMP']) ? 'now' : $value;
 			$value = date_format($value, 'U');
+
 			return $value;
 		}
 

--- a/libraries/src/Table/TablePropertyInterface.php
+++ b/libraries/src/Table/TablePropertyInterface.php
@@ -17,7 +17,7 @@ use Joomla\Database\DatabaseDriver;
  *
  * @since  __DEPLOY_VERSION__
  */
-interface TablePropertyInterface // SqlDataInterface //TablePropertyInterface
+interface TablePropertyInterface
 {
 	/**
 	 * Class constructor, overridden in descendant classes.

--- a/libraries/src/Table/TablePropertyInterface.php
+++ b/libraries/src/Table/TablePropertyInterface.php
@@ -15,7 +15,7 @@ use Joomla\Database\DatabaseDriver;
 /**
  * Table property class interface.
  *
- * @since  3.2
+ * @since  __DEPLOY_VERSION__
  */
 interface TablePropertyInterface // SqlDataInterface //TablePropertyInterface
 {

--- a/libraries/src/Table/TablePropertyInterface.php
+++ b/libraries/src/Table/TablePropertyInterface.php
@@ -33,8 +33,7 @@ interface TablePropertyInterface // SqlDataInterface //TablePropertyInterface
 	 *
 	 * @return  number|string|boolean  The date string in SQL datetime format.
 	 *
-	 * @link    http://dev.mysql.com/doc/refman/5.0/en/datetime.html
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function toSql();
 }

--- a/libraries/src/Table/TablePropertyInterface.php
+++ b/libraries/src/Table/TablePropertyInterface.php
@@ -24,7 +24,7 @@ interface TablePropertyInterface // SqlDataInterface //TablePropertyInterface
 	 *
 	 * @param   mixed  $value  Value geted from cell BaseData
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function __construct($value = null);
 

--- a/libraries/src/Table/TablePropertyInterface.php
+++ b/libraries/src/Table/TablePropertyInterface.php
@@ -2,7 +2,7 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright  (C) 2014 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright  (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/libraries/src/Table/TablePropertyInterface.php
+++ b/libraries/src/Table/TablePropertyInterface.php
@@ -30,6 +30,7 @@ interface TablePropertyInterface // SqlDataInterface //TablePropertyInterface
 
 	/**
 	 * Gets the date as an SQL datetime string.
+	 * @link http://dev.mysql.com/doc/refman/5.0/en/datetime.html	 
 	 *
 	 * @return  number|string|boolean  The date string in SQL datetime format.
 	 *

--- a/libraries/src/Table/TablePropertyInterface.php
+++ b/libraries/src/Table/TablePropertyInterface.php
@@ -30,7 +30,7 @@ interface TablePropertyInterface // SqlDataInterface //TablePropertyInterface
 
 	/**
 	 * Gets the date as an SQL datetime string.
-	 * 
+	 *
 	 * @return  number|string|boolean  The date string in SQL datetime format.
 	 *
 	 * @link    http://dev.mysql.com/doc/refman/5.0/en/datetime.html

--- a/libraries/src/Table/TablePropertyInterface.php
+++ b/libraries/src/Table/TablePropertyInterface.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2014 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Table;
+
+\defined('JPATH_PLATFORM') or die;
+
+use Joomla\Database\DatabaseDriver;
+
+/**
+ * Table property class interface.
+ *
+ * @since  3.2
+ */
+interface TablePropertyInterface // SqlDataInterface //TablePropertyInterface
+{
+	/**
+	 * Class constructor, overridden in descendant classes.
+	 *
+	 * @param   mixed  $value  Value geted from cell BaseData
+	 *
+	 * @since   4.0.0
+	 */
+	public function __construct($value = null);
+
+	/**
+	 * Gets the date as an SQL datetime string.
+	 * 
+	 * @return  number|string|boolean  The date string in SQL datetime format.
+	 *
+	 * @link    http://dev.mysql.com/doc/refman/5.0/en/datetime.html
+	 * @since   4.0.0
+	 */
+	public function toSql();
+}


### PR DESCRIPTION
Based on the problem of saving data with different types.
[[4.0] Error when saving an object in JTable->save()](https://github.com/joomla/joomla-cms/discussions/33840)

I've done a great job of implementing a typizations sub-framework for a **`Table`** class.
The problem is that before you could not create properties of the **`Table`** class with different types, you were forced to create properties without types. You had to use the default types.

But now in the modern world, you can use the **`Table`** class with fully typed properties. You don't need to worry that a DateTime property will cause an error. The DateTime property and other properties will be automatically converted to the database type before being saved. When the **`Table`** is loaded, all properties will be automatically converted to objects, such as a DateTime object.

Now, when programming, you will focus only on business logic.
.
At the same time, the updated **`Table`** class supports the previous usage scenarios. You don't need to redo the programs you've already created.
.
Bonus: The update made it possible to stop using the methods of the deprecated CMSObject class. The new **`Table`** class still inherits the CMSObject class, but now no method is used from this parent class.
.
The new **`Table`** class will allow you to discard the parent CMSObject class without loss in the future.
I checked this class, it does not violate the CMS in any way. But I still think that the code requires minor optimization.
.
I ask you not to ban my work, but to help solve the problem of complete typizations of classes, since technologies do not stand still.
In the modern world, typizations is a basic feature for frameworks.
