### PR TITLE
[4.0] Build tools: watch functionality revised

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -49,3 +49,15 @@ There are three options here:
 - `npm run lint:css -- --fix`: Check and fix the code style for all the SCSS files (might not fix everything)
 - `npm run gzip`: Creates `.gz` files for all the `.min.js` and `.min.css`
 - `npm run versioning`: Creates the correct version hash for all the assets inside the joomla.asset.json files (excluding templates)
+
+## Working efficiently with the Joomla build tools
+
+Usually when cotributing to the project the scope of the contribution should be limited, eg fixing some css bug, a javascript bug or some markup or a bug that involves changes in all these areas. The build tools were created so that you spent less time on compiling assets rather than testing a possible solution. *Embrace the watchers* and let the computer help you succeed faster and safer. There are 2 watcher at the moment: one for the Media Manager (client app based on VueJS) and another one that handles templates and the source (build) folder.
+
+Assuming that you are working on the Media Manager you can run in your terminal (already in the root folder of the Joomla repo) `npm run watch:com_media`. This watcher will automatically recomile the app on every save (there is a debounce of 0.3s so if you have autosave will be clever to reduce the tasks).
+
+Assuming that you are working on the Web Authenication JavaScript you can run in your terminal (already in the root folder of the Joomla repo) `npm run watch -- build/media_source/plg_system_webauthn`. This watcher will automatically recomile any JavaScript file inside the folder `build/media_source/plg_system_webauthn/js` on every save. But there's more, since you asked the watcher to check the parent folder (eg `build/media_source/plg_system_webauthn`) you can also edit the SCSS files in the `build/media_source/plg_system_webauthn/scss` or the css files in `build/media_source/plg_system_webauthn/css`. The same example for editing some SCSS in the cassiopeia template would require a command like: `npm run watch -- templates/cassiopeia/scss`.
+
+Once you get your code doing what it meant to do make sure that you checked that you are not breaking any of the Code Style rules by running `npm run lint:css -- --fix` and `npm run lint:js -- --fix` (the `-- --fix` will try to fix anything that's not trivial).
+
+Happy coding

--- a/build/build-modules-js/javascript/build-com_media-js.es6.js
+++ b/build/build-modules-js/javascript/build-com_media-js.es6.js
@@ -118,3 +118,61 @@ module.exports.mediaManager = async () => {
   minifyJs('media/com_media/js/media-manager.js');
   return buildLegacy(resolve('media/com_media/js/media-manager.js'));
 };
+
+module.exports.watchMediaManager = async () => {
+  // eslint-disable-next-line no-console
+  console.log('Watching Media Manager js+vue files...');
+
+  await rollup.watch({
+    input: resolve(inputJS),
+    plugins: [
+      VuePlugin({
+        target: 'browser',
+        css: false,
+        compileTemplate: true,
+        template: {
+          isProduction: true,
+        },
+      }),
+      nodeResolve(),
+      replace({
+        preventAssignment: true,
+        'process.env.NODE_ENV': JSON.stringify('production'),
+      }),
+      babel({
+        exclude: 'node_modules/core-js/**',
+        babelHelpers: 'bundled',
+        babelrc: false,
+        presets: [
+          [
+            '@babel/preset-env',
+            {
+              targets: {
+                browsers: [
+                  '> 1%',
+                  'not ie 11',
+                  'not op_mini all',
+                ],
+              },
+              loose: true,
+              bugfixes: false,
+              ignoreBrowserslistConfig: true,
+            },
+          ],
+        ],
+      }),
+    ],
+    output: [
+      {
+        format: 'es',
+        sourcemap: false,
+        file: 'media/com_media/js/media-manager.js',
+      },
+      {
+        format: 'es',
+        sourcemap: false,
+        file: 'media/com_media/js/media-manager.min.js',
+      },
+    ]
+  });
+};

--- a/build/build-modules-js/javascript/build-com_media-js.es6.js
+++ b/build/build-modules-js/javascript/build-com_media-js.es6.js
@@ -173,6 +173,6 @@ module.exports.watchMediaManager = async () => {
         sourcemap: false,
         file: 'media/com_media/js/media-manager.min.js',
       },
-    ]
+    ],
   });
 };

--- a/build/build-modules-js/javascript/build-com_media-js.es6.js
+++ b/build/build-modules-js/javascript/build-com_media-js.es6.js
@@ -122,8 +122,10 @@ module.exports.mediaManager = async () => {
 module.exports.watchMediaManager = async () => {
   // eslint-disable-next-line no-console
   console.log('Watching Media Manager js+vue files...');
+  // eslint-disable-next-line no-console
+  console.log('=========');
 
-  await rollup.watch({
+  const watcher = rollup.watch({
     input: resolve(inputJS),
     plugins: [
       VuePlugin({
@@ -174,5 +176,14 @@ module.exports.watchMediaManager = async () => {
         file: 'media/com_media/js/media-manager.min.js',
       },
     ],
+  });
+
+  watcher.on('event', (event) => {
+    if (event.code === 'BUNDLE_END') {
+      // eslint-disable-next-line no-console
+      console.log(`File ${event.output[0]} updated ✅
+File ${event.output[1]} updated ✅
+=========`);
+    }
   });
 };

--- a/build/build-modules-js/watch.es6.js
+++ b/build/build-modules-js/watch.es6.js
@@ -1,13 +1,16 @@
 const watch = require('watch');
-const { join, extname } = require('path');
+const { join, extname, basename } = require('path');
 const { handleESMFile } = require('./javascript/compile-to-es2017.es6.js');
 const { handleES5File } = require('./javascript/handle-es5.es6.js');
+const { handleScssFile } = require('./stylesheets/handle-scss.es6.js');
+const { handleCssFile } = require('./stylesheets/handle-css.es6.js');
 const { debounce } = require('./utils/debounce.es6.js');
 
 const RootPath = process.cwd();
 
-module.exports.watching = () => {
-  watch.createMonitor(join(RootPath, 'build/media_source'), (monitor) => {
+module.exports.watching = (path) => {
+  const watchingPath = path ? join(RootPath, path) : join(RootPath, 'build/media_source');
+  watch.createMonitor(watchingPath, (monitor) => {
     monitor.on('created', (file) => {
       if (extname(file) === '.js') {
         if (file.match(/\.w-c\.es6\.js$/) || file.match(/\.es6\.js$/)) {
@@ -18,7 +21,12 @@ module.exports.watching = () => {
         }
       }
 
-      // @todo css and scss
+      if (extname(file) === '.scss' && !basename(file).startsWith('_')) {
+        debounce(handleScssFile(file), 300);
+      }
+      if (extname(file) === '.css' ) {
+        debounce(handleCssFile(file), 300);
+      }
     });
     monitor.on('changed', (file) => {
       if (extname(file) === '.js') {
@@ -29,10 +37,16 @@ module.exports.watching = () => {
           debounce(handleES5File(file), 300);
         }
       }
-      // @todo css and scss
+
+      if (extname(file) === '.scss' && !basename(file).startsWith('_')) {
+        debounce(handleScssFile(file), 300);
+      }
+      if (extname(file) === '.css' ) {
+        debounce(handleCssFile(file), 300);
+      }
     });
     monitor.on('removed', (file) => {
-      // Handle this case as well
+      // @todo Handle this case as well
       // eslint-disable-next-line no-console
       console.log(file);
     });

--- a/build/build-modules-js/watch.es6.js
+++ b/build/build-modules-js/watch.es6.js
@@ -24,7 +24,7 @@ module.exports.watching = (path) => {
       if (extname(file) === '.scss' && !basename(file).startsWith('_')) {
         debounce(handleScssFile(file), 300);
       }
-      if (extname(file) === '.css' ) {
+      if (extname(file) === '.css') {
         debounce(handleCssFile(file), 300);
       }
     });
@@ -41,7 +41,7 @@ module.exports.watching = (path) => {
       if (extname(file) === '.scss' && !basename(file).startsWith('_')) {
         debounce(handleScssFile(file), 300);
       }
-      if (extname(file) === '.css' ) {
+      if (extname(file) === '.css') {
         debounce(handleCssFile(file), 300);
       }
     });

--- a/build/build-modules-js/watch.es6.js
+++ b/build/build-modules-js/watch.es6.js
@@ -1,5 +1,7 @@
 const watch = require('watch');
-const { join, extname, basename } = require('path');
+const {
+  join, extname, basename, dirname,
+} = require('path');
 const { handleESMFile } = require('./javascript/compile-to-es2017.es6.js');
 const { handleES5File } = require('./javascript/handle-es5.es6.js');
 const { handleScssFile } = require('./stylesheets/handle-scss.es6.js');
@@ -8,47 +10,30 @@ const { debounce } = require('./utils/debounce.es6.js');
 
 const RootPath = process.cwd();
 
+const processFile = (file) => {
+  if (extname(file) === '.js' && !dirname(file).startsWith(join(RootPath, 'build/media_source/vendor/bootstrap/js'))) {
+    if (file.match(/\.w-c\.es6\.js$/) || file.match(/\.es6\.js$/)) {
+      debounce(handleESMFile(file), 300);
+    }
+    if (file.match(/\.es5\.js/)) {
+      debounce(handleES5File(file), 300);
+    }
+  }
+
+  if (extname(file) === '.scss' && !basename(file).startsWith('_')) {
+    debounce(handleScssFile(file), 300);
+  }
+  if (extname(file) === '.css') {
+    debounce(handleCssFile(file), 300);
+  }
+};
+
 module.exports.watching = (path) => {
   const watchingPath = path ? join(RootPath, path) : join(RootPath, 'build/media_source');
   watch.createMonitor(watchingPath, (monitor) => {
-    monitor.on('created', (file) => {
-      if (extname(file) === '.js') {
-        if (file.match(/\.w-c\.es6\.js$/) || file.match(/\.es6\.js$/)) {
-          debounce(handleESMFile(file), 300);
-        }
-        if (file.match(/\.es5\.js/)) {
-          debounce(handleES5File(file), 300);
-        }
-      }
-
-      if (extname(file) === '.scss' && !basename(file).startsWith('_')) {
-        debounce(handleScssFile(file), 300);
-      }
-      if (extname(file) === '.css') {
-        debounce(handleCssFile(file), 300);
-      }
-    });
-    monitor.on('changed', (file) => {
-      if (extname(file) === '.js') {
-        if (file.match(/\.w-c\.es6\.js$/) || file.match(/\.es6\.js$/)) {
-          debounce(handleESMFile(file), 300);
-        }
-        if (file.match(/\.es5\.js/)) {
-          debounce(handleES5File(file), 300);
-        }
-      }
-
-      if (extname(file) === '.scss' && !basename(file).startsWith('_')) {
-        debounce(handleScssFile(file), 300);
-      }
-      if (extname(file) === '.css') {
-        debounce(handleCssFile(file), 300);
-      }
-    });
-    monitor.on('removed', (file) => {
-      // @todo Handle this case as well
-      // eslint-disable-next-line no-console
-      console.log(file);
-    });
+    monitor.on('created', (file) => processFile(file));
+    monitor.on('changed', (file) => processFile(file));
+    // @todo Handle this case as well
+    // monitor.on('removed', (file) => removeFile(file));
   });
 };

--- a/build/build.js
+++ b/build/build.js
@@ -119,7 +119,7 @@ if (Program.compileJs) {
 
 // Compress/transpile the javascript files
 if (Program.watch) {
-  watching();
+  watching(Program.args[0]);
 }
 
 // Gzip js/css files

--- a/build/build.js
+++ b/build/build.js
@@ -31,7 +31,7 @@ const { patchPackages } = require('./build-modules-js/init/patches.es6.js');
 const { cleanVendors } = require('./build-modules-js/init/cleanup-media.es6.js');
 const { recreateMediaFolder } = require('./build-modules-js/init/recreate-media.es6');
 const { watching } = require('./build-modules-js/watch.es6.js');
-const { mediaManager } = require('./build-modules-js/javascript/build-com_media-js.es6');
+const { mediaManager, watchMediaManager } = require('./build-modules-js/javascript/build-com_media-js.es6');
 const { compressFiles } = require('./build-modules-js/compress.es6.js');
 const { versioning } = require('./build-modules-js/versioning.es6.js');
 const { Timer } = require('./build-modules-js/utils/timer.es6.js');
@@ -140,7 +140,7 @@ if (Program.comMedia) {
 
 // Watch & Compile the media manager
 if (Program.watchComMedia) {
-  mediaManager(true);
+  watchMediaManager(true);
 }
 
 // Update the .js/.css versions


### PR DESCRIPTION
Pull Request for Issue #34590.

### Summary of Changes

- Restores the watch functionality
- Allows the `--watch` to watch a specific folder
- Implement the scss/css part

### Testing Instructions
##### Com Media
- At you cmd run `npm run watch:com_media`
- then edit `administrator/components/com_media/resources/scripts/components/breadcrumb/breadcrumb.vue`
- Check both `media/com_media/js/media-manager.js` and `media/com_media/js/media-manager.min.js` that the mofified time was few seconds before and the content in both files is unmanggled JS

##### ES6, WebComponents, ES5
- run `npm run watch -- build/media_source/templates/administrator`
- Edit and save the file `build/media_source/templates/administrator/atum/js/template.es6.js`
- observe the modification time in the `media/templates/administrator/atum/js/template...` files

##### SCSS, CSS
- run `npm run watch -- build/media_source/plg_system_webauthn`
- Edit and save the file `build/media_source/plg_system_webauthn/scss/button.scss`
- observe the modification time in the `media_source/plg_system_webauthn/scss/button...` files


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

Yes, updated

There is one case that the watcher is not handling atm: if the source file gets deleted the compiled files are not removed as well.


@laoneo let me know if this is ok