### PR TITLE
[4.0] phpmailer - security update

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2156,16 +2156,16 @@
         },
         {
             "name": "phpmailer/phpmailer",
-            "version": "v6.4.1",
+            "version": "v6.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPMailer/PHPMailer.git",
-                "reference": "9256f12d8fb0cd0500f93b19e18c356906cbed3d"
+                "reference": "a5b5c43e50b7fba655f793ad27303cd74c57363c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/9256f12d8fb0cd0500f93b19e18c356906cbed3d",
-                "reference": "9256f12d8fb0cd0500f93b19e18c356906cbed3d",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/a5b5c43e50b7fba655f793ad27303cd74c57363c",
+                "reference": "a5b5c43e50b7fba655f793ad27303cd74c57363c",
                 "shasum": ""
             },
             "require": {
@@ -2218,7 +2218,7 @@
                 }
             ],
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
-            "time": "2021-04-29T12:25:04+00:00"
+            "time": "2021-06-16T14:33:43+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
This pr addresses two security issues

Version 6.5.0 (June 16th, 2021)

- **SECURITY Fixes CVE-2021-34551**, a complex RCE affecting Windows hosts. See SECURITY.md for details.
- The fix for this issue changes the way that language files are loaded. While they remain in the same PHP-like format, they are processed as plain text, and any code in them will not be run, including operations such as concatenation using the . operator.
- Deprecation The current translation file format using PHP arrays is now deprecated; the next major version will introduce a new format.
- **SECURITY Fixes CVE-2021-3603** that may permit untrusted code to be run from an address validator. See SECURITY.md for details.
- The fix for this issue includes a **minor BC break**: callables injected into validateAddress, or indirectly through the $validator class property, may no longer be simple strings. If you want to inject your own validator, provide a closure instead of a function name.
- Haraka message ID strings are now recognised
