### PR TITLE
[4.0] Fix condition for readmore in newsflash

### DIFF
--- a/modules/mod_articles_news/tmpl/_item.php
+++ b/modules/mod_articles_news/tmpl/_item.php
@@ -48,6 +48,6 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 <?php echo $item->afterDisplayContent; ?>
 
-<?php if (isset($item->link) && $item->readmore != 0 && $params->get('readmore')) : ?>
+<?php if (isset($item->link) && $params->get('readmore')) : ?>
 	<?php echo LayoutHelper::render('joomla.content.readmore', array('item' => $item, 'params' => $item->params, 'link' => $item->link)); ?>
 <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Newsflash module always shows the readmore button, also if it is switched off


### Testing Instructions
Use blog sample data. Swich off the readmore-button in options of mod_articles_news.


### Actual result BEFORE applying this Pull Request
Readmore button in the newsflash module is always displayed.


### Expected result AFTER applying this Pull Request
Readmore is displayed only if the param is set



