### PR TITLE
[4.0] Content versions button [a11y]

### DIFF
--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -81,15 +81,14 @@ $wa->useScript('com_contenthistory.admin-history-modal');
 					</td>
 					<td>
 						<?php if ($item->keep_forever) : ?>
-							<a class="btn btn-secondary btn-sm active" rel="tooltip" href="javascript:void(0);"
-								onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','history.keep')">
-								<?php echo Text::_('JYES'); ?>&nbsp;<span class="icon-lock" aria-hidden="true"></span>
-							</a>
+							<button type="button" class="btn btn-secondary btn-sm active" onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','history.keep')">
+								<?php echo Text::_('JYES'); ?>
+								&nbsp;<span class="icon-lock" aria-hidden="true"></span>
+							</button>
 						<?php else : ?>
-							<a class="btn btn-secondary btn-sm active" rel="tooltip" href="javascript:void(0);"
-								onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','history.keep')">
+							<button type="buttton" class="btn btn-secondary btn-sm active" onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','history.keep')">
 								<?php echo Text::_('JNO'); ?>
-							</a>
+							</button>
 						<?php endif; ?>
 					</td>
 					<td class="d-none d-md-table-cell">


### PR DESCRIPTION
Content versions for an article has a button to indicate if the version should be kept forever or not.

However it is incorrectly an `a` link designed to look like a button but not act like a button.

If the action is to take you to a new page then its a link - otherwise its a button.

A button can be activated with both the space and enter keys. A link just by the enter key.

BONUS: This also fixes #34592

![image](https://user-images.githubusercontent.com/1296369/123227256-54706100-d4cc-11eb-969f-cd9d7cf22505.png)
