### PR TITLE
[4.0] Remove Empty Trash button in empty state in com_contact

### DIFF
--- a/administrator/components/com_contact/src/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contacts/HtmlView.php
@@ -207,7 +207,7 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
+		if (!$this->isEmptyState && $this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
 		{
 			$toolbar->delete('contacts.delete')
 				->text('JTOOLBAR_EMPTY_TRASH')


### PR DESCRIPTION
### Summary of Changes
Add `!$this->isEmptyState` when adding `toolbar->delete()`

### Testing Instructions
1. Add a contact (if you don't have any)
2. Trash the contact
3. Delete the contact

https://user-images.githubusercontent.com/61203226/123255160-24957d80-d50d-11eb-84c3-d701c37653e4.mp4

### Actual result BEFORE applying this Pull Request
Empty Trash button in Emptystate 
![trash-before](https://user-images.githubusercontent.com/61203226/123254977-f021c180-d50c-11eb-9346-2a283985b218.JPG)

### Expected result AFTER applying this Pull Request
No Empty Trash button in Emptystate 
![trash-after](https://user-images.githubusercontent.com/61203226/123254993-f3b54880-d50c-11eb-8758-5a6e9a20be88.JPG)

### Documentation Changes Required
No
