### PR TITLE
[4.0] com_users groups counts [a11y]

### DIFF
--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -104,12 +104,24 @@ $wa->useScript('com_users.admin-users-groups');
 									</a>
 								</td>
 								<td class="text-center btns itemnumber d-none d-md-table-cell">
-									<a class="btn <?php echo $item->count_enabled > 0 ? 'btn-success' : 'btn-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_users&view=users&filter[group_id]=' . (int) $item->id . '&filter[state]=0'); ?>">
-										<?php echo $item->count_enabled; ?></a>
+									<a class="btn <?php echo $item->count_enabled > 0 ? 'btn-success' : 'btn-secondary'; ?>"
+										href="<?php echo Route::_('index.php?option=com_users&view=users&filter[group_id]=' . (int) $item->id . '&filter[state]=0'); ?>"
+										aria-describedby="tip-enabled<?php echo $i; ?>">
+										<?php echo $item->count_enabled; ?>
+									</a>
+									<div role="tooltip" id="tip-enabled<?php echo $i; ?>">
+										<?php echo Text::_('COM_USERS_COUNT_ENABLED_USERS'); ?>
+									</div>
 								</td>
 								<td class="text-center btns itemnumber d-none d-md-table-cell">
-									<a class="btn <?php echo $item->count_disabled > 0 ? 'btn-danger' : 'btn-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_users&view=users&filter[group_id]=' . (int) $item->id . '&filter[state]=1'); ?>">
-										<?php echo $item->count_disabled; ?></a>
+									<a class="btn <?php echo $item->count_disabled > 0 ? 'btn-danger' : 'btn-secondary'; ?>"
+										href="<?php echo Route::_('index.php?option=com_users&view=users&filter[group_id]=' . (int) $item->id . '&filter[state]=1'); ?>"
+										aria-describedby="tip-blocked<?php echo $i; ?>">
+										<?php echo $item->count_disabled; ?>
+									</a>
+									<div role="tooltip" id="tip-blocked<?php echo $i; ?>">
+										<?php echo Text::_('COM_USERS_COUNT_DISABLED_USERS'); ?>
+									</div>
 								</td>
 								<td class="d-none d-md-table-cell">
 									<?php echo (int) $item->id; ?>


### PR DESCRIPTION
This pr is similar to #34615 but this time for user groups

To test apply PR and go to the list of user groups

The count of users in each group in the enabled and blocked states now has a tooltip

![image](https://user-images.githubusercontent.com/1296369/123428106-5c5bfe00-d5bd-11eb-9373-1466bde93df4.png)

