### PR TITLE
[4.0] com_finder indexed content [a11y]

### DIFF
--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -121,16 +121,28 @@ $wa->useScript('com_finder.maps');
 							<?php endif; ?>
 							<td class="text-center btns itemnumber">
 							<?php if ($item->level > 1) : ?>
-								<a class="btn <?php echo ((int) $item->count_published > 0) ? 'btn-success' : 'btn-secondary'; ?>" title="<?php echo Text::_('COM_FINDER_MAPS_COUNT_PUBLISHED_ITEMS'); ?>" href="<?php echo Route::_('index.php?option=com_finder&view=index&filter[state]=1&filter[content_map]=' . $item->id); ?>">
-								<?php echo (int) $item->count_published; ?></a>
+								<a class="btn <?php echo ((int) $item->count_published > 0) ? 'btn-success' : 'btn-secondary'; ?>"
+									href="<?php echo Route::_('index.php?option=com_finder&view=index&filter[state]=1&filter[content_map]=' . $item->id); ?>"
+									aria-describedby="tip-publish<?php echo $i; ?>">
+									<?php echo (int) $item->count_published; ?>
+								</a>
+							<div role="tooltip" id="tip-enabled<?php echo $i; ?>">
+								<?php echo Text::_('COM_FINDER_MAPS_COUNT_PUBLISHED_ITEMS'); ?>
+							</div>
 							<?php else : ?>
 								-
 							<?php endif; ?>
 							</td>
 							<td class="text-center btns itemnumber">
 							<?php if ($item->level > 1) : ?>
-								<a class="btn <?php echo ((int) $item->count_unpublished > 0) ? 'btn-danger' : 'btn-secondary'; ?>" title="<?php echo Text::_('COM_FINDER_MAPS_COUNT_UNPUBLISHED_ITEMS'); ?>" href="<?php echo Route::_('index.php?option=com_finder&view=index&filter[state]=0&filter[content_map]=' . $item->id); ?>">
-								<?php echo (int) $item->count_unpublished; ?></a>
+								<a class="btn <?php echo ((int) $item->count_unpublished > 0) ? 'btn-danger' : 'btn-secondary'; ?>"
+									href="<?php echo Route::_('index.php?option=com_finder&view=index&filter[state]=0&filter[content_map]=' . $item->id); ?>"
+									aria-describedby="tip-unpublish<?php echo $i; ?>">
+									<?php echo (int) $item->count_unpublished; ?>
+								</a>
+								<div role="tooltip" id="tip-enabled<?php echo $i; ?>">
+									<?php echo Text::_('COM_FINDER_MAPS_COUNT_UNPUBLISHED_ITEMS'); ?>
+								</div>
 							<?php else : ?>
 								-
 							<?php endif; ?>

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -140,7 +140,7 @@ $wa->useScript('com_finder.maps');
 									aria-describedby="tip-unpublish<?php echo $i; ?>">
 									<?php echo (int) $item->count_unpublished; ?>
 								</a>
-								<div role="tooltip" id="tip-enabled<?php echo $i; ?>">
+								<div role="tooltip" id="tip-unpublish<?php echo $i; ?>">
 									<?php echo Text::_('COM_FINDER_MAPS_COUNT_UNPUBLISHED_ITEMS'); ?>
 								</div>
 							<?php else : ?>

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -126,9 +126,9 @@ $wa->useScript('com_finder.maps');
 									aria-describedby="tip-publish<?php echo $i; ?>">
 									<?php echo (int) $item->count_published; ?>
 								</a>
-							<div role="tooltip" id="tip-enabled<?php echo $i; ?>">
-								<?php echo Text::_('COM_FINDER_MAPS_COUNT_PUBLISHED_ITEMS'); ?>
-							</div>
+								<div role="tooltip" id="tip-publish<?php echo $i; ?>">
+									<?php echo Text::_('COM_FINDER_MAPS_COUNT_PUBLISHED_ITEMS'); ?>
+								</div>
 							<?php else : ?>
 								-
 							<?php endif; ?>


### PR DESCRIPTION
This pr is similar to #34615 but this time for content maps indexed content

To test apply PR and go to Smart Search -> Content Maps

The count of indexed content in each group in the published and unpublished states now has a tooltip
![image](https://user-images.githubusercontent.com/1296369/123430304-f02ec980-d5bf-11eb-9070-2e77487c77d7.png)