### PR TITLE
[4.0] specific css

### DIFF
--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -119,7 +119,7 @@ a {
   }
 }
 
-.com-content-article {
+.com-content-article__body {
   ol,
   ul {
     overflow: hidden;


### PR DESCRIPTION
This PR corrects the change in #33560 which caused the issue reported in #34446

To test with the sample data.
Check that the readmore button on blog views has a complete border when it is active
Check that the tag buttons have a complete border when it is active

Dont forget to rebuild the scss
