### PR TITLE
[4.0] new tinymce and codemirror

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2736,9 +2736,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.61.1",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.1.tgz",
-      "integrity": "sha512-+D1NZjAucuzE93vJGbAaXzvoBHwp9nJZWWWF9utjv25+5AZUiah6CIlfb4ikG4MoDsFsCG8niiJH5++OO2LgIQ=="
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.0.tgz",
+      "integrity": "sha512-Xnl3304iCc8nyVZuRkzDVVwc794uc9QNX0UcPGeNic1fbzkSrO4l4GVXho9tRNKBgPYZXgocUqXyfIv3BILhCQ=="
     },
     "node_modules/color": {
       "version": "3.1.3",
@@ -9084,9 +9084,9 @@
       "dev": true
     },
     "node_modules/tinymce": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.8.1.tgz",
-      "integrity": "sha512-1zGXdZplWQafstlC7sri0ttCgMagsiXDc9N3I8JNrPOsWAeTfq4AAJWZoxsQBYn8gYcuPu/WzMKG5SoJjxI1VA=="
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.8.2.tgz",
+      "integrity": "sha512-qfWThBrSzbj4DoUk+lgGeDoP2GzLDSWrfvVUxf40HZhTzsG15X2nZ4N49IFqwaVgRl5AyFDtuWiEH/lCmiAcRA=="
     },
     "node_modules/tmp": {
       "version": "0.2.1",
@@ -12243,9 +12243,9 @@
       }
     },
     "codemirror": {
-      "version": "5.61.1",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.61.1.tgz",
-      "integrity": "sha512-+D1NZjAucuzE93vJGbAaXzvoBHwp9nJZWWWF9utjv25+5AZUiah6CIlfb4ikG4MoDsFsCG8niiJH5++OO2LgIQ=="
+      "version": "5.62.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.0.tgz",
+      "integrity": "sha512-Xnl3304iCc8nyVZuRkzDVVwc794uc9QNX0UcPGeNic1fbzkSrO4l4GVXho9tRNKBgPYZXgocUqXyfIv3BILhCQ=="
     },
     "color": {
       "version": "3.1.3",
@@ -17618,9 +17618,9 @@
       "dev": true
     },
     "tinymce": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.8.1.tgz",
-      "integrity": "sha512-1zGXdZplWQafstlC7sri0ttCgMagsiXDc9N3I8JNrPOsWAeTfq4AAJWZoxsQBYn8gYcuPu/WzMKG5SoJjxI1VA=="
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-5.8.2.tgz",
+      "integrity": "sha512-qfWThBrSzbj4DoUk+lgGeDoP2GzLDSWrfvVUxf40HZhTzsG15X2nZ4N49IFqwaVgRl5AyFDtuWiEH/lCmiAcRA=="
     },
     "tmp": {
       "version": "0.2.1",

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_codemirror</name>
-	<version>5.61.1</version>
+	<version>5.62.0</version>
 	<creationDate>28 March 2011</creationDate>
 	<author>Marijn Haverbeke</author>
 	<authorEmail>marijnh@gmail.com</authorEmail>

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_tinymce</name>
-	<version>5.8.1</version>
+	<version>5.8.2</version>
 	<creationDate>2005-2021</creationDate>
 	<author>Tiny Technologies, Inc</author>
 	<authorEmail>N/A</authorEmail>


### PR DESCRIPTION
To test make sure the version in the plugin matches the version numbers below

### Codemirror
21-06-2021: Version 5.62.0:

lint addon: Add support for highlighting lines with errors or warnings.
Improve support for vim-style cursors in a number of themes.

### Tinymce
Version 5.8.2 - June 23, 2021
Fixed an issue when pasting cells from tables containing colgroups into tables without colgroups.
Fixed an issue that could cause an invalid toolbar button state when multiple inline editors were on a single page.
