### PR TITLE
[4.0] Add back "/libraries/vendor/bin" to folder deletion in script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7076,6 +7076,7 @@ class JoomlaInstallerScript
 			'/libraries/vendor/ozdemirburak/iris/src',
 			'/libraries/vendor/ozdemirburak/iris',
 			'/libraries/vendor/ozdemirburak',
+			'/libraries/vendor/bin',
 			'/components/com_menus/src/Controller',
 			'/components/com_csp/src/Controller',
 			'/components/com_csp/src',


### PR DESCRIPTION
Pull Request for https://github.com/wilsonge/joomla-cms/pull/69#issuecomment-869218814 .

### Summary of Changes

With PR #34289 folders `/bin` and `/libraries/vendor/bin` have been removed from the list of folders to be deleted on update in script.php because these folders might contain files or subfolders added by the site admin.

For `/libraries/vendor/bin` this was wrong because that folder is maintained by composer and completely cleared on the development environment when doing a composer install.

See also the comment here https://github.com/wilsonge/joomla-cms/pull/69#issuecomment-869218814 .

This PR here corrects this by adding that folder back.

As that folder has been removed from the installation and update packages with 4.0 RC 1, the folder is added back to section `4.0 from Beta 7 to RC 1` like it was before PR #34289 .

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

No folder `/libraries/vendor/bin` in section `4.0 from Beta 7 to RC 1` of the `$folders` array in method `deleteUnexistingFiles` of file `administrator/components/com_admin/script.php`.

### Expected result AFTER applying this Pull Request

Folder `/libraries/vendor/bin` in section `4.0 from Beta 7 to RC 1` of the `$folders` array in method `deleteUnexistingFiles` of file `administrator/components/com_admin/script.php`.

Hint: Folders within a version specific section are ordered reverse alphabetical.

### Documentation Changes Required

None.