### PR TITLE
[4.0] media manager toolbar

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -8,6 +8,7 @@
   min-height: 43px;
   padding: 8px 1rem;
   color: var(--atum-text-dark); //#0c192e;
+  background: $white;
   background-image: linear-gradient(var(--toolbar-bg), var(--atum-bg-dark-3));
   box-shadow: 0 2px 10px -8px var(--atum-bg-dark-50);
 


### PR DESCRIPTION
The toolbar in the media manager is sticky but it has no background. This simple PR adds a solid white background (just as it has in the cassiopeia template.

To test make sure you have enough images in media manager to make it scroll.

You will see there is no background on the toolbar when you scroll and you can see the images underneath it

Apply this PR and rebuild the css and repeat and you now have a solid background
