### PR TITLE
Get finder plugin id from memory intstead of the db

### DIFF
--- a/administrator/components/com_finder/src/Helper/FinderHelper.php
+++ b/administrator/components/com_finder/src/Helper/FinderHelper.php
@@ -29,6 +29,14 @@ class FinderHelper
 	public static $extension = 'com_finder';
 
 	/**
+	 * The finder plugin id.
+	 *
+	 * @var int
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected static $pluginId;
+
+	/**
 	 * Gets the finder system plugin extension id.
 	 *
 	 * @return  integer  The finder system plugin extension id.
@@ -37,23 +45,26 @@ class FinderHelper
 	 */
 	public static function getFinderPluginId()
 	{
-		$db    = Factory::getDbo();
-		$query = $db->getQuery(true)
-			->select($db->quoteName('extension_id'))
-			->from($db->quoteName('#__extensions'))
-			->where($db->quoteName('folder') . ' = ' . $db->quote('content'))
-			->where($db->quoteName('element') . ' = ' . $db->quote('finder'));
-		$db->setQuery($query);
-
-		try
+		if (self::$pluginId === null)
 		{
-			$result = (int) $db->loadResult();
-		}
-		catch (\RuntimeException $e)
-		{
-			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+			$db    = Factory::getDbo();
+			$query = $db->getQuery(true)
+				->select($db->quoteName('extension_id'))
+				->from($db->quoteName('#__extensions'))
+				->where($db->quoteName('folder') . ' = ' . $db->quote('content'))
+				->where($db->quoteName('element') . ' = ' . $db->quote('finder'));
+			$db->setQuery($query);
+
+			try
+			{
+				self::$pluginId = (int) $db->loadResult();
+			}
+			catch (\RuntimeException $e)
+			{
+				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+			}
 		}
 
-		return $result;
+		return self::$pluginId;
 	}
 }

--- a/administrator/components/com_finder/src/Helper/FinderHelper.php
+++ b/administrator/components/com_finder/src/Helper/FinderHelper.php
@@ -31,7 +31,7 @@ class FinderHelper
 	/**
 	 * The finder plugin id.
 	 *
-	 * @var int
+	 * @var integer
 	 * @since __DEPLOY_VERSION__
 	 */
 	protected static $pluginId;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The function `getFinderPluginId` is called more than once in the com_finder component (e.g. called both in the controller and the view in the same cycle). There is no need to query the database for something already fetched.

### Testing Instructions
1. Disable the "Smart Search Content Plugin".
2. Check the warning message at the top of the Smart Search component.
3. Click the link with the plugin name, in the warning to open the plugin's modal.

### Actual result BEFORE applying this Pull Request
Click the link in the warning to open the plugin's modal.


### Expected result AFTER applying this Pull Request
Click the link in the warning to open the plugin's modal.


### Documentation Changes Required
No
