### PR TITLE
[4.0] Fix color of Yes/No button in Versions

### DIFF
--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -81,12 +81,12 @@ $wa->useScript('com_contenthistory.admin-history-modal');
 					</td>
 					<td>
 						<?php if ($item->keep_forever) : ?>
-							<button type="button" class="btn btn-secondary btn-sm active" onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','history.keep')">
+							<button type="button" class="btn btn-secondary btn-sm" onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','history.keep')">
 								<?php echo Text::_('JYES'); ?>
 								&nbsp;<span class="icon-lock" aria-hidden="true"></span>
 							</button>
 						<?php else : ?>
-							<button type="buttton" class="btn btn-secondary btn-sm active" onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','history.keep')">
+							<button type="buttton" class="btn btn-secondary btn-sm" onclick="return Joomla.listItemTask('cb<?php echo $i; ?>','history.keep')">
 								<?php echo Text::_('JNO'); ?>
 							</button>
 						<?php endif; ?>


### PR DESCRIPTION
### Summary of Changes
Remove class so Yes/No button change color on hover.


### Testing Instructions
Edit an article.
Click Versions button.
Hover cursor on Yes/No button under Keep Forever column.


### Actual result BEFORE applying this Pull Request
Black button with no visual change on hover.


### Expected result AFTER applying this Pull Request
Blue button and on hover change to black button.