### PR TITLE
Add missing context to workflow category field in com_content

### DIFF
--- a/administrator/components/com_content/forms/category.xml
+++ b/administrator/components/com_content/forms/category.xml
@@ -10,7 +10,7 @@
 				size="1"
 				sql_select="id, title"
 				sql_from="#__workflows"
-				sql_where="published = 1"
+				sql_where="published = 1 AND extension = 'com_content.article'"
 				sql_order="ordering"
 				key_field="id"
 				value_field="title"

--- a/administrator/components/com_content/src/Helper/ContentHelper.php
+++ b/administrator/components/com_content/src/Helper/ContentHelper.php
@@ -136,7 +136,7 @@ class ContentHelper extends \Joomla\CMS\Helper\ContentHelper
 						[
 							$db->quoteName('id') . ' = :workflowId',
 							$db->quoteName('published') . ' = 1',
-							$db->quoteName('extension') . ' = ' . $db->quote('com_content.article')
+							$db->quoteName('extension') . ' = ' . $db->quote('com_content.article'),
 						]
 					)
 					->bind(':workflowId', $workflow_id, ParameterType::INTEGER);

--- a/administrator/components/com_content/src/Helper/ContentHelper.php
+++ b/administrator/components/com_content/src/Helper/ContentHelper.php
@@ -105,7 +105,7 @@ class ContentHelper extends \Joomla\CMS\Helper\ContentHelper
 				[
 					$db->quoteName('default') . ' = 1',
 					$db->quoteName('published') . ' = 1',
-					$db->quoteName('extension') . ' = ' . $db->quote('com_content.article')
+					$db->quoteName('extension') . ' = ' . $db->quote('com_content.article'),
 				]
 			);
 

--- a/administrator/components/com_content/src/Helper/ContentHelper.php
+++ b/administrator/components/com_content/src/Helper/ContentHelper.php
@@ -105,6 +105,7 @@ class ContentHelper extends \Joomla\CMS\Helper\ContentHelper
 				[
 					$db->quoteName('default') . ' = 1',
 					$db->quoteName('published') . ' = 1',
+					$db->quoteName('extension') . ' = ' . $db->quote('com_content.article')
 				]
 			);
 
@@ -135,6 +136,7 @@ class ContentHelper extends \Joomla\CMS\Helper\ContentHelper
 						[
 							$db->quoteName('id') . ' = :workflowId',
 							$db->quoteName('published') . ' = 1',
+							$db->quoteName('extension') . ' = ' . $db->quote('com_content.article')
 						]
 					)
 					->bind(':workflowId', $workflow_id, ParameterType::INTEGER);


### PR DESCRIPTION
### Summary of Changes
The workflow selection has no context set, so in the futur if other extensions want to use the workflow, wrong information could be displayed.


### Testing Instructions
If you activate the workflow and go to the category, there is a workflow selection.
After applying the PR, the field works like before.

#### 2nd test:
Create a new workflow, go to the database and change the context to "com_banners.banner". The new workflow shouldn't be visible anywhere in com_content now.


