### PR TITLE
[4.0] override truncate

### DIFF
--- a/administrator/components/com_languages/tmpl/overrides/default.php
+++ b/administrator/components/com_languages/tmpl/overrides/default.php
@@ -83,7 +83,7 @@ $oppositeStrings  = LanguageHelper::parseIniFile($oppositeFilename);
 									<?php endif; ?>
 								</th>
 								<td class="d-none d-md-table-cell">
-									<span id="string[<?php echo $this->escape($key); ?>]"><?php echo $this->escape($text); ?></span>
+									<span id="string[<?php echo $this->escape($key); ?>]"><?php echo HTMLHelper::_('string.truncate', $this->escape($text), 200); ?></span>
 								</td>
 								<td class="d-none d-md-table-cell">
 									<?php echo $language; ?>


### PR DESCRIPTION
PR for #34699 

This PR truncates the display of very long language string overrides in the list of language overrides to a limit of 200 characters

To test create an override for any string and add a long piece of text

### Before
![image](https://user-images.githubusercontent.com/1296369/124364456-9c645600-dc39-11eb-8c63-f0823f48a282.png)


### After
![image](https://user-images.githubusercontent.com/1296369/124364442-89518600-dc39-11eb-8b04-28fd5b7242c5.png)
