### PR TITLE
[4.0] Admin container menu

### DIFF
--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -133,11 +133,6 @@ if ($clientId === 1)
 						$this->form->setFieldAttribute('publish_up', 'showon', '');
 						$this->form->setFieldAttribute('publish_down', 'showon', '');
 					}
-
-					if (!$isModal && $this->item->type == 'container')
-					{
-						echo $this->loadTemplate('container');
-					}
 					?>
 				<?php
 					// Set main fields.


### PR DESCRIPTION
Create a new admin menu and then an admin menu item of type system links ->component menu container

You will see the tree displayed twice

After the pr it is displayed just the once

### before
![image](https://user-images.githubusercontent.com/1296369/124367271-a1330500-dc4d-11eb-9d66-6f3062267298.png)

### after
![image](https://user-images.githubusercontent.com/1296369/124367262-895b8100-dc4d-11eb-9ff5-2ddd23cb3fdd.png)
