### PR TITLE
[4.0] component missing in menu

### DIFF
--- a/administrator/components/com_menus/presets/help.xml
+++ b/administrator/components/com_menus/presets/help.xml
@@ -13,6 +13,7 @@
 		<menuitem
 			title="MOD_MENU_HELP_JOOMLA"
 			type="component"
+			element="com_admin"
 			link="index.php?option=com_admin&amp;view=help"
 		/>
 	</menuitem>
@@ -40,6 +41,7 @@
 		<menuitem
 			title="MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM"
 			type="component"
+			element="com_admin"
 			target="_blank"
 			link="index.php?option=com_admin&amp;view=help&amp;layout=langforum"
 		/>


### PR DESCRIPTION
Pull Request for Issue #34192

Create a new admin menu and use the help preset

### Before
![image](https://user-images.githubusercontent.com/1296369/124367679-7d71be00-dc51-11eb-9c03-3033f98fa135.png)

### After
![image](https://user-images.githubusercontent.com/1296369/124367665-4b605c00-dc51-11eb-9fd9-24254c3732df.png)

Note for testing you will need to create a new menu for the before and after