### PR TITLE
[4.0] Overriding JTOOLBAR_DEFAULT to Home

### DIFF
--- a/administrator/language/en-GB/com_menus.ini
+++ b/administrator/language/en-GB/com_menus.ini
@@ -211,3 +211,4 @@ JLIB_RULES_SETTING_NOTES_COM_MENUS="Changes apply to this component only.<br><em
 ; Alternate language strings for the default menu item
 JDEFAULT="Home"
 JLIB_HTML_SETDEFAULT_ITEM="Set as Home"
+JTOOLBAR_DEFAULT="Home"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
File `administrator/language/en-GB/com_menus.ini` has an override for constants. Everything looks good, but in the ACTION drop-down list the "Default" constant is not overridden.

```
; Alternate language strings for the default menu item
JDEFAULT="Home"
JLIB_HTML_SETDEFAULT_ITEM="Set as Home"
```

![Screenshot_1](https://user-images.githubusercontent.com/8440661/124383052-244a6e80-dcd3-11eb-9ce5-30c36c75c28a.png)

![Screenshot_2](https://user-images.githubusercontent.com/8440661/124383055-257b9b80-dcd3-11eb-9638-7765cdbefead.png)