### PR TITLE
[4.0] Empty Trash button in clients and newsfeed

### DIFF
--- a/administrator/components/com_banners/src/View/Clients/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Clients/HtmlView.php
@@ -162,7 +162,7 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		if ($this->state->get('filter.state') == -2 && $canDo->get('core.delete'))
+		if (!$this->isEmptyState && $this->state->get('filter.state') == -2 && $canDo->get('core.delete'))
 		{
 			$toolbar->delete('clients.delete')
 				->text('JTOOLBAR_EMPTY_TRASH')

--- a/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
@@ -180,7 +180,7 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		if ($state->get('filter.published') == -2 && $canDo->get('core.delete'))
+		if (!$this->isEmptyState && $state->get('filter.published') == -2 && $canDo->get('core.delete'))
 		{
 			$toolbar->delete('newsfeeds.delete')
 				->text('JTOOLBAR_EMPTY_TRASH')


### PR DESCRIPTION
### Summary of Changes
Add `!$this->isEmptyState` when adding `toolbar->delete()`
It's similar to PR #34619 

### Testing Instructions
For clients
1. Add a client (if you don't have any)
2. Trash the client
3. Delete the client
and repeat the same for newsfeeds.

### Actual result BEFORE applying this Pull Request
![clients_before](https://user-images.githubusercontent.com/61203226/124455034-c0917580-dda6-11eb-897e-39ebb08ce6af.JPG)
![newsfeed_before](https://user-images.githubusercontent.com/61203226/124455041-c25b3900-dda6-11eb-98a9-a7c1cf18f504.JPG)

### Expected result AFTER applying this Pull Request
![clients_after](https://user-images.githubusercontent.com/61203226/124455062-c7b88380-dda6-11eb-908a-192e1262ef50.JPG)
![newsfeed_after](https://user-images.githubusercontent.com/61203226/124455065-c8e9b080-dda6-11eb-8b02-45b0a1bb8fc1.JPG)

### Documentation Changes Required
No
