### PR TITLE
[4.0] Click to check the checkbox in Search filters

### DIFF
--- a/administrator/components/com_finder/tmpl/filters/default.php
+++ b/administrator/components/com_finder/tmpl/filters/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+HTMLHelper::_('behavior.multiselect');
+
 $user      = Factory::getUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Add `HTMLHelper::_('behavior.multiselect');`

### Testing Instructions
1. Create a new search filter
2. Click on a table row, checkbox didn't check
3. Apply the PR
4. Again click on a table row, checkbox checked

### Actual result BEFORE applying this Pull Request
![filter_before](https://user-images.githubusercontent.com/61203226/124461309-1584ba00-ddae-11eb-8dde-a9828750bac1.gif)

### Expected result AFTER applying this Pull Request
![filter_after](https://user-images.githubusercontent.com/61203226/124461318-17e71400-ddae-11eb-879e-1fd6d2e96f39.gif)


### Documentation Changes Required
No