### PR TITLE
[4.0] Replace the accessibility icon: universal-access instead of wheelchair

### DIFF
--- a/build/media_source/system/scss/_icomoon.scss
+++ b/build/media_source/system/scss/_icomoon.scss
@@ -25,8 +25,7 @@ $jicon-css-prefix: icon !default;
 
 // Create brand icons mapping array
 $jicons-brand: (
-  joomla : $fa-var-joomla,
-  accessible : $fa-var-accessible-icon
+  joomla : $fa-var-joomla
 ) !default;
 
 // Parse brands mapping array
@@ -75,6 +74,7 @@ $jicons-special: (
 
 // Create standard icons mapping array
 $jicons: (
+  accessible : $fa-var-universal-access,
   add : $fa-var-plus,
   address-book : $fa-var-address-book,
   address : $fa-var-address-book,


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Thanks @brianteeman for the hint.

The commonly used icon for accessibility is the wheel chair icon. 
But this is not suitable for web accessibility. Now we can use the universal-access  icon instead.

### Testing Instructions
Apply the patch, run npm 

The easy way: Replace any icon in inspector by "icon-accessible" as for example here
![grafik](https://user-images.githubusercontent.com/1035262/124469303-7904ec80-dd9a-11eb-9451-9b73d9f02f81.png)

Or open any layout  (example administrator\modules\mod_login\tmpl\default.php) 
and replace an icon by icon-accessible (for example the icon-eye)

### Actual result BEFORE applying this Pull Request
icon-accessible 
![grafik](https://user-images.githubusercontent.com/1035262/124470239-aaca8300-dd9b-11eb-85df-bd8087562424.png)



### Expected result AFTER applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/124470690-3ba15e80-dd9c-11eb-9163-38ff5411c22c.png)


@hans2103 Could not replace the icon in Jicons-brand, moved to $icons
https://github.com/joomla/joomla-cms/blob/83e3dd33a2853a72939fb4e3d682f90ee2ad414d/build/media_source/system/scss/_icomoon.scss#L29


