### PR TITLE
[4.0] Stop table headers wrapping

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
@@ -14,10 +14,6 @@
       .sysinfo & {
         white-space: normal;
       }
-
-      @include media-breakpoint-down(md) {
-        white-space: normal;
-      }
     }
 
     a {


### PR DESCRIPTION
On mobiles the table headers are set to white-space: normal instead of nowrap
This was not correct

### before
![image](https://user-images.githubusercontent.com/1296369/124474068-fd09a500-dd97-11eb-9297-9edf278fee6b.png)

### after
![image](https://user-images.githubusercontent.com/1296369/124474032-f0854c80-dd97-11eb-8719-e26926ad51dc.png)
