### PR TITLE
[4.0] "Select Menu Item" in login module config

### DIFF
--- a/build/media_source/com_finder/joomla.asset.json
+++ b/build/media_source/com_finder/joomla.asset.json
@@ -43,7 +43,8 @@
       "type": "script",
       "uri": "com_finder/finder-es5.min.js",
       "dependencies": [
-        "core"
+        "core",
+        "awesomplete"
       ],
       "attributes": {
         "nomodule": true,

--- a/components/com_finder/tmpl/search/default_form.php
+++ b/components/com_finder/tmpl/search/default_form.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Router\Route;
 */
 if ($this->params->get('show_autosuggest', 1))
 {
-	$this->document->getWebAssetManager()->usePreset('awesomplete');
+	$this->document->getWebAssetManager()->useStyle('awesomplete');
 	$this->document->addScriptOptions('finder-search', array('url' => Route::_('index.php?option=com_finder&task=suggestions.suggest&format=json&tmpl=component')));
 }
 

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -52,7 +52,7 @@ $wa->getRegistry()->addExtensionRegistryFile('com_finder');
  */
 if ($params->get('show_autosuggest', 1))
 {
-	$wa->usePreset('awesomplete');
+	$wa->useStyle('awesomplete');
 	$app->getDocument()->addScriptOptions('finder-search', array('url' => Route::_('index.php?option=com_finder&task=suggestions.suggest&format=json&tmpl=component')));
 }
 

--- a/modules/mod_login/mod_login.xml
+++ b/modules/mod_login/mod_login.xml
@@ -52,7 +52,7 @@
 					edit="true"
 					clear="true"
 					>
-					<option value="">JOPTION_SELECT_MENU</option>
+					<option value="">JOPTION_SELECT_MENU_ITEM</option>
 				</field>
 
 				<field
@@ -66,7 +66,7 @@
 					edit="true"
 					clear="true"
 					>
-					<option value="">JOPTION_SELECT_MENU</option>
+					<option value="">JOPTION_SELECT_MENU_ITEM</option>
 				</field>
 
 				<field
@@ -79,7 +79,7 @@
 					edit="true"
 					clear="true"
 					>
-					<option value="">JOPTION_SELECT_MENU</option>
+					<option value="">JOPTION_SELECT_MENU_ITEM</option>
 				</field>
 
 				<field


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Open the mod_login in the backend.
There are 3 settings labelled "Select Menu".
Though all of them concern the selection of a Menu Item (NOT a menu).

Change the label to "Select Menu Item"


### Testing Instructions
Open the _mod_login_ 


### Actual result BEFORE applying this Pull Request
 The 3 settings labelled "Select Menu"


### Expected result AFTER applying this Pull Request

 The 3 settings labelled "Select Menu Item"

### Documentation Changes Required
No
