### PR TITLE
[4.0] "Select menu item" in mod_login settings.

### DIFF
--- a/modules/mod_login/mod_login.xml
+++ b/modules/mod_login/mod_login.xml
@@ -24,109 +24,109 @@
 		<fields name="params">
 			<fieldset name="basic" addfieldprefix="Joomla\Component\Menus\Administrator\Field">
 				<field
-					name="pretext"
-					type="textarea"
-					label="MOD_LOGIN_FIELD_PRE_TEXT_LABEL"
-					filter="safehtml"
-					cols="30"
-					rows="5"
+						name="pretext"
+						type="textarea"
+						label="MOD_LOGIN_FIELD_PRE_TEXT_LABEL"
+						filter="safehtml"
+						cols="30"
+						rows="5"
 				/>
 
 				<field
-					name="posttext"
-					type="textarea"
-					label="MOD_LOGIN_FIELD_POST_TEXT_LABEL"
-					filter="safehtml"
-					cols="30"
-					rows="5"
+						name="posttext"
+						type="textarea"
+						label="MOD_LOGIN_FIELD_POST_TEXT_LABEL"
+						filter="safehtml"
+						cols="30"
+						rows="5"
 				/>
 
 				<field
-					name="login"
-					type="modal_menu"
-					label="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_LABEL"
-					description="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_DESC"
-					disable="separator,alias,heading,url"
-					select="true"
-					new="true"
-					edit="true"
-					clear="true"
-					>
-					<option value="">JOPTION_SELECT_MENU</option>
+						name="login"
+						type="modal_menu"
+						label="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_LABEL"
+						description="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_DESC"
+						disable="separator,alias,heading,url"
+						select="true"
+						new="true"
+						edit="true"
+						clear="true"
+				>
+					<option value="">JOPTION_SELECT_MENU_ITEM</option>
 				</field>
 
 				<field
-					name="logout"
-					type="modal_menu"
-					label="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_LABEL"
-					description="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_DESC"
-					disable="separator,alias,heading,url"
-					select="true"
-					new="true"
-					edit="true"
-					clear="true"
-					>
-					<option value="">JOPTION_SELECT_MENU</option>
+						name="logout"
+						type="modal_menu"
+						label="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_LABEL"
+						description="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_DESC"
+						disable="separator,alias,heading,url"
+						select="true"
+						new="true"
+						edit="true"
+						clear="true"
+				>
+					<option value="">JOPTION_SELECT_MENU_ITEM</option>
 				</field>
 
 				<field
-					name="customRegLinkMenu"
-					type="modal_menu"
-					label="MOD_LOGIN_FIELD_REGISTRATION_MENU_LABEL"
-					disable="separator,alias,heading,url"
-					select="true"
-					new="true"
-					edit="true"
-					clear="true"
-					>
-					<option value="">JOPTION_SELECT_MENU</option>
+						name="customRegLinkMenu"
+						type="modal_menu"
+						label="MOD_LOGIN_FIELD_REGISTRATION_MENU_LABEL"
+						disable="separator,alias,heading,url"
+						select="true"
+						new="true"
+						edit="true"
+						clear="true"
+				>
+					<option value="">JOPTION_SELECT_MENU_ITEM</option>
 				</field>
 
 				<field
-					name="greeting"
-					type="radio"
-					layout="joomla.form.field.radio.switcher"
-					label="MOD_LOGIN_FIELD_GREETING_LABEL"
-					default="1"
-					filter="integer"
-					>
+						name="greeting"
+						type="radio"
+						layout="joomla.form.field.radio.switcher"
+						label="MOD_LOGIN_FIELD_GREETING_LABEL"
+						default="1"
+						filter="integer"
+				>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
 				</field>
 
 				<field
-					name="name"
-					type="radio"
-					layout="joomla.form.field.radio.switcher"
-					label="MOD_LOGIN_FIELD_NAME_LABEL"
-					default="0"
-					filter="integer"
-					showon="greeting:1"
-					>
+						name="name"
+						type="radio"
+						layout="joomla.form.field.radio.switcher"
+						label="MOD_LOGIN_FIELD_NAME_LABEL"
+						default="0"
+						filter="integer"
+						showon="greeting:1"
+				>
 					<option value="0">MOD_LOGIN_VALUE_NAME</option>
 					<option value="1">MOD_LOGIN_VALUE_USERNAME</option>
 				</field>
 
 				<field
-					name="profilelink"
-					type="radio"
-					label="MOD_LOGIN_FIELD_PROFILE_LABEL"
-					layout="joomla.form.field.radio.switcher"
-					default="0"
-					filter="integer"
-					>
+						name="profilelink"
+						type="radio"
+						label="MOD_LOGIN_FIELD_PROFILE_LABEL"
+						layout="joomla.form.field.radio.switcher"
+						default="0"
+						filter="integer"
+				>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
 				</field>
 
 				<field
-					name="usetext"
-					type="radio"
-					layout="joomla.form.field.radio.switcher"
-					label="MOD_LOGIN_FIELD_USETEXT_LABEL"
-					default="0"
-					filter="integer"
-					>
+						name="usetext"
+						type="radio"
+						layout="joomla.form.field.radio.switcher"
+						label="MOD_LOGIN_FIELD_USETEXT_LABEL"
+						default="0"
+						filter="integer"
+				>
 					<option value="0">MOD_LOGIN_VALUE_ICONS</option>
 					<option value="1">MOD_LOGIN_VALUE_TEXT</option>
 				</field>
@@ -134,19 +134,19 @@
 
 			<fieldset name="advanced">
 				<field
-					name="layout"
-					type="modulelayout"
-					label="JFIELD_ALT_LAYOUT_LABEL"
-					class="form-select"
-					validate="moduleLayout"
+						name="layout"
+						type="modulelayout"
+						label="JFIELD_ALT_LAYOUT_LABEL"
+						class="form-select"
+						validate="moduleLayout"
 				/>
 
 				<field
-					name="moduleclass_sfx"
-					type="textarea"
-					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
-					rows="3"
-					validate="CssIdentifier"
+						name="moduleclass_sfx"
+						type="textarea"
+						label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
+						rows="3"
+						validate="CssIdentifier"
 				/>
 			</fieldset>
 		</fields>

--- a/modules/mod_login/mod_login.xml
+++ b/modules/mod_login/mod_login.xml
@@ -24,109 +24,109 @@
 		<fields name="params">
 			<fieldset name="basic" addfieldprefix="Joomla\Component\Menus\Administrator\Field">
 				<field
-						name="pretext"
-						type="textarea"
-						label="MOD_LOGIN_FIELD_PRE_TEXT_LABEL"
-						filter="safehtml"
-						cols="30"
-						rows="5"
+					name="pretext"
+					type="textarea"
+					label="MOD_LOGIN_FIELD_PRE_TEXT_LABEL"
+					filter="safehtml"
+					cols="30"
+					rows="5"
 				/>
 
 				<field
-						name="posttext"
-						type="textarea"
-						label="MOD_LOGIN_FIELD_POST_TEXT_LABEL"
-						filter="safehtml"
-						cols="30"
-						rows="5"
+					name="posttext"
+					type="textarea"
+					label="MOD_LOGIN_FIELD_POST_TEXT_LABEL"
+					filter="safehtml"
+					cols="30"
+					rows="5"
 				/>
 
 				<field
-						name="login"
-						type="modal_menu"
-						label="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_LABEL"
-						description="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_DESC"
-						disable="separator,alias,heading,url"
-						select="true"
-						new="true"
-						edit="true"
-						clear="true"
-				>
+					name="login"
+					type="modal_menu"
+					label="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_LABEL"
+					description="MOD_LOGIN_FIELD_LOGIN_REDIRECTURL_DESC"
+					disable="separator,alias,heading,url"
+					select="true"
+					new="true"
+					edit="true"
+					clear="true"
+					>
 					<option value="">JOPTION_SELECT_MENU_ITEM</option>
 				</field>
 
 				<field
-						name="logout"
-						type="modal_menu"
-						label="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_LABEL"
-						description="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_DESC"
-						disable="separator,alias,heading,url"
-						select="true"
-						new="true"
-						edit="true"
-						clear="true"
-				>
+					name="logout"
+					type="modal_menu"
+					label="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_LABEL"
+					description="MOD_LOGIN_FIELD_LOGOUT_REDIRECTURL_DESC"
+					disable="separator,alias,heading,url"
+					select="true"
+					new="true"
+					edit="true"
+					clear="true"
+					>
 					<option value="">JOPTION_SELECT_MENU_ITEM</option>
 				</field>
 
 				<field
-						name="customRegLinkMenu"
-						type="modal_menu"
-						label="MOD_LOGIN_FIELD_REGISTRATION_MENU_LABEL"
-						disable="separator,alias,heading,url"
-						select="true"
-						new="true"
-						edit="true"
-						clear="true"
-				>
+					name="customRegLinkMenu"
+					type="modal_menu"
+					label="MOD_LOGIN_FIELD_REGISTRATION_MENU_LABEL"
+					disable="separator,alias,heading,url"
+					select="true"
+					new="true"
+					edit="true"
+					clear="true"
+					>
 					<option value="">JOPTION_SELECT_MENU_ITEM</option>
 				</field>
 
 				<field
-						name="greeting"
-						type="radio"
-						layout="joomla.form.field.radio.switcher"
-						label="MOD_LOGIN_FIELD_GREETING_LABEL"
-						default="1"
-						filter="integer"
-				>
+					name="greeting"
+					type="radio"
+					layout="joomla.form.field.radio.switcher"
+					label="MOD_LOGIN_FIELD_GREETING_LABEL"
+					default="1"
+					filter="integer"
+					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
 				</field>
 
 				<field
-						name="name"
-						type="radio"
-						layout="joomla.form.field.radio.switcher"
-						label="MOD_LOGIN_FIELD_NAME_LABEL"
-						default="0"
-						filter="integer"
-						showon="greeting:1"
-				>
+					name="name"
+					type="radio"
+					layout="joomla.form.field.radio.switcher"
+					label="MOD_LOGIN_FIELD_NAME_LABEL"
+					default="0"
+					filter="integer"
+					showon="greeting:1"
+					>
 					<option value="0">MOD_LOGIN_VALUE_NAME</option>
 					<option value="1">MOD_LOGIN_VALUE_USERNAME</option>
 				</field>
 
 				<field
-						name="profilelink"
-						type="radio"
-						label="MOD_LOGIN_FIELD_PROFILE_LABEL"
-						layout="joomla.form.field.radio.switcher"
-						default="0"
-						filter="integer"
-				>
+					name="profilelink"
+					type="radio"
+					label="MOD_LOGIN_FIELD_PROFILE_LABEL"
+					layout="joomla.form.field.radio.switcher"
+					default="0"
+					filter="integer"
+					>
 					<option value="0">JHIDE</option>
 					<option value="1">JSHOW</option>
 				</field>
 
 				<field
-						name="usetext"
-						type="radio"
-						layout="joomla.form.field.radio.switcher"
-						label="MOD_LOGIN_FIELD_USETEXT_LABEL"
-						default="0"
-						filter="integer"
-				>
+					name="usetext"
+					type="radio"
+					layout="joomla.form.field.radio.switcher"
+					label="MOD_LOGIN_FIELD_USETEXT_LABEL"
+					default="0"
+					filter="integer"
+					>
 					<option value="0">MOD_LOGIN_VALUE_ICONS</option>
 					<option value="1">MOD_LOGIN_VALUE_TEXT</option>
 				</field>
@@ -134,19 +134,19 @@
 
 			<fieldset name="advanced">
 				<field
-						name="layout"
-						type="modulelayout"
-						label="JFIELD_ALT_LAYOUT_LABEL"
-						class="form-select"
-						validate="moduleLayout"
+					name="layout"
+					type="modulelayout"
+					label="JFIELD_ALT_LAYOUT_LABEL"
+					class="form-select"
+					validate="moduleLayout"
 				/>
 
 				<field
-						name="moduleclass_sfx"
-						type="textarea"
-						label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
-						rows="3"
-						validate="CssIdentifier"
+					name="moduleclass_sfx"
+					type="textarea"
+					label="COM_MODULES_FIELD_MODULECLASS_SFX_LABEL"
+					rows="3"
+					validate="CssIdentifier"
 				/>
 			</fieldset>
 		</fields>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Open the _mod_login_ in the backend.
There are 3 settings labelled "Select Menu".
Though all of them concern the selection of a Menu Item (NOT a menu).

Change the label to "Select Menu Item"

### Testing Instructions
Open the _mod_login_


### Actual result BEFORE applying this Pull Request
The 3 settings labelled "Select Menu"


### Expected result AFTER applying this Pull Request
The 3 settings labelled "Select Menu Item"


### Documentation Changes Required
No
