### PR TITLE
make status order icon responsively correct in mobile view

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_table.scss
@@ -16,7 +16,7 @@
       }
 
       @include media-breakpoint-down(md) {
-        white-space: normal;
+        white-space: nowrap;
       }
     }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

On every page which has status column in which the status icon was not properly aligned in mobile view.
The order icon was going below the status.

it is same issue as #34709 

### Testing Instructions

- Firstly, run `npm ci`  in order to compile new SCSS changes

and

- You need to have some entry on every page that has a status column.

### Actual result BEFORE applying this Pull Request

![before](https://user-images.githubusercontent.com/59458280/124498103-7b3a6b80-ddd9-11eb-8ce5-79b11e792550.png)


### Expected result AFTER applying this Pull Request

![after](https://user-images.githubusercontent.com/59458280/124498122-7ecdf280-ddd9-11eb-90c5-5e23dd03f655.png)



