### PR TITLE
[4.0] Empty Trash button in tags

### DIFF
--- a/administrator/components/com_tags/src/View/Tags/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tags/HtmlView.php
@@ -180,7 +180,7 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		if ($this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
+		if (!$this->isEmptyState && $this->state->get('filter.published') == -2 && $canDo->get('core.delete'))
 		{
 			$toolbar->delete('tags.delete')
 				->text('JTOOLBAR_EMPTY_TRASH')


### PR DESCRIPTION
### Summary of Changes
Add !$this->isEmptyState when adding toolbar->delete()
It's similar to PR #34712

### Testing Instructions
Trash all the tags and then empty trash for all tags


### Actual result BEFORE applying this Pull Request
![tags_before](https://user-images.githubusercontent.com/61203226/124509212-26095480-ddef-11eb-9899-7c70670dba55.JPG)

### Expected result AFTER applying this Pull Request
![tags_after](https://user-images.githubusercontent.com/61203226/124509216-286bae80-ddef-11eb-8b11-3aa701f9de7b.JPG)

### Documentation Changes Required
No
