### PR TITLE
[4.0] Convert back "circle" classes to "unfeatured".

### DIFF
--- a/administrator/components/com_contact/src/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contacts/HtmlView.php
@@ -178,7 +178,7 @@ class HtmlView extends BaseHtmlView
 				->text('JFEATURE')
 				->task('contacts.featured')
 				->listCheck(true);
-			$childBar->standardButton('circle')
+			$childBar->standardButton('unfeatured')
 				->text('JUNFEATURE')
 				->task('contacts.unfeatured')
 				->listCheck(true);

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -215,7 +215,7 @@ class HtmlView extends BaseHtmlView
 					->task('articles.featured')
 					->listCheck(true);
 
-				$childBar->standardButton('circle')
+				$childBar->standardButton('unfeatured')
 					->text('JUNFEATURE')
 					->task('articles.unfeatured')
 					->listCheck(true);

--- a/build/media_source/system/scss/_icomoon.scss
+++ b/build/media_source/system/scss/_icomoon.scss
@@ -427,7 +427,7 @@ $jicons: (
   unblock : $fa-var-sync,
   undo-2 : $fa-var-undo,
   undo : $fa-var-undo,
-  unfeatured : $fa-var-star,
+  unfeatured : $fa-var-circle,
   universal : $fa-var-universal-access,
   universal-access : $fa-var-universal-access,
   unlock-alt : $fa-var-unlock-alt,

--- a/libraries/src/Button/FeaturedButton.php
+++ b/libraries/src/Button/FeaturedButton.php
@@ -29,7 +29,7 @@ class FeaturedButton extends ActionButton
 	 */
 	protected function preprocess()
 	{
-		$this->addState(0, 'featured', 'icon-circle',
+		$this->addState(0, 'featured', 'icon-unfeatured',
 			Text::_('JGLOBAL_TOGGLE_FEATURED'), ['tip_title' => Text::_('JUNFEATURED')]
 		);
 		$this->addState(1, 'unfeatured', 'icon-color-featured icon-star',

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -270,7 +270,7 @@ abstract class JGrid
 	 * @see     JHtmlJGrid::state()
 	 * @since   1.6
 	 */
-	public static function isdefault($value, $i, $prefix = '', $enabled = true, $checkbox = 'cb', $formId = null, $active_class = 'icon-color-featured icon-star', $inactive_class = 'icon-circle')
+	public static function isdefault($value, $i, $prefix = '', $enabled = true, $checkbox = 'cb', $formId = null, $active_class = 'icon-color-featured icon-star', $inactive_class = 'icon-unfeatured')
 	{
 		if (is_array($prefix))
 		{


### PR DESCRIPTION
Pull Request for Issue #34502 .

### Summary of Changes
The "unfeatured" icons/buttons were changed to "circle" instead of changing the global declaration, so IDs were changed etc.
This PR changed them back and updates the global "icon-unfeatured" icon to circle.


### Testing Instructions
Test 1:
Check unfeatured icon in com_content.

Test 2:
Activate workflow and check action dropdown


### Actual result BEFORE applying this Pull Request
Unfeature icon is now "circle"
Dropdown for workflow broken


### Expected result AFTER applying this Pull Request
"Unfeature icon" is back to "unfeatured"
Not visible with activated workflow


### Additional
https://github.com/joomla/joomla-cms/pull/33417/files

