### PR TITLE
[4.0] Component menu image to be styled as component font-icon

### DIFF
--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -26,11 +26,11 @@ use Joomla\CMS\Router\Route;
 					}
 					elseif (substr($child->img, 0, 6) === 'image:')
 					{
-						$iconImage = '<img src="' . substr($child->img, 6) . '" aria-hidden="true">';
+						$iconImage = '<img class="icon-" src="' . substr($child->img, 6) . '" aria-hidden="true">';
 					}
 					elseif (!empty($child->img))
 					{
-						$iconImage = '<img src="' . $child->img . '" aria-hidden="true">';
+						$iconImage = '<img class="icon-" src="' . $child->img . '" aria-hidden="true">';
 					}
 					elseif ($child->icon)
 					{


### PR DESCRIPTION
### Summary of Changes
If you try to use an image file in the component menu, this is shown differently than the icons used in Joomla components.
It does not have the same spacing.

### Testing Instructions
For the shake of testing i created a very simple component that can be [downloaded from github](https://github.com/sakiss/com_texticon/raw/main/com_icontest.zip).

It is just an empty component that uses an svg icon in it's menu.

Install it and click the components dashboard icon.

![component_dashboard](https://user-images.githubusercontent.com/1838041/124651754-fcf6cb80-dea3-11eb-91ee-08ec904c9df7.png)

### Actual result BEFORE applying this Pull Request
Icon stuck to the component name
![icon_test_before](https://user-images.githubusercontent.com/1838041/124651884-27488900-dea4-11eb-8805-d3adda7e4276.png)

### Expected result AFTER applying this Pull Request
Icon having the same spacing as the other component icons.
![icon_test_after](https://user-images.githubusercontent.com/1838041/124651944-3596a500-dea4-11eb-9d36-53fba676f36d.png)


### Documentation Changes Required
No
