### PR TITLE
[4.0] Use ExtensionHelper::getExtensionRecord to get finder plugin ID

### DIFF
--- a/administrator/components/com_finder/src/Helper/FinderHelper.php
+++ b/administrator/components/com_finder/src/Helper/FinderHelper.php
@@ -11,7 +11,7 @@ namespace Joomla\Component\Finder\Administrator\Helper;
 
 \defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
+use Joomla\CMS\Extension\ExtensionHelper;
 
 /**
  * Helper class for Finder.
@@ -29,14 +29,6 @@ class FinderHelper
 	public static $extension = 'com_finder';
 
 	/**
-	 * The finder plugin id.
-	 *
-	 * @var integer
-	 * @since __DEPLOY_VERSION__
-	 */
-	protected static $pluginId;
-
-	/**
 	 * Gets the finder system plugin extension id.
 	 *
 	 * @return  integer  The finder system plugin extension id.
@@ -45,26 +37,8 @@ class FinderHelper
 	 */
 	public static function getFinderPluginId()
 	{
-		if (self::$pluginId === null)
-		{
-			$db    = Factory::getDbo();
-			$query = $db->getQuery(true)
-				->select($db->quoteName('extension_id'))
-				->from($db->quoteName('#__extensions'))
-				->where($db->quoteName('folder') . ' = ' . $db->quote('content'))
-				->where($db->quoteName('element') . ' = ' . $db->quote('finder'));
-			$db->setQuery($query);
+		$pluginRecord = ExtensionHelper::getExtensionRecord('finder', 'plugin', null, 'content');
 
-			try
-			{
-				self::$pluginId = (int) $db->loadResult();
-			}
-			catch (\RuntimeException $e)
-			{
-				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-			}
-		}
-
-		return self::$pluginId;
+		return $pluginRecord !== null ? $pluginRecord->extension_id : 0;
 	}
 }

--- a/administrator/components/com_finder/tmpl/index/emptystate.php
+++ b/administrator/components/com_finder/tmpl/index/emptystate.php
@@ -9,8 +9,10 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Router\Route;
 
 $displayData = [
 	'textPrefix' => 'COM_FINDER',
@@ -23,3 +25,29 @@ $displayData = [
 ];
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);
+
+if ($this->finderPluginId) : ?>
+	<?php $link = Route::_('index.php?option=com_plugins&client_id=0&task=plugin.edit&extension_id=' . $this->finderPluginId . '&tmpl=component&layout=modal'); ?>
+	<?php echo HTMLHelper::_(
+		'bootstrap.renderModal',
+		'plugin' . $this->finderPluginId . 'Modal',
+		array(
+			'url'         => $link,
+			'title'       => Text::_('COM_FINDER_EDIT_PLUGIN_SETTINGS'),
+			'height'      => '400px',
+			'width'       => '800px',
+			'bodyHeight'  => '70',
+			'modalWidth'  => '80',
+			'closeButton' => false,
+			'backdrop'    => 'static',
+			'keyboard'    => false,
+			'footer'      => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal"'
+				. ' onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->finderPluginId . 'Modal\', buttonSelector: \'#closeBtn\'})">'
+				. Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
+				. '<button type="button" class="btn btn-primary" data-bs-dismiss="modal" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->finderPluginId . 'Modal\', buttonSelector: \'#saveBtn\'})">'
+				. Text::_("JSAVE") . '</button>'
+				. '<button type="button" class="btn btn-success" onclick="Joomla.iframeButtonClick({iframeSelector: \'#plugin' . $this->finderPluginId . 'Modal\', buttonSelector: \'#applyBtn\'}); return false;">'
+				. Text::_("JAPPLY") . '</button>'
+		)
+	); ?>
+<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Instead of writing code to query #__extensions table to get finder plugin ID, this PR uses our extension ExtensionHelper::getExtensionRecord library method to get ID of the plugin as agreed by @wilsonge  as https://github.com/joomla/joomla-cms/pull/34645#issuecomment-872780288


### Testing Instructions
1. Apply patch
2. Go to Extensions -> Plugins, disable **Content - Smart Search** plugin.
3. Access to Components -> Smart Search -> Index, there should be a warning message ask you to enable the plugin
4. Click on the link (see the screenshot), make sure the right plugin is opened on modal popup so that you can enable it

![Smart-Search-Indexed-Content-Joomla-4-Administration](https://user-images.githubusercontent.com/977664/124960151-3a935a00-e046-11eb-9903-96614f68fe82.png)


### Actual result BEFORE applying this Pull Request
Works, but more code than needed.


### Expected result AFTER applying this Pull Request
Works and less code to maintain.