### PR TITLE
[4.0] Fix error when component does not support workflow at all in category view

### DIFF
--- a/administrator/components/com_categories/tmpl/category/edit.php
+++ b/administrator/components/com_categories/tmpl/category/edit.php
@@ -34,12 +34,14 @@ $this->ignore_fieldsets = ['jmetadata', 'item_associations'];
 
 $c = Factory::getApplication()->bootComponent($this->state->get('category.extension'));
 
-$wcontext = $c->getCategoryWorkflowContext($this->state->get('category.section'));
-
-if (!$c instanceof WorkflowServiceInterface
-	|| !$c->isWorkflowActive($wcontext))
+if ($c instanceof WorkflowServiceInterface)
 {
-	$this->ignore_fieldsets[] = 'workflow';
+	$wcontext = $c->getCategoryWorkflowContext($this->state->get('category.section'));
+
+	if (!$c->isWorkflowActive($wcontext))
+	{
+		$this->ignore_fieldsets[] = 'workflow';
+	}
 }
 
 $this->useCoreUI = true;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/31374#issuecomment-876594730.

### Summary of Changes
Fix wrong check for components using categories without workflow


### Testing Instructions
Go to the banners component and create/edit a category


### Actual result BEFORE applying this Pull Request
Error: ```Call to undefined method Joomla\Component\Banners\Administrator\Extension\BannersComponent::getCategoryWorkflowContext()```


### Expected result AFTER applying this Pull Request
No error.

Described function from https://github.com/joomla/joomla-cms/pull/31374 in com_content still works.


