### PR TITLE
[4.0] Revert PR #34608 "Fix metismenu caret wrapping" because it has broken styling of the active menu item

### DIFF
--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_component.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_component.php
@@ -68,11 +68,9 @@ elseif ($item->browserNav == 2)
 	$attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
 }
 
-echo '<span class="mm-toggler-component__wrapper">';
 echo HTMLHelper::link(OutputFilter::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $linktype, $attributes);
 
 if ($showAll && $item->deeper)
 {
 	echo '<button class="mm-collapsed mm-toggler mm-toggler-link" aria-haspopup="true" aria-expanded="false" aria-label="' . $item->title . '"></button>';
 }
-echo '</span>';

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_url.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_url.php
@@ -64,11 +64,9 @@ elseif ($item->browserNav == 2)
 	$attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
 }
 
-echo '<span class="mm-toggler-url__wrapper">';
 echo HTMLHelper::link(OutputFilter::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $linktype, $attributes);
 
 if ($showAll && $item->deeper)
 {
 	echo '<button class="mm-collapsed mm-toggler mm-toggler-link" aria-haspopup="true" aria-expanded="false" aria-label="' . $item->title . '"></button>';
 }
-echo '</span>';

--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -180,45 +180,7 @@
         background: $white;
       }
 
-      > .mm-toggler-component__wrapper a,
-      > .mm-toggler-url__wrapper a {
-        position: relative;
-      }
-
-      > .mm-toggler-component__wrapper,
-      > .mm-toggler-url__wrapper {
-
-        > a:hover::after,
-        > button:hover::before,
-        &.active > a::after,
-        &.active > button::before {
-          right: 0;
-          left: 0;
-          background: $white;
-        }
-      }
-
-      > .mm-toggler-component__wrapper > a::after,
-      > .mm-toggler-component__wrapper > button::before,
-      > .mm-toggler-url__wrapper > a::after,
-      > .mm-toggler-url__wrapper > button::before {
-
-        @include media-breakpoint-up(md) {
-          position: absolute;
-          right: 50%;
-          bottom: 0;
-          left: 50%;
-          display: block;
-          height: 2px;
-          margin: auto;
-          content: "";
-          background: transparent;
-          opacity: .2;
-          transition: all .2s ease, background-color .2s ease;
-        }
-      }
-
-      button.mm-toggler-link:hover::before,
+      > button.mm-toggler-link:hover::before,
       &.active > button.mm-toggler-link::before {
         right: 0;
         left: .5em;
@@ -243,36 +205,6 @@
 
       > ul {
         min-width: 12rem;
-        max-width: 90vw;
-      }
-    }
-
-    .metismenu > li.level-1 > .mm-toggler-url__wrapper,
-    .metismenu > li.level-1 > .mm-toggler-component__wrapper {
-
-      > a:hover,
-      > button:hover {
-
-        @include media-breakpoint-up(md) {
-          text-decoration: none;
-        }
-      }
-    }
-
-    li.level-2 {
-
-      .mm-toggler {
-        min-height: 1.5em;
-        color: $gray-900;
-      }
-    }
-  }
-
-  .metismenu > .metismenu-item {
-    > .mm-toggler-component__wrapper,
-    > .mm-toggler-url__wrapper {
-      a {
-        color: #fff;
       }
     }
   }

--- a/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/templates/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -63,20 +63,6 @@
           outline-offset: 2px;
         }
 
-        > .mm-toggler-component__wrapper,
-        > .mm-toggler-url__wrapper {
-          display: flex;
-          align-items: center;
-          height: 100%;
-          overflow: visible;
-
-          > a:focus,
-          > button:focus {
-            outline: 1px dotted $gray-400;
-            outline-offset: 2px;
-          }
-        }
-
         &.active > a,
         &.active > button,
         > a:hover,
@@ -202,16 +188,6 @@
         }
       }
     }
-
-    @include media-breakpoint-down(md) {
-
-      &.mod-menu .metismenu-item>span,
-      &.mod-menu .metismenu-item>a,
-      &.mod-menu .metismenu-item>button {
-        text-align: left;
-        white-space: break-spaces;
-      }
-    }
   }
 
   .sidebar-right,
@@ -220,13 +196,6 @@
       .mm-collapse {
         position: relative;
         background-color: hsla(0, 0%, 0%, .03);
-      }
-
-      .metismenu-item>span,
-      .metismenu-item>a,
-      .metismenu-item>button {
-        text-align: left;
-        white-space: break-spaces;
       }
 
       li.parent {
@@ -251,17 +220,6 @@
           width: auto;
           height: 1px;
           border-bottom: 1px solid $gray-400;
-        }
-      }
-    }
-  }
-
-  .metismenu .metismenu-item {
-    .mm-toggler-component__wrapper,
-    .mm-toggler-url__wrapper {
-      a {
-        &:hover {
-          text-decoration: underline;
         }
       }
     }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This reverts PR #34608 "Fix metismenu caret wrapping" because it has broken styling of the active menu item.

The PR has added a span between the `li` element and the link but did not adjust existing SCSS for this, so the parent selectors `&.` don't match anymore for the menu item types modified by that PR. Instead of correcting SCSS that PR has added more SCSS, which leads to redundant hardly maintainable code, and the additional SCSS is not complete.

As a result of this, at least the styling of the active menu item has been broken by that PR.

It can be that the PR has broken more based on parent selectors which don't match anymore, but I haven't tested everything. RTL could be one thing, especially for menu items of level 3 or more.

Therefore it is the best to revert that PR for now.

### Testing Instructions

Make a new installation and then install Sample Data Blog.

After that, create a few copies of the Main Menu Blog and put them on different positions. Change the layout from "collapsible-dropdown" to "dropdown" for the copies, and for some of them use menu class "menu-horizontal".

![2021-07-10_00](https://user-images.githubusercontent.com/7413183/125169646-7693ff80-e1ab-11eb-8594-05265656b654.png)

Then check if a menu item with a link (i.e. type "URL" or "Component") is underlined when it is active or one of its submenu items is active, like is it done with the menu items without link (type "Heading" or "Separator").

### Actual result BEFORE applying this Pull Request

While the active menu item and its parents are underlined underlined when the menu item is of a type without a link (type "Heading" or "Separator"), this doesn't happen when the menu item is of a type with a link (i.e. type "URL" or "Component") which have been modified by PR #34608 .

See the red marks in the following screenshot: 

![2021-07-10_02](https://user-images.githubusercontent.com/7413183/125169658-86abdf00-e1ab-11eb-94b0-a3d83760d4c3.png)

![2021-07-10_01](https://user-images.githubusercontent.com/7413183/125169648-7bf14a00-e1ab-11eb-8191-e805614882c4.png)

As said, for menu items without a link which have not been modified by PR #34608 it works:

![2021-07-10_03](https://user-images.githubusercontent.com/7413183/125169670-8e6b8380-e1ab-11eb-802a-4a94934d4793.png)

The above screenshots shows examples top menu items because that's the most visible thing, but of course parent menu items at lower levels should work the same.

### Expected result AFTER applying this Pull Request

All types of menu items and their parents are underlined (with a pseudo element in the header and with text decoration elsewhere) in the same way when they are the active menu item.

The following screenshot shows the example for a top menu item because that's the most visible thing, but of course parent menu items at lower levels should work the same.

![2021-07-10_05](https://user-images.githubusercontent.com/7413183/125169956-dd65e880-e1ac-11eb-8660-a223fe1c5b44.png)

### Documentation Changes Required

None.