### PR TITLE
[4.0] Component menu image to be styled as component font-icon (revisited)

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -103,7 +103,8 @@
     color: var(--atum-bg-dark);
     background: var(--card-bg);
 
-    > [class^="icon-"] {
+    > [class^="icon-"],
+    > img {
       margin-inline-end: .5rem;
     }
   }

--- a/administrator/templates/atum/scss/vendor/bootstrap/_card.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_card.scss
@@ -31,7 +31,8 @@
     color: var(--atum-bg-dark);
     background: var(--card-bg);
 
-    > [class^="icon-"] {
+    > [class^="icon-"],
+    > img {
       margin-inline-end: .5rem;
     }
   }


### PR DESCRIPTION
Pull Request as a replacement for PR #34725

### Summary of Changes

When components use images rather than font icons, there is no empty space between the image and the text, while there is such space with icons.

### Testing Instructions

Check PR #34725 for instructions

### Actual result BEFORE applying this Pull Request

No space between image and text

### Expected result AFTER applying this Pull Request

Right spacing between image and text

### Documentation Changes Required

None