### PR TITLE
[4.0] Don't load hardcoded English language file in post installation messa…

### DIFF
--- a/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php
+++ b/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php
@@ -31,6 +31,6 @@ catch (RuntimeException $e)
 $joomlaFilesExtensionId = ExtensionHelper::getExtensionRecord('joomla', 'file')->extension_id;
 
 // Load the com_postinstall language file
-$app->getLanguage()->load('com_postinstall', JPATH_ADMINISTRATOR, 'en-GB', true);
+$app->getLanguage()->load('com_postinstall', JPATH_ADMINISTRATOR);
 
 require ModuleHelper::getLayoutPath('mod_post_installation_messages', $params->get('layout', 'default'));


### PR DESCRIPTION
Pull Request for Issue #34730 .

### Summary of Changes
Alternative to https://github.com/joomla/joomla-cms/pull/34737 - the post installation module hardcodes loading the english file - this shouldn't be required - just load the native language file.

### Testing Instructions
Install a language such as french and navigate to the post-installation messages page


### Actual result BEFORE applying this Pull Request
<img width="1280" alt="Screenshot 2021-07-10 at 18 29 23" src="https://user-images.githubusercontent.com/1986000/125171576-de971580-e1ac-11eb-8942-1d14d61afb29.png">


### Expected result AFTER applying this Pull Request
<img width="1280" alt="Screenshot 2021-07-10 at 18 29 36" src="https://user-images.githubusercontent.com/1986000/125171572-db9c2500-e1ac-11eb-931c-997969ff79a8.png">


### Documentation Changes Required
None
