### PR TITLE
[4.0] Fix SQL error 1093 "You can't specify target table ..." when updating from 3.10 with certain versions of MySQL 5.7

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-03-05.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2018-03-05.sql
@@ -20,8 +20,8 @@ INSERT INTO `#__extensions` (`name`, `type`, `element`, `folder`, `client_id`, `
 ('cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '{}', '{}', '', '', 0, '0000-00-00 00:00:00', 0, 0);
 
 INSERT INTO `#__template_styles` (`template`, `client_id`, `home`, `title`, `params`) VALUES
-('atum', 1, (CASE WHEN (SELECT count FROM (SELECT count(`id`) AS count FROM `#__template_styles` WHERE home = '1' AND client_id = 1 AND `template` IN ('isis', 'hathor')) as c) = 0 THEN '0' ELSE '1' END), 'atum - Default', '{}'),
-('cassiopeia', 0, (CASE WHEN (SELECT count FROM (SELECT count(`id`) AS count FROM `#__template_styles` WHERE home = '1' AND client_id = 0 AND `template` IN ('protostar', 'beez3')) as c) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', '{}');
+('atum', 1, (CASE WHEN (SELECT b.`count` FROM (SELECT count(a.`id`) AS `count` FROM `#__template_styles` a WHERE a.`home` = '1' AND a.`client_id` = 1 AND a.`template` IN ('isis', 'hathor')) AS b) = 0 THEN '0' ELSE '1' END), 'atum - Default', '{}'),
+('cassiopeia', 0, (CASE WHEN (SELECT d.`count` FROM (SELECT count(c.`id`) AS `count` FROM `#__template_styles` c WHERE c.`home` = '1' AND c.`client_id` = 0 AND c.`template` IN ('protostar', 'beez3')) AS d) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', '{}');
 
 --
 -- Move mod_version to the right position for the atum template

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-03-05.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2018-03-05.sql
@@ -20,8 +20,8 @@ INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "
 ('cassiopeia', 'template', 'cassiopeia', '', 0, 1, 1, 0, '{}', '{}', '', '', 0, '1970-01-01 00:00:00', 0, 0);
 
 INSERT INTO "#__template_styles" ("template", "client_id", "home", "title", "params") VALUES
-('atum', 1, (CASE WHEN (SELECT count FROM (SELECT count("id") AS count FROM "#__template_styles" WHERE home = '1' AND client_id = 1 AND "template" IN ('isis', 'hathor')) as c) = 0 THEN '0' ELSE '1' END), 'atum - Default', '{}'),
-('cassiopeia', 0, (CASE WHEN (SELECT count FROM (SELECT count("id") AS count FROM "#__template_styles" WHERE home = '1' AND client_id = 0 AND "template" IN ('protostar', 'beez3')) as c) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', '{}');
+('atum', 1, (CASE WHEN (SELECT b."count" FROM (SELECT count(a."id") AS "count" FROM "#__template_styles" a WHERE a."home" = '1' AND a."client_id" = 1 AND a."template" IN ('isis', 'hathor')) AS b) = 0 THEN '0' ELSE '1' END), 'atum - Default', '{}'),
+('cassiopeia', 0, (CASE WHEN (SELECT d."count" FROM (SELECT count(c."id") AS "count" FROM "#__template_styles" c WHERE c."home" = '1' AND c."client_id" = 0 AND c."template" IN ('protostar', 'beez3')) AS d) = 0 THEN '0' ELSE '1' END), 'cassiopeia - Default', '{}');
 
 --
 -- Move mod_version to the right position for the atum template


### PR DESCRIPTION
Pull Request for Issue #32888 .

### Summary of Changes

This pull request (PR) adds proper names quoting and correct use of table aliases to the SQL statement for inserting the new template styles when updating from 3.10 to 4.

This fixes issue #32888 , which happens only on particular versions of MySQL 5.7 and results in the update from 3.10 to 4 being broken because the SQL updates fail with SQL error 1093 when executing the statement modified by this PR.

For sure MySQL version 5.7.14 which has been reported in issue #32888 has that problem, and very likely also version 5.7.9 which has been reported in issue #22231 , which has the same cause.

With MySQL 5.6 I could not reproduce the problem, and later versions of MySQL than the one mentioned above seem not to have the problem either.

The same changes as for MySQL are done for the PostgreSQL update script for consistency and for being safe from PostgreSQL becoming more strict in future regarding correct quoting of names which are equal to reserved words (e.g. "count").

### Testing Instructions

#### Test 1: Reproduce the issue

For reproducing the issue it needs a MySQL database server version 5.7.14.

Because I haven't found any XAMPP version which includes this MySQL version, it needs to set up a MySQL server of that version.

You can find the downloads here: https://downloads.mysql.com/archives/installer/ .

Make sure that you have selected version 5.7.14 before downloading.

If that link doesn't work for you (not sure if it requires an Oracle Tech Network account), you can also download it from here: https://test5.richard-fath.de/mysql-installer-community-5.7.14.0.msi (MD5 checksum is b4df226b58390f8b3d02d264a785e715).

Make an installation of MySQL server including the client tools, if necessary on a separate (virtual) computer if you don't want to mess up your existing installation e.g. of XAMPP, and then use that database server from remote, i.e. not use "localhost" but the FQDN of that database server for your Joomla installation.

1. Make a new installation of current 3.10-dev or latest nightly or the last alpha version, using a PHP version which is supported by Joomla 4 and the database server prepared as described above.

2. Try to update that 3.10 installation to the latest 4.0 nightly build.

Result: See issue #32888. The update fails with SQL error "1093 You can't specify target table '#__template_styles' for update in FROM clause", and frontend and backend are broken.

When checking for the last SQL statement logged in the update log "administrator/logs/joomla_update.php", it is the statement coming just before the one modified by this PR.

#### Test 2: Verify that this PR fixes the issue

1. Repeat the previous test 1 starting at the same starting point and using again an empty database in the same MySQL 5.7.14 server, but this time use the update package or custom update URL created by Drone for this PR.

Result: The update succeeds. There is only the usual alert about the missing template found, which disappears after navigating around in backend.

2. Go to "System -> Maintenance -> Database" and check if there are database errors shown.

Result: There is one problem shown for the CMS.

3. Verify that it is only the problem with not matching CMS version which is normal when using development packages by hovering over the "One Problem" button.

Result: Only the usual version problem.

![2021-07-12_03](https://user-images.githubusercontent.com/7413183/125282995-4322b380-e318-11eb-9dad-f617a25d74ab.png)

4. Verify if the new J4 templates are default templates.

Result: Atum is the default backend template, and Cassiopeia is the default frontend template.

#### Test 3: Verify that the SQL statement modified by this PR still does what it shall do

1. Start again with a 3.10 and an empty database and attempt to update to the patched J4 package for this PR , but before updating create a copy of the Protostar template and make this copy the default frontend template.

2. Verify if the new J4 templates are default templates.

Result: Atum is the default backend template, but Cassiopeia is not the default frontend template. This is still the copy of Protostar, and so frontend will be broken.

Alternatively you could install a 3rd party template on 3.10 before updating, which is compatible to 3.10 and 4, if you can find such a template, and make that the default.

Testing the same for the backend template will be harder. You need to find one which is compatible to 3.10 and 4 and make that the default backend template before updating.

The result in general should be:

If the Protostar or the beez3 template is the default frontend template on 3.10, Cassiopeia will be the default frontend template after the update, otherwise not, and if the Isis or the Hathor template is the default backend template on 3.10, Atum will be the default backend template after the update, otherwise not.

#### Test 4: Verify that nothing is broken for other MySQL versions or PostgreSQL

Execute test 3 on any other version of MySQL than those which have the issue, or on any PostgreSQL version.

The result should be the same.

### Actual result BEFORE applying this Pull Request

When using certain versions of MySQL 5.7, e.g. for sure 5.7.14, as database server, an update from any 3.10 version to current J4 is broken because the SQL updates fail with SQL error 1093 when executing the statement modified by this PR at the very beginning of the database updates.

When using the button to go to the control panel, the backend is broken and looks like this:

![2021-07-12_04](https://user-images.githubusercontent.com/7413183/125287390-2341be80-e31d-11eb-8f6b-fb8e1365c2f2.png)


### Expected result AFTER applying this Pull Request

Updates from 3.10 to 4 succeed with these MySQL versions, and for other versions of MySQL or for MariaDB or PostgreSQL nothing changes.

### Documentation Changes Required

None.