### PR TITLE
[4.0] Linked Image (atum) a11y

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -115,10 +115,9 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
 					<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" <?php echo $logoBrandSmallAlt; ?>>
 					</div>
 				<?php else : ?>
-					<a class="logo <?php echo $sidebarState === 'closed' ? 'small' : ''; ?>" href="<?php echo Route::_('index.php'); ?>"
-						aria-label="<?php echo Text::_('TPL_ATUM_BACK_TO_CONTROL_PANEL'); ?>">
-						<img src="<?php echo $logoBrandLarge; ?>" <?php echo $logoBrandLargeAlt; ?>>
-						<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" <?php echo $logoBrandSmallAlt; ?>>
+					<a class="logo <?php echo $sidebarState === 'closed' ? 'small' : ''; ?>" href="<?php echo Route::_('index.php'); ?>">
+						<img src="<?php echo $logoBrandLarge; ?>" alt="<?php echo Text::_('TPL_ATUM_BACK_TO_CONTROL_PANEL'); ?>">
+						<img class="logo-collapsed" src="<?php echo $logoBrandSmall; ?>" alt="<?php echo Text::_('TPL_ATUM_BACK_TO_CONTROL_PANEL'); ?>">
 					</a>
 				<?php endif; ?>
 			</div>


### PR DESCRIPTION
When an image is used for functional purposes eg a link then then alt text should describe the function and not the image. Otherwise the link may appear to be empty to assistive technology and therefore ignored.

https://www.w3.org/WAI/tutorials/images/functional/#image-used-alone-as-a-linked-logo

In the atum template the logo in the top right is sometimes used as a link to the homepage. So in those circumstance it needs an alt text that describe where the link takes you that and not an aria label on the image.
