### PR TITLE
[4.0] Add fallback for the new media setting and fix some phpcs

### DIFF
--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -207,7 +207,7 @@ class MediaHelper
 
 		$filetype = array_pop($filetypes);
 
-		$allowable = array_map('trim', explode(',', $params->get('restrict_uploads_extensions')));
+		$allowable = array_map('trim', explode(',', $params->get('restrict_uploads_extensions', 'bmp,gif,jpg,jpeg,png,webp,ico,mp3,m4a,mp4a,ogg,mp4,mp4v,mpeg,mov,odg,odp,ods,odt,pdf,png,ppt,txt,xcf,xls,csv')));
 		$ignored   = array_map('trim', explode(',', $params->get('ignore_extensions')));
 
 		if ($filetype == '' || $filetype == false || (!\in_array($filetype, $allowable) && !\in_array($filetype, $ignored)))
@@ -228,7 +228,7 @@ class MediaHelper
 
 		if ($params->get('restrict_uploads', 1))
 		{
-			$allowedExtensions = array_map('trim', explode(',', $params->get('restrict_uploads_extensions')));
+			$allowedExtensions = array_map('trim', explode(',', $params->get('restrict_uploads_extensions', 'bmp,gif,jpg,jpeg,png,webp,ico,mp3,m4a,mp4a,ogg,mp4,mp4v,mpeg,mov,odg,odp,ods,odt,pdf,png,ppt,txt,xcf,xls,csv')));
 
 			if (\in_array($filetype, $allowedExtensions))
 			{

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -49,7 +49,8 @@ class PlgButtonImage extends CMSPlugin
 		$extension = $app->input->get('option');
 
 		// For categories we check the extension (ex: component.section)
-		if ($extension === 'com_categories') {
+		if ($extension === 'com_categories')
+		{
 			$parts     = explode('.', $app->input->get('extension', 'com_content'));
 			$extension = $parts[0];
 		}
@@ -63,7 +64,8 @@ class PlgButtonImage extends CMSPlugin
 			|| ($user->authorise('core.edit.own', $asset) && $author === $user->id)
 			|| (count($user->getAuthorisedCategories($extension, 'core.edit')) > 0)
 			|| (count($user->getAuthorisedCategories($extension, 'core.edit.own')) > 0 && $author === $user->id)
-		) {
+		)
+		{
 			$doc->getWebAssetManager()
 				->useScript('webcomponent.media-select')
 				->useScript('webcomponent.field-media')
@@ -73,7 +75,8 @@ class PlgButtonImage extends CMSPlugin
 				$name . '_ImageModal',
 			]);
 
-			if (count($doc->getScriptOptions('media-picker')) === 0) {
+			if (count($doc->getScriptOptions('media-picker')) === 0)
+			{
 				$imagesExt = array_map(
 					'trim',
 					explode(


### PR DESCRIPTION
Pull Request for Issue #34634 

### Summary of Changes

Add fallback for the new media setting and fix some phpcs

### Testing Instructions

Install 3.10-alpha9
Upgrade to the latest 4.0
Notice that you can not upload images in the media manager
Install a new 3.10-alpha9
Update using this update server (https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/34778/downloads/45806/pr_list.xml)
Notice that the upload works

### Actual result BEFORE applying this Pull Request

Media Manager Upload works

### Expected result AFTER applying this Pull Request

Media Manager upload does not work when the option is not set yet.

### Documentation Changes Required

none