### PR TITLE
Remove rebuild buttom from menus

### DIFF
--- a/administrator/components/com_menus/src/Controller/MenusController.php
+++ b/administrator/components/com_menus/src/Controller/MenusController.php
@@ -111,38 +111,6 @@ class MenusController extends BaseController
 	}
 
 	/**
-	 * Rebuild the menu tree.
-	 *
-	 * @return  boolean  False on failure or error, true on success.
-	 *
-	 * @since   1.6
-	 */
-	public function rebuild()
-	{
-		$this->checkToken();
-
-		$this->setRedirect('index.php?option=com_menus&view=menus');
-
-		/** @var \Joomla\Component\Menus\Administrator\Model\ItemModel $model */
-		$model = $this->getModel('Item');
-
-		if ($model->rebuild())
-		{
-			// Reorder succeeded.
-			$this->setMessage(Text::_('COM_MENUS_ITEMS_REBUILD_SUCCESS'));
-
-			return true;
-		}
-		else
-		{
-			// Rebuild failed.
-			$this->setMessage(Text::sprintf('COM_MENUS_ITEMS_REBUILD_FAILED', $model->getError()), 'error');
-
-			return false;
-		}
-	}
-
-	/**
 	 * Temporary method. This should go into the 1.5 to 1.6 upgrade routines.
 	 *
 	 * @return  void

--- a/administrator/components/com_menus/src/View/Menus/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menus/HtmlView.php
@@ -125,8 +125,6 @@ class HtmlView extends BaseHtmlView
 			ToolbarHelper::deleteList('COM_MENUS_MENU_CONFIRM_DELETE', 'menus.delete', 'JTOOLBAR_DELETE');
 		}
 
-		ToolbarHelper::custom('menus.rebuild', 'refresh', '', 'JTOOLBAR_REBUILD', false);
-
 		if ($canDo->get('core.admin') && $this->state->get('client_id') == 1)
 		{
 			ToolbarHelper::custom('menu.exportXml', 'download', '', 'COM_MENUS_MENU_EXPORT_BUTTON', true);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/34739#issuecomment-876759725 .

### Summary of Changes
Remove the rebuild buttom from menus.
Why? Menus cannot be rebuilt.
This button belongs only to menuItems.

### Testing Instructions
See the Menus Oerview before and after patch,

### Actual result BEFORE applying this Pull Request
Button "rebuild" on Menus and MenuItems


### Expected result AFTER applying this Pull Request
Button "rebuild" only on MenuItems


### Documentation Changes Required
yes
