### PR TITLE
[4.0] Finder Indexer does not work when debug is enabled

### DIFF
--- a/build/media_source/com_finder/js/indexer.es6.js
+++ b/build/media_source/com_finder/js/indexer.es6.js
@@ -82,7 +82,7 @@
             Object.entries(json.pluginState).forEach((context) => {
               let item = `<dt class="col-sm-3">${context[0]}</dt>`;
               item += `<dd id="finder-${context[0].replace(/\s+/g, '-').toLowerCase()}" class="col-sm-9"></dd>`;
-              debuglist.insertAdjacentHTML('beforeend', Joomla.sanitizeHtml(item));
+              debuglist.insertAdjacentHTML('beforeend', Joomla.sanitizeHtml(item, { dd: ['class', 'id'] }));
             });
           }
         }


### PR DESCRIPTION
Pull Request for Issue #34665 .

### Summary of Changes
Fixes finder when debug mode is enabled - due to the default JS filter not allowing `<dd>` tags by default. @dgrammatiko tagging you in case you have a better fix - as it's from the sanitiseHtml stuff - but I think this is fine.

### Testing Instructions
Go to the Joomla Configuration > System and enable the "System Debug".
Go to components Smart Search and click the "Clear Index" button.
Go to components Smart Search and click the "Index" button.

### Actual result BEFORE applying this Pull Request
Finder loads the modal but never progresses to show a progress bar

### Expected result AFTER applying this Pull Request
Finder index's all content as expected

### Documentation Changes Required
None
