### PR TITLE
fixed getMetaData function undefined when user use Ajax call back function

### DIFF
--- a/modules/mod_banners/src/Helper/BannersHelper.php
+++ b/modules/mod_banners/src/Helper/BannersHelper.php
@@ -14,6 +14,7 @@ namespace Joomla\Module\Banners\Site\Helper;
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Environment\Browser;
+use Joomla\CMS\Factory;
 use Joomla\Component\Banners\Site\Model\BannersModel;
 use Joomla\Registry\Registry;
 
@@ -35,7 +36,7 @@ class BannersHelper
 	 */
 	public static function getList(Registry $params, BannersModel $model, CMSApplication $app)
 	{
-		$keywords = explode(',', $app->getDocument()->getMetaData('keywords'));
+		$keywords = explode(',', Factory::getDocument()->getMetaData('keywords'));
 		$config   = ComponentHelper::getParams('com_banners');
 
 		$model->setState('filter.client_id', (int) $params->get('cid'));


### PR DESCRIPTION
…ction

When the user uses the ajax call back function getList on this module. this will return 500 because $app->getDocument() return null so getMetaData function undefined.

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

