### PR TITLE
[3.x] Fix short array syntax

### DIFF
--- a/administrator/components/com_installer/models/install.php
+++ b/administrator/components/com_installer/models/install.php
@@ -388,7 +388,7 @@ class InstallerModelInstall extends JModelLegacy
 		// We only allow http & https here
 		$uri = new JUri($url);
 
-		if (!in_array($uri->getScheme(), ['http', 'https']))
+		if (!in_array($uri->getScheme(), array('http', 'https')))
 		{
 			JError::raiseWarning('', JText::_('COM_INSTALLER_MSG_INSTALL_INVALID_URL_SCHEME'));
 


### PR DESCRIPTION
### Summary of Changes

Make sure we dont use the short array syntax within Joomla 3.x

### Testing Instructions

Make sure you can install extensions from URL in php 5.3 

### Actual result BEFORE applying this Pull Request

Parse error: syntax error, unexpected '[' in administrator\components\com_installer\models\install.php on line 391

### Expected result AFTER applying this Pull Request

Works

### Documentation Changes Required

none