### PR TITLE
[4][com_joomlaupdate] untraslated warning strings

### DIFF
--- a/administrator/components/com_joomlaupdate/src/View/Upload/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Upload/HtmlView.php
@@ -65,14 +65,14 @@ class HtmlView extends BaseHtmlView
 		$language = Factory::getLanguage();
 		$language->load('com_installer', JPATH_ADMINISTRATOR, 'en-GB', false, true);
 		$language->load('com_installer', JPATH_ADMINISTRATOR, null, true);
-		
+
 		$this->updateInfo = $this->get('UpdateInformation');
 		$this->selfUpdateAvailable = $this->get('CheckForSelfUpdate');
 
 		if ($this->getLayout() !== 'captive')
 		{
 			$this->warnings = $this->get('Items', 'warnings');
-		}		
+		}
 
 		$this->addToolbar();
 

--- a/administrator/components/com_joomlaupdate/src/View/Upload/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Upload/HtmlView.php
@@ -61,18 +61,18 @@ class HtmlView extends BaseHtmlView
 	 */
 	public function display($tpl = null)
 	{
+		// Load com_installer's language
+		$language = Factory::getLanguage();
+		$language->load('com_installer', JPATH_ADMINISTRATOR, 'en-GB', false, true);
+		$language->load('com_installer', JPATH_ADMINISTRATOR, null, true);
+		
 		$this->updateInfo = $this->get('UpdateInformation');
 		$this->selfUpdateAvailable = $this->get('CheckForSelfUpdate');
 
 		if ($this->getLayout() !== 'captive')
 		{
 			$this->warnings = $this->get('Items', 'warnings');
-		}
-
-		// Load com_installer's language
-		$language = Factory::getLanguage();
-		$language->load('com_installer', JPATH_ADMINISTRATOR, 'en-GB', false, true);
-		$language->load('com_installer', JPATH_ADMINISTRATOR, null, true);
+		}		
 
 		$this->addToolbar();
 


### PR DESCRIPTION
Pull Request for Issue #34792.

### Summary of Changes
1st Load com_installer's language


### Testing Instructions
4.0 nightly. With PHP temporary folder not explicitly set in php.ini or otherwise.
In back-end go to: index.php?option=com_joomlaupdate&view=upload


### Actual result BEFORE applying this Pull Request
string untranslated


### Expected result AFTER applying this Pull Request
string translated




