### PR TITLE
[4.0] Fix sticky toolbar

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -122,7 +122,6 @@ caption {
 .container-main,
 .system-debug {
   padding-bottom: 50px;
-  overflow: auto;
 }
 
 body .container-main {


### PR DESCRIPTION
Pull Request for Issue #34793. Revert #34426.

### Summary of Changes
Fix toolbar scrolls out of view.


### Testing Instructions
Download/install the prebuilt package.
or
Apply PR.
Run `npm run build:css`

Go to Global Configuration.
Scroll down.

### Actual result BEFORE applying this Pull Request
Toolbar scrolls out of view.


### Expected result AFTER applying this Pull Request
Toolbar sticks at the top.