### PR TITLE
[4.0] Fix wrong parameter type for language in prepared statement

### DIFF
--- a/components/com_banners/src/Model/BannersModel.php
+++ b/components/com_banners/src/Model/BannersModel.php
@@ -255,7 +255,7 @@ class BannersModel extends ListModel
 		// Filter by language
 		if ($this->getState('filter.language'))
 		{
-			$query->whereIn($db->quoteName('a.language'), [Factory::getLanguage()->getTag(), '*']);
+			$query->whereIn($db->quoteName('a.language'), [Factory::getLanguage()->getTag(), '*'], ParameterType::STRING);
 		}
 
 		$query->order($db->quoteName('a.sticky') . ' DESC, ' . ($randomise ? $query->rand() : $db->quoteName('a.ordering')));

--- a/components/com_contact/src/Model/CategoryModel.php
+++ b/components/com_contact/src/Model/CategoryModel.php
@@ -227,10 +227,9 @@ class CategoryModel extends ListModel
 		}
 
 		// Filter on the language.
-		if ($language = $this->getState('filter.language'))
+		if ($this->getState('filter.language'))
 		{
-			$language = [Factory::getLanguage()->getTag(), '*'];
-			$query->whereIn($db->quoteName('a.language'), $language);
+			$query->whereIn($db->quoteName('a.language'), [Factory::getLanguage()->getTag(), '*'], ParameterType::STRING);
 		}
 
 		// Set sortname ordering if selected

--- a/components/com_contact/src/Model/FeaturedModel.php
+++ b/components/com_contact/src/Model/FeaturedModel.php
@@ -143,8 +143,7 @@ class FeaturedModel extends ListModel
 		// Filter by language
 		if ($this->getState('filter.language'))
 		{
-			$language = [Factory::getLanguage()->getTag(), '*'];
-			$query->whereIn($db->quoteName('a.language'), $language, ParameterType::STRING);
+			$query->whereIn($db->quoteName('a.language'), [Factory::getLanguage()->getTag(), '*'], ParameterType::STRING);
 		}
 
 		// Add the list ordering clause.

--- a/components/com_newsfeeds/src/Model/CategoryModel.php
+++ b/components/com_newsfeeds/src/Model/CategoryModel.php
@@ -214,7 +214,7 @@ class CategoryModel extends ListModel
 		// Filter by language
 		if ($this->getState('filter.language'))
 		{
-			$query->whereIn($db->quoteName('a.language'), [Factory::getLanguage()->getTag(), '*']);
+			$query->whereIn($db->quoteName('a.language'), [Factory::getLanguage()->getTag(), '*'], ParameterType::STRING);
 		}
 
 		// Add the list ordering clause.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR corrects parameter type for prepared statement for language in query. We need to use  ParameterType::STRING (instead of using ParameterType::INTEGER by default which would result in wrong data returned). For reference, we have correct code in com_content https://github.com/joomla/joomla-cms/blob/4.0-dev/components/com_content/src/Model/ArticlesModel.php#L637

### Testing Instructions
Code review should be enough.

