### PR TITLE
[4.0] Correct namespace import

### DIFF
--- a/administrator/components/com_banners/tmpl/download/default.php
+++ b/administrator/components/com_banners/tmpl/download/default.php
@@ -11,7 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
-use \Joomla\CMS\Session\Session;
+use Joomla\CMS\Session\Session;
 
 /** @var \Joomla\Component\Banners\Administrator\View\Download\HtmlView $this */
 

--- a/administrator/components/com_cache/src/View/Cache/HtmlView.php
+++ b/administrator/components/com_cache/src/View/Cache/HtmlView.php
@@ -11,7 +11,6 @@ namespace Joomla\Component\Cache\Administrator\View\Cache;
 
 \defined('_JEXEC') or die;
 
-use Exception;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/reinstall.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/reinstall.php
@@ -13,7 +13,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\Session\Session;
 
 /** @var HtmlView $this */
 

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/selfupdate.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/selfupdate.php
@@ -8,8 +8,6 @@
  */
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
-use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/update.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/update.php
@@ -13,7 +13,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\Session\Session;
 
 /** @var HtmlView $this */
 

--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -13,7 +13,6 @@ namespace Joomla\Component\Tags\Site\Service;
 
 use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Categories\CategoryFactoryInterface;
-use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Component\Router\RouterBase;
 use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\Database\DatabaseInterface;

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Extension\ExtensionHelper;
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;

--- a/plugins/system/remember/remember.php
+++ b/plugins/system/remember/remember.php
@@ -9,10 +9,10 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\User\UserHelper;
-use Joomla\CMS\Log\Log;
 
 /**
  * Joomla! System Remember Me Plugin

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\Plugin\CMSPlugin;
-use Joomla\CMS\Session\SessionManager;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\User;
 use Joomla\CMS\User\UserHelper;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses optimize import tool from phpstorm to correct namespace import:

- Remove un-used classes in use statement
- Sort import
- Correct class from `\Joomla\CMS\Session\Session;` to `Joomla\CMS\Session\Session;
`

### Testing Instructions
Code review.