### PR TITLE
[4.0] Clean up Category models

### DIFF
--- a/components/com_contact/src/Model/CategoryModel.php
+++ b/components/com_contact/src/Model/CategoryModel.php
@@ -319,7 +319,7 @@ class CategoryModel extends ListModel
 
 		$user = Factory::getUser();
 
-		if ((!$user->authorise('core.edit.state', 'com_contact')) && (!$user->authorise('core.edit', 'com_contact')))
+		if (!$user->authorise('core.edit.state', 'com_contact') && !$user->authorise('core.edit', 'com_contact'))
 		{
 			// Limit to published for people who can't edit or edit.state.
 			$this->setState('filter.published', 1);

--- a/components/com_contact/src/Model/CategoryModel.php
+++ b/components/com_contact/src/Model/CategoryModel.php
@@ -46,7 +46,7 @@ class CategoryModel extends ListModel
 	protected $_leftsibling = null;
 
 	/**
-	 * Category right right of this one
+	 * Category right of this one
 	 *
 	 * @var    CategoryNode|null
 	 */

--- a/components/com_contact/src/Model/CategoryModel.php
+++ b/components/com_contact/src/Model/CategoryModel.php
@@ -39,18 +39,18 @@ class CategoryModel extends ListModel
 	protected $_item = null;
 
 	/**
-	 * Array of contacts in the category
+	 * Category left of this one
 	 *
-	 * @var    \stdClass[]
+	 * @var    CategoryNode|null
 	 */
-	protected $_articles = null;
+	protected $_leftsibling = null;
 
 	/**
-	 * Category left and right of this one
+	 * Category right right of this one
 	 *
-	 * @var    CategoryNode[]|null
+	 * @var    CategoryNode|null
 	 */
-	protected $_siblings = null;
+	protected $_rightsibling = null;
 
 	/**
 	 * Array of child-categories
@@ -65,20 +65,6 @@ class CategoryModel extends ListModel
 	 * @var    CategoryNode|null
 	 */
 	protected $_parent = null;
-
-	/**
-	 * The category that applies.
-	 *
-	 * @var    object
-	 */
-	protected $_category = null;
-
-	/**
-	 * The list of other contact categories.
-	 *
-	 * @var    array
-	 */
-	protected $_categories = null;
 
 	/**
 	 * Constructor.
@@ -359,9 +345,7 @@ class CategoryModel extends ListModel
 	{
 		if (!is_object($this->_item))
 		{
-			$app = Factory::getApplication();
-			$menu = $app->getMenu();
-			$active = $menu->getActive();
+			$active = Factory::getApplication()->getMenu()->getActive();
 
 			if ($active)
 			{

--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -122,7 +122,7 @@ class ArticlesModel extends ListModel
 		$this->setState('params', $params);
 		$user = Factory::getUser();
 
-		if ((!$user->authorise('core.edit.state', 'com_content')) && (!$user->authorise('core.edit', 'com_content')))
+		if (!$user->authorise('core.edit.state', 'com_content') && !$user->authorise('core.edit', 'com_content'))
 		{
 			// Filter on published for those who do not have edit or edit.state rights.
 			$this->setState('filter.published', ContentComponent::CONDITION_PUBLISHED);
@@ -131,7 +131,7 @@ class ArticlesModel extends ListModel
 		$this->setState('filter.language', Multilanguage::isEnabled());
 
 		// Process show_noauth parameter
-		if ((!$params->get('show_noauth')) || (!ComponentHelper::getParams('com_content')->get('show_noauth')))
+		if (!$params->get('show_noauth') || !ComponentHelper::getParams('com_content')->get('show_noauth'))
 		{
 			$this->setState('filter.access', true);
 		}

--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -77,7 +77,7 @@ class CategoryModel extends ListModel
 	 * @var		string
 	 */
 	protected $_context = 'com_content.category';
-	
+
 	/**
 	 * Constructor.
 	 *
@@ -159,7 +159,7 @@ class CategoryModel extends ListModel
 			$asset .= '.category.' . $pk;
 		}
 
-		if ((!$user->authorise('core.edit.state', $asset)) &&  (!$user->authorise('core.edit', $asset)))
+		if (!$user->authorise('core.edit.state', $asset) &&  !$user->authorise('core.edit', $asset))
 		{
 			// Limit to published for people who can't edit or edit.state.
 			$this->setState('filter.published', 1);

--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -44,11 +44,18 @@ class CategoryModel extends ListModel
 	protected $_articles = null;
 
 	/**
-	 * Category left and right of this one
+	 * Category left of this one
 	 *
-	 * @var    CategoryNode[]|null
+	 * @var    CategoryNode|null
 	 */
-	protected $_siblings = null;
+	protected $_leftsibling = null;
+
+	/**
+	 * Category right of this one
+	 *
+	 * @var    CategoryNode|null
+	 */
+	protected $_rightsibling = null;
 
 	/**
 	 * Array of child-categories
@@ -70,21 +77,7 @@ class CategoryModel extends ListModel
 	 * @var		string
 	 */
 	protected $_context = 'com_content.category';
-
-	/**
-	 * The category that applies.
-	 *
-	 * @var	   object
-	 */
-	protected $_category = null;
-
-	/**
-	 * The list of categories.
-	 *
-	 * @var	   array
-	 */
-	protected $_categories = null;
-
+	
 	/**
 	 * Constructor.
 	 *

--- a/components/com_newsfeeds/src/Model/CategoryModel.php
+++ b/components/com_newsfeeds/src/Model/CategoryModel.php
@@ -261,7 +261,7 @@ class CategoryModel extends ListModel
 
 		$user = Factory::getUser();
 
-		if ((!$user->authorise('core.edit.state', 'com_newsfeeds')) && (!$user->authorise('core.edit', 'com_newsfeeds')))
+		if (!$user->authorise('core.edit.state', 'com_newsfeeds') && !$user->authorise('core.edit', 'com_newsfeeds'))
 		{
 			// Limit to published for people who can't edit or edit.state.
 			$this->setState('filter.published', 1);

--- a/components/com_newsfeeds/src/Model/CategoryModel.php
+++ b/components/com_newsfeeds/src/Model/CategoryModel.php
@@ -45,7 +45,7 @@ class CategoryModel extends ListModel
 	protected $_leftsibling = null;
 
 	/**
-	 * Category rightof this one
+	 * Category right of this one
 	 *
 	 * @var    CategoryNode[]|null
 	 */

--- a/components/com_newsfeeds/src/Model/CategoryModel.php
+++ b/components/com_newsfeeds/src/Model/CategoryModel.php
@@ -38,18 +38,18 @@ class CategoryModel extends ListModel
 	protected $_item = null;
 
 	/**
-	 * Array of newsfeeds in the category
+	 * Category left of this one
 	 *
-	 * @var    \stdClass[]
+	 * @var    CategoryNode|null
 	 */
-	protected $_articles = null;
+	protected $_leftsibling = null;
 
 	/**
-	 * Category left and right of this one
+	 * Category rightof this one
 	 *
 	 * @var    CategoryNode[]|null
 	 */
-	protected $_siblings = null;
+	protected $_rightsibling = null;
 
 	/**
 	 * Array of child-categories
@@ -64,20 +64,6 @@ class CategoryModel extends ListModel
 	 * @var    CategoryNode|null
 	 */
 	protected $_parent = null;
-
-	/**
-	 * The category that applies.
-	 *
-	 * @var    object
-	 */
-	protected $_category = null;
-
-	/**
-	 * The list of other newsfeed categories.
-	 *
-	 * @var    array
-	 */
-	protected $_categories = null;
 
 	/**
 	 * Constructor.
@@ -301,9 +287,7 @@ class CategoryModel extends ListModel
 	{
 		if (!is_object($this->_item))
 		{
-			$app = Factory::getApplication();
-			$menu = $app->getMenu();
-			$active = $menu->getActive();
+			$active = Factory::getApplication()->getMenu()->getActive();
 
 			if ($active)
 			{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PRs made several clean up to Category model class in our components:

- Remove un-used class properties (maybe it was used in the past, or even it is there by copy/paste during development)
- Added missing _leftsibling and _rightsibling class properties
- Remove unnessary bracket (). We are having more than needed in some line of code.
- Simpy the code to get active menu item from:

```php
$app = Factory::getApplication();
$menu = $app->getMenu();
$active = $menu->getActive();
```

To single line of code:
```php
$active = Factory::getApplication()->getMenu()->getActive();
```

### Testing Instructions
Code review should be enough. If you have good IDE like phpstorm, it will clearly show you that the removed class properties are un-used.