### PR TITLE
[4.0] Badge icon

### DIFF
--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -86,3 +86,7 @@
 .plg_system_webauthn_login_button svg path {
   fill: var(--white);
 }
+
+.badge > span {
+  margin-inline-end: .5rem;
+}


### PR DESCRIPTION
This pr adds spacing between the icon and the text. as far as I can see this is only used in one place as shown below

### Before
![image](https://user-images.githubusercontent.com/1296369/126060934-12835165-47ce-4665-a04e-ebbe20fdfb17.png)

### After
![image](https://user-images.githubusercontent.com/1296369/126060922-54337e24-ac63-4354-be00-e8490c31072d.png)

This is a css change
