### PR TITLE
[4.0] webauthn rtl

### DIFF
--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -74,13 +74,7 @@
 
 // WebAuthn
 .plg_system_webauthn_login_button svg {
-  [dir=ltr] & {
-    margin-right: 2px;
-  }
-
-  [dir=rtl] & {
-    margin-left: 2px;
-  }
+  margin-inline-end: 2px;
 }
 
 .plg_system_webauthn_login_button svg path {

--- a/templates/cassiopeia/scss/blocks/_icons.scss
+++ b/templates/cassiopeia/scss/blocks/_icons.scss
@@ -67,13 +67,7 @@
 
 // WebAuthn
 .plg_system_webauthn_login_button svg {
-  [dir=ltr] & {
-    margin-right: 2px;
-  }
-
-  [dir=rtl] & {
-    margin-left: 2px;
-  }
+  margin-inline-end: 2px;
 }
 
 .plg_system_webauthn_login_button svg path {


### PR DESCRIPTION
It is not necessary to have separate classes for rtl and ltr to put a 2px gap between the text and the icon. margin-inline-end works in both directions

This is an scss change

The webauthn stuff will only display if your site is https

There is no visible change in either LTR or RTL after this PR
