### PR TITLE
[3.x] [RFC] Fix SQL error 1093 in com_finder's removeOrphanNodes function with particular MySQL server versions

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/taxonomy.php
+++ b/administrator/components/com_finder/helpers/indexer/taxonomy.php
@@ -349,6 +349,7 @@ class FinderIndexerTaxonomy
 		$query->clear()
 			->delete($db->quoteName('#__finder_taxonomy'))
 			->where($db->quoteName('id') . ' IN (' . implode(',', $ids) . ')');
+
 		$db->setQuery($query);
 		
 		$db->execute();

--- a/administrator/components/com_finder/helpers/indexer/taxonomy.php
+++ b/administrator/components/com_finder/helpers/indexer/taxonomy.php
@@ -329,23 +329,28 @@ class FinderIndexerTaxonomy
 	{
 		// Delete all orphaned nodes.
 		$db = JFactory::getDbo();
-		$query     = $db->getQuery(true);
-		$subquery  = $db->getQuery(true);
-		$subquery1 = $db->getQuery(true);
 
-		$subquery1->select($db->quoteName('t.id'))
+		$query = $db->getQuery(true)
+			->select($db->quoteName('t.id'))
 			->from($db->quoteName('#__finder_taxonomy', 't'))
 			->join('LEFT', $db->quoteName('#__finder_taxonomy_map', 'm') . ' ON ' . $db->quoteName('m.node_id') . '=' . $db->quoteName('t.id'))
 			->where($db->quoteName('t.parent_id') . ' > 1 ')
 			->where($db->quoteName('m.link_id') . ' IS NULL');
 
-		$subquery->select($db->quoteName('id'))
-			->from('(' . $subquery1 . ') temp');
-
-		$query->delete($db->quoteName('#__finder_taxonomy'))
-			->where($db->quoteName('id') . ' IN (' . $subquery . ')');
-
 		$db->setQuery($query);
+		
+		$ids = $db->loadColumn();
+
+		if (empty($ids))
+		{
+			return 0;
+		}
+
+		$query->clear()
+			->delete($db->quoteName('#__finder_taxonomy'))
+			->where($db->quoteName('id') . ' IN (' . implode(',', $ids) . ')');
+		$db->setQuery($query);
+		
 		$db->execute();
 
 		return $db->getAffectedRows();


### PR DESCRIPTION
Pull Request for Issue #22231 .

**_Important for maintainers:_** This PR shall not be merged up into 4.0-dev (or its changes shall not be applied when merging up) because there the issue is already solved with #26392 in the same way as here for the first part with the `SELECT` but then handled differently for the `DELETE` due to different data structures of com_finder in J4.

### Summary of Changes

This pull request (PR) splits the `DELETE` statement on the `#__finder_taxonomy` table in the `removeOrphanNodes` function, which has a subquery on the same target table, into 2 separate SQL statements, the `SELECT` to get the orphan nodes' ID's and the `DELETE` statement using the result of that `SELECT` in its `WHERE` clause.

This solves the SQL error reported with issue #22231 , which happens only with particular versions of MySQL 5.7, for sure with 5.7.9.

Normally such buggy versions are updated by webspace providers or package providers for Linux with their regular patch cycle. 
But on self managed hosts this may not happen, and so these buggy versions are still in use. So the number of installations using these versions seems to be small, but not zero.

In Joomla 4 the same issue has already been fixed with #26392 in the same way as here, i.e. the inner subquery with the join has been separated into a `SELECT`, and then the result is used to delete the orphan records. But due to other J4 changes deleting is then done in a different way.

### To be Done

It has to be investigated if we have such SQL statements (`DELETE` or `UPDATE` statements with a subquery which contains the same target table) elsewhere, and if so, provide a similar fix as here.

### Request for Comment

The alternative to this PR and the investigation mentioned above would be to exclude the buggy MySQL versions from our supported versions, similar as we already do in a footnote on PHP versions for certain buggy PHP versions.

But it would take some investigation effort to find out which versions exactly have that problem, and that effort could not be small.

@wilsonge @HLeithner @zero-24 I'd like to know your opinion on this. Opinions of others are of course welcome, too.

### Testing Instructions

#### Test 1: Reproduce the issue

_Requirements:_ For this test it needs a MySQL database server version 5.7.9. If you have something older, try if you can reproduce the issue, too, and report back the result. It might be that the issue affects also other, older versions than 5.7.9.

You very likely won't have such old versions available. And I think you don't want to mess up your existing testing environment with replacing any present MySQL or MariaDB database server by that MySQL version.

But if you have a real or virtual computer available which can be connected to a real or virtual network so it can be reached by the webserver of your testing environment, or if you can use docker for that, you can install a MySQL database server 5.7.9 on that computer and use that computer as database server for a Joomla installation using the webserver of your testing environment.

If the computer which you can use runs on Windows OS, you can find the downloads here: https://test5.richard-fath.de/mysql-installer-community-5.7.9.1.msi .

I know it is a not little work to do that, but if you can, please spend that time.

Otherwise, if you can't, skip this test and go to section "Test 2".

_Step 1:_ If you don't have that already, make a new installation of current staging or latest 3.9 nightly build or 3.9.28 using a MySQL database server 5.7.9, and at the end of the installation chose to install some kind of sample data, e.g. "Blog".

_Step 2:_ Log in to backend and go to "Components - Smart Search - Indexed Content". On a new installation you might see an alert about the smart search content plugin not being enabled. You can ignore that for now.

_Step 3:_ Use the "Index" button to start indexing.

_Result:_ The indexer modal is shown with a progress bar working, but after a while it end with an SQL error "You can't specify target table '#__finder_taxonomy' for update in FROM clause". See the first screenshot in section "Actual result BEFORE applying this Pull Request" below.

_Step 4:_ Go to "Extensions - Plugins" and filter for Type = "finder".

_Step 5:_ Disable all "Smart Search" plugins.

_Result:_ An error alert is shown with the same SQL error as in step 3. See the second screenshot in section "Actual result BEFORE applying this Pull Request" below.

_Step 6:_ Continue with the next test "Test 2".

#### Test 2: Verify that this PR fixes the issue on MySQL 5.7.9 and nothing is broken on other MySQL versions or other databases

_Requirements:_
- You can use any kind and version of database, MySQL, MariaDB or PostgreSQL. If you have more than one, test with all of them. Please report back which database server(s) and version(s) you have tested.
- If you have executed "Test 1" before, just apply the patch of this PR.
- If you have not executed "Test 1" before because you don't have a MySQL 5.7.9 database server, use an existing installation of current staging or latest 3.9 nightly build or 3.9.28 which has some content which can be indexed by Smart Search (if necessary create that content), otherwise make a new installation and at the end chose to install some sample data, e.g. "Blog". In both cases apply the patch of this PR at the end.

_Step 1:_ In backend, go to "Extensions - Plugins" and filter for Type = "finder".

_Step 2:_ Enable all "Smart Search" plugins.

_Step 3:_ Go to "Components - Smart Search - Indexed Content" and use the "Index" button.

_Result:_ The indexer modal is shown with a progress bar working, and at the end it finishes with success and the modal is closed.

_Step 4:_ Check which indexed content is shown.

_Result:_ There is indexed content shown not only for the root categories of indexable extensions but also for content, e.g. articles.

E.g. with "Blog" sample data: 

![2021-07-17_j3-finder-sql-fix_indexed-plugin-enabled](https://user-images.githubusercontent.com/7413183/126067840-2ad22175-1490-4690-87b5-3e3bbf44ee9a.png)

_Step 5:_ Go to "Extensions - Plugins" and disable all "Smart Search" plugins.

_Result:_ The plugins are disabled, no error alert is shown.

_Step 6:_ Go to "Components - Smart Search - Indexed Content" and check which indexed content is shown compared to step 4.

_Result:_ Only the root categories of indexable extensions are shown but no content like e.g. articles. 

![2021-07-17_j3-finder-sql-fix_indexed-plugin-disabled](https://user-images.githubusercontent.com/7413183/126067856-6b6fd753-7a16-4ffb-a553-1d2f035b876e.png)

### Actual result BEFORE applying this Pull Request

When using the "Index" button on "Components - Smart Search - Indexed Content":

![2021-07-17_j3-finder-sql-fix_indexer-error](https://user-images.githubusercontent.com/7413183/126066199-91cd9c5f-fcb0-47ad-a37a-8baa1e8b401c.png)

When disabling enabled Smart Search plugins on "Extensions - Plugins":

![2021-07-17_j3-finder-sql-fix_disable-plugins-error](https://user-images.githubusercontent.com/7413183/126066240-888d5e2e-16e7-488f-aaf5-bf36da57db8d.png)

### Expected result AFTER applying this Pull Request

- No SQL error when running the indexer or disabling Smart Search plugins.
- Removing orphan nodes works as before, e.g. when disabling Smart Search plugins, content for the corresponding extension is removed from indexed content without any SQL error.

### Documentation Changes Required

None.