### PR TITLE
[4.0] content voting css

### DIFF
--- a/build/media_source/plg_content_vote/css/rating.css
+++ b/build/media_source/plg_content_vote/css/rating.css
@@ -1,27 +1,20 @@
-[dir=ltr] .content_rating ul {
+.content_rating ul {
 	list-style: none;
-	padding-left: 0;
+	padding-inline-start: 0;
 	margin-bottom: 0.5em;
 }
 
-[dir=rtl] .content_rating ul {
-	list-style: none;
-	padding-right: 0;
-	margin-bottom: 0.5em;
-}
-
-.content_rating .vote-star {
+.content_rating .vote-star,
+.content_rating .vote-star-empty,
+.content_rating .vote-star-half {
 	display: inline-block;
 }
 
-.content_rating .vote-star svg {
+.content_rating .vote-star svg,
+.content_rating .vote-star-half svg {
 	width: 1em;
 	height: 1em;
 	fill: #fd7e14;
-}
-
-.content_rating .vote-star-empty {
-	display: inline-block;
 }
 
 .content_rating .vote-star-empty svg {
@@ -30,19 +23,11 @@
 	fill: #d3d3d3;
 }
 
-[dir=ltr] .content_rating .vote-star-half {
-	display: inline-block;
-	margin-left: -1em;
+.content_rating .vote-star-half {
+	margin-inline-start: -1em;
 }
 
 [dir=rtl] .content_rating .vote-star-half {
-	display: inline-block;
-	margin-right: -1em;
 	transform: scaleX(-1);
 }
 
-.content_rating .vote-star-half svg {
-	width: 1em;
-	height: 1em;
-	fill: #fd7e14;
-}


### PR DESCRIPTION
Updates the css for the content voting plugin to use logical css properties and therefore minimise the need for RTL specific css

Enable the content- voting plugin
In article options set voting to show

There should be no visible difference before or after
