### PR TITLE
[4.0] mod_languages css

### DIFF
--- a/build/media_source/mod_languages/css/template.css
+++ b/build/media_source/mod_languages/css/template.css
@@ -19,14 +19,11 @@ div.mod-languages .dropdown-menu {
 div.mod-languages ul.lang-block li {
   display: block;
   padding: .5rem 0;
+  text-align: start;
 }
 
 div.mod-languages ul li.lang-active {
   background-color: #f0f0f0;
-}
-
-html[dir=rtl] div.mod-languages ul.lang-block li {
-  text-align: right;
 }
 
 div.mod-languages img {


### PR DESCRIPTION
This PR changes the css so that we don't need to have any RTL specific css as it now uses logical css properties.

To test you will need a multilingual site and have set the language switcher module to be displayed as a dropdown. After the pr there will be no visible change

### RTL
![image](https://user-images.githubusercontent.com/1296369/126067181-b97bed79-23d4-428c-a9bd-adda2b582ba7.png)

### LTR
![image](https://user-images.githubusercontent.com/1296369/126067174-184fa3b9-1961-4800-9570-1b9897ed5331.png)
