### PR TITLE
[4.0] cassiopeia offline css

### DIFF
--- a/templates/cassiopeia/scss/offline.scss
+++ b/templates/cassiopeia/scss/offline.scss
@@ -39,11 +39,6 @@
   [dir=rtl] & {
     background-image: $cassiopeia-header-grad-rtl;
   }
-
-}
-
-html[dir=rtl] .header {
-  border-radius: 5px 0 0 5px;
 }
 
 .login {


### PR DESCRIPTION
There was a different setting for the border-radius in RTL. This was both incorrect and not needed.

Set site to offline with an RTL language

### Before
![image](https://user-images.githubusercontent.com/1296369/126067935-bd99358c-8336-4fe0-b096-50a85b05c609.png)

### After
![image](https://user-images.githubusercontent.com/1296369/126067916-ee5964c2-3f06-4902-89a9-3360b06a0b6e.png)
