### PR TITLE
[4.0] edit tooltip css cassiopeia

### DIFF
--- a/templates/cassiopeia/scss/blocks/_form.scss
+++ b/templates/cassiopeia/scss/blocks/_form.scss
@@ -78,6 +78,7 @@ td .form-control {
   padding: .5em;
   margin: .5em;
   color: $black;
+  text-align: start;
   background: $white;
   border: 1px solid $gray-600;
   border-radius: $border-radius;
@@ -91,14 +92,6 @@ td .form-control {
   &[id^=editcontact-] {
     right: auto;
     margin-inline-start: -10em;
-  }
-
-  [dir=ltr] & {
-    text-align: left;
-  }
-
-  [dir=rtl] & {
-    text-align: right;
   }
 }
 


### PR DESCRIPTION
This PR switches text-align to use logical properties so removes the need for the extra rtl css

This can be seen in the front end when logged in and hovering on the edit module button. There should be no visible change with this pr

### rtl
![image](https://user-images.githubusercontent.com/1296369/126068247-b8a75d83-dec0-4377-a216-255175e4329f.png)

### ltr
![image](https://user-images.githubusercontent.com/1296369/126068248-362dae8f-72e4-4275-933d-98bb18c05b01.png)
