### PR TITLE
[4.0] Easier add links to com_fields

### DIFF
--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -343,7 +343,7 @@ class CssMenu
 				parse_str($item->link, $query);
 				$assetName = $query['extension'] ?? 'com_content';
 			}
-			elseif ($item->element === 'com_fields')
+			elseif ($item->element === 'com_fields' || strpos($item->link, 'index.php?option=com_fields&') !== false)
 			{
 				parse_str($item->link, $query);
 

--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -310,6 +310,19 @@ class CssMenu
 				}
 			}
 
+			$uri   = new Uri($item->link);
+			$query = $uri->getQuery(true);
+
+			/**
+			 * If component is passed in the link via option variable, we set $item->element to this value for further
+			 * processing. It is needed for links from menu items of third party extensions link to Joomla! core
+			 * components like com_categories, com_fields...
+			 */
+			if ($option = $uri->getVar('option'))
+			{
+				$item->element = $option;
+			}
+
 			// Exclude item if is not enabled
 			if ($item->element && !ComponentHelper::isEnabled($item->element))
 			{
@@ -340,13 +353,10 @@ class CssMenu
 
 			if ($item->element === 'com_categories')
 			{
-				parse_str($item->link, $query);
 				$assetName = $query['extension'] ?? 'com_content';
 			}
-			elseif ($item->element === 'com_fields' || strpos($item->link, 'index.php?option=com_fields&') !== false)
+			elseif ($item->element === 'com_fields')
 			{
-				parse_str($item->link, $query);
-
 				// Only display Fields menus when enabled in the component
 				$createFields = null;
 
@@ -381,8 +391,6 @@ class CssMenu
 			}
 			elseif ($item->element === 'com_workflow')
 			{
-				parse_str($item->link, $query);
-
 				// Only display Workflow menus when enabled in the component
 				$workflow = null;
 
@@ -419,8 +427,6 @@ class CssMenu
 			}
 			elseif ($item->element === 'com_admin')
 			{
-				parse_str($item->link, $query);
-
 				if (isset($query['view']) && $query['view'] === 'sysinfo' && !$user->authorise('core.admin'))
 				{
 					$parent->removeChild($item);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR makes a small modification to administrator mod_menu so that third party extensions (which integrate with Joomla! custom fields) can add links to fields and field groups of com_fields by place these links in component menu like this https://github.com/joomdonation/weblinks/blob/4.0-compatible/src/administrator/components/com_weblinks/weblinks.xml#L55-L58 instead of having to write many code to insert these menu items manually like this block of code  https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_admin/script.php#L7485-L7528
 
(and trust me, it is even more complicated during updating extension) 


### Testing Instructions

## Test 1

Make sure the menu items in the sidebar still the same before and after patch

## Test 2

1. Download weblinks package for Joomla 4 at https://github.com/joomla-extensions/weblinks/files/6836285/pkg-weblinks-4.0.0-dev.zip, install it
2. Access to Weblinks -> Links, click on Options button in the toolbar. Go to **Integration** tab, set **Edit Custom Fields** parameter to **No**
3. Before patch, you always see **Fields** and **Field Groups** menu links under **Weblinks**
![fields_and_fields_groups](https://user-images.githubusercontent.com/977664/126073351-f41866b3-ab96-43fa-b1cb-2712eb1e827d.png)
4. After patch, the **Fields** and **Field Groups** menu items will be removed when you set the parameter to No. When you set the option back to Yes, these menu links are visible again.
