### PR TITLE
[4.0] input-group-append prepend

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -133,21 +133,6 @@ td .form-control {
   bottom: auto;
 }
 
-.input-group-append {
-  overflow: hidden;
-  transform: translate3d(0, 0, 0);
-
-  [dir=ltr] & {
-    border-top-right-radius: $border-radius;
-    border-bottom-right-radius: $border-radius;
-  }
-
-  [dir=rtl] & {
-    border-top-left-radius: $border-radius;
-    border-bottom-left-radius: $border-radius;
-  }
-}
-
 .input-group > .form-control[readonly] {
   margin-right: 1px;
 }

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -123,27 +123,6 @@ ul {
   }
 }
 
-// SearchTools rounded corners
-.input-group > .input-group-prepend > .btn,
-.input-group > .input-group-prepend > .input-group-text,
-.input-group > .input-group-append:not(:last-child) > .btn,
-.input-group > .input-group-append:not(:last-child) > .input-group-text,
-.input-group > .input-group-append:last-child > .btn:not(:last-child):not(.dropdown-toggle),
-.input-group > .input-group-append:last-child > .input-group-text:not(:last-child) {
-  @include border-start-radius($border-radius);
-  @include border-end-radius(0);
-}
-
-.input-group > .input-group-append > .btn,
-.input-group > .input-group-append > .input-group-text,
-.input-group > .input-group-prepend:not(:first-child) > .btn,
-.input-group > .input-group-prepend:not(:first-child) > .input-group-text,
-.input-group > .input-group-prepend:first-child > .btn:not(:first-child),
-.input-group > .input-group-prepend:first-child > .input-group-text:not(:first-child) {
-  @include border-start-radius($border-radius);
-  @include border-end-radius(0);
-}
-
 .input-group > .form-control:not(:last-child),
 .input-group > .form-select:not(:last-child) {
   @include border-start-radius(0);

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -82,16 +82,6 @@ a {
 
 .btn-group {
   margin-bottom: $cassiopeia-grid-gutter;
-  > .input-group-append {
-    > .btn-primary {
-      @include border-end-radius($border-radius);
-      @include border-start-radius(0);
-    }
-    > .btn-secondary {
-      margin-left: $cassiopeia-grid-gutter/2;
-    }
-  }
-
   > input {
     padding: $cassiopeia-grid-gutter/2;
     border: 1px solid $gray-400;
@@ -101,18 +91,6 @@ a {
 }
 
 [dir="rtl"] .btn-group {
-  > .input-group-append {
-    > .btn-primary {
-      @include border-start-radius($border-radius);
-      @include border-end-radius(0);
-    }
-
-    > .btn-secondary {
-      margin-right: $cassiopeia-grid-gutter/2;
-      margin-left: 0;
-    }
-  }
-
   > input {
     @include border-end-radius($border-radius);
     @include border-start-radius(0);

--- a/templates/cassiopeia/scss/template-rtl.scss
+++ b/templates/cassiopeia/scss/template-rtl.scss
@@ -14,11 +14,6 @@ body,
   float: right !important;
 }
 
-.input-group-prepend .btn,
-.input-group-append .btn {
-  right: -1px;
-}
-
 .form-check {
   padding-right: 1.25rem;
   padding-left: 0;
@@ -70,26 +65,6 @@ body,
   input {
     @include border-start-radius(0);
   }
-}
-
-.input-group > .input-group-prepend > .btn,
-.input-group > .input-group-prepend > .input-group-text,
-.input-group > .input-group-append:not(:last-child) > .btn,
-.input-group > .input-group-append:not(:last-child) > .input-group-text,
-.input-group > .input-group-append:last-child > .btn:not(:last-child):not(.dropdown-toggle),
-.input-group > .input-group-append:last-child > .input-group-text:not(:last-child) {
-  @include border-start-radius($border-radius);
-  @include border-end-radius(0);
-}
-
-.input-group > .input-group-append > .btn,
-.input-group > .input-group-append > .input-group-text,
-.input-group > .input-group-prepend:not(:first-child) > .btn,
-.input-group > .input-group-prepend:not(:first-child) > .input-group-text,
-.input-group > .input-group-prepend:first-child > .btn:not(:first-child),
-.input-group > .input-group-prepend:first-child > .input-group-text:not(:first-child) {
-  @include border-start-radius($border-radius);
-  @include border-end-radius(0);
 }
 
 .input-group > .form-control:not(:last-child),


### PR DESCRIPTION
This css class was removed in bootstrap 5 and we are not using the markup anywhere in the core so it makes no sense to keep it and keep maintaining css that isnt used.

To test I guess code review, make sure the scss still compiles and confirm that the classes are not being used.

NOTE: it is still used in plg_installer_webinstaller and that will be addressed in a sperate pr as it also requires upstream changes
