### PR TITLE
[4.0] Add classes set for radio field

### DIFF
--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -83,7 +83,7 @@ $attr .= $dataAttribute;
 		// Initialize some option attributes.
 		$optionValue = (string) $option->value;
 		$optionId    = $id . $i;
-		$attributes  = $optionValue == $value ? 'checked class="active"' : '';
+		$attributes  = $optionValue == $value ? 'checked class="active ' . $class . '"' : ($class ? 'class="' . $class . '"' : '');
 		$attributes  .= $optionValue != $value && $readonly || $disabled ? ' disabled' : '';
 		?>
 		<?php echo sprintf($input, $optionId, $name, $this->escape($optionValue), $attributes); ?>


### PR DESCRIPTION
### Summary of Changes
Using the switcher field it is now impossible to specify any classes on the input element even though the field element is passed to the layout. In the layout this value is just ignored.


### Testing Instructions
1. Open the file `/administrator/components/com_config/forms/application.xml`
2. Go to line 297
3. After this line add `class="test"`
4. Save the file
5. Go to `<URL>/administrator/index.php?option=com_config`
6. Click on the `System` tab
7. Inspect the `Debug System` switcher
8. Notice that the class is not set on the input elements
9. Apply patch
10. Reload the page
11. Inspect the `Debug System` switcher
12. Notice that the `test` class is set on the input elements


### Actual result BEFORE applying this Pull Request
There is no class set on the input element


### Expected result AFTER applying this Pull Request
The specified class is set on the input element


### Documentation Changes Required
None
