### PR TITLE
[4.0] quickicons rtl

### DIFF
--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -142,7 +142,10 @@
 
 #content .menu-quicktask {
   position: absolute;
-  right: 1.25rem;
+
+  [dir=ltr] & {
+    right: 1.25rem;
+  }
 
   [dir=rtl] & {
     left: 1.25rem;


### PR DESCRIPTION
Fixes the scss for the display of the add new + link on rtl dashboards

### Before
![image](https://user-images.githubusercontent.com/1296369/126080820-7a64ed09-9f19-4daa-9640-4b41ca691702.png)

### After
![image](https://user-images.githubusercontent.com/1296369/126080794-ec531834-a0c4-4553-9f7b-4a2d0f405fd0.png)
