### PR TITLE
[4.0] search module icon

### DIFF
--- a/templates/cassiopeia/scss/vendor/_awesomplete.scss
+++ b/templates/cassiopeia/scss/vendor/_awesomplete.scss
@@ -11,11 +11,7 @@
     display: flex;
     align-items: center;
     .icon-search {
-      margin-right: .2em;
-      [dir=rtl] & {
-        margin-right: 0;
-        margin-left: .2em;
-      }
+      margin-inline-end: .2em;
     }
   }
 }


### PR DESCRIPTION
It is not necessary to have separate classes for rtl and ltr to put a .2em gap between the text and the icon. margin-inline-end works in both directions

This is an scss change

There is no visible change in either LTR or RTL after this PR

![image](https://user-images.githubusercontent.com/1296369/126081437-6ec58b3c-507e-45e1-ab32-b2e24a6fa73a.png)
