### PR TITLE
[4.0] lint build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "watch": "node build/build.js --watch",
     "watch:com_media": "node build/build.js --watch-com-media",
     "lint:js": "eslint --config build/.eslintrc --ignore-pattern '/media/' --ext .es6.js,.es6,.vue .",
-    "lint:css": "stylelint --config build/.stylelintrc.json -s scss \"administrator/components/com_media/resources/**/*.scss\" \"administrator/templates/**/*.scss\" \"build/media_source/**/*.scss\" \"templates/**/*.scss\" \"installation/template/**/*.scss\"",
+    "lint:css": "stylelint --config build/.stylelintrc.json -s scss \"administrator/templates/**/*.scss\" \"build/media_source/**/*.scss\" \"templates/**/*.scss\" \"installation/template/**/*.scss\"",
     "test": "karma start tests/javascript/karma.conf.js --single-run",
     "install": "node build/build.js --prepare",
     "update": "node build/build.js --copy-assets && node build/build.js --build-pages && node build/build.js --compile-js && node build/build.js --compile-css && node build/build.js --compile-bs && node build/build.js --com-media",


### PR DESCRIPTION
We no longer have any scss files in administrator/components/com_media so there is no need for it to be in the path for the lint script.

Code review