### PR TITLE
[4.0] Fix image preview for media form field

### DIFF
--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -11,6 +11,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Helper\MediaHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
@@ -73,12 +74,19 @@ switch ($preview) {
 }
 
 // Pre fill the contents of the popover
-if ($showPreview) {
-	if ($value && file_exists(JPATH_ROOT . '/' . $value)) {
-		$src = Uri::root() . $value;
-	} else {
+if ($showPreview)
+{
+	$cleanValue = MediaHelper::getCleanMediaFieldValue($value);
+
+	if ($cleanValue && file_exists(JPATH_ROOT . '/' . $cleanValue))
+	{
+		$src = Uri::root() . $cleanValue;
+	}
+	else
+	{
 		$src = '';
 	}
+
 	$width = $previewWidth;
 	$height = $previewHeight;
 	$style = '';

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -80,7 +80,7 @@ if ($showPreview)
 
 	if ($cleanValue && file_exists(JPATH_ROOT . '/' . $cleanValue))
 	{
-		$src = Uri::root() . $cleanValue;
+		$src = Uri::root() . $value;
 	}
 	else
 	{

--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -464,4 +464,25 @@ class MediaHelper
 
 		return false;
 	}
+
+	/**
+	 * Helper method get clean data for value stores in a Media form field by removing adapter information
+	 * from the value if available (in this case, the value will have this format:
+	 * images/headers/blue-flower.jpg#joomlaImage://local-images/headers/blue-flower.jpg?width=700&height=180)
+	 *
+	 * @param   string  $value
+	 *
+	 * @return  string
+	 *
+	 * @since   __DEPLOY_VERSION
+	 */
+	public static function getCleanMediaFieldValue($value)
+	{
+		if ($pos = strpos($value, '#'))
+		{
+			return substr($value, 0, $pos);
+		}
+
+		return $value;
+	}
 }

--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -474,7 +474,7 @@ class MediaHelper
 	 *
 	 * @return  string
 	 *
-	 * @since   __DEPLOY_VERSION
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public static function getCleanMediaFieldValue($value)
 	{


### PR DESCRIPTION
Pull Request for Issue #34810.

### Summary of Changes
The value stored in media form field (at least for image) contains adapter information (for example, images/headers/blue-flower.jpg#joomlaImage://local-images/headers/blue-flower.jpg?width=700&height=180), thus file_exist checks on this line https://github.com/joomla/joomla-cms/blob/4.0-dev/layouts/joomla/form/field/media.php#L77 return false and it results in preview image is not being displayed properly as described in the issue https://github.com/joomla/joomla-cms/issues/34810

This PR solves it by clean the value (removes adapter information) before file_exists check. A new method is added to MediaHelper class so that we can use on other places when it is needed (or even could be used by third party extensions developer - for example, we need to check and make sure the selected image is valid before resizing...)


### Testing Instructions
1. Look at https://github.com/joomla/joomla-cms/issues/34810, confirm the issue
2. Apply patch, confirm that the issue is sorted.