### PR TITLE
[4.0] Remove unused css

### DIFF
--- a/templates/cassiopeia/scss/blocks/_toolbar.scss
+++ b/templates/cassiopeia/scss/blocks/_toolbar.scss
@@ -155,34 +155,6 @@
     width: 100%;
   }
 
-  .toggler-toolbar {
-    top: 4px;
-    z-index: $zindex-alerts;
-    width: 50px;
-    height: 50px;
-    border: 4px solid #f0f4fb;
-
-    [dir=ltr] & {
-      right: 4px;
-    }
-
-    [dir=rtl] & {
-      left: 4px;
-    }
-
-    .toggler-toolbar-icon::before {
-      font: normal normal 900 20px/1 "Font Awesome 5 Free";
-      color: $white;
-      content: "\f00d";
-    }
-
-    &.collapsed .toggler-toolbar-icon::before {
-      display: inline-block;
-      content: "\f085";
-      transform: translate(-4px);
-    }
-  }
-
   .subhead {
 
     joomla-toolbar-button,


### PR DESCRIPTION
This css was added in error with #33403

It is not needed in the front end as this is used only for the mobile admin ui toggler seen below

![image](https://user-images.githubusercontent.com/1296369/126122368-e6ddaf94-3af4-461f-9435-b5662fbeb2ba.png)
