### PR TITLE
[4.0] RTL logical property mod-list

### DIFF
--- a/templates/cassiopeia/scss/blocks/_modifiers.scss
+++ b/templates/cassiopeia/scss/blocks/_modifiers.scss
@@ -297,12 +297,8 @@
 }
 
 .mod-list {
-  padding-left: 0;
+  padding-inline-start: 0;
   list-style: none;
-
-  [dir=rtl] & {
-    padding-right: 0;
-  }
 
   li {
     padding: .25em 0;


### PR DESCRIPTION
The class mod-list is used extensively in the site modules.

This PR replaces the use of separate LTR and RTL classes by using css logical properties
