### PR TITLE
[4.0] remove css for unsupported browser

### DIFF
--- a/administrator/templates/atum/scss/blocks/_toolbar.scss
+++ b/administrator/templates/atum/scss/blocks/_toolbar.scss
@@ -207,10 +207,3 @@
     }
   }
 }
-
-// In Microsoft Edge, sticky positioning doesn't work when combined with dir "rtl" attribute
-@supports (-ms-ime-align: auto) {
-  [dir=rtl] .subhead {
-    position: relative;
-  }
-}


### PR DESCRIPTION
This PR removes some css that was added #27897 to support EdgeHTML inline with this comment https://github.com/joomla/joomla-cms/issues/27831#issuecomment-583764646

The policy (as far as I can find from the build scripts) is now latest version -1 and the edgeHTML browser is now end of life from MS

So we can remove this _hack_
