### PR TITLE
[4.0] com_templates column border

### DIFF
--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -262,7 +262,7 @@ meter {
       --gutter-x: 4rem;
 
       > * + * {
-        border-left: 1px solid var(--template-bg-dark-10);
+        border-inline-start: 1px solid var(--template-bg-dark-10);
       }
     }
   }


### PR DESCRIPTION
Change the border to use logical css property which fixes the bug that the border was in the wrong place in RTL etc without the need for any specific rtl classes. There is no visible change in ltr

### Before
![image](https://user-images.githubusercontent.com/1296369/126129280-47ebf484-9e40-4952-bd36-946807b2b203.png)

### After
![image](https://user-images.githubusercontent.com/1296369/126129118-d76088d9-3594-4714-9915-aaad359f21f4.png)

