### PR TITLE
[4.0] Atum mobile burger

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -254,6 +254,7 @@
     padding: 10px 15px;
 
     [dir="rtl"] & {
+      right: auto;
       left: 0;
     }
 


### PR DESCRIPTION
The css to move the burger menu to the left when in rtl was incomplete.

### before
![image](https://user-images.githubusercontent.com/1296369/126144148-5b15160a-65c4-4b09-b44f-a9cf450403e9.png)

### after
![image](https://user-images.githubusercontent.com/1296369/126144162-df1fe0a5-a972-4cbc-9cc0-852592a0122a.png)
