### PR TITLE
[4.0] admin logo rtl margin

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -25,15 +25,6 @@ ul {
   float: right;
 }
 
-// Header
-.header {
-  .logo svg,
-  .logo img {
-    margin-right: .8rem;
-    margin-left: auto;
-  }
-}
-
 .menu-collapse {
   right: 0;
   left: auto;


### PR DESCRIPTION
The margins on the logo and sidebar were changed in LTR but the RTL override was not updated. As its no longer needed this PR removes the override.

### Before
![image](https://user-images.githubusercontent.com/1296369/126162873-ef6c94d2-4ccc-4f55-b653-3304617f2ddc.png)

### After
![image](https://user-images.githubusercontent.com/1296369/126163018-58fd782c-77e0-4e55-9fa8-013e6060fce2.png)