### PR TITLE
[4.0] Cassiopeia - Remove 'debug' from grid area and add min-height to 'body'

### DIFF
--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -43,8 +43,7 @@
         ". side-l comp comp side-r ."
         ". bot-a bot-a bot-a bot-a ."
         ". bot-b bot-b bot-b bot-b ."
-        ". footer footer footer footer ."
-        ". debug debug debug debug .";
+        ". footer footer footer footer .";
     }
 
     &.wrapper-fluid {
@@ -112,8 +111,4 @@
 
 .container-footer {
   grid-area: footer;
-}
-
-.system-debug {
-  grid-area: debug;
 }

--- a/templates/cassiopeia/scss/blocks/_global.scss
+++ b/templates/cassiopeia/scss/blocks/_global.scss
@@ -15,6 +15,7 @@ html {
 
 body {
   position: relative;
+  min-height: 100vh;
 }
 
 img {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Removed the grid area `debug`
Added min-height to `body`

### Testing Instructions
Create a page with short content.
Test with debug enabled.

### Actual result BEFORE applying this Pull Request
If the css grid contains an area for `debug` the template adds a gap under the footer.
In short pages the footer shows middle on the page instead of at the bottom, because the body has no height defined:
![Screenshot 2021-07-20 at 12-05-25 Love](https://user-images.githubusercontent.com/9153168/126308330-315b329c-4c6c-4ecf-9712-e4ddf8400fd3.png)
![Screenshot 2021-07-20 at 12-06-07 Love](https://user-images.githubusercontent.com/9153168/126308412-8a19a2c5-3d0f-4197-a9bc-080e49f00c69.png)
![Screenshot 2021-07-20 at 12-06-25 Love](https://user-images.githubusercontent.com/9153168/126308433-060177e9-e27a-41f6-bee9-c7fc9b76bb82.png)


### Expected result AFTER applying this Pull Request
No gap under the footer, footer at the bottom of the page no matter the length of the content, debug is displayed correctly without specifically defined grid area
![Screenshot 2021-07-20 at 12-04-28 Love](https://user-images.githubusercontent.com/9153168/126308455-8f4f5ad3-9b1b-469e-9175-1f15702c3481.png)
![Screenshot 2021-07-20 at 12-03-46 Love](https://user-images.githubusercontent.com/9153168/126308494-55141e6c-61ed-4fc6-8dd3-2d69cb1141ac.png)
![Screenshot 2021-07-20 at 12-04-06 Love](https://user-images.githubusercontent.com/9153168/126308517-51c20b51-eb15-4296-a75d-3c0bb4083835.png)

### Documentation Changes Required

