### PR TITLE
[4.0] Alert close

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -125,7 +125,6 @@
     [dir=rtl] & {
       right: auto;
       left: 0;
-      padding: .2rem .6rem;
     }
   }
 


### PR DESCRIPTION
The padding of the close X on joomla-alerts was changed with the UI repaint but the rtl override was kept in error.

### Before
![image](https://user-images.githubusercontent.com/1296369/126455931-b9e343ae-e44f-45b6-888a-cedb5abf82c6.png)

### After
![image](https://user-images.githubusercontent.com/1296369/126455837-c7070895-c45b-422f-a478-467a22bd909e.png)

Easiest place to test is probably the admin login page when using the wrong username