### PR TITLE
[4.0] modal buttons rtl

### DIFF
--- a/administrator/templates/atum/scss/blocks/_modals.scss
+++ b/administrator/templates/atum/scss/blocks/_modals.scss
@@ -4,7 +4,7 @@
 
   .btn {
     padding: 0 22px;
-    margin-right: .5rem;
+    margin-inline-end: .5rem;
     font-size: 1rem;
     line-height: 2.3rem;
     color: var(--template-text-dark);


### PR DESCRIPTION
This PR fixes a bug with the margin when in rtl that can be seeon in com_templates when you open the modal to create a new file. By switching to logical css properties for the margin it now works correctly in RTL and LTR without any additional classes.

### Before
![image](https://user-images.githubusercontent.com/1296369/126479097-6a96dcdb-6392-417e-9951-c6fc389d3843.png)

### After
![image](https://user-images.githubusercontent.com/1296369/126479109-af2fec37-9ac1-4212-be61-9b4fc048471a.png)
