### PR TITLE
4.0] pre-updatecheck rtl fixes 

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
@@ -239,7 +239,7 @@ $updatePossible = true;
 				<div class="w-100">
 					<?php foreach ($compatibilityTypes as $compatibilityType => $data) : ?>
 					<div class="<?php echo $data['group'] > 0 ? 'hidden' : ''; ?> compatibilityTable" id="compatibilityTable<?php echo (int) $data['group']; ?>">
-						<h4 class="text-<?php echo $data['class']; ?> d-flex align-items-center">
+						<h4 class="text-<?php echo $data['class']; ?> align-items-center">
 							<span class="fa fa-<?php echo $data['icon']; ?> me-2"></span>
 							<?php echo Text::_($compatibilityType); ?>
 							<?php if ($data['group'] > 0) : ?>

--- a/administrator/language/en-GB/langmetadata.xml
+++ b/administrator/language/en-GB/langmetadata.xml
@@ -13,7 +13,7 @@
 		<name>English (United Kingdom)</name>
 		<nativeName>English (United Kingdom)</nativeName>
 		<tag>en-GB</tag>
-		<rtl>1</rtl>
+		<rtl>0</rtl>
 		<locale>en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain, uk, united kingdom, united-kingdom</locale>
 		<firstDay>0</firstDay>
 		<weekEnd>0,6</weekEnd>

--- a/administrator/language/en-GB/langmetadata.xml
+++ b/administrator/language/en-GB/langmetadata.xml
@@ -13,7 +13,7 @@
 		<name>English (United Kingdom)</name>
 		<nativeName>English (United Kingdom)</nativeName>
 		<tag>en-GB</tag>
-		<rtl>0</rtl>
+		<rtl>1</rtl>
 		<locale>en_GB.utf8, en_GB.UTF-8, en_GB, eng_GB, en, english, english-uk, uk, gbr, britain, england, great britain, uk, united kingdom, united-kingdom</locale>
 		<firstDay>0</firstDay>
 		<weekEnd>0,6</weekEnd>

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -110,6 +110,7 @@ textarea {
 label,
 caption {
   font-size: $label-font-size;
+  text-align: start;
 }
 
 .logo {


### PR DESCRIPTION
php and css changes for the joomla update component pre-update check tab to correctly align the caption and the title

### LTR before and after
![image](https://user-images.githubusercontent.com/1296369/126500289-deed5cf8-8616-40ce-94b3-1d6743a5b561.png)


### RTL before
![image](https://user-images.githubusercontent.com/1296369/126500330-103b648f-612c-4b01-a573-0f5fd8ed3c87.png)


### RTL after
![image](https://user-images.githubusercontent.com/1296369/126500387-0cf61ace-f698-4158-94d4-06851d70cb93.png)
