### PR TITLE
[4.0] tags images

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_tags.scss
+++ b/administrator/templates/atum/scss/pages/_com_tags.scss
@@ -13,10 +13,10 @@
   }
 
   #fieldset-image-intro {
-    margin-right: 15px;
+    margin-inline-end: 15px;
   }
 
   #fieldset-image-fulltext {
-    margin-left: 15px;
+    margin-inline-start: 15px;
   }
 }


### PR DESCRIPTION
This PR fixes a bug in RTL as shown in the images by using logical css properties instead of adding additional rtl specific classes. There is no visible change in LTR

### Before
![image](https://user-images.githubusercontent.com/1296369/126542181-721d561e-fef3-4593-89ba-af049a9a6dd5.png)

### After
![image](https://user-images.githubusercontent.com/1296369/126542175-1481e9c0-b4aa-4f5b-81b8-9529606395bc.png)
