### PR TITLE
[4.0] users groups margin

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_users.scss
+++ b/administrator/templates/atum/scss/pages/_com_users.scss
@@ -23,7 +23,7 @@
 
   #fieldset-groups {
     .controls {
-      margin-left: 2rem;
+      margin-inline-start: 2rem;
     }
   }
 }


### PR DESCRIPTION
This PR fixes a bug in RTL as shown in the images by using logical css properties instead of adding additional rtl specific classes.

### Before/After LTR
![image](https://user-images.githubusercontent.com/1296369/126543003-8880b73e-1009-4ac5-a355-4da4a4e2b58a.png)

### Before TRL
![image](https://user-images.githubusercontent.com/1296369/126542992-79d78ca1-0519-40fe-ac88-763f0e91d5f8.png)

### After RTL
![image](https://user-images.githubusercontent.com/1296369/126542977-7d771a89-1928-4cd4-aa46-135b37c39648.png)
