### PR TITLE
[4.0] actions button rtl

### DIFF
--- a/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/administrator/templates/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -17,6 +17,7 @@
 
 .dropdown-item {
   border-bottom: 1px solid rgba(0, 0, 0, .1);
+  text-align: start;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
This PR fixes the alignment of items in the actions dropdown menu using logical css properties. There is no visible change in LTR

### LTR Before/After
![image](https://user-images.githubusercontent.com/1296369/126569044-f8f7bbb6-9a66-4624-a336-2e921d727476.png)

### RTL Before
![image](https://user-images.githubusercontent.com/1296369/126569051-66915193-423f-4e13-9c1a-ab850eb202ee.png)

### RTL After
![image](https://user-images.githubusercontent.com/1296369/126569047-9aa1da58-d2d3-4a25-8ec4-45dab3612547.png)
