### PR TITLE
Fixed the aria-describedby not being set correctly

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
@@ -270,6 +270,7 @@
       haveName.forEach((elem) => {
         const $el = elem;
         const name = $el.getAttribute('name');
+        const aria = $el.getAttribute('aria-describedby');
         const id = name
           .replace(/(\[\]$)/g, '')
           .replace(/(\]\[)/g, '__')
@@ -333,6 +334,10 @@
         $el.name = nameNew;
         if ($el.id) {
           $el.id = idNew;
+        }
+
+        if (aria) {
+          $el.setAttribute('aria-describedby', nameNew);
         }
 
         // Check if there is a label for this input

--- a/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
@@ -337,7 +337,7 @@
         }
 
         if (aria) {
-          $el.setAttribute('aria-describedby', nameNew);
+          $el.setAttribute('aria-describedby', `${nameNew}-desc`);
         }
 
         // Check if there is a label for this input


### PR DESCRIPTION
### Summary of Changes
In a repeatable subform we replace the `X` with the number of the row being created, however this is not done for the `aria-describedby`. This fixes that and also updates the `aria-describedby` tag.


### Testing Instructions
1. Login to the Joomla 4 backend
2. Go to System -> Global Configuration
3. Click on Users at the bottom of the list on the left
4. Click on the `Email Domain Options` tab
5. Click on the + to add a new row
6. Inspect the Domain name input field
7. Notice that it says `<input type="text" name="jform[domains][__field10][name]" id="jform_domains____field10__name" value="" class="form-control required" aria-describedby="jform[domains][__field1X][name]-desc" required="">`
8. Apply the PR
9. Reload the page
10. Click on the + to add a new row
11. Inspect the Domain name input field
12. Notice that it now says `<input type="text" name="jform[domains][__field10][name]" id="jform_domains____field10__name" value="" class="form-control required" aria-describedby="jform[domains][__field10][name]-desc" required="">`

### Actual result BEFORE applying this Pull Request
The `aria-describedby` is not updated
`<input type="text" name="jform[domains][__field10][name]" id="jform_domains____field10__name" value="" class="form-control required" aria-describedby="jform[domains][__field1X][name]-desc" required="">`

### Expected result AFTER applying this Pull Request
The `aria-describedby` is updated
`<input type="text" name="jform[domains][__field10][name]" id="jform_domains____field10__name" value="" class="form-control required" aria-describedby="jform[domains][__field10][name]-desc" required="">`

### Documentation Changes Required
None
