### PR TITLE
Fix changing user in backend always destroyed user session

### DIFF
--- a/administrator/components/com_users/models/user.php
+++ b/administrator/components/com_users/models/user.php
@@ -305,7 +305,7 @@ class UsersModelUser extends JModelAdmin
 		}
 
 		// Destroy all active sessions for the user after changing the password or blocking him
-		if ($data['password'] || $data['block'])
+		if ($data['password2'] || $data['block'])
 		{
 			UserHelper::destroyUserSessions($user->id, true);
 		}


### PR DESCRIPTION
Pull Request for Issue #34798 .

### Summary of Changes
User session shouldn't get destroyed if not changing password/blocking user.