### PR TITLE
Fix hover menu in RTL

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -225,8 +225,8 @@
     background-color: var(--template-bg-dark-60);
     border-radius: 0 $border-radius $border-radius 0;
     [dir=rtl] & {
-      left: unset;
       right: 100%;
+      left: unset;
       border-radius: $border-radius 0 0 $border-radius;
     }
   }

--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -224,6 +224,11 @@
     pointer-events: none;
     background-color: var(--template-bg-dark-60);
     border-radius: 0 $border-radius $border-radius 0;
+    [dir=rtl] & {
+      left: unset;
+      right: 100%;
+      border-radius: $border-radius 0 0 $border-radius;
+    }
   }
 
   .main-nav > li > ul {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/34843 .

### Summary of Changes
Fixes the menu hover in RTL


### Testing Instructions
Swap en-GB to RTL mode. Close the menu (see the screenshot in the issue) and hover over the menu items. Before patch no items fly out. After patch they do.

### Documentation Changes Required
None
