### PR TITLE
[4.0] mail templates title

### DIFF
--- a/administrator/components/com_mails/tmpl/template/edit.php
+++ b/administrator/components/com_mails/tmpl/template/edit.php
@@ -43,8 +43,8 @@ $this->document->addScriptOptions('com_mails', ['templateData' => $this->templat
 		<div class="row">
 			<div class="col-md-12">
 				<h1><?php echo Text::_($component . '_MAIL_' . $sub_id . '_TITLE'); ?> - <?php echo $this->escape($this->item->language); ?>
-					<span class="small">(<?php echo $this->escape($this->master->template_id); ?>)</span>
 				</h1>
+				<div class="small"><?php echo $this->escape($this->master->template_id); ?></div>
 				<p><?php echo Text::_($component . '_MAIL_' . $sub_id . '_DESC'); ?></p>
 			</div>
 		</div>


### PR DESCRIPTION
This PR addresses several issues.
1. The technical name of the mail template is moved out of the H1 and onto its own line. Its not part of the title and is obviously non-translatable and also not screen reader friendly so it is moved to a new line
2. Hard coding parentheses in the html is a problem as some languages use different characters to the brace. We can remove them completely now that its on its own line.

No language strings are harmed in the mergin of this PR.

### Before
![image](https://user-images.githubusercontent.com/1296369/126750398-e2aa9dfc-52f7-4818-b4fd-cf98c435a577.png)

### After
![image](https://user-images.githubusercontent.com/1296369/126750413-f94d4a7a-bc79-4fa5-a1e6-b3f031f8de0c.png)
