### PR TITLE
[4.0] Transition Button - Replace hardcoded taskPrefix with option

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -222,7 +222,7 @@ $assoc = Associations::isEnabled();
 									'title' => Text::_($item->stage_title),
 									'tip_content' => Text::sprintf('JWORKFLOW', Text::_($item->workflow_title)),
 									'id' => 'workflow-' . $item->id,
-									'task_prefix' => 'articles'
+									'task' => 'articles.runTransition'
 								];
 
 								echo (new TransitionButton($options))

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -221,7 +221,8 @@ $assoc = Associations::isEnabled();
 									'transitions' => $transitions,
 									'title' => Text::_($item->stage_title),
 									'tip_content' => Text::sprintf('JWORKFLOW', Text::_($item->workflow_title)),
-									'id' => 'workflow-' . $item->id
+									'id' => 'workflow-' . $item->id,
+									'task_prefix' => 'articles'
 								];
 
 								echo (new TransitionButton($options))

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -227,7 +227,8 @@ $assoc = Associations::isEnabled();
 									'transitions' => $transitions,
 									'title' => Text::_($item->stage_title),
 									'tip_content' => Text::sprintf('JWORKFLOW', Text::_($item->workflow_title)),
-									'id' => 'workflow-' . $item->id
+									'id' => 'workflow-' . $item->id,
+									'task_prefix' => 'articles'
 								];
 
 								echo (new TransitionButton($options))

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -228,7 +228,7 @@ $assoc = Associations::isEnabled();
 									'title' => Text::_($item->stage_title),
 									'tip_content' => Text::sprintf('JWORKFLOW', Text::_($item->workflow_title)),
 									'id' => 'workflow-' . $item->id,
-									'task_prefix' => 'articles'
+									'task' => 'articles.runTransitions'
 								];
 
 								echo (new TransitionButton($options))

--- a/layouts/joomla/button/transition-button.php
+++ b/layouts/joomla/button/transition-button.php
@@ -27,6 +27,7 @@ $id = $options['id'];
 $tipTitle = $options['tip_title'];
 $tipContent = $options['tip_content'];
 $checkboxName = $options['checkbox_name'];
+$taskPrefix = $options['task_prefix'];
 
 ?>
 <button type="button" class="tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?>"
@@ -61,7 +62,7 @@ $checkboxName = $options['checkbox_name'];
 				'id'        => 'transition-select_' . (int) $row ?? '',
 				'list.attr' => [
 					'class'    => 'form-select form-select-sm w-auto',
-					'onchange' => "this.form.transition_id.value=this.value;Joomla.listItemTask('" . $checkboxName . $this->escape($row ?? '') . "', 'articles.runTransition')"]
+					'onchange' => "this.form.transition_id.value=this.value;Joomla.listItemTask('" . $checkboxName . $this->escape($row ?? '') . "', '" . $taskPrefix . ".runTransition')"]
 				];
 
 			echo HTMLHelper::_('select.genericlist', $transitions, '', $attribs);

--- a/layouts/joomla/button/transition-button.php
+++ b/layouts/joomla/button/transition-button.php
@@ -27,7 +27,7 @@ $id = $options['id'];
 $tipTitle = $options['tip_title'];
 $tipContent = $options['tip_content'];
 $checkboxName = $options['checkbox_name'];
-$taskPrefix = $options['task_prefix'];
+$task = $options['task'];
 
 ?>
 <button type="button" class="tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?>"
@@ -62,7 +62,7 @@ $taskPrefix = $options['task_prefix'];
 				'id'        => 'transition-select_' . (int) $row ?? '',
 				'list.attr' => [
 					'class'    => 'form-select form-select-sm w-auto',
-					'onchange' => "this.form.transition_id.value=this.value;Joomla.listItemTask('" . $checkboxName . $this->escape($row ?? '') . "', '" . $taskPrefix . ".runTransition')"]
+					'onchange' => "this.form.transition_id.value=this.value;Joomla.listItemTask('" . $checkboxName . $this->escape($row ?? '') . "', '" . $task . "')"]
 				];
 
 			echo HTMLHelper::_('select.genericlist', $transitions, '', $attribs);


### PR DESCRIPTION
### Summary of Changes
https://github.com/joomla/joomla-cms/blob/0d92dec69e3c8588b1de6b35c2967e3e1b34af72/layouts/joomla/button/transition-button.php#L64
In `transition-button` layout, The onChange action is hard-coded to work for `articles` only because of `articles.runTransition`

This is a library layout and not a component-specific layout hence articles should not be hardcoded here and it should be taken as an option.


### Testing Instructions
1. Enable Workflows (Articles -> Options -> Integrations)
2. Ensure that transitions work as intended after patch.
3. Optionally, you can also check that the code of the transition field is same before and after patch:
![image](https://user-images.githubusercontent.com/53610833/126796606-8dc6d1e7-cbbf-47c4-b2f9-04009a6f05e1.png)



### Expected result AFTER applying this Pull Request
Transitions work as they did before


### Documentation Changes Required
Not sure
