### PR TITLE
After Switching Admin Language, in the message displayed, show Native Title instead of Title [in English]

### DIFF
--- a/administrator/components/com_languages/src/Controller/InstalledController.php
+++ b/administrator/components/com_languages/src/Controller/InstalledController.php
@@ -12,7 +12,7 @@ namespace Joomla\Component\Languages\Administrator\Controller;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Installer\Installer;
+use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
@@ -92,8 +92,8 @@ class InstalledController extends BaseController
 			$file = JPATH_ADMINISTRATOR . '/language/' . $cid . '/' . $cid . '.xml';
 		}
 
-		$info         = Installer::parseXMLInstallFile($file);
-		$languageName = $info['name'];
+		$info = LanguageHelper::parseXMLLanguageFile($file);
+		$languageName = $info['nativeName'];
 
 		if ($model->switchAdminLanguage($cid))
 		{

--- a/administrator/components/com_languages/src/Controller/InstalledController.php
+++ b/administrator/components/com_languages/src/Controller/InstalledController.php
@@ -92,7 +92,7 @@ class InstalledController extends BaseController
 			$file = JPATH_ADMINISTRATOR . '/language/' . $cid . '/' . $cid . '.xml';
 		}
 
-		$info = LanguageHelper::parseXMLLanguageFile($file);
+		$info         = LanguageHelper::parseXMLLanguageFile($file);
 		$languageName = $info['nativeName'];
 
 		if ($model->switchAdminLanguage($cid))


### PR DESCRIPTION
Pull Request for Issue # .

It is not an issue; but, an improvement.


### Summary of Changes

For example, if German is Switched as the back-end Administrator language, following message is displayed:
Die Administrationssprache wurde auf "German (Germany)" geändert. 

With the change proposed, the following message would be displayed:
Die Administrationssprache wurde auf "Deutsch (Deutschland)" geändert.

When the message is displayed in the native language (e.g., German), it would be nice/better to show the language's Native Name/Title instead of the Name/Title in English.


### Testing Instructions

1. Log into Joomla! 4's back-end (_site-url/administrator_) with an account that has Super User privileges
2. Install the German language by going to the screen "Extensions: Languages" (System => Install -> Languages)
3. Go to the screen "Languages: Installed (Site)" (System => Manage -> Languages)
4. Choose "Administrator" from the dropdown (that show the client) - The screen "Languages: Installed (Administrator)" would be shown and the list of languages installed that has Administrator pack would be shown
5. Choose the language German and click on the button "Switch Language"

Now the German language would be the back-end administrator language.  Also, a message confirming the language switch would be displayed as shown below in the German language.

`Die Administrationssprache wurde auf "German (Germany)" geändert. `

Notice that even though the message is in German, the language name shown is in English.

NOW, APPLY THE PATCH WITH THE CHANGE PROPOSED AND REPEAT THE TEST STEPS 1 TO 5 AS LISTED ABOVE.

After, German language is made as the back-end administrator language, following message would be displayed confirming the language switch.

`Die Administrationssprache wurde auf "Deutsch (Deutschland)" geändert.
`

**Notice the difference in the name of the language displayed between the messages before and after the change.**


### Actual result BEFORE applying this Pull Request

Notice that the message is in the native language (e.g, German) whereas the language name shown is in English.

![Original_Language_Title_Shown](https://user-images.githubusercontent.com/4947580/126809525-151709de-cee7-4798-aeb0-4233083e0b2e.jpg)


### Expected result AFTER applying this Pull Request

Notice that the message is in the native language (e.g., German) and the language name shown is also in the native language (e.g., German).

![Revised_Language_Native-Title_Shown](https://user-images.githubusercontent.com/4947580/126809574-bde08590-b37f-4060-9789-f4606518db1e.jpg)


### Documentation Changes Required

Probably Joomla! 4 documentation screenshot in case if the switching message is shown in the screenshot.