### PR TITLE
[4.0] Redo the image editing api

### DIFF
--- a/administrator/components/com_media/src/Plugin/MediaActionPlugin.php
+++ b/administrator/components/com_media/src/Plugin/MediaActionPlugin.php
@@ -75,7 +75,8 @@ class MediaActionPlugin extends CMSPlugin
 		HTMLHelper::_(
 			'script',
 			'plg_media-action_' . $this->_name . '/' . $this->_name . '.js',
-			['version' => 'auto', 'relative' => true]
+			['version' => 'auto', 'relative' => true],
+			['type' => 'module']
 		);
 	}
 

--- a/administrator/components/com_media/tmpl/file/default.php
+++ b/administrator/components/com_media/tmpl/file/default.php
@@ -21,8 +21,9 @@ use Joomla\CMS\Uri\Uri;
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')
-	->useScript('com_media.edit-images')
 	->useStyle('com_media.mediamanager');
+
+$script = $wa->getAsset('script', 'com_media.edit-images')->getUri(true);
 
 $params = ComponentHelper::getParams('com_media');
 $input  = Factory::getApplication()->input;
@@ -62,10 +63,11 @@ $this->useCoreUI = true;
 <form action="#" method="post" name="adminForm" id="media-form" class="form-validate main-card media-form mt-3">
 	<?php $fieldSets = $form->getFieldsets(); ?>
 	<?php if ($fieldSets) : ?>
-		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', ['active' => 'attrib-' . reset($fieldSets)->name, 'recall' => true, 'breakpoint' => 768]); ?>
+		<?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', ['active' => 'attrib-' . reset($fieldSets)->name, 'breakpoint' => 768]); ?>
 		<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 		<?php echo '<div id="media-manager-edit-container" class="media-manager-edit"></div>'; ?>
 		<?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 	<?php endif; ?>
 	<input type="hidden" name="mediatypes" value="<?php echo $mediaTypes; ?>">
 </form>
+<script type="module" src="<?php echo $script; ?>"></script>

--- a/administrator/components/com_media/tmpl/file/default.php
+++ b/administrator/components/com_media/tmpl/file/default.php
@@ -33,6 +33,8 @@ $form = $this->form;
 
 $tmpl = $input->getCmd('tmpl');
 
+$input->set('hidemainmenu', true);
+
 // Load the toolbar when we are in an iframe
 if ($tmpl == 'component') {
 	echo '<div class="subhead noshadow">';

--- a/administrator/components/com_media/tmpl/file/default.php
+++ b/administrator/components/com_media/tmpl/file/default.php
@@ -72,4 +72,4 @@ $this->useCoreUI = true;
 	<?php endif; ?>
 	<input type="hidden" name="mediatypes" value="<?php echo $mediaTypes; ?>">
 </form>
-<script type="module" src="<?php echo $script; ?>"></script>
+<script type="module" src="<?php echo $script . '?' . $this->document->getMediaVersion(); ?>"></script>

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -2,304 +2,332 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-Joomla = window.Joomla || {};
+if (!Joomla) {
+  throw new Error('Joomla API is not properly initialized');
+}
 
 Joomla.MediaManager = Joomla.MediaManager || {};
+class Edit {
+  constructor() {
+    // Get the options from Joomla.optionStorage
+    this.options = Joomla.getOptions('com_media', {});
 
-(() => {
-  'use strict';
-
-  // Get the options from Joomla.optionStorage
-  const options = Joomla.getOptions('com_media', {});
-
-  if (!options) {
-    throw new Error('Initialization error "edit-images.js"');
-  }
-
-  // Initiate the registry
-  Joomla.MediaManager.Edit.original = {
-    filename: options.uploadPath.split('/').pop(),
-    extension: options.uploadPath.split('.').pop(),
-    contents: `data:image/${options.uploadPath.split('.').pop()};base64,${options.contents}`,
-  };
-  Joomla.MediaManager.Edit.history = {};
-  Joomla.MediaManager.Edit.current = {};
-
-  const activate = (name, data) => {
-    if (!data.contents) {
-      return;
-    }
-    // Create the images for edit and preview
-    const baseContainer = document.getElementById('media-manager-edit-container');
-    const editContainer = document.createElement('div');
-    const previewContainer = document.createElement('div');
-    const imageSrc = document.createElement('img');
-    const imagePreview = document.createElement('img');
-
-    baseContainer.innerHTML = '';
-    imageSrc.src = data.contents;
-    imageSrc.id = 'image-source';
-    imageSrc.style.maxWidth = '100%';
-    imagePreview.src = data.contents;
-    imagePreview.id = 'image-preview';
-    imagePreview.style.maxWidth = '100%';
-    editContainer.classList.add('hidden');
-
-    editContainer.appendChild(imageSrc);
-    baseContainer.appendChild(editContainer);
-
-    previewContainer.appendChild(imagePreview);
-    baseContainer.appendChild(previewContainer);
-
-    // Activate the first plugin
-    Joomla.MediaManager.Edit[name.toLowerCase()].Activate(data);
-  };
-
-  // Reset the image to the initial state
-  Joomla.MediaManager.Edit.Reset = (current) => {
-    if (!current || (current && current === 'initial')) {
-      Joomla.MediaManager.Edit.current.contents = Joomla.MediaManager.Edit.original.contents;
+    if (!this.options) {
+      throw new Error('Initialization error "edit-images.js"');
     }
 
-    // Clear the DOM
-    const container = document.getElementById('media-manager-edit-container');
-    container.innerHTML = '';
+    this.extension = this.options.uploadPath.split('.').pop();
+    this.fileType = ['jpeg', 'jpg'].includes(this.extension) ? 'jpeg' : this.extension;
 
-    // Reactivate the current plugin
-    const tabsUlElement = document.getElementById('myTab').firstElementChild;
-
-    if (tabsUlElement.tagName !== 'UL') {
-      return;
-    }
-
-    const links = [].slice.call(tabsUlElement.querySelectorAll('a'));
-
-    links.forEach((link) => {
-      if (!link.hasAttribute('active')) {
-        return;
-      }
-
-      Joomla.MediaManager.Edit[link.id.replace('tab-attrib-', '').toLowerCase()].Deactivate();
-
-      let data = Joomla.MediaManager.Edit.current;
-      if (!current || (current && current !== true)) {
-        data = Joomla.MediaManager.Edit.original;
-      }
-
-      link.click();
-
-      // Move the container to the correct tab
-      const mediaContainer = document.getElementById('media-manager-edit-container');
-      const tab = document.getElementById(link.id.replace('tab-', ''));
-      tab.insertAdjacentElement('beforeend', mediaContainer);
-
-      activate(link.id.replace('tab-attrib-', ''), data);
-    });
-  };
-
-  // Create history entry
-  window.addEventListener('mediaManager.history.point', () => {
-    if (Joomla.MediaManager.Edit.original !== Joomla.MediaManager.Edit.current.contents) {
-      const key = Object.keys(Joomla.MediaManager.Edit.history).length;
-      if (Joomla.MediaManager.Edit.history[key] && Joomla.MediaManager.Edit.history[key - 1]
-        && Joomla.MediaManager.Edit.history[key] === Joomla.MediaManager.Edit.history[key - 1]) {
-        return;
-      }
-      Joomla.MediaManager.Edit.history[key + 1] = Joomla.MediaManager.Edit.current.contents;
-    }
-  });
-
-  // @TODO History
-  Joomla.MediaManager.Edit.Undo = () => { };
-  // @TODO History
-  Joomla.MediaManager.Edit.Redo = () => { };
-
-  // @TODO Create the progress bar
-  Joomla.MediaManager.Edit.createProgressBar = () => { };
-
-  // @TODO Update the progress bar
-  Joomla.MediaManager.Edit.updateProgressBar = (/* position */) => { };
-
-  // @TODO Remove the progress bar
-  Joomla.MediaManager.Edit.removeProgressBar = () => { };
-
-  // Customize the buttons
-  Joomla.submitbutton = (task) => {
-    const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
-    const pathName = window.location.pathname.replace(/&view=file.*/g, '');
-    const name = options.uploadPath.split('/').pop();
-    const forUpload = {
-      name,
-      content: Joomla.MediaManager.Edit.current.contents.replace(`data:image/${format};base64,`, ''),
+    // Initiate the registry
+    this.original = {
+      filename: this.options.uploadPath.split('/').pop(),
+      extension: this.extension,
+      contents: `data:image/${this.fileType};base64,${this.options.contents}`,
     };
+    this.history = {};
+    this.current = {};
+    this.plugins = {};
+    this.baseContainer = document.getElementById('media-manager-edit-container');
 
-    // eslint-disable-next-line prefer-destructuring
-    const uploadPath = options.uploadPath;
-
-    const url = `${options.apiBaseUrl}&task=api.files&path=${uploadPath}`;
-
-    const type = 'application/json';
-
-    forUpload[options.csrfToken] = '1';
-
-    let fileDirectory = uploadPath.split('/');
-    fileDirectory.pop();
-    fileDirectory = fileDirectory.join('/');
-
-    // If we are in root add a backslash
-    if (fileDirectory.endsWith(':')) {
-      fileDirectory = `${fileDirectory}/`;
+    if (!this.baseContainer) {
+      throw new Error('The image preview container is missing');
     }
 
-    // Respect the images_only URI param
-    const mediaTypes = document.querySelector('input[name="mediatypes"]');
-    let mediatypes;
-    if (mediaTypes) {
-      mediatypes = `&mediatypes=${mediaTypes.value ? mediaTypes.value : '0'}`;
-    }
+    Joomla.MediaManager.Edit = this;
+    window.dispatchEvent(new CustomEvent('media-manager-edit-init'));
 
-    switch (task) {
-      case 'apply':
-        Joomla.UploadFile.exec(name, JSON.stringify(forUpload), uploadPath, url, type);
-        Joomla.MediaManager.Edit.Reset(true);
-        break;
-      case 'save':
-        // eslint-disable-next-line func-names
-        Joomla.UploadFile.exec(name, JSON.stringify(forUpload), uploadPath, url, type, function () {
-          if (this.readyState === XMLHttpRequest.DONE) {
-            if (window.self !== window.top) {
-              window.location = `${pathName}?option=com_media&view=media${mediatypes}&path=${fileDirectory}&tmpl=component`;
-            } else {
-              window.location = `${pathName}?option=com_media&view=media${mediatypes}&path=${fileDirectory}`;
-            }
-          }
-        });
-        break;
-      case 'cancel':
-        if (window.self !== window.top) {
-          window.location = `${pathName}?option=com_media&view=media${mediatypes}&path=${fileDirectory}&tmpl=component`;
-        } else {
-          window.location = `${pathName}?option=com_media&view=media${mediatypes}&path=${fileDirectory}`;
-        }
-        break;
-      case 'reset':
-        Joomla.MediaManager.Edit.Reset('initial');
-        break;
-      case 'undo':
-        // @TODO magic goes here
-        break;
-      case 'redo':
-        // @TODO other magic goes here
-        break;
-      default:
-        break;
-    }
-  };
-
-  /**
-   * @TODO Extend Joomla.request and drop this code!!!!
-   */
-  // The upload object
-  Joomla.UploadFile = {};
-
-  /**
-   * @TODO Extend Joomla.request and drop this code!!!!
-   */
-  Joomla.UploadFile.exec = (name, data, uploadPath, url, type, stateChangeCallback) => {
-    const xhr = new XMLHttpRequest();
-
-    xhr.upload.onprogress = (e) => {
-      Joomla.MediaManager.Edit.updateProgressBar((e.loaded / e.total) * 100);
-    };
-
-    if (typeof stateChangeCallback === 'function') {
-      xhr.onreadystatechange = stateChangeCallback;
-    }
-
-    xhr.onload = () => {
-      let resp;
-      try {
-        resp = JSON.parse(xhr.responseText);
-      } catch (er) {
-        resp = null;
-      }
-
-      if (resp) {
-        if (xhr.status === 200) {
-          if (resp.success === true) {
-            Joomla.MediaManager.Edit.removeProgressBar();
-          }
-
-          if (resp.status === '1') {
-            Joomla.renderMessages({ success: [resp.message] }, 'true');
-            Joomla.MediaManager.Edit.removeProgressBar();
-          }
-        }
-      } else {
-        Joomla.MediaManager.Edit.removeProgressBar();
-      }
-    };
-
-    xhr.onerror = () => {
-      Joomla.MediaManager.Edit.removeProgressBar();
-    };
-
-    xhr.open('PUT', url, true);
-    xhr.setRequestHeader('Content-Type', type);
-    Joomla.MediaManager.Edit.createProgressBar();
-    xhr.send(data);
-  };
-
-  // Once the DOM is ready, initialize everything
-  document.addEventListener('DOMContentLoaded', () => {
-    const func = () => {
-      const tabsUlElement = document.getElementById('myTab').firstElementChild;
-
-      if (tabsUlElement.tagName !== 'UL') {
-        setTimeout(func, 50);
-        return;
-      }
-
-      const links = [].slice.call(tabsUlElement.querySelectorAll('a'));
+    // Once the DOM is ready, initialize everything
+    customElements.whenDefined('joomla-tab').then(async () => {
+      const tabContainer = document.getElementById('myTab');
+      const tabsUlElement = tabContainer.firstElementChild;
+      const links = [].slice.call(tabsUlElement.querySelectorAll('button[aria-controls]'));
+      this.createImageContainer(this.original);
 
       if (links[0]) {
-        activate(links[0].id.replace('tab-attrib-', ''), Joomla.MediaManager.Edit.original);
+        const tabId = links[0].getAttribute('aria-controls');
+        try {
+          await this.activate(tabId.replace('attrib-', ''));
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.log(e);
+        }
       }
 
       // Couple the tabs with the plugin objects
-      links.forEach((link) => {
-        link.addEventListener('joomla.tab.shown', ({ relatedTarget, target }) => {
-          const container = document.getElementById('media-manager-edit-container');
+      links.forEach((link, index) => {
+        link.addEventListener('joomla.tab.shown', async ({ relatedTarget, target }) => {
           if (relatedTarget) {
-            Joomla.MediaManager.Edit[relatedTarget.id.replace('tab-attrib-', '').toLowerCase()].Deactivate();
-
-            // Clear the DOM
-            container.innerHTML = '';
+            try {
+              await this.plugins[relatedTarget.getAttribute('aria-controls').replace('attrib-', '')].Deactivate(this.imagePreview);
+            } catch (e) {
+              // eslint-disable-next-line no-console
+              console.log(e);
+            }
           }
 
-          let data = Joomla.MediaManager.Edit.current;
-
-          if (!('contents' in Joomla.MediaManager.Edit.current)) {
-            data = Joomla.MediaManager.Edit.original;
+          const tab = document.getElementById(link.getAttribute('aria-controls'));
+          // Move the image container to the correct tab
+          tab.insertAdjacentElement('beforeend', this.baseContainer);
+          try {
+            await this.activate(target.getAttribute('aria-controls').replace('attrib-', ''));
+          } catch (e) {
+            // eslint-disable-next-line no-console
+            console.log(e);
           }
-
-          // Move the container to the correct tab
-          const tab = document.getElementById(target.id.replace('tab-', ''));
-          tab.insertAdjacentElement('beforeend', container);
-
-          activate(target.id.replace('tab-attrib-', ''), data);
         });
 
-        link.click();
+        tabContainer.activateTab(index, false);
       });
 
-      if (links[0]) {
-        links[0].click();
-        activate(links[0].id.replace('tab-attrib-', ''), Joomla.MediaManager.Edit.original);
+      const tabId = links[0].getAttribute('aria-controls');
+      tabContainer.activateTab(0, false);
+      try {
+        await this.activate(tabId.replace('attrib-', ''));
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log(e);
       }
-    };
+    });
 
-    // @TODO use promises here
-    setTimeout(func, 50);
-  });
-})();
+    this.addHistoryPoint = this.addHistoryPoint.bind(this);
+    this.createImageContainer = this.createImageContainer.bind(this);
+    this.activate = this.activate.bind(this);
+    this.Reset = this.Reset.bind(this);
+    this.Undo = this.Undo.bind(this);
+    this.Redo = this.Redo.bind(this);
+    this.createProgressBar = this.createProgressBar.bind(this);
+    this.updateProgressBar = this.updateProgressBar.bind(this);
+    this.removeProgressBar = this.removeProgressBar.bind(this);
+    this.exec = this.exec.bind(this);
+    this.xhrOnload = this.xhrOnload.bind(this);
+    this.xhrOnerror = this.xhrOnerror.bind(this);
+    this.xhrOnprogress = this.xhrOnprogress.bind(this);
+
+    // Create history entry
+    window.addEventListener('mediaManager.history.point', this.addHistoryPoint.bind(this));
+  }
+
+  addHistoryPoint() {
+    if (this.original !== this.current.contents) {
+      const key = Object.keys(this.history).length;
+      if (this.history[key] && this.history[key - 1]
+        && this.history[key] === this.history[key - 1]) {
+        return;
+      }
+      this.history[key + 1] = this.current.contents;
+    }
+  }
+
+  // Create the images for edit and preview
+  createImageContainer(data) {
+    if (!data.contents) {
+      throw new Error('Initialization error "edit-images.js"');
+    }
+
+    this.imagePreview = document.createElement('img');
+    this.imagePreview.src = data.contents;
+    this.imagePreview.id = 'image-preview';
+    this.baseContainer.style.maxWidth = '100%';
+    this.baseContainer.appendChild(this.imagePreview);
+  }
+
+  async activate(name) {
+    // Activate the first plugin
+    if (name) {
+      try {
+        await this.plugins[name.toLowerCase()].Activate(this.imagePreview);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log(e);
+      }
+    }
+  }
+
+  // Reset the image to the initial state
+  Reset(current) {
+    if (!current || (current && current === 'initial')) {
+      this.current.contents = this.original.contents;
+      this.history = {};
+    }
+
+    // Reactivate the current plugin
+    const tabContainer = document.getElementById('myTab');
+    const tabsUlElement = tabContainer.firstElementChild;
+    const links = [].slice.call(tabsUlElement.querySelectorAll('button[aria-controls]'));
+
+    links.forEach(async (link) => {
+      if (link.getAttribute('aria-expanded') !== 'true') {
+        return;
+      }
+
+      try {
+        await this.plugins[link.getAttribute('aria-controls').replace('attrib-', '')].Deactivate(this.imagePreview);
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log(e);
+      }
+
+      link.click();
+      try {
+        await this.activate(link.getAttribute('aria-controls').replace('attrib-', ''));
+      } catch (e) {
+        // eslint-disable-next-line no-console
+        console.log(e);
+      }
+    });
+  }
+
+  // @TODO History
+  // Undo() { }
+
+  // @TODO History
+  // Redo() { }
+
+  // @TODO Create the progress bar
+  // createProgressBar() { }
+
+  // @TODO Update the progress bar
+  // updateProgressBar(/* position */) { }
+
+  // @TODO Remove the progress bar
+  // removeProgressBar() { }
+
+  exec(name, data, uploadPath, url, type, stateChangeCallback) {
+    this.xhr = new XMLHttpRequest();
+
+    this.xhr.upload.onprogress = this.xhrOnprogress;
+
+    if (typeof stateChangeCallback === 'function') {
+      this.xhr.onreadystatechange = stateChangeCallback;
+    }
+
+    this.xhr.onload = this.xhrOnload;
+
+    this.xhr.onerror = this.xhrOnerror;
+
+    this.xhr.open('PUT', url, true);
+    this.xhr.setRequestHeader('Content-Type', type);
+    this.createProgressBar();
+    this.xhr.send(data);
+  }
+
+  xhrOnerror() {
+    this.removeProgressBar();
+  }
+
+  xhrOnload() {
+    let resp;
+    try {
+      resp = JSON.parse(this.xhr.responseText);
+    } catch (er) {
+      resp = null;
+    }
+
+    if (resp) {
+      if (this.xhr.status === 200) {
+        if (resp.success === true) {
+          this.removeProgressBar();
+        }
+
+        if (resp.status === '1') {
+          Joomla.renderMessages({ success: [resp.message] }, 'true');
+          this.removeProgressBar();
+        }
+      }
+    } else {
+      this.removeProgressBar();
+    }
+  }
+
+  xhrOnprogress(e) {
+    this.updateProgressBar((e.loaded / e.total) * 100);
+  }
+}
+
+// Initiate the Editor API
+// eslint-disable-next-line no-new
+new Edit();
+
+// Customize the Toolbar buttons behavior
+Joomla.submitbutton = (task) => {
+  const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
+  const pathName = window.location.pathname.replace(/&view=file.*/g, '');
+  const name = Joomla.MediaManager.Edit.options.uploadPath.split('/').pop();
+  const forUpload = {
+    name,
+    content: Joomla.MediaManager.Edit.current.contents.replace(`data:image/${format};base64,`, ''),
+  };
+
+  const { uploadPath } = Joomla.MediaManager.Edit.options;
+  const url = `${Joomla.MediaManager.Edit.options.apiBaseUrl}&task=api.files&path=${uploadPath}`;
+  const type = 'application/json';
+  forUpload[Joomla.MediaManager.Edit.options.csrfToken] = '1';
+
+  let fileDirectory = uploadPath.split('/');
+  fileDirectory.pop();
+  fileDirectory = fileDirectory.join('/');
+
+  // If we are in root add a backslash
+  if (fileDirectory.endsWith(':')) {
+    fileDirectory = `${fileDirectory}/`;
+  }
+
+  // Respect the images_only URI param
+  const mediaTypes = document.querySelector('input[name="mediatypes"]');
+  let mediatypes;
+  if (mediaTypes) {
+    mediatypes = `&mediatypes=${mediaTypes.value ? mediaTypes.value : '0'}`;
+  }
+
+  switch (task) {
+    case 'apply':
+      Joomla.MediaManager.Edit.exec(name, JSON.stringify(forUpload), uploadPath, url, type);
+      Joomla.MediaManager.Edit.imagePreview.src = Joomla.MediaManager.Edit.current.contents;
+      Joomla.MediaManager.Edit.original = Joomla.MediaManager.Edit.current;
+      Joomla.MediaManager.Edit.history = {};
+
+      (async () => {
+        const activeTab = [].slice.call(document.querySelectorAll('joomla-tab-element'))
+          .filter((tab) => tab.hasAttribute('active'));
+        try {
+          await Joomla.MediaManager.Edit.plugins[activeTab[0].id.replace('attrib-', '')].Deactivate(Joomla.MediaManager.Edit.imagePreview);
+          await Joomla.MediaManager.Edit.plugins[activeTab[0].id.replace('attrib-', '')].Activate(Joomla.MediaManager.Edit.imagePreview);
+        } catch (e) {
+          // eslint-disable-next-line no-console
+          console.log(e);
+        }
+      })();
+      break;
+    case 'save':
+      // eslint-disable-next-line func-names
+      Joomla.MediaManager.Edit.exec(name, JSON.stringify(forUpload), uploadPath, url, type, () => {
+        if (this.readyState === XMLHttpRequest.DONE) {
+          if (window.self !== window.top) {
+            window.location = `${pathName}?option=com_media&view=media${mediatypes}&path=${fileDirectory}&tmpl=component`;
+          } else {
+            window.location = `${pathName}?option=com_media&view=media${mediatypes}&path=${fileDirectory}`;
+          }
+        }
+      });
+      break;
+    case 'cancel':
+      if (window.self !== window.top) {
+        window.location = `${pathName}?option=com_media&view=media${mediatypes}&path=${fileDirectory}&tmpl=component`;
+      } else {
+        window.location = `${pathName}?option=com_media&view=media${mediatypes}&path=${fileDirectory}`;
+      }
+      break;
+    case 'reset':
+      Joomla.MediaManager.Edit.Reset('initial');
+      break;
+    case 'undo':
+      // @TODO magic goes here
+      break;
+    case 'redo':
+      // @TODO other magic goes here
+      break;
+    default:
+      break;
+  }
+};

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -128,7 +128,7 @@ class Edit {
     this.imagePreview = document.createElement('img');
     this.imagePreview.src = data.contents;
     this.imagePreview.id = 'image-preview';
-    this.baseContainer.style.maxWidth = '100%';
+    this.imagePreview.style.maxWidth = '100%';
     this.baseContainer.appendChild(this.imagePreview);
   }
 

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -125,6 +125,7 @@ class Edit {
     this.imagePreview = document.createElement('img');
     this.imagePreview.src = data.contents;
     this.imagePreview.id = 'image-preview';
+    this.imagePreview.style.width = '100%';
     this.imagePreview.style.maxWidth = '100%';
     this.baseContainer.appendChild(this.imagePreview);
   }

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -230,10 +230,12 @@ class Edit {
       } else {
         this.removeProgressBar();
       }
+      this.xhr = null;
     };
 
     this.xhr.onerror = () => {
       this.removeProgressBar();
+      this.xhr = null;
     };
 
     this.xhr.open('PUT', url, true);

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -126,6 +126,7 @@ class Edit {
     this.imagePreview.src = data.contents;
     this.imagePreview.id = 'image-preview';
     this.imagePreview.style.width = '100%';
+    this.imagePreview.style.height = 'auto';
     this.imagePreview.style.maxWidth = '100%';
     this.baseContainer.appendChild(this.imagePreview);
   }

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -73,7 +73,7 @@ class Edit {
         });
       });
 
-      links.map((link) => link.click())
+      links.map((link) => link.click());
       links[0].click();
       links[0].blur();
 

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -27,7 +27,7 @@ class Edit {
       contents: `data:image/${this.fileType};base64,${this.options.contents}`,
     };
     this.history = {};
-    this.current = {};
+    this.current = this.original;
     this.plugins = {};
     this.baseContainer = document.getElementById('media-manager-edit-container');
 
@@ -140,6 +140,9 @@ class Edit {
   }
 
   async activate(name) {
+    this.imagePreview = null;
+    this.createImageContainer(this.current.contents);
+
     // Activate the first plugin
     if (name) {
       try {

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -208,7 +208,7 @@ class Edit {
 
   /**
    * Uploads
-   * Puplic
+   * Public
    */
   upload(url, stateChangeCallback) {
     let format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -35,6 +35,8 @@ class Edit {
       throw new Error('The image preview container is missing');
     }
 
+    this.createImageContainer(this.original);
+
     Joomla.MediaManager.Edit = this;
     window.dispatchEvent(new CustomEvent('media-manager-edit-init'));
 
@@ -43,20 +45,14 @@ class Edit {
       const tabContainer = document.getElementById('myTab');
       const tabsUlElement = tabContainer.firstElementChild;
       const links = [].slice.call(tabsUlElement.querySelectorAll('button[aria-controls]'));
-      this.createImageContainer(this.original);
-
-      if (links[0]) {
-        const tabId = links[0].getAttribute('aria-controls');
-        try {
-          await this.activate(tabId.replace('attrib-', ''));
-        } catch (e) {
-          // eslint-disable-next-line no-console
-          console.log(e);
-        }
-      }
 
       // Couple the tabs with the plugin objects
       links.forEach((link, index) => {
+        const tab = document.getElementById(link.getAttribute('aria-controls'));
+        if (index === 0) {
+          tab.insertAdjacentElement('beforeend', this.baseContainer);
+        }
+
         link.addEventListener('joomla.tab.shown', async ({ relatedTarget, target }) => {
           if (relatedTarget) {
             try {
@@ -66,8 +62,6 @@ class Edit {
               console.log(e);
             }
           }
-
-          const tab = document.getElementById(link.getAttribute('aria-controls'));
           // Move the image container to the correct tab
           tab.insertAdjacentElement('beforeend', this.baseContainer);
           try {
@@ -77,18 +71,16 @@ class Edit {
             console.log(e);
           }
         });
-
-        tabContainer.activateTab(index, false);
       });
 
-      const tabId = links[0].getAttribute('aria-controls');
-      tabContainer.activateTab(0, false);
-      try {
-        await this.activate(tabId.replace('attrib-', ''));
-      } catch (e) {
-        // eslint-disable-next-line no-console
-        console.log(e);
-      }
+      links.map((link) => link.click())
+      links[0].click();
+      links[0].blur();
+
+      setTimeout(() => {
+        links[0].click();
+        links[0].blur();
+      }, 400);
     });
 
     this.addHistoryPoint = this.addHistoryPoint.bind(this);
@@ -140,9 +132,6 @@ class Edit {
   }
 
   async activate(name) {
-    this.imagePreview = null;
-    this.createImageContainer(this.current.contents);
-
     // Activate the first plugin
     if (name) {
       try {

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -285,7 +285,7 @@ new Edit();
  */
 const getUrl = (isModal) => {
   const newUrl = Joomla.MediaManager.Edit.options.currentUrl;
-  let params = new URLSearchParams(newUrl.search);
+  const params = new URLSearchParams(newUrl.search);
   params.set('view', 'media');
   params.delete('path');
   params.delete('mediatypes');

--- a/build/media_source/com_media/scss/components/_media-edit.scss
+++ b/build/media_source/com_media/scss/components/_media-edit.scss
@@ -8,7 +8,7 @@
   }
 
   joomla-tab-element {
-    grid-template-columns: repeat(auto-fit, minmax(240px,1fr));
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 
     > fieldset {
       padding: 2rem;

--- a/build/media_source/com_media/scss/components/_media-edit.scss
+++ b/build/media_source/com_media/scss/components/_media-edit.scss
@@ -8,7 +8,7 @@
   }
 
   joomla-tab-element {
-    grid-template-columns: repeat(4, minmax(240px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(240px,1fr));
 
     > fieldset {
       padding: 2rem;
@@ -47,7 +47,8 @@
 }
 
 .media-manager-edit {
-  grid-column: span 3;
+  grid-column-start: 2;
+  grid-column-end: 5;
   background-color: #fff;
   background-image: linear-gradient(45deg,hsl(var(--hue), 20%, 97%) 25%,transparent 0,transparent 75%,#fafafa 0,hsl(var(--hue),20%,97%)),linear-gradient(45deg,#fafafa 25%,transparent 0,transparent 75%,hsl(var(--hue), 20%, 97%) 0,hsl(var(--hue), 20%, 97%));
   background-position: 0 0,10px 10px;

--- a/build/media_source/plg_media-action_crop/js/crop.es6.js
+++ b/build/media_source/plg_media-action_crop/js/crop.es6.js
@@ -44,8 +44,6 @@ const init = (image) => {
     rotatable: false,
     autoCropArea: 1,
     // scalable: false,
-    maxContainerWidth: image.width,
-    maxContainerHeight: image.height,
     crop(e) {
       formElements.cropX.value = Math.round(e.detail.x);
       formElements.cropY.value = Math.round(e.detail.y);

--- a/build/media_source/plg_media-action_crop/js/crop.es6.js
+++ b/build/media_source/plg_media-action_crop/js/crop.es6.js
@@ -39,15 +39,16 @@ const init = (image) => {
 
   // Initiate the cropper
   Joomla.MediaManager.Edit.plugins.crop.cropper = new Cropper(image, {
-    viewMode: 2,
-    responsive: true,
+    viewMode: 1,
     restore: true,
     autoCrop: true,
     movable: false,
     zoomable: false,
     rotatable: false,
     autoCropArea: 1,
-    scalable: false,
+    // scalable: false,
+    minContainerWidth: image.offsetWidth,
+    minContainerHeight: image.offsetHeight,
     crop(e) {
       formElements.cropX.value = Math.round(e.detail.x);
       formElements.cropY.value = Math.round(e.detail.y);

--- a/build/media_source/plg_media-action_crop/js/crop.es6.js
+++ b/build/media_source/plg_media-action_crop/js/crop.es6.js
@@ -5,27 +5,23 @@
 /* global Cropper */
 let formElements;
 let activated = false;
+let instance;
 
 const addListeners = () => {
   formElements.cropX.addEventListener('change', ({ currentTarget }) => {
-    Joomla.MediaManager.Edit.plugins.crop.cropper
-      .setData({ x: parseInt(currentTarget.value, 10) });
+    instance.setData({ x: parseInt(currentTarget.value, 10) });
   });
   formElements.cropY.addEventListener('change', ({ currentTarget }) => {
-    Joomla.MediaManager.Edit.plugins.crop.cropper
-      .setData({ y: parseInt(currentTarget.value, 10) });
+    instance.setData({ y: parseInt(currentTarget.value, 10) });
   });
   formElements.cropWidth.addEventListener('change', ({ currentTarget }) => {
-    Joomla.MediaManager.Edit.plugins.crop.cropper
-      .setData({ width: parseInt(currentTarget.value, 10) });
+    instance.setData({ width: parseInt(currentTarget.value, 10) });
   });
   formElements.cropHeight.addEventListener('change', ({ currentTarget }) => {
-    Joomla.MediaManager.Edit.plugins.crop.cropper
-      .setData({ height: parseInt(currentTarget.value, 10) });
+    instance.setData({ height: parseInt(currentTarget.value, 10) });
   });
   formElements.aspectRatio.addEventListener('change', ({ currentTarget }) => {
-    Joomla.MediaManager.Edit.plugins.crop.cropper
-      .setAspectRatio(currentTarget.value);
+    instance.setAspectRatio(currentTarget.value);
   });
   activated = true;
 };
@@ -38,7 +34,7 @@ const init = (image) => {
   }
 
   // Initiate the cropper
-  Joomla.MediaManager.Edit.plugins.crop.cropper = new Cropper(image, {
+  instance = new Cropper(image, {
     viewMode: 1,
     responsive: true,
     restore: true,
@@ -70,6 +66,8 @@ const init = (image) => {
   if (!activated) {
     addListeners();
   }
+
+  instance.setAspectRatio(formElements.cropAspectRatioOption.value);
 };
 
 // Register the Events
@@ -86,20 +84,16 @@ window.addEventListener('media-manager-edit-init', () => {
   Joomla.MediaManager.Edit.plugins.crop = {
     Activate(image) {
       return new Promise((resolve /* , reject */) => {
-        if (activated) {
-          Joomla.MediaManager.Edit.plugins.crop.cropper.enable();
-        } else {
-          init(image);
-        }
-        Joomla.MediaManager.Edit.plugins.crop.cropper
-          .setAspectRatio(formElements.cropAspectRatioOption.value);
+        init(image);
+
         resolve();
       });
     },
     Deactivate(image) {
       return new Promise((resolve /* , reject */) => {
         if (image.cropper) {
-          image.cropper.disable();
+          image.cropper.destroy();
+          instance = null;
         }
         resolve();
       });

--- a/build/media_source/plg_media-action_crop/js/crop.es6.js
+++ b/build/media_source/plg_media-action_crop/js/crop.es6.js
@@ -47,8 +47,6 @@ const init = (image) => {
     rotatable: false,
     autoCropArea: 1,
     // scalable: false,
-    minContainerWidth: image.offsetWidth,
-    minContainerHeight: image.offsetHeight,
     crop(e) {
       formElements.cropX.value = Math.round(e.detail.x);
       formElements.cropY.value = Math.round(e.detail.y);

--- a/build/media_source/plg_media-action_crop/js/crop.es6.js
+++ b/build/media_source/plg_media-action_crop/js/crop.es6.js
@@ -2,93 +2,102 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-
 /* global Cropper */
+let formElements;
+let activated = false;
 
-Joomla = window.Joomla || {};
+const addListeners = () => {
+  formElements.cropX.addEventListener('change', ({ currentTarget }) => {
+    Joomla.MediaManager.Edit.plugins.crop.cropper
+      .setData({ x: parseInt(currentTarget.value, 10) });
+  });
+  formElements.cropY.addEventListener('change', ({ currentTarget }) => {
+    Joomla.MediaManager.Edit.plugins.crop.cropper
+      .setData({ y: parseInt(currentTarget.value, 10) });
+  });
+  formElements.cropWidth.addEventListener('change', ({ currentTarget }) => {
+    Joomla.MediaManager.Edit.plugins.crop.cropper
+      .setData({ width: parseInt(currentTarget.value, 10) });
+  });
+  formElements.cropHeight.addEventListener('change', ({ currentTarget }) => {
+    Joomla.MediaManager.Edit.plugins.crop.cropper
+      .setData({ height: parseInt(currentTarget.value, 10) });
+  });
+  formElements.aspectRatio.addEventListener('change', ({ currentTarget }) => {
+    Joomla.MediaManager.Edit.plugins.crop.cropper
+      .setAspectRatio(currentTarget.value);
+  });
+  activated = true;
+};
 
-Joomla.MediaManager = Joomla.MediaManager || {};
-Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
+const init = (image) => {
+  // Set default aspect ratio after numeric check, option has a dummy value
+  const defaultCropFactor = image.naturalWidth / image.naturalHeight;
+  if (!Number.isNaN(defaultCropFactor) && Number.isFinite(defaultCropFactor)) {
+    formElements.cropAspectRatioOption.value = defaultCropFactor;
+  }
 
-(() => {
-  'use strict';
+  // Initiate the cropper
+  Joomla.MediaManager.Edit.plugins.crop.cropper = new Cropper(image, {
+    viewMode: 2,
+    responsive: true,
+    restore: true,
+    autoCrop: true,
+    movable: false,
+    zoomable: false,
+    rotatable: false,
+    autoCropArea: 1,
+    scalable: false,
+    crop(e) {
+      formElements.cropX.value = Math.round(e.detail.x);
+      formElements.cropY.value = Math.round(e.detail.y);
+      formElements.cropWidth.value = Math.round(e.detail.width);
+      formElements.cropHeight.value = Math.round(e.detail.height);
+      const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
+      const quality = formElements.cropQuality.value;
 
-  const initCrop = () => {
-    const image = document.getElementById('image-preview');
+      // Update the store
+      Joomla.MediaManager.Edit.current.contents = this.cropper.getCroppedCanvas().toDataURL(`image/${format}`, quality);
 
-    // Initiate the cropper
-    Joomla.MediaManager.Edit.crop.cropper = new Cropper(image, {
-      viewMode: 1,
-      responsive: true,
-      restore: true,
-      autoCrop: true,
-      movable: false,
-      zoomable: false,
-      rotatable: false,
-      autoCropArea: 1,
-      // scalable: false,
-      minContainerWidth: image.offsetWidth,
-      minContainerHeight: image.offsetHeight,
-      crop(e) {
-        document.getElementById('jform_crop_x').value = Math.round(e.detail.x);
-        document.getElementById('jform_crop_y').value = Math.round(e.detail.y);
-        document.getElementById('jform_crop_width').value = Math.round(e.detail.width);
-        document.getElementById('jform_crop_height').value = Math.round(e.detail.height);
-
-        const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
-
-        const quality = document.getElementById('jform_crop_quality').value;
-
-        // Update the store
-        Joomla.MediaManager.Edit.current.contents = this.cropper.getCroppedCanvas().toDataURL(`image/${format}`, quality);
-
-        // Notify the app that a change has been made
-        window.dispatchEvent(new Event('mediaManager.history.point'));
-      },
-    });
-
-    document.getElementById('jform_crop_x').addEventListener('change', ({ target }) => {
-      Joomla.MediaManager.Edit.crop.cropper.setData({ x: parseInt(target.value, 10) });
-    });
-    document.getElementById('jform_crop_y').addEventListener('change', ({ target }) => {
-      Joomla.MediaManager.Edit.crop.cropper.setData({ y: parseInt(target.value, 10) });
-    });
-    document.getElementById('jform_crop_width').addEventListener('change', ({ target }) => {
-      Joomla.MediaManager.Edit.crop.cropper.setData({ width: parseInt(target.value, 10) });
-    });
-    document.getElementById('jform_crop_height').addEventListener('change', ({ target }) => {
-      Joomla.MediaManager.Edit.crop.cropper.setData({ height: parseInt(target.value, 10) });
-    });
-    document.getElementById('jform_aspectRatio').addEventListener('change', ({ target }) => {
-      Joomla.MediaManager.Edit.crop.cropper.setAspectRatio(target.value);
-    });
-
-    // Wait for the image to load its data
-    image.addEventListener('load', () => {
-      // Get all option elements if future need
-      const elements = [].slice.call(document.querySelectorAll('.crop-aspect-ratio-option'));
-
-      // Set default aspect ratio after numeric check, option has a dummy value
-      const defaultCropFactor = image.naturalWidth / image.naturalHeight;
-      if (!Number.isNaN(defaultCropFactor) && Number.isFinite(defaultCropFactor)) {
-        elements[0].value = defaultCropFactor;
-      }
-      Joomla.MediaManager.Edit.crop.cropper.setAspectRatio(elements[0].value);
-    });
-  };
-
-  // Register the Events
-  Joomla.MediaManager.Edit.crop = {
-    Activate(mediaData) {
-      // Initialize
-      initCrop(mediaData);
+      // Notify the app that a change has been made
+      window.dispatchEvent(new Event('mediaManager.history.point'));
     },
-    Deactivate() {
-      if (!Joomla.MediaManager.Edit.crop.cropper) {
-        return;
-      }
-      // Destroy the instance
-      Joomla.MediaManager.Edit.crop.cropper.destroy();
+  });
+
+  // Add listeners
+  if (!activated) {
+    addListeners();
+  }
+};
+
+// Register the Events
+window.addEventListener('media-manager-edit-init', () => {
+  formElements = {
+    aspectRatio: document.getElementById('jform_aspectRatio'),
+    cropHeight: document.getElementById('jform_crop_height'),
+    cropWidth: document.getElementById('jform_crop_width'),
+    cropY: document.getElementById('jform_crop_y'),
+    cropX: document.getElementById('jform_crop_x'),
+    cropQuality: document.getElementById('jform_crop_quality'),
+    cropAspectRatioOption: document.querySelector('.crop-aspect-ratio-option'),
+  };
+  Joomla.MediaManager.Edit.plugins.crop = {
+    Activate(image) {
+      return new Promise((resolve /* , reject */) => {
+        init(image);
+        Joomla.MediaManager.Edit.plugins.crop.cropper
+          .setAspectRatio(formElements.cropAspectRatioOption.value);
+        resolve();
+      });
+    },
+    Deactivate(image) {
+      return new Promise((resolve /* , reject */) => {
+        if (image.cropper) {
+          image.cropper.destroy();
+          delete Joomla.MediaManager.Edit.plugins.crop.cropper;
+        }
+        resolve();
+      });
     },
   };
-})();
+}, { once: true });

--- a/build/media_source/plg_media-action_crop/js/crop.es6.js
+++ b/build/media_source/plg_media-action_crop/js/crop.es6.js
@@ -8,6 +8,7 @@ let activated = false;
 
 const addListeners = () => {
   formElements.cropX.addEventListener('change', ({ currentTarget }) => {
+    console.log(currentTarget.value);
     Joomla.MediaManager.Edit.plugins.crop.cropper
       .setData({ x: parseInt(currentTarget.value, 10) });
   });
@@ -40,6 +41,7 @@ const init = (image) => {
   // Initiate the cropper
   Joomla.MediaManager.Edit.plugins.crop.cropper = new Cropper(image, {
     viewMode: 1,
+    responsive: true,
     restore: true,
     autoCrop: true,
     movable: false,
@@ -47,6 +49,8 @@ const init = (image) => {
     rotatable: false,
     autoCropArea: 1,
     // scalable: false,
+    maxContainerWidth: image.width,
+    maxContainerHeight: image.height,
     crop(e) {
       formElements.cropX.value = Math.round(e.detail.x);
       formElements.cropY.value = Math.round(e.detail.y);
@@ -83,7 +87,11 @@ window.addEventListener('media-manager-edit-init', () => {
   Joomla.MediaManager.Edit.plugins.crop = {
     Activate(image) {
       return new Promise((resolve /* , reject */) => {
-        init(image);
+        if (activated) {
+          Joomla.MediaManager.Edit.plugins.crop.cropper.enable();
+        } else {
+          init(image);
+        }
         Joomla.MediaManager.Edit.plugins.crop.cropper
           .setAspectRatio(formElements.cropAspectRatioOption.value);
         resolve();
@@ -92,8 +100,7 @@ window.addEventListener('media-manager-edit-init', () => {
     Deactivate(image) {
       return new Promise((resolve /* , reject */) => {
         if (image.cropper) {
-          image.cropper.destroy();
-          delete Joomla.MediaManager.Edit.plugins.crop.cropper;
+          image.cropper.disable();
         }
         resolve();
       });

--- a/build/media_source/plg_media-action_crop/js/crop.es6.js
+++ b/build/media_source/plg_media-action_crop/js/crop.es6.js
@@ -2,6 +2,7 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
+
 /* global Cropper */
 let formElements;
 let activated = false;

--- a/build/media_source/plg_media-action_crop/js/crop.es6.js
+++ b/build/media_source/plg_media-action_crop/js/crop.es6.js
@@ -2,7 +2,6 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-
 /* global Cropper */
 let formElements;
 let activated = false;

--- a/build/media_source/plg_media-action_crop/js/crop.es6.js
+++ b/build/media_source/plg_media-action_crop/js/crop.es6.js
@@ -8,7 +8,6 @@ let activated = false;
 
 const addListeners = () => {
   formElements.cropX.addEventListener('change', ({ currentTarget }) => {
-    console.log(currentTarget.value);
     Joomla.MediaManager.Edit.plugins.crop.cropper
       .setData({ x: parseInt(currentTarget.value, 10) });
   });

--- a/build/media_source/plg_media-action_resize/js/resize.es6.js
+++ b/build/media_source/plg_media-action_resize/js/resize.es6.js
@@ -2,85 +2,93 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-Joomla = window.Joomla || {};
+let formElements;
+let activated = false;
 
-Joomla.MediaManager = Joomla.MediaManager || {};
-Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
+// Update image
+const resize = (width, height, image) => {
+  // The canvas where we will resize the image
+  let canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  canvas.getContext('2d').drawImage(image, 0, 0, width, height);
 
-(() => {
-  'use strict';
+  // The format
+  const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
 
-  // Update image
-  const resize = (width, height) => {
-    // The image element
-    const image = document.getElementById('image-source');
+  // The quality
+  const quality = formElements.resizeQuality.value;
 
-    // The canvas where we will resize the image
-    const canvas = document.createElement('canvas');
-    canvas.width = width;
-    canvas.height = height;
-    canvas.getContext('2d').drawImage(image, 0, 0, width, height);
+  // Creating the data from the canvas
+  Joomla.MediaManager.Edit.current.contents = canvas.toDataURL(`image/${format}`, quality);
 
-    // The format
-    const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
+  // Updating the preview element
+  image.width = width;
+  image.height = height;
+  image.src = Joomla.MediaManager.Edit.current.contents;
 
-    // The quality
-    const quality = document.getElementById('jform_resize_quality').value;
+  // Update the width input box
+  formElements.resizeWidth.value = parseInt(width, 10);
 
-    // Creating the data from the canvas
-    Joomla.MediaManager.Edit.current.contents = canvas.toDataURL(`image/${format}`, quality);
+  // Update the height input box
+  formElements.resizeHeight.value = parseInt(height, 10);
 
-    // Updating the preview element
-    const preview = document.getElementById('image-preview');
-    preview.width = width;
-    preview.height = height;
-    preview.src = Joomla.MediaManager.Edit.current.contents;
+  // Notify the app that a change has been made
+  window.dispatchEvent(new Event('mediaManager.history.point'));
 
-    // Update the width input box
-    document.getElementById('jform_resize_width').value = parseInt(width, 10);
+  canvas = null;
+};
 
-    // Update the height input box
-    document.getElementById('jform_resize_height').value = parseInt(height, 10);
+const addListeners = (image) => {
+  // The listeners
+  formElements.resizeWidth.addEventListener('change', ({ target }) => {
+    resize(
+      parseInt(target.value, 10),
+      parseInt(target.value, 10) / (image.width / image.height),
+      image,
+    );
+  });
+  formElements.resizeHeight.addEventListener('change', ({ target }) => {
+    resize(
+      parseInt(target.value, 10) * (image.width / image.height),
+      parseInt(target.value, 10),
+      image,
+    );
+  });
+};
 
-    // Notify the app that a change has been made
-    window.dispatchEvent(new Event('mediaManager.history.point'));
-  };
+const initResize = (image) => {
+  // Update the input boxes
+  formElements.resizeWidth.value = image.width;
+  formElements.resizeHeight.value = image.height;
 
-  const initResize = () => {
-    const funct = () => {
-      const image = document.getElementById('image-source');
+  if (!activated) {
+    activated = true;
+    addListeners(image);
+  }
+};
 
-      const resizeWidthInputBox = document.getElementById('jform_resize_width');
-      const resizeHeightInputBox = document.getElementById('jform_resize_height');
-
-      // Update the input boxes
-      resizeWidthInputBox.value = image.width;
-      resizeHeightInputBox.value = image.height;
-
-      // The listeners
-      resizeWidthInputBox.addEventListener('change', ({ target }) => {
-        resize(
-          parseInt(target.value, 10),
-          parseInt(target.value, 10) / (image.width / image.height),
-        );
-      });
-      resizeHeightInputBox.addEventListener('change', ({ target }) => {
-        resize(
-          parseInt(target.value, 10) * (image.width / image.height),
-          parseInt(target.value, 10),
-        );
-      });
-    };
-    setTimeout(funct, 1000);
+window.addEventListener('media-manager-edit-init', () => {
+  // Get the form elements
+  formElements = {
+    resizeWidth: document.getElementById('jform_resize_width'),
+    resizeHeight: document.getElementById('jform_resize_height'),
+    resizeQuality: document.getElementById('jform_resize_quality'),
   };
 
   // Register the Events
-  Joomla.MediaManager.Edit.resize = {
-    Activate(mediaData) {
-      // Initialize
-      initResize(mediaData);
+  Joomla.MediaManager.Edit.plugins.resize = {
+    Activate(image) {
+      return new Promise((resolve /* , reject */) => {
+        // Initialize
+        initResize(image);
+        resolve();
+      });
     },
-    Deactivate() {
+    Deactivate(/* image */) {
+      return new Promise((resolve /* , reject */) => {
+        resolve();
+      });
     },
   };
-})();
+}, { once: true });

--- a/build/media_source/plg_media-action_resize/js/resize.es6.js
+++ b/build/media_source/plg_media-action_resize/js/resize.es6.js
@@ -59,8 +59,8 @@ const addListeners = (image) => {
 
 const initResize = (image) => {
   // Update the input boxes
-  formElements.resizeWidth.value = image.width;
-  formElements.resizeHeight.value = image.height;
+  formElements.resizeWidth.value = image.naturalWidth;
+  formElements.resizeHeight.value = image.naturalHeight;
 
   if (!activated) {
     activated = true;

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -75,7 +75,6 @@ const initRotate = (image) => {
         element.addEventListener('click', ({ target }) => {
           rotate(parseInt(target.value, 10));
 
-          target.value = 0;
           // Deselect all buttons
           [].slice.call(document.querySelectorAll('#jform_rotate_distinct label'))
             .forEach((element) => {

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -13,47 +13,52 @@ const rotate = (angle, image) => {
   if ((angle >= 0 && angle < 45)
     || (angle >= 135 && angle < 225)
     || (angle >= 315 && angle <= 360)) {
-    canvas.width = image.naturalWidth;
-    canvas.height = image.naturalWidth;
+    canvas.width = image.width;
+    canvas.height = image.height;
   } else {
     // swap
-    canvas.width = image.naturalWidth;
-    canvas.height = image.naturalWidth;
+    canvas.width = image.height;
+    canvas.height = image.width;
   }
 
   const ctx = canvas.getContext('2d');
   ctx.translate(canvas.width / 2, canvas.height / 2);
   ctx.rotate((angle * Math.PI) / 180);
-  ctx.drawImage(image, -image.width / 2, -image.height / 2);
+  const img = new Image();
+  img.src = image.src;
+  img.onload = () => {
+    ctx.drawImage(image, -image.width / 2, -image.height / 2);
 
-  // The format
-  const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : 'jpg';
+    // The format
+    const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : 'jpg';
 
-  // The quality
-  const quality = document.getElementById('jform_rotate_quality').value;
+    // The quality
+    const quality = document.getElementById('jform_rotate_quality').value;
 
-  // Creating the data from the canvas
-  Joomla.MediaManager.Edit.current.contents = canvas.toDataURL(`image/${format}`, quality);
+    // Creating the data from the canvas
+    Joomla.MediaManager.Edit.current.contents = canvas.toDataURL(`image/${format}`, quality);
 
-  // Updating the preview element
-  image.width = canvas.width;
-  image.height = canvas.height;
-  image.src = Joomla.MediaManager.Edit.current.contents;
+    // Updating the preview element
+    image.width = canvas.width;
+    image.height = canvas.height;
+    image.src = Joomla.MediaManager.Edit.current.contents;
 
-  // Update the height input box
-  document.getElementById('jform_rotate_a').value = angle;
+    // Update the height input box
+    document.getElementById('jform_rotate_a').value = angle;
 
-  // Notify the app that a change has been made
-  window.dispatchEvent(new Event('mediaManager.history.point'));
-  canvas = null;
+    // Notify the app that a change has been made
+    window.dispatchEvent(new Event('mediaManager.history.point'));
+    canvas = null;
+  }
 };
 
 const initRotate = (image) => {
   if (!activated) {
     // The number input listener
-    document.getElementById('jform_rotate_a').addEventListener('input', ({ target }) => {
+    document.getElementById('jform_rotate_a').addEventListener('change', ({ target }) => {
       rotate(parseInt(target.value, 10), image);
 
+      target.value = 0;
       // Deselect all buttons
       const elements = [].slice.call(document.querySelectorAll('#jform_rotate_distinct label'));
       elements.forEach((element) => {

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -6,7 +6,7 @@ let activated = false;
 
 // Update image
 const rotate = (angle, image) => {
-  // The canvas where we will resize the image
+  // The canvas where we will rotate the image
   let canvas = document.createElement('canvas');
 
   // Pseudo rectangle calculation

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -43,7 +43,7 @@ const rotate = (angle, image) => {
   requestAnimationFrame(
     () => requestAnimationFrame(() => {
       image.src = Joomla.MediaManager.Edit.current.contents;
-    })
+    }),
   );
 
   // Update the angle input box

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -2,95 +2,93 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-Joomla = window.Joomla || {};
+const activated = false;
 
-Joomla.MediaManager = Joomla.MediaManager || {};
-Joomla.MediaManager.Edit = Joomla.MediaManager.Edit || {};
+// Update image
+const rotate = (angle, image) => {
+  // The canvas where we will resize the image
+  let canvas = document.createElement('canvas');
 
-(() => {
-  'use strict';
+  // Pseudo rectangle calculation
+  if ((angle >= 0 && angle < 45)
+    || (angle >= 135 && angle < 225)
+    || (angle >= 315 && angle <= 360)) {
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalWidth;
+  } else {
+    // swap
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalWidth;
+  }
 
-  // Update image
-  const rotate = (angle) => {
-    // The image element
-    const image = document.getElementById('image-source');
+  const ctx = canvas.getContext('2d');
+  ctx.translate(canvas.width / 2, canvas.height / 2);
+  ctx.rotate((angle * Math.PI) / 180);
+  ctx.drawImage(image, -image.width / 2, -image.height / 2);
 
-    // The canvas where we will resize the image
-    const canvas = document.createElement('canvas');
+  // The format
+  const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : 'jpg';
 
-    // Pseudo rectangle calculation
-    if ((angle >= 0 && angle < 45)
-      || (angle >= 135 && angle < 225)
-      || (angle >= 315 && angle <= 360)) {
-      canvas.width = image.width;
-      canvas.height = image.height;
-    } else {
-      // swap
-      canvas.width = image.height;
-      canvas.height = image.width;
-    }
-    const ctx = canvas.getContext('2d');
-    ctx.translate(canvas.width / 2, canvas.height / 2);
-    ctx.rotate((angle * Math.PI) / 180);
-    ctx.drawImage(image, -image.width / 2, -image.height / 2);
+  // The quality
+  const quality = document.getElementById('jform_rotate_quality').value;
 
-    // The format
-    const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : 'jpg';
+  // Creating the data from the canvas
+  Joomla.MediaManager.Edit.current.contents = canvas.toDataURL(`image/${format}`, quality);
 
-    // The quality
-    const quality = document.getElementById('jform_rotate_quality').value;
+  // Updating the preview element
+  image.width = canvas.width;
+  image.height = canvas.height;
+  image.src = Joomla.MediaManager.Edit.current.contents;
 
-    // Creating the data from the canvas
-    Joomla.MediaManager.Edit.current.contents = canvas.toDataURL(`image/${format}`, quality);
+  // Update the height input box
+  document.getElementById('jform_rotate_a').value = angle;
 
-    // Updating the preview element
-    const preview = document.getElementById('image-preview');
-    preview.width = canvas.width;
-    preview.height = canvas.height;
-    preview.src = Joomla.MediaManager.Edit.current.contents;
+  // Notify the app that a change has been made
+  window.dispatchEvent(new Event('mediaManager.history.point'));
+  canvas = null;
+};
 
-    // Update the height input box
-    document.getElementById('jform_rotate_a').value = angle;
+const initRotate = (image) => {
+  if (!activated) {
+    // The number input listener
+    document.getElementById('jform_rotate_a').addEventListener('input', ({ target }) => {
+      rotate(parseInt(target.value, 10), image);
 
-    // Notify the app that a change has been made
-    window.dispatchEvent(new Event('mediaManager.history.point'));
-  };
-
-  const initRotate = () => {
-    const funct = () => {
-      // The number input listener
-      document.getElementById('jform_rotate_a').addEventListener('input', ({ target }) => {
-        rotate(parseInt(target.value, 10));
-
-        // Deselect all buttons
-        const elements = [].slice.call(document.querySelectorAll('#jform_rotate_distinct label'));
-        elements.forEach((element) => {
-          element.classList.remove('active');
-          element.classList.remove('focus');
-        });
-      });
-
-      // The 90 degree rotate buttons listeners
+      // Deselect all buttons
       const elements = [].slice.call(document.querySelectorAll('#jform_rotate_distinct label'));
       elements.forEach((element) => {
-        element.addEventListener('click', ({ target }) => {
-          const inputElement = document.querySelector(`#${target.getAttribute('for')}`);
-          if (inputElement) {
-            rotate(parseInt(inputElement.value, 10));
-          }
-        });
+        element.classList.remove('active');
+        element.classList.remove('focus');
       });
-    };
-    setTimeout(funct, 1000);
-  };
+    });
 
+    // The 90 degree rotate buttons listeners
+    const elements = [].slice.call(document.querySelectorAll('#jform_rotate_distinct label'));
+    elements.forEach((element) => {
+      element.addEventListener('click', ({ target }) => {
+        const inputElement = document.querySelector(`#${target.getAttribute('for')}`);
+        if (inputElement) {
+          rotate(parseInt(inputElement.value, 10), image);
+        }
+      });
+    });
+  }
+};
+
+window.addEventListener('media-manager-edit-init', () => {
   // Register the Events
-  Joomla.MediaManager.Edit.rotate = {
-    Activate(mediaData) {
-      // Initialize
-      initRotate(mediaData);
+  Joomla.MediaManager.Edit.plugins.rotate = {
+    Activate(image) {
+      return new Promise((resolve) => {
+        // Initialize
+        initRotate(image);
+        resolve();
+      });
     },
-    Deactivate() {
+    Deactivate(/* image */) {
+      return new Promise((resolve) => {
+        resolve();
+      });
     },
   };
-})();
+}, { once: true });

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -6,7 +6,7 @@ const activated = false;
 
 // Update image
 const rotate = (angle, image) => {
-  // The canvas where we will resize the image
+  // The canvas where we will rotate the image
   let canvas = document.createElement('canvas');
 
   // Pseudo rectangle calculation

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -49,7 +49,7 @@ const rotate = (angle, image) => {
     // Notify the app that a change has been made
     window.dispatchEvent(new Event('mediaManager.history.point'));
     canvas = null;
-  }
+  };
 };
 
 const initRotate = (image) => {

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -39,7 +39,12 @@ const rotate = (angle, image) => {
   // Updating the preview element
   image.width = canvas.width;
   image.height = canvas.height;
-  image.src = Joomla.MediaManager.Edit.current.contents;
+  image.src = '';
+  requestAnimationFrame(
+    () => requestAnimationFrame(() => {
+      image.src = Joomla.MediaManager.Edit.current.contents;
+    })
+  );
 
   // Update the angle input box
   document.getElementById('jform_rotate_a').value = angle;

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -2,12 +2,11 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-const activated = false;
+let activated = false;
 
 // Update image
-const rotate = (angle) => {
+const rotate = (angle, image) => {
   // The canvas where we will resize the image
-  const image = document.getElementById('image-preview');
   let canvas = document.createElement('canvas');
 
   // Pseudo rectangle calculation
@@ -24,13 +23,9 @@ const rotate = (angle) => {
 
   const ctx = canvas.getContext('2d');
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  ctx.save();
   ctx.translate(canvas.width / 2, canvas.height / 2);
-  ctx.rotate(angle * Math.PI / 180);
-  const img = new Image();
-  img.src = image.src;
-  ctx.drawImage(img, -image.naturalWidth / 2, -image.naturalHeight / 2);
-  ctx.restore();
+  ctx.rotate((angle * Math.PI) / 180);
+  ctx.drawImage(image, -image.naturalWidth / 2, -image.naturalHeight / 2);
 
   // The format
   const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : 'jpg';
@@ -58,7 +53,7 @@ const initRotate = (image) => {
   if (!activated) {
     // The number input listener
     document.getElementById('jform_rotate_a').addEventListener('change', ({ target }) => {
-      rotate(parseInt(target.value, 10));
+      rotate(parseInt(target.value, 10), image);
 
       target.value = 0;
       // Deselect all buttons
@@ -71,18 +66,20 @@ const initRotate = (image) => {
 
     // The 90 degree rotate buttons listeners
     [].slice.call(document.querySelectorAll('#jform_rotate_distinct [type=radio]'))
-      .map((element) => {
+      .forEach((element) => {
         element.addEventListener('click', ({ target }) => {
-          rotate(parseInt(target.value, 10));
+          rotate(parseInt(target.value, 10), image);
 
           // Deselect all buttons
           [].slice.call(document.querySelectorAll('#jform_rotate_distinct label'))
-            .forEach((element) => {
-              element.classList.remove('active');
-              element.classList.remove('focus');
+            .forEach((el) => {
+              el.classList.remove('active');
+              el.classList.remove('focus');
             });
         });
       });
+
+    activated = true;
   }
 };
 

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -5,78 +5,85 @@
 const activated = false;
 
 // Update image
-const rotate = (angle, image) => {
-  // The canvas where we will rotate the image
+const rotate = (angle) => {
+  // The canvas where we will resize the image
+  const image = document.getElementById('image-preview');
   let canvas = document.createElement('canvas');
 
   // Pseudo rectangle calculation
   if ((angle >= 0 && angle < 45)
     || (angle >= 135 && angle < 225)
     || (angle >= 315 && angle <= 360)) {
-    canvas.width = image.width;
-    canvas.height = image.height;
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
   } else {
     // swap
-    canvas.width = image.height;
-    canvas.height = image.width;
+    canvas.width = image.naturalHeight;
+    canvas.height = image.naturalWidth;
   }
 
   const ctx = canvas.getContext('2d');
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.save();
   ctx.translate(canvas.width / 2, canvas.height / 2);
-  ctx.rotate((angle * Math.PI) / 180);
+  ctx.rotate(angle * Math.PI / 180);
   const img = new Image();
   img.src = image.src;
-  img.onload = () => {
-    ctx.drawImage(image, -image.width / 2, -image.height / 2);
+  ctx.drawImage(img, -image.naturalWidth / 2, -image.naturalHeight / 2);
+  ctx.restore();
 
-    // The format
-    const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : 'jpg';
+  // The format
+  const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : 'jpg';
 
-    // The quality
-    const quality = document.getElementById('jform_rotate_quality').value;
+  // The quality
+  const quality = document.getElementById('jform_rotate_quality').value;
 
-    // Creating the data from the canvas
-    Joomla.MediaManager.Edit.current.contents = canvas.toDataURL(`image/${format}`, quality);
+  // Creating the data from the canvas
+  Joomla.MediaManager.Edit.current.contents = canvas.toDataURL(`image/${format}`, quality);
 
-    // Updating the preview element
-    image.width = canvas.width;
-    image.height = canvas.height;
-    image.src = Joomla.MediaManager.Edit.current.contents;
+  // Updating the preview element
+  image.width = canvas.width;
+  image.height = canvas.height;
+  image.src = Joomla.MediaManager.Edit.current.contents;
 
-    // Update the height input box
-    document.getElementById('jform_rotate_a').value = angle;
+  // Update the angle input box
+  document.getElementById('jform_rotate_a').value = angle;
 
-    // Notify the app that a change has been made
-    window.dispatchEvent(new Event('mediaManager.history.point'));
-    canvas = null;
-  };
+  // Notify the app that a change has been made
+  window.dispatchEvent(new Event('mediaManager.history.point'));
+  canvas = null;
 };
 
 const initRotate = (image) => {
   if (!activated) {
     // The number input listener
     document.getElementById('jform_rotate_a').addEventListener('change', ({ target }) => {
-      rotate(parseInt(target.value, 10), image);
+      rotate(parseInt(target.value, 10));
 
       target.value = 0;
       // Deselect all buttons
-      const elements = [].slice.call(document.querySelectorAll('#jform_rotate_distinct label'));
-      elements.forEach((element) => {
-        element.classList.remove('active');
-        element.classList.remove('focus');
-      });
+      [].slice.call(document.querySelectorAll('#jform_rotate_distinct label'))
+        .forEach((element) => {
+          element.classList.remove('active');
+          element.classList.remove('focus');
+        });
     });
 
     // The 90 degree rotate buttons listeners
-    const elements = [].slice.call(document.querySelectorAll('#jform_rotate_distinct label'));
-    elements.forEach((element) => {
-      element.addEventListener('click', ({ target }) => {
-        const inputElement = document.querySelector(`#${target.getAttribute('for')}`);
-        if (inputElement) {
-          rotate(parseInt(inputElement.value, 10), image);
-        }
+    [].slice.call(document.querySelectorAll('#jform_rotate_distinct [type=radio]'))
+      .map((element) => {
+        element.addEventListener('click', ({ target }) => {
+          rotate(parseInt(target.value, 10));
+
+          target.value = 0;
+          // Deselect all buttons
+          [].slice.call(document.querySelectorAll('#jform_rotate_distinct label'))
+            .forEach((element) => {
+              element.classList.remove('active');
+              element.classList.remove('focus');
+            });
+        });
       });
-    });
   }
 };
 


### PR DESCRIPTION
Pull Request is the second part for  the Tabs reworked code: https://github.com/joomla/joomla-cms/pull/34813

### Summary of Changes
Some changes to the API:
- Now it's async (used to be synchronous, but that won't work for many cases, current libraries, etc)
- Fixing all the problems with:
- - Empty fields on load
- - Save needed a click away to update the image
- - other inconsistencies


### Testing Instructions
#### This PR is not testable with the downladable version

Apply this PR!!!
You need to run `npm install`

Try to edit some images and using all the existing options

### Actual result BEFORE applying this Pull Request

Many bugs

### Expected result AFTER applying this Pull Request

No (obvious) bugs

### Documentation Changes Required

The old registration was something like:
```js
  // Register the Events
  Joomla.MediaManager.Edit.crop = {
    Activate(mediaData) {
      // Initialize
      initCrop(mediaData);
    },
    Deactivate() {
      if (!Joomla.MediaManager.Edit.crop.cropper) {
        return;
      }
      // Destroy the instance
      Joomla.MediaManager.Edit.crop.cropper.destroy();
    },
  };
```

Which is changed to:

```js
// Register the Events
window.addEventListener('media-manager-edit-init', () => {
  Joomla.MediaManager.Edit.plugins.crop = {
    Activate(image) {
      return new Promise((resolve /* , reject */) => {
        init(image);
        Joomla.MediaManager.Edit.plugins.crop.cropper
          .setAspectRatio(formElements.cropAspectRatioOption.value);
        resolve();
      });
    },
    Deactivate(image) {
      return new Promise((resolve /* , reject */) => {
        if (image.cropper) {
          image.cropper.destroy();
          delete Joomla.MediaManager.Edit.plugins.crop.cropper;
        }
        resolve();
      });
    },
  };
}, { once: true });

```

So most of the changes are just changes in the initialization step:
- there's an event for the registration, on the window, named 'media-manager-edit-init'
- The plugin name is now one level deeper, from `Joomla.MediaManager.Edit.crop` to `Joomla.MediaManager.Edit.plugins.crop`
- Both the `Activate` and `Deactivate` functions should return a promise.

@wilsonge sorry...