### PR TITLE
[4.0] Codemirror update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2755,9 +2755,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.0.tgz",
-      "integrity": "sha512-Xnl3304iCc8nyVZuRkzDVVwc794uc9QNX0UcPGeNic1fbzkSrO4l4GVXho9tRNKBgPYZXgocUqXyfIv3BILhCQ=="
+      "version": "5.62.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.2.tgz",
+      "integrity": "sha512-tVFMUa4J3Q8JUd1KL9yQzQB0/BJt7ZYZujZmTPgo/54Lpuq3ez4C8x/ATUY/wv7b7X3AUq8o3Xd+2C5ZrCGWHw=="
     },
     "node_modules/color": {
       "version": "3.1.3",
@@ -12116,9 +12116,9 @@
       }
     },
     "codemirror": {
-      "version": "5.62.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.0.tgz",
-      "integrity": "sha512-Xnl3304iCc8nyVZuRkzDVVwc794uc9QNX0UcPGeNic1fbzkSrO4l4GVXho9tRNKBgPYZXgocUqXyfIv3BILhCQ=="
+      "version": "5.62.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.2.tgz",
+      "integrity": "sha512-tVFMUa4J3Q8JUd1KL9yQzQB0/BJt7ZYZujZmTPgo/54Lpuq3ez4C8x/ATUY/wv7b7X3AUq8o3Xd+2C5ZrCGWHw=="
     },
     "color": {
       "version": "3.1.3",

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_codemirror</name>
-	<version>5.62.0</version>
+	<version>5.62.2</version>
 	<creationDate>28 March 2011</creationDate>
 	<author>Marijn Haverbeke</author>
 	<authorEmail>marijnh@gmail.com</authorEmail>


### PR DESCRIPTION
21-07-2021: Version 5.62.2:

- lint addon: Fix a regression that broke several addon options.

20-07-2021: Version 5.62.1:

- vim bindings: Make matching of upper-case characters more Unicode-aware.
- lint addon: Prevent options passed to the addon itself from being given to the linter.
- show-hint addon: Improve screen reader support.
- search addon: Avoid using innerHTML.
