### PR TITLE
[4.0] Use preload instead of prefetch alternative

### DIFF
--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -29,22 +29,25 @@ $wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $para
 $paramsFontScheme = $this->params->get('useFontScheme', false);
 $fontStyles       = '';
 
-if ($paramsFontScheme) {
-	if (preg_match('/^https\:\/\//i', $paramsFontScheme)) {
+if ($paramsFontScheme)
+{
+	if (stripos($paramsFontScheme, 'https://') === 0)
+	{
 		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', []);
 		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', []);
 		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style']);
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
-		preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches);
 
-		if (count($matches) > 0)
+		if (preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches) > 0)
 		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . (count($matches[1]) === 2 ? str_replace('+', ' ', $matches[1][1]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . str_replace('+', ' ', isset($matches[1][1]) ? $matches[1][1] : $matches[1][0]) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
 		}
-	} else {
+	}
+	else
+	{
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, ['version' => 'auto'], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 		$this->getPreloadManager()->preload($wa->getAsset('style', 'fontscheme.current')->getUri() . '?' . $this->getMediaVersion(), ['as' => 'style']);
 	}

--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -12,7 +12,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 
-/** @var JDocumentHtml $this */
+/** @var Joomla\CMS\Document\HtmlDocument $this */
 
 $app = Factory::getApplication();
 $wa  = $this->getWebAssetManager();

--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -39,14 +39,13 @@ if ($paramsFontScheme) {
 
 		if (count($matches) > 0) {
 			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;';
+			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;
+			--cassiopeia-font-weight-normal: 400;
+			--cassiopeia-font-weight-headings: 700;';
 		}
 	} else {
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, ['version' => 'auto'], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 		$this->getPreloadManager()->preload($wa->getAsset('style', 'fontscheme.current')->getUri() . '?' . $this->getMediaVersion(), ['as' => 'style']);
-
-		$fontStyles = '--cassiopeia-font-family-body: "Roboto", sans-serif;
-			--cassiopeia-font-family-headings: "Roboto", sans-serif;';
 	}
 }
 
@@ -63,8 +62,6 @@ $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'l
 		--template-link-color: #2a69b8;
 		--template-special-color: #001B4C;
 		$fontStyles
-		--cassiopeia-font-weight-normal: 400;
-		--cassiopeia-font-weight-headings: 700;
 	}");
 
 

--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -39,7 +39,7 @@ if ($paramsFontScheme) {
 
 		if (count($matches) > 0)
 		{
-			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
+			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
 			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';

--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -37,9 +37,10 @@ if ($paramsFontScheme) {
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 		preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches);
 
-		if (count($matches) > 0) {
+		if (count($matches) > 0)
+		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
 		}

--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -40,7 +40,7 @@ if ($paramsFontScheme) {
 		if (count($matches) > 0)
 		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . (count($matches[1]) === 2 ? str_replace('+', ' ', $matches[1][1]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
 		}

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -41,22 +41,25 @@ $wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $para
 $paramsFontScheme = $this->params->get('useFontScheme', false);
 $fontStyles       = '';
 
-if ($paramsFontScheme) {
-	if (preg_match('/^https\:\/\//i', $paramsFontScheme)) {
+if ($paramsFontScheme)
+{
+	if (stripos($paramsFontScheme, 'https://') === 0)
+	{
 		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', []);
 		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', []);
 		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style']);
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
-		preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches);
 
-		if (count($matches) > 0)
+		if (preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches) > 0)
 		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . (count($matches[1]) === 2 ? str_replace('+', ' ', $matches[1][1]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . str_replace('+', ' ', isset($matches[1][1]) ? $matches[1][1] : $matches[1][0]) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
 		}
-	} else {
+	}
+	else
+	{
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, ['version' => 'auto'], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 		$this->getPreloadManager()->preload($wa->getAsset('style', 'fontscheme.current')->getUri() . '?' . $this->getMediaVersion(), ['as' => 'style']);
 	}

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -49,9 +49,10 @@ if ($paramsFontScheme) {
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 		preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches);
 
-		if (count($matches) > 0) {
+		if (count($matches) > 0)
+		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
 		}

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -52,7 +52,7 @@ if ($paramsFontScheme) {
 		if (count($matches) > 0)
 		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . (count($matches[1]) === 2 ? str_replace('+', ' ', $matches[1][1]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
 		}

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -51,14 +51,13 @@ if ($paramsFontScheme) {
 
 		if (count($matches) > 0) {
 			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;';
+			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;
+			--cassiopeia-font-weight-normal: 400;
+			--cassiopeia-font-weight-headings: 700;';
 		}
 	} else {
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, ['version' => 'auto'], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 		$this->getPreloadManager()->preload($wa->getAsset('style', 'fontscheme.current')->getUri() . '?' . $this->getMediaVersion(), ['as' => 'style']);
-
-		$fontStyles = '--cassiopeia-font-family-body: "Roboto", sans-serif;
-			--cassiopeia-font-family-headings: "Roboto", sans-serif;';
 	}
 }
 
@@ -75,8 +74,6 @@ $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'l
 		--template-link-color: #2a69b8;
 		--template-special-color: #001B4C;
 		$fontStyles
-		--cassiopeia-font-weight-normal: 400;
-		--cassiopeia-font-weight-headings: 700;
 	}");
 
 // Override 'template.active' asset to set correct ltr/rtl dependency

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -51,7 +51,7 @@ if ($paramsFontScheme) {
 
 		if (count($matches) > 0)
 		{
-			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
+			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
 			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -36,17 +36,30 @@ $templatePath = 'templates/' . $this->template;
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
 $wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $paramsColorName . '.css');
-$this->getPreloadManager()->prefetch($wa->getAsset('style', $assetColorName)->getUri(), ['as' => 'style']);
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);
+$fontStyles       = '';
 
-if ($paramsFontScheme)
-{
-	// Prefetch the stylesheet for the font scheme, actually we need to prefetch the font(s)
-	$assetFontScheme  = 'fontscheme.' . $paramsFontScheme;
-	$wa->registerAndUseStyle($assetFontScheme, $templatePath . '/css/global/' . $paramsFontScheme . '.css');
-	$this->getPreloadManager()->prefetch($wa->getAsset('style', $assetFontScheme)->getUri(), ['as' => 'style']);
+if ($paramsFontScheme) {
+	if (preg_match('/^https\:\/\//i', $paramsFontScheme)) {
+		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', []);
+		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', []);
+		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style']);
+		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
+		preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches);
+
+		if (count($matches) > 0) {
+			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;';
+		}
+	} else {
+		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, ['version' => 'auto'], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
+		$this->getPreloadManager()->preload($wa->getAsset('style', 'fontscheme.current')->getUri() . '?' . $this->getMediaVersion(), ['as' => 'style']);
+
+		$fontStyles = '--cassiopeia-font-family-body: "Roboto", sans-serif;
+			--cassiopeia-font-family-headings: "Roboto", sans-serif;';
+	}
 }
 
 // Enable assets
@@ -54,14 +67,17 @@ $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'l
 	->useStyle('template.active.language')
 	->useStyle('template.user')
 	->useScript('template.user')
-	->addInlineStyle(':root {
+	->addInlineStyle(":root {
 		--hue: 214;
 		--template-bg-light: #f0f4fb;
 		--template-text-dark: #495057;
 		--template-text-light: #ffffff;
 		--template-link-color: #2a69b8;
 		--template-special-color: #001B4C;
-	}');
+		$fontStyles
+		--cassiopeia-font-weight-normal: 400;
+		--cassiopeia-font-weight-headings: 700;
+	}");
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
 $wa->registerStyle('template.active', '', [], [], ['template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -48,18 +48,17 @@ $fontStyles       = '';
 
 if ($paramsFontScheme)
 {
-	if (preg_match('/^https\:\/\//i', $paramsFontScheme))
+	if (stripos($paramsFontScheme, 'https://') === 0)
 	{
 		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', []);
 		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', []);
 		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style']);
-		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print','rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
-		preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches);
+		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 
-		if (count($matches) > 0)
+		if (preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches) > 0)
 		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . (count($matches[1]) === 2 ? str_replace('+', ' ', $matches[1][1]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . str_replace('+', ' ', isset($matches[1][1]) ? $matches[1][1] : $matches[1][0]) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
 		}
@@ -77,14 +76,14 @@ $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'l
 	->useStyle('template.user')
 	->useScript('template.user')
 	->addInlineStyle(":root {
-			--hue: 214;
-			--template-bg-light: #f0f4fb;
-			--template-text-dark: #495057;
-			--template-text-light: #ffffff;
-			--template-link-color: #2a69b8;
-			--template-special-color: #001B4C;
-			$fontStyles
-		}");
+		--hue: 214;
+		--template-bg-light: #f0f4fb;
+		--template-text-dark: #495057;
+		--template-text-light: #ffffff;
+		--template-link-color: #2a69b8;
+		--template-special-color: #001B4C;
+		$fontStyles
+	}");
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
 $wa->registerStyle('template.active', '', [], [], ['template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -59,7 +59,7 @@ if ($paramsFontScheme)
 		if (count($matches) > 0)
 		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
 		}

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -59,7 +59,7 @@ if ($paramsFontScheme)
 		if (count($matches) > 0)
 		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . (count($matches[1]) === 2 ? str_replace('+', ' ', $matches[1][1]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
 		}

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -59,16 +59,15 @@ if ($paramsFontScheme)
 		if (count($matches) > 0)
 		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;';
+			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;
+			--cassiopeia-font-weight-normal: 400;
+			--cassiopeia-font-weight-headings: 700;';
 		}
 	}
 	else
 	{
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, ['version' => 'auto'], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 		$this->getPreloadManager()->preload($wa->getAsset('style', 'fontscheme.current')->getUri() . '?' . $this->getMediaVersion(), ['as' => 'style']);
-
-		$fontStyles = '--cassiopeia-font-family-body: "Roboto", sans-serif;
-			--cassiopeia-font-family-headings: "Roboto", sans-serif;';
 	}
 }
 
@@ -85,8 +84,6 @@ $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'l
 			--template-link-color: #2a69b8;
 			--template-special-color: #001B4C;
 			$fontStyles
-			--cassiopeia-font-weight-normal: 400;
-			--cassiopeia-font-weight-headings: 700;
 		}");
 
 // Override 'template.active' asset to set correct ltr/rtl dependency

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -58,7 +58,7 @@ if ($paramsFontScheme)
 
 		if (count($matches) > 0)
 		{
-			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
+			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
 			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -74,20 +74,20 @@ if ($paramsFontScheme)
 
 // Enable assets
 $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
-->useStyle('template.active.language')
-->useStyle('template.user')
-->useScript('template.user')
-->addInlineStyle(":root {
-		--hue: 214;
-		--template-bg-light: #f0f4fb;
-		--template-text-dark: #495057;
-		--template-text-light: #ffffff;
-		--template-link-color: #2a69b8;
-		--template-special-color: #001B4C;
-		$fontStyles
-		--cassiopeia-font-weight-normal: 400;
-		--cassiopeia-font-weight-headings: 700;
-	}");
+	->useStyle('template.active.language')
+	->useStyle('template.user')
+	->useScript('template.user')
+	->addInlineStyle(":root {
+			--hue: 214;
+			--template-bg-light: #f0f4fb;
+			--template-text-dark: #495057;
+			--template-text-light: #ffffff;
+			--template-link-color: #2a69b8;
+			--template-special-color: #001B4C;
+			$fontStyles
+			--cassiopeia-font-weight-normal: 400;
+			--cassiopeia-font-weight-headings: 700;
+		}");
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
 $wa->registerStyle('template.active', '', [], [], ['template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -41,32 +41,53 @@ $templatePath = 'templates/' . $this->template;
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
 $wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $paramsColorName . '.css');
-$this->getPreloadManager()->prefetch($wa->getAsset('style', $assetColorName)->getUri(), ['as' => 'style']);
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);
+$fontStyles       = '';
 
 if ($paramsFontScheme)
 {
-	// Prefetch the stylesheet for the font scheme, actually we need to prefetch the font(s)
-	$assetFontScheme  = 'fontscheme.' . $paramsFontScheme;
-	$wa->registerAndUseStyle($assetFontScheme, $templatePath . '/css/global/' . $paramsFontScheme . '.css');
-	$this->getPreloadManager()->prefetch($wa->getAsset('style', $assetFontScheme)->getUri(), ['as' => 'style']);
+	if (preg_match('/^https\:\/\//i', $paramsFontScheme))
+	{
+		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', []);
+		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', []);
+		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style']);
+		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print','rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
+		preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches);
+
+		if (count($matches) > 0)
+		{
+			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;';
+		}
+	}
+	else
+	{
+		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, ['version' => 'auto'], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
+		$this->getPreloadManager()->preload($wa->getAsset('style', 'fontscheme.current')->getUri() . '?' . $this->getMediaVersion(), ['as' => 'style']);
+
+		$fontStyles = '--cassiopeia-font-family-body: "Roboto", sans-serif;
+			--cassiopeia-font-family-headings: "Roboto", sans-serif;';
+	}
 }
 
 // Enable assets
 $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
-	->useStyle('template.active.language')
-	->useStyle('template.user')
-	->useScript('template.user')
-	->addInlineStyle(':root {
+->useStyle('template.active.language')
+->useStyle('template.user')
+->useScript('template.user')
+->addInlineStyle(":root {
 		--hue: 214;
 		--template-bg-light: #f0f4fb;
 		--template-text-dark: #495057;
 		--template-text-light: #ffffff;
 		--template-link-color: #2a69b8;
 		--template-special-color: #001B4C;
-	}');
+		$fontStyles
+		--cassiopeia-font-weight-normal: 400;
+		--cassiopeia-font-weight-headings: 700;
+	}");
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
 $wa->registerStyle('template.active', '', [], [], ['template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -10,8 +10,8 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Helper\AuthenticationHelper;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Helper\AuthenticationHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
@@ -37,22 +37,25 @@ $wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $para
 $paramsFontScheme = $this->params->get('useFontScheme', false);
 $fontStyles       = '';
 
-if ($paramsFontScheme) {
-	if (preg_match('/^https\:\/\//i', $paramsFontScheme)) {
+if ($paramsFontScheme)
+{
+	if (stripos($paramsFontScheme, 'https://') === 0)
+	{
 		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', []);
 		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', []);
 		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style']);
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
-		preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches);
 
-		if (count($matches) > 0)
+		if (preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches) > 0)
 		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . (count($matches[1]) === 2 ? str_replace('+', ' ', $matches[1][1]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . str_replace('+', ' ', isset($matches[1][1]) ? $matches[1][1] : $matches[1][0]) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
 		}
-	} else {
+	}
+	else
+	{
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, ['version' => 'auto'], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 		$this->getPreloadManager()->preload($wa->getAsset('style', 'fontscheme.current')->getUri() . '?' . $this->getMediaVersion(), ['as' => 'style']);
 	}

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -48,7 +48,7 @@ if ($paramsFontScheme) {
 		if (count($matches) > 0)
 		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . (count($matches[1]) === 2 ? str_replace('+', ' ', $matches[1][1]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
 		}

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -47,7 +47,7 @@ if ($paramsFontScheme) {
 
 		if (count($matches) > 0)
 		{
-			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
+			$fontStyles = '--cassiopeia-font-family-body: "' . str_replace('+', ' ', $matches[1][0]) . '", sans-serif;
 			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -47,14 +47,13 @@ if ($paramsFontScheme) {
 
 		if (count($matches) > 0) {
 			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;';
+			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;
+			--cassiopeia-font-weight-normal: 400;
+			--cassiopeia-font-weight-headings: 700;';
 			}
 	} else {
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, ['version' => 'auto'], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 		$this->getPreloadManager()->preload($wa->getAsset('style', 'fontscheme.current')->getUri() . '?' . $this->getMediaVersion(), ['as' => 'style']);
-
-		$fontStyles = '--cassiopeia-font-family-body: "Roboto", sans-serif;
-			--cassiopeia-font-family-headings: "Roboto", sans-serif;';
 	}
 }
 
@@ -71,8 +70,6 @@ $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'l
 		--template-link-color: #2a69b8;
 		--template-special-color: #001B4C;
 		$fontStyles
-		--cassiopeia-font-weight-normal: 400;
-		--cassiopeia-font-weight-headings: 700;
 	}");
 
 // Override 'template.active' asset to set correct ltr/rtl dependency

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -32,33 +32,48 @@ $templatePath = 'templates/' . $this->template;
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
 $wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $paramsColorName . '.css');
-$this->getPreloadManager()->prefetch($wa->getAsset('style', $assetColorName)->getUri(), ['as' => 'style']);
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);
+$fontStyles       = '';
 
-if ($paramsFontScheme)
-{
-	// Prefetch the stylesheet for the font scheme, actually we need to prefetch the font(s)
-	$assetFontScheme  = 'fontscheme.' . $paramsFontScheme;
-	$wa->registerAndUseStyle($assetFontScheme, $templatePath . '/css/global/' . $paramsFontScheme . '.css');
-	$this->getPreloadManager()->prefetch($wa->getAsset('style', $assetFontScheme)->getUri(), ['as' => 'style']);
+if ($paramsFontScheme) {
+	if (preg_match('/^https\:\/\//i', $paramsFontScheme)) {
+		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', []);
+		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', []);
+		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style']);
+		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
+		preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches);
+
+		if (count($matches) > 0) {
+			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;';
+			}
+	} else {
+		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, ['version' => 'auto'], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
+		$this->getPreloadManager()->preload($wa->getAsset('style', 'fontscheme.current')->getUri() . '?' . $this->getMediaVersion(), ['as' => 'style']);
+
+		$fontStyles = '--cassiopeia-font-family-body: "Roboto", sans-serif;
+			--cassiopeia-font-family-headings: "Roboto", sans-serif;';
+	}
 }
 
 // Enable assets
 $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
-	->useStyle('template.offline')
 	->useStyle('template.active.language')
 	->useStyle('template.user')
 	->useScript('template.user')
-	->addInlineStyle(':root {
+	->addInlineStyle(":root {
 		--hue: 214;
 		--template-bg-light: #f0f4fb;
 		--template-text-dark: #495057;
 		--template-text-light: #ffffff;
 		--template-link-color: #2a69b8;
 		--template-special-color: #001B4C;
-	}');
+		$fontStyles
+		--cassiopeia-font-weight-normal: 400;
+		--cassiopeia-font-weight-headings: 700;
+	}");
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
 $wa->registerStyle('template.active', '', [], [], ['template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
-/** @var JDocumentHtml $this */
+/** @var Joomla\CMS\Document\HtmlDocument $this */
 
 $twofactormethods = AuthenticationHelper::getTwoFactorMethods();
 $extraButtons     = AuthenticationHelper::getLoginButtons('form-login');

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -45,12 +45,13 @@ if ($paramsFontScheme) {
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 		preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches);
 
-		if (count($matches) > 0) {
+		if (count($matches) > 0)
+		{
 			$fontStyles = '--cassiopeia-font-family-body: "' . $matches[1][0] . '", sans-serif;
-			--cassiopeia-font-family-headings: "' . count($matches) === 2 ? $matches[2][0] : $matches[1][0] . '", sans-serif;
+			--cassiopeia-font-family-headings: "' . (count($matches) === 3 ? str_replace('+', ' ', $matches[2][0]) : str_replace('+', ' ', $matches[1][0])) . '", sans-serif;
 			--cassiopeia-font-weight-normal: 400;
 			--cassiopeia-font-weight-headings: 700;';
-			}
+		}
 	} else {
 		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, ['version' => 'auto'], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
 		$this->getPreloadManager()->preload($wa->getAsset('style', 'fontscheme.current')->getUri() . '?' . $this->getMediaVersion(), ['as' => 'style']);

--- a/templates/cassiopeia/scss/global/fonts-local_roboto.scss
+++ b/templates/cassiopeia/scss/global/fonts-local_roboto.scss
@@ -1,10 +1,3 @@
 // Fonts
 $roboto-font-path: "../../../../media/vendor/roboto-fontface/fonts" !default;
 @import "../../../../media/vendor/roboto-fontface/scss/roboto/sass/roboto-fontface";
-
-:root {
-  --cassiopeia-font-family-body: "Roboto", sans-serif;
-  --cassiopeia-font-family-headings: "Roboto", sans-serif;
-  --cassiopeia-font-weight-headings: 700;
-  --cassiopeia-font-weight-normal: 400;
-}

--- a/templates/cassiopeia/scss/global/fonts-local_roboto.scss
+++ b/templates/cassiopeia/scss/global/fonts-local_roboto.scss
@@ -1,3 +1,10 @@
 // Fonts
 $roboto-font-path: "../../../../media/vendor/roboto-fontface/fonts" !default;
 @import "../../../../media/vendor/roboto-fontface/scss/roboto/sass/roboto-fontface";
+
+:root {
+  --cassiopeia-font-family-body: "Roboto", sans-serif;
+  --cassiopeia-font-family-headings: "Roboto", sans-serif;
+  --cassiopeia-font-weight-headings: 700;
+  --cassiopeia-font-weight-normal: 400;
+}

--- a/templates/cassiopeia/scss/global/fonts-web_fira-sans.scss
+++ b/templates/cassiopeia/scss/global/fonts-web_fira-sans.scss
@@ -1,9 +1,0 @@
-// Fonts
-@import url("https://fonts.googleapis.com/css2?family=Fira+Sans:wght@100;300;400;700&display=swap");
-
-:root {
-  --cassiopeia-font-family-body: "Fira Sans", sans-serif;
-  --cassiopeia-font-family-headings: "Fira Sans", sans-serif;
-  --cassiopeia-font-weight-headings: 700;
-  --cassiopeia-font-weight-normal: 400;
-}

--- a/templates/cassiopeia/scss/global/fonts-web_roboto+noto-sans.scss
+++ b/templates/cassiopeia/scss/global/fonts-web_roboto+noto-sans.scss
@@ -1,9 +1,0 @@
-// Fonts
-@import url("https://fonts.googleapis.com/css2?family=Noto+Sans:wght@100;300;400;700&family=Roboto:wght@100;300;400;700&display=swap");
-
-:root {
-  --cassiopeia-font-family-body: "Noto Sans", sans-serif;
-  --cassiopeia-font-family-headings: "Roboto", sans-serif;
-  --cassiopeia-font-weight-headings: 400;
-  --cassiopeia-font-weight-normal: 400;
-}

--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -93,11 +93,11 @@
 					>
 					<option value="0">JNONE</option>
 					<group label="TPL_CASSIOPEIA_FONT_GROUP_LOCAL">
-						<option value="fonts-local_roboto">Roboto (local)</option>
+						<option value="templates/cassiopeia/css/global/fonts-local_roboto.css">Roboto (local)</option>
 					</group>
 					<group label="TPL_CASSIOPEIA_FONT_GROUP_WEB">
-						<option value="fonts-web_fira-sans">Fira Sans (web)</option>
-						<option value="fonts-web_roboto+noto-sans">Roboto + Noto Sans (web)</option>
+						<option value="https://fonts.googleapis.com/css2?family=Fira+Sans:wght@100;300;400;700&amp;display=swap">Fira Sans (web)</option>
+						<option value="https://fonts.googleapis.com/css2?family=Noto+Sans:wght@100;300;400;700&amp;family=Roboto:wght@100;300;400;700&amp;display=swap">Roboto + Noto Sans (web)</option>
 					</group>
 				</field>
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Prefetch = load an asset for the next navigation (this is very low priority)
Preload = load an asset with higher priority for the current page

In short, proload is what is needed for the css (color, fonts)

This PR is essentially is implementing basically the https://css-tricks.com/the-fastest-google-fonts/ with some extras:
- the webfont will also be available even if Javascript is disabled (the same thing I did for font awesome)
- the preload is done in the actual headers of the response
- Inlined the CSS Properties for all the fonts
- The code is written in a way that a custom google font URL can be used (not exposed to UI, but a simple input and a toggle button will do the trick)

- There are changes in the SQL that are not automatically applied
- There are SCSS files that were deleted

### Testing Instructions

Apply the PR, and make sure to save the Cassiopeia default style!!!
Check all the fonts and the loading (preferably by emulating a very slow connection)

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required
