### PR TITLE
[4.0] Ignore files and folders of the eos310 plugin in build/deleted_file_check.php

### DIFF
--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -66,8 +66,10 @@ $previousReleaseExclude = [
 	$options['from'] . '/components/com_search',
 	$options['from'] . '/images/sampledata',
 	$options['from'] . '/installation',
+	$options['from'] . '/media/plg_quickicon_eos310',
 	$options['from'] . '/modules/mod_search',
 	$options['from'] . '/plugins/fields/repeatable',
+	$options['from'] . '/plugins/quickicon/eos310',
 	$options['from'] . '/plugins/search',
 ];
 
@@ -158,6 +160,8 @@ $filesToKeep = [
 	"'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.sys.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_fields_repeatable.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_fields_repeatable.sys.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_quickicon_eos310.ini',",
+	"'/administrator/language/en-GB/en-GB.plg_quickicon_eos310.sys.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_categories.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_categories.sys.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_search_contacts.ini',",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Ignore files and folders of the eos310 plugin in build/deleted_file_check.php because files and folders of this plugin will be deleted when uninstalling it, which is implemented with PR #34895 .

In general we handle the repeatable field plugin in the same way.

### Testing Instructions

#### Requirement

It needs a git clone of the CMS repository or your fork of it. A normal installation based e.g. on nightly build will not be enough because the test concerns the "build" folder, which is not included in the installation packages.

For the same reason, this PR cannot be applied with patchtester.

#### Preparation

Because we don't have a 3.10 nightly build yet which includes the 3.10 EOS plugin, it needs to create a 3.10 full installation package based on the current 3.10-dev branch.

To do that, checkout the 3.10-dev branch. If necessary, update it to latest 3.10-dev of the upstream repository here.

Then open a command window and change directory to the root folder of your git clone.

Now enter following command and wait until it has finished:

```
php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2
```

After that, you can find the package `Joomla_3.10.0-alpha10-dev-Development-Full_Package.zip` in the `build/tmp/packages` folder.

Save the package somewhere outside of the root folder of your git clone.

If the package build doesn't work for you for some reason, you can download the package from here: https://test5.richard-fath.de/Joomla_3.10.0-alpha10-dev-Development-Full_Package.zip

Now checkout the 4.0-dev branch. If necessary, update it to latest 4.0-dev of the upstream repository here.

Now you can build again a package like described above and find the result `Joomla_4.0.0-rc5-dev-Development-Full_Package.zip` again in folder `build/tmp/packages`, or download the latest 4.0 nightly build from here: https://developer.joomla.org/nightlies/Joomla_4.0.0-rc5-dev-Development-Full_Package.zip .

In both cases save the package somewhere outside of the root folder of your git clone.

Now, still being on the 4.0-dev branch, unpack the previously built or downloaded 3.10 and 4.0 packages to the `build` folder into a folder with the same name as the package, so you have following folder relative to the root:
- build/Joomla_3.10.0-alpha10-dev-Development-Full_Package
- build/Joomla_4.0.0-rc5-dev-Development-Full_Package

Now you are ready for the test.

#### Test procedure

1. On a clean, current 4.0-dev branch prepared as described above, open a command window (e.g. Windows CMD on Windows or bash on Linux) in the root folder of your git clone.

2. Change directory to the `build` folder:
```
cd build
```

3. Enter following command and wait until it has finished:
```
php ./deleted_file_check.php --from=./Joomla_3.10.0-alpha10-dev-Development-Full_Package --to=./Joomla_4.0.0-rc5-dev-Development-Full_Package
```
Result: Three files have been created:
- deleted_files.txt
- deleted_folders.txt
- renamed_files.txt

4. Rename the three generated files
```
mv deleted_files.txt deleted_files_1.txt
mv deleted_folders.txt deleted_folders_1.txt
mv renamed_files.txt renamed_files_1.txt
```

5. Apply the patch of this PR.

6. Repeat step 3.

7. Compare the files generated the previous step 6 with those created in step 3.

Result: The screenshots below show on the left hand side of the comparison the file created in step 6 with this PR applied and on the right hand side the one created in step 3 without this PR applied.

- deleted_files.txt shows the following three differences

![2021-07-25_pr-34898_1](https://user-images.githubusercontent.com/7413183/126908198-731331cf-0fc7-4927-bda9-a5a2fdbb192b.png)

![2021-07-25_pr-34898_2](https://user-images.githubusercontent.com/7413183/126908202-e21cdcb9-422b-43ce-b906-25d5261d1e5f.png)

![2021-07-25_pr-34898_3](https://user-images.githubusercontent.com/7413183/126908205-1564bf60-4365-4644-99c1-c81e1101d975.png)

- deleted_folders.txt shows the following two differences

![2021-07-25_pr-34898_4](https://user-images.githubusercontent.com/7413183/126908208-9761ac00-2b9b-4d06-b8ed-236565246146.png)

![2021-07-25_pr-34898_5](https://user-images.githubusercontent.com/7413183/126908213-399e3c59-01e6-419e-ba86-de5fad269cd9.png)

- renamed_files.txt doesn't show any difference

### Actual result BEFORE applying this Pull Request

The files and folders of the 3.10 EOS plugin will be included in the lists of files and folders to be deleted on update.

When updating script.php based on these lists and then updating a clean, current 3.10-dev branch to a 4.0 update package with these changes and the changes from PR #34895 , the update will end with following error:

![2021-07-25_eos-uninstall-error](https://user-images.githubusercontent.com/7413183/126908335-339b15dd-388c-4f71-8629-c583d8a2ec44.png)

### Expected result AFTER applying this Pull Request

The files and folders of the 3.10 EOS plugin will **not** be included in the lists of files and folders to be deleted on update.

They will be deleted when the plugin is uninstalled after PR #34895 has been merged.

### Documentation Changes Required

None.