### PR TITLE
[4.0] cog icon

### DIFF
--- a/administrator/templates/atum/html/layouts/chromes/body.php
+++ b/administrator/templates/atum/html/layouts/chromes/body.php
@@ -46,7 +46,7 @@ $headerClass = $headerClass ? ' ' . htmlspecialchars($headerClass, ENT_QUOTES, '
 			<?php $dropdownPosition = Factory::getLanguage()->isRtl() ? 'start' : 'end'; ?>
 			<div class="module-actions dropdown">
 				<button type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="btn" id="dropdownMenuButton-<?php echo $id; ?>">
-					<span class="icon-cog" aria-hidden="true"></span>
+					<span class="icon-cogs" aria-hidden="true"></span>
 					<span class="visually-hidden"><?php echo Text::sprintf('JACTION_EDIT_MODULE', $module->title); ?></span>
 				</button>
 				<div class="dropdown-menu dropdown-menu-<?php echo $dropdownPosition; ?>" aria-labelledby="dropdownMenuButton-<?php echo $id; ?>">

--- a/administrator/templates/atum/html/layouts/chromes/well.php
+++ b/administrator/templates/atum/html/layouts/chromes/well.php
@@ -51,7 +51,7 @@ $headerIcon = $params->get('header_icon') ? '<span class="' . htmlspecialchars($
 					<?php $dropdownPosition = Factory::getLanguage()->isRtl() ? 'start' : 'end'; ?>
 					<div class="module-actions dropdown">
 						<button type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="btn" id="dropdownMenuButton-<?php echo $id; ?>">
-							<span class="icon-cog" aria-hidden="true"></span>
+							<span class="icon-cogs" aria-hidden="true"></span>
 							<span class="visually-hidden"><?php echo Text::sprintf('JACTION_EDIT_MODULE', $module->title); ?></span>
 						</button>
 						<div class="dropdown-menu dropdown-menu-<?php echo $dropdownPosition; ?>" aria-labelledby="dropdownMenuButton-<?php echo $id; ?>">


### PR DESCRIPTION
Currently we are using the same cog-icon as both an illustrative image next to options and as a functional image for the mmodule dropdown.

To avoid confusion this PR changes the functional image to a slightly different icon.

### Before
![image](https://user-images.githubusercontent.com/1296369/126905561-2354345a-7a4f-4d5b-a38a-6d143a063e55.png)



### After
![image](https://user-images.githubusercontent.com/1296369/126905536-3cd098ba-d139-4235-84d1-dbb328ed8ef4.png)




NOTE: personally I would prefer if these buttons looked like buttons but thats beyond the scope of this PR
