### PR TITLE
[4.0] Render the full information in the installer

### DIFF
--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -112,6 +112,15 @@ body {
 
 .j-install-step-form {
   padding: .65rem 1.2rem;
+
+  // Remove default bootstrap margins in the installer forms.
+  .control-group {
+    margin-bottom: 0;
+
+    .control-label {
+      padding: 0;
+    }
+  }
 }
 
 .languageForm {

--- a/installation/tmpl/setup/default.php
+++ b/installation/tmpl/setup/default.php
@@ -92,12 +92,24 @@ HTMLHelper::_('behavior.formvalidator');
 				<div class="mb-3">
 					<?php echo $this->form->renderField('db_prefix'); ?>
 				</div>
-				<?php echo $this->form->renderField('db_encryption'); ?>
-				<?php echo $this->form->renderField('db_sslkey'); ?>
-				<?php echo $this->form->renderField('db_sslcert'); ?>
-				<?php echo $this->form->renderField('db_sslverifyservercert'); ?>
-				<?php echo $this->form->renderField('db_sslca'); ?>
-				<?php echo $this->form->renderField('db_sslcipher'); ?>
+				<div class="mb-3">
+					<?php echo $this->form->renderField('db_encryption'); ?>
+				</div>
+				<div class="mb-3">
+					<?php echo $this->form->renderField('db_sslkey'); ?>
+				</div>
+				<div class="mb-3">
+					<?php echo $this->form->renderField('db_sslcert'); ?>
+				</div>
+				<div class="mb-3">
+					<?php echo $this->form->renderField('db_sslverifyservercert'); ?>
+				</div>
+				<div class="mb-3">
+					<?php echo $this->form->renderField('db_sslca'); ?>
+				</div>
+				<div class="mb-3">
+					<?php echo $this->form->renderField('db_sslcipher'); ?>
+				</div>
 				<div class="mb-3">
 					<?php //echo $this->form->getLabel('db_old'); ?>
 					<?php echo $this->form->getInput('db_old'); ?>

--- a/installation/tmpl/setup/default.php
+++ b/installation/tmpl/setup/default.php
@@ -25,8 +25,7 @@ HTMLHelper::_('behavior.formvalidator');
 			</legend>
 			<div class="j-install-step-form">
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('language'); ?>
-					<?php echo $this->form->getInput('language'); ?>
+					<?php echo $this->form->renderField('language'); ?>
 				</div>
 				<input type="hidden" name="task" value="language.set">
 				<input type="hidden" name="format" value="json">
@@ -41,8 +40,7 @@ HTMLHelper::_('behavior.formvalidator');
 			</legend>
 			<div class="j-install-step-form">
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('site_name'); ?>
-					<?php echo $this->form->getInput('site_name'); ?>
+					<?php echo $this->form->renderField('site_name'); ?>
 				</div>
 				<div class="mb-3 mt-4">
 					<button class="btn btn-primary w-100" id="step1"><?php echo Text::_('INSTL_SETUP_LOGIN_DATA'); ?> <span class="icon-chevron-right" aria-hidden="true"></span></button>
@@ -55,20 +53,16 @@ HTMLHelper::_('behavior.formvalidator');
 			</legend>
 			<div class="j-install-step-form">
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('admin_user'); ?>
-					<?php echo $this->form->getInput('admin_user'); ?>
+					<?php echo $this->form->renderField('admin_user'); ?>
 				</div>
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('admin_username'); ?>
-					<?php echo $this->form->getInput('admin_username'); ?>
+					<?php echo $this->form->renderField('admin_username'); ?>
 				</div>
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('admin_password'); ?>
-					<?php echo $this->form->getInput('admin_password'); ?>
+					<?php echo $this->form->renderField('admin_password'); ?>
 				</div>
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('admin_email'); ?>
-					<?php echo $this->form->getInput('admin_email'); ?>
+					<?php echo $this->form->renderField('admin_email'); ?>
 				</div>
 				<div class="mb-3 mt-4">
 					<button class="btn btn-primary w-100" id="step2"><?php echo Text::_('INSTL_CONNECT_DB'); ?> <span class="icon-chevron-right" aria-hidden="true"></span></button>
@@ -81,35 +75,29 @@ HTMLHelper::_('behavior.formvalidator');
 			</legend>
 			<div class="j-install-step-form">
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('db_type'); ?>
-					<?php echo $this->form->getInput('db_type'); ?>
+					<?php echo $this->form->renderField('db_type'); ?>
 				</div>
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('db_host'); ?>
-					<?php echo $this->form->getInput('db_host'); ?>
+					<?php echo $this->form->renderField('db_host'); ?>
 				</div>
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('db_user'); ?>
-					<?php echo $this->form->getInput('db_user'); ?>
+					<?php echo $this->form->renderField('db_user'); ?>
 				</div>
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('db_pass'); ?>
-					<?php echo $this->form->getInput('db_pass'); ?>
+					<?php echo $this->form->renderField('db_pass'); ?>
 				</div>
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('db_name'); ?>
-					<?php echo $this->form->getInput('db_name'); ?>
+					<?php echo $this->form->renderField('db_name'); ?>
 				</div>
 				<div class="mb-3">
-					<?php echo $this->form->getLabel('db_prefix'); ?>
-					<?php echo $this->form->getInput('db_prefix'); ?>
+					<?php echo $this->form->renderField('db_prefix'); ?>
 				</div>
-				<?php echo $this->form->getField('db_encryption')->renderField(); ?>
-				<?php echo $this->form->getField('db_sslkey')->renderField(); ?>
-				<?php echo $this->form->getField('db_sslcert')->renderField(); ?>
-				<?php echo $this->form->getField('db_sslverifyservercert')->renderField(); ?>
-				<?php echo $this->form->getField('db_sslca')->renderField(); ?>
-				<?php echo $this->form->getField('db_sslcipher')->renderField(); ?>
+				<?php echo $this->form->renderField('db_encryption'); ?>
+				<?php echo $this->form->renderField('db_sslkey'); ?>
+				<?php echo $this->form->renderField('db_sslcert'); ?>
+				<?php echo $this->form->renderField('db_sslverifyservercert'); ?>
+				<?php echo $this->form->renderField('db_sslca'); ?>
+				<?php echo $this->form->renderField('db_sslcipher'); ?>
 				<div class="mb-3">
 					<?php //echo $this->form->getLabel('db_old'); ?>
 					<?php echo $this->form->getInput('db_old'); ?>


### PR DESCRIPTION
Partial Pull Request for Issue #34873 .

### Summary of Changes
Partial fix for issue mentioned - Render fields in the installer using the renderField method. This renders a description stating the number of minimum characters that had been hidden until now. Eventually this should be replaced by javascript stating the correct number of figures. But it's a start. 

As we now render the full control group - we override the CSS to not add extra paddings (it's honestly barely noticeable on my Laptop 13" screen - but just covers bases)

### Testing Instructions
Check that a description appears on the password field for the admin user stating the minimum length is 12 characters

### Documentation Changes Required
None.
