### PR TITLE
[4.0] mail-templates flags

### DIFF
--- a/administrator/components/com_mails/tmpl/templates/default.php
+++ b/administrator/components/com_mails/tmpl/templates/default.php
@@ -72,8 +72,8 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 									<?php echo Text::_($component); ?>
 								</td>
 								<?php if (count($this->languages) > 1) : ?>
-									<td class="text-center">
-										<ul class="list-unstyled d-flex">
+									<td>
+										<ul class="list-unstyled d-flex justify-content-center">
 										<?php foreach ($this->languages as $language) : ?>
 											<li class="p-1">
 												<a href="<?php echo Route::_('index.php?option=com_mails&task=template.edit&template_id=' . $item->template_id . '&language=' . $language->lang_code); ?>">


### PR DESCRIPTION
PR #33320 by @joomdonation updated the view of the mail templates listings including making the flags centered

PR #34530 by @chmst updated the flags cell to be a list

As a result while the column header is centered the flags are not

This PR resolves that using `justify-content-center`

### Before
![image](https://user-images.githubusercontent.com/1296369/126914027-4936fb81-ef78-41f2-a358-c750ab6e0052.png)


### After
![image](https://user-images.githubusercontent.com/1296369/126914000-12ec6740-d760-409f-94aa-8b05ab8b5acb.png)
