### PR TITLE
[3.10] Fix deprecations for Content History Helper

### DIFF
--- a/libraries/classmap.php
+++ b/libraries/classmap.php
@@ -114,7 +114,7 @@ JLoader::registerAlias('JErrorPage',                        '\\Joomla\\CMS\\Exce
 JLoader::registerAlias('JAuthenticationHelper',             '\\Joomla\\CMS\\Helper\\AuthenticationHelper', '5.0');
 JLoader::registerAlias('JHelper',                           '\\Joomla\\CMS\\Helper\\CMSHelper', '5.0');
 JLoader::registerAlias('JHelperContent',                    '\\Joomla\\CMS\\Helper\\ContentHelper', '5.0');
-JLoader::registerAlias('JHelperContenthistory',             '\\Joomla\\CMS\\Helper\\ContentHistoryHelper', '5.0');
+JLoader::registerAlias('JHelperContenthistory',             '\\Joomla\\CMS\\Helper\\ContentHistoryHelper', '4.0');
 JLoader::registerAlias('JLibraryHelper',                    '\\Joomla\\CMS\\Helper\\LibraryHelper', '5.0');
 JLoader::registerAlias('JHelperMedia',                      '\\Joomla\\CMS\\Helper\\MediaHelper', '5.0');
 JLoader::registerAlias('JModuleHelper',                     '\\Joomla\\CMS\\Helper\\ModuleHelper', '5.0');

--- a/libraries/src/Helper/ContentHistoryHelper.php
+++ b/libraries/src/Helper/ContentHistoryHelper.php
@@ -17,7 +17,8 @@ use Joomla\CMS\Table\Table;
  * Versions helper class, provides methods to perform various tasks relevant
  * versioning of content.
  *
- * @since  3.2
+ * @since       3.2
+ * @deprecated  4.0  Deprecated in favour of \Joomla\CMS\Versioning\Versioning in Joomla 4
  */
 class ContentHistoryHelper extends CMSHelper
 {
@@ -26,6 +27,7 @@ class ContentHistoryHelper extends CMSHelper
 	 *
 	 * @var    string
 	 * @since  3.2
+	 * @deprecated  4.0
 	 */
 	public $typeAlias = null;
 
@@ -35,6 +37,7 @@ class ContentHistoryHelper extends CMSHelper
 	 * @param   string  $typeAlias  The type of content to be versioned (for example, 'com_content.article').
 	 *
 	 * @since   3.2
+	 * @deprecated  4.0
 	 */
 	public function __construct($typeAlias = null)
 	{
@@ -49,6 +52,7 @@ class ContentHistoryHelper extends CMSHelper
 	 * @return  boolean  true on success, otherwise false.
 	 *
 	 * @since   3.2
+	 * @deprecated  4.0  Use \Joomla\CMS\Versioning\Versioning::delete in Joomla 4
 	 */
 	public function deleteHistory($table)
 	{
@@ -75,6 +79,7 @@ class ContentHistoryHelper extends CMSHelper
 	 * @return  mixed   The return value or null if the query failed.
 	 *
 	 * @since   3.2
+	 * @deprecated  4.0  Use \Joomla\CMS\Versioning\Versioning::get in Joomla 4
 	 */
 	public function getHistory($typeId, $id)
 	{
@@ -99,6 +104,7 @@ class ContentHistoryHelper extends CMSHelper
 	 * @return  boolean  True on success, otherwise false.
 	 *
 	 * @since   3.2
+	 * @deprecated  4.0  Use \Joomla\CMS\Versioning\Versioning::store in Joomla 4
 	 */
 	public function store($table)
 	{


### PR DESCRIPTION
Successor Pull Request for Issue #30932 .

### Summary of Changes
This class has been removed from J4 for about 18 months as part of https://github.com/joomla/joomla-cms/pull/29217 - this adds the missing deprecations into 3.10

### Testing Instructions
Code Review

### Documentation Changes Required
No - part of the J4 migration docs. 
