### PR TITLE
[4.0]Translate menus

### DIFF
--- a/administrator/components/com_menus/presets/default.xml
+++ b/administrator/components/com_menus/presets/default.xml
@@ -144,7 +144,7 @@
 			sql_order="a.id DESC"
 			>
 			<menuitem
-				title="{sql:title} "
+				title="{sql:title}"
 				quicktask-title="MOD_MENU_MENU_MANAGER_NEW_SITE_MENU_ITEM"
 				type="component"
 				element="com_menus"

--- a/administrator/components/com_menus/presets/default.xml
+++ b/administrator/components/com_menus/presets/default.xml
@@ -130,7 +130,7 @@
 		Following is an example of repeatable group based on simple database query.
 		This requires sql_* attributes (sql_select and sql_from are required)
 		The values can be used like - "{sql:columnName}" in any attribute of repeated elements.
-		The repeated elements are place inside this xml node but they will be populated in the same level in the rendered menu
+		The repeated elements are placed inside this xml node but they will be populated in the same level in the rendered menu
 		-->
 		<menuitem
 			type="separator"

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -989,7 +989,7 @@ class MenusHelper extends ContentHelper
 		// Translate attributes for iterator values
 		foreach ($replace as $var => $val)
 		{
-			$item->title   = str_replace("{sql:$var}", $val, $item->title);
+			$item->title   = str_replace("{sql:$var}", $val, trim($item->title));
 			$item->element = str_replace("{sql:$var}", $val, $item->element);
 			$item->link    = str_replace("{sql:$var}", $val, $item->link);
 			$item->class   = str_replace("{sql:$var}", $val, $item->class);
@@ -998,7 +998,6 @@ class MenusHelper extends ContentHelper
 		}
 
 		$item->setParams($params);
-
 		return $item;
 	}
 }

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -989,7 +989,7 @@ class MenusHelper extends ContentHelper
 		// Translate attributes for iterator values
 		foreach ($replace as $var => $val)
 		{
-			$item->title   = str_replace("{sql:$var}", $val, trim($item->title));
+			$item->title   = str_replace("{sql:$var}", $val, ($item->title));
 			$item->element = str_replace("{sql:$var}", $val, $item->element);
 			$item->link    = str_replace("{sql:$var}", $val, $item->link);
 			$item->class   = str_replace("{sql:$var}", $val, $item->class);
@@ -999,5 +999,6 @@ class MenusHelper extends ContentHelper
 
 		$item->setParams($params);
 		return $item;
+
 	}
 }

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -989,7 +989,7 @@ class MenusHelper extends ContentHelper
 		// Translate attributes for iterator values
 		foreach ($replace as $var => $val)
 		{
-			$item->title   = str_replace("{sql:$var}", $val, ($item->title));
+			$item->title   = str_replace("{sql:$var}", $val, trim($item->title));
 			$item->element = str_replace("{sql:$var}", $val, $item->element);
 			$item->link    = str_replace("{sql:$var}", $val, $item->link);
 			$item->class   = str_replace("{sql:$var}", $val, $item->class);
@@ -998,7 +998,7 @@ class MenusHelper extends ContentHelper
 		}
 
 		$item->setParams($params);
-		return $item;
 
+		return $item;
 	}
 }

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -989,7 +989,7 @@ class MenusHelper extends ContentHelper
 		// Translate attributes for iterator values
 		foreach ($replace as $var => $val)
 		{
-			$item->title   = str_replace("{sql:$var}", $val, trim($item->title));
+			$item->title   = str_replace("{sql:$var}", $val, $item->title);
 			$item->element = str_replace("{sql:$var}", $val, $item->element);
 			$item->link    = str_replace("{sql:$var}", $val, $item->link);
 			$item->class   = str_replace("{sql:$var}", $val, $item->class);


### PR DESCRIPTION
On a site with multiple admin languages you would expect that the name of the menu could be translated.

## Test instructions
Create an admin menu and give it a title such as JADMINISTRATOR
Create a site menu and give it a title such as JSITE

## Expected behaviour
The names of both menus are translated

## Actual behaviour
Only the name of the admin menu is translated

## Solution
~I have no idea why but~ there is an extra space at the end of `$item->title` so the string being passed through JText is "JSITE " which obviously doesn't match. ~I have no idea why there is not an extra space for the admin menu~


![image](https://user-images.githubusercontent.com/1296369/126916109-4e824415-693a-49a6-9b7e-076b13b20664.png)



This PR trims `$item->title` so that now the site menu name is also translated.

~No idea if this is a hack/bandage or the correct solution but its been bugging me for hours and I can't find the space~

### Before
![image](https://user-images.githubusercontent.com/1296369/126915975-bf86b117-716c-43d7-b589-534ed7781e9b.png)

![image](https://user-images.githubusercontent.com/1296369/126916032-1163725d-b231-4deb-8409-df41e1da31d6.png)

### After
![image](https://user-images.githubusercontent.com/1296369/126915983-3e0647c7-e9f5-4154-a5d4-70fa19d2543a.png)

![image](https://user-images.githubusercontent.com/1296369/126916006-cdb75bdc-b7b6-491c-b46e-30f0946ab9b7.png)
