### PR TITLE
[4.0] Change message to log

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -483,7 +483,7 @@ class UpdateModel extends BaseDatabaseModel
 	{
 		try
 		{
-			Log::add(Text::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_URL', $url), Log::INFO, 'Update');
+			Log::add(Text::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_URL', $url), Log::INFO, 'ERROR');
 		}
 		catch (\RuntimeException $exception)
 		{

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -273,7 +273,7 @@ class AdministratorApplication extends CMSApplication
 		if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')
 			&& !is_file(JPATH_THEMES . '/' . $template->parent . '/index.php'))
 		{
-			Log::add(Text::_('JERROR_ALERTNOTEMPLATE'), Log::WARNING, 'jerror');
+			Log::add(Text::_('JERROR_ALERTNOTEMPLATE'), Log::WARNING, 'Update');
 
 			$template->params = new Registry;
 			$template->template = 'atum';

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Router;
 use Joomla\CMS\Session\Session;
@@ -272,7 +273,8 @@ class AdministratorApplication extends CMSApplication
 		if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')
 			&& !is_file(JPATH_THEMES . '/' . $template->parent . '/index.php'))
 		{
-			$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
+			Log::add(Text::_('JERROR_ALERTNOTEMPLATE'),Log::WARNING,'jerror');
+
 			$template->params = new Registry;
 			$template->template = 'atum';
 

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -273,7 +273,7 @@ class AdministratorApplication extends CMSApplication
 		if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')
 			&& !is_file(JPATH_THEMES . '/' . $template->parent . '/index.php'))
 		{
-			Log::add(Text::_('JERROR_ALERTNOTEMPLATE'),Log::WARNING,'jerror');
+			Log::add(Text::_('JERROR_ALERTNOTEMPLATE'), Log::WARNING, 'jerror');
 
 			$template->params = new Registry;
 			$template->template = 'atum';


### PR DESCRIPTION
Pull Request for Issue #34908 .

When you update from 3.10 you immediately get an error message `The template for this display is not available.`

On an update this is a false positive.

This PR changes it from a visible message to a log

https://github.com/joomla/joomla-cms/issues/34908#issuecomment-886514944

testing is time consuming for such a minor change and can probably be accepted by code review