### PR TITLE
[4.0] Remove jerror logging in to messagequeue logger

### DIFF
--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -74,12 +74,6 @@ if (in_array('phar', stream_get_wrappers()))
 // Define the Joomla version if not already defined.
 defined('JVERSION') or define('JVERSION', (new JVersion)->getShortVersion());
 
-// Set up the message queue logger for web requests
-if (array_key_exists('REQUEST_METHOD', $_SERVER))
-{
-	JLog::addLogger(['logger' => 'messagequeue'], JLog::ALL, ['jerror']);
-}
-
 // Register the Crypto lib
 JLoader::register('Crypto', JPATH_PLATFORM . '/php-encryption/Crypto.php');
 

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Router;
 use Joomla\CMS\Session\Session;
@@ -272,7 +273,7 @@ class AdministratorApplication extends CMSApplication
 		if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')
 			&& !is_file(JPATH_THEMES . '/' . $template->parent . '/index.php'))
 		{
-			$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
+			Log::add(Text::_('JERROR_ALERTNOTEMPLATE'), Log::WARNING, 'jerror');
 			$template->params = new Registry;
 			$template->template = 'atum';
 

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Input\Input;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Log\Log;
 use Joomla\CMS\Pathway\Pathway;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
@@ -551,7 +552,7 @@ final class SiteApplication extends CMSApplication
 			{
 				if (!is_file(JPATH_THEMES . '/' . $template->parent . '/index.php'))
 				{
-					$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
+					Log::add(Text::_('JERROR_ALERTNOTEMPLATE'), Log::WARNING, 'jerror');
 
 					// Try to find data for 'cassiopeia' template
 					$original_tmpl = $template->template;
@@ -575,7 +576,7 @@ final class SiteApplication extends CMSApplication
 		}
 		elseif (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php'))
 		{
-			$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
+			Log::add(Text::_('JERROR_ALERTNOTEMPLATE'), Log::WARNING, 'jerror');
 
 			// Try to find data for 'cassiopeia' template
 			$original_tmpl = $template->template;


### PR DESCRIPTION
Pull Request for Issue #34908

### Summary of Changes

I have removed messagequeue logger from bootstrap, and added changes from #34912 by @brianteeman 


### Testing Instructions
Please follow #34908


### Documentation Changes Required

Logging of `jerror` can be configured in global configuration:
![Screenshot_2021-07-26_15-33-40](https://user-images.githubusercontent.com/1568198/126989793-ae2b7835-0f04-46a9-8332-149d54bda034.png)

