### PR TITLE
[4.0] Make dropdown full width

### DIFF
--- a/administrator/components/com_fields/tmpl/fields/default_batch_body.php
+++ b/administrator/components/com_fields/tmpl/fields/default_batch_body.php
@@ -38,7 +38,7 @@ $context = $this->escape($this->state->get('filter.context'));
 	</div>
 	<div class="row">
 		<div class="form-group col-md-6">
-			<div class="control-group">
+			<div class="controls">
 				<?php $options = array(
 					HTMLHelper::_('select.option', 'c', Text::_('JLIB_HTML_BATCH_COPY')),
 					HTMLHelper::_('select.option', 'm', Text::_('JLIB_HTML_BATCH_MOVE'))


### PR DESCRIPTION
### Summary of Changes
Change class to make the dropdown full width. This is the same markup as in the other modals.


### Testing Instructions
Go to Content > Fields
Create a new field.
In list view, click checkbox.
Under `Actions` dropdown, select Batch.
See `To Move or Copy your selection please select a group.`


### Actual result BEFORE applying this Pull Request
![field-batch-before](https://user-images.githubusercontent.com/368084/127027053-234be944-7b9a-4232-8632-40964ea58d91.jpg)



### Expected result AFTER applying this Pull Request
![field-batch-after](https://user-images.githubusercontent.com/368084/127027059-8aa9a39e-6ecc-4373-b1d5-b59568a1fc4c.jpg)


