### PR TITLE
[4.0] Remove temp url code in adapter interface as it is not used

### DIFF
--- a/administrator/components/com_media/src/Adapter/AdapterInterface.php
+++ b/administrator/components/com_media/src/Adapter/AdapterInterface.php
@@ -209,17 +209,4 @@ interface AdapterInterface
 	 * @since   4.0.0
 	 */
 	public function search(string $path, string $needle, bool $recursive = false): array;
-
-	/**
-	 * Returns a temporary url for the given path.
-	 * This is used internally in media manager
-	 *
-	 * @param   string  $path  The path to file
-	 *
-	 * @return  string
-	 *
-	 * @since   4.0.0
-	 * @throws  \Joomla\Component\Media\Administrator\Exception\FileNotFoundException
-	 */
-	public function getTemporaryUrl(string $path): string;
 }

--- a/administrator/components/com_media/src/Controller/ApiController.php
+++ b/administrator/components/com_media/src/Controller/ApiController.php
@@ -135,7 +135,6 @@ class ApiController extends BaseController
 		// Grab options
 		$options              = [];
 		$options['url']       = $this->input->getBool('url', false);
-		$options['temp']      = $this->input->getBool('temp', false);
 		$options['search']    = $this->input->getString('search', '');
 		$options['recursive'] = $this->input->getBool('recursive', true);
 		$options['content']   = $this->input->getBool('content', false);

--- a/administrator/components/com_media/src/Model/ApiModel.php
+++ b/administrator/components/com_media/src/Model/ApiModel.php
@@ -100,14 +100,7 @@ class ApiModel extends BaseDatabaseModel
 
 		if (isset($options['url']) && $options['url'] && $file->type == 'file')
 		{
-			if (isset($options['temp']) && $options['temp'])
-			{
-				$file->tempUrl = $this->getTemporaryUrl($adapter, $file->path);
-			}
-			else
-			{
-				$file->url = $this->getUrl($adapter, $file->path);
-			}
+			$file->url = $this->getUrl($adapter, $file->path);
 		}
 
 		if (isset($options['content']) && $options['content'] && $file->type == 'file')
@@ -168,14 +161,7 @@ class ApiModel extends BaseDatabaseModel
 			// Check if we need more information
 			if (isset($options['url']) && $options['url'] && $file->type == 'file')
 			{
-				if (isset($options['temp']) && $options['temp'])
-				{
-					$file->tempUrl = $this->getTemporaryUrl($adapter, $file->path);
-				}
-				else
-				{
-					$file->url = $this->getUrl($adapter, $file->path);
-				}
+				$file->url = $this->getUrl($adapter, $file->path);
 			}
 
 			if (isset($options['content']) && $options['content'] && $file->type == 'file')
@@ -487,29 +473,6 @@ class ApiModel extends BaseDatabaseModel
 	public function search($adapter, $needle, $path = '/', $recursive = true)
 	{
 		return $this->getAdapter($adapter)->search($path, $needle, $recursive);
-	}
-
-	/**
-	 * Returns a temporary url for the given path.
-	 * This is used internally in media manager
-	 *
-	 * @param   string  $adapter  The adapter
-	 * @param   string  $path     The path to file
-	 *
-	 * @return string
-	 *
-	 * @since   4.0.0
-	 * @throws \Exception
-	 */
-	public function getTemporaryUrl($adapter, $path)
-	{
-		// Check if it is a media file
-		if (!$this->isMediaFile($path))
-		{
-			throw new InvalidPathException;
-		}
-
-		return $this->getAdapter($adapter)->getTemporaryUrl($path);
 	}
 
 	/**

--- a/plugins/filesystem/local/src/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/src/Adapter/LocalAdapter.php
@@ -735,22 +735,6 @@ class LocalAdapter implements AdapterInterface
 	}
 
 	/**
-	 * Returns a temporary url for the given path.
-	 * This is used internally in media manager
-	 *
-	 * @param   string  $path  The path to file
-	 *
-	 * @return  string
-	 *
-	 * @since   4.0.0
-	 * @throws  FileNotFoundException
-	 */
-	public function getTemporaryUrl(string $path): string
-	{
-		return $this->getUrl($path);
-	}
-
-	/**
 	 * Replace spaces on a path with %20
 	 *
 	 * @param   string  $path  The Path to be encoded


### PR DESCRIPTION
### Summary of Changes
Removes the temporary url code as it was used in the past in an unit test. This test got removed already.
The code has ben introduced in 77e9696a9e4c3d0b89065350d5f88df2e078b30e.

### Testing Instructions
Browse around in media manager.

### Actual result BEFORE applying this Pull Request
Everything works.

### Expected result AFTER applying this Pull Request
Everything works.