### PR TITLE
[4.0] List Views (consistency)

### DIFF
--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -120,9 +120,9 @@ Text::script('COM_ASSOCIATIONS_PURGE_CONFIRM_PROMPT', true);
 											<span title="<?php echo Text::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
 										<?php endif; ?>
 										<?php if (!empty($this->typeFields['alias'])) : ?>
-											<span class="small">
+											<div class="small">
 												<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-											</span>
+											</div>
 										<?php endif; ?>
 										<?php if (!empty($this->typeFields['catid'])) : ?>
 											<div class="small">

--- a/administrator/components/com_banners/tmpl/banners/default.php
+++ b/administrator/components/com_banners/tmpl/banners/default.php
@@ -137,9 +137,9 @@ if ($saveOrder && !empty($this->items))
 											<?php else : ?>
 												<?php echo $this->escape($item->name); ?>
 											<?php endif; ?>
-											<span class="small break-word">
+											<div class="small break-word">
 												<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-											</span>
+											</div>
 											<div class="small">
 												<?php echo Text::_('JCATEGORY') . ': ' . $this->escape($item->category_title); ?>
 											</div>

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -200,13 +200,13 @@ if ($saveOrder && !empty($this->items))
 										<?php endif; ?>
 										<div>
 										<?php echo $prefix; ?>
-										<span class="small">
-											<?php if (empty($item->note)) : ?>
-												<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-											<?php else : ?>
-												<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
-											<?php endif; ?>
-										</span>
+											<span class="small">
+												<?php if (empty($item->note)) : ?>
+													<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
+												<?php else : ?>
+													<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
+												<?php endif; ?>
+											</span>
 										</div>
 									</th>
 									<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) : ?>

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -142,9 +142,9 @@ if ($saveOrder && !empty($this->items))
 										<?php else : ?>
 											<?php echo $this->escape($item->name); ?>
 										<?php endif; ?>
-										<span class="small">
+										<div class="small">
 											<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-										</span>
+										</div>
 										<div class="small">
 											<?php echo Text::_('JCATEGORY') . ': ' . $this->escape($item->category_title); ?>
 										</div>

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -144,13 +144,13 @@ if (count($this->filterForm->getField('context')->options) > 1)
 											<?php else : ?>
 												<?php echo $this->escape($item->title); ?>
 											<?php endif; ?>
-											<span class="small break-word">
+											<div class="small break-word">
 												<?php if (empty($item->note)) : ?>
 													<?php echo Text::sprintf('JGLOBAL_LIST_NAME', $this->escape($item->name)); ?>
 												<?php else : ?>
 													<?php echo Text::sprintf('JGLOBAL_LIST_NAME_NOTE', $this->escape($item->name), $this->escape($item->note)); ?>
 												<?php endif; ?>
-											</span>
+											</div>
 											<?php if ($item->only_use_in_subform) : ?>
 												<div class="small badge bg-secondary">
 													<?php echo Text::_('COM_FIELDS_FIELD_ONLY_USE_IN_SUBFORM_BADGE'); ?>

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -136,11 +136,11 @@ if (count($this->filterForm->getField('context')->options) > 1)
 											<?php else : ?>
 												<?php echo $this->escape($item->title); ?>
 											<?php endif; ?>
-											<span class="small break-word">
+											<div class="small break-word">
 												<?php if ($item->note) : ?>
 													<?php echo Text::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)); ?>
 												<?php endif; ?>
-											</span>
+											</div>
 										</div>
 									</th>
 									<td class="small d-none d-md-table-cell">

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -102,12 +102,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<?php else : ?>
 										<?php echo Text::_($item->update_site_name); ?>
 									<?php endif; ?>
-									<br>
-									<span class="small break-word">
+									<div class="small break-word">
 										<a href="<?php echo $item->location; ?>" target="_blank" rel="noopener noreferrer"><?php echo $this->escape($item->location); ?></a>
-									</span>
-									<br>
-									<span class="small break-word">
+									</div>
+									<div class="small break-word">
 										<?php if ($item->downloadKey['valid']) : ?>
 										<span class="badge bg-info">
 											<?php echo Text::_('COM_INSTALLER_DOWNLOADKEY_EXTRA_QUERY_LABEL'); ?>
@@ -123,7 +121,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 											</span>
 										</span>
 										<?php endif; ?>
-									</span>
+									</div>
 								</th>
 								<td class="d-none d-md-table-cell">
 									<span tabindex="0">

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -182,15 +182,15 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
 									<div>
 										<?php echo $prefix; ?>
 										<span class="small">
-										<?php if ($item->type != 'url') : ?>
-											<?php if (empty($item->note)) : ?>
-												<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-											<?php else : ?>
-												<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
+											<?php if ($item->type != 'url') : ?>
+												<?php if (empty($item->note)) : ?>
+													<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
+												<?php else : ?>
+													<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
+												<?php endif; ?>
+											<?php elseif ($item->type == 'url' && $item->note) : ?>
+												<?php echo Text::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)); ?>
 											<?php endif; ?>
-										<?php elseif ($item->type == 'url' && $item->note) : ?>
-											<?php echo Text::sprintf('JGLOBAL_LIST_NOTE', $this->escape($item->note)); ?>
-										<?php endif; ?>
 										</span>
 									</div>
 									<div title="<?php echo $this->escape($item->path); ?>">

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -133,9 +133,9 @@ if ($saveOrder && !empty($this->items))
 										<?php else : ?>
 												<?php echo $this->escape($item->name); ?>
 										<?php endif; ?>
-										<span class="small">
+										<div class="small">
 											<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
-										</span>
+										</div>
 										<div class="small">
 											<?php echo Text::_('JCATEGORY') . ': ' . $this->escape($item->category_title); ?>
 										</div>

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -200,13 +200,13 @@ if ($saveOrder && !empty($this->items))
 								<?php else : ?>
 									<?php echo $this->escape($item->title); ?>
 								<?php endif; ?>
-								<span class="small" title="<?php echo $this->escape($item->path); ?>">
+								<div class="small" title="<?php echo $this->escape($item->path); ?>">
 									<?php if (empty($item->note)) : ?>
 										<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 									<?php else : ?>
 										<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
 									<?php endif; ?>
-								</span>
+								</div>
 							</th>
 
 						<?php if (isset($this->items[0]) && property_exists($this->items[0], 'count_published')) : ?>


### PR DESCRIPTION
In some list views the title cell contains additional information eg alias or category.
Sometimes they are on the same line, sometimes they are on new lines.

This PR makes them all on new lines for consistency. It is also much easier this way if you need to scan through a list looking for something.

## Changed views 
### Associations
![image](https://user-images.githubusercontent.com/1296369/127119593-82614dc6-3cf5-40dc-9fb9-859cd286dad5.png)

### Banners
![image](https://user-images.githubusercontent.com/1296369/127119671-9e740f21-8b9d-404c-a65d-b3ec3c7a5936.png)

### Contacts
![image](https://user-images.githubusercontent.com/1296369/127119807-04663e71-3d20-4309-946e-286637effb55.png)

### Fields
![image](https://user-images.githubusercontent.com/1296369/127119999-a5cdccc4-573a-4236-ab30-f02107a34708.png)

### Field Groups
![image](https://user-images.githubusercontent.com/1296369/127120044-976d5df4-6e55-4526-91c2-0128d8f3a4eb.png)

### Newsfeeds
![image](https://user-images.githubusercontent.com/1296369/127120092-cc6ba41e-9b64-4743-9f02-0630e3cc0be3.png)

### Tags
![image](https://user-images.githubusercontent.com/1296369/127120130-a7d81702-403b-49d3-a89a-626c01b156c4.png)

### Update Sites
#### No visible change just markup fix
![image](https://user-images.githubusercontent.com/1296369/127120320-0d493682-cd66-42dd-bb47-e7583334f080.png)

