### PR TITLE
[4.0] Media Manager: invalidate browser's cache

### DIFF
--- a/administrator/components/com_media/resources/scripts/app/Api.es6.js
+++ b/administrator/components/com_media/resources/scripts/app/Api.es6.js
@@ -26,6 +26,7 @@ class Api {
     this.audioExtensions = options.audioExtensions;
     this.videoExtensions = options.videoExtensions;
     this.documentExtensions = options.documentExtensions;
+    this.mediaVersion = (new Date().getTime()).toString();
   }
 
   /**

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -204,7 +204,7 @@ export default {
     canEdit() {
       return ['jpg', 'jpeg', 'png'].indexOf(this.item.extension.toLowerCase()) > -1;
     },
-    /* Get a UID */
+    /* Get the hashed URL */
     getHashedURL() {
       if (this.item.adapter.startsWith('local-')) {
         return `url(${this.item.thumb_path}?${api.mediaVersion})`;

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -8,7 +8,7 @@
       <div class="image-background">
         <div
           class="image-cropped"
-          :style="{ backgroundImage: 'url(' + getHashedURL + ')' }"
+          :style="{ backgroundImage: getHashedURL }"
         />
       </div>
     </div>
@@ -207,9 +207,9 @@ export default {
     /* Get a UID */
     getHashedURL() {
       if (this.item.adapter.startsWith('local-')) {
-        return `${this.item.thumb_path}?${api.mediaVersion}`;
+        return `url(${this.item.thumb_path}?${api.mediaVersion})`;
       }
-      return this.item.thumb_path;
+      return `url(${this.item.thumb_path})`;
     },
   },
   methods: {

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -8,7 +8,7 @@
       <div class="image-background">
         <div
           class="image-cropped"
-          :style="{ backgroundImage: 'url(' + thumbUrl + getHash +')' }"
+          :style="{ backgroundImage: 'url(' + getHashedURL + ')' }"
         />
       </div>
     </div>
@@ -200,20 +200,16 @@ export default {
     };
   },
   computed: {
-    /* Get the item url */
-    thumbUrl() {
-      return this.item.thumb_path;
-    },
     /* Check if the item is an image to edit */
     canEdit() {
       return ['jpg', 'jpeg', 'png'].indexOf(this.item.extension.toLowerCase()) > -1;
     },
     /* Get a UID */
-    getHash() {
+    getHashedURL() {
       if (this.item.adapter.startsWith('local-')) {
-        return `?${api.mediaVersion}`;
+        return `${this.item.thumb_path}?${api.mediaVersion}`;
       }
-      return '';
+      return this.item.thumb_path;
     },
   },
   methods: {

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -8,7 +8,7 @@
       <div class="image-background">
         <div
           class="image-cropped"
-          :style="{ backgroundImage: 'url(' + thumbUrl + ')' }"
+          :style="{ backgroundImage: 'url(' + thumbUrl + '?' + getHash +')' }"
         />
       </div>
     </div>
@@ -187,6 +187,7 @@
 </template>
 
 <script>
+import { api } from '../../../app/Api.es6';
 import * as types from '../../../store/mutation-types.es6';
 
 export default {
@@ -207,6 +208,10 @@ export default {
     canEdit() {
       return ['jpg', 'jpeg', 'png'].indexOf(this.item.extension.toLowerCase()) > -1;
     },
+    /* Get a UID */
+    getHash() {
+      return api.mediaVersion;
+    }
   },
   methods: {
     /* Preview an item */

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -211,7 +211,7 @@ export default {
     /* Get a UID */
     getHash() {
       return api.mediaVersion;
-    }
+    },
   },
   methods: {
     /* Preview an item */

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -212,6 +212,7 @@ export default {
     getHash() {
       if (this.item.adapter.startsWith('local-')) {
         return `?${api.mediaVersion}`;
+      }
       return '';
     },
   },

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -8,7 +8,7 @@
       <div class="image-background">
         <div
           class="image-cropped"
-          :style="{ backgroundImage: 'url(' + thumbUrl + '?' + getHash +')' }"
+          :style="{ backgroundImage: 'url(' + thumbUrl + getHash +')' }"
         />
       </div>
     </div>
@@ -210,7 +210,9 @@ export default {
     },
     /* Get a UID */
     getHash() {
-      return api.mediaVersion;
+      if (this.item.adapter.startsWith('local-')) {
+        return `?${api.mediaVersion}`;
+      return '';
     },
   },
   methods: {

--- a/administrator/components/com_media/resources/scripts/components/modals/preview-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/preview-modal.vue
@@ -40,7 +40,7 @@
         />
         <img
           v-if="isImage()"
-          :src=" item.url + getHash "
+          :src="getHashedURL"
           :type="item.mime_type"
         >
       </div>
@@ -69,12 +69,12 @@ export default {
       // Use the currently selected directory as a fallback
       return this.$store.state.previewItem;
     },
-    /* Get a UID */
-    getHash() {
+    /* Get the hashed URL */
+    getHashedURL() {
       if (this.item.adapter.startsWith('local-')) {
-        return `?${api.mediaVersion}`;
+        return `${this.item.url}?${api.mediaVersion}`;
       }
-      return '';
+      return this.item.url;
     },
   },
   methods: {

--- a/administrator/components/com_media/resources/scripts/components/modals/preview-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/preview-modal.vue
@@ -40,7 +40,7 @@
         />
         <img
           v-if="isImage()"
-          :src=" item.url + '?' + getHash "
+          :src=" item.url + getHash "
           :type="item.mime_type"
         >
       </div>
@@ -71,7 +71,10 @@ export default {
     },
     /* Get a UID */
     getHash() {
-      return api.mediaVersion;
+      if (this.item.adapter.startsWith('local-')) {
+        return `?${api.mediaVersion}`;
+      }
+      return '';
     },
   },
   methods: {

--- a/administrator/components/com_media/resources/scripts/components/modals/preview-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/preview-modal.vue
@@ -40,7 +40,7 @@
         />
         <img
           v-if="isImage()"
-          :src="item.url"
+          :src=" item.url + '?' + getHash "
           :type="item.mime_type"
         >
       </div>
@@ -58,6 +58,7 @@
 </template>
 
 <script>
+import { api } from '../../app/Api.es6';
 import * as types from '../../store/mutation-types.es6';
 
 export default {
@@ -67,6 +68,10 @@ export default {
     item() {
       // Use the currently selected directory as a fallback
       return this.$store.state.previewItem;
+    },
+    /* Get a UID */
+    getHash() {
+      return api.mediaVersion;
     },
   },
   methods: {


### PR DESCRIPTION
Pull Request as a supplementary to https://github.com/joomla/joomla-cms/pull/34885

### Summary of Changes
- adds a hash to the thumb and the preview image URLs
- The hash is generated once in the app's lifecycle (efficient)


### Testing Instructions
This relies on https://github.com/joomla/joomla-cms/pull/34885 so if it's not already merged you need to apply that code first

Also, you need to set expire headers in your NginX (or Apache or whatever you're using) so the browser could cache files for some given period (eg 1 year)

Edit a file and check that the media manager **displays** the edited version!

Also, check the media manager's source code

![Screenshot 2021-07-27 at 12 43 40](https://user-images.githubusercontent.com/3889375/127141380-2615afc2-be0d-4b05-bade-aa9deeadaa64.png)

![Screenshot 2021-07-27 at 12 43 57](https://user-images.githubusercontent.com/3889375/127141391-0db638e9-b089-4428-b1b8-6c722578ae62.png)


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

No. Joomla **SHOULD** cache (and invalidate) **all the static assets**.
The media manager team had some plans for a db layer but that was never implemented. Something needs to be done in the direction of storing/retrieving related data, both for cache invalidation but most importantly for the external adapters...
I know cache invalidation is hard but the project should try to fix the fundamentals before going to fancy things like `Responsive Images with Art Direction` which by the way has a number of architectural flaws...  

