### PR TITLE
[4.0] Remove template alert for Administrator app

### DIFF
--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -272,7 +272,6 @@ class AdministratorApplication extends CMSApplication
 		if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')
 			&& !is_file(JPATH_THEMES . '/' . $template->parent . '/index.php'))
 		{
-			$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
 			$template->params = new Registry;
 			$template->template = 'atum';
 


### PR DESCRIPTION
Pull Request for Issue #34908 .

### Summary of Changes

Remove template alert for Administrator app. It stays for a Site app.

> Because we cannot use `jerror` for log there, and seems we do not have another appretiere category, so instead of introducing new category (that will be only here and no one will know about it) I suggest to remove that line.


### Testing Instructions
Please follow #34908


### Documentation Changes Required
none
