### PR TITLE
[4.0] reverse category order

### DIFF
--- a/administrator/components/com_categories/tmpl/categories/default_batch_body.php
+++ b/administrator/components/com_categories/tmpl/categories/default_batch_body.php
@@ -50,7 +50,7 @@ $extension = $this->escape($this->state->get('filter.extension'));
 	<?php if ($extension === 'com_content') : ?>
 	<div class="row">
 		<div class="form-group col-md-6">
-			<div class="control-group">
+			<div class="controls">
 				<label id="flip-ordering-id-lbl" for="flip-ordering-id" class="control-label">
 					<?php echo Text::_('JLIB_HTML_BATCH_FLIPORDERING_LABEL'); ?>
 				</label>


### PR DESCRIPTION
Use the correct class to ensure the display of the field is full width

### Before
![image](https://user-images.githubusercontent.com/1296369/127198973-eef6e313-6a6b-4920-a615-c22ffd85ceaa.png)

### After
![image](https://user-images.githubusercontent.com/1296369/127198856-9ad1b4a3-c335-40fe-891e-819eb2437e23.png)

