### PR TITLE
[4.0] Stabilizing MM preview for external adapters

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -14,7 +14,7 @@ if (!Joomla) {
  */
 const getExtension = (path) => {
   const parts = path.split(/[#]/);
-  if (parts.length) {
+  if (parts.length > 1) {
     return parts[1].split(/[?]/)[0].split('.').pop().trim();
   }
   return path.split(/[#?]/)[0].split('.').pop().trim();
@@ -186,7 +186,7 @@ class JoomlaFieldMedia extends HTMLElement {
     this.setValue('');
   }
 
-  updatePreview(withValue) {
+  updatePreview() {
     if (['true', 'static'].indexOf(this.preview) === -1 || this.preview === 'false' || !this.previewElement) {
       return;
     }
@@ -194,7 +194,6 @@ class JoomlaFieldMedia extends HTMLElement {
     // Reset preview
     if (this.preview) {
       let { value } = this.inputElement;
-      if (withValue) value = withValue;
       const { supportedExtensions } = this;
       if (!value) {
         this.buttonClearEl.style.display = 'none';

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -197,7 +197,7 @@ const insertAsImage = async (media, editor, fieldClass) => {
         }
       }
       editor.value = `${Joomla.selectedMediaFile.url}#joomlaImage://${media.path.replace(':', '')}?width=${Joomla.selectedMediaFile.width}&height=${Joomla.selectedMediaFile.height}`;
-      fieldClass.updatePreview(Joomla.selectedMediaFile.url);
+      fieldClass.updatePreview();
     }
   }
 };


### PR DESCRIPTION
Pull Request for pr #34922.

### Summary of Changes
Followup of #34922. When an image is selected an error is thrown as the normal url is used. Now it uses the proper one. Didn't test that part not in the old pr.

@dgrammatiko please have a look here...