### PR TITLE
[4.0] Atum: Prevent warping custom logos in header

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -42,6 +42,8 @@
           display: inline-block;
           width: 20px;
           height: 20px;
+          object-fit: contain;
+          object-position: center center;
         }
       }
     }
@@ -51,7 +53,8 @@
       width: 150px;
       height: 30px;
       margin: 0 .35rem;
-
+      object-fit: contain;
+      object-position: left center;
       &.logo-collapsed {
         display: none;
       }


### PR DESCRIPTION
Pull Request for Issue #34355 .

### Summary of Changes
By adding a few lines of CSS, we are able to ensure that custom logos in the admin template are not warped even if they don't fit the exact dimensions of the space available.


### Testing Instructions

1. Go to `System > Templates > Administrator Template Styles`.
2. Open a style of your choice and navigate to `Image Settings`.
3. Scroll down to "Brand Large". Upload an image with dimensions other than 30x150 pixels.
4. Scroll down to "Brand Small". Upload an image that is not square aspect ratio.
5. Save and close.


### Actual result BEFORE applying this Pull Request
"Brand Large" and "Brand Small" images are stretched and warped to fit specific pixel dimensions regardless of their original proportions or size.


### Expected result AFTER applying this Pull Request
"Brand Large" and "Brand Small" display with the correct aspect ratio, within the space available.


### Documentation Changes Required
None.
