### PR TITLE
[4.0] Do not crash when no adapters ar available

### DIFF
--- a/administrator/components/com_media/resources/scripts/store/state.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/state.es6.js
@@ -26,8 +26,8 @@ const loadedDisks = options.providers.map((disk) => ({
   displayName: disk.displayName,
   drives: getDrives(disk.adapterNames, disk.name),
 }));
-
-if (loadedDisks[0].drives[0] === undefined || loadedDisks[0].drives.length === 0) {
+const defaultDisk = loadedDisks.find(disk => disk.drives.length > 0 && disk.drives[0] !== undefined);
+if (!defaultDisk) {
   throw new TypeError('No default media drive was found');
 }
 
@@ -49,8 +49,8 @@ export default {
   disks: loadedDisks,
   // The loaded directories
   directories: loadedDisks.map((disk) => ({
-    path: disk.drives[0].root,
-    name: disk.displayName,
+    path: defaultDisk.drives[0].root,
+    name: defaultDisk.displayName,
     directories: [],
     files: [],
     directory: null,
@@ -59,7 +59,7 @@ export default {
   files: [],
   // The selected disk. Providers are ordered by plugin ordering, so we set the first provider
   // in the list as the default provider and load first drive on it as default
-  selectedDirectory: options.currentPath || loadedDisks[0].drives[0].root,
+  selectedDirectory: options.currentPath || defaultDisk.drives[0].root,
   // The currently selected items
   selectedItems: [],
   // The state of the infobar

--- a/administrator/components/com_media/resources/scripts/store/state.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/state.es6.js
@@ -26,7 +26,8 @@ const loadedDisks = options.providers.map((disk) => ({
   displayName: disk.displayName,
   drives: getDrives(disk.adapterNames, disk.name),
 }));
-const defaultDisk = loadedDisks.find(disk => disk.drives.length > 0 && disk.drives[0] !== undefined);
+const defaultDisk = loadedDisks.find((disk) => disk.drives.length > 0
+  && disk.drives[0] !== undefined);
 if (!defaultDisk) {
   throw new TypeError('No default media drive was found');
 }
@@ -48,7 +49,7 @@ export default {
   // Will hold the activated filesystem disks
   disks: loadedDisks,
   // The loaded directories
-  directories: loadedDisks.map((disk) => ({
+  directories: loadedDisks.map(() => ({
     path: defaultDisk.drives[0].root,
     name: defaultDisk.displayName,
     directories: [],

--- a/administrator/components/com_media/src/Model/MediaModel.php
+++ b/administrator/components/com_media/src/Model/MediaModel.php
@@ -45,9 +45,10 @@ class MediaModel extends BaseDatabaseModel
 
 		foreach ($providerManager->getProviders() as $provider)
 		{
-			$result = new \stdClass;
-			$result->name = $provider->getID();
-			$result->displayName = $provider->getDisplayName();
+			$result               = new \stdClass;
+			$result->name         = $provider->getID();
+			$result->displayName  = $provider->getDisplayName();
+			$result->adapterNames = [];
 
 			foreach ($provider->getAdapters() as $adapter)
 			{


### PR DESCRIPTION
### Summary of Changes
When a filesystem plugin is loaded before the local one which has no disks, the media manager crashes.

@dgrammatiko any comment?