### PR TITLE
[4.0] Don't upscale images

### DIFF
--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -125,7 +125,6 @@ class Edit {
     this.imagePreview = document.createElement('img');
     this.imagePreview.src = data.contents;
     this.imagePreview.id = 'image-preview';
-    this.imagePreview.style.width = '100%';
     this.imagePreview.style.height = 'auto';
     this.imagePreview.style.maxWidth = '100%';
     this.baseContainer.appendChild(this.imagePreview);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Small images in the media edit won't be upscaled


### Testing Instructions
Try to edit any of the Joomla images in the root of the images folder. The images shouldn't be upscaled in the rotate and resize tabs


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

NO