### PR TITLE
[4.0] Updating or uninstalling one library no longer removes another when both belong to same vendor.

### DIFF
--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -309,7 +309,7 @@ class LibraryAdapter extends InstallerAdapter
 		// Delete empty vendor folders
 		if (2 === \count($elementParts))
 		{
-			$folders = Folder::folders(JPATH_PLATFORM . '/' . $elementParts[0], '.', false, true);
+			$folders = Folder::folders(JPATH_PLATFORM . '/' . $elementParts[0]);
 
 			if (empty($folders))
 			{

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -310,6 +310,7 @@ class LibraryAdapter extends InstallerAdapter
 		if (2 === \count($elementParts))
 		{
 			$folders = Folder::folders(JPATH_PLATFORM . '/' . $elementParts[0], '.', false, true, array(), array());
+
 			if (empty($folders))
 			{
 				Folder::delete(JPATH_MANIFESTS . '/libraries/' . $elementParts[0]);

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -309,8 +309,12 @@ class LibraryAdapter extends InstallerAdapter
 		// Delete empty vendor folders
 		if (2 === \count($elementParts))
 		{
-			Folder::delete(JPATH_MANIFESTS . '/libraries/' . $elementParts[0]);
-			Folder::delete(JPATH_PLATFORM . '/' . $elementParts[0]);
+			$folders = Folder::folders(JPATH_PLATFORM . '/' . $elementParts[0], '.', false, true, array(), array());
+			if (empty($folders))
+			{
+				Folder::delete(JPATH_MANIFESTS . '/libraries/' . $elementParts[0]);
+				Folder::delete(JPATH_PLATFORM . '/' . $elementParts[0]);
+			}
 		}
 	}
 

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -309,7 +309,7 @@ class LibraryAdapter extends InstallerAdapter
 		// Delete empty vendor folders
 		if (2 === \count($elementParts))
 		{
-			$folders = Folder::folders(JPATH_PLATFORM . '/' . $elementParts[0], '.', false, true, array(), array());
+			$folders = Folder::folders(JPATH_PLATFORM . '/' . $elementParts[0], '.', false, true);
 
 			if (empty($folders))
 			{


### PR DESCRIPTION
Pull Request for Issue # .
#34910

### Summary of Changes

Check if there are any other children before removing vendor folder.

### Testing Instructions

As described in #34910

### Actual result BEFORE applying this Pull Request

Updating or uninstalling one library removes another when both belong to same vendor.

### Expected result AFTER applying this Pull Request

Updating or uninstalling one library no longer removes another when both belong to same vendor.

### Documentation Changes Required

Check if using library names like these is documented.

<libraryname>mycompany/mylibrary1</libraryname>

<libraryname>mycompany/mylibrary2</libraryname>
