### PR TITLE
[4.0] com_config site hr

### DIFF
--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -40,7 +40,6 @@ $wa->useScript('keepalive')
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>
 
-	<hr>
 	<div class="mb-2">
 	<button type="button" class="btn btn-primary" data-submit-task="config.apply">
 		<span class="icon-check" aria-hidden="true"></span>

--- a/components/com_config/tmpl/templates/default.php
+++ b/components/com_config/tmpl/templates/default.php
@@ -47,7 +47,6 @@ $wa->useScript('keepalive')
 	<input type="hidden" name="task" value="">
 	<?php echo HTMLHelper::_('form.token'); ?>
 
-	<hr>
 	<div class="mb-2">
 	<button type="button" class="btn btn-primary " data-submit-task="templates.apply">
 		<span class="icon-check text-white" aria-hidden="true"></span>


### PR DESCRIPTION
Pull Request for Issue #34937 .

### Summary of Changes
There are 6 forms on the frontend that have save and cancel button.
Two of them had a stray hr above the buttons.

This PR removes the hr from directly above the buttons on the Site Settings and Template Settings forms in the **frontend**
