### PR TITLE
Add new logging category and add sample log entry for it

### DIFF
--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -77,26 +77,7 @@ defined('JVERSION') or define('JVERSION', (new JVersion)->getShortVersion());
 // Set up the message queue logger for web requests
 if (array_key_exists('REQUEST_METHOD', $_SERVER))
 {
-	\Joomla\CMS\Log\Log::addLogger(['logger' => 'messagequeue'], JLog::ALL, ['jerror']);
-
-	// We only log errors unless Site Debug is enabled
-	$logLevels = \Joomla\CMS\Log\Log::ERROR | \Joomla\CMS\Log\Log::CRITICAL |
-		\Joomla\CMS\Log\Log::ALERT | \Joomla\CMS\Log\Log::EMERGENCY;
-
-	if (\defined('JDEBUG') && JDEBUG)
-	{
-		$logLevels = \Joomla\CMS\Log\Log::ALL;
-	}
-
-	/**
-	 * This error category is explicitly designed for core errors that need logging. It is NOT intended for use
-	 * by 3rd party extensions
-	 */
-	\Joomla\CMS\Log\Log::addLogger(
-		['text_file' => 'joomla_core_errors.php'],
-		$logLevels,
-		["system"]
-	);
+	JLog::addLogger(['logger' => 'messagequeue'], JLog::ALL, ['jerror']);
 }
 
 // Register the Crypto lib

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -77,7 +77,26 @@ defined('JVERSION') or define('JVERSION', (new JVersion)->getShortVersion());
 // Set up the message queue logger for web requests
 if (array_key_exists('REQUEST_METHOD', $_SERVER))
 {
-	JLog::addLogger(['logger' => 'messagequeue'], JLog::ALL, ['jerror']);
+	\Joomla\CMS\Log\Log::addLogger(['logger' => 'messagequeue'], JLog::ALL, ['jerror']);
+
+	// We only log errors unless Site Debug is enabled
+	$logLevels = \Joomla\CMS\Log\Log::ERROR | \Joomla\CMS\Log\Log::CRITICAL |
+		\Joomla\CMS\Log\Log::ALERT | \Joomla\CMS\Log\Log::EMERGENCY;
+
+	if (\defined('JDEBUG') && JDEBUG)
+	{
+		$logLevels = \Joomla\CMS\Log\Log::ALL;
+	}
+
+	/**
+	 * This error category is explicitly designed for core errors that need logging. It is NOT intended for use
+	 * by 3rd party extensions
+	 */
+	\Joomla\CMS\Log\Log::addLogger(
+		['text_file' => 'joomla_core_errors.php'],
+		$logLevels,
+		["system"]
+	);
 }
 
 // Register the Crypto lib

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -272,7 +272,7 @@ class AdministratorApplication extends CMSApplication
 		if (!is_file(JPATH_THEMES . '/' . $template->template . '/index.php')
 			&& !is_file(JPATH_THEMES . '/' . $template->parent . '/index.php'))
 		{
-			$this->enqueueMessage(Text::_('JERROR_ALERTNOTEMPLATE'), 'error');
+			$this->getLogger()->error(Text::_('JERROR_ALERTNOTEMPLATE'), ['category' => 'system']);
 			$template->params = new Registry;
 			$template->template = 'atum';
 

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -1392,6 +1392,16 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 			Log::addLogger(['text_file' => 'deprecated.php'], Log::ALL, ['deprecated']);
 		}
 
+		// We only log errors unless Site Debug is enabled
+		$logLevels = Log::ERROR | Log::CRITICAL | Log::ALERT | Log::EMERGENCY;
+
+		if ($this->get('debug'))
+		{
+			$logLevels = Log::ALL;
+		}
+
+		Log::addLogger(['text_file' => 'joomla_core_errors.php'], $logLevels, ['system']);
+
 		// Log everything (except deprecated APIs, these are logged separately with the option above).
 		if ($this->get('log_everything'))
 		{


### PR DESCRIPTION
Pull Request for Issue #34908 .

### Summary of Changes
Add new category for logging system errors within Joomla Core to file. This is something we should expand with additional errors we want don't want to show to end users of the site (in whatever client - remember editors in the backend may not be fully trusted users!)


### Testing Instructions
Please follow #34908

Alternatively - in your database go to the template styles column and change the template name from atum to an alternative such as `atum2`.


### Actual result BEFORE applying this Pull Request
Error shown on screen


### Expected result AFTER applying this Pull Request
Error logged to file (by default `JROOT/administrator/logs/joomla_core_errors.php`). File name can be debated to death obviously.

### Documentation Changes Required
Yes - we should include this file in documentation on how to debug core - even if it's just a one off!
