### PR TITLE
[4.0] Replace Factory::getDbo() with $this->getDbo()

### DIFF
--- a/administrator/components/com_finder/src/Model/FilterModel.php
+++ b/administrator/components/com_finder/src/Model/FilterModel.php
@@ -146,7 +146,7 @@ class FilterModel extends AdminModel
 	 */
 	public function getTotal()
 	{
-		$db    = Factory::getDbo();
+		$db    = $this->getDbo();
 		$query = $db->getQuery(true)
 			->select('MAX(link_id)')
 			->from('#__finder_links');

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -646,7 +646,7 @@ ENDDATA;
 		$installer->setUpgrade(true);
 		$installer->setOverwrite(true);
 
-		$installer->extension = new \Joomla\CMS\Table\Extension(Factory::getDbo());
+		$installer->extension = new \Joomla\CMS\Table\Extension($this->getDbo());
 		$installer->extension->load(ExtensionHelper::getExtensionRecord('joomla', 'file')->extension_id);
 
 		$installer->setAdapter($installer->extension->type);
@@ -713,7 +713,7 @@ ENDDATA;
 		}
 
 		$id = $db->loadResult();
-		$row = new \Joomla\CMS\Table\Extension(Factory::getDbo());
+		$row = new \Joomla\CMS\Table\Extension($this->getDbo());
 
 		if ($id)
 		{
@@ -806,7 +806,7 @@ ENDDATA;
 		ob_end_clean();
 
 		// Clobber any possible pending updates.
-		$update = new \Joomla\CMS\Table\Update(Factory::getDbo());
+		$update = new \Joomla\CMS\Table\Update($this->getDbo());
 		$uid = $update->find(
 			array('element' => 'joomla', 'type' => 'file', 'client_id' => '0', 'folder' => '')
 		);

--- a/administrator/components/com_languages/src/Model/OverridesModel.php
+++ b/administrator/components/com_languages/src/Model/OverridesModel.php
@@ -259,7 +259,7 @@ class OverridesModel extends ListModel
 	 */
 	public function purge()
 	{
-		$db = Factory::getDbo();
+		$db = $this->getDbo();
 
 		// Note: TRUNCATE is a DDL operation
 		// This may or may not mean depending on your database

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -114,7 +114,7 @@ class TemplateModel extends FormModel
 	public function getTemplateList()
 	{
 		// Get a db connection.
-		$db = Factory::getDbo();
+		$db = $this->getDbo();
 
 		// Create a new query object.
 		$query = $db->getQuery(true);
@@ -154,7 +154,7 @@ class TemplateModel extends FormModel
 	public function getUpdatedList($state = false, $all = false, $cleanup = false)
 	{
 		// Get a db connection.
-		$db = Factory::getDbo();
+		$db = $this->getDbo();
 
 		// Create a new query object.
 		$query = $db->getQuery(true);
@@ -318,7 +318,7 @@ class TemplateModel extends FormModel
 	 */
 	public function publish($ids, $value, $exid)
 	{
-		$db = Factory::getDbo();
+		$db = $this->getDbo();
 
 		foreach ($ids as $id)
 		{

--- a/administrator/components/com_templates/src/Model/TemplatesModel.php
+++ b/administrator/components/com_templates/src/Model/TemplatesModel.php
@@ -93,7 +93,7 @@ class TemplatesModel extends ListModel
 	 */
 	public function updated($exid)
 	{
-		$db = Factory::getDbo();
+		$db = $this->getDbo();
 
 		// Select the required fields from the table
 		$query = $db->getQuery(true)


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
General rule is within model classes (for none static methods, of course), we should use `$this->getDbo();` instead of `Factory::getDbo();` to get database object.

However, there are still few places in our code use `Factory::getDbo();` and this PR just fixes that.

### Testing Instructions
1. Code review
2. Or:
- Update your site to this package generated by this PR and make sure it is updated properly (this test the change in UpdateModel)
- Access to System -> Site Templates and make sure it is still being loaded
- Access to Components -> Smart Search -> Filters and make sure it is still being loaded
- Access to System -> Language Overrides, click on Clear Cache button and make sure no error happens.