### PR TITLE
[4.0] Correctly handle multiple critical extensions within an package that is joomla 4 compatible

### DIFF
--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -369,15 +369,8 @@ Joomla = window.Joomla || {};
 
     // Process the nonCoreCriticalPlugin list
     if (extensionData.compatibilityData.resultGroup === 3) {
-      let pluginInfo;
-
-      for (let i = PreUpdateChecker.nonCoreCriticalPlugins.length - 1; i >= 0; i -= 1) {
-        pluginInfo = PreUpdateChecker.nonCoreCriticalPlugins[i];
-
-        if (pluginInfo.package_id === extensionId || pluginInfo.extension_id === extensionId) {
-          PreUpdateChecker.nonCoreCriticalPlugins.splice(i, 1);
-        }
-      }
+      PreUpdateChecker.nonCoreCriticalPlugins = PreUpdateChecker.nonCoreCriticalPlugins
+        .filter((ext) => !(ext.package_id === extensionId || ext.extension_id === extensionId));
     }
 
     // Have we finished?

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -370,7 +370,7 @@ Joomla = window.Joomla || {};
     // Process the nonCoreCriticalPlugin list
     if (extensionData.compatibilityData.resultGroup === 3) {
       PreUpdateChecker.nonCoreCriticalPlugins = PreUpdateChecker.nonCoreCriticalPlugins
-        .filter((ext) => !(ext.package_id === extensionId || ext.extension_id === extensionId));
+        .filter((ext) => !(ext.package_id.toString() === extensionId || ext.extension_id.toString() === extensionId));
     }
 
     // Have we finished?

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -370,6 +370,7 @@ Joomla = window.Joomla || {};
     // Process the nonCoreCriticalPlugin list
     if (extensionData.compatibilityData.resultGroup === 3) {
       PreUpdateChecker.nonCoreCriticalPlugins = PreUpdateChecker.nonCoreCriticalPlugins
+        // eslint-disable-next-line max-len
         .filter((ext) => !(ext.package_id.toString() === extensionId || ext.extension_id.toString() === extensionId));
     }
 

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -369,12 +369,15 @@ Joomla = window.Joomla || {};
 
     // Process the nonCoreCriticalPlugin list
     if (extensionData.compatibilityData.resultGroup === 3) {
-      PreUpdateChecker.nonCoreCriticalPlugins.forEach((plugin, cpi) => {
-        if (plugin.package_id.toString() === extensionId
-            || plugin.extension_id.toString() === extensionId) {
-          PreUpdateChecker.nonCoreCriticalPlugins.splice(cpi, 1);
+      let pluginInfo;
+
+      for (let i = PreUpdateChecker.nonCoreCriticalPlugins.length - 1; i >= 0; i -= 1) {
+        pluginInfo = PreUpdateChecker.nonCoreCriticalPlugins[i];
+
+        if (pluginInfo.package_id === extensionId || pluginInfo.extension_id === extensionId) {
+          PreUpdateChecker.nonCoreCriticalPlugins.splice(i, 1);
         }
-      });
+      }
     }
 
     // Have we finished?


### PR DESCRIPTION
Pull Request for Issue #34968 .

### Summary of Changes

Port PR #34776 to the 4.0-dev branch.

### Testing Instructions

1. Install latest akeeba, enable the system plugin (backup on update) and the action log plugin.
2. Point your update server to the Joomla 4 nightlies (custom URL: [https://update.joomla.org/core/nightlies/next_major_list.xml](https://update.joomla.org/core/nightlies/next_major_list.xml)) in order to get the pre-update checker shown.
3. Apply this PR
4. Clear the browser / JS cache.

### Actual result BEFORE applying this Pull Request

The pre upgrade checker shows a message about potentially not compatible plugins within that package.

### Expected result AFTER applying this Pull Request

The pre update checker shows no message about that plugins cause they are compatible..

### Documentation Changes Required

None.