### PR TITLE
[4.0] Menu preset import. Add separator counter for reliable alias creation.

### DIFF
--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -54,7 +54,7 @@ class MenusHelper extends ContentHelper
 	 *
 	 * @var  integer
 	 *
-	 * @since   4.0.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	protected static $separatorCount = 0;
 

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -50,6 +50,15 @@ class MenusHelper extends ContentHelper
 	protected static $presets = null;
 
 	/**
+	 * Counts separator menu items during preset imports for unique alias creation.
+	 *
+	 * @var  integer
+	 *
+	 * @since   4.0.0
+	 */
+	protected static $separatorCount = 0;
+
+	/**
 	 * Gets a standard form of a link for lookups.
 	 *
 	 * @param   mixed  $request  A link string or array of request variables.
@@ -468,9 +477,10 @@ class MenusHelper extends ContentHelper
 	 */
 	protected static function installPresetItems($node, $menutype)
 	{
-		$db    = Factory::getDbo();
-		$query = $db->getQuery(true);
-		$items = $node->getChildren();
+		$db             = Factory::getDbo();
+		$query          = $db->getQuery(true);
+		$items          = $node->getChildren();
+		$separatorCount = 0;
 
 		static $components = array();
 
@@ -506,7 +516,7 @@ class MenusHelper extends ContentHelper
 			{
 				// Do not reuse a separator
 				$item->title = $item->title ?: '-';
-				$item->alias = microtime(true);
+				$item->alias = microtime(true) . '-' . self::$separatorCount++;
 			}
 			elseif ($item->type == 'heading' || $item->type == 'container')
 			{

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -477,10 +477,9 @@ class MenusHelper extends ContentHelper
 	 */
 	protected static function installPresetItems($node, $menutype)
 	{
-		$db             = Factory::getDbo();
-		$query          = $db->getQuery(true);
-		$items          = $node->getChildren();
-		$separatorCount = 0;
+		$db    = Factory::getDbo();
+		$query = $db->getQuery(true);
+		$items = $node->getChildren();
 
 		static $components = array();
 


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/34964

### Summary of Changes
- Add a variable that count up `separator` menu items to create a guaranteed unique alias for each of them.
- I haven't established the `$separatorCount` variable in method `installPresetItems()` because it looks like presets are imported stepwise (several calls of this method that reset the counter to 0). Maybe overcautious?

### Testing Instructions
- See instructions ín issue on https://github.com/joomla/joomla-cms/issues/34964 please.

### Actual result BEFORE applying this Pull Request
- See image in issue on https://github.com/joomla/joomla-cms/issues/34964 please.

### Expected result AFTER applying this Pull Request
- See image below with 4 successful tests that failed before.
- At least 87 menu items imported with preset alternate.xml.
- it is expected that each test run will add one more menu item entry (cross-reference to already existing menus).

![29-07-_2021_15-46-10](https://user-images.githubusercontent.com/20780646/127503862-d88e753b-f7cd-44e0-9815-7a4ece336d50.jpg)


