### PR TITLE
[4.0] Fix fatal error while rebuilding update sites

### DIFF
--- a/administrator/components/com_installer/src/Model/UpdatesitesModel.php
+++ b/administrator/components/com_installer/src/Model/UpdatesitesModel.php
@@ -376,12 +376,18 @@ class UpdatesitesModel extends InstallerModel
 					// Is it a valid Joomla installation manifest file?
 					$manifest = $tmpInstaller->isManifest($file);
 
+
 					if ($manifest !== null)
 					{
 						/**
 						 * Search if the extension exists in the extensions table. Excluding Joomla
 						 * core extensions (id < 10000) and discovered extensions.
 						 */
+
+						$name    = (string) $manifest->name;
+						$pkgName = (string) $manifest->packagename;
+						$type    = (string) $manifest['type'];
+
 						$query = $db->getQuery(true)
 							->select($db->quoteName('extension_id'))
 							->from($db->quoteName('#__extensions'))
@@ -400,9 +406,9 @@ class UpdatesitesModel extends InstallerModel
 								'OR'
 							)
 							->whereNotIn($db->quoteName('extension_id'), $joomlaCoreExtensionIds)
-							->bind(':name', $manifest->name)
-							->bind(':pkgname', $manifest->packagename)
-							->bind(':type', $manifest['type']);
+							->bind(':name', $name)
+							->bind(':pkgname', $pkgName)
+							->bind(':type', $type);
 						$db->setQuery($query);
 
 						$eid = (int) $db->loadResult();

--- a/administrator/components/com_installer/src/Model/UpdatesitesModel.php
+++ b/administrator/components/com_installer/src/Model/UpdatesitesModel.php
@@ -376,7 +376,6 @@ class UpdatesitesModel extends InstallerModel
 					// Is it a valid Joomla installation manifest file?
 					$manifest = $tmpInstaller->isManifest($file);
 
-
 					if ($manifest !== null)
 					{
 						/**


### PR DESCRIPTION
Pull Request for Issue #34984.

### Summary of Changes
We need to cast the values to string before bind value to prepared statemement

### Testing Instructions
1. Set Debug System to enabled in Global Configuration
2. Rebuild update sites
3. Before patch: You got fatal error
4. After patch: update sites rebuilt successfully