### PR TITLE
[4.0] Fix searchtools error checkActiveStatus

### DIFF
--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -174,14 +174,12 @@ Joomla = window.Joomla || {};
       }
 
       // Do we need to add to mark filter as enabled?
-      if (this.getFilterFields()) {
-        this.getFilterFields().forEach((i) => {
+      this.getFilterFields().forEach((i) => {
+        self.checkFilter(i);
+        i.addEventListener('change', () => {
           self.checkFilter(i);
-          i.addEventListener('change', () => {
-            self.checkFilter(i);
-          });
         });
-      }
+      });
 
       if (this.clearButton) {
         this.clearButton.addEventListener('click', self.clear);
@@ -245,16 +243,14 @@ Joomla = window.Joomla || {};
         self.searchField.value = '';
       }
 
-      if (self.getFilterFields()) {
-        self.getFilterFields().forEach((i) => {
-          i.value = '';
-          self.checkFilter(i);
+      self.getFilterFields().forEach((i) => {
+        i.value = '';
+        self.checkFilter(i);
 
-          if (window.jQuery && window.jQuery.chosen) {
-            window.jQuery(i).trigger('chosen:updated');
-          }
-        });
-      }
+        if (window.jQuery && window.jQuery.chosen) {
+          window.jQuery(i).trigger('chosen:updated');
+        }
+      });
 
       if (self.clearListOptions) {
         self.getListFields().forEach((i) => {
@@ -286,18 +282,15 @@ Joomla = window.Joomla || {};
 
     // eslint-disable-next-line class-methods-use-this
     checkActiveStatus(cont) {
-      const els = this.getFilterFields();
       let activeFilterCount = 0;
 
-      if (els) {
-        els.forEach((item) => {
-          if (item.classList.contains('active')) {
-            activeFilterCount += 1;
-            cont.filterButton.classList.remove('btn-secondary');
-            cont.filterButton.classList.add('btn-primary');
-          }
-        });
-      }
+      this.getFilterFields().forEach((item) => {
+        if (item.classList.contains('active')) {
+          activeFilterCount += 1;
+          cont.filterButton.classList.remove('btn-secondary');
+          cont.filterButton.classList.add('btn-primary');
+        }
+      });
 
       // If there are no active filters - remove the filtered caption area from the table
       if (activeFilterCount === 0) {
@@ -361,6 +354,8 @@ Joomla = window.Joomla || {};
       if (this.filterContainer) {
         return Array.prototype.slice.call(this.filterContainer.querySelectorAll('select,input'));
       }
+
+      return [];
     }
 
     getListFields() {

--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -286,16 +286,18 @@ Joomla = window.Joomla || {};
 
     // eslint-disable-next-line class-methods-use-this
     checkActiveStatus(cont) {
-      const els = [].slice.call(this.getFilterFields());
+      const els = this.getFilterFields();
       let activeFilterCount = 0;
 
-      els.forEach((item) => {
-        if (item.classList.contains('active')) {
-          activeFilterCount += 1;
-          cont.filterButton.classList.remove('btn-secondary');
-          cont.filterButton.classList.add('btn-primary');
-        }
-      });
+      if (els) {
+        els.forEach((item) => {
+          if (item.classList.contains('active')) {
+            activeFilterCount += 1;
+            cont.filterButton.classList.remove('btn-secondary');
+            cont.filterButton.classList.add('btn-primary');
+          }
+        });
+      }
 
       // If there are no active filters - remove the filtered caption area from the table
       if (activeFilterCount === 0) {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Look like `[].slice.call` does not accept `undefined` as a valid argument, so when there no filter container defined in search tool, this line of code https://github.com/joomla/joomla-cms/blob/4.0-dev/build/media_source/system/js/searchtools.es6.js#L289 throws some error in console.

```
Uncaught TypeError: Cannot convert undefined or null to object
    at slice (<anonymous>)
    at Searchtools.checkActiveStatus (searchtools.js?c804da20519ee3655f5ac687001b9f31321af327:262)
    at new Searchtools (searchtools.js?c804da20519ee3655f5ac687001b9f31321af327:194)
    at HTMLDocument.onBoot (searchtools.js?c804da20519ee3655f5ac687001b9f31321af327:504)
```

This PR prevents that error by adding a if check, similar with what we do in other places in that script, for example https://github.com/joomla/joomla-cms/blob/4.0-dev/build/media_source/system/js/searchtools.es6.js#L177

### Testing Instructions
As this only happens on third party extensions (found this while testing my extensions), it's hard to call for end-users test. Hopefully code review would be enough. @dgrammatiko @Fedik Could you help?
