### PR TITLE
[4.0] Menu preset export fix warning

### DIFF
--- a/administrator/components/com_menus/src/View/Menu/XmlView.php
+++ b/administrator/components/com_menus/src/View/Menu/XmlView.php
@@ -134,7 +134,7 @@ class XmlView extends BaseHtmlView
 			$node['element'] = $item->element;
 		}
 
-		if ($item->class)
+		if (isset($item->class))
 		{
 			$node['class'] = htmlentities($item->class, ENT_XML1);
 		}
@@ -172,9 +172,12 @@ class XmlView extends BaseHtmlView
 			$node->addChild('params', htmlentities((string) $item->getParams(), ENT_XML1));
 		}
 
-		foreach ($item->submenu as $sub)
+		if (isset($item->submenu))
 		{
-			$this->addXmlChild($node, $sub);
+			foreach ($item->submenu as $sub)
+			{
+				$this->addXmlChild($node, $sub);
+			}
 		}
 	}
 }

--- a/administrator/components/com_menus/src/View/Menu/XmlView.php
+++ b/administrator/components/com_menus/src/View/Menu/XmlView.php
@@ -134,7 +134,7 @@ class XmlView extends BaseHtmlView
 			$node['element'] = $item->element;
 		}
 
-		if (isset($item->class))
+		if (isset($item->class) && $item->class)
 		{
 			$node['class'] = htmlentities($item->class, ENT_XML1);
 		}


### PR DESCRIPTION
Pull Request for Issue #34977 .

### Summary of Changes
added `isset()`


### Testing Instructions

see #34977
or export an preset menu

### Actual result BEFORE applying this Pull Request
warnings 
```
[30-Jul-2021 13:07:57 UTC] PHP Warning:  Undefined property: Joomla\CMS\Menu\AdministratorMenuItem::$class in /shared/httpd/dev4/joomla-cms/administrator/components/com_menus/src/View/Menu/XmlView.php on line 137
[30-Jul-2021 13:08:46 UTC] PHP Warning:  Undefined property: Joomla\CMS\Menu\AdministratorMenuItem::$submenu in /shared/httpd/dev4/joomla-cms/administrator/components/com_menus/src/View/Menu/XmlView.php on line 175
[30-Jul-2021 13:08:51 UTC] PHP Warning:  foreach() argument must be of type array|object, null given in /shared/httpd/dev4/joomla-cms/administrator/components/com_menus/src/View/Menu/XmlView.php on line 175


```
### Expected result AFTER applying this Pull Request
no warnings


