### PR TITLE
[4.0] Fix fatal error while uninstall deleted plugin

### DIFF
--- a/libraries/src/Installer/Adapter/PluginAdapter.php
+++ b/libraries/src/Installer/Adapter/PluginAdapter.php
@@ -232,7 +232,7 @@ class PluginAdapter extends InstallerAdapter
 	 */
 	public function getElement($element = null)
 	{
-		if (!$element)
+		if (!$element && $this->getManifest())
 		{
 			// Backward Compatibility
 			// @todo Deprecate in future version
@@ -421,7 +421,10 @@ class PluginAdapter extends InstallerAdapter
 		$this->parent->findManifest();
 		$this->setManifest($this->parent->getManifest());
 
-		$this->group = (string) $this->getManifest()->attributes()->group;
+		if ($this->getManifest())
+		{
+			$this->group = (string) $this->getManifest()->attributes()->group;
+		}
 
 		// Attempt to load the language file; might have uninstall strings
 		$this->loadLanguage($this->parent->getPath('source'));


### PR DESCRIPTION
Pull Request for Issue #34992.

### Summary of Changes
Currently, if we uninstall a plugin which was deleted for some reasons (or at least the manifest file was deleted), we will get fatal error because in the PluginAdater, we have code which didn't handle the case manifest not found.

This PR just adds some check to prevent these fatal error and allows these plugins still be uninstalled properly (mean the folder being deleted, the record is deleted from extensions table). 

I think we can do it better. For example, in **getElement**, we can just return `$this->extension->folder` (it's plugin group) and in the code to detect plugin group, we can use `$this->extension->folder`, too, instead of getting these information from manifest object. But this is just handle some special case, so I think it is fine.

### Testing Instructions
1. Try to delete a plugin folder (or delete the xml file of that plugin)
2. Uninstall that plugin
3. Before patch: you will get fatal error
4. After patch, the plugin will be uninstalled. Joomla also shows a warning to tell users that manifest not found.