### PR TITLE
[4.0] Cassiopeia - Possible solution for main content height

### DIFF
--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -12,9 +12,9 @@
       ". side-l side-l side-l side-l ."
       ". bot-a bot-a bot-a bot-a ."
       ". bot-b bot-b bot-b bot-b ."
-      ". footer footer footer footer ."
-      ". debug debug debug debug .";
+      ". footer footer footer footer .";
     grid-template-columns: [full-start] minmax(0, 1fr) [main-start] repeat(4, minmax(0, 19.875rem)) [main-end] minmax(0, 1fr) [full-end];
+    grid-template-rows: auto auto auto auto 1fr auto auto auto auto auto;
     grid-gap: 0 $cassiopeia-grid-gutter;
 
     > [class^="container-"],
@@ -45,6 +45,7 @@
         ". bot-a bot-a bot-a bot-a ."
         ". bot-b bot-b bot-b bot-b ."
         ". footer footer footer footer .";
+      grid-template-rows: auto auto auto auto 1fr auto auto auto;
     }
 
     &.wrapper-fluid {


### PR DESCRIPTION
Pull Request for Issue #35003 .

### Summary of Changes
Removed debug area for mobile view (I missed that on my last PR)
Added a `grid-template-rows` definition to make the main content part 1fr in height

### Testing Instructions
See issue #35003 and description of PR #34849 
Please test with and without modules and content and in different display sizes. Also test with short content and some module in footer position.


### Actual result BEFORE applying this Pull Request
See issue


### Expected result AFTER applying this Pull Request
The main content is aligned to top no matter if no content is present.
![image](https://user-images.githubusercontent.com/9153168/127745143-4e3f026b-d66f-475a-8010-9d978859b5a2.png)


### Documentation Changes Required

