### PR TITLE
[4.0] Make note field hideable

### DIFF
--- a/libraries/src/Form/Field/NoteField.php
+++ b/libraries/src/Form/Field/NoteField.php
@@ -60,7 +60,7 @@ class NoteField extends FormField
 		{
 			return '';
 		}
-		
+
 		$html  = [];
 		$class = [];
 

--- a/libraries/src/Form/Field/NoteField.php
+++ b/libraries/src/Form/Field/NoteField.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Form\Field;
 \defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Form\FormField;
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
 /**
@@ -59,23 +60,29 @@ class NoteField extends FormField
 		{
 			return '';
 		}
+		
+		$html  = [];
+		$class = [];
 
-		$title = $this->element['label'] ? (string) $this->element['label'] : ($this->element['title'] ? (string) $this->element['title'] : '');
-		$heading = $this->element['heading'] ? (string) $this->element['heading'] : 'h4';
-		$description = (string) $this->element['description'];
-		$class = !empty($this->class) ? ' class="' . $this->class . '"' : '';
-		$close = (string) $this->element['close'];
-
-		$html = array();
-
-		if ($close)
+		if (!empty($this->class))
 		{
-			$close = $close === 'true' ? 'alert' : $close;
-			$html[] = '<button type="button" class="btn-close" data-dismiss="' . $close . '">&times;</button>';
+			$class[] = $this->class;
 		}
 
-		$html[] = !empty($title) ? '<' . $heading . '>' . Text::_($title) . '</' . $heading . '>' : '';
-		$html[] = !empty($description) ? Text::_($description) : '';
+		if ($close = (string) $this->element['close'])
+		{
+			HTMLHelper::_('bootstrap.alert');
+			$close   = $close === 'true' ? 'alert' : $close;
+			$html[]  = '<button type="button" class="btn-close" data-bs-dismiss="' . $close . '"></button>';
+			$class[] = 'alert-dismissible show';
+		}
+
+		$class       = $class ? ' class="' . implode(' ', $class) . '"' : '';
+		$title       = $this->element['label'] ? (string) $this->element['label'] : ($this->element['title'] ? (string) $this->element['title'] : '');
+		$heading     = $this->element['heading'] ? (string) $this->element['heading'] : 'h4';
+		$description = (string) $this->element['description'];
+		$html[]      = !empty($title) ? '<' . $heading . '>' . Text::_($title) . '</' . $heading . '>' : '';
+		$html[]      = !empty($description) ? Text::_($description) : '';
 
 		return '</div><div ' . $class . '>' . implode('', $html);
 	}


### PR DESCRIPTION
Fixes https://github.com/joomla/joomla-cms/issues/35016

### Summary of Changes
- load bootstrap.alert if necessary.
- change wrong attribute `data-dismiss` to `data-bs-dismiss`
- use class `data-dismissible` to right align close button
- remove `&times;` to avoid a double `X` in button

### Testing Instructions
- Please see https://github.com/joomla/joomla-cms/issues/35016

### Actual result BEFORE applying this Pull Request
- Alert didn't close when dismiss button clicked

### Expected result AFTER applying this Pull Request
- Alert does close when dismiss button clicked
- Correctly styled alert

![02-08-_2021_00-00-18](https://user-images.githubusercontent.com/20780646/127787395-22e57633-dfda-49a5-94a9-88eadef97ca0.jpg)
