### PR TITLE
[4.0] tab focus

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -51,6 +51,10 @@ joomla-tab {
       border-bottom: 0;
       box-shadow: none;
 
+      &:focus-visible {
+        z-index: 1;
+      }
+
       &[aria-expanded=true],
       &:focus,
       &:hover {


### PR DESCRIPTION
When navigating with the keyboard a focus outline is applied to the tabs
![tabs](https://user-images.githubusercontent.com/1296369/127827524-c24a6ce1-5546-450d-8635-4ab4e6e31b2e.gif)

However as can be seen in this enlargement the outline is cut on the right.
![image](https://user-images.githubusercontent.com/1296369/127827662-03d31c3a-3e56-4226-8923-ae21eafdb2a4.png)

This PR adjusts the z-index to prevent that
![image](https://user-images.githubusercontent.com/1296369/127827710-b80ca31d-f93c-4fbd-b85e-024142eaf5d3.png)

There is a scss change so you will need to rebuild it for testing