### PR TITLE
Change \ to / in element field.

### DIFF
--- a/administrator/components/com_installer/src/Model/DiscoverModel.php
+++ b/administrator/components/com_installer/src/Model/DiscoverModel.php
@@ -170,12 +170,12 @@ class DiscoverModel extends InstallerModel
 		foreach ($installedtmp as $install)
 		{
 			$key = implode(':',
-				array(
+				[
 					$install->type,
 					str_replace('\\', '/', $install->element),
 					$install->folder,
 					$install->client_id
-				)
+				]
 			);
 			$extensions[$key] = $install;
 		}
@@ -186,12 +186,12 @@ class DiscoverModel extends InstallerModel
 		{
 			// Check if we have a match on the element
 			$key = implode(':',
-				array(
+				[
 					$result->type,
 					str_replace('\\', '/', $result->element),
 					$result->folder,
 					$result->client_id
-				)
+				]
 			);
 
 			if (!array_key_exists($key, $extensions))

--- a/administrator/components/com_installer/src/Model/DiscoverModel.php
+++ b/administrator/components/com_installer/src/Model/DiscoverModel.php
@@ -169,7 +169,12 @@ class DiscoverModel extends InstallerModel
 
 		foreach ($installedtmp as $install)
 		{
-			$key = implode(':', array($install->type, $install->element, $install->folder, $install->client_id));
+			$key = implode(':',
+				array(
+					$install->type,
+					str_replace('\\', '/', $install->element),
+					$install->folder,
+					$install->client_id));
 			$extensions[$key] = $install;
 		}
 
@@ -178,7 +183,12 @@ class DiscoverModel extends InstallerModel
 		foreach ($results as $result)
 		{
 			// Check if we have a match on the element
-			$key = implode(':', array($result->type, $result->element, $result->folder, $result->client_id));
+			$key = implode(':',
+				array(
+					$result->type,
+					str_replace('\\', '/', $result->element),
+					$result->folder,
+					$result->client_id));
 
 			if (!array_key_exists($key, $extensions))
 			{

--- a/administrator/components/com_installer/src/Model/DiscoverModel.php
+++ b/administrator/components/com_installer/src/Model/DiscoverModel.php
@@ -174,7 +174,9 @@ class DiscoverModel extends InstallerModel
 					$install->type,
 					str_replace('\\', '/', $install->element),
 					$install->folder,
-					$install->client_id));
+					$install->client_id
+				)
+			);
 			$extensions[$key] = $install;
 		}
 
@@ -188,7 +190,9 @@ class DiscoverModel extends InstallerModel
 					$result->type,
 					str_replace('\\', '/', $result->element),
 					$result->folder,
-					$result->client_id));
+					$result->client_id
+				)
+			);
 
 			if (!array_key_exists($key, $extensions))
 			{

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -77,7 +77,7 @@ class LibraryAdapter extends InstallerAdapter
 	{
 		if ($this->parent->parseFiles($this->getManifest()->files, -1) === false)
 		{
-			throw new \RuntimeException(Text::sprintf('JLIB_INSTALLER_ABORT_LIB_COPY_FILES', $this->element));
+			throw new \RuntimeException(Text::_('JLIB_INSTALLER_ABORT_LIB_COPY_FILES'));
 		}
 	}
 

--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -77,7 +77,7 @@ class LibraryAdapter extends InstallerAdapter
 	{
 		if ($this->parent->parseFiles($this->getManifest()->files, -1) === false)
 		{
-			throw new \RuntimeException(Text::_('JLIB_INSTALLER_ABORT_LIB_COPY_FILES'));
+			throw new \RuntimeException(Text::sprintf('JLIB_INSTALLER_ABORT_LIB_COPY_FILES', $this->element));
 		}
 	}
 


### PR DESCRIPTION
Pull Request for Issue #35015 .

### Summary of Changes

Added str_replace() to change \ to /.
Looks like only the str_replace() at line 189 maybe essential but included one at line 175 for consistency and clarity.

### Testing Instructions

Use a MS Windows hosted test site (may not be a problem on Linux sites).
Install this library:
[lib_bftest1.zip](https://github.com/joomla/joomla-cms/files/6915941/lib_bftest1.zip)

### Actual result BEFORE applying this Pull Request

The library installed correctly AND appears in the Extensions:Discover listing.
Can then be installed again from there - get 2 records in the extensions table!

Need to uninstall both before testing the patch.

### Expected result AFTER applying this Pull Request

The library installed correctly and does not appear in the Extensions:Discover listing.

### Documentation Changes Required

docs.joomla.org/Manifest_files
Has been updated with J4.0 library related information since originally written ...

Current documentation on manifest files for libraries is rather limited (no longer true!).
https://docs.joomla.org/Manifest_files

More information on this can be found elsewhere, such as ...
https://www.joomlashack.com/blog/how-tos/development/how-to-package-joomla-libraries/ (see comments at end)
https://joomla.stackexchange.com/questions/13681/manifest-file-format-for-installing-a-library-package

This pull request and previous pull request #34910 appear to complete an 'almost working' undocumented feature, namely ...

_What is not immediately obvious is that you can include a slash (/) in the folder name, so you can put all your company libraries into JPATH_SITE/libraries/mycompany using this:_
```
<libraryname>mycompany/mydosomething</libraryname>
<libraryname>mycompany/mydosomethingelse</libraryname>
```
