### PR TITLE
Fix language strings plural suffixes unit test failing when executing JLanguageTest.php alone

### DIFF
--- a/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
+++ b/tests/unit/suites/libraries/joomla/language/JLanguageTest.php
@@ -285,6 +285,12 @@ class JLanguageTest extends \PHPUnit\Framework\TestCase
 			$this->object->getPluralSuffixes(1),
 			'Line: ' . __LINE__
 		);
+
+		$this->assertEquals(
+			array('OTHER', 'MORE'),
+			$this->object->getPluralSuffixes(2),
+			'Line: ' . __LINE__
+		);
 	}
 
 	/**

--- a/tests/unit/suites/libraries/joomla/language/data/language/en-GB/en-GB.localise.php
+++ b/tests/unit/suites/libraries/joomla/language/data/language/en-GB/en-GB.localise.php
@@ -30,11 +30,11 @@ abstract class En_GBLocalise
 		}
 		elseif ($count == 1)
 		{
-			$return = array('1');
+			$return = array('ONE', '1');
 		}
 		else
 		{
-			$return = array('MORE');
+			$return = array('OTHER', 'MORE');
 		}
 		return $return;
 	}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes unit tests for the "getPluralSuffixes" function of JText currently failing when executed locally (at least on Linux).

No idea why they don't fail in drone CI.

The failure is caused by file "tests/unit/suites/libraries/joomla/language/data/language/en-GB/en-GB.localise.php" having not been adapted with PR #28763 .

In addition, this PR adds a missing test case for the "more than 1" case.

### Testing Instructions

1. On a git clone, checkout and if necessary update the staging branch so it's up to date with the staging branch here.
2. Open a command window and change directory to the root folder of that git clone.
3. Run `composer install`.
4. Run `./libraries/vendor/phpunit/phpunit/phpunit ./tests/unit/suites/libraries/joomla/language/JLanguageTest.php`
Result: See section "Actual result BEFORE applying this Pull Request" below.
5. Revert all local changes by running these 2 git commands:
`git clean -d -x -f`
`git checkout .`
6. Apply the changes from this PR.
7. Repeat steps 2 to 4.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

```
richard@vmubu01:~/lamp/public_html/joomla-cms$ ./libraries/vendor/phpunit/phpunit/phpunit ./tests/unit/suites/libraries/joomla/language/JLanguageTest.php
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.
Warning:	The Xdebug extension is not loaded
		No code coverage will be generated.

......F.....................................

Time: 113 ms, Memory: 10.00MB

There was 1 failure:

1) JLanguageTest::testGetPluralSuffixes
Line: 286
Failed asserting that two arrays are equal.
--- Expected
+++ Actual
@@ @@
 Array (
-    0 => 'ONE'
-    1 => '1'
+    0 => '1'
 )

/home/richard/lamp/public_html/joomla-cms/tests/unit/suites/libraries/joomla/language/JLanguageTest.php:286

FAILURES!
Tests: 44, Assertions: 119, Failures: 1.
```

### Expected result AFTER applying this Pull Request

```
richard@vmubu01:~/lamp/public_html/joomla-cms$ ./libraries/vendor/phpunit/phpunit/phpunit ./tests/unit/suites/libraries/joomla/language/JLanguageTest.php
PHPUnit 4.8.36 by Sebastian Bergmann and contributors.
Warning:	The Xdebug extension is not loaded
		No code coverage will be generated.

............................................

Time: 118 ms, Memory: 8.00MB

OK (44 tests, 120 assertions)
```

### Documentation Changes Required

None.