### PR TITLE
The order of panel widgets in the system section

### DIFF
--- a/administrator/components/com_menus/presets/system.xml
+++ b/administrator/components/com_menus/presets/system.xml
@@ -19,99 +19,6 @@
 	</menuitem>
 
 	<menuitem
-		title="MOD_MENU_MAINTAIN"
-		type="heading"
-		icon="tools"
-		>
-		<menuitem
-			title="MOD_MENU_CLEAR_CACHE"
-			type="component"
-			element="com_cache"
-			link="index.php?option=com_cache"
-			permission="core.manage;com_cache"
-		/>
-
-		<menuitem
-			title="MOD_MENU_SYSTEM_INFORMATION_DATABASE"
-			type="component"
-			element="com_installer"
-			link="index.php?option=com_installer&amp;view=database"
-			permission="core.manage;com_installer"
-			ajax-badge="index.php?option=com_installer&amp;task=database.getMenuBadgeData&amp;format=json"
-		/>
-
-		<menuitem
-			title="MOD_MENU_GLOBAL_CHECKIN"
-			type="component"
-			element="com_checkin"
-			link="index.php?option=com_checkin"
-			permission="core.manage;com_checkin"
-			ajax-badge="index.php?option=com_checkin&amp;task=getMenuBadgeData&amp;format=json"
-		/>
-	</menuitem>
-
-	<menuitem
-		title="MOD_MENU_INFORMATION"
-		type="heading"
-		icon="info-circle"
-		>
-		<menuitem
-			title="MOD_MENU_INFORMATION_WARNINGS"
-			type="component"
-			element="com_installer"
-			link="index.php?option=com_installer&amp;view=warnings"
-			permission="core.manage;com_installer"
-			ajax-badge="index.php?option=com_installer&amp;task=getMenuBadgeData&amp;format=json"
-		/>
-
-		<menuitem
-			title="MOD_MENU_INFORMATION_POST_INSTALL_MESSAGES"
-			type="component"
-			element="com_postinstall"
-			link="index.php?option=com_postinstall"
-			permission="core.manage;com_postinstall"
-			ajax-badge="index.php?option=com_postinstall&amp;task=getMenuBadgeData&amp;format=json"
-		/>
-
-		<menuitem
-			title="MOD_MENU_SYSTEM_INFORMATION_SYSINFO"
-			type="component"
-			element="com_admin"
-			link="index.php?option=com_admin&amp;view=sysinfo"
-			permission="core.admin"
-		/>
-	</menuitem>
-
-	<menuitem
-		title="MOD_MENU_INSTALL"
-		type="heading"
-		icon="upload"
-		permission="core.manage;com_installer"
-		>
-		<menuitem
-			title="MOD_MENU_INSTALL_EXTENSIONS"
-			type="component"
-			element="com_installer"
-			link="index.php?option=com_installer&amp;view=install"
-		/>
-
-		<menuitem
-			title="MOD_MENU_INSTALL_DISCOVER"
-			type="component"
-			element="com_installer"
-			link="index.php?option=com_installer&amp;view=discover"
-			ajax-badge="index.php?option=com_installer&amp;task=discover.getMenuBadgeData&amp;format=json"
-		/>
-
-		<menuitem
-			title="MOD_MENU_INSTALL_LANGUAGES"
-			type="component"
-			element="com_installer"
-			link="index.php?option=com_installer&amp;view=languages"
-		/>
-	</menuitem>
-
-	<menuitem
 		title="MOD_MENU_MANAGE"
 		type="heading"
 		icon="tasks"
@@ -182,6 +89,38 @@
 	</menuitem>
 
 	<menuitem
+		title="MOD_MENU_INFORMATION"
+		type="heading"
+		icon="info-circle"
+		>
+		<menuitem
+			title="MOD_MENU_INFORMATION_WARNINGS"
+			type="component"
+			element="com_installer"
+			link="index.php?option=com_installer&amp;view=warnings"
+			permission="core.manage;com_installer"
+			ajax-badge="index.php?option=com_installer&amp;task=getMenuBadgeData&amp;format=json"
+		/>
+
+		<menuitem
+			title="MOD_MENU_INFORMATION_POST_INSTALL_MESSAGES"
+			type="component"
+			element="com_postinstall"
+			link="index.php?option=com_postinstall"
+			permission="core.manage;com_postinstall"
+			ajax-badge="index.php?option=com_postinstall&amp;task=getMenuBadgeData&amp;format=json"
+		/>
+
+		<menuitem
+			title="MOD_MENU_SYSTEM_INFORMATION_SYSINFO"
+			type="component"
+			element="com_admin"
+			link="index.php?option=com_admin&amp;view=sysinfo"
+			permission="core.admin"
+		/>
+	</menuitem>
+
+	<menuitem
 		title="MOD_MENU_UPDATE"
 		type="heading"
 		icon="sync"
@@ -210,6 +149,35 @@
 			element="com_installer"
 			link="index.php?option=com_installer&amp;view=updatesites"
 			permission="core.manage;com_installer"
+		/>
+	</menuitem>
+
+	<menuitem
+		title="MOD_MENU_INSTALL"
+		type="heading"
+		icon="upload"
+		permission="core.manage;com_installer"
+		>
+		<menuitem
+			title="MOD_MENU_INSTALL_EXTENSIONS"
+			type="component"
+			element="com_installer"
+			link="index.php?option=com_installer&amp;view=install"
+		/>
+
+		<menuitem
+			title="MOD_MENU_INSTALL_DISCOVER"
+			type="component"
+			element="com_installer"
+			link="index.php?option=com_installer&amp;view=discover"
+			ajax-badge="index.php?option=com_installer&amp;task=discover.getMenuBadgeData&amp;format=json"
+		/>
+
+		<menuitem
+			title="MOD_MENU_INSTALL_LANGUAGES"
+			type="component"
+			element="com_installer"
+			link="index.php?option=com_installer&amp;view=languages"
 		/>
 	</menuitem>
 
@@ -252,6 +220,38 @@
 				type="component"
 				element="com_mails"
 				link="index.php?option=com_mails&amp;view=templates"
+		/>
+	</menuitem>
+
+	<menuitem
+		title="MOD_MENU_MAINTAIN"
+		type="heading"
+		icon="tools"
+		>
+		<menuitem
+			title="MOD_MENU_CLEAR_CACHE"
+			type="component"
+			element="com_cache"
+			link="index.php?option=com_cache"
+			permission="core.manage;com_cache"
+		/>
+
+		<menuitem
+			title="MOD_MENU_SYSTEM_INFORMATION_DATABASE"
+			type="component"
+			element="com_installer"
+			link="index.php?option=com_installer&amp;view=database"
+			permission="core.manage;com_installer"
+			ajax-badge="index.php?option=com_installer&amp;task=database.getMenuBadgeData&amp;format=json"
+		/>
+
+		<menuitem
+			title="MOD_MENU_GLOBAL_CHECKIN"
+			type="component"
+			element="com_checkin"
+			link="index.php?option=com_checkin"
+			permission="core.manage;com_checkin"
+			ajax-badge="index.php?option=com_checkin&amp;task=getMenuBadgeData&amp;format=json"
 		/>
 	</menuitem>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6898474/127853303-ed6658ab-beb2-4d56-8bab-84feb7ac9c46.png)

Colleagues, by what principle are the link panels in the system section sorted?
I would prefer the SETUP and MANAGE panels to be the first.
I feel tension every time I open a panel and try to find the right panel somewhere in the middle of other panels. And if the screen is small, then you will have to search for the most popular panel by rewinding the page.
.
Let's place the SETUP and MANAGE panels first.

I marked with numbers how I would like to see the order. But, I may be inaccurate. The main thing is that I would like to see the SETUP and MANAGE the in  first position.
