### PR TITLE
[4.0] Improve Language::transliterate method

### DIFF
--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -400,7 +400,7 @@ class Language
 			}
 		}
 
-		// Run out transliterator for common symbols,
+		// Run our transliterator for common symbols,
 		// This need to be executed before native php transliterator, because it may not have all required transliterators
 		$string = Transliterate::utf8_latin_to_ascii($string);
 

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -393,7 +393,7 @@ class Language
 		{
 			$string = \call_user_func($this->transliterator, $string);
 
-			// Check if all symbols was transliterated, otherwise continue
+			// Check if all symbols were transliterated, otherwise continue
 			if (mb_check_encoding($string, 'ASCII'))
 			{
 				return $string;

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -388,15 +388,22 @@ class Language
 	 */
 	public function transliterate($string)
 	{
+		// First check for transliterator provided by translation
+		if ($this->transliterator !== null)
+		{
+			$string = \call_user_func($this->transliterator, $string);
+
+			// Check if all symbols was transliterated, otherwise continue
+			if (mb_check_encoding($string, 'ASCII'))
+			{
+				return $string;
+			}
+		}
+
 		// Override custom and core transliterate method with native php function if enabled
 		if (function_exists('transliterator_transliterate') && function_exists('iconv'))
 		{
-			return iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $string));
-		}
-
-		if ($this->transliterator !== null)
-		{
-			return \call_user_func($this->transliterator, $string);
+			return iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('de-ASCII; Any-Latin; Latin-ASCII; Lower()', $string));
 		}
 
 		$string = Transliterate::utf8_latin_to_ascii($string);


### PR DESCRIPTION
Pull Request for Issue #35014 .

### Summary of Changes

I have changed transliterator_transliterate rule to support umlauts.
And transliterator provided by translator team now have a bigger priority.


### Testing Instructions

Make sure your server have `php-intl` installed.

Create and article with alias `äüö-and-ґїію-完 成-اليوم`
(For test you can use English backend)

### Actual result BEFORE applying this Pull Request
Umlauts transliterated incorrectly `auo-and-giiu-wan-cheng-alywm`


### Expected result AFTER applying this Pull Request
You should get `aeueoe-and-giiu-wan-cheng-alywm`


### Documentation Changes Required
nope
