### PR TITLE
Remove wrong information from code comment

### DIFF
--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -331,7 +331,7 @@ class InstallerModelUpdatesites extends InstallerModel
 
 					if (!is_null($manifest))
 					{
-						// Search if the extension exists in the extensions table. Excluding joomla core extensions (id < 10000) and discovered extensions.
+						// Search if the extension exists in the extensions table. Excluding joomla core extensions and discovered extensions.
 						$query = $db->getQuery(true)
 							->select($db->quoteName('extension_id'))
 							->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_installer/models/updatesites.php
+++ b/administrator/components/com_installer/models/updatesites.php
@@ -331,7 +331,7 @@ class InstallerModelUpdatesites extends InstallerModel
 
 					if (!is_null($manifest))
 					{
-						// Search if the extension exists in the extensions table. Excluding joomla core extensions and discovered extensions.
+						// Search if the extension exists in the extensions table. Excluding joomla core extensions and discovered but not yet installed extensions.
 						$query = $db->getQuery(true)
 							->select($db->quoteName('extension_id'))
 							->from($db->quoteName('#__extensions'))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) removes misleading information from a code comment.

We once have implemented the [ExtensionHelper](https://github.com/joomla/joomla-cms/blob/3.10-dev/libraries/src/Extension/ExtensionHelper.php) to safely determine if an extension is core or not because the formerly used criterion "extension_id < 10000" is not fulfilled on sites with a longer update history where the "copy the files, run the database fixer and do a discovery installation" method once was used when that method was documented to be valid.

All checks for "extension_id < 10000" have been replaced by using the [ExtensionHelper](https://github.com/joomla/joomla-cms/blob/3.10-dev/libraries/src/Extension/ExtensionHelper.php).

But the comment fixed by this PR here still tells the old way, and this is dangerous in case if someone with old experience wants to contribute and finds it and thinks that's the way it has to be done.

In addition this PR extends the same comment regarding discovered extensions so it's more clear (as suggested by @brianteeman ).

### Testing Instructions

Code review: Check that the SQL statement below the comment changed by this PR does not use any hard-coded value of 10000 in the `where` but uses
`->where($db->quoteName('extension_id') . ' NOT IN (' . $joomlaCoreExtensionIds . ')')`
to limit the `extension_id` to get core extensions only.

See https://github.com/richard67/joomla-cms/blob/202fa5cb040b18d0685dd52ec5c6f623f42053ff/administrator/components/com_installer/models/updatesites.php#L334-L347 .

### Actual result BEFORE applying this Pull Request

Comment tells that core extensions have an extension_id lower than 10000 but that's not always true.

### Expected result AFTER applying this Pull Request

Misleading part of the comment removed.

### Documentation Changes Required

None.