### PR TITLE
[J4] Deleting jumps in SystemPanel

### DIFF
--- a/administrator/components/com_menus/presets/system.xml
+++ b/administrator/components/com_menus/presets/system.xml
@@ -19,99 +19,6 @@
 	</menuitem>
 
 	<menuitem
-		title="MOD_MENU_MAINTAIN"
-		type="heading"
-		icon="tools"
-		>
-		<menuitem
-			title="MOD_MENU_CLEAR_CACHE"
-			type="component"
-			element="com_cache"
-			link="index.php?option=com_cache"
-			permission="core.manage;com_cache"
-		/>
-
-		<menuitem
-			title="MOD_MENU_SYSTEM_INFORMATION_DATABASE"
-			type="component"
-			element="com_installer"
-			link="index.php?option=com_installer&amp;view=database"
-			permission="core.manage;com_installer"
-			ajax-badge="index.php?option=com_installer&amp;task=database.getMenuBadgeData&amp;format=json"
-		/>
-
-		<menuitem
-			title="MOD_MENU_GLOBAL_CHECKIN"
-			type="component"
-			element="com_checkin"
-			link="index.php?option=com_checkin"
-			permission="core.manage;com_checkin"
-			ajax-badge="index.php?option=com_checkin&amp;task=getMenuBadgeData&amp;format=json"
-		/>
-	</menuitem>
-
-	<menuitem
-		title="MOD_MENU_INFORMATION"
-		type="heading"
-		icon="info-circle"
-		>
-		<menuitem
-			title="MOD_MENU_INFORMATION_WARNINGS"
-			type="component"
-			element="com_installer"
-			link="index.php?option=com_installer&amp;view=warnings"
-			permission="core.manage;com_installer"
-			ajax-badge="index.php?option=com_installer&amp;task=getMenuBadgeData&amp;format=json"
-		/>
-
-		<menuitem
-			title="MOD_MENU_INFORMATION_POST_INSTALL_MESSAGES"
-			type="component"
-			element="com_postinstall"
-			link="index.php?option=com_postinstall"
-			permission="core.manage;com_postinstall"
-			ajax-badge="index.php?option=com_postinstall&amp;task=getMenuBadgeData&amp;format=json"
-		/>
-
-		<menuitem
-			title="MOD_MENU_SYSTEM_INFORMATION_SYSINFO"
-			type="component"
-			element="com_admin"
-			link="index.php?option=com_admin&amp;view=sysinfo"
-			permission="core.admin"
-		/>
-	</menuitem>
-
-	<menuitem
-		title="MOD_MENU_INSTALL"
-		type="heading"
-		icon="upload"
-		permission="core.manage;com_installer"
-		>
-		<menuitem
-			title="MOD_MENU_INSTALL_EXTENSIONS"
-			type="component"
-			element="com_installer"
-			link="index.php?option=com_installer&amp;view=install"
-		/>
-
-		<menuitem
-			title="MOD_MENU_INSTALL_DISCOVER"
-			type="component"
-			element="com_installer"
-			link="index.php?option=com_installer&amp;view=discover"
-			ajax-badge="index.php?option=com_installer&amp;task=discover.getMenuBadgeData&amp;format=json"
-		/>
-
-		<menuitem
-			title="MOD_MENU_INSTALL_LANGUAGES"
-			type="component"
-			element="com_installer"
-			link="index.php?option=com_installer&amp;view=languages"
-		/>
-	</menuitem>
-
-	<menuitem
 		title="MOD_MENU_MANAGE"
 		type="heading"
 		icon="tasks"
@@ -182,6 +89,38 @@
 	</menuitem>
 
 	<menuitem
+		title="MOD_MENU_INFORMATION"
+		type="heading"
+		icon="info-circle"
+		>
+		<menuitem
+			title="MOD_MENU_INFORMATION_WARNINGS"
+			type="component"
+			element="com_installer"
+			link="index.php?option=com_installer&amp;view=warnings"
+			permission="core.manage;com_installer"
+			ajax-badge="index.php?option=com_installer&amp;task=getMenuBadgeData&amp;format=json"
+		/>
+
+		<menuitem
+			title="MOD_MENU_INFORMATION_POST_INSTALL_MESSAGES"
+			type="component"
+			element="com_postinstall"
+			link="index.php?option=com_postinstall"
+			permission="core.manage;com_postinstall"
+			ajax-badge="index.php?option=com_postinstall&amp;task=getMenuBadgeData&amp;format=json"
+		/>
+
+		<menuitem
+			title="MOD_MENU_SYSTEM_INFORMATION_SYSINFO"
+			type="component"
+			element="com_admin"
+			link="index.php?option=com_admin&amp;view=sysinfo"
+			permission="core.admin"
+		/>
+	</menuitem>
+
+	<menuitem
 		title="MOD_MENU_UPDATE"
 		type="heading"
 		icon="sync"
@@ -210,6 +149,35 @@
 			element="com_installer"
 			link="index.php?option=com_installer&amp;view=updatesites"
 			permission="core.manage;com_installer"
+		/>
+	</menuitem>
+
+	<menuitem
+		title="MOD_MENU_INSTALL"
+		type="heading"
+		icon="upload"
+		permission="core.manage;com_installer"
+		>
+		<menuitem
+			title="MOD_MENU_INSTALL_EXTENSIONS"
+			type="component"
+			element="com_installer"
+			link="index.php?option=com_installer&amp;view=install"
+		/>
+
+		<menuitem
+			title="MOD_MENU_INSTALL_DISCOVER"
+			type="component"
+			element="com_installer"
+			link="index.php?option=com_installer&amp;view=discover"
+			ajax-badge="index.php?option=com_installer&amp;task=discover.getMenuBadgeData&amp;format=json"
+		/>
+
+		<menuitem
+			title="MOD_MENU_INSTALL_LANGUAGES"
+			type="component"
+			element="com_installer"
+			link="index.php?option=com_installer&amp;view=languages"
 		/>
 	</menuitem>
 
@@ -252,6 +220,38 @@
 				type="component"
 				element="com_mails"
 				link="index.php?option=com_mails&amp;view=templates"
+		/>
+	</menuitem>
+
+	<menuitem
+		title="MOD_MENU_MAINTAIN"
+		type="heading"
+		icon="tools"
+		>
+		<menuitem
+			title="MOD_MENU_CLEAR_CACHE"
+			type="component"
+			element="com_cache"
+			link="index.php?option=com_cache"
+			permission="core.manage;com_cache"
+		/>
+
+		<menuitem
+			title="MOD_MENU_SYSTEM_INFORMATION_DATABASE"
+			type="component"
+			element="com_installer"
+			link="index.php?option=com_installer&amp;view=database"
+			permission="core.manage;com_installer"
+			ajax-badge="index.php?option=com_installer&amp;task=database.getMenuBadgeData&amp;format=json"
+		/>
+
+		<menuitem
+			title="MOD_MENU_GLOBAL_CHECKIN"
+			type="component"
+			element="com_checkin"
+			link="index.php?option=com_checkin"
+			permission="core.manage;com_checkin"
+			ajax-badge="index.php?option=com_checkin&amp;task=getMenuBadgeData&amp;format=json"
 		/>
 	</menuitem>
 

--- a/administrator/templates/atum/scss/_variables.scss
+++ b/administrator/templates/atum/scss/_variables.scss
@@ -105,7 +105,7 @@ $alert-border-level:               0;
 $alert-color-level:                0;
 
 // Global
-$atum-box-shadow:                  0 2px 10px -8px var(--template-bg-dark-50);
+$atum-box-shadow:                  0 2px 1px -8px var(--template-bg-dark-50);
 $enable-rounded:                   true;
 $input-box-shadow:                 inset 0 0 0 .1rem #e9e9e9;
 $input-btn-padding-y:              .5rem;

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -214,7 +214,7 @@ a[target="_blank"]::before {
   }
   @include media-breakpoint-up(lg) {
     grid-template-columns: 1fr 1fr 1fr;
-    column-count: 2;
+    column-count: 3;
   }
 }
 

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -207,11 +207,6 @@ a[target="_blank"]::before {
   grid-gap: 0 15px;
   grid-template-columns: 1fr;
   display: block;
-
-  .module-wrapper {
-    float: left;
-    width: 100%;
-  }
   
   @include media-breakpoint-up(md) {
     grid-template-columns: 1fr 1fr;

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -212,6 +212,10 @@ a[target="_blank"]::before {
     grid-template-columns: 1fr 1fr;
     column-count: 2;
   }
+  @include media-breakpoint-up(ld) {
+    grid-template-columns: 1fr 1fr 1fr;
+    column-count: 2;
+  }
 }
 
 .cpanel-help,
@@ -219,6 +223,10 @@ a[target="_blank"]::before {
 
   .card-columns {
     @include media-breakpoint-up(md) {
+      grid-template-columns: 1fr 1fr;
+      column-count: 2;
+    }
+    @include media-breakpoint-up(ld) {
       grid-template-columns: 1fr 1fr 1fr;
       column-count: 3;
     }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -221,7 +221,7 @@ a[target="_blank"]::before {
 .cpanel-help,
 .cpanel-system {
 
-  .card-columns {    
+  .card-columns {
     grid-template-columns: 1fr;
     column-count: 1;
 

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -206,7 +206,7 @@ a[target="_blank"]::before {
   display: grid;
   grid-gap: 0 15px;
   grid-template-columns: 1fr;
-  display: block;  
+  display: block;
   @include media-breakpoint-up(md) {
     grid-template-columns: 1fr 1fr;
   }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -206,7 +206,6 @@ a[target="_blank"]::before {
   display: block;
   grid-gap: 0 15px;
   grid-template-columns: 1fr;
-  
   @include media-breakpoint-up(md) {
     grid-template-columns: 1fr 1fr;
   }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -206,8 +206,7 @@ a[target="_blank"]::before {
   display: grid;
   grid-gap: 0 15px;
   grid-template-columns: 1fr;
-  display: block;
-  
+  display: block;  
   @include media-breakpoint-up(md) {
     grid-template-columns: 1fr 1fr;
   }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -212,7 +212,7 @@ a[target="_blank"]::before {
     grid-template-columns: 1fr 1fr;
     column-count: 2;
   }
-  @include media-breakpoint-up(ld) {
+  @include media-breakpoint-up(lg) {
     grid-template-columns: 1fr 1fr 1fr;
     column-count: 2;
   }
@@ -221,12 +221,15 @@ a[target="_blank"]::before {
 .cpanel-help,
 .cpanel-system {
 
-  .card-columns {
+  .card-columns {    
+    grid-template-columns: 1fr;
+    column-count: 1;
+
     @include media-breakpoint-up(md) {
       grid-template-columns: 1fr 1fr;
       column-count: 2;
     }
-    @include media-breakpoint-up(ld) {
+    @include media-breakpoint-up(lg) {
       grid-template-columns: 1fr 1fr 1fr;
       column-count: 3;
     }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -207,7 +207,7 @@ a[target="_blank"]::before {
   grid-gap: 0 15px;
   grid-template-columns: 1fr;
   column-count: 1;
-  
+
   @include media-breakpoint-up(md) {
     grid-template-columns: 1fr 1fr;
     column-count: 2;

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -211,7 +211,6 @@ a[target="_blank"]::before {
   @include media-breakpoint-up(md) {
     grid-template-columns: 1fr 1fr;
   }
-  
 }
 
 .cpanel-help,

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -206,8 +206,15 @@ a[target="_blank"]::before {
   display: block;
   grid-gap: 0 15px;
   grid-template-columns: 1fr;
+  -webkit-column-count: 1;
+  -moz-column-count: 1;
+  column-count: 1;
+  
   @include media-breakpoint-up(md) {
     grid-template-columns: 1fr 1fr;
+    -webkit-column-count: 2;
+    -moz-column-count: 2;
+    column-count: 2;
   }
 }
 
@@ -217,6 +224,9 @@ a[target="_blank"]::before {
   .card-columns {
     @include media-breakpoint-up(md) {
       grid-template-columns: 1fr 1fr 1fr;
+      -webkit-column-count: 3;
+      -moz-column-count: 3;
+      column-count: 3;
     }
   }
 }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -203,10 +203,10 @@ a[target="_blank"]::before {
 }
 
 .card-columns {
-  display: grid;
+  display: block;
   grid-gap: 0 15px;
   grid-template-columns: 1fr;
-  display: block;
+  
   @include media-breakpoint-up(md) {
     grid-template-columns: 1fr 1fr;
   }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -206,14 +206,10 @@ a[target="_blank"]::before {
   display: block;
   grid-gap: 0 15px;
   grid-template-columns: 1fr;
-  -webkit-column-count: 1;
-  -moz-column-count: 1;
   column-count: 1;
   
   @include media-breakpoint-up(md) {
     grid-template-columns: 1fr 1fr;
-    -webkit-column-count: 2;
-    -moz-column-count: 2;
     column-count: 2;
   }
 }
@@ -224,8 +220,6 @@ a[target="_blank"]::before {
   .card-columns {
     @include media-breakpoint-up(md) {
       grid-template-columns: 1fr 1fr 1fr;
-      -webkit-column-count: 3;
-      -moz-column-count: 3;
       column-count: 3;
     }
   }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -208,13 +208,13 @@ a[target="_blank"]::before {
   grid-template-columns: 1fr;
   column-count: 1;
 
-  @include media-breakpoint-up(md) {
-    grid-template-columns: 1fr 1fr;
-    column-count: 2;
-  }
   @include media-breakpoint-up(lg) {
     grid-template-columns: 1fr 1fr 1fr;
     column-count: 3;
+  }
+  @include media-breakpoint-up(md) {
+    grid-template-columns: 1fr 1fr;
+    column-count: 2;
   }
 }
 
@@ -225,13 +225,13 @@ a[target="_blank"]::before {
     grid-template-columns: 1fr;
     column-count: 1;
 
-    @include media-breakpoint-up(md) {
-      grid-template-columns: 1fr 1fr;
-      column-count: 2;
-    }
     @include media-breakpoint-up(lg) {
       grid-template-columns: 1fr 1fr 1fr;
       column-count: 3;
+    }
+    @include media-breakpoint-up(md) {
+      grid-template-columns: 1fr 1fr;
+      column-count: 2;
     }
   }
 }

--- a/administrator/templates/atum/scss/blocks/_global.scss
+++ b/administrator/templates/atum/scss/blocks/_global.scss
@@ -206,10 +206,17 @@ a[target="_blank"]::before {
   display: grid;
   grid-gap: 0 15px;
   grid-template-columns: 1fr;
+  display: block;
 
+  .module-wrapper {
+    float: left;
+    width: 100%;
+  }
+  
   @include media-breakpoint-up(md) {
     grid-template-columns: 1fr 1fr;
   }
+  
 }
 
 .cpanel-help,

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -66,17 +66,19 @@
     }
   }
 }
-.card-columns {
-  grid-template-columns: 1fr;
-  column-count: 1;
+.com-cpanel {
+  .card-columns {
+    grid-template-columns: 1fr;
+    column-count: 1;
 
-  @include media-breakpoint-up(md) {
-    grid-template-columns: 1fr 1fr;
-    column-count: 2;
-  }
-  @include media-breakpoint-up(lg) {
-    grid-template-columns: 1fr 1fr 1fr;
-    column-count: 3;
+    @include media-breakpoint-up(md) {
+      grid-template-columns: 1fr 1fr;
+      column-count: 2;
+    }
+    @include media-breakpoint-up(lg) {
+      grid-template-columns: 1fr 1fr 1fr;
+      column-count: 3;
+    }
   }
 }
 

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -67,8 +67,7 @@
   }
 }
 
-.com-cpanel {
-  .card-columns {
+.com-cpanel .card-columns {
     grid-template-columns: 1fr;
     column-count: 1;
 
@@ -83,7 +82,6 @@
     @include media-breakpoint-up(sm) {
       grid-template-columns: 1fr;
       column-count: 1;
-    }
   }
 }
 .com_cpanel {

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -72,17 +72,17 @@
     grid-template-columns: 1fr;
     column-count: 1;
 
-    @include media-breakpoint-up(sm) {
-      grid-template-columns: 1fr;
-      column-count: 1;
+    @include media-breakpoint-up(lg) {
+      grid-template-columns: 1fr 1fr 1fr;
+      column-count: 3;
     }
     @include media-breakpoint-up(md) {
       grid-template-columns: 1fr 1fr;
       column-count: 2;
     }
-    @include media-breakpoint-up(lg) {
-      grid-template-columns: 1fr 1fr 1fr;
-      column-count: 3;
+    @include media-breakpoint-up(sm) {
+      grid-template-columns: 1fr;
+      column-count: 1;
     }
   }
 }

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -66,11 +66,7 @@
     }
   }
 }
-
 .com-cpanel .card-columns {
-    grid-template-columns: 1fr;
-    column-count: 1;
-
     @include media-breakpoint-up(lg) {
       grid-template-columns: 1fr 1fr 1fr;
       column-count: 3;

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -66,11 +66,16 @@
     }
   }
 }
+
 .com-cpanel {
   .card-columns {
     grid-template-columns: 1fr;
     column-count: 1;
 
+    @include media-breakpoint-up(sm) {
+      grid-template-columns: 1fr;
+      column-count: 1;
+    }
     @include media-breakpoint-up(md) {
       grid-template-columns: 1fr 1fr;
       column-count: 2;
@@ -81,7 +86,6 @@
     }
   }
 }
-
 .com_cpanel {
 
   .content {

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -66,7 +66,11 @@
     }
   }
 }
-.com-cpanel .card-columns {
+
+.com-cpanel {
+  .card-columns {
+    display: grid;
+    
     @include media-breakpoint-up(lg) {
       grid-template-columns: 1fr 1fr 1fr;
       column-count: 3;
@@ -78,6 +82,7 @@
     @include media-breakpoint-up(sm) {
       grid-template-columns: 1fr;
       column-count: 1;
+    }
   }
 }
 .com_cpanel {

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -70,7 +70,7 @@
 .com-cpanel {
   .card-columns {
     display: grid;
-    
+
     @include media-breakpoint-up(lg) {
       grid-template-columns: 1fr 1fr 1fr;
       column-count: 3;

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -67,8 +67,7 @@
   }
 }
 
-.com-cpanel {
-  .card-columns {
+.cpanel > .card-columns {
     display: grid;
 
     @include media-breakpoint-up(lg) {
@@ -83,7 +82,6 @@
       grid-template-columns: 1fr;
       column-count: 1;
     }
-  }
 }
 .com_cpanel {
 

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -66,6 +66,19 @@
     }
   }
 }
+.card-columns {
+  grid-template-columns: 1fr;
+  column-count: 1;
+
+  @include media-breakpoint-up(md) {
+    grid-template-columns: 1fr 1fr;
+    column-count: 2;
+  }
+  @include media-breakpoint-up(lg) {
+    grid-template-columns: 1fr 1fr 1fr;
+    column-count: 3;
+  }
+}
 
 .com_cpanel {
 

--- a/administrator/templates/atum/scss/pages/_com_modules.scss
+++ b/administrator/templates/atum/scss/pages/_com_modules.scss
@@ -6,6 +6,7 @@
 
 .new-module {
   display: inline-flex;
+  width: 100%;
   overflow: hidden;
   color: hsl(var(--hue),30%,40%);
   background-color: hsl(var(--hue), 60%, 97%);

--- a/administrator/templates/atum/scss/pages/_com_modules.scss
+++ b/administrator/templates/atum/scss/pages/_com_modules.scss
@@ -1,12 +1,12 @@
 .new-modules {
   .card-columns {
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+    display: grid;
   }
 }
 
 .new-module {
-  display: inline-flex;
-  width: 100%;
+  display: flex;
   overflow: hidden;
   color: hsl(var(--hue),30%,40%);
   background-color: hsl(var(--hue), 60%, 97%);

--- a/administrator/templates/atum/scss/pages/_com_modules.scss
+++ b/administrator/templates/atum/scss/pages/_com_modules.scss
@@ -5,7 +5,7 @@
 }
 
 .new-module {
-  display: flex;
+  display: inline-flex;
   overflow: hidden;
   color: hsl(var(--hue),30%,40%);
   background-color: hsl(var(--hue), 60%, 97%);


### PR DESCRIPTION
Colleagues, I did not delete Masonry. I added a few properties to test the absence of page jumps.

I ask you to test these changes and compare them with RC. You will see the superiority.

The Masonry layout implies automatic placement depending on the height of the block. So that the lower border of the parent's space is aligned with the content. Which leads to jumping blocks.
Thus, the order of the blocks was imposed on us by the JS Masonry script. At your discretion. But in the cards there were blocks in which the number of elements is the same. Even they can't be swapped at our discretion. The JS script has its own logic.
I turned off Masonry. Sorted the blocks as the creator/maintainer of the sites.
As a result, it was possible to remove the block jumps when the page was loading.
Please test the PR

Please test it, and I need advice on what to remove from the unnecessary properties of the previous styles.
