### PR TITLE
[4.0] com_contact.contact. Empty params (null) in onContentPrepare of a plugin

### DIFF
--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -346,7 +346,7 @@ class HtmlView extends BaseHtmlView
 			$item->text = $item->misc;
 		}
 
-		$app->triggerEvent('onContentPrepare', array ('com_contact.contact', &$item, &$this->params, $offset));
+		$app->triggerEvent('onContentPrepare', array ('com_contact.contact', &$item, &$item->params, $offset));
 
 		// Store the events for later
 		$item->event = new \stdClass;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/35044

See issue and comments there for illumination.

## If you want to test:
- Hold open a single contact page in frontend
- In a plugin with `public function onContentPrepare($context, &$article, $params, $page = 0)`
- Add lines early:
```
if ($context === 'com_contact.contact')
{
echo 'DEBUG $params <pre>' . print_r($params, true) . '</pre>';exit;
}
```
- Reload contact page.
- - Without pr: Empty output (null).
- - With pr: Registry object output = params of contact page.

