### PR TITLE
[4.0] login field required / aria-invalid

### DIFF
--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -35,7 +35,7 @@ Text::script('JHIDEPASSWORD');
 		<div class="mod-login__username form-group">
 			<?php if (!$params->get('usetext', 0)) : ?>
 				<div class="input-group">
-					<input id="modlgn-username-<?php echo $module->id; ?>" type="text" name="username" class="form-control" autocomplete="username" placeholder="<?php echo Text::_('MOD_LOGIN_VALUE_USERNAME'); ?>">
+					<input id="modlgn-username-<?php echo $module->id; ?>" type="text" name="username" aria-required="true" aria-invalid="false" class="form-control" autocomplete="username" placeholder="<?php echo Text::_('MOD_LOGIN_VALUE_USERNAME'); ?>">
 					<label for="modlgn-username-<?php echo $module->id; ?>" class="visually-hidden"><?php echo Text::_('MOD_LOGIN_VALUE_USERNAME'); ?></label>
 					<span class="input-group-text" title="<?php echo Text::_('MOD_LOGIN_VALUE_USERNAME'); ?>">
 						<span class="icon-user icon-fw" aria-hidden="true"></span>
@@ -50,7 +50,7 @@ Text::script('JHIDEPASSWORD');
 		<div class="mod-login__password form-group">
 			<?php if (!$params->get('usetext', 0)) : ?>
 				<div class="input-group">
-					<input id="modlgn-passwd-<?php echo $module->id; ?>" type="password" name="password" autocomplete="current-password" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>">
+					<input id="modlgn-passwd-<?php echo $module->id; ?>" type="password" name="password" aria-required="true" aria-invalid="false" autocomplete="current-password" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>">
 					<label for="modlgn-passwd-<?php echo $module->id; ?>" class="visually-hidden"><?php echo Text::_('JGLOBAL_PASSWORD'); ?></label>
 					<button type="button" class="btn btn-secondary input-password-toggle">
 						<span class="icon-eye icon-fw" aria-hidden="true"></span>


### PR DESCRIPTION
Pull Request for Issue #26317 [](https://github.com/joomla/joomla-cms/issues/26317)

### Summary of Changes
Added Aria-invalid in the login form.



### Testing Instructions



### Actual result BEFORE applying this Pull Request
If you call the login page with a screenreader and click into the login field, the screen reader reports that the input is invalid.


### Expected result AFTER applying this Pull Request
aria-invalid can also be used to indicate that a required field has not been filled in. The attribute should be programmatically set as a result of a validation process.



### Documentation Changes Required

no