### PR TITLE
[4.0] Editors have only the resolved url for images

### DIFF
--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -176,9 +176,9 @@ const insertAsImage = async (media, editor, fieldClass) => {
       }
 
       if (figCaption) {
-        imageElement = `<figure${figClasses}><img src="${Joomla.selectedMediaFile.url}"${classes}${isLazy}${alt}/><figcaption>${figCaption}</figcaption></figure>`;
+        imageElement = `<figure${figClasses}><img src="${Joomla.selectedMediaFile.url}"${classes}${isLazy}${alt} data-path="${Joomla.selectedMediaFile.path}"/><figcaption>${figCaption}</figcaption></figure>`;
       } else {
-        imageElement = `<img src="${Joomla.selectedMediaFile.url}"${classes}${isLazy}${alt}/>`;
+        imageElement = `<img src="${Joomla.selectedMediaFile.url}"${classes}${isLazy}${alt} data-path="${Joomla.selectedMediaFile.path}"/>`;
       }
 
       if (attribs) {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- This PR adds a `data-path` that reflects to the **unresolved** URI for an image
- It affects only images inserted into an editor
- Allows plugins to work with external adapters (now it's impossible to get from the resolved URL to the adapter, path, etc)


### Testing Instructions
Apply the patch
run `npm install`
Create a new article and try to insert an image into the editor
Switch to code view and observe that there is a `data-path` attribute. Image tag looks like: `<img src="images/joomla_black.png" width="225" height="50" loading="lazy" data-path="local-images:/joomla_black.png" />`


### Actual result BEFORE applying this Pull Request

No way to get to the adapter/path

### Expected result AFTER applying this Pull Request



### Documentation Changes Required

@wilsonge I will be extremelly thankful if this could be patched before GA 