### PR TITLE
[4.0] Fix state filter options in workflows manager

### DIFF
--- a/administrator/components/com_workflow/forms/filter_stages.xml
+++ b/administrator/components/com_workflow/forms/filter_stages.xml
@@ -13,7 +13,7 @@
 			type="status"
 			label="JSTATUS"
 			onchange="this.form.submit();"
-			filter="-2,0,1"
+			optionsFilter="-2,0,1"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
 		</field>

--- a/administrator/components/com_workflow/forms/filter_transitions.xml
+++ b/administrator/components/com_workflow/forms/filter_transitions.xml
@@ -13,7 +13,7 @@
 			type="status"
 			label="JSTATUS"
 			onchange="this.form.submit();"
-			filter="-2,0,1"
+			optionsFilter="-2,0,1"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
 		</field>

--- a/administrator/components/com_workflow/forms/filter_workflows.xml
+++ b/administrator/components/com_workflow/forms/filter_workflows.xml
@@ -22,7 +22,7 @@
 			type="status"
 			label="JSTATUS"
 			onchange="this.form.submit();"
-			filter="-2,0,1"
+			optionsFilter="-2,0,1"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
 		</field>


### PR DESCRIPTION
### Summary of Changes
Fixes the options on display by using the right `optionsFilter` attribute instead of `filter`.

### Testing Instructions
Go to the workflow manager for some extension, for example `yoursite.example/index.php?option=com_workflow&extension=com_content`


### Actual result BEFORE applying this Pull Request
The state filter lists states not supported by com_workflows

![image](https://user-images.githubusercontent.com/72784348/128484411-39cde712-e86f-439b-bb9e-fdc6f2a25fb9.png)



### Expected result AFTER applying this Pull Request
The state filter only lists states supported by com_workflows (the labels are still not right)

![image](https://user-images.githubusercontent.com/72784348/128484460-1b279582-c40d-4e2f-9f70-6e0e3486819e.png)


### Documentation Changes Required
None
