### PR TITLE
[4.0] Fix missing npm update of custom elements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "diff": "^4.0.2",
         "dragula": "3.7.2",
         "focus-visible": "^5.2.0",
-        "joomla-ui-custom-elements": "0.1.0 ",
+        "joomla-ui-custom-elements": "0.2.0",
         "jquery": "^3.6.0",
         "jquery-migrate": "^3.3.2",
         "mark.js": "^8.11.1",
@@ -5363,9 +5363,9 @@
       "dev": true
     },
     "node_modules/joomla-ui-custom-elements": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/joomla-ui-custom-elements/-/joomla-ui-custom-elements-0.1.0.tgz",
-      "integrity": "sha512-uJBWEA8lo+sWkpz4FYdfYRNBwWBBcwc0lTPUbuSkhDcMZ6cuTSYMyuVEXe0LF+zL8WgMKZBT2nBF5myGt52cdg=="
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/joomla-ui-custom-elements/-/joomla-ui-custom-elements-0.2.0.tgz",
+      "integrity": "sha512-Rgm5yjvYn3C9juR9QMU/8H4mBXtpayb6zfgA5uIx7EHgGjGQzk3njCykatC7mrcrIjp3Fei5hghP5nHpQxlbGg=="
     },
     "node_modules/jquery": {
       "version": "3.6.0",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

In package.json we currently have `"joomla-ui-custom-elements": "0.2.0",` but in package-lock.json we have `"joomla-ui-custom-elements": "0.1.0 ",`:

https://github.com/joomla/joomla-cms/blob/4.0-dev/package.json#L48

https://github.com/joomla/joomla-cms/blob/4.0-dev/package-lock.json#L27

So it seems that the change from PR #34813 later got lost, possibly when merging PR #34888 .

This means if you work on the current 4.0-dev branch you still have version 0.1.0 of custom elements after an `npm ci`, but after an `npm install` you would have version 0.2.0.

This pull request (PR) here fixes that.

One way how this could have happened is that the latter PR had a conflict for the package-lock.json when it was merged. Or something else happened later.

=> Ping @wilsonge .

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

In package-lock.json we have `"joomla-ui-custom-elements": "0.1.0 ",`, and so nightly build packages contain that version of Custom Elements, and the next RC will contain it, too, if this PR here will not be merged before, and so the changes from PR #34813 might not work.

### Expected result AFTER applying this Pull Request

Custom Elements version 0.2.0 being used.

### Documentation Changes Required

None.