### PR TITLE
[4.0] Remove wrong bootstrap css

### DIFF
--- a/templates/cassiopeia/scss/vendor/bootstrap/_dropdown.scss
+++ b/templates/cassiopeia/scss/vendor/bootstrap/_dropdown.scss
@@ -7,10 +7,6 @@
   border-color: $cassiopeia-border-color;
 }
 
-.dropdown-item {
-  padding: 3px .75rem;
-}
-
 .dropdown-menu-end {
 
   &::after {


### PR DESCRIPTION
### Summary of Changes
Removes an very old CSS which makes no sense but kills correct bootstrap dropdown. Corrects alignment.


### Actual result BEFORE applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1229869/128568107-9a840060-0fb3-42c0-94f1-e26280c7a4f4.png)

![grafik](https://user-images.githubusercontent.com/1229869/128568154-5f1c725f-9b64-4430-86c1-3fe446302d90.png)

### Expected result AFTER applying this Pull Request

![grafik](https://user-images.githubusercontent.com/1229869/128568260-1ce425ac-4dd8-48ae-b98e-3581c09ca339.png)

![grafik](https://user-images.githubusercontent.com/1229869/128568309-585327ad-a47e-4502-a2c1-c8eb68875adb.png)
