### PR TITLE
[4.0] fix translator note in joomla.ini / plg_editors_tinymce.ini

### DIFF
--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -243,8 +243,7 @@ JFIELD_MEDIA_ALT_CHECK_LABEL="No Description"
 JFIELD_MEDIA_ALT_LABEL="Image Description (Alt Text)"
 JFIELD_MEDIA_DOWNLOAD_CHECK_DESC_LABEL="Use a download link"
 JFIELD_MEDIA_DOWNLOAD_CHECK_LABEL="Download"
-; Do not translate the text between the {}
-JFIELD_MEDIA_DOWNLOAD_FILE="Download {file}"
+JFIELD_MEDIA_DOWNLOAD_FILE="Download {file}" ; Do not translate the text between the {}
 JFIELD_MEDIA_EMBED_CHECK_DESC_LABEL="Use native elements audio, video or object"
 JFIELD_MEDIA_EMBED_CHECK_LABEL="Embed"
 JFIELD_MEDIA_CLASS_LABEL="Image Class"

--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -254,10 +254,8 @@ JFIELD_MEDIA_LAZY_LABEL="Image will be lazyloaded"
 JFIELD_MEDIA_SUMMARY_LABEL="Additional Data"
 JFIELD_MEDIA_WIDTH_LABEL="Width"
 JFIELD_MEDIA_TITLE_LABEL="Title"
-; Do not translate the text between the {}
-JFIELD_MEDIA_UNSUPPORTED="You don't have a {extension} plugin, but you can {tag} download the {extension} file.</a>"
-; Do not translate the text between the {}
-JFIELD_META_DESCRIPTION_COUNTER="{remaining} characters remaining of {maxlength} characters."
+JFIELD_MEDIA_UNSUPPORTED="You don't have a {extension} plugin, but you can {tag} download the {extension} file.</a>" ; Do not translate the text between the {}
+JFIELD_META_DESCRIPTION_COUNTER="{remaining} characters remaining of {maxlength} characters." ; Do not translate the text between the {}
 JFIELD_META_DESCRIPTION_DESC="An optional paragraph to be used as the description of the page in the HTML output. This will generally display in the results of search engines."
 JFIELD_META_DESCRIPTION_LABEL="Meta Description"
 JFIELD_META_KEYWORDS_DESC="An optional comma-separated list of keywords and/or phrases to be used in the HTML output."

--- a/administrator/language/en-GB/plg_editors_tinymce.ini
+++ b/administrator/language/en-GB/plg_editors_tinymce.ini
@@ -51,8 +51,7 @@ PLG_TINY_FIELD_SKIN_ADMIN_LABEL="Administrator Skin"
 PLG_TINY_FIELD_SKIN_INFO_DESC="Copy your new skins to: /media/editors/tinymce/skins/ui."
 PLG_TINY_FIELD_SKIN_INFO_LABEL="For customised skins go to: <a href=\"http://skin.tiny.cloud\" target=\"_blank\">Skin Creator</a>"
 PLG_TINY_FIELD_SKIN_LABEL="Site Skin"
-;do not translate the word Markdown
-PLG_TINY_FIELD_TEXTPATTERN_DESC="Use Markdown syntax to compose content with links, lists, and other styles."
+PLG_TINY_FIELD_TEXTPATTERN_DESC="Use Markdown syntax to compose content with links, lists, and other styles." ; Do not translate the word Markdown
 PLG_TINY_FIELD_TEXTPATTERN_LABEL="Markdown"
 PLG_TINY_FIELD_TOOLBAR_MODE_LABEL="Toolbar Mode"
 PLG_TINY_FIELD_URLS_LABEL="URLs"

--- a/api/language/en-GB/joomla.ini
+++ b/api/language/en-GB/joomla.ini
@@ -243,8 +243,7 @@ JFIELD_MEDIA_ALT_CHECK_LABEL="No Description"
 JFIELD_MEDIA_ALT_LABEL="Image Description (Alt Text)"
 JFIELD_MEDIA_DOWNLOAD_CHECK_DESC_LABEL="Use a download link"
 JFIELD_MEDIA_DOWNLOAD_CHECK_LABEL="Download"
-; Do not translate the text between the {}
-JFIELD_MEDIA_DOWNLOAD_FILE="Download {file}"
+JFIELD_MEDIA_DOWNLOAD_FILE="Download {file}" ; Do not translate the text between the {}
 JFIELD_MEDIA_EMBED_CHECK_DESC_LABEL="Use native elements audio, video or object"
 JFIELD_MEDIA_EMBED_CHECK_LABEL="Embed"
 JFIELD_MEDIA_CLASS_LABEL="Image Class"

--- a/language/en-GB/joomla.ini
+++ b/language/en-GB/joomla.ini
@@ -188,8 +188,7 @@ JFIELD_MEDIA_ALT_CHECK_LABEL="No Description"
 JFIELD_MEDIA_ALT_LABEL="Image Description (Alt Text)"
 JFIELD_MEDIA_DOWNLOAD_CHECK_DESC_LABEL="Use a download link"
 JFIELD_MEDIA_DOWNLOAD_CHECK_LABEL="Download"
-; Do not translate the text between the {}
-JFIELD_MEDIA_DOWNLOAD_FILE="Download {file}"
+JFIELD_MEDIA_DOWNLOAD_FILE="Download {file}" ; Do not translate the text between the {}
 JFIELD_MEDIA_EMBED_CHECK_DESC_LABEL="Use native elements audio, video or object"
 JFIELD_MEDIA_EMBED_CHECK_LABEL="Embed"
 JFIELD_MEDIA_CLASS_LABEL="Image Class"


### PR DESCRIPTION
### Summary of Changes

the comment for the translators was inserted after the string

### Testing Instructions

not required

### Actual result BEFORE applying this Pull Request

e.g. 

```
; Do not translate the text between the {}
JFIELD_MEDIA_DOWNLOAD_FILE="Download {file}"
```
### Expected result AFTER applying this Pull Request

`JFIELD_MEDIA_DOWNLOAD_FILE="Download {file}" ; Do not translate the text between the {}`

### Documentation Changes Required

.