### PR TITLE
[3.x] [WiP] Delete folders on update only if they are empty

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2313,16 +2313,13 @@ class JoomlaInstallerScript
 
 			if (JFolder::exists($folderPath)
 			{
-				if (JFolder::isEmpty($folderPath)
-				{
-					if (!JFolder::delete($folderPath))
-					{
-						echo JText::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $folder) . '<br />';
-					}
-				}
-				else
+				if (!JFolder::isEmpty($folderPath)
 				{
 					echo JText::sprintf('FILES_JOOMLA_ERROR_FOLDER_NOT_EMPTY', $folder) . '<br />';
+				}
+				elseif (!JFolder::delete($folderPath))
+				{
+					echo JText::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $folder) . '<br />';
 				}
 			}
 		}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2297,7 +2297,9 @@ class JoomlaInstallerScript
 
 		foreach ($files as $file)
 		{
-			if (JFile::exists(JPATH_ROOT . $file) && !JFile::delete(JPATH_ROOT . $file))
+			$filePath = JPATH_ROOT . $file;
+
+			if (JFile::exists($filePath) && !JFile::delete($filePath))
 			{
 				echo JText::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $file) . '<br />';
 			}
@@ -2307,9 +2309,21 @@ class JoomlaInstallerScript
 
 		foreach ($folders as $folder)
 		{
-			if (JFolder::exists(JPATH_ROOT . $folder) && !JFolder::delete(JPATH_ROOT . $folder))
+			$folderPath = JPATH_ROOT . $folder;
+
+			if (JFolder::exists($folderPath)
 			{
-				echo JText::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $folder) . '<br />';
+				if (JFolder::isEmpty($folderPath)
+				{
+					if (!JFolder::delete($folderPath))
+					{
+						echo JText::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $folder) . '<br />';
+					}
+				}
+				else
+				{
+					echo JText::sprintf('FILES_JOOMLA_ERROR_FOLDER_NOT_EMPTY', $folder) . '<br />';
+				}
 			}
 		}
 

--- a/language/en-GB/en-GB.files_joomla.sys.ini
+++ b/language/en-GB/en-GB.files_joomla.sys.ini
@@ -5,7 +5,7 @@
 
 FILES_JOOMLA="Joomla CMS"
 FILES_JOOMLA_ERROR_FILE_FOLDER="Error on deleting file or folder %s"
-FILES_JOOMLA_ERROR_FOLDER_NOT_EMPTY="Error on deleting folder %s: The folder is not empty."
+FILES_JOOMLA_ERROR_FOLDER_NOT_EMPTY="Error on deleting folder %s: The folder doesn't exist or is not empty."
 FILES_JOOMLA_ERROR_MANIFEST="Error on updating manifest cache: (type, element, folder, client) = (%s, %s, %s, %s)"
 FILES_JOOMLA_XML_DESCRIPTION="Joomla! 3 Content Management System."
 

--- a/language/en-GB/en-GB.files_joomla.sys.ini
+++ b/language/en-GB/en-GB.files_joomla.sys.ini
@@ -5,6 +5,7 @@
 
 FILES_JOOMLA="Joomla CMS"
 FILES_JOOMLA_ERROR_FILE_FOLDER="Error on deleting file or folder %s"
+FILES_JOOMLA_ERROR_FOLDER_NOT_EMPTY="Error on deleting folder %s: The folder is not empty."
 FILES_JOOMLA_ERROR_MANIFEST="Error on updating manifest cache: (type, element, folder, client) = (%s, %s, %s, %s)"
 FILES_JOOMLA_XML_DESCRIPTION="Joomla! 3 Content Management System."
 

--- a/language/en-GB/en-GB.files_joomla.sys.ini
+++ b/language/en-GB/en-GB.files_joomla.sys.ini
@@ -5,7 +5,7 @@
 
 FILES_JOOMLA="Joomla CMS"
 FILES_JOOMLA_ERROR_FILE_FOLDER="Error on deleting file or folder %s"
-FILES_JOOMLA_ERROR_FOLDER_NOT_EMPTY="Error on deleting folder %s: The folder doesn't exist or is not empty."
+FILES_JOOMLA_ERROR_FOLDER_NOT_EMPTY="Error on deleting folder %s: The folder doesn't exist or is not empty"
 FILES_JOOMLA_ERROR_MANIFEST="Error on updating manifest cache: (type, element, folder, client) = (%s, %s, %s, %s)"
 FILES_JOOMLA_XML_DESCRIPTION="Joomla! 3 Content Management System."
 

--- a/libraries/src/Filesystem/Folder.php
+++ b/libraries/src/Filesystem/Folder.php
@@ -728,4 +728,48 @@ abstract class Folder
 
 		return preg_replace($regex, '', $path);
 	}
+
+	/**
+	 * Checks if a folder is empty.
+	 *
+	 * @param   string  $path  The path of the folder to check.
+	 *
+	 * @return  boolean  True if the folder is a valid empty folder.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isEmpty($path)
+	{
+		// Check to make sure the path valid and clean
+		$pathObject = new PathWrapper;
+		$path = $pathObject->clean($path);
+
+		// Is the path a folder?
+		if (!is_dir($path))
+		{
+			Log::add(Text::sprintf('JLIB_FILESYSTEM_ERROR_PATH_IS_NOT_A_FOLDER_FILES', $path), Log::WARNING, 'jerror');
+
+			return false;
+		}
+
+		if (!($handle = @opendir($path)))
+		{
+			return false;
+		}
+
+		// Return false as soon as the first file or subfolder found
+		while (($entry = readdir($handle)) !== false)
+		{
+			if ($entry !== '.' && $entry !== '..')
+			{
+				closedir($handle);
+
+				return false;
+			}
+		}
+
+		closedir($handle);
+
+		return true;
+	}
 }


### PR DESCRIPTION
Pull Request for Issue #34298 .

### Summary of Changes

_Work in Progress (WiP)_

Change function "deleteUnexistingFiles" in the CMS installer script "administrator/components/com_admin/script.php" so that folders are only attempted to be deleted if they are empty when updating the CMS.

### Testing Instructions

_Will be added soon._

### Actual result BEFORE applying this Pull Request

_Will be added soon._

### Expected result AFTER applying this Pull Request

_Will be added soon._

### Documentation Changes Required

None.