### PR TITLE
[4.0] [WiP] Delete folders on update only if they are empty

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7316,13 +7316,15 @@ class JoomlaInstallerScript
 
 		foreach ($files as $file)
 		{
-			if ($fileExists = File::exists(JPATH_ROOT . $file))
+			$filePath = JPATH_ROOT . $file;
+
+			if ($fileExists = File::exists($filePath))
 			{
 				$status['files_exist'][] = $file;
 
 				if ($dryRun === false)
 				{
-					if (File::delete(JPATH_ROOT . $file))
+					if (File::delete($filePath))
 					{
 						$status['files_deleted'][] = $file;
 					}
@@ -7336,13 +7338,19 @@ class JoomlaInstallerScript
 
 		foreach ($folders as $folder)
 		{
-			if ($folderExists = Folder::exists(JPATH_ROOT . $folder))
+			$folderPath = JPATH_ROOT . $folder;
+
+			if ($folderExists = Folder::exists($folderPath))
 			{
 				$status['folders_exist'][] = $folder;
 
-				if ($dryRun === false)
+				if (!(Folder::isEmpty($folderPath)))
 				{
-					if (Folder::delete(JPATH_ROOT . $folder))
+					$status['folders_errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FOLDER_NOT_EMPTY', $folder);
+				}
+				elseif ($dryRun === false)
+				{
+					if (Folder::delete($folderPath))
 					{
 						$status['folders_deleted'][] = $folder;
 					}
@@ -7356,14 +7364,17 @@ class JoomlaInstallerScript
 
 		$this->fixFilenameCasing();
 
-		if ($suppressOutput === false && \count($status['folders_errors']))
+		if ($suppressOutput === false)
 		{
-			echo implode('<br>', $status['folders_errors']);
-		}
+			if (\count($status['folders_errors']))
+			{
+				echo implode('<br>', $status['folders_errors']);
+			}
 
-		if ($suppressOutput === false && \count($status['files_errors']))
-		{
-			echo implode('<br>', $status['files_errors']);
+			if (\count($status['files_errors']))
+			{
+				echo implode('<br>', $status['files_errors']);
+			}
 		}
 
 		return $status;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7344,7 +7344,7 @@ class JoomlaInstallerScript
 			{
 				$status['folders_exist'][] = $folder;
 
-				if (!(Folder::isEmpty($folderPath)))
+				if (!Folder::isEmpty($folderPath))
 				{
 					$status['folders_errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FOLDER_NOT_EMPTY', $folder);
 				}

--- a/language/en-GB/files_joomla.sys.ini
+++ b/language/en-GB/files_joomla.sys.ini
@@ -5,5 +5,6 @@
 
 FILES_JOOMLA="Joomla CMS"
 FILES_JOOMLA_ERROR_FILE_FOLDER="Error on deleting file or folder %s"
+FILES_JOOMLA_ERROR_FOLDER_NOT_EMPTY="Error on deleting folder %s: The folder doesn't exist or is not empty"
 FILES_JOOMLA_ERROR_MANIFEST="Error on updating manifest cache: (type, element, folder, client) = (%s, %s, %s, %s)"
 FILES_JOOMLA_XML_DESCRIPTION="Joomla! 4 Content Management System."

--- a/libraries/src/Filesystem/Folder.php
+++ b/libraries/src/Filesystem/Folder.php
@@ -717,4 +717,47 @@ abstract class Folder
 
 		return preg_replace($regex, '', $path);
 	}
+
+	/**
+	 * Checks if a folder is empty.
+	 *
+	 * @param   string  $path  The path of the folder to check.
+	 *
+	 * @return  boolean  True if the folder is a valid empty folder.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function isEmpty($path)
+	{
+		// Check to make sure the path valid and clean
+		$path = Path::clean($path);
+
+		// Is the path a folder?
+		if (!is_dir($path))
+		{
+			Log::add(Text::sprintf('JLIB_FILESYSTEM_ERROR_PATH_IS_NOT_A_FOLDER', __METHOD__, $path), Log::WARNING, 'jerror');
+
+			return false;
+		}
+
+		if (!($handle = @opendir($path)))
+		{
+			return false;
+		}
+
+		// Return false as soon as the first file or subfolder found
+		while (($entry = readdir($handle)) !== false)
+		{
+			if ($entry !== '.' && $entry !== '..')
+			{
+				closedir($handle);
+
+				return false;
+			}
+		}
+
+		closedir($handle);
+
+		return true;
+	}
 }


### PR DESCRIPTION
Pull Request for Issue #34298 .

### Summary of Changes

_Work in Progress (WiP)_

Change function "deleteUnexistingFiles" in the CMS installer script "administrator/components/com_admin/script.php" so that folders are only attempted to be deleted if they are empty when updating the CMS.

### Testing Instructions

_Will be added soon._

### Actual result BEFORE applying this Pull Request

_Will be added soon._

### Expected result AFTER applying this Pull Request

_Will be added soon._

### Documentation Changes Required

None.