### PR TITLE
[4.0] Fix mail template API failing with SQL error when creating mail templates programmatically

### DIFF
--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -418,6 +418,7 @@ class MailTemplate
 		$template->subject = $subject;
 		$template->body = $body;
 		$template->htmlbody = $htmlbody;
+		$template->attachments = '';
 		$params = new \stdClass;
 		$params->tags = array($tags);
 		$template->params = json_encode($params);


### PR DESCRIPTION
Pull Request for Issue #35071 .

### Summary of Changes

Add the attachments column to the mail template object when creating a new record with `$db->insertObject` in `Joomla\CMS\Mail\MailTemplate::createTemplate`.

As a column with data type TEXT, the `attachments` column of the `#__mail_templates` doesn't have a default value, see PR #27937 and PR #17860 and also https://stackoverflow.com/questions/3466872/why-cant-a-text-column-have-a-default-value-in-mysql for the reasons.

Therefore a property for that column has to exist in the object when creating a new record with `$db->insertObject`.

This pull request (PR) only fixes the SQL error reported by the issue. It does not add the ability to specify attachments when using `Joomla\CMS\Mail\MailTemplate::createTemplate` or `Joomla\CMS\Mail\MailTemplate::updateTemplate`.

This could and in my opinion should be done with a future PR with a suitable milestone, e.g. 4.1.

### Testing Instructions

1. On a clean, current 4.0-dev branch or latest nightly build or 4.0 RC 5, add the following code to the index.php of the Cassiopeia template as shown in the screenshot below the code:

```
use Joomla\CMS\Mail\MailTemplate;

$result = MailTemplate::createTemplate(
	'com_config.test_mail_' . date('Ymd_His'),
	'COM_CONFIG_SENDMAIL_SUBJECT',
	'COM_CONFIG_SENDMAIL_BODY',
	["sitename","method"]
);

echo $result ? 'Mail template created.' : 'creating mail template failed.';
```

![j4-test-mail-template-create_1](https://user-images.githubusercontent.com/7413183/128681196-26ab3ca6-1f05-43df-b7df-a7f8b8bdc6d2.png)

2. Go to the site (frontend).

Result: See section "Actual result BEFORE applying this Pull Request" below.

3. Apply the patch of this PR.

4. Go again to the site (frontend) or if still there reload the page.

Result: See 1st screenshot in section "Expected result AFTER applying this Pull Request" below.

5. Check in database if the mail template record template has been created.

Result: See 2nd screenshot in section "Expected result AFTER applying this Pull Request" below.

Hint: The created mail template will not be shown in backend due to the way how mail templates work, as there is no language string for the dynamically `created template_id`. But this was necessary in order not to violate the primary key uniqueness.

6. Check if editing other mail templates works as before.

Result: Editing mail templates works.

### Actual result BEFORE applying this Pull Request

![j4-test-mail-template-create_2](https://user-images.githubusercontent.com/7413183/128681523-cc377b0f-1728-430c-8558-39e4ac5d35ea.png)

### Expected result AFTER applying this Pull Request

Creating mail templates programmatically works:

![j4-test-mail-template-create_3](https://user-images.githubusercontent.com/7413183/128681735-2757ee54-790d-48f9-b55f-56c3bfbfc299.png)

With every page load a new record has been created:

![j4-test-mail-template-create_4](https://user-images.githubusercontent.com/7413183/128681867-3277b01c-01b5-44a1-b138-79186437eb2d.png)

### Documentation Changes Required

None.