### PR TITLE
[4.0] Update Information

### DIFF
--- a/administrator/templates/atum/scss/pages/_com_joomlaupdate.scss
+++ b/administrator/templates/atum/scss/pages/_com_joomlaupdate.scss
@@ -1,0 +1,7 @@
+// com_joomlaupdate
+
+.com_joomlaupdate {
+  caption {
+    caption-side: top;
+  }
+}

--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -61,6 +61,7 @@
 @import "pages/com_config";
 @import "pages/com_content";
 @import "pages/com_cpanel";
+@import "pages/com_joomlaupdate";
 @import "pages/com_modules";
 @import "pages/com_tags";
 @import "pages/com_privacy";


### PR DESCRIPTION
By default bootstrap displays the caption for all tables below the actual table. Normally thats not an issue as they are also hidden and only used for screenreaders. However in the update component they are displayed and have important/useful information. You only really see why it a bad idea the information being at the end of the table is a problem when you are on a smaller screen or have a lot of data in the table.

## Before
![image](https://user-images.githubusercontent.com/1296369/128701852-836ba921-3687-46fc-ba1f-052ddcd6b6ac.png)

![image](https://user-images.githubusercontent.com/1296369/128701922-3d00125d-a798-41b8-8611-803f8e41417d.png)

## After
![image](https://user-images.githubusercontent.com/1296369/128701937-563fb76b-5df6-496b-bb8e-0ad89d5de2d0.png)
