### PR TITLE
Fix body overflow in dashboard due to dropdown

### DIFF
--- a/administrator/templates/atum/html/layouts/chromes/well.php
+++ b/administrator/templates/atum/html/layouts/chromes/well.php
@@ -50,7 +50,7 @@ $headerIcon = $params->get('header_icon') ? '<span class="' . htmlspecialchars($
 				<?php if ($canEdit || $canChange) : ?>
 					<?php $dropdownPosition = Factory::getLanguage()->isRtl() ? 'start' : 'end'; ?>
 					<div class="module-actions dropdown">
-						<button type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="btn" id="dropdownMenuButton-<?php echo $id; ?>">
+						<button type="button" data-bs-toggle="dropdown" data-bs-display="static" aria-haspopup="true" aria-expanded="false" class="btn" id="dropdownMenuButton-<?php echo $id; ?>">
 							<span class="icon-cogs" aria-hidden="true"></span>
 							<span class="visually-hidden"><?php echo Text::sprintf('JACTION_EDIT_MODULE', $module->title); ?></span>
 						</button>

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -88,6 +88,7 @@
 
   .card-header {
     display: flex;
+    align-items: center;
     padding: 1rem 1rem .75rem;
     font-weight: $font-weight-bold;
     color: var(--template-bg-dark);
@@ -96,6 +97,11 @@
     > [class^="icon-"],
     > img {
       margin-inline-end: .5rem;
+    }
+
+    .btn {
+      margin-top: .25em;
+      margin-bottom: .25em;
     }
   }
 

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -73,10 +73,6 @@
     margin-top: 2rem;
   }
 
-  .module-wrapper {
-    overflow-x: hidden;
-  }
-
   .card {
     p:last-child {
       margin-bottom: 0;
@@ -116,7 +112,6 @@
 
     > * {
       padding: 0;
-      margin-top: -10px;
       color: var(--template-bg-dark-70);
     }
   }

--- a/administrator/templates/atum/scss/pages/_com_cpanel.scss
+++ b/administrator/templates/atum/scss/pages/_com_cpanel.scss
@@ -73,6 +73,10 @@
     margin-top: 2rem;
   }
 
+  .module-wrapper {
+    overflow-x: hidden;
+  }
+
   .card {
     p:last-child {
       margin-bottom: 0;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
When the cogs icon is clicked to edit or unpublish a module in the dashboard, it creates an overflow of the body, This patch adds an overflow hidden to the module to prevent this.

![Image 2](https://user-images.githubusercontent.com/5610413/128732383-109dabc2-d45b-4d95-8bff-e26727e2bbb7.jpg)

### Testing Instructions
Apply the patch, build the CSS and click on one of the cogs icons in the dashboard. The body should not overflow.

### Actual result BEFORE applying this Pull Request
Body has an overflow (See screenshot)

### Expected result AFTER applying this Pull Request
Overflow fixed.

### Documentation Changes Required
No
