### PR TITLE
[4][webservices] - patch article strip html tags

### DIFF
--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -946,11 +946,13 @@
 		<field
 			name="introtext"
 			label="COM_CONTENT_FIELD_INTROTEXT"
+			filter="JComponentHelper::filterText"
 		/>
 
 		<field
 			name="fulltext"
 			label="COM_CONTENT_FIELD_FULLTEXT"
+			filter="JComponentHelper::filterText"
 		/>
 	</fields>
 

--- a/api/components/com_content/src/Controller/ArticlesController.php
+++ b/api/components/com_content/src/Controller/ArticlesController.php
@@ -100,22 +100,6 @@ class ArticlesController extends ApiController
 			}
 		}
 
-		if (isset($data['articletext']))
-		{
-			$pattern = '#<hr\s+id=("|\')system-readmore("|\')\s*\/*>#i';
-			$tagPos = preg_match($pattern, $data['articletext']);
-
-			if ($tagPos == 0)
-			{
-				$data['introtext'] = $data['articletext'];
-				$data['fulltext'] = '';
-			}
-			else
-			{
-				list ($data['introtext'], $data['fulltext']) = preg_split($pattern, $data['articletext'], 2);
-			}
-		}
-
 		return $data;
 	}
 }

--- a/api/components/com_content/src/Controller/ArticlesController.php
+++ b/api/components/com_content/src/Controller/ArticlesController.php
@@ -100,6 +100,22 @@ class ArticlesController extends ApiController
 			}
 		}
 
+		if (isset($data['articletext']))
+		{
+			$pattern = '#<hr\s+id=("|\')system-readmore("|\')\s*\/*>#i';
+			$tagPos = preg_match($pattern, $data['articletext']);
+
+			if ($tagPos == 0)
+			{
+				$data['introtext'] = $data['articletext'];
+				$data['fulltext'] = '';
+			}
+			else
+			{
+				list ($data['introtext'], $data['fulltext']) = preg_split($pattern, $data['articletext'], 2);
+			}
+		}
+
 		return $data;
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #34933 .

### Summary of Changes
don't strip all the html tags use the filter


### Testing Instructions
PATCH an `introtext` and /or `fulltext`
```
curl --location --request PATCH 'http://[yoursite]/index.php/v1/content/articles/54' \
--header 'Content-Type: application/json' \
--header 'Authorization: Bearer [yourkey]' \
--data-raw '{
    "title":"Test PATCH",
    "introtext": "<p><strong>Bold </strong><em>Italic </em><span style=\"text-decoration: underline;\">underscore </span><span style=\"text-decoration: line-through;\">striketrough</span> <span style=\"color: #ff0000;\">Red</span></p>",
    "fulltext": "adfkjvgh kdkjsfhdkjs ghkdfgkjdfh jdfvgdkjf vdkj gdkfjghkdjfghdkfjghdkj gdkfghdkjf hgdkfgh kdfk kjghkdgd de<p><strong>Bold </strong><em>Italic </em></p>"
 }'
```


### Actual result BEFORE applying this Pull Request
all html tags in  an `introtext` and /or `fulltext` are stripped out on PATCH



### Expected result AFTER applying this Pull Request
the PATCH works as expected
![image](https://user-images.githubusercontent.com/181681/146555608-4a539a63-7971-4690-a54c-803847574819.png)


