### PR TITLE
[3.10] Patch syntax errors on lower PHP Versions

### DIFF
--- a/plugins/quickicon/eos310/eos310.php
+++ b/plugins/quickicon/eos310/eos310.php
@@ -113,7 +113,7 @@ class PlgQuickiconEos310 extends CMSPlugin
 			$messageText = Text::sprintf(
 				$this->currentMessage['messageText'],
 				HTMLHelper::_('date', static::EOS_DATE, Text::_('DATE_FORMAT_LC3')),
-				$this->currentMessage['messageLink'],
+				$this->currentMessage['messageLink']
 			);
 
 			if ($this->currentMessage['snoozable'])
@@ -126,7 +126,7 @@ class PlgQuickiconEos310 extends CMSPlugin
 
 			$this->app->enqueueMessage(
 				$messageText,
-				$this->currentMessage['messageType'],
+				$this->currentMessage['messageType']
 			);
 		}
 
@@ -137,7 +137,7 @@ class PlgQuickiconEos310 extends CMSPlugin
 				'date',
 				static::EOS_DATE,
 				Text::_('DATE_FORMAT_LC3')
-			),
+			)
 		);
 
 		// The message as quickicon


### PR DESCRIPTION
Pull Request for Issue #35089 

### Summary of Changes

Patch syntax errors on lower PHP Versions

### Testing Instructions

Test the EOS plugin on PHP 7.0.7 or lower

### Actual result BEFORE applying this Pull Request

syntax error, unexpected ')'

### Expected result AFTER applying this Pull Request

No syntax error

### Documentation Changes Required

none