### PR TITLE
[4.0] Fix categories accordion

### DIFF
--- a/build/media_source/com_categories/joomla.asset.json
+++ b/build/media_source/com_categories/joomla.asset.json
@@ -6,6 +6,14 @@
   "license": "GPL-2.0-or-later",
   "assets": [
     {
+      "name": "com_categories.shared-categories-accordion",
+      "type": "preset",
+      "dependencies": [
+        "com_categories.shared-categories-accordion#style",
+        "com_categories.shared-categories-accordion#script"
+      ]
+    },
+    {
       "name": "com_categories.shared-categories-accordion.es5",
       "type": "script",
       "uri": "com_categories/shared-categories-accordion-es5.min.js",

--- a/build/media_source/com_categories/js/shared-categories-accordion.es6.js
+++ b/build/media_source/com_categories/js/shared-categories-accordion.es6.js
@@ -38,7 +38,7 @@ const handleCategoryToggleButtonClick = ({ currentTarget }) => {
     ),
   );
 
-  const categoryId = button.dataset.id;
+  const { categoryId } = button.dataset;
   const target = document.getElementById(`category-${categoryId}`);
   target.toggleAttribute('hidden');
 };

--- a/build/media_source/com_categories/js/shared-categories-accordion.es6.js
+++ b/build/media_source/com_categories/js/shared-categories-accordion.es6.js
@@ -38,7 +38,8 @@ const handleCategoryToggleButtonClick = ({ currentTarget }) => {
     ),
   );
 
-  const target = button.nextElementSibling;
+  const categoryId = button.dataset.id;
+  const target = document.getElementById(`category-${categoryId}`);
   target.toggleAttribute('hidden');
 };
 

--- a/components/com_content/tmpl/categories/default.php
+++ b/components/com_content/tmpl/categories/default.php
@@ -19,8 +19,7 @@ Text::script('JGLOBAL_COLLAPSE_CATEGORIES');
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_categories');
-$wa->useStyle('com_categories.shared-categories-accordion');
-$wa->useScript('com_categories.shared-categories-accordion');
+$wa->usePreset('com_categories.shared-categories-accordion');
 
 ?>
 <div class="com-content-categories categories-list">

--- a/components/com_content/tmpl/categories/default_items.php
+++ b/components/com_content/tmpl/categories/default_items.php
@@ -34,7 +34,7 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 					<button
 						type="button"
 						id="category-btn-<?php echo $item->id; ?>"
-						data-id="<?php echo $item->id; ?>"
+						data-category-id="<?php echo $item->id; ?>"
 						class="btn btn-secondary btn-sm"
 						aria-expanded="false"
 						aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"

--- a/components/com_content/tmpl/categories/default_items.php
+++ b/components/com_content/tmpl/categories/default_items.php
@@ -34,6 +34,7 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 					<button
 						type="button"
 						id="category-btn-<?php echo $item->id; ?>"
+						data-id="<?php echo $item->id; ?>"
 						class="btn btn-secondary btn-sm"
 						aria-expanded="false"
 						aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The categories accordion implemented in this PR https://github.com/joomla/joomla-cms/pull/33052 won't work properly when the menu item created to display categories tree when the sub-category has image or description and one of the two settings below set to show:

- **Category Image** set to Show
- Or **Subcategories Descriptions** set to Show

If image or description is being show, `button.nextElementSibling` will point to wrong div tag (you can see it by reading the code at https://github.com/joomla/joomla-cms/blob/4.0-dev/components/com_content/tmpl/categories/default_items.php#L34-L53

This PRs solve it by adding an attribute to the button to allow getting ID of the category and use it to get the right div which contains children categories of that category

I also made small modification to build/media_source/com_categories/joomla.asset.json to define **preset** so that we can call usePreset to load both JS and CSS in a single line of code.


### Testing Instructions
1. Setup categories and sub-categories for articles. Please remember to enter description for these categories
2. Create a menu item to link to **List All Categories in an Article Category Tree** menu item type of com_content. In the menu item parameters, look at Category tab, set :
- Empty Categories: Show
- Subcategories Descriptions: Show
3. Before patch:

- Accordion on categories page does not work properly.

4. After patch: According on works properly. To apply patch, please update your installation to the update package generated by this PR https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/35093/downloads/46491/Joomla_4.0.0-rc7-dev+pr.35093-Development-Update_Package.zip