### PR TITLE
[4.0] Correct assets name for workflow state -> stage and ID

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-13.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-13.sql
@@ -4,5 +4,5 @@ UPDATE `#__assets`
  WHERE `name` = 'com_content.state.1';
 
 UPDATE `#__workflow_stages`
-   SET `asset_id` = 57
+   SET `asset_id` = (SELECT MAX(`id`) FROM `#__assets` WHERE `name` = 'com_content.stage.1')
  WHERE `asset_id` = 0;

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-13.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-13.sql
@@ -1,0 +1,8 @@
+-- after 4.0.0 RC6
+UPDATE `#__assets`
+   SET `name` = 'com_content.stage.1'
+ WHERE `name` = 'com_content.state.1';
+
+UPDATE `#__workflow_stages`
+   SET `asset_id` = 57
+ WHERE `asset_id` = 0;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-13.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-13.sql
@@ -1,0 +1,8 @@
+-- after 4.0.0 RC6
+UPDATE "#__assets"
+SET "name" = 'com_content.stage.1'
+WHERE "name" = 'com_content.state.1';
+
+UPDATE "#__workflow_stages"
+SET "asset_id" = 57
+WHERE "asset_id" = 0;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-13.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-13.sql
@@ -4,5 +4,5 @@ SET "name" = 'com_content.stage.1'
 WHERE "name" = 'com_content.state.1';
 
 UPDATE "#__workflow_stages"
-SET "asset_id" = 57
+SET "asset_id" = (SELECT MAX("id") FROM "#__assets" WHERE "name" = 'com_content.stage.1')
 WHERE "asset_id" = 0;

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-13.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-13.sql
@@ -1,7 +1,7 @@
 -- after 4.0.0 RC6
 UPDATE "#__assets"
-SET "name" = 'com_content.stage.1'
-WHERE "name" = 'com_content.state.1';
+   SET "name" = 'com_content.stage.1'
+ WHERE "name" = 'com_content.state.1';
 
 UPDATE "#__workflow_stages"
    SET "asset_id" = (SELECT MAX("id") FROM "#__assets" WHERE "name" = 'com_content.stage.1')

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-13.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-13.sql
@@ -4,5 +4,5 @@ SET "name" = 'com_content.stage.1'
 WHERE "name" = 'com_content.state.1';
 
 UPDATE "#__workflow_stages"
-SET "asset_id" = (SELECT MAX("id") FROM "#__assets" WHERE "name" = 'com_content.stage.1')
-WHERE "asset_id" = 0;
+   SET "asset_id" = (SELECT MAX("id") FROM "#__assets" WHERE "name" = 'com_content.stage.1')
+ WHERE "asset_id" = 0;

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -76,7 +76,7 @@ INSERT INTO `#__assets` (`id`, `parent_id`, `lft`, `rgt`, `level`, `name`, `titl
 (54, 16, 52, 53, 2, 'com_menus.menu.1', 'Main Menu', '{}'),
 (55, 18, 94, 95, 2, 'com_modules.module.87', 'Sample Data', '{}'),
 (56, 8, 20, 37, 2, 'com_content.workflow.1', 'COM_WORKFLOW_BASIC_WORKFLOW', '{}'),
-(57, 56, 21, 22, 3, 'com_content.state.1', 'COM_WORKFLOW_BASIC_STAGE', '{}'),
+(57, 56, 21, 22, 3, 'com_content.stage.1', 'COM_WORKFLOW_BASIC_STAGE', '{}'),
 (58, 56, 23, 24, 3, 'com_content.transition.1', 'Publish', '{}'),
 (59, 56, 25, 26, 3, 'com_content.transition.2', 'Unpublish', '{}'),
 (60, 56, 27, 28, 3, 'com_content.transition.3', 'Archive', '{}'),
@@ -1126,7 +1126,7 @@ CREATE TABLE IF NOT EXISTS `#__workflow_stages` (
 --
 
 INSERT INTO `#__workflow_stages` (`id`, `asset_id`, `ordering`, `workflow_id`, `published`, `title`, `description`, `default`) VALUES
-(1, 0, 1, 1, 1, 'COM_WORKFLOW_BASIC_STAGE', '', 1);
+(1, 57, 1, 1, 1, 'COM_WORKFLOW_BASIC_STAGE', '', 1);
 
 -- --------------------------------------------------------
 

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -82,7 +82,7 @@ INSERT INTO "#__assets" ("id", "parent_id", "lft", "rgt", "level", "name", "titl
 (54, 16, 52, 53, 2, 'com_menus.menu.1', 'Main Menu', '{}'),
 (55, 18, 94, 95, 2, 'com_modules.module.87', 'Sample Data', '{}'),
 (56, 8, 20, 37, 2, 'com_content.workflow.1', 'COM_WORKFLOW_BASIC_WORKFLOW', '{}'),
-(57, 56, 21, 22, 3, 'com_content.state.1', 'COM_WORKFLOW_BASIC_STAGE', '{}'),
+(57, 56, 21, 22, 3, 'com_content.stage.1', 'COM_WORKFLOW_BASIC_STAGE', '{}'),
 (58, 56, 23, 24, 3, 'com_content.transition.1', 'Publish', '{}'),
 (59, 56, 25, 26, 3, 'com_content.transition.2', 'Unpublish', '{}'),
 (60, 56, 27, 28, 3, 'com_content.transition.3', 'Archive', '{}'),


### PR DESCRIPTION
Correction assets installation data. Asset `name` for sample stage is currently incorrect (`com_content.state.1` instead of `com_content.stage.1`) and default `asset_id` for `#__workflow_stages` should not be related to 0 but the correct asset.