### PR TITLE
[3.10] Disable the critical plugins check for non-major updates.

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -101,7 +101,14 @@ class JoomlaupdateViewDefault extends JViewLegacy
 		$this->phpOptions             = $model->getPhpOptions();
 		$this->phpSettings            = $model->getPhpSettings();
 		$this->nonCoreExtensions      = $model->getNonCoreExtensions();
-		$this->nonCoreCriticalPlugins = $model->getNonCorePlugins(array('system','user','authentication','actionlog','twofactorauth'));
+
+		// Disable the critical plugins check for non-major updates.
+		$this->nonCoreCriticalPlugins = false;
+
+		if (version_compare($this->updateInfo['latest'], '4', '>='))
+		{
+			$this->nonCoreCriticalPlugins = $model->getNonCorePlugins(array('system','user','authentication','actionlog','twofactorauth'));
+		}
 
 		// Set the toolbar information.
 		JToolbarHelper::title(JText::_('COM_JOOMLAUPDATE_OVERVIEW'), 'loop install');


### PR DESCRIPTION
### Summary of Changes

Disable the critical plugins check for non-major updates for example when updating between 3.10 -> 3.10

### Testing Instructions

Install 3.10-rc2
Install https://regularlabs.com/whatnothing
Use the nighly update server: https://update.joomla.org/core/nightlies/next_minor_list.xml

Set the update server to 4: https://update.joomla.org/core/nightlies/next_major_list.xml
than you get the warning again
![image](https://user-images.githubusercontent.com/2596554/129256230-988dc226-46f1-4e31-b414-96534cd881e6.png)


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/2596554/129255488-1d233eaf-a135-45ca-905c-0cb1d0eb83a9.png)


### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/2596554/129255568-2f15e25a-5836-46e4-9195-2979e59c5526.png)


### Documentation Changes Required

None

cc @joomla/cms-release-team @HLeithner @bembelimen 