### PR TITLE
[4.0] Use com_mails/access.xml for permissions

### DIFF
--- a/administrator/components/com_mails/config.xml
+++ b/administrator/components/com_mails/config.xml
@@ -62,7 +62,7 @@
 			label="JCONFIG_PERMISSIONS_LABEL"
 			filter="rules"
 			validate="rules"
-			component="com_messages"
+			component="com_mails"
 			section="component"
 		/>
 	</fieldset>


### PR DESCRIPTION
### Summary of Changes
Use `com_mails/access.xml` for permissions of com_mails instead of  `com_messages/access.xml` for the permissions.


### Actual result BEFORE applying this Pull Request
<img width="1677" alt="Screenshot 2021-08-13 at 15 39 04" src="https://user-images.githubusercontent.com/522834/129365992-a342aaf2-271c-4006-87af-eda30ad83e0e.png">


### Expected result AFTER applying this Pull Request
<img width="1675" alt="Screenshot 2021-08-13 at 15 39 36" src="https://user-images.githubusercontent.com/522834/129366035-a8412bd3-a0ab-466b-846c-0dba4e335d43.png">
