### PR TITLE
fixed sidebar scroll issue

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -3,7 +3,7 @@
 .sidebar-wrapper {
   z-index: $zindex-sidebar;
   min-height: calc(100vh - 69px);
-  overflow: hidden;
+  overflow: visible;
   background-color: var(--template-sidebar-bg);
   box-shadow: 0 0 20px -10px var(--template-bg-dark-50);
 


### PR DESCRIPTION
Pull Request for Issue #35068 

### Summary of Changes
Currently, the left navigation expands and scroll down when you scroll the page. For example, if you have 20 components, you expand the components menu and click on the last link. The page loads with the last link down at the bottom of the page. you need to scroll down to see the bottom links.

### Actual result BEFORE applying this Pull Request
![Modules (Administrator) - pinak - Administration - Brave 14-08-2021 11_25_14](https://user-images.githubusercontent.com/59458280/129435668-5c937505-6907-4a5d-b8be-9926abfc2764.png)


### Expected result AFTER applying this Pull Request
![Modules (Administrator) - pinak - Administration - Brave 14-08-2021 11_25_29](https://user-images.githubusercontent.com/59458280/129435669-57abfd4c-7a82-493c-9674-10fa8764114f.png)


### Documentation Changes Required

