### PR TITLE
[4.0] Make edit_lock layout reusable for other extensions

### DIFF
--- a/layouts/joomla/content/icons/edit_lock.php
+++ b/layouts/joomla/content/icons/edit_lock.php
@@ -11,15 +11,18 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
-if (isset($displayData['article']))
+if (isset($displayData['ariaDescribed']))
 {
-	$article = $displayData['article'];
+	$aria_described = $displayData['ariaDescribed'];
+}
+elseif (isset($displayData['article']))
+{
+	$article        = $displayData['article'];
 	$aria_described = 'editarticle-' . (int) $article->id;
 }
-
-if (isset($displayData['contact']))
+elseif (isset($displayData['contact']))
 {
-	$contact = $displayData['contact'];
+	$contact        = $displayData['contact'];
 	$aria_described = 'editcontact-' . (int) $contact->id;
 }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The layout **layouts/joomla/content/icons/edit_lock.php** is used to display lock icon (when the item is being checked out by different user and could not be edited by the current logged in user)

For some reasons, in the code, we hardcode it to **article** and **contact** only, thus prevent other extensions (found this when checking weblinks layout) from using it.

This PR extends the code abit to make layout reusable by other extensions (weblinks in the case) by passing `ariaDescribed`  to display data and use it if provided. That removes the limit for **article** and **contact** only.


### Testing Instructions
Code review only.

Hope it is accepted so that we can re-use this layout in com_weblinks instead of having to implement it.