### PR TITLE
Fix layout article categories list as tree

### DIFF
--- a/build/media_source/com_categories/css/shared-categories-accordion.css
+++ b/build/media_source/com_categories/css/shared-categories-accordion.css
@@ -1,13 +1,16 @@
 .com-content-categories__item {
+  border-bottom: 1px solid #dfe3e7;
+}
+.com-content-categories__item-title-wrapper {
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
   padding: .5rem 0;
-  border-bottom: 1px solid #dfe3e7;
 }
 .com-content-categories__children {
   flex-basis: 100%;
   padding-inline-start: 1.5rem;
+  border-top: 1px solid #dfe3e7;
 }
 .com-content-categories__children .com-content-categories__item:last-child {
   border-bottom: none;

--- a/components/com_content/tmpl/categories/default_items.php
+++ b/components/com_content/tmpl/categories/default_items.php
@@ -20,28 +20,30 @@ if ($this->maxLevelcat != 0 && count($this->items[$this->parent->id]) > 0) :
 		<?php foreach ($this->items[$this->parent->id] as $id => $item) : ?>
 			<?php if ($this->params->get('show_empty_categories_cat') || $item->numitems || count($item->getChildren())) : ?>
 			<div class="com-content-categories__item">
-				<div>
-					<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
-					<?php echo $this->escape($item->title); ?></a>
-					<?php if ($this->params->get('show_cat_num_articles_cat') == 1) :?>
-						<span class="badge bg-info">
-							<?php echo Text::_('COM_CONTENT_NUM_ITEMS'); ?>&nbsp;
-							<?php echo $item->numitems; ?>
-						</span>
+				<div class="com-content-categories__item-title-wrapper">
+					<div class="com-content-categories__item-title">
+						<a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
+						<?php echo $this->escape($item->title); ?></a>
+						<?php if ($this->params->get('show_cat_num_articles_cat') == 1) :?>
+							<span class="badge bg-info">
+								<?php echo Text::_('COM_CONTENT_NUM_ITEMS'); ?>&nbsp;
+								<?php echo $item->numitems; ?>
+							</span>
+						<?php endif; ?>
+					</div>
+					<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
+						<button
+							type="button"
+							id="category-btn-<?php echo $item->id; ?>"
+							data-category-id="<?php echo $item->id; ?>"
+							class="btn btn-secondary btn-sm"
+							aria-expanded="false"
+							aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"
+						>
+							<span class="icon-plus" aria-hidden="true"></span>
+						</button>
 					<?php endif; ?>
 				</div>
-				<?php if (count($item->getChildren()) > 0 && $this->maxLevelcat > 1) : ?>
-					<button
-						type="button"
-						id="category-btn-<?php echo $item->id; ?>"
-						data-category-id="<?php echo $item->id; ?>"
-						class="btn btn-secondary btn-sm"
-						aria-expanded="false"
-						aria-label="<?php echo Text::_('JGLOBAL_EXPAND_CATEGORIES'); ?>"
-					>
-						<span class="icon-plus" aria-hidden="true"></span>
-					</button>
-				<?php endif; ?>
 				<?php if ($this->params->get('show_description_image') && $item->getParams()->get('image')) : ?>
 					<img src="<?php echo $item->getParams()->get('image'); ?>" alt="<?php echo htmlspecialchars($item->getParams()->get('image_alt'), ENT_COMPAT, 'UTF-8'); ?>">
 				<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # .
This is an addition to the PR #35093

### Summary of Changes
Changed layout of categories list as tree. Also added an extra separator line on top of the first child 

### Testing Instruction
In the article categories, create some categories with some nested categories in it.
Add a description in every category and also add an image in the options tab.
Create a menu item of  Articles -> List All Categories in an Article Category Tree
Make sure in the option tab that the categorie image and description are set to show.
To create the new CSS files run: npm run build:css 

### Actual result BEFORE applying this Pull Request
![Image-3](https://user-images.githubusercontent.com/5610413/129445102-226f6979-c10a-484f-96b3-c56da0a98d3e.jpg)

### Expected result AFTER applying this Pull Request
![Image-4](https://user-images.githubusercontent.com/5610413/129445109-97b65971-f46d-4c6a-b224-1af10ea812c8.jpg)

### Documentation Changes Required

