### PR TITLE
[4] Remove PHP from a plain text file

### DIFF
--- a/installation/INSTALL
+++ b/installation/INSTALL
@@ -1,14 +1,3 @@
-<?php
-/**
- * @package    Joomla.Installation
- *
- * @copyright  (C) 2005 Open Source Matters, Inc. <https://www.joomla.org>
- * @license    GNU General Public License version 2 or later; see LICENSE.txt
- */
-
-defined('_JEXEC') or die;
-?>
-
 REQUIREMENTS
 ------------
 

--- a/installation/INSTALL
+++ b/installation/INSTALL
@@ -1,3 +1,7 @@
+# @copyright  (C) 2005 Open Source Matters, Inc. <https://www.joomla.org>
+# @license    GNU General Public License version 2 or later; see LICENSE.txt
+
+
 REQUIREMENTS
 ------------
 


### PR DESCRIPTION
Code review.

There is no point having a PHP comment in a file without a PHP extension, it will never be parsed and doesn't ever run. 