### PR TITLE
[4] Remove default secret

### DIFF
--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -52,7 +52,7 @@ class JConfig
 	public $dbsslcipher = '';
 
 	/* Server Settings */
-	public $secret = '';     // Use something very secure
+	public $secret = '';     // Use something very secure. For example on linux the following command `cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w ${1:-16} | head -n 1`
 	public $gzip = false;
 	public $error_reporting = 'default';
 	public $helpurl = 'https://help.joomla.org/proxy?keyref=Help{major}{minor}:{keyref}&lang={langcode}';

--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -52,7 +52,7 @@ class JConfig
 	public $dbsslcipher = '';
 
 	/* Server Settings */
-	public $secret = 'FBVtggIk5lAzEU9H';     // Change this to something more secure
+	public $secret = '';     // Use something very secure
 	public $gzip = false;
 	public $error_reporting = 'default';
 	public $helpurl = 'https://help.joomla.org/proxy?keyref=Help{major}{minor}:{keyref}&lang={langcode}';


### PR DESCRIPTION
Code review

Security 101: Do not provide guessable defaults for secrets or credentials because [users cannot be trusted to change default credentials and secrets](https://github.com/search?q=FBVtggIk5lAzEU9H&type=code).

Also can be used to fingerprint/google dork.