### PR TITLE
[4] remove redundant sessions folder in installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 /administrator/logs
 /cache
 /installation/cache
-/installation/sessions
 /tmp
 /configuration.php
 /.htaccess

--- a/installation/sessions/.gitignore
+++ b/installation/sessions/.gitignore
@@ -1,1 +1,0 @@
-!.gitignore


### PR DESCRIPTION
Core review

This folder is never used. Therefore it doesnt need to exist. 