### PR TITLE
[4.0] Subform styling for non table layout

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -182,10 +182,10 @@ div.subform-repeatable-group {
 // Highlight draggable section
 .subform-repeatable-group[draggable="true"] {
   // For non table layout
-  background-color: var(--template-bg-dark-3);
+  background-color: $teal;
 
   // For table layout
   > td {
-    background-color: var(--template-bg-dark-3);
+    background-color: $teal;
   }
 }

--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -144,9 +144,9 @@ td .form-control {
 // Subform - non table layout
 div.subform-repeatable-group {
   margin-top: 20px;
-  border: $input-border;
-  padding: 32px 32px 16px 28px;
   position: relative;
+  padding: 32px 32px 16px 28px;
+  border: $input-border;
   border-radius: $border-radius;
 
   > .btn-toolbar {
@@ -159,8 +159,8 @@ div.subform-repeatable-group {
       position: absolute;
 
       &.group-add {
-        bottom: -1px;
         right: -1px;
+        bottom: -1px;
         border-radius: $border-radius 0 $border-radius 0;
       }
       &.group-remove {
@@ -169,11 +169,11 @@ div.subform-repeatable-group {
         border-radius: 0 $border-radius 0 $border-radius;
       }
       &.group-move {
-        right: 100%;
         top: 50%;
+        right: 100%;
         margin-top: -27px;
-        border-radius: $border-radius 0 0 $border-radius;
         line-height: 52px;
+        border-radius: $border-radius 0 0 $border-radius;
       }
     }
   }

--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -178,3 +178,14 @@ div.subform-repeatable-group {
     }
   }
 }
+
+// Highlight draggable section
+.subform-repeatable-group[draggable="true"] {
+  // For non table layout
+  background-color: var(--template-bg-dark-3);
+
+  // For table layout
+  > td {
+    background-color: var(--template-bg-dark-3);
+  }
+}

--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -143,8 +143,8 @@ td .form-control {
 
 // Subform - non table layout
 div.subform-repeatable-group {
-  margin-top: 20px;
   position: relative;
+  margin-top: 20px;
   padding: 32px 32px 16px 28px;
   border: $input-border;
   border-radius: $border-radius;

--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -140,3 +140,41 @@ td .form-control {
 .form-group {
   @extend .mb-3;
 }
+
+// Subform - non table layout
+div.subform-repeatable-group {
+  margin-top: 20px;
+  border: $input-border;
+  padding: 32px 32px 16px 28px;
+  position: relative;
+  border-radius: $border-radius;
+
+  > .btn-toolbar {
+
+    .btn-group {
+      position: static;
+    }
+
+    .btn {
+      position: absolute;
+
+      &.group-add {
+        bottom: -1px;
+        right: -1px;
+        border-radius: $border-radius 0 $border-radius 0;
+      }
+      &.group-remove {
+        top: -1px;
+        right: -1px;
+        border-radius: 0 $border-radius 0 $border-radius;
+      }
+      &.group-move {
+        right: 100%;
+        top: 50%;
+        margin-top: -27px;
+        border-radius: $border-radius 0 0 $border-radius;
+        line-height: 52px;
+      }
+    }
+  }
+}

--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -144,8 +144,8 @@ td .form-control {
 // Subform - non table layout
 div.subform-repeatable-group {
   position: relative;
-  margin-top: 20px;
   padding: 32px 32px 16px 28px;
+  margin-top: 20px;
   border: $input-border;
   border-radius: $border-radius;
 

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -96,7 +96,7 @@ else
 						<td style="width:8%;">
 							<?php if (!empty($buttons['add'])) : ?>
 								<div class="btn-group">
-									<button type="button" class="group-add btn btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
+									<button type="button" class="group-add btn btn-sm btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
 										<span class="icon-plus" aria-hidden="true"></span>
 									</button>
 								</div>

--- a/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
@@ -35,17 +35,17 @@ extract($displayData);
 	<td>
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?>
-				<button type="button" class="group-add btn btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
+				<button type="button" class="group-add btn btn-sm btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
 					<span class="icon-plus" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?>
-				<button type="button" class="group-remove btn btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>">
+				<button type="button" class="group-remove btn btn-sm btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>">
 					<span class="icon-minus" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?>
-				<button type="button" class="group-move btn btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>">
+				<button type="button" class="group-move btn btn-sm btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>">
 					<span class="icon-arrows-alt" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable-table/section.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section.php
@@ -33,17 +33,17 @@ extract($displayData);
 	<td>
 		<div class="btn-group">
 			<?php if (!empty($buttons['add'])) : ?>
-				<button type="button" class="group-add btn btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
+				<button type="button" class="group-add btn btn-sm btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>">
 					<span class="icon-plus" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>
 			<?php if (!empty($buttons['remove'])) : ?>
-				<button type="button" class="group-remove btn btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>">
+				<button type="button" class="group-remove btn btn-sm btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>">
 					<span class="icon-minus" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>
 			<?php if (!empty($buttons['move'])) : ?>
-				<button type="button" class="group-move btn btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>">
+				<button type="button" class="group-move btn btn-sm btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>">
 					<span class="icon-arrows-alt" aria-hidden="true"></span>
 				</button>
 			<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
@@ -27,9 +27,9 @@ extract($displayData);
 	<?php if (!empty($buttons)) : ?>
 	<div class="btn-toolbar text-end">
 		<div class="btn-group">
-			<?php if (!empty($buttons['add'])) : ?><button type="button" class="group-add btn btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>"><span class="icon-plus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
-			<?php if (!empty($buttons['remove'])) : ?><button type="button" class="group-remove btn btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>"><span class="icon-minus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
-			<?php if (!empty($buttons['move'])) : ?><button type="button" class="group-move btn btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['add'])) : ?><button type="button" class="group-add btn btn-sm btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>"><span class="icon-plus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['remove'])) : ?><button type="button" class="group-remove btn btn-sm btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>"><span class="icon-minus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['move'])) : ?><button type="button" class="group-move btn btn-sm btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </button><?php endif; ?>
 		</div>
 	</div>
 	<?php endif; ?>

--- a/layouts/joomla/form/field/subform/repeatable/section.php
+++ b/layouts/joomla/form/field/subform/repeatable/section.php
@@ -27,9 +27,9 @@ extract($displayData);
 	<?php if (!empty($buttons)) : ?>
 	<div class="btn-toolbar text-end">
 		<div class="btn-group">
-			<?php if (!empty($buttons['add'])) : ?><button type="button" class="group-add btn btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>"><span class="icon-plus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
-			<?php if (!empty($buttons['remove'])) : ?><button type="button" class="group-remove btn btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>"><span class="icon-minus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
-			<?php if (!empty($buttons['move'])) : ?><button type="button" class="group-move btn btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['add'])) : ?><button type="button" class="group-add btn btn-sm btn-success" aria-label="<?php echo Text::_('JGLOBAL_FIELD_ADD'); ?>"><span class="icon-plus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['remove'])) : ?><button type="button" class="group-remove btn btn-sm btn-danger" aria-label="<?php echo Text::_('JGLOBAL_FIELD_REMOVE'); ?>"><span class="icon-minus icon-white" aria-hidden="true"></span> </button><?php endif; ?>
+			<?php if (!empty($buttons['move'])) : ?><button type="button" class="group-move btn btn-sm btn-primary" aria-label="<?php echo Text::_('JGLOBAL_FIELD_MOVE'); ?>"><span class="icon-arrows-alt icon-white" aria-hidden="true"></span> </button><?php endif; ?>
 		</div>
 	</div>
 	<?php endif; ?>


### PR DESCRIPTION
### Summary of Changes
Fixing subform styling.
Adopted from joomla 3


### Testing Instructions
Apply patch, run `node build/build.js --compile-css`

Add subform field somewhere, example in mod_custom xml
```xml
<field type="subform" name="subform" label="subform" multiple="true">
  <form>
    <field type="text" name="text" label="text" />
    <field type="textarea" name="textarea" label="textarea" />
  </form>
</field>
```

### Actual result BEFORE applying this Pull Request

![Screenshot_2021-08-15_14-18-40](https://user-images.githubusercontent.com/1568198/129477783-c4ba29c3-4c0e-4b30-854a-9a7e695c5911.png)


### Expected result AFTER applying this Pull Request
![Screenshot_2021-08-15_14-41-32](https://user-images.githubusercontent.com/1568198/129477791-910895f7-66f9-4b58-b298-9adac39bfe70.png)



### Documentation Changes Required

