### PR TITLE
[4] fix check extension for update

### DIFF
--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -320,7 +320,7 @@ class Updater extends Adapter
 							array(
 								'element'   => $current_update->get('element'),
 								'type'      => $current_update->get('type'),
-								'client_id' => $current_update->get('client_id'),
+								'client_id' => (int) $current_update->get('client_id'),
 								'folder'    => $current_update->get('folder'),
 							)
 						);
@@ -330,7 +330,7 @@ class Updater extends Adapter
 							array(
 								'element'   => $current_update->get('element'),
 								'type'      => $current_update->get('type'),
-								'client_id' => $current_update->get('client_id'),
+								'client_id' => (int) $current_update->get('client_id'),
 								'folder'    => $current_update->get('folder'),
 							)
 						);


### PR DESCRIPTION
### Summary of Changes
cast to int `client_id`


### Testing Instructions
go to Extensions: Update
click on Check for updates
use postgresql


### Actual result BEFORE applying this Pull Request
`An error has occurred.

    22 22P02, 7, ERROR: invalid input syntax for integer: "" LINE 3: ...ement = 'job' AND type = 'plugin' AND client_id = '' AND fol... ^ `


### Expected result AFTER applying this Pull Request

it shows  extension updates



