### PR TITLE
Allow empty folder in zip file

### DIFF
--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -1712,7 +1712,7 @@ class Installer extends Adapter
 					// The source file / folder does not exist. Nothing to copy so set an error.
 					Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_NO_FILE', $filesource), Log::WARNING, 'jerror');
 
-					// Okay to ignore missing folder - it maybe an empty folder in the zip file.
+					// Okay to ignore missing folder - it may be an empty folder in the zip file.
 					if ($filetype === 'folder')
 					{
 						continue;

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -1709,10 +1709,10 @@ class Installer extends Adapter
 
 				if (!file_exists($filesource))
 				{
-					// The source file / folder does not exist. Nothing to copy so set an error
+					// The source file / folder does not exist. Nothing to copy so set an error.
 					Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_NO_FILE', $filesource), Log::WARNING, 'jerror');
 
-					// Okay to ignore missing folder - it maybe an empty folder in the zip file
+					// Okay to ignore missing folder - it maybe an empty folder in the zip file.
 					if ($filetype === 'folder')
 					{
 						continue;

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -1371,7 +1371,7 @@ class Installer extends Adapter
 
 			/*
 			 * Before we can add a file to the copyfiles array we need to ensure
-			 * that the folder we are copying our file to exits and if it doesn't,
+			 * that the folder we are copying our file to exists and if it doesn't,
 			 * we need to create it.
 			 */
 
@@ -1495,7 +1495,7 @@ class Installer extends Adapter
 
 			/*
 			 * Before we can add a file to the copyfiles array we need to ensure
-			 * that the folder we are copying our file to exits and if it doesn't,
+			 * that the folder we are copying our file to exists and if it doesn't,
 			 * we need to create it.
 			 */
 
@@ -1584,7 +1584,7 @@ class Installer extends Adapter
 
 			/*
 			 * Before we can add a file to the copyfiles array we need to ensure
-			 * that the folder we are copying our file to exits and if it doesn't,
+			 * that the folder we are copying our file to exists and if it doesn't,
 			 * we need to create it.
 			 */
 
@@ -1709,11 +1709,14 @@ class Installer extends Adapter
 
 				if (!file_exists($filesource))
 				{
-					/*
-					 * The source file does not exist.  Nothing to copy so set an error
-					 * and return false.
-					 */
+					// The source file / folder does not exist. Nothing to copy so set an error
 					Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_NO_FILE', $filesource), Log::WARNING, 'jerror');
+
+					// Okay to ignore missing folder - it maybe an empty folder in the zip file
+					if ($filetype === 'folder')
+					{
+						continue;
+					}
 
 					return false;
 				}


### PR DESCRIPTION
### Summary of Changes

Only throw error if file does not exist.
If folder in zip file is empty then extract does not create the folder.
This caused the library installation to fail.

### Testing Instructions

Install library
[lib_bftest1.zip](https://github.com/joomla/joomla-cms/files/6991587/lib_bftest1.zip)


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/3941269/129549677-b04d0caf-93ac-4312-8929-ae599de0402f.png)


### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/3941269/129549840-773e2e9e-cd2e-410c-b528-e40978615385.png)


### Documentation Changes Required

None.
