### PR TITLE
[4.0] [a11y] Fix broken aria reference in mod_language_switcher

### DIFF
--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -37,7 +37,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 				</button>
 			<?php endif; ?>
 		<?php endforeach; ?>
-		<ul role="listbox" aria-labelledby="language_picker_des" class="lang-block dropdown-menu">
+		<ul role="listbox" aria-labelledby="language_picker_des_<?php echo $module->id; ?>" class="lang-block dropdown-menu">
 
 		<?php foreach ($list as $language) : ?>
 			<?php
@@ -71,7 +71,7 @@ $wa->registerAndUseStyle('mod_languages', 'mod_languages/template.css');
 		</ul>
 	</div>
 <?php else : ?>
-	<ul role="listbox" aria-labelledby="language_picker_des" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>">
+	<ul role="listbox" aria-labelledby="language_picker_des_<?php echo $module->id; ?>" class="mod-languages__list <?php echo $params->get('inline', 1) ? 'lang-inline' : 'lang-block'; ?>">
 
 	<?php foreach ($list as $language) : ?>
 		<?php


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
If a dropdown is used in language module, WAVE finds a broken reference. 


### Testing Instructions
Make a multilingual site. In the language-swither module set Dropown param to "yes".  


### Actual result BEFORE applying this Pull Request
The tool WAVE finds a  "broken aria reference" 

![grafik](https://user-images.githubusercontent.com/1035262/129622547-e412283c-5551-4470-956c-ff628bf1c128.png)


### Expected result AFTER applying this Pull Request
No error found in the language switcher by WAVE

![grafik](https://user-images.githubusercontent.com/1035262/129622218-69a2d1cf-7e5d-4b0a-98a5-b77eb0a47f30.png)



### Documentation Changes Required

