### PR TITLE
[J4] not working switch RECORD HITS

### DIFF
--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -297,7 +297,6 @@
 			label="JGLOBAL_SHOW_HITS_LABEL"
 			layout="joomla.form.field.radio.switcher"
 			default="1"
-			showon="record_hits:1"
 			>
 			<option value="0">JHIDE</option>
 			<option value="1">JSHOW</option>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6898474/128238875-fd884b74-a53b-46c5-b020-ace4ce5abfe4.png)
![image](https://user-images.githubusercontent.com/6898474/128239158-cb814349-0f5c-4a70-9f92-4341000ac344.png)

In the Article settings. The RECORD HITS field is disabled.
But this value is displayed on the site.
The fact is that the disabled RECORD HITS field hides another HITS field.
I believe that it should be like this:
- Either the RECORD HITS field will not hide the HITS field.
- Either disabling the RECORD HITS field will automatically deactivate the HITS field.
![image](https://user-images.githubusercontent.com/6898474/128240189-14b98eb6-6467-415b-af7b-5524bbf04d38.png)
 