### PR TITLE
[4.0] Load default language overrides

### DIFF
--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -193,6 +193,16 @@ class Language
 		$this->metadata = LanguageHelper::getMetadata($this->lang);
 		$this->setDebug($debug);
 
+		/*
+		Let's load the default override once, so we can profit from that, too
+		But make sure, that we don't enforce it on each language file load.
+		So don't put it in $this->override
+		*/
+		if ($lang !== $this->default)
+		{
+			$this->loadLanguage(JPATH_BASE . '/language/overrides/' . $this->default . '.override.ini');
+		}
+
 		$this->override = $this->parse(JPATH_BASE . '/language/overrides/' . $lang . '.override.ini');
 
 		// Look for a language specific localise class

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -198,7 +198,7 @@ class Language
 		But make sure, that we don't enforce it on each language file load.
 		So don't put it in $this->override
 		*/
-		if ($lang !== $this->default)
+		if (!$this->debug && $lang !== $this->default)
 		{
 			$this->loadLanguage(JPATH_BASE . '/language/overrides/' . $this->default . '.override.ini');
 		}


### PR DESCRIPTION
### Summary of Changes
On multilingual sites the translations of language strings falls back to the default language (when not in debug mode). But if you have created some language overrides this behaviour does not apply.


### Testing Instructions
- Create a multlingual page
- Install and activate at least one additional language to en-GB
- Create a language override for a not existing constant like: ```TEST_CONSTANT="Test"``` for the english frontend language
- open the index.php of your frontend template and put: ```echo Text::_('TEST_CONSTANT');```
- Switch to the 2nd language


### Actual result BEFORE applying this Pull Request
```TEST_CONSTANT``` is outputted.


### Expected result AFTER applying this Pull Request
```Test``` is outputted.
