### PR TITLE
[4] Remove space in XML Atom Feed

### DIFF
--- a/libraries/src/Document/Renderer/Feed/AtomRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/AtomRenderer.php
@@ -78,7 +78,7 @@ class AtomRenderer extends DocumentRenderer
 
 		$feed_title = htmlspecialchars($title, ENT_COMPAT, 'UTF-8');
 
-		$feed = "<feed xmlns=\"http://www.w3.org/2005/Atom\" ";
+		$feed = "<feed xmlns=\"http://www.w3.org/2005/Atom\"";
 
 		if ($data->getLanguage() != '')
 		{


### PR DESCRIPTION
### Summary of Changes

Remove space in XML Atom Feed

### Testing Instructions

Visit your atom feed at http://example.com/index.php?format\feed&type=atom

### Actual result BEFORE applying this Pull Request

Trailing space before closing tag

```xml
<feed xmlns="http://www.w3.org/2005/Atom" >
```

or with lang note double spacing

```xml 
<feed xmlns="http://www.w3.org/2005/Atom"  xml:lang="en-gb">
```

### Expected result AFTER applying this Pull Request

No trailing space 

```xml
<feed xmlns="http://www.w3.org/2005/Atom">
```

or with lang note single spacing

```xml 
<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-gb">
```

### Documentation Changes Required

None