### PR TITLE
[3.10] Add missing mssql updates

### DIFF
--- a/administrator/components/com_admin/sql/updates/sqlazure/3.10.1-2021-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/sqlazure/3.10.1-2021-08-17.sql
@@ -1,0 +1,6 @@
+--
+-- These database columns are not used in Joomla 3.10 but will be used in Joomla 4.
+-- They are added to 3.10 because otherwise the update to 4 will fail.
+--
+ALTER TABLE [#__template_styles] ADD [inheritable] [smallint] NOT NULL DEFAULT 0;
+ALTER TABLE [#__template_styles] ADD [parent] [nvarchar](50) NOT NULL DEFAULT '';

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2579,6 +2579,8 @@ CREATE TABLE "#__template_styles" (
   "client_id" tinyint NOT NULL DEFAULT 0,
   "home" nvarchar(7) NOT NULL DEFAULT '0',
   "title" nvarchar(255) NOT NULL DEFAULT '',
+	"inheritable" smallint NOT NULL DEFAULT '0',
+  "parent" nvarchar(50) NOT NULL DEFAULT '',
   "params" nvarchar(max) NOT NULL,
  CONSTRAINT "PK_#__template_styles_id" PRIMARY KEY CLUSTERED
 (

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2579,7 +2579,7 @@ CREATE TABLE "#__template_styles" (
   "client_id" tinyint NOT NULL DEFAULT 0,
   "home" nvarchar(7) NOT NULL DEFAULT '0',
   "title" nvarchar(255) NOT NULL DEFAULT '',
-  "inheritable" smallint NOT NULL DEFAULT '0',
+  "inheritable" smallint NOT NULL DEFAULT 0,
   "parent" nvarchar(50) NOT NULL DEFAULT '',
   "params" nvarchar(max) NOT NULL,
  CONSTRAINT "PK_#__template_styles_id" PRIMARY KEY CLUSTERED

--- a/installation/sql/sqlazure/joomla.sql
+++ b/installation/sql/sqlazure/joomla.sql
@@ -2579,7 +2579,7 @@ CREATE TABLE "#__template_styles" (
   "client_id" tinyint NOT NULL DEFAULT 0,
   "home" nvarchar(7) NOT NULL DEFAULT '0',
   "title" nvarchar(255) NOT NULL DEFAULT '',
-	"inheritable" smallint NOT NULL DEFAULT '0',
+  "inheritable" smallint NOT NULL DEFAULT '0',
   "parent" nvarchar(50) NOT NULL DEFAULT '',
   "params" nvarchar(max) NOT NULL,
  CONSTRAINT "PK_#__template_styles_id" PRIMARY KEY CLUSTERED


### PR DESCRIPTION
### Summary of Changes

Add missing mssql updates for `#__template_styles`

### Testing Instructions

code review or testing mssql

@richard67 nothing urgent but please take a look that we didnt broken the mssql syntax here.

### Actual result BEFORE applying this Pull Request

The structure is not 1:1 with mysql and postgressql

### Expected result AFTER applying this Pull Request

the structure is 1:1 while it does not have an impact as the colums are not used nor are you allowed to upgrade from 3.10 to 4 using mssql

### Documentation Changes Required

none.