### PR TITLE
Handle com_search migration to a core supported extension

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -567,6 +567,12 @@ class JoomlaInstallerScript
 	{
 		$extensions = ExtensionHelper::getCoreExtensions();
 
+		// If we have the search package around, it may not have a manifest cache entry after upgrades from 3.x, so add it to the list
+		if (File::exists(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml'))
+		{
+			$extensions[] = array('package', 'pkg_search', '', 0);
+		}
+
 		// Attempt to refresh manifest caches
 		$db    = Factory::getDbo();
 		$query = $db->getQuery(true)
@@ -594,12 +600,6 @@ class JoomlaInstallerScript
 			echo Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br>';
 
 			return;
-		}
-
-		// If we have the search package around, it may not have a manifest cache entry after upgrades from 3.x, so add it to the list
-		if (File::exists(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml'))
-		{
-			$extensions[] = ExtensionHelper::getExtensionRecord('pkg_search', 'package');
 		}
 
 		$installer = new Installer;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -599,7 +599,7 @@ class JoomlaInstallerScript
 		// If we have the search package around, it may not have a manifest cache entry after upgrades from 3.x, so add it to the list
 		if (File::exists(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml'))
 		{
-			$extensions[] = ExtensionHelper::getExtensionRecord('pkg_search', 'package')->extension_id;
+			$extensions[] = ExtensionHelper::getExtensionRecord('pkg_search', 'package');
 		}
 
 		$installer = new Installer;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7403,7 +7403,7 @@ class JoomlaInstallerScript
 		{
 			$packageId = ExtensionHelper::getExtensionRecord('pkg_search', 'package')->extension_id;
 			$installer = new Installer;
-			$installer->refreshManifestCache($packageId)
+			$installer->refreshManifestCache($packageId);
 		}
 
 		if ($suppressOutput === false && \count($status['folders_errors']))

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7386,6 +7386,20 @@ class JoomlaInstallerScript
 
 		$this->fixFilenameCasing();
 
+		/*
+		 * Needed for updates from 3.x
+		 * If com_search doesn't exist then assume we can delete the search package manifest (included in the update packages)
+		 */
+		$searchInstalled = ExtensionHelper::getExtensionRecord('com_search', 'component');
+
+		if ($searchInstalled === null)
+		{
+			if (File::exists(JPATH_MANIFESTS . '/packages/pkg_search.xml'))
+			{
+				File::delete(JPATH_MANIFESTS . '/packages/pkg_search.xml');
+			}
+		}
+
 		if ($suppressOutput === false && \count($status['folders_errors']))
 		{
 			echo implode('<br>', $status['folders_errors']);

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7401,7 +7401,7 @@ class JoomlaInstallerScript
 		// Now we know we are keeping the search package. Refresh it's manifest cache so we have a definite version.
 		if (File::exists(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml'))
 		{
-			$packageId = ExtensionHelper::getExtensionRecord('com_search', 'component')->extension_id;
+			$packageId = ExtensionHelper::getExtensionRecord('pkg_search', 'package')->extension_id;
 			$installer = new Installer;
 			$installer->refreshManifestCache($packageId)
 		}

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7389,10 +7389,10 @@ class JoomlaInstallerScript
 		/*
 		 * Needed for updates from 3.x
 		 * If com_search doesn't exist then assume we can delete the search package manifest (included in the update packages)
+		 * We deliberately check for the presence of the files in case people have previously uninstalled their search extension
+		 * but an update has put the files back. In that case it exists even if they don't believe in it!
 		 */
-		$searchInstalled = ExtensionHelper::getExtensionRecord('com_search', 'component');
-
-		if ($searchInstalled === null)
+		if (!File::exists(JPATH_ADMINISTRATOR . '/components/com_search/search.php'))
 		{
 			if (File::exists(JPATH_MANIFESTS . '/packages/pkg_search.xml'))
 			{

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7387,7 +7387,7 @@ class JoomlaInstallerScript
 		$this->fixFilenameCasing();
 
 		/*
-		 * Needed for updates from 3.x
+		 * Needed for updates from 3.10
 		 * If com_search doesn't exist then assume we can delete the search package manifest (included in the update packages)
 		 * We deliberately check for the presence of the files in case people have previously uninstalled their search extension
 		 * but an update has put the files back. In that case it exists even if they don't believe in it!
@@ -7396,6 +7396,14 @@ class JoomlaInstallerScript
 			&& File::exists(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml'))
 		{
 			File::delete(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml');
+		}
+
+		// Now we know we are keeping the search package. Refresh it's manifest cache so we have a definite version.
+		if (File::exists(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml'))
+		{
+			$packageId = ExtensionHelper::getExtensionRecord('com_search', 'component')->extension_id;
+			$installer = new Installer;
+			$installer->refreshManifestCache($packageId)
 		}
 
 		if ($suppressOutput === false && \count($status['folders_errors']))

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -596,6 +596,12 @@ class JoomlaInstallerScript
 			return;
 		}
 
+		// If we have the search package around, it may not have a manifest cache entry after upgrades from 3.x, so add it to the list
+		if (File::exists(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml'))
+		{
+			$extensions[] = ExtensionHelper::getExtensionRecord('pkg_search', 'package')->extension_id;
+		}
+
 		$installer = new Installer;
 
 		foreach ($extensions as $extension)
@@ -7396,14 +7402,6 @@ class JoomlaInstallerScript
 			&& File::exists(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml'))
 		{
 			File::delete(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml');
-		}
-
-		// Now we know we are keeping the search package. Refresh it's manifest cache so we have a definite version.
-		if (File::exists(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml'))
-		{
-			$packageId = ExtensionHelper::getExtensionRecord('pkg_search', 'package')->extension_id;
-			$installer = new Installer;
-			$installer->refreshManifestCache($packageId);
 		}
 
 		if ($suppressOutput === false && \count($status['folders_errors']))

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7392,12 +7392,10 @@ class JoomlaInstallerScript
 		 * We deliberately check for the presence of the files in case people have previously uninstalled their search extension
 		 * but an update has put the files back. In that case it exists even if they don't believe in it!
 		 */
-		if (!File::exists(JPATH_ADMINISTRATOR . '/components/com_search/search.php'))
+		if (!File::exists(JPATH_ROOT . '/administrator/components/com_search/search.php')
+			&& File::exists(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml'))
 		{
-			if (File::exists(JPATH_MANIFESTS . '/packages/pkg_search.xml'))
-			{
-				File::delete(JPATH_MANIFESTS . '/packages/pkg_search.xml');
-			}
+			File::delete(JPATH_ROOT . '/administrator/manifests/packages/pkg_search.xml');
 		}
 
 		if ($suppressOutput === false && \count($status['folders_errors']))

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-17.sql
@@ -1,0 +1,16 @@
+INSERT INTO `#__extensions` (`name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+('search', 'package', 'pkg_search', '', 0, 1, 1, 0, '', '', '', 0, NULL, 0, 0);
+
+UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'com_search' AND `type` = 'component';
+UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'mod_search' AND `type` = 'module' AND `client_id` = 0;
+UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'categories' AND `type` = 'plugin' AND `folder` = 'search';
+UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'contacts' AND `type` = 'plugin' AND `folder` = 'search';
+UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'content' AND `type` = 'plugin' AND `folder` = 'search';
+UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'newsfeeds' AND `type` = 'plugin' AND `folder` = 'search';
+UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'tags' AND `type` = 'plugin' AND `folder` = 'search';
+
+INSERT INTO `#__update_sites` (`name`, `type`, `location`, `enabled`) VALUES
+('Search Update Site', 'extension', 'https://raw.githubusercontent.com/joomla-extensions/search/main/manifest.xml', 1);
+
+INSERT INTO `#__update_sites_extensions` (`update_site_id`, `extension_id`) VALUES
+((SELECT `update_site_id` FROM `#__update_sites` WHERE `name` = 'Search Update Site'), (SELECT `extension_id` FROM `#__extensions` WHERE `name` = 'pkg_search' AND `type` = 'package'));

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-17.sql
@@ -13,4 +13,4 @@ INSERT INTO `#__update_sites` (`name`, `type`, `location`, `enabled`) VALUES
 ('Search Update Site', 'extension', 'https://raw.githubusercontent.com/joomla-extensions/search/main/manifest.xml', 1);
 
 INSERT INTO `#__update_sites_extensions` (`update_site_id`, `extension_id`) VALUES
-((SELECT `update_site_id` FROM `#__update_sites` WHERE `name` = 'Search Update Site'), (SELECT `extension_id` FROM `#__extensions` WHERE `name` = 'pkg_search' AND `type` = 'package'));
+((SELECT `update_site_id` FROM `#__update_sites` WHERE `name` = 'Search Update Site'), (SELECT `extension_id` FROM `#__extensions` WHERE `element` = 'pkg_search' AND `type` = 'package'));

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-17.sql
@@ -13,4 +13,4 @@ INSERT INTO "#__update_sites" ("name", "type", "location", "enabled") VALUES
 ('Search Update Site', 'extension', 'https://raw.githubusercontent.com/joomla-extensions/search/main/manifest.xml', 1);
 
 INSERT INTO "#__update_sites_extensions" ("update_site_id", "extension_id") VALUES
-((SELECT "update_site_id" FROM "#__update_sites" WHERE "name" = 'Search Update Site'), (SELECT "extension_id" FROM "#__extensions" WHERE "name" = 'pkg_search' AND "type" = 'package'));
+((SELECT "update_site_id" FROM "#__update_sites" WHERE "name" = 'Search Update Site'), (SELECT "extension_id" FROM "#__extensions" WHERE "element" = 'pkg_search' AND "type" = 'package'));

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-17.sql
@@ -1,0 +1,16 @@
+INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
+('search', 'package', 'pkg_search', '', 0, 1, 1, 0, '', '', '', 0, NULL, 0, 0);
+
+UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'com_search' AND "type" = 'component';
+UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'mod_search' AND "type" = 'module' AND "client_id" = 0;
+UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'categories' AND "type" = 'plugin' AND "folder" = 'search';
+UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'contacts' AND "type" = 'plugin' AND "folder" = 'search';
+UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'content' AND "type" = 'plugin' AND "folder" = 'search';
+UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'newsfeeds' AND "type" = 'plugin' AND "folder" = 'search';
+UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'tags' AND "type" = 'plugin' AND "folder" = 'search';
+
+INSERT INTO "#__update_sites" ("name", "type", "location", "enabled") VALUES
+('Search Update Site', 'extension', 'https://raw.githubusercontent.com/joomla-extensions/search/main/manifest.xml', 1);
+
+INSERT INTO "#__update_sites_extensions" ("update_site_id", "extension_id") VALUES
+((SELECT "update_site_id" FROM "#__update_sites" WHERE "name" = 'Search Update Site'), (SELECT "extension_id" FROM "#__extensions" WHERE "name" = 'pkg_search' AND "type" = 'package'));

--- a/administrator/manifests/packages/pkg_search.xml
+++ b/administrator/manifests/packages/pkg_search.xml
@@ -10,7 +10,7 @@
     <author>Joomla! Project</author>
     <authorEmail>admin@joomla.org</authorEmail>
     <authorUrl>www.joomla.org</authorUrl>
-    <version>4.0.0-dev</version>
+    <version>4.0.0</version>
     <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
     <scriptfile>script.php</scriptfile>
     <files>

--- a/administrator/manifests/packages/pkg_search.xml
+++ b/administrator/manifests/packages/pkg_search.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<extension type="package" version="4.0" method="upgrade">
+    <name>pkg_search</name>
+    <packagename>search</packagename>
+    <creationDate>17.08.2021</creationDate>
+    <packager>Joomla! Project</packager>
+    <copyright>(C) 2021 Open Source Matters. All rights reserved.</copyright>
+    <packageremail>admin@joomla.org</packageremail>
+    <packagerurl>www.joomla.org</packagerurl>
+    <author>Joomla! Project</author>
+    <authorEmail>admin@joomla.org</authorEmail>
+    <authorUrl>www.joomla.org</authorUrl>
+    <version>4.0.0-dev</version>
+    <license>GNU General Public License version 2 or later; see LICENSE.txt</license>
+    <scriptfile>script.php</scriptfile>
+    <files>
+        <!-- The id for each extension is the element stored in the DB -->
+        <file type="component" id="com_search">com_search.zip</file>
+        <file type="module" id="mod_search" client="site">mod_search.zip</file>
+        <file type="plugin" id="categories" group="search">plg_search_categories.zip</file>
+        <file type="plugin" id="contacts" group="search">plg_search_contacts.zip</file>
+        <file type="plugin" id="content" group="search">plg_search_content.zip</file>
+        <file type="plugin" id="newsfeeds" group="search">plg_search_newsfeeds.zip</file>
+        <file type="plugin" id="tags" group="search">plg_search_tags.zip</file>
+    </files>
+    <languages folder="language">
+        <language tag="en-GB">en-GB/en-GB.pkg_search.sys.ini</language>
+    </languages>
+    <updateservers>
+        <!-- Note: No spaces or linebreaks allowed between the server tags -->
+        <server type="extension" name="Search Update Site">https://raw.githubusercontent.com/joomla-extensions/search/main/manifest.xml</server>
+    </updateservers>
+</extension>

--- a/build/build.php
+++ b/build/build.php
@@ -545,6 +545,9 @@ for ($num = $release - 1; $num >= 0; $num--)
 echo "Build full package files.\n";
 chdir($time);
 
+// The search package manifest should not be present for new installs, temporarily move it
+system('mv administrator/manifests/packages/pkg_search.xml ../pkg_search.xml');
+
 // Create full archive packages.
 if (!$excludeBzip2)
 {
@@ -591,6 +594,9 @@ system('rm -r images/headers');
 system('rm -r images/sampledata');
 system('rm images/joomla_black.png');
 system('rm images/powered_by.png');
+
+// Move the search manifest back
+system('mv ../pkg_search.xml administrator/manifests/packages/pkg_search.xml');
 
 if (!$excludeBzip2)
 {


### PR DESCRIPTION
Based off the similar weblinks changes in https://github.com/joomla/joomla-cms/commit/4cb0f4098fc7c9d102be2b61331db75f800011c1#diff-8f1d3c21971b32c52ff266bd3493b44c11de5e923e32367379b68e1912171be4