### PR TITLE
[4.0] Always show the "delete install folder button"

### DIFF
--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -176,12 +176,12 @@ HTMLHelper::_('behavior.formvalidator');
 				</table>
 
 				<?php endif; ?>
-				<?php if ($this->development) : ?>
-					<div class="alert flex-column mb-1" id="removeInstallationTab">
+				<div class="alert flex-column mb-1" id="removeInstallationTab">
+					<?php if ($this->development) : ?>
 						<span class="mb-1 font-weight-bold"><?php echo Text::_('INSTL_SITE_DEVMODE_LABEL'); ?></span>
-						<button class="btn btn-danger mb-1" id="removeInstallationFolder"><?php echo Text::sprintf('INSTL_COMPLETE_REMOVE_FOLDER', 'installation'); ?></button>
-					</div>
-				<?php endif; ?>
+					<?php endif; ?>
+					<button class="btn btn-danger mb-1" id="removeInstallationFolder"><?php echo Text::sprintf('INSTL_COMPLETE_REMOVE_FOLDER', 'installation'); ?></button>
+				</div>
 				<?php echo HTMLHelper::_('form.token'); ?>
 
 				<div class="form-group j-install-last-step d-grid gap-2">

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -176,15 +176,10 @@ HTMLHelper::_('behavior.formvalidator');
 				</table>
 
 				<?php endif; ?>
-				<div class="alert flex-column mb-1" id="removeInstallationTab">
-					<?php if ($this->development) : ?>
-						<span class="mb-1 font-weight-bold"><?php echo Text::_('INSTL_SITE_DEVMODE_LABEL'); ?></span>
-					<?php endif; ?>
-					<button class="btn btn-danger mb-1" id="removeInstallationFolder"><?php echo Text::sprintf('INSTL_COMPLETE_REMOVE_FOLDER', 'installation'); ?></button>
-				</div>
 				<?php echo HTMLHelper::_('form.token'); ?>
 
 				<div class="form-group j-install-last-step d-grid gap-2">
+					<button class="btn btn-danger mt-1 w-100" id="removeInstallationFolder"><?php echo Text::sprintf('INSTL_COMPLETE_REMOVE_FOLDER', 'installation'); ?></button>
 					<a class="btn btn-primary w-100" href="<?php echo Uri::root(); ?>" title="<?php echo Text::_('JSITE'); ?>"><span class="icon-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?></a>
 					<a class="btn btn-primary w-100" href="<?php echo Uri::root(); ?>administrator/" title="<?php echo Text::_('JADMINISTRATOR'); ?>"><span class="icon-lock" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_ADMIN_BTN'); ?></a>
 				</div>


### PR DESCRIPTION
### Summary of Changes

Always show the "delete install folder button"

### Testing Instructions

Try to install 4.0.0 stable

### Actual result BEFORE applying this Pull Request

You can not finish the installer as you can not remove the install folder

### Expected result AFTER applying this Pull Request

You can finish the installer by removing the installer folder

![image](https://user-images.githubusercontent.com/2596554/129674909-cd37e098-a9b8-4453-94e1-e1b376283c5a.png)

### Documentation Changes Required

none