### PR TITLE
Installation cleanup

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6662,12 +6662,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-projects/joomla-browser.git",
-                "reference": "a2541641ae581543457f3491338c8c79439b1c95"
+                "reference": "db8e97cb93aac70d39ff0b62dcb2e79b4b079603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/a2541641ae581543457f3491338c8c79439b1c95",
-                "reference": "a2541641ae581543457f3491338c8c79439b1c95",
+                "url": "https://api.github.com/repos/joomla-projects/joomla-browser/zipball/db8e97cb93aac70d39ff0b62dcb2e79b4b079603",
+                "reference": "db8e97cb93aac70d39ff0b62dcb2e79b4b079603",
                 "shasum": ""
             },
             "require": {
@@ -6709,7 +6709,7 @@
                 "issues": "https://github.com/joomla-projects/joomla-browser/issues",
                 "source": "https://github.com/joomla-projects/joomla-browser/tree/v4.0.0"
             },
-            "time": "2021-07-26T18:53:12+00:00"
+            "time": "2021-08-17T08:03:25+00:00"
         },
         {
             "name": "joomla/cms-coding-standards",

--- a/installation/src/Model/CleanupModel.php
+++ b/installation/src/Model/CleanupModel.php
@@ -38,7 +38,8 @@ class CleanupModel extends BaseInstallationModel
 			$return = File::move(JPATH_ROOT . '/robots.txt.dist', JPATH_ROOT . '/robots.txt');
 		}
 
-		if (function_exists('opcache_reset')) {
+		if (function_exists('opcache_reset'))
+		{
 			\opcache_reset();
 		}
 

--- a/installation/src/Model/CleanupModel.php
+++ b/installation/src/Model/CleanupModel.php
@@ -14,6 +14,9 @@ namespace Joomla\CMS\Installation\Model;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
 
+use function clearstatcache;
+use function function_exists;
+
 /**
  * Cleanup model for the Joomla Core Installer.
  *
@@ -37,6 +40,12 @@ class CleanupModel extends BaseInstallationModel
 		{
 			$return = File::move(JPATH_ROOT . '/robots.txt.dist', JPATH_ROOT . '/robots.txt');
 		}
+
+		if (function_exists('opcache_reset')) {
+			\opcache_reset();
+		}
+
+		\clearstatcache(true, JPATH_INSTALLATION . '/index.php');
 
 		return $return;
 	}

--- a/installation/src/Model/CleanupModel.php
+++ b/installation/src/Model/CleanupModel.php
@@ -14,9 +14,6 @@ namespace Joomla\CMS\Installation\Model;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
 
-use function clearstatcache;
-use function function_exists;
-
 /**
  * Cleanup model for the Joomla Core Installer.
  *

--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -51,7 +51,7 @@ completeInstallationOptions.forEach(function(item) {
         });
 
         // In development mode we show the user a pretty button to allow them to choose whether to delete the installation
-        // directory or not. In stable the decision is made forward. Maximum extermination!
+        // directory or not. In stable the decision is made for us. Maximum extermination!
         if ('development' in item.dataset) {
             window.location.href = item.dataset.href;
         } else {

--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -51,7 +51,7 @@ completeInstallationOptions.forEach(function(item) {
         });
 
         // In development mode we show the user a pretty button to allow them to choose whether to delete the installation
-        // directory or not. In stable the decision is made for us. Maximum extermination!
+        // directory or not. In stable release we always delete the folder. Maximum extermination!
         if ('development' in item.dataset) {
             window.location.href = item.dataset.href;
         } else {

--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -45,6 +45,11 @@ const completeInstallationOptions = document.querySelectorAll('.complete-install
 
 completeInstallationOptions.forEach(function(item) {
     item.addEventListener('click', function (e) {
+        // Evil voodoo. Once a button is clicked ensure they don't spam click it...
+        completeInstallationOptions.forEach(function(nestedItem) {
+            nestedItem.disabled = true;
+        });
+
         // In development mode we show the user a pretty button to allow them to choose whether to delete the installation
         // directory or not. In stable the decision is made forward. Maximum extermination!
         if ('development' in item.dataset) {
@@ -78,7 +83,11 @@ Joomla.deleteJoomlaInstallationDirectory = function (redirectUrl) {
                 const customInstallation = document.getElementById('customInstallation');
                 customInstallation.parentNode.removeChild(customInstallation);
                 const removeInstallationTab = document.getElementById('removeInstallationTab');
-                removeInstallationTab.parentNode.removeChild(removeInstallationTab);
+
+                // This will only exist in debug mode
+                if (removeInstallationTab) {
+                    removeInstallationTab.parentNode.removeChild(removeInstallationTab);
+                }
 
                 if (redirectUrl) {
                     window.location.href = redirectUrl;

--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -36,37 +36,59 @@ if (document.getElementById('removeInstallationFolder')) {
 			e.preventDefault();
 			let confirm = window.confirm(Joomla.Text._('INSTL_REMOVE_INST_FOLDER').replace('%s', 'installation'));
 			if (confirm) {
-				Joomla.request({
-					method: "POST",
-					url: Joomla.installationBaseUrl + '?task=installation.removeFolder&format=json',
-					perform: true,
-					token: true,
-					headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-					onSuccess: function (response) {
+			    Joomla.deleteJoomlaInstallationDirectory();
+			}
+		});
+}
+
+const completeInstallationOptions = document.querySelectorAll('.complete-installation');
+
+completeInstallationOptions.forEach(function(item) {
+    item.addEventListener('click', function (e) {
+        // In development mode we show the user a pretty button to allow them to choose whether to delete the installation
+        // directory or not. In stable the decision is made forward. Maximum extermination!
+        if ('development' in item.dataset) {
+            window.location.href = item.dataset.href;
+        } else {
+            Joomla.deleteJoomlaInstallationDirectory(item.dataset.href);
+        }
+
+        return false;
+    });
+});
+
+Joomla.deleteJoomlaInstallationDirectory = function (redirectUrl) {
+    Joomla.request({
+        method: "POST",
+        url: Joomla.installationBaseUrl + '?task=installation.removeFolder&format=json',
+        perform: true,
+        token: true,
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        onSuccess: function (response) {
             const successresponse = JSON.parse(response);
             if (successresponse.error === true) {
-              if (successresponse.messages) {
-                Joomla.renderMessages(successresponse.messages, '#system-message-container');
-                Joomla.loadOptions({'csrf.token': successresponse.token});
-              } else {
-                // Stuff went wrong. No error messages. Just panic bail!
-                Joomla.renderMessages('Unknown error deleting the installation folder.', '#system-message-container');
-              }
+                if (successresponse.messages) {
+                    Joomla.renderMessages(successresponse.messages, '#system-message-container');
+                    Joomla.loadOptions({'csrf.token': successresponse.token});
+                } else {
+                    // Stuff went wrong. No error messages. Just panic bail!
+                    Joomla.renderMessages('Unknown error deleting the installation folder.', '#system-message-container');
+                }
             } else {
-              const customInstallation = document.getElementById('customInstallation');
-              customInstallation.parentNode.removeChild(customInstallation);
-              const removeInstallationTab = document.getElementById('removeInstallationTab');
-              removeInstallationTab.parentNode.removeChild(removeInstallationTab);
+                const customInstallation = document.getElementById('customInstallation');
+                customInstallation.parentNode.removeChild(customInstallation);
+                const removeInstallationTab = document.getElementById('removeInstallationTab');
+                removeInstallationTab.parentNode.removeChild(removeInstallationTab);
+
+                if (redirectUrl) {
+                    window.location.href = redirectUrl;
+                }
             }
-					},
-					onError: function (xhr) {
+        },
+        onError: function (xhr) {
             Joomla.renderMessages({ error: [xhr] }, '#system-message-container');
-					}
-					}
-				);
-			}
-		}
-		);
+        }
+    });
 }
 
 if (document.getElementById('installLanguagesButton')) {

--- a/installation/template/js/remove.js
+++ b/installation/template/js/remove.js
@@ -45,7 +45,7 @@ const completeInstallationOptions = document.querySelectorAll('.complete-install
 
 completeInstallationOptions.forEach(function(item) {
     item.addEventListener('click', function (e) {
-        // Evil voodoo. Once a button is clicked ensure they don't spam click it...
+        // Once a button is clicked ensure they can't click it again...
         completeInstallationOptions.forEach(function(nestedItem) {
             nestedItem.disabled = true;
         });

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -190,7 +190,7 @@ HTMLHelper::_('behavior.formvalidator');
 						<span class="icon-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?>
 					</button>
 					<button type="button" class="complete-installation btn btn-primary w-100"
-					   data-href="<?php echo Uri::root(); ?>administrator/" <?php if ($this->development): ?>data-development<?php endif; ?> title="<?php echo Text::_('JADMINISTRATOR'); ?>">
+					   data-href="<?php echo Uri::root(); ?>administrator/" <?php if ($this->development): ?>data-development<?php endif; ?>">
 						<span class="icon-lock" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_ADMIN_BTN'); ?>
 					</button>
 				</div>

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -186,7 +186,7 @@ HTMLHelper::_('behavior.formvalidator');
 
 				<div class="form-group j-install-last-step d-grid gap-2">
 					<button type="button" class="complete-installation btn btn-primary w-100"
-					   data-href="<?php echo Uri::root(); ?>" <?php if ($this->development): ?>data-development<?php endif; ?> title="<?php echo Text::_('JSITE'); ?>">
+					   data-href="<?php echo Uri::root(); ?>" <?php if ($this->development): ?>data-development<?php endif; ?>">
 						<span class="icon-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?>
 					</button>
 					<button type="button" class="complete-installation btn btn-primary w-100"

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -186,13 +186,13 @@ HTMLHelper::_('behavior.formvalidator');
 
 				<div class="form-group j-install-last-step d-grid gap-2">
 					<button type="button" class="complete-installation btn btn-primary w-100"
-                       data-href="<?php echo Uri::root(); ?>" <?php if ($this->development): ?>data-development<?php endif; ?> title="<?php echo Text::_('JSITE'); ?>">
-                        <span class="icon-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?>
-                    </button>
+					   data-href="<?php echo Uri::root(); ?>" <?php if ($this->development): ?>data-development<?php endif; ?> title="<?php echo Text::_('JSITE'); ?>">
+						<span class="icon-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?>
+					</button>
 					<button type="button" class="complete-installation btn btn-primary w-100"
-                       data-href="<?php echo Uri::root(); ?>administrator/" <?php if ($this->development): ?>data-development<?php endif; ?> title="<?php echo Text::_('JADMINISTRATOR'); ?>">
-                        <span class="icon-lock" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_ADMIN_BTN'); ?>
-                    </button>
+					   data-href="<?php echo Uri::root(); ?>administrator/" <?php if ($this->development): ?>data-development<?php endif; ?> title="<?php echo Text::_('JADMINISTRATOR'); ?>">
+						<span class="icon-lock" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_ADMIN_BTN'); ?>
+					</button>
 				</div>
 			</div>
 		</div>

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -185,8 +185,14 @@ HTMLHelper::_('behavior.formvalidator');
 				<?php echo HTMLHelper::_('form.token'); ?>
 
 				<div class="form-group j-install-last-step d-grid gap-2">
-					<a class="btn btn-primary w-100" href="<?php echo Uri::root(); ?>" title="<?php echo Text::_('JSITE'); ?>"><span class="icon-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?></a>
-					<a class="btn btn-primary w-100" href="<?php echo Uri::root(); ?>administrator/" title="<?php echo Text::_('JADMINISTRATOR'); ?>"><span class="icon-lock" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_ADMIN_BTN'); ?></a>
+					<button type="button" class="complete-installation btn btn-primary w-100"
+                       data-href="<?php echo Uri::root(); ?>" <?php if ($this->development): ?>data-development<?php endif; ?> title="<?php echo Text::_('JSITE'); ?>">
+                        <span class="icon-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?>
+                    </button>
+					<button type="button" class="complete-installation btn btn-primary w-100"
+                       data-href="<?php echo Uri::root(); ?>administrator/" <?php if ($this->development): ?>data-development<?php endif; ?> title="<?php echo Text::_('JADMINISTRATOR'); ?>">
+                        <span class="icon-lock" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_ADMIN_BTN'); ?>
+                    </button>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
### Summary of Changes
Completing installation now deletes the installation directory "automatically" before continuing when not in development mode. When in development mode you continue to get the existing button.

This allows the user to delete installation rather than currently being stuck as the red button is already currently only shown in development mode. Massive shoutout to @zero-24 for last minute finding this one. Would have made for a very fast 4.0.1 otherwise :)

### Testing Instructions
### Actual result BEFORE applying this Pull Request
You can't delete the installation directory when the build is "stable"


### Expected result AFTER applying this Pull Request
![Screenshot 2021-08-17 at 08 29 50](https://user-images.githubusercontent.com/1986000/129683013-33240456-6067-4e0b-94c2-cd6d40e53477.png)
![Screenshot 2021-08-17 at 08 30 08](https://user-images.githubusercontent.com/1986000/129683065-d4572b5a-28b3-48d6-be52-aef8e0af7e4e.png)

In development mode the installation directory is not deleted when clicking complete. Only when pressing the big red button. In stable mode it is only when you click either continue button the installation directory is deleted and you are allowed to proceed

1. Go to the installer and change the `Joomla\Version\Version::DEV_STATUS` to be `Stable`. Ensure you can't see the red button but when clicking on complete the installation directory is removed before you are allowed to proceed
2. Go to the installer leaving yourself in dev mode. Ensure the red button is available and on clicking it you have the installation folder deleted. But when clicking on complete the redirect happens with no installation folder removal.

### Documentation Changes Required
None.
