### PR TITLE
Combine update statements for package_id of search extensions

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-17.sql
@@ -1,13 +1,12 @@
 INSERT INTO `#__extensions` (`name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `manifest_cache`, `params`, `custom_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
 ('search', 'package', 'pkg_search', '', 0, 1, 1, 0, '', '', '', 0, NULL, 0, 0);
 
-UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'com_search' AND `type` = 'component';
-UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'mod_search' AND `type` = 'module' AND `client_id` = 0;
-UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'categories' AND `type` = 'plugin' AND `folder` = 'search';
-UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'contacts' AND `type` = 'plugin' AND `folder` = 'search';
-UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'content' AND `type` = 'plugin' AND `folder` = 'search';
-UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'newsfeeds' AND `type` = 'plugin' AND `folder` = 'search';
-UPDATE `#__extensions` SET `package_id` = (SELECT a.`extension_id` FROM `#__extensions` a WHERE a.`type`='package' AND a.`element`='pkg_search') WHERE `element` = 'tags' AND `type` = 'plugin' AND `folder` = 'search';
+UPDATE `#__extensions` a
+ CROSS JOIN (SELECT `extension_id` FROM `#__extensions` WHERE `type`='package' AND `element`='pkg_search') AS b
+   SET a.`package_id` = b.`extension_id`
+ WHERE (`type` = 'component' AND `element` = 'com_search')
+    OR (`type` = 'module' AND `element` = 'mod_search' AND `client_id` = 0)
+    OR (`type` = 'plugin' AND `element` IN ('categories', 'contacts', 'content', 'newsfeeds','tags') AND `folder` = 'search');
 
 INSERT INTO `#__update_sites` (`name`, `type`, `location`, `enabled`) VALUES
 ('Search Update Site', 'extension', 'https://raw.githubusercontent.com/joomla-extensions/search/main/manifest.xml', 1);

--- a/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.0.0-2021-08-17.sql
@@ -6,7 +6,7 @@ UPDATE `#__extensions` a
    SET a.`package_id` = b.`extension_id`
  WHERE (`type` = 'component' AND `element` = 'com_search')
     OR (`type` = 'module' AND `element` = 'mod_search' AND `client_id` = 0)
-    OR (`type` = 'plugin' AND `element` IN ('categories', 'contacts', 'content', 'newsfeeds','tags') AND `folder` = 'search');
+    OR (`type` = 'plugin' AND `element` IN ('categories', 'contacts', 'content', 'newsfeeds', 'tags') AND `folder` = 'search');
 
 INSERT INTO `#__update_sites` (`name`, `type`, `location`, `enabled`) VALUES
 ('Search Update Site', 'extension', 'https://raw.githubusercontent.com/joomla-extensions/search/main/manifest.xml', 1);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-17.sql
@@ -1,9 +1,9 @@
 INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
 ('search', 'package', 'pkg_search', '', 0, 1, 1, 0, '', '', '', 0, NULL, 0, 0);
 
-UPDATE "#__extensions" a
- CROSS JOIN (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS b
-   SET a."package_id" = b."extension_id"
+UPDATE "#__extensions"
+   SET "package_id" = b."extension_id"
+  FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS b
  WHERE ("type" = 'component' AND "element" = 'com_search')
     OR ("type" = 'module' AND "element" = 'mod_search' AND "client_id" = 0)
     OR ("type" = 'plugin' AND "element" IN ('categories', 'contacts', 'content', 'newsfeeds','tags') AND "folder" = 'search');

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-17.sql
@@ -1,13 +1,12 @@
 INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "manifest_cache", "params", "custom_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
 ('search', 'package', 'pkg_search', '', 0, 1, 1, 0, '', '', '', 0, NULL, 0, 0);
 
-UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'com_search' AND "type" = 'component';
-UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'mod_search' AND "type" = 'module' AND "client_id" = 0;
-UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'categories' AND "type" = 'plugin' AND "folder" = 'search';
-UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'contacts' AND "type" = 'plugin' AND "folder" = 'search';
-UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'content' AND "type" = 'plugin' AND "folder" = 'search';
-UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'newsfeeds' AND "type" = 'plugin' AND "folder" = 'search';
-UPDATE "#__extensions" SET "package_id" = sub.extension_id FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS sub WHERE "element" = 'tags' AND "type" = 'plugin' AND "folder" = 'search';
+UPDATE "#__extensions" a
+ CROSS JOIN (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS b
+   SET a."package_id" = b."extension_id"
+ WHERE ("type" = 'component' AND "element" = 'com_search')
+    OR ("type" = 'module' AND "element" = 'mod_search' AND "client_id" = 0)
+    OR ("type" = 'plugin' AND "element" IN ('categories', 'contacts', 'content', 'newsfeeds','tags') AND "folder" = 'search');
 
 INSERT INTO "#__update_sites" ("name", "type", "location", "enabled") VALUES
 ('Search Update Site', 'extension', 'https://raw.githubusercontent.com/joomla-extensions/search/main/manifest.xml', 1);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-17.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.0.0-2021-08-17.sql
@@ -6,7 +6,7 @@ UPDATE "#__extensions"
   FROM (SELECT "extension_id" FROM "#__extensions" WHERE "type"='package' AND "element"='pkg_search') AS b
  WHERE ("type" = 'component' AND "element" = 'com_search')
     OR ("type" = 'module' AND "element" = 'mod_search' AND "client_id" = 0)
-    OR ("type" = 'plugin' AND "element" IN ('categories', 'contacts', 'content', 'newsfeeds','tags') AND "folder" = 'search');
+    OR ("type" = 'plugin' AND "element" IN ('categories', 'contacts', 'content', 'newsfeeds', 'tags') AND "folder" = 'search');
 
 INSERT INTO "#__update_sites" ("name", "type", "location", "enabled") VALUES
 ('Search Update Site', 'extension', 'https://raw.githubusercontent.com/joomla-extensions/search/main/manifest.xml', 1);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix the SQL update statement from PR #35164 for certain older MySQL or MariaDB versions.

Use (almost) the same changes also for PostgreSQL because it's better SQL.

CROSS JOIN is supported on MySQL 5.6. so it is ok for Joomla 4.

On PostgreSQL it is supported too, but not in UPDATE statements, it seems, therefore the slightly different syntax for PostgreSQL.

### Testing Instructions

1. Update from 3.10 to 4.0 using a new package which includes the merged PR #35164 .
You can build a package with following command:
`php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2`
Result: See section "Actual result BEFORE applying this Pull Request" below.

2. Do the same again but use the update package built by drone for this PR.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

On certain older MySQL (5.7 in my case) or MariaDB versions:

![2021-08-17_j4-update-sql-error](https://user-images.githubusercontent.com/7413183/129705498-f24f0564-a1bc-462c-8df7-0661f31102bd.png)

On newer versions of MySQL or MariaDB and on PostgreSQL there is no such error.

### Expected result AFTER applying this Pull Request

No such SQL error on any supported database version.

### Documentation Changes Required

None.