### PR TITLE
[4.1] [GSoC 21] Media Manager - Add a player plugin to better preview audio and video files

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/modals/modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/modal.vue
@@ -69,6 +69,9 @@ export default {
     },
   },
   mounted() {
+    // Pass open event to parent
+    this.$emit('open');
+
     // Listen to keydown events on the document
     document.addEventListener('keydown', this.onKeyDown);
   },

--- a/administrator/components/com_media/tmpl/media/default.php
+++ b/administrator/components/com_media/tmpl/media/default.php
@@ -20,6 +20,8 @@ $input  = Factory::getApplication()->input;
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
+	->useStyle('mediaelement')
+	->useScript('mediaelement')
 	->useStyle('com_media.mediamanager')
 	->useScript('com_media.mediamanager');
 

--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -520,6 +520,29 @@
           "build/mediaelementplayer-legacy.min.css": "css/mediaelementplayer-legacy.min.css",
           "build/mediaelementplayer-legacy.css": "css/mediaelementplayer-legacy.css"
         },
+        "provideAssets": [
+          {
+            "name": "mediaelement",
+            "type": "style",
+            "uri": "mediaelementplayer.min.css"
+          },
+          {
+            "name": "mediaelement",
+            "type": "script",
+            "uri": "mediaelement-and-player.min.js",
+            "attributes": {
+              "defer": true
+            }
+          },
+          {
+            "name": "mediaelement",
+            "type": "preset",
+            "dependencies": [
+              "mediaelement#style",
+              "mediaelement#script"
+            ]
+          }
+        ],
         "filesExtra": {
           "build/mediaelement-flash-audio-ogg.swf": "js/mediaelement-flash-audio-ogg.swf",
           "build/mediaelement-flash-audio.swf": "js/mediaelement-flash-audio.swf",

--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -211,6 +211,14 @@
   border-radius: $grid-item-border-radius;
 }
 
+.player-wrapper {
+  width: 500px;
+
+  @media screen and (max-width: 576px) {
+    width: 300px;
+  }
+}
+
 .file-background, .folder-background {
   padding-bottom: 100%;
   background-color: hsl(var(--hue), 20%, 97%);


### PR DESCRIPTION
Pull Request for the "Media Type Improvements" task of the final evaluation period of [Media Manager](https://github.com/joomla-projects/gsoc21_media-manager).


### Summary of Changes

- Add and improve video/audio preview by using the MediaElement player plugin.


### Testing Instructions

1. **Upload files.** Upload video or audio files in Media Manager.

![image](https://user-images.githubusercontent.com/62054743/129708641-810c2fa7-4cd4-40ef-8f0a-ee6c1fccb21f.png)


2. **Preview.** Preview them by either double-clicking on them or using the "Preview Item" button. Video files:

![image](https://user-images.githubusercontent.com/62054743/129709007-1cc622df-b259-4f06-a1ea-77826566479f.png)

Audio files:

![image](https://user-images.githubusercontent.com/62054743/129709044-82d4d0ca-746e-4ce1-81c4-1253546f799b.png)

### Documentation Changes Required
I don't think so.

Special thanks to my mentors (@sebenns, @fancyFranci, @GeraintEdwards, @shivamdiehard, Chris Keen) and @bembelimen for assisting me with the project.

