### PR TITLE
Correct typo of "__DEPLOY VERSION__" with correct released version 4.0.0

### DIFF
--- a/libraries/src/Document/JsonapiDocument.php
+++ b/libraries/src/Document/JsonapiDocument.php
@@ -19,7 +19,7 @@ use Tobscure\JsonApi\ElementInterface;
  * JsonapiDocument class, provides an easy interface to parse output in JSON-API format.
  *
  * @link   http://www.jsonapi.org/
- * @since  __DEPLOY VERSION__
+ * @since  4.0.0
  */
 class JsonapiDocument extends JsonDocument implements \JsonSerializable
 {


### PR DESCRIPTION
Correct typo of `__DEPLOY VERSION__` with correct released version 4.0.0