### PR TITLE
[4] Remove undefined class

### DIFF
--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -2768,8 +2768,6 @@ class AKCoreTimer extends AKAbstractObject
 
 	/**
 	 * Public constructor, creates the timer object and calculates the execution time limits
-	 *
-	 * @return AECoreTimer
 	 */
 	public function __construct()
 	{


### PR DESCRIPTION
Code review,

Constructors dont ever return - they construct. 

The comment refers to the non-existing class `AECoreTimer` so thats blatantly wrong, as even the class being constructed is called `AKCoreTimer` (note the K and the E) 

