### PR TITLE
[4] Add folder permissions check for com_joomlaupdate

### DIFF
--- a/administrator/components/com_admin/src/Model/SysinfoModel.php
+++ b/administrator/components/com_admin/src/Model/SysinfoModel.php
@@ -535,6 +535,7 @@ class SysinfoModel extends BaseDatabaseModel
 		$cparams  = ComponentHelper::getParams('com_media');
 
 		$this->addDirectory('administrator/components', JPATH_ADMINISTRATOR . '/components');
+		$this->addDirectory('administrator/components/com_joomlaupdate', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
 		$this->addDirectory('administrator/language', JPATH_ADMINISTRATOR . '/language');
 
 		// List all admin languages


### PR DESCRIPTION
### Summary of Changes

Add folder permissions check for administrator/components/com_joomlaupdate

This is important as Joomla will write a `restoration.php` file in this folder during Joomla Core Upgrade (this file contains the `kickstart.security.password` and other params which is used by the `restore.php` extraction process. 

If this folder is not writable then you can see ajax errors like `Access Denied` 

### Testing Instructions

Go to http://example.com/administrator/index.php?option=com_admin&view=sysinfo Permissions Tab

### Actual result BEFORE applying this Pull Request

administrator/components/com_joomlaupdate not listed

### Expected result AFTER applying this Pull Request

administrator/components/com_joomlaupdate listed and its writable permission checked and documented. 

### Documentation Changes Required

None