### PR TITLE
[4] Correctly format incoming localised JS calendar date to PHP/SQL date

### DIFF
--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -350,8 +350,9 @@ class CalendarField extends FormField
 			// Convert from a localised JS date/time format back to a standard `Y-m-d H:i:s` PHP/SQL format
 			$myDateTime = DateTime::createFromFormat(
 				// Note: M and S are using in the date-helper.js
-				str_replace(['%','M','S'], ['','i','s'], Text::_('DATE_FORMAT_CALENDAR_DATETIME')
-				), $value);
+				str_replace(['%','M','S'], ['','i','s'], Text::_('DATE_FORMAT_CALENDAR_DATETIME')),
+				$value
+			);
 			$value = $myDateTime->format(Date::$format);
 		}
 

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -10,6 +10,8 @@ namespace Joomla\CMS\Form\Field;
 
 \defined('JPATH_PLATFORM') or die;
 
+use DateTime;
+use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Language\Text;
@@ -342,6 +344,16 @@ class CalendarField extends FormField
 
 		// Get the field filter type.
 		$filter = (string) $this->element['filter'];
+
+		if ($value)
+		{
+			// Convert from a localised JS date/time format back to a standard `Y-m-d H:i:s` PHP/SQL format
+			$myDateTime = DateTime::createFromFormat(
+				// Note: M and S are using in the date-helper.js
+				str_replace(['%','M','S'], ['','i','s'], Text::_('DATE_FORMAT_CALENDAR_DATETIME')
+				), $value);
+			$value = $myDateTime->format(Date::$format);
+		}
 
 		$return = $value;
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/35204 replaces https://github.com/joomla/joomla-cms/pull/35207

### Summary of Changes

Correctly re-translate the date/time string in the calendar based on language file

Language packs use `H M S` which is passed the JS in `date-helper.js` and not `H i s` like PHP does so needs extra cleaning up to reuse the `DATE_FORMAT_CALENDAR_DATETIME="%m-%d-%Y %H:%M:%S"` value in PHP 

### Testing Instructions

Install Joomla 4 with US language set as default
Try to create an article manually specifying a start publishing date and try to save

### Actual result BEFORE applying this Pull Request

<img width="1369" alt="Screenshot 2021-08-17 at 22 52 52" src="https://user-images.githubusercontent.com/400092/129809044-56cae4f2-fc16-4f16-bd33-1b0cef6b676a.png">


### Expected result AFTER applying this Pull Request

Article Saves

### Documentation Changes Required
