### PR TITLE
[4] Dont delete /installation in development mode

### DIFF
--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -186,7 +186,7 @@ HTMLHelper::_('behavior.formvalidator');
 
 				<div class="form-group j-install-last-step d-grid gap-2">
 					<button type="button" class="complete-installation btn btn-primary w-100"
-					   data-href="<?php echo Uri::root(); ?>" <?php if ($this->development): ?>data-development="1"<?php endif; ?>">
+					   data-href="<?php echo Uri::root(); ?>" <?php if ($this->development): ?>data-development<?php endif; ?>>
 						<span class="icon-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?>
 					</button>
 					<button type="button" class="complete-installation btn btn-primary w-100"

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -190,7 +190,7 @@ HTMLHelper::_('behavior.formvalidator');
 						<span class="icon-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?>
 					</button>
 					<button type="button" class="complete-installation btn btn-primary w-100"
-					   data-href="<?php echo Uri::root(); ?>administrator/" <?php if ($this->development): ?>data-development="1"<?php endif; ?>">
+					   data-href="<?php echo Uri::root(); ?>administrator/" <?php if ($this->development): ?>data-development<?php endif; ?>>
 						<span class="icon-lock" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_ADMIN_BTN'); ?>
 					</button>
 				</div>

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -186,11 +186,11 @@ HTMLHelper::_('behavior.formvalidator');
 
 				<div class="form-group j-install-last-step d-grid gap-2">
 					<button type="button" class="complete-installation btn btn-primary w-100"
-					   data-href="<?php echo Uri::root(); ?>" <?php if ($this->development): ?>data-development<?php endif; ?>">
+					   data-href="<?php echo Uri::root(); ?>" <?php if ($this->development): ?>data-development="1"<?php endif; ?>">
 						<span class="icon-eye" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_SITE_BTN'); ?>
 					</button>
 					<button type="button" class="complete-installation btn btn-primary w-100"
-					   data-href="<?php echo Uri::root(); ?>administrator/" <?php if ($this->development): ?>data-development<?php endif; ?>">
+					   data-href="<?php echo Uri::root(); ?>administrator/" <?php if ($this->development): ?>data-development="1"<?php endif; ?>">
 						<span class="icon-lock" aria-hidden="true"></span> <?php echo Text::_('INSTL_COMPLETE_ADMIN_BTN'); ?>
 					</button>
 				</div>


### PR DESCRIPTION
Pull Request for Issue #35218

### Summary of Changes

When in dev mode (4.0-dev) the complete installation buttons would delete the installation folder by mistake because the data-development attribute on the button did not have a default value and JS `'development' in item.dataset` would return false 

It seems that JS attributes need a value for them to appear "in".

### Testing Instructions

install Joomla - on this final page click the complete buttons (either) and check if /installation gets deleted

<img width="715" alt="Screenshot 2021-08-18 at 15 23 30" src="https://user-images.githubusercontent.com/400092/129915778-1428b907-df54-41a9-93fb-1a422b19664a.png">


### Actual result BEFORE applying this Pull Request

/installation is deleted even when in dev mode

### Expected result AFTER applying this Pull Request

/installation is not deleted even when in dev mode

### Documentation Changes Required

