### PR TITLE
[4.0] Add deprecation note for CMSObject

### DIFF
--- a/libraries/src/Object/CMSObject.php
+++ b/libraries/src/Object/CMSObject.php
@@ -17,7 +17,7 @@ namespace Joomla\CMS\Object;
  * and an internal error handler.
  *
  * @since       1.7.0
- * @deprecated  4.0.0
+ * @deprecated  4.0.0  Use \StdClass or Joomla\Registry\Registry instead
  */
 class CMSObject
 {

--- a/libraries/src/Object/CMSObject.php
+++ b/libraries/src/Object/CMSObject.php
@@ -17,7 +17,7 @@ namespace Joomla\CMS\Object;
  * and an internal error handler.
  *
  * @since       1.7.0
- * @deprecated  4.0.0  Use \StdClass or Joomla\Registry\Registry instead
+ * @deprecated  4.0.0  Use \stdClass or \Joomla\Registry\Registry instead.
  */
 class CMSObject
 {


### PR DESCRIPTION
### Summary of Changes
CMSObject was deprecated in #4910 but it isn't always immediately obvious what to use instead. Depending on the use case, either `stdClass` or `Registry` replaces CMSObject. This PR adds a deprecation note which provides some useful clarity.