### PR TITLE
Fix CalendarField::filter to use correct format

### DIFF
--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -53,7 +53,7 @@ class CalendarField extends FormField
 	/**
 	 * Whether format should be translated
 	 *
-	 * @var    bool
+	 * @var    boolean
 	 * @since  __DEPLOY_VERSION__
 	 */
 	protected $translateFormat;

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -198,7 +198,7 @@ class CalendarField extends FormField
 			$this->singleheader = (string) $this->element['singleheader'] ? (string) $this->element['singleheader'] : 'false';
 			$this->minyear      = \strlen((string) $this->element['minyear']) ? (string) $this->element['minyear'] : null;
 			$this->maxyear      = \strlen((string) $this->element['maxyear']) ? (string) $this->element['maxyear'] : null;
-			$this->translateFormat = ((string) $element['translateformat']) !== 'false';
+			$this->translateFormat = (string) $element['translateformat'] && ((string) $element['translateformat']) !== 'false';
 
 			if ($this->maxyear < 0 || $this->minyear > 0)
 			{

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -363,7 +363,7 @@ class CalendarField extends FormField
 		$app = Factory::getApplication();
 
 		// Get the field filter type.
-		$filter = strtoupper((string) $this->element['filter']);
+		$filter = (string) $this->element['filter'];
 
 		$return = $value;
 

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -206,7 +206,7 @@ class CalendarField extends FormField
 
 			if ($translateFormat && $translateFormat !== 'false')
 			{
-				$showTime              = (string) $this->element['showtime'];
+				$showTime = (string) $this->element['showtime'];
 
 				$lang  = Factory::getLanguage();
 				$debug = $lang->setDebug(false);


### PR DESCRIPTION
Pull Request for Issue #35204 .

### Summary of Changes

Correcting CalendarField::filter to use `DATE_FORMAT_FILTER_DATETIME` for translated date.
Was broken somewhere after #12414

Technical note: there should be 2 string translated:
`DATE_FORMAT_CALENDAR_DATETIME` - used for display (uses strftime format)
`DATE_FORMAT_FILTER_DATETIME` - used for server side filtering  (uses datetime format),

### Testing Instructions
Please follow #35204

### Documentation Changes Required
none
