### PR TITLE
Fix caching when HTMLDocument::countModules is used

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -693,12 +693,7 @@ class HtmlDocument extends Document
 
 		foreach ($modules as $module)
 		{
-			if (empty($module->contentRendered))
-			{
-				// Preserve content if loaded from cache
-				$module->content = $renderer->render($module, ['contentOnly' => true]);
-				$module->contentRendered = true;
-			}
+			$renderer->render($module, ['contentOnly' => true]);
 
 			if (trim($module->content) !== '')
 			{

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -695,6 +695,8 @@ class HtmlDocument extends Document
 		{
 			if (empty($module->contentRendered))
 			{
+				// Use style "raw", that will render only the content of the module, and precache it, see ModuleHelper::renderRawModule
+				// This style only for internal use, and should not be used within template markup.
 				$renderer->render($module, array('style' => 'raw'));
 			}
 

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -693,7 +693,10 @@ class HtmlDocument extends Document
 
 		foreach ($modules as $module)
 		{
-			$renderer->render($module, ['contentOnly' => true]);
+			if (empty($module->contentRendered))
+			{
+				$renderer->render($module, ['contentOnly' => true]);
+			}
 
 			if (trim($module->content) !== '')
 			{

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -695,9 +695,9 @@ class HtmlDocument extends Document
 		{
 			if (empty($module->contentRendered))
 			{
-				// Use style "raw", that will render only the content of the module, and precache it, see ModuleHelper::renderRawModule
-				// This style only for internal use, and should not be used within template markup.
-				$renderer->render($module, array('style' => 'raw'));
+				// Preserve content if loaded from cache
+				$module->content = $renderer->render($module, ['countOnly' => true]);
+				$module->contentRendered = true;
 			}
 
 			if (trim($module->content) !== '')

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -696,7 +696,7 @@ class HtmlDocument extends Document
 			if (empty($module->contentRendered))
 			{
 				// Preserve content if loaded from cache
-				$module->content = $renderer->render($module, ['countOnly' => true]);
+				$module->content = $renderer->render($module, ['contentOnly' => true]);
 				$module->contentRendered = true;
 			}
 

--- a/libraries/src/Document/Renderer/Html/ModuleRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModuleRenderer.php
@@ -92,7 +92,10 @@ class ModuleRenderer extends DocumentRenderer
 			$cacheparams->methodparams = array($module, $attribs);
 			$cacheparams->cachesuffix = $attribs['contentOnly'] ?? false;
 
-			return ModuleHelper::moduleCache($module, $params, $cacheparams);
+			// It need to be done here because the cache controller does not keep reference to the module object
+			$module->content = ModuleHelper::moduleCache($module, $params, $cacheparams);
+
+			return $module->content;
 		}
 
 		return ModuleHelper::renderModule($module, $attribs);

--- a/libraries/src/Document/Renderer/Html/ModuleRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModuleRenderer.php
@@ -90,7 +90,7 @@ class ModuleRenderer extends DocumentRenderer
 			$cacheparams->class = ModuleHelper::class;
 			$cacheparams->method = 'renderModule';
 			$cacheparams->methodparams = array($module, $attribs);
-			$cacheparams->cachesuffix = $attribs['countOnly'] ?? false;
+			$cacheparams->cachesuffix = $attribs['contentOnly'] ?? false;
 
 			return ModuleHelper::moduleCache($module, $params, $cacheparams);
 		}

--- a/libraries/src/Document/Renderer/Html/ModuleRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModuleRenderer.php
@@ -84,26 +84,15 @@ class ModuleRenderer extends DocumentRenderer
 
 		if ($params->get('cache', 0) == 1 && Factory::getApplication()->get('caching') >= 1 && $cachemode !== 'id' && $cachemode !== 'safeuri')
 		{
-			// Check if a raw style is requested, which should render only a content, without chrome style
-			$isRawStyle = !empty($attribs['style']) && $attribs['style'] === 'raw';
-
 			// Default to itemid creating method and workarounds on
 			$cacheparams = new \stdClass;
 			$cacheparams->cachemode = $cachemode;
 			$cacheparams->class = ModuleHelper::class;
 			$cacheparams->method = 'renderModule';
 			$cacheparams->methodparams = array($module, $attribs);
-			$cacheparams->cachesuffix = $isRawStyle ? 'style-raw' : '';
+			$cacheparams->cachesuffix = $attribs['countOnly'] ?? false;
 
 			$result = ModuleHelper::moduleCache($module, $params, $cacheparams);
-
-			// For a raw style set the content to the module, so it will not be rendered again next time, see ModuleHelper::renderRawModule
-			// It need to be done here because the cache controller does not keep reference to the module object
-			if ($isRawStyle)
-			{
-				$module->content = $result;
-				$module->contentRendered = true;
-			}
 
 			return $result;
 		}

--- a/libraries/src/Document/Renderer/Html/ModuleRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModuleRenderer.php
@@ -84,14 +84,28 @@ class ModuleRenderer extends DocumentRenderer
 
 		if ($params->get('cache', 0) == 1 && Factory::getApplication()->get('caching') >= 1 && $cachemode !== 'id' && $cachemode !== 'safeuri')
 		{
+			// Check if a raw style is requested, which should render only a content, without chrome style
+			$isRawStyle = !empty($attribs['style']) && $attribs['style'] === 'raw';
+
 			// Default to itemid creating method and workarounds on
 			$cacheparams = new \stdClass;
 			$cacheparams->cachemode = $cachemode;
 			$cacheparams->class = ModuleHelper::class;
 			$cacheparams->method = 'renderModule';
 			$cacheparams->methodparams = array($module, $attribs);
+			$cacheparams->cachesuffix = $isRawStyle ? 'style-raw' : '';
 
-			return ModuleHelper::moduleCache($module, $params, $cacheparams);
+			$result = ModuleHelper::moduleCache($module, $params, $cacheparams);
+
+			// For a raw style set the content to the module, so it will not be rendered again next time, see ModuleHelper::renderRawModule
+			// It need to be done here because the cache controller does not keep reference to the module object
+			if ($isRawStyle)
+			{
+				$module->content = $result;
+				$module->contentRendered = true;
+			}
+
+			return $result;
 		}
 
 		return ModuleHelper::renderModule($module, $attribs);

--- a/libraries/src/Document/Renderer/Html/ModuleRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModuleRenderer.php
@@ -94,6 +94,7 @@ class ModuleRenderer extends DocumentRenderer
 
 			// It need to be done here because the cache controller does not keep reference to the module object
 			$module->content = ModuleHelper::moduleCache($module, $params, $cacheparams);
+			$module->contentRendered = true;
 
 			return $module->content;
 		}

--- a/libraries/src/Document/Renderer/Html/ModuleRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModuleRenderer.php
@@ -92,9 +92,7 @@ class ModuleRenderer extends DocumentRenderer
 			$cacheparams->methodparams = array($module, $attribs);
 			$cacheparams->cachesuffix = $attribs['countOnly'] ?? false;
 
-			$result = ModuleHelper::moduleCache($module, $params, $cacheparams);
-
-			return $result;
+			return ModuleHelper::moduleCache($module, $params, $cacheparams);
 		}
 
 		return ModuleHelper::renderModule($module, $attribs);

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -165,6 +165,12 @@ abstract class ModuleHelper
 		// Render the module content
 		static::renderRawModule($module, $params, $attribs);
 
+		// Return early if only the content is required
+		if (!empty($attribs['contentOnly']))
+		{
+			return $module->content;
+		}
+
 		if (JDEBUG)
 		{
 			Profiler::getInstance('Application')->mark('beforeRenderModule ' . $module->module . ' (' . $module->title . ')');
@@ -213,8 +219,7 @@ abstract class ModuleHelper
 		// If the $module is nulled it will return an empty content, otherwise it will render the module normally.
 		$app->triggerEvent('onRenderModule', array(&$module, &$attribs));
 
-		// Don't apply chromes if we only need the content
-		if ($module === null || !isset($module->content) || !empty($attribs['contentOnly']))
+		if ($module === null || !isset($module->content))
 		{
 			return '';
 		}

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -165,6 +165,8 @@ abstract class ModuleHelper
 		// Render the module content
 		static::renderRawModule($module, $params, $attribs);
 
+		// Check for a "raw" style: render module content only.
+		// This style only for internal use, and should not be used within template markup.
 		if (!empty($attribs['style']) && $attribs['style'] === 'raw')
 		{
 			return $module->content;
@@ -592,6 +594,11 @@ abstract class ModuleHelper
 			$cacheparams->cachegroup = $module->module;
 		}
 
+		if (!isset($cacheparams->cachesuffix))
+		{
+			$cacheparams->cachesuffix = '';
+		}
+
 		$user = Factory::getUser();
 		$app  = Factory::getApplication();
 
@@ -622,7 +629,7 @@ abstract class ModuleHelper
 				$ret = $cache->get(
 					array($cacheparams->class, $cacheparams->method),
 					$cacheparams->methodparams,
-					$cacheparams->modeparams,
+					$cacheparams->modeparams . $cacheparams->cachesuffix,
 					$wrkarounds,
 					$wrkaroundoptions
 				);
@@ -652,7 +659,7 @@ abstract class ModuleHelper
 				$ret = $cache->get(
 					array($cacheparams->class, $cacheparams->method),
 					$cacheparams->methodparams,
-					$module->id . $view_levels . $secureid,
+					$module->id . $view_levels . $secureid . $cacheparams->cachesuffix,
 					$wrkarounds,
 					$wrkaroundoptions
 				);
@@ -662,7 +669,7 @@ abstract class ModuleHelper
 				$ret = $cache->get(
 					array($cacheparams->class, $cacheparams->method),
 					$cacheparams->methodparams,
-					$module->module . md5(serialize($cacheparams->methodparams)),
+					$module->module . md5(serialize($cacheparams->methodparams)) . $cacheparams->cachesuffix,
 					$wrkarounds,
 					$wrkaroundoptions
 				);
@@ -673,7 +680,7 @@ abstract class ModuleHelper
 				$ret = $cache->get(
 					array($cacheparams->class, $cacheparams->method),
 					$cacheparams->methodparams,
-					$module->id . $view_levels . $app->input->getInt('Itemid', null),
+					$module->id . $view_levels . $app->input->getInt('Itemid', null) . $cacheparams->cachesuffix,
 					$wrkarounds,
 					$wrkaroundoptions
 				);

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -213,8 +213,8 @@ abstract class ModuleHelper
 		// If the $module is nulled it will return an empty content, otherwise it will render the module normally.
 		$app->triggerEvent('onRenderModule', array(&$module, &$attribs));
 
-		// Don't apply chromes if we count only
-		if ($module === null || !isset($module->content) || !empty($attribs['countOnly']))
+		// Don't apply chromes if we only need the content
+		if ($module === null || !isset($module->content) || !empty($attribs['contentOnly']))
 		{
 			return '';
 		}

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -165,13 +165,6 @@ abstract class ModuleHelper
 		// Render the module content
 		static::renderRawModule($module, $params, $attribs);
 
-		// Check for a "raw" style: render module content only.
-		// This style only for internal use, and should not be used within template markup.
-		if (!empty($attribs['style']) && $attribs['style'] === 'raw')
-		{
-			return $module->content;
-		}
-
 		if (JDEBUG)
 		{
 			Profiler::getInstance('Application')->mark('beforeRenderModule ' . $module->module . ' (' . $module->title . ')');
@@ -220,7 +213,8 @@ abstract class ModuleHelper
 		// If the $module is nulled it will return an empty content, otherwise it will render the module normally.
 		$app->triggerEvent('onRenderModule', array(&$module, &$attribs));
 
-		if ($module === null || !isset($module->content))
+		// Don't apply chromes if we count only
+		if ($module === null || !isset($module->content) || !empty($attribs['countOnly']))
 		{
 			return '';
 		}


### PR DESCRIPTION
Pull Request for Issue #35180 and #34568 .

### Summary of Changes
Fix modules caching when `$this->countModules('position', true)` is used in a template.


### Testing Instructions
Please follow #35180


### Actual result BEFORE applying this Pull Request
Some modules have broken style


### Expected result AFTER applying this Pull Request
All works 


### Documentation Changes Required
none

reference #19416