### PR TITLE
[4] Dont attempt LDAP connection if no host provided

### DIFF
--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -42,7 +42,7 @@ class PlgAuthenticationLdap extends CMSPlugin
 		{
 			return false;
 		}
-		
+
 		// For JLog
 		$response->type = 'LDAP';
 

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -37,6 +37,12 @@ class PlgAuthenticationLdap extends CMSPlugin
 	 */
 	public function onUserAuthenticate($credentials, $options, &$response)
 	{
+		// If LDAP not correctly configured then bail early.
+		if (!$this->params->get('host'))
+		{
+			return false;
+		}
+		
 		// For JLog
 		$response->type = 'LDAP';
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/35216

### Summary of Changes

It is possible to publish the LDAP Authentication plugin by just clicking a toggle in the plugin list view.

If you do this you can lock yourself out of your site, because if you try to login then a connection is attempted to LDAP, but cause there is no LDAP server host provided we get a fatal type error deep in Symfony Options Resolver.

### Testing Instructions

Login to Joomla 4 admin
System -> Plugins -> toggle "Authentication - LDAP" 

### Actual result BEFORE applying this Pull Request

Fatal Error.

`The option "host" with value null is expected to be of type "string", but is of type "null".`

### Expected result AFTER applying this Pull Request

You can still login with users already in the users table. 

### Documentation Changes Required

