### PR TITLE
Add PHP6|7|8 to file extensions to scan for short tags

### DIFF
--- a/libraries/src/Filter/InputFilter.php
+++ b/libraries/src/Filter/InputFilter.php
@@ -204,7 +204,7 @@ class InputFilter extends BaseInputFilter
 
 			// Which file extensions to scan for short tags
 			'shorttag_extensions'        => array(
-				'inc', 'phps', 'class', 'php3', 'php4', 'php5', 'txt', 'dat', 'tpl', 'tmpl',
+				'inc', 'phps', 'class', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8', 'txt', 'dat', 'tpl', 'tmpl',
 			),
 
 			// Forbidden extensions anywhere in the content


### PR DESCRIPTION
@joomla/security @SniperSister 

Keeping our list up to date and inline with the `self::FORBIDDEN_FILE_EXTENSIONS` in the same class

Yes, yes, I know I know, there was never PHP 6 released :) 