### PR TITLE
[4] Add padding in breadcrumbs when "You are here" not shown.

### DIFF
--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -21,7 +21,7 @@ use Joomla\CMS\Router\Route;
 			</li>
 		<?php else : ?>
 			<li class="mod-breadcrumbs__divider float-start">
-				<span class="divider icon-location" aria-hidden="true"></span>
+				<span class="divider icon-location" aria-hidden="true"></span>&nbsp;
 			</li>
 		<?php endif; ?>
 

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -21,7 +21,7 @@ use Joomla\CMS\Router\Route;
 			</li>
 		<?php else : ?>
 			<li class="mod-breadcrumbs__divider float-start">
-				<span class="divider icon-location" aria-hidden="true"></span>&nbsp;
+				<span class="divider icon-location icon-fw" aria-hidden="true"></span>
 			</li>
 		<?php endif; ?>
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Add padding in breadcrumbs when "You are here" not shown and an image is shown instead

### Testing Instructions

Edit breadcrumbs module - set "You are here" to OFF.

### Actual result BEFORE applying this Pull Request


<img width="433" alt="Screenshot 2021-08-20 at 16 04 26" src="https://user-images.githubusercontent.com/400092/130253881-016d4f5b-56ec-4735-a174-9e1a838faf0e.png">


### Expected result AFTER applying this Pull Request

<img width="389" alt="Screenshot 2021-08-20 at 16 04 32" src="https://user-images.githubusercontent.com/400092/130253839-e4ff4f88-b6f2-4acc-b5ea-db9651bcadb2.png">

### Documentation Changes Required

