### PR TITLE
[4] Layout One time emergency passwords correctly

### DIFF
--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -103,9 +103,7 @@ $this->useCoreUI = true;
 				</div>
 			<?php else : ?>
 				<?php foreach ($this->otpConfig->otep as $otep) : ?>
-					<span class="col-lg-3">
-						<?php echo substr($otep, 0, 4); ?>-<?php echo substr($otep, 4, 4); ?>-<?php echo substr($otep, 8, 4); ?>-<?php echo substr($otep, 12, 4); ?>
-					</span>
+					<?php echo substr($otep, 0, 4); ?>-<?php echo substr($otep, 4, 4); ?>-<?php echo substr($otep, 8, 4); ?>-<?php echo substr($otep, 12, 4); ?><br>
 				<?php endforeach; ?>
 			<?php endif; ?>
 

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -103,7 +103,7 @@ $this->useCoreUI = true;
 				</div>
 			<?php else : ?>
 				<?php foreach ($this->otpConfig->otep as $otep) : ?>
-					<?php echo substr($otep, 0, 4); ?>-<?php echo substr($otep, 4, 4); ?>-<?php echo substr($otep, 8, 4); ?>-<?php echo substr($otep, 12, 4); ?><br>
+					<?php echo wordwrap($otep, 4, '-', true); ?><br>
 				<?php endforeach; ?>
 			<?php endif; ?>
 


### PR DESCRIPTION
### Summary of Changes

Correct HTML so that the "One time emergency passwords" can be laid out and copy and pasted to a safe place with ease.

### Testing Instructions

Enable 2FA as a user, view your "One time emergency passwords". 

### Actual result BEFORE applying this Pull Request

<img width="1563" alt="Screenshot 2021-08-20 at 16 25 24" src="https://user-images.githubusercontent.com/400092/130256481-8f5b2a8d-9559-4184-8f58-6e65b2c89c79.png">


### Expected result AFTER applying this Pull Request
<img width="394" alt="Screenshot 2021-08-20 at 16 23 14" src="https://user-images.githubusercontent.com/400092/130256447-6bbc59e4-ab1f-4389-a42a-181a368d5390.png">



### Documentation Changes Required

