### PR TITLE
[4] Dont use native constant that might be unavailable.

### DIFF
--- a/libraries/src/Authentication/Password/Argon2idHandler.php
+++ b/libraries/src/Authentication/Password/Argon2idHandler.php
@@ -22,6 +22,9 @@ class Argon2idHandler extends BaseArgon2idHandler implements CheckIfRehashNeeded
 	/**
 	 * Check if the password requires rehashing
 	 *
+	 * Note: PHP's native `PASSWORD_ARGON2ID` constant is not used as PHP may be compiled without this constant
+	 *       It is also only available as of PHP 7.3.0.
+	 *
 	 * @param   string  $hash  The password hash to check
 	 *
 	 * @return  boolean
@@ -30,6 +33,6 @@ class Argon2idHandler extends BaseArgon2idHandler implements CheckIfRehashNeeded
 	 */
 	public function checkIfRehashNeeded(string $hash): bool
 	{
-		return password_needs_rehash($hash, PASSWORD_ARGON2ID);
+		return password_needs_rehash($hash, 'argon2id');
 	}
 }


### PR DESCRIPTION
Code review

`PASSWORD_ARGON2ID` php native constant is only available from PHP 7.3.0 onwards whereas Joomla 4 has to support 7.2.5

PHP may also be compiled without argon support and therefore this constant would not be available.

Just like stated (repeatedly) in [UserHelper](https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/src/User/UserHelper.php)

https://github.com/joomla/joomla-cms/blob/55b02c923b65dc9016a3f82671bb9bd9177e2e4d/libraries/src/User/UserHelper.php#L46
