### PR TITLE
[3.10] Make sure the pre-Upgrade Checker is only shown when there is a update

### DIFF
--- a/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
+++ b/administrator/components/com_joomlaupdate/views/default/tmpl/default_update.php
@@ -228,7 +228,7 @@ defined('_JEXEC') or die;
 				</table>
 			</td>
 		</tr>
-		<tr id="preupdatecheckbox" >
+		<tr id="preupdatecheckbox">
 			<td>
 				<?php echo JText::_('COM_JOOMLAUPDATE_VIEW_DEFAULT_NON_CORE_PLUGIN_CONFIRMATION'); ?>
 			</td>

--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -268,6 +268,7 @@ class JoomlaupdateViewDefault extends JViewLegacy
 	public function shouldDisplayPreUpdateCheck()
 	{
 		return isset($this->updateInfo['object']->downloadurl->_data)
+			&& $this->updateInfo['hasUpdate']
 			&& $this->getModel()->isDatabaseTypeSupported()
 			&& $this->getModel()->isPhpVersionSupported();
 	}

--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -268,12 +268,11 @@ class JoomlaupdateViewDefault extends JViewLegacy
 	public function shouldDisplayPreUpdateCheck()
 	{
 		$nextMinor = JVersion::MAJOR_VERSION . '.' . (JVersion::MINOR_VERSION + 1);
-		$nextMajor = (JVersion::MAJOR_VERSION + 1);
 
-		// Show only when we have an update and when we update to the next minor or major.
+		// Show only when we found a download URL, we have an update and when we update to the next minor or greater.
 		return $this->updateInfo['hasUpdate']
-			&& (version_compare($this->updateInfo['latest'], $nextMajor, '>=')
-				|| version_compare($this->updateInfo['latest'], $nextMinor, '>='));
+				&& version_compare($this->updateInfo['latest'], $nextMinor, '>=');
+	}
 	}
 }
 

--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -267,7 +267,14 @@ class JoomlaupdateViewDefault extends JViewLegacy
 	 */
 	public function shouldDisplayPreUpdateCheck()
 	{
+		$nextMinor = JVersion::MAJOR_VERSION . '.' . (JVersion::MINOR_VERSION + 1);
+		$nextMajor = (JVersion::MAJOR_VERSION + 1);
+
+		// Show only when we found a download URL, we have an update and when we update to the next minor or major.
 		return isset($this->updateInfo['object']->downloadurl->_data)
-			&& $this->updateInfo['hasUpdate'];
+			&& $this->updateInfo['hasUpdate']
+			&& (version_compare($this->updateInfo['latest'], $nextMajor, '>=')
+				|| version_compare($this->updateInfo['latest'], $nextMinor, '>='));
 	}
 }
+

--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -268,8 +268,6 @@ class JoomlaupdateViewDefault extends JViewLegacy
 	public function shouldDisplayPreUpdateCheck()
 	{
 		return isset($this->updateInfo['object']->downloadurl->_data)
-			&& $this->updateInfo['hasUpdate']
-			&& $this->getModel()->isDatabaseTypeSupported()
-			&& $this->getModel()->isPhpVersionSupported();
+			&& $this->updateInfo['hasUpdate'];
 	}
 }

--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -103,7 +103,7 @@ class JoomlaupdateViewDefault extends JViewLegacy
 		$this->nonCoreExtensions      = $model->getNonCoreExtensions();
 
 		// Disable the critical plugins check for non-major updates.
-		$this->nonCoreCriticalPlugins = false;
+		$this->nonCoreCriticalPlugins = array();
 
 		if (version_compare($this->updateInfo['latest'], '4', '>='))
 		{

--- a/administrator/components/com_joomlaupdate/views/default/view.html.php
+++ b/administrator/components/com_joomlaupdate/views/default/view.html.php
@@ -270,9 +270,8 @@ class JoomlaupdateViewDefault extends JViewLegacy
 		$nextMinor = JVersion::MAJOR_VERSION . '.' . (JVersion::MINOR_VERSION + 1);
 		$nextMajor = (JVersion::MAJOR_VERSION + 1);
 
-		// Show only when we found a download URL, we have an update and when we update to the next minor or major.
-		return isset($this->updateInfo['object']->downloadurl->_data)
-			&& $this->updateInfo['hasUpdate']
+		// Show only when we have an update and when we update to the next minor or major.
+		return $this->updateInfo['hasUpdate']
 			&& (version_compare($this->updateInfo['latest'], $nextMajor, '>=')
 				|| version_compare($this->updateInfo['latest'], $nextMinor, '>='));
 	}


### PR DESCRIPTION
### Summary of Changes

Make sure the pre-Upgrade Checker is only shown only shown when there is a update and not on reinstall
This now also makes sure the pre upgrade checker is also shown when the PHP or mysql version is not meet as thats a report also shown in the pre-upgrade checker itself.

### Testing Instructions

#### First test
- Install 3.10.0
- search for updates
- the pre upgrade checker shows up
- apply patch
- the pre upgrade checker does not show up
- switch to Joomla Next
- the pre upgrade checker shows again
- switch to: https://update.joomla.org/core/nightlies/next_patch_list.xml
- the pre upgrade checker does not show up (for patch releases)

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/2596554/130291941-26fb2f0b-5bec-4ff0-9ae8-c2bd7b7035ad.png)


### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/2596554/130291903-2e34e9b9-211c-4254-b519-1aa6eed80f99.png)


### Documentation Changes Required

none