### PR TITLE
[3.10] Backport: Add PHP6|7|8 to file extensions to scan for short tags

### DIFF
--- a/libraries/src/Filter/InputFilter.php
+++ b/libraries/src/Filter/InputFilter.php
@@ -508,7 +508,7 @@ class InputFilter extends BaseInputFilter
 
 			// Which file extensions to scan for short tags
 			'shorttag_extensions'        => array(
-				'inc', 'phps', 'class', 'php3', 'php4', 'php5', 'txt', 'dat', 'tpl', 'tmpl',
+				'inc', 'phps', 'class', 'php3', 'php4', 'php5', 'php6', 'php7', 'php8', 'txt', 'dat', 'tpl', 'tmpl',
 			),
 
 			// Forbidden extensions anywhere in the content


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/35243

### Summary of Changes

Backport: Add PHP6|7|8 to file extensions to scan for short tags from https://github.com/joomla/joomla-cms/pull/35243 by @PhilETaylor 