### PR TITLE
[3.10] Backport Add folder permissions check for com_joomlaupdate

### DIFF
--- a/administrator/components/com_admin/models/sysinfo.php
+++ b/administrator/components/com_admin/models/sysinfo.php
@@ -527,6 +527,7 @@ class AdminModelSysInfo extends JModelLegacy
 		$cparams  = JComponentHelper::getParams('com_media');
 
 		$this->addDirectory('administrator/components', JPATH_ADMINISTRATOR . '/components');
+		$this->addDirectory('administrator/components/com_joomlaupdate', JPATH_ADMINISTRATOR . '/components/com_joomlaupdate');
 		$this->addDirectory('administrator/language', JPATH_ADMINISTRATOR . '/language');
 
 		// List all admin languages


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/35199

### Summary of Changes

[3.10] Backport Add folder permissions check for com_joomlaupdate from @PhilETaylor 

> Add folder permissions check for administrator/components/com_joomlaupdate
>
> This is important as Joomla will write a `restoration.php` file in this folder during Joomla Core Upgrade (this file contains the `kickstart.security.password` and other params which is used by the `restore.php` extraction process. 
>
> If this folder is not writable then you can see ajax errors like `Access Denied` 

### Testing Instructions

Apply this patch
Go to System -> System Information -> Permissions

### Actual result BEFORE applying this Pull Request

No check for com_joomlaupdate write permissions

### Expected result AFTER applying this Pull Request

There is a check for com_joomlaupdate write permissions

### Documentation Changes Required

none