### PR TITLE
[3.10] Remove unused fields so they do not cause javascript errors during pre-update check

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1475,8 +1475,10 @@ ENDDATA;
 		{
 			$decode = json_decode($extension->manifest_cache);
 
-			// Removed description so that CDATA content does not cause javascript error during pre-update check
+			// Removed unused fields so they do not cause javascript errors during pre-update check
 			unset($decode->description);
+			unset($decode->copyright);
+			unset($decode->creationDate);
 
 			$this->translateExtensionName($extension);
 			$extension->version = isset($decode->version)
@@ -1549,8 +1551,10 @@ ENDDATA;
 		{
 			$decode = json_decode($plugin->manifest_cache);
 
-			// Removed description so that CDATA content does not cause javascript error during pre-update check
-			$decode->description = '';
+			// Removed unused fields so they do not cause javascript errors during pre-update check
+			unset($decode->description);
+			unset($decode->copyright);
+			unset($decode->creationDate);
 
 			$this->translateExtensionName($plugin);
 			$plugin->version = isset($decode->version)

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1475,7 +1475,7 @@ ENDDATA;
 		{
 			$decode = json_decode($extension->manifest_cache);
 
-			// Removed unused fields so they do not cause javascript errors during pre-update check
+			// Remove unused fields so they do not cause javascript errors during pre-update check
 			unset($decode->description);
 			unset($decode->copyright);
 			unset($decode->creationDate);
@@ -1551,7 +1551,7 @@ ENDDATA;
 		{
 			$decode = json_decode($plugin->manifest_cache);
 
-			// Removed unused fields so they do not cause javascript errors during pre-update check
+			// Remove unused fields so they do not cause javascript errors during pre-update check
 			unset($decode->description);
 			unset($decode->copyright);
 			unset($decode->creationDate);


### PR DESCRIPTION
Pull Request for Issue #35224

### Summary of Changes

Remove unused fields so they do not cause javascript errors during pre-update check

### Testing Instructions

- install 3.10.0
- Install an extension that uses the "©" symbol in the copyright statement. (example: https://www.web357.com/product/www-redirect-joomla-plugin)
- set the update server to Joomla Next
- Notice that the pre upgrade checker does not start
- apply this patch
- the pre-upgrade checker runs

### Actual result BEFORE applying this Pull Request

The pre-upgrade checker gets confused by the "©" symbol and does not run

### Expected result AFTER applying this Pull Request

The pre-upgrade checker runs

### Documentation Changes Required

none