### PR TITLE
Remove non functioning Third Party GA Beacon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Joomla! CMS™ [![Analytics](https://ga-beacon.appspot.com/UA-544070-3/joomla-cms/readme)](https://github.com/igrigorik/ga-beacon)
+Joomla! CMS™ 
 ====================
 
 Build Status


### PR DESCRIPTION
### Summary of Changes

Remove the beacon that is not working from README.md - this has been broken for some time now (2016). 

### Actual result BEFORE applying this Pull Request

<img width="566" alt="Screenshot 2021-08-21 at 22 05 26" src="https://user-images.githubusercontent.com/400092/130334770-7df9eac5-4231-4dca-9391-51fd36c39e7b.png">

# see their FAQ:

https://github.com/igrigorik/ga-beacon#faq

> Can I use this to track visits to my GitHub README and other GitHub-served content? No, you cannot - see 
> https://github.com/igrigorik/ga-beacon/commit/6acd8627bb7be36f24f5516e9873c92719a50e55

