### PR TITLE
[4.0] Improve size of user list

### DIFF
--- a/administrator/components/com_users/src/Service/HTML/Users.php
+++ b/administrator/components/com_users/src/Service/HTML/Users.php
@@ -66,8 +66,7 @@ class Users
 		$title = Text::_('COM_USERS_ADD_NOTE');
 
 		return '<a href="' . Route::_('index.php?option=com_users&task=note.add&u_id=' . (int) $userId)
-			. '" class="btn btn-secondary btn-sm"><span class="icon-plus pe-1" aria-hidden="true">'
-			. '</span>' . $title . '</a>';
+			. '" class="dropdown-item">' . $title . '</a>';
 	}
 
 	/**
@@ -90,7 +89,7 @@ class Users
 		$title = Text::_('COM_USERS_FILTER_NOTES');
 
 		return '<a href="' . Route::_('index.php?option=com_users&view=notes&filter[search]=uid:' . (int) $userId)
-			. '" class="dropdown-item"><span class="icon-list pe-1" aria-hidden="true"></span>' . $title . '</a>';
+			. '" class="dropdown-item">' . $title . '</a>';
 	}
 
 	/**
@@ -113,7 +112,7 @@ class Users
 		$title = Text::plural('COM_USERS_N_USER_NOTES', $count);
 
 		return '<button  type="button" data-bs-target="#userModal_' . (int) $userId . '" id="modal-' . (int) $userId
-			. '" data-bs-toggle="modal" class="dropdown-item"><span class="icon-eye pe-1" aria-hidden="true"></span>' . $title . '</button>';
+			. '" data-bs-toggle="modal" class="dropdown-item">' . $title . '</button>';
 	}
 
 	/**

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -54,9 +54,6 @@ $tfa        = PluginHelper::isEnabled('twofactorauth');
 								<th scope="col">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_NAME', 'a.name', $listDirn, $listOrder); ?>
 								</th>
-								<th scope="col" class="text-center d-none d-md-table-cell">
-									<?php echo Text::_('COM_USERS_DEBUG_PERMISSIONS'); ?>
-								</th>
 								<th scope="col" class="w-10 d-none d-md-table-cell">
 									<?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_USERNAME', 'a.username', $listDirn, $listOrder); ?>
 								</th>
@@ -115,29 +112,27 @@ $tfa        = PluginHelper::isEnabled('twofactorauth');
 										<?php echo $this->escape($item->name); ?>
 									<?php endif; ?>
 									</div>
-									<div class="btn-group">
-										<?php echo HTMLHelper::_('users.addNote', $item->id); ?>
-										<?php if ($item->note_count > 0) : ?>
-										<button type="button" class="btn btn-secondary btn-sm dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-											<span class="visually-hidden"><?php echo Text::_('JGLOBAL_TOGGLE_DROPDOWN'); ?></span>
+									<div class="dropdown mt-2">
+										<button type="button" class="btn btn-secondary btn-sm dropdown-toggle" data-toggle="dropdown">
+											<span class="fa fa-user-cog" aria-hidden="true"></span>
+											<?php echo Text::_('INFO'); ?>
 										</button>
 										<div class="dropdown-menu">
-											<?php echo HTMLHelper::_('users.filterNotes', $item->note_count, $item->id); ?>
-											<?php echo HTMLHelper::_('users.notes', $item->note_count, $item->id); ?>
+											<a class="dropdown-item" href="<?php echo Route::_('index.php?option=com_users&view=debuguser&user_id=' . (int) $item->id); ?>">
+												<?php echo Text::_('COM_USERS_DEBUG_PERMISSIONS'); ?>
+											</a>
+											<?php echo HTMLHelper::_('users.addNote', $item->id); ?>
+											<?php if ($item->note_count > 0) : ?>
+												<?php echo HTMLHelper::_('users.filterNotes', $item->note_count, $item->id); ?>
+												<?php echo HTMLHelper::_('users.notes', $item->note_count, $item->id); ?>
+											<?php endif; ?>
 										</div>
-										<?php endif; ?>
 									</div>
 									<?php echo HTMLHelper::_('users.notesModal', $item->note_count, $item->id); ?>
 									<?php if ($item->requireReset == '1') : ?>
 										<span class="badge bg-warning text-dark"><?php echo Text::_('COM_USERS_PASSWORD_RESET_REQUIRED'); ?></span>
 									<?php endif; ?>
 								</th>
-								<td class="text-center btns d-none d-md-table-cell">
-									<a href="<?php echo Route::_('index.php?option=com_users&view=debuguser&user_id=' . (int) $item->id); ?>">
-										<span class="icon-list" aria-hidden="true"></span>
-										<span class="visually-hidden"><?php echo Text::_('COM_USERS_DEBUG_PERMISSIONS'); ?></span>
-									</a>
-								</td>
 								<td class="break-word d-none d-md-table-cell">
 									<?php echo $this->escape($item->username); ?>
 								</td>


### PR DESCRIPTION
### Summary of Changes
This PR improves the user list view in the backend by moving the permission column into a dropdown and removes horizontal scrolling.


### Testing Instructions
- Go to the user list
- Check the horizontal scrolling
- Apply patch
- No horizontal scrolling, no permission column but the button in the user name column has that option now


### Actual result BEFORE applying this Pull Request
Horizontal scrolling

![grafik](https://user-images.githubusercontent.com/1229869/130338998-22cefd49-69c8-47c3-94ae-56f2860ca92c.png)


### Expected result AFTER applying this Pull Request
No horizontal scrolling.

![grafik](https://user-images.githubusercontent.com/1229869/130338989-08070199-350f-4878-9806-4f7d11314c69.png)


