### PR TITLE
[4] Cleanup of restore.php - duplicated copyright/license blocks.

### DIFF
--- a/administrator/components/com_joomlaupdate/restore.php
+++ b/administrator/components/com_joomlaupdate/restore.php
@@ -9,16 +9,6 @@
  * @note        This file has been modified by the Joomla! Project and no longer reflects the original work of its author.
  */
 
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
-
 define('_AKEEBA_RESTORATION', 1);
 defined('DS') or define('DS', DIRECTORY_SEPARATOR);
 
@@ -146,16 +136,6 @@ function debugMsg($msg)
 		echo $msg . "\n";
 	}
 }
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
 
 /**
  * The base class of Akeeba Engine objects. Allows for error and warnings logging
@@ -425,16 +405,6 @@ abstract class AKAbstractObject
 	}
 
 }
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
 
 /**
  * The superclass of all Akeeba Kickstart parts. The "parts" are intelligent stateful
@@ -796,16 +766,6 @@ abstract class AKAbstractPart extends AKAbstractObject
 		}
 	}
 }
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
 
 /**
  * The base class of unarchiver classes
@@ -1419,16 +1379,6 @@ abstract class AKAbstractUnarchiver extends AKAbstractPart
 }
 
 /**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
-
-/**
  * File post processor engines base class
  */
 abstract class AKAbstractPostproc extends AKAbstractObject
@@ -1475,17 +1425,6 @@ abstract class AKAbstractPostproc extends AKAbstractObject
 	abstract public function rename($from, $to);
 }
 
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
-
 /**
  * Descendants of this class can be used in the unarchiver's observer methods (attach, detach and notify)
  *
@@ -1496,17 +1435,6 @@ abstract class AKAbstractPartObserver
 {
 	abstract public function update($object, $message);
 }
-
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
 
 /**
  * Direct file writer
@@ -1632,16 +1560,6 @@ class AKPostprocDirect extends AKAbstractPostproc
 	}
 
 }
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
 
 /**
  * JPA archive extraction class
@@ -2420,16 +2338,6 @@ class AKUnarchiverJPA extends AKAbstractUnarchiver
 }
 
 /**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
-
-/**
  * ZIP archive extraction class
  *
  * Since the file data portion of ZIP and JPA are similarly structured (it's empty for dirs,
@@ -2746,16 +2654,6 @@ class AKUnarchiverZIP extends AKUnarchiverJPA
 }
 
 /**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
-
-/**
  * Timer class
  */
 class AKCoreTimer extends AKAbstractObject
@@ -2943,16 +2841,6 @@ class AKCoreTimer extends AKAbstractObject
 }
 
 /**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
-
-/**
  * A filesystem scanner which uses opendir()
  */
 class AKUtilsLister extends AKAbstractObject
@@ -3047,16 +2935,6 @@ class AKUtilsLister extends AKAbstractObject
 		return $arr;
 	}
 }
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
 
 /**
  * A simple INI-based i18n engine
@@ -3552,16 +3430,6 @@ class AKText extends AKAbstractObject
 }
 
 /**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
-
-/**
  * The Akeeba Kickstart Factory class
  * This class is reponssible for instanciating all Akeeba Kicsktart classes
  */
@@ -3845,16 +3713,6 @@ class AKFactory
 }
 
 /**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
-
-/**
  * Interface for AES encryption adapters
  */
 interface AKEncryptionAESAdapterInterface
@@ -3883,16 +3741,6 @@ interface AKEncryptionAESAdapterInterface
 	 */
 	public function isSupported();
 }
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
 
 /**
  * Abstract AES encryption class
@@ -3971,16 +3819,6 @@ abstract class AKEncryptionAESAdapterAbstract
 		return str_repeat("\0", $blockSize - $paddingBytes);
 	}
 }
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
 
 class Mcrypt extends AKEncryptionAESAdapterAbstract implements AKEncryptionAESAdapterInterface
 {
@@ -4073,16 +3911,6 @@ class Mcrypt extends AKEncryptionAESAdapterAbstract implements AKEncryptionAESAd
 		return mcrypt_get_iv_size($this->cipherType, $this->cipherMode);
 	}
 }
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
 
 class OpenSSL extends AKEncryptionAESAdapterAbstract implements AKEncryptionAESAdapterInterface
 {
@@ -4178,16 +4006,6 @@ class OpenSSL extends AKEncryptionAESAdapterAbstract implements AKEncryptionAESA
 		return openssl_cipher_iv_length($this->method);
 	}
 }
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
 
 /**
  * AES implementation in PHP (c) Chris Veness 2005-2016.
@@ -5029,16 +4847,6 @@ class AKEncryptionAES
 }
 
 /**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
-
-/**
  * The Master Setup will read the configuration parameters from restoration.php or
  * the JSON-encoded "configuration" input variable and return the status.
  *
@@ -5225,16 +5033,6 @@ function masterSetup()
 		}
 	}
 }
-
-/**
- * Akeeba Restore
- * A JSON-powered JPA, JPS and ZIP archive extraction library
- *
- * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
- * @license     GNU GPL v2 or - at your option - any later version
- * @package     akeebabackup
- * @subpackage  kickstart
- */
 
 // Mini-controller for restore.php
 if (!defined('KICKSTART'))


### PR DESCRIPTION
Removes 20 duplicates the following, while still remaining compliant. I believe the duplicates originated as each class was originally its own file, and merged by a build process to create this single file. The same duplicated copyright/license statements, including the `@note` are also at the top of the file, covering all the classes in the file, so the duplicates are not necessary. 

```
/**
 * Akeeba Restore
 * A JSON-powered JPA, JPS and ZIP archive extraction library
 *
 * @copyright   2008-2017 Nicholas K. Dionysopoulos / Akeeba Ltd.
 * @license     GNU GPL v2 or - at your option - any later version
 * @package     akeebabackup
 * @subpackage  kickstart
 */
```

No PHP code changes. 

@nikosdion 