### PR TITLE
[4] Highlight the Home Dashboard link only when active page

### DIFF
--- a/build/media_source/mod_menu/js/admin-menu.es6.js
+++ b/build/media_source/mod_menu/js/admin-menu.es6.js
@@ -66,7 +66,9 @@ if (sidebar && !sidebar.getAttribute('data-hidden')) {
 
   // Set active class
   allLinks.forEach((link) => {
-    if (currentUrl.indexOf(link.href) === 0) {
+    if (
+      (!link.href.match(/index\.php$/) && currentUrl.indexOf(link.href) === 0)
+      || (link.href.match(/index\.php$/) && currentUrl.match(/index\.php$/))) {
       link.setAttribute('aria-current', 'page');
       link.classList.add('mm-active');
 


### PR DESCRIPTION
Pull Request for Issue #34484

### Summary of Changes

Only highlight the Home Dashboard if the current url is the index.php page

### Testing Instructions

Visit the Home Dashboard in Joomla 4 admin - Note Home Dashboard is highlighted
Go to any other menu item - note Home Dashboard is not highlighted but the correct item is. 

### Actual result BEFORE applying this Pull Request

 Home Dashboard is always highlighted

### Expected result AFTER applying this Pull Request

 Home Dashboard is only highlighted when actually the page we are on

### Documentation Changes Required

none.

