### PR TITLE
[4] Build tools should preserve the original timestamps

### DIFF
--- a/build/build-modules-js/error-pages.es6.js
+++ b/build/build-modules-js/error-pages.es6.js
@@ -147,7 +147,7 @@ module.exports.createErrorPages = async (options) => {
     await writeFile(
       `${RootPath}${options.settings.errorPages[name].destFile}`,
       template,
-      { encoding: 'utf8', mode: 0o2644 },
+      { encoding: 'utf8', mode: 0o644 },
     );
 
     // eslint-disable-next-line no-console

--- a/build/build-modules-js/error-pages.es6.js
+++ b/build/build-modules-js/error-pages.es6.js
@@ -141,13 +141,13 @@ module.exports.createErrorPages = async (options) => {
     }
 
     if (!mediaExists) {
-      await mkdir(dirname(`${RootPath}${options.settings.errorPages[name].destFile}`), { recursive: true });
+      await mkdir(dirname(`${RootPath}${options.settings.errorPages[name].destFile}`), { recursive: true, mode: 0o755 });
     }
 
     await writeFile(
       `${RootPath}${options.settings.errorPages[name].destFile}`,
       template,
-      { encoding: 'utf8' },
+      { encoding: 'utf8', mode: 0o2644 },
     );
 
     // eslint-disable-next-line no-console

--- a/build/build-modules-js/init/cleanup-media.es6.js
+++ b/build/build-modules-js/init/cleanup-media.es6.js
@@ -24,10 +24,10 @@ module.exports.cleanVendors = async () => {
     // console.error('/media has been removed.');
 
     // Recreate the media folder
-    await mkdir(join(RootPath, 'media/vendor/debugbar'), { recursive: true });
+    await mkdir(join(RootPath, 'media/vendor/debugbar'), { recursive: true, mode: 0o755 });
 
     // Copy some assets from a PHP package
-    await copy(join(RootPath, 'libraries/vendor/maximebf/debugbar/src/DebugBar/Resources'), join(RootPath, 'media/vendor/debugbar'));
+    await copy(join(RootPath, 'libraries/vendor/maximebf/debugbar/src/DebugBar/Resources'), join(RootPath, 'media/vendor/debugbar'), { preserveTimestamps: true });
     await remove(join(RootPath, 'media/vendor/debugbar/vendor/font-awesome'));
     await remove(join(RootPath, 'media/vendor/debugbar/vendor/jquery'));
   } else {

--- a/build/build-modules-js/init/common/concat-files.es6.js
+++ b/build/build-modules-js/init/common/concat-files.es6.js
@@ -22,5 +22,5 @@ module.exports.concatFiles = async (files, output) => {
 
   const res = await Promise.all(promises);
 
-  await writeFile(`${RootPath}/${output}`, res.join(' '), { encoding: 'utf8', mode: 0o2644 });
+  await writeFile(`${RootPath}/${output}`, res.join(' '), { encoding: 'utf8', mode: 0o644 });
 };

--- a/build/build-modules-js/init/common/concat-files.es6.js
+++ b/build/build-modules-js/init/common/concat-files.es6.js
@@ -22,5 +22,5 @@ module.exports.concatFiles = async (files, output) => {
 
   const res = await Promise.all(promises);
 
-  await writeFile(`${RootPath}/${output}`, res.join(' '));
+  await writeFile(`${RootPath}/${output}`, res.join(' '), { encoding: 'utf8', mode: 0o2644 });
 };

--- a/build/build-modules-js/init/common/copy-all-files.es6.js
+++ b/build/build-modules-js/init/common/copy-all-files.es6.js
@@ -15,5 +15,5 @@ const RootPath = process.cwd();
 module.exports.copyAllFiles = async (dirName, name, type) => {
   const folderName = dirName === '/' ? '/' : `/${dirName}`;
   await copy(join(RootPath, `node_modules/${name}/${folderName}`),
-    join(RootPath, `media/vendor/${name.replace(/.+\//, '')}/${type}`), { preserveTimestamps: true } );
+    join(RootPath, `media/vendor/${name.replace(/.+\//, '')}/${type}`), { preserveTimestamps: true });
 };

--- a/build/build-modules-js/init/common/copy-all-files.es6.js
+++ b/build/build-modules-js/init/common/copy-all-files.es6.js
@@ -15,5 +15,5 @@ const RootPath = process.cwd();
 module.exports.copyAllFiles = async (dirName, name, type) => {
   const folderName = dirName === '/' ? '/' : `/${dirName}`;
   await copy(join(RootPath, `node_modules/${name}/${folderName}`),
-    join(RootPath, `media/vendor/${name.replace(/.+\//, '')}/${type}`));
+    join(RootPath, `media/vendor/${name.replace(/.+\//, '')}/${type}`), { preserveTimestamps: true } );
 };

--- a/build/build-modules-js/init/exemptions/codemirror.es6.js
+++ b/build/build-modules-js/init/exemptions/codemirror.es6.js
@@ -15,7 +15,7 @@ const xmlVersionStr = /(<version>)(.+)(<\/version>)/;
 module.exports.codeMirror = async (packageName, version) => {
   const itemvendorPath = join(RootPath, `media/vendor/${packageName}`);
   if (!await existsSync(itemvendorPath)) {
-    await mkdir(itemvendorPath, { recursive: true });
+    await mkdir(itemvendorPath, { recursive: true, mode: 0o755 });
     await mkdir(join(itemvendorPath, 'addon'), { mode: 0o755 });
     await mkdir(join(itemvendorPath, 'lib'), { mode: 0o755 });
     await mkdir(join(itemvendorPath, 'mode'), { mode: 0o755 });

--- a/build/build-modules-js/init/exemptions/codemirror.es6.js
+++ b/build/build-modules-js/init/exemptions/codemirror.es6.js
@@ -16,11 +16,11 @@ module.exports.codeMirror = async (packageName, version) => {
   const itemvendorPath = join(RootPath, `media/vendor/${packageName}`);
   if (!await existsSync(itemvendorPath)) {
     await mkdir(itemvendorPath, { recursive: true });
-    await mkdir(join(itemvendorPath, 'addon'));
-    await mkdir(join(itemvendorPath, 'lib'));
-    await mkdir(join(itemvendorPath, 'mode'));
-    await mkdir(join(itemvendorPath, 'keymap'));
-    await mkdir(join(itemvendorPath, 'theme'));
+    await mkdir(join(itemvendorPath, 'addon'), { mode: 0o755 });
+    await mkdir(join(itemvendorPath, 'lib'), { mode: 0o755 });
+    await mkdir(join(itemvendorPath, 'mode'), { mode: 0o755 });
+    await mkdir(join(itemvendorPath, 'keymap'), { mode: 0o755 });
+    await mkdir(join(itemvendorPath, 'theme'), { mode: 0o755 });
   }
 
   await copyAllFiles('addon', 'codemirror', 'addon');
@@ -65,5 +65,5 @@ module.exports.codeMirror = async (packageName, version) => {
   // Update the XML file for Codemirror
   let codemirrorXml = await readFile(`${RootPath}/plugins/editors/codemirror/codemirror.xml`, { encoding: 'utf8' });
   codemirrorXml = codemirrorXml.replace(xmlVersionStr, `$1${version}$3`);
-  await writeFile(`${RootPath}/plugins/editors/codemirror/codemirror.xml`, codemirrorXml, { encoding: 'utf8' });
+  await writeFile(`${RootPath}/plugins/editors/codemirror/codemirror.xml`, codemirrorXml, { encoding: 'utf8', mode: 0o2644 });
 };

--- a/build/build-modules-js/init/exemptions/codemirror.es6.js
+++ b/build/build-modules-js/init/exemptions/codemirror.es6.js
@@ -65,5 +65,5 @@ module.exports.codeMirror = async (packageName, version) => {
   // Update the XML file for Codemirror
   let codemirrorXml = await readFile(`${RootPath}/plugins/editors/codemirror/codemirror.xml`, { encoding: 'utf8' });
   codemirrorXml = codemirrorXml.replace(xmlVersionStr, `$1${version}$3`);
-  await writeFile(`${RootPath}/plugins/editors/codemirror/codemirror.xml`, codemirrorXml, { encoding: 'utf8', mode: 0o2644 });
+  await writeFile(`${RootPath}/plugins/editors/codemirror/codemirror.xml`, codemirrorXml, { encoding: 'utf8', mode: 0o644 });
 };

--- a/build/build-modules-js/init/exemptions/tinymce.es6.js
+++ b/build/build-modules-js/init/exemptions/tinymce.es6.js
@@ -25,7 +25,7 @@ const copyArrayFiles = async (dirName, files, name, type) => {
     const folderName = dirName === '/' ? '/' : `/${dirName}/`;
 
     if (existsSync(`node_modules/${name}${folderName}${file}`)) {
-      promises.push(copy(`node_modules/${name}${folderName}${file}`, `media/vendor/${name.replace(/.+\//, '')}${type ? `/${type}` : ''}/${file}`));
+      promises.push(copy(`node_modules/${name}${folderName}${file}`, `media/vendor/${name.replace(/.+\//, '')}${type ? `/${type}` : ''}/${file}`, { preserveTimestamps: true }));
     }
   }
 
@@ -39,13 +39,13 @@ module.exports.tinyMCE = async (packageName, version) => {
   const itemvendorPath = join(RootPath, `media/vendor/${packageName}`);
 
   if (!await existsSync(itemvendorPath)) {
-    await mkdir(itemvendorPath);
-    await mkdir(join(itemvendorPath, 'icons'));
-    await mkdir(join(itemvendorPath, 'plugins'));
-    await mkdir(join(itemvendorPath, 'langs'));
-    await mkdir(join(itemvendorPath, 'skins'));
-    await mkdir(join(itemvendorPath, 'themes'));
-    await mkdir(join(itemvendorPath, 'templates'));
+    await mkdir(itemvendorPath, { mode: 0o755 });
+    await mkdir(join(itemvendorPath, 'icons'), { mode: 0o755 });
+    await mkdir(join(itemvendorPath, 'plugins'), { mode: 0o755 });
+    await mkdir(join(itemvendorPath, 'langs'), { mode: 0o755 });
+    await mkdir(join(itemvendorPath, 'skins'), { mode: 0o755 });
+    await mkdir(join(itemvendorPath, 'themes'), { mode: 0o755 });
+    await mkdir(join(itemvendorPath, 'templates'), { mode: 0o755 });
   }
 
   await copyAllFiles('icons', 'tinymce', 'icons');
@@ -58,13 +58,13 @@ module.exports.tinyMCE = async (packageName, version) => {
   // Update the XML file for tinyMCE
   let tinyXml = await readFile(`${RootPath}/plugins/editors/tinymce/tinymce.xml`, { encoding: 'utf8' });
   tinyXml = tinyXml.replace(xmlVersionStr, `$1${version}$3`);
-  await writeFile(`${RootPath}/plugins/editors/tinymce/tinymce.xml`, tinyXml, { encoding: 'utf8' });
+  await writeFile(`${RootPath}/plugins/editors/tinymce/tinymce.xml`, tinyXml, { encoding: 'utf8', mode: 0o2644 });
 
   // Remove that sourcemap...
   let tinyWrongMap = await readFile(`${RootPath}/media/vendor/tinymce/skins/ui/oxide/skin.min.css`, { encoding: 'utf8' });
   tinyWrongMap = tinyWrongMap.replace('/*# sourceMappingURL=skin.min.css.map */', '');
-  await writeFile(`${RootPath}/media/vendor/tinymce/skins/ui/oxide/skin.min.css`, tinyWrongMap, { encoding: 'utf8' });
+  await writeFile(`${RootPath}/media/vendor/tinymce/skins/ui/oxide/skin.min.css`, tinyWrongMap, { encoding: 'utf8', mode: 0o2644 });
 
   // Restore our code on the vendor folders
-  await copy(join(RootPath, 'build/media_source/vendor/tinymce/templates'), join(RootPath, 'media/vendor/tinymce/templates'));
+  await copy(join(RootPath, 'build/media_source/vendor/tinymce/templates'), join(RootPath, 'media/vendor/tinymce/templates'), { preserveTimestamps: true });
 };

--- a/build/build-modules-js/init/exemptions/tinymce.es6.js
+++ b/build/build-modules-js/init/exemptions/tinymce.es6.js
@@ -58,12 +58,12 @@ module.exports.tinyMCE = async (packageName, version) => {
   // Update the XML file for tinyMCE
   let tinyXml = await readFile(`${RootPath}/plugins/editors/tinymce/tinymce.xml`, { encoding: 'utf8' });
   tinyXml = tinyXml.replace(xmlVersionStr, `$1${version}$3`);
-  await writeFile(`${RootPath}/plugins/editors/tinymce/tinymce.xml`, tinyXml, { encoding: 'utf8', mode: 0o2644 });
+  await writeFile(`${RootPath}/plugins/editors/tinymce/tinymce.xml`, tinyXml, { encoding: 'utf8', mode: 0o644 });
 
   // Remove that sourcemap...
   let tinyWrongMap = await readFile(`${RootPath}/media/vendor/tinymce/skins/ui/oxide/skin.min.css`, { encoding: 'utf8' });
   tinyWrongMap = tinyWrongMap.replace('/*# sourceMappingURL=skin.min.css.map */', '');
-  await writeFile(`${RootPath}/media/vendor/tinymce/skins/ui/oxide/skin.min.css`, tinyWrongMap, { encoding: 'utf8', mode: 0o2644 });
+  await writeFile(`${RootPath}/media/vendor/tinymce/skins/ui/oxide/skin.min.css`, tinyWrongMap, { encoding: 'utf8', mode: 0o644 });
 
   // Restore our code on the vendor folders
   await copy(join(RootPath, 'build/media_source/vendor/tinymce/templates'), join(RootPath, 'media/vendor/tinymce/templates'), { preserveTimestamps: true });

--- a/build/build-modules-js/init/localise-packages.es6.js
+++ b/build/build-modules-js/init/localise-packages.es6.js
@@ -20,7 +20,7 @@ const copyFilesTo = async (files, srcDir, destDir) => {
 
   async function doTheCopy(source, dest) {
     await ensureDir(dirname(dest));
-    await copy(source, dest);
+    await copy(source, dest, { preserveTimestamps: true });
   }
 
   // Copy each file
@@ -70,6 +70,7 @@ const resolvePackage = async (vendor, packageName, mediaVendorPath, options, reg
     await copy(
       `${join(RootPath, `node_modules/${packageName}`)}/${options.settings.vendors[packageName].licenseFilename}`,
       `${dest}/${options.settings.vendors[packageName].licenseFilename}`,
+      { preserveTimestamps: true },
     );
   }
 
@@ -127,7 +128,7 @@ module.exports.localisePackages = async (options) => {
   const promises = [];
 
   if (!await existsSync(mediaVendorPath)) {
-    await mkdir(mediaVendorPath, { recursive: true });
+    await mkdir(mediaVendorPath, { recursive: true, mode: 0o755 });
   }
 
   // Loop to get some text for the package.json
@@ -144,6 +145,6 @@ module.exports.localisePackages = async (options) => {
   await writeFile(
     join(mediaVendorPath, 'joomla.asset.json'),
     JSON.stringify(registry, null, 2),
-    { encoding: 'utf8' },
+    { encoding: 'utf8', mode: 0o2644 },
   );
 };

--- a/build/build-modules-js/init/localise-packages.es6.js
+++ b/build/build-modules-js/init/localise-packages.es6.js
@@ -145,6 +145,6 @@ module.exports.localisePackages = async (options) => {
   await writeFile(
     join(mediaVendorPath, 'joomla.asset.json'),
     JSON.stringify(registry, null, 2),
-    { encoding: 'utf8', mode: 0o2644 },
+    { encoding: 'utf8', mode: 0o644 },
   );
 };

--- a/build/build-modules-js/init/minify-vendor.es6.js
+++ b/build/build-modules-js/init/minify-vendor.es6.js
@@ -75,7 +75,7 @@ const minifyJS = async (file) => {
   await writeFile(
     newFile,
     minified,
-    { encoding: 'utf8', mode: 0o2644 },
+    { encoding: 'utf8', mode: 0o644 },
   );
 };
 

--- a/build/build-modules-js/init/minify-vendor.es6.js
+++ b/build/build-modules-js/init/minify-vendor.es6.js
@@ -75,7 +75,7 @@ const minifyJS = async (file) => {
   await writeFile(
     newFile,
     minified,
-    { encoding: 'utf8' },
+    { encoding: 'utf8', mode: 0o2644 },
   );
 };
 

--- a/build/build-modules-js/init/patches.es6.js
+++ b/build/build-modules-js/init/patches.es6.js
@@ -21,12 +21,12 @@ module.exports.patchPackages = async (options) => {
   ChosenJs = ChosenJs.replace('}).call(this);', `  document.AbstractChosen = AbstractChosen;
   document.Chosen = Chosen;
 }).call(this);`);
-  await writeFile(chosenPath, ChosenJs, { encoding: 'utf8' });
+  await writeFile(chosenPath, ChosenJs, { encoding: 'utf8', mode: 0o2644 });
 
   // Append initialising code to the end of the Short-and-Sweet javascript
   dest = join(mediaVendorPath, 'short-and-sweet');
   const shortandsweetPath = `${dest}/${options.settings.vendors['short-and-sweet'].js['dist/short-and-sweet.min.js']}`;
   let ShortandsweetJs = await readFile(shortandsweetPath, { encoding: 'utf8' });
   ShortandsweetJs = ShortandsweetJs.concat('shortAndSweet(\'textarea.charcount\', {counterClassName: \'small text-muted\'});');
-  await writeFile(shortandsweetPath, ShortandsweetJs, { encoding: 'utf8' });
+  await writeFile(shortandsweetPath, ShortandsweetJs, { encoding: 'utf8', mode: 0o2644 });
 };

--- a/build/build-modules-js/init/patches.es6.js
+++ b/build/build-modules-js/init/patches.es6.js
@@ -21,12 +21,12 @@ module.exports.patchPackages = async (options) => {
   ChosenJs = ChosenJs.replace('}).call(this);', `  document.AbstractChosen = AbstractChosen;
   document.Chosen = Chosen;
 }).call(this);`);
-  await writeFile(chosenPath, ChosenJs, { encoding: 'utf8', mode: 0o2644 });
+  await writeFile(chosenPath, ChosenJs, { encoding: 'utf8', mode: 0o644 });
 
   // Append initialising code to the end of the Short-and-Sweet javascript
   dest = join(mediaVendorPath, 'short-and-sweet');
   const shortandsweetPath = `${dest}/${options.settings.vendors['short-and-sweet'].js['dist/short-and-sweet.min.js']}`;
   let ShortandsweetJs = await readFile(shortandsweetPath, { encoding: 'utf8' });
   ShortandsweetJs = ShortandsweetJs.concat('shortAndSweet(\'textarea.charcount\', {counterClassName: \'small text-muted\'});');
-  await writeFile(shortandsweetPath, ShortandsweetJs, { encoding: 'utf8', mode: 0o2644 });
+  await writeFile(shortandsweetPath, ShortandsweetJs, { encoding: 'utf8', mode: 0o644 });
 };

--- a/build/build-modules-js/init/recreate-media.es6.js
+++ b/build/build-modules-js/init/recreate-media.es6.js
@@ -48,5 +48,5 @@ module.exports.recreateMediaFolder = async (options) => {
     return true;
   };
 
-  await copy(join(RootPath, 'build/media_source'), join(RootPath, 'media'), { filter: filterFunc });
+  await copy(join(RootPath, 'build/media_source'), join(RootPath, 'media'), { filter: filterFunc, preserveTimestamps: true });
 };

--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -19,8 +19,8 @@ const getCurrentUnixTime = Math.round((new Date()).getTime() / 1000);
 const createMinified = async (file) => {
   const initial = await readFile(resolve(outputFolder, file), { encoding: 'utf8' });
   const mini = await minify(initial.replace('./popper.js', `./popper.min.js?${getCurrentUnixTime}`).replace('./dom.js', `./dom.min.js?${getCurrentUnixTime}`), { sourceMap: false, format: { comments: false } });
-  await writeFile(resolve(outputFolder, file), initial.replace('./popper.js', `./popper.js?${getCurrentUnixTime}`).replace('./dom.js', `./dom.js?${getCurrentUnixTime}`), { encoding: 'utf8', mode: 0o2644 });
-  await writeFile(resolve(outputFolder, file.replace('.js', '.min.js')), mini.code, { encoding: 'utf8', mode: 0o2644 });
+  await writeFile(resolve(outputFolder, file), initial.replace('./popper.js', `./popper.js?${getCurrentUnixTime}`).replace('./dom.js', `./dom.js?${getCurrentUnixTime}`), { encoding: 'utf8', mode: 0o644 });
+  await writeFile(resolve(outputFolder, file.replace('.js', '.min.js')), mini.code, { encoding: 'utf8', mode: 0o644 });
 };
 
 const build = async () => {
@@ -171,7 +171,7 @@ module.exports.bootstrapJs = async () => {
       await buildLegacy(inputFolder, 'index.es6.js');
       const es5File = await readFile(resolve(outputFolder, 'bootstrap-es5.js'), { encoding: 'utf8' });
       const mini = await minify(es5File, { sourceMap: false, format: { comments: false } });
-      await writeFile(resolve(outputFolder, 'bootstrap-es5.min.js'), mini.code, { encoding: 'utf8', mode: 0o2644 });
+      await writeFile(resolve(outputFolder, 'bootstrap-es5.min.js'), mini.code, { encoding: 'utf8', mode: 0o644 });
       // eslint-disable-next-line no-console
       console.log('✅ Legacy done!');
     } catch (error) {

--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -19,8 +19,8 @@ const getCurrentUnixTime = Math.round((new Date()).getTime() / 1000);
 const createMinified = async (file) => {
   const initial = await readFile(resolve(outputFolder, file), { encoding: 'utf8' });
   const mini = await minify(initial.replace('./popper.js', `./popper.min.js?${getCurrentUnixTime}`).replace('./dom.js', `./dom.min.js?${getCurrentUnixTime}`), { sourceMap: false, format: { comments: false } });
-  await writeFile(resolve(outputFolder, file), initial.replace('./popper.js', `./popper.js?${getCurrentUnixTime}`).replace('./dom.js', `./dom.js?${getCurrentUnixTime}`), { encoding: 'utf8' });
-  await writeFile(resolve(outputFolder, file.replace('.js', '.min.js')), mini.code, { encoding: 'utf8' });
+  await writeFile(resolve(outputFolder, file), initial.replace('./popper.js', `./popper.js?${getCurrentUnixTime}`).replace('./dom.js', `./dom.js?${getCurrentUnixTime}`), { encoding: 'utf8', mode: 0o2644 });
+  await writeFile(resolve(outputFolder, file.replace('.js', '.min.js')), mini.code, { encoding: 'utf8', mode: 0o2644 });
 };
 
 const build = async () => {
@@ -171,7 +171,7 @@ module.exports.bootstrapJs = async () => {
       await buildLegacy(inputFolder, 'index.es6.js');
       const es5File = await readFile(resolve(outputFolder, 'bootstrap-es5.js'), { encoding: 'utf8' });
       const mini = await minify(es5File, { sourceMap: false, format: { comments: false } });
-      await writeFile(resolve(outputFolder, 'bootstrap-es5.min.js'), mini.code, { encoding: 'utf8' });
+      await writeFile(resolve(outputFolder, 'bootstrap-es5.min.js'), mini.code, { encoding: 'utf8', mode: 0o2644 });
       // eslint-disable-next-line no-console
       console.log('✅ Legacy done!');
     } catch (error) {

--- a/build/build-modules-js/javascript/handle-es5.es6.js
+++ b/build/build-modules-js/javascript/handle-es5.es6.js
@@ -9,7 +9,7 @@ module.exports.handleES5File = async (file) => {
     // ES5 file, we will copy the file and then minify it in place
     // Ensure that the directories exist or create them
     await FsExtra.ensureDir(dirname(file).replace(`${sep}build${sep}media_source${sep}`, `${sep}media${sep}`));
-    await FsExtra.copy(file, file.replace(`${sep}build${sep}media_source${sep}`, `${sep}media${sep}`).replace('.es5.js', '.js'));
+    await FsExtra.copy(file, file.replace(`${sep}build${sep}media_source${sep}`, `${sep}media${sep}`).replace('.es5.js', '.js'), { preserveTimestamps: true });
     // eslint-disable-next-line no-console
     console.log(`Legacy js file: ${basename(file)}: ✅ copied`);
 

--- a/build/build-modules-js/javascript/minify.es6.js
+++ b/build/build-modules-js/javascript/minify.es6.js
@@ -10,7 +10,7 @@ const { basename } = require('path');
 const minifyFile = async (file) => {
   const fileContent = await readFile(file, { encoding: 'utf8' });
   const content = await minify(fileContent, { sourceMap: false, format: { comments: false } });
-  await writeFile(file.replace('.js', '.min.js'), content.code, { encoding: 'utf8', mode: 0o2644 });
+  await writeFile(file.replace('.js', '.min.js'), content.code, { encoding: 'utf8', mode: 0o644 });
   // eslint-disable-next-line no-console
   console.log(`Legacy js file: ${basename(file)}: ✅ minified`);
 };

--- a/build/build-modules-js/javascript/minify.es6.js
+++ b/build/build-modules-js/javascript/minify.es6.js
@@ -10,7 +10,7 @@ const { basename } = require('path');
 const minifyFile = async (file) => {
   const fileContent = await readFile(file, { encoding: 'utf8' });
   const content = await minify(fileContent, { sourceMap: false, format: { comments: false } });
-  await writeFile(file.replace('.js', '.min.js'), content.code, { encoding: 'utf8' });
+  await writeFile(file.replace('.js', '.min.js'), content.code, { encoding: 'utf8', mode: 0o2644 });
   // eslint-disable-next-line no-console
   console.log(`Legacy js file: ${basename(file)}: ✅ minified`);
 };

--- a/build/build-modules-js/stylesheets/handle-css.es6.js
+++ b/build/build-modules-js/stylesheets/handle-css.es6.js
@@ -14,7 +14,7 @@ module.exports.handleCssFile = async (file) => {
     await ensureDir(dirname(outputFile), { recursive: true, mode: 0o2644 });
 
     if (file !== outputFile) {
-      await copy(file, outputFile, { overwrite: true });
+      await copy(file, outputFile, { preserveTimestamps: true, overwrite: true });
     }
 
     const content = await readFile(file, { encoding: 'utf8' });

--- a/build/build-modules-js/stylesheets/handle-css.es6.js
+++ b/build/build-modules-js/stylesheets/handle-css.es6.js
@@ -11,7 +11,7 @@ module.exports.handleCssFile = async (file) => {
   try {
     // CSS file, we will copy the file and then minify it in place
     // Ensure that the directories exist or create them
-    await ensureDir(dirname(outputFile), { recursive: true, mode: 0o644 });
+    await ensureDir(dirname(outputFile), { recursive: true, mode: 0o755 });
 
     if (file !== outputFile) {
       await copy(file, outputFile, { preserveTimestamps: true, overwrite: true });

--- a/build/build-modules-js/stylesheets/handle-css.es6.js
+++ b/build/build-modules-js/stylesheets/handle-css.es6.js
@@ -11,7 +11,7 @@ module.exports.handleCssFile = async (file) => {
   try {
     // CSS file, we will copy the file and then minify it in place
     // Ensure that the directories exist or create them
-    await ensureDir(dirname(outputFile), { recursive: true, mode: 0o2644 });
+    await ensureDir(dirname(outputFile), { recursive: true, mode: 0o644 });
 
     if (file !== outputFile) {
       await copy(file, outputFile, { preserveTimestamps: true, overwrite: true });
@@ -21,7 +21,7 @@ module.exports.handleCssFile = async (file) => {
     const cssMin = await Postcss([Autoprefixer, CssNano]).process(content, { from: undefined });
 
     // Ensure the folder exists or create it
-    await writeFile(outputFile.replace('.css', '.min.css'), cssMin.css.toString(), { encoding: 'utf8', mode: 0o2644 });
+    await writeFile(outputFile.replace('.css', '.min.css'), cssMin.css.toString(), { encoding: 'utf8', mode: 0o644 });
 
     // eslint-disable-next-line no-console
     console.log(`✅ CSS file copied/minified: ${file}`);

--- a/build/build-modules-js/stylesheets/handle-scss.es6.js
+++ b/build/build-modules-js/stylesheets/handle-scss.es6.js
@@ -29,7 +29,7 @@ module.exports.handleScssFile = async (file) => {
   await writeFile(
     cssFile,
     res.css,
-    { encoding: 'utf8', mode: 0o2644 },
+    { encoding: 'utf8', mode: 0o644 },
   );
 
   const cssMin = await Postcss([CssNano]).process(res.css, { from: undefined });
@@ -39,7 +39,7 @@ module.exports.handleScssFile = async (file) => {
   await writeFile(
     cssFile.replace('.css', '.min.css'),
     cssMin.css,
-    { encoding: 'utf8', mode: 0o2644 },
+    { encoding: 'utf8', mode: 0o644 },
   );
 
   // eslint-disable-next-line no-console

--- a/build/build-modules-js/stylesheets/scss-transform.es6.js
+++ b/build/build-modules-js/stylesheets/scss-transform.es6.js
@@ -31,7 +31,7 @@ module.exports.compile = async (file) => {
   await Fs.writeFile(
     cssFile,
     res.css.toString(),
-    { encoding: 'utf8', mode: 0o2644 },
+    { encoding: 'utf8', mode: 0o644 },
   );
 
   const cssMin = await Postcss([CssNano]).process(res.css.toString(), { from: undefined });
@@ -41,7 +41,7 @@ module.exports.compile = async (file) => {
   await Fs.writeFile(
     cssFile.replace('.css', '.min.css'),
     cssMin.css.toString(),
-    { encoding: 'utf8', mode: 0o2644 },
+    { encoding: 'utf8', mode: 0o644 },
   );
 
   // eslint-disable-next-line no-console

--- a/build/build-modules-js/versioning.es6.js
+++ b/build/build-modules-js/versioning.es6.js
@@ -101,7 +101,7 @@ const fixVersion = async (directory) => {
   await Promise.all(processes);
 
   jsonData.assets = final[directory];
-  await writeFile(`${RootPath}${sep}media${sep}${directory}${sep}joomla.asset.json`, JSON.stringify(jsonData, '', 2), { encoding: 'utf8', mode: 0o2644 });
+  await writeFile(`${RootPath}${sep}media${sep}${directory}${sep}joomla.asset.json`, JSON.stringify(jsonData, '', 2), { encoding: 'utf8', mode: 0o644 });
 };
 
 /**

--- a/build/build-modules-js/versioning.es6.js
+++ b/build/build-modules-js/versioning.es6.js
@@ -101,7 +101,7 @@ const fixVersion = async (directory) => {
   await Promise.all(processes);
 
   jsonData.assets = final[directory];
-  await writeFile(`${RootPath}${sep}media${sep}${directory}${sep}joomla.asset.json`, JSON.stringify(jsonData, '', 2), { encoding: 'utf8' });
+  await writeFile(`${RootPath}${sep}media${sep}${directory}${sep}joomla.asset.json`, JSON.stringify(jsonData, '', 2), { encoding: 'utf8', mode: 0o2644 });
 };
 
 /**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- adds a flag to preserve the timestamps for folder/files copied from `build/media_source` to `media`
- adds a flag for `mkdir` to use `mode: 0o755`
- adds a flag for `writeFile` to use `mode: 0o644` and also `encoding: 'utf8'`
 
### Testing Instructions

The timestamp flag is documented here: https://github.com/jprichardson/node-fs-extra/blob/master/docs/copy.md

The flags mode and encoding for `writeFile`: https://nodejs.org/api/fs.html#fs_fspromises_writefile_file_data_options

The flags recursive and mode for `mkdir`: https://nodejs.org/api/fs.html#fs_fspromises_mkdir_path_options

Check that ALL files are still generated and with correct timestamps and mode

 
### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

No