### PR TITLE
Removed fixed width of logo in Cassiopeia header

### DIFF
--- a/templates/cassiopeia/images/logo.svg
+++ b/templates/cassiopeia/images/logo.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 647 70"><title>logo</title>
+<svg width="288" height="31" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 647 70"><title>logo</title>
 <path d="M306,248h0c0-19,14-35,35-35s20,4,26,10l-9,11c-5-5-10-8-17-8s-19,9-19,21h0c0,12,8,21,19,21s12-3,17-8l9,10c-7,7-14,12-27,12S306,268,306,248Z" transform="translate(-306 -213)" style="fill:#fff"/>
 <path d="M407,214h13l28,68H433l-6-15H399l-6,15H378Zm15,40-9-22-9,22Z" transform="translate(-306 -213)" style="fill:#fff"/>
 <path d="M458,272l9-11c6,5,12,8,20,8s10-2,10-6h0c0-4-2-6-13-9s-22-7-22-21h0c0-12,10-20,23-20a38,38,0,0,1,25,9l-8,11c-6-4-12-7-17-7s-9,3-9,6h0c0,4,3,6,14,9s21,9,21,20h0c0,13-10,21-24,21A42,42,0,0,1,458,272Z" transform="translate(-306 -213)" style="fill:#fff"/>

--- a/templates/cassiopeia/images/logo.svg
+++ b/templates/cassiopeia/images/logo.svg
@@ -1,4 +1,4 @@
-<svg width="18em" height="2em" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 647 70"><title>logo</title>
+<svg width="288" height="32" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 647 70"><title>logo</title>
 <path d="M306,248h0c0-19,14-35,35-35s20,4,26,10l-9,11c-5-5-10-8-17-8s-19,9-19,21h0c0,12,8,21,19,21s12-3,17-8l9,10c-7,7-14,12-27,12S306,268,306,248Z" transform="translate(-306 -213)" style="fill:#fff"/>
 <path d="M407,214h13l28,68H433l-6-15H399l-6,15H378Zm15,40-9-22-9,22Z" transform="translate(-306 -213)" style="fill:#fff"/>
 <path d="M458,272l9-11c6,5,12,8,20,8s10-2,10-6h0c0-4-2-6-13-9s-22-7-22-21h0c0-12,10-20,23-20a38,38,0,0,1,25,9l-8,11c-6-4-12-7-17-7s-9,3-9,6h0c0,4,3,6,14,9s21,9,21,20h0c0,13-10,21-24,21A42,42,0,0,1,458,272Z" transform="translate(-306 -213)" style="fill:#fff"/>

--- a/templates/cassiopeia/images/logo.svg
+++ b/templates/cassiopeia/images/logo.svg
@@ -1,4 +1,4 @@
-<svg width="288" height="31" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 647 70"><title>logo</title>
+<svg width="18em" height="2em" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 647 70"><title>logo</title>
 <path d="M306,248h0c0-19,14-35,35-35s20,4,26,10l-9,11c-5-5-10-8-17-8s-19,9-19,21h0c0,12,8,21,19,21s12-3,17-8l9,10c-7,7-14,12-27,12S306,268,306,248Z" transform="translate(-306 -213)" style="fill:#fff"/>
 <path d="M407,214h13l28,68H433l-6-15H399l-6,15H378Zm15,40-9-22-9,22Z" transform="translate(-306 -213)" style="fill:#fff"/>
 <path d="M458,272l9-11c6,5,12,8,20,8s10-2,10-6h0c0-4-2-6-13-9s-22-7-22-21h0c0-12,10-20,23-20a38,38,0,0,1,25,9l-8,11c-6-4-12-7-17-7s-9,3-9,6h0c0,4,3,6,14,9s21,9,21,20h0c0,13-10,21-24,21A42,42,0,0,1,458,272Z" transform="translate(-306 -213)" style="fill:#fff"/>

--- a/templates/cassiopeia/scss/blocks/_header.scss
+++ b/templates/cassiopeia/scss/blocks/_header.scss
@@ -38,11 +38,6 @@
       margin-left: auto;
     }
 
-    img {
-      width: 18rem;
-      min-width: 18rem;
-    }
-
     a {
       color: $white;
     }


### PR DESCRIPTION
Pull Request for Issue #35314

### Summary of Changes
The logo has a fixed width which will resize custom banner images. Smaller images will be scaled up which results in blur images. This PR adds a size to the Cassiopeia logo image/svg and removes the fixed width of the logo in the CSS.

### Testing Instructions
See Issue #35314 to reproduce the issue. after applying the PR the issue is fixes,

### Actual result BEFORE applying this Pull Request
Custom logo is stretched if the banner image is smaller the the original Cassiopeia image.

### Expected result AFTER applying this Pull Request
Custom logo has the correct size an scales nicely on mobile

### Documentation Changes Required
No
