### PR TITLE
[4] Fix spinner bg

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
@@ -117,7 +117,7 @@ $updatePossible = true;
 			<button class="nav-link d-flex justify-content-between align-items-center" id="joomlaupdate-precheck-extensions-tab" data-bs-toggle="pill" data-bs-target="#joomlaupdate-precheck-extensions-content" type="button" role="tab" aria-controls="joomlaupdate-precheck-extensions-content" aria-selected="false">
 				<?php echo Text::_('COM_JOOMLAUPDATE_PREUPDATE_EXTENSIONS'); ?>
 				<?php $labelClass = 'success'; ?>
-				<span class="fa fa-spinner fa-spin fa-fw py-1 bg-white ms-2 text-info" aria-hidden="true"></span>
+				<span class="fa fa-spinner fa-spin fa-fw py-1 ms-2" aria-hidden="true"></span>
 			</button>
 		</div>
 

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -123,7 +123,7 @@ Joomla = window.Joomla || {};
       default:
     }
     if (infoIcon) {
-      infoIcon.classList.remove('fa-spinner', 'fa-spin', 'text-info');
+      infoIcon.classList.remove('fa-spinner', 'fa-spin');
       infoIcon.classList.add(`fa-${iconClass}`, `text-${iconColor}`, 'bg-white');
     }
     // Hide table of addons to load

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -124,7 +124,7 @@ Joomla = window.Joomla || {};
     }
     if (infoIcon) {
       infoIcon.classList.remove('fa-spinner', 'fa-spin', 'text-info');
-      infoIcon.classList.add(`fa-${iconClass}`, `text-${iconColor}`);
+      infoIcon.classList.add(`fa-${iconClass}`, `text-${iconColor}`, 'bg-white');
     }
     // Hide table of addons to load
     const checkedExtensions = document.querySelector('#compatibilityTable0');


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/35334

### Summary of Changes

dont hardcode color

remember to `nom run build:js`

### Testing Instructions

slow down the checking of `fetchExtensionCompatibility` method by putting in a `sleep(10);` in the method.

look at the icons - click the tab on and off checking the colour - after 10 seconds see triangle has white bg

### Actual result BEFORE applying this Pull Request

![68747470733a2f2f6973737565732e6a6f6f6d6c612e6f72672f75706c6f6164732f312f66303337646639316665316333646132303832343835636466316235393438612e676966](https://user-images.githubusercontent.com/400092/130598523-fade4857-da75-463a-ad6f-2ee8167c44ee.gif)


### Expected result AFTER applying this Pull Request

<img width="245" alt="Screenshot 2021-08-24 at 11 04 37" src="https://user-images.githubusercontent.com/400092/130598419-1349c24f-43de-4cb6-9ffb-097ebbddcc75.png">
<img width="242" alt="Screenshot 2021-08-24 at 11 04 34" src="https://user-images.githubusercontent.com/400092/130598426-54fdfc9a-e8dc-41d7-9b3c-2db329981a1a.png">
<img width="276" alt="Screenshot 2021-08-24 at 11 06 50" src="https://user-images.githubusercontent.com/400092/130598465-7eb8d3c8-bac3-40a3-80e8-e8adb6a7eb52.png">


### Documentation Changes Required

