### PR TITLE
[4] Catch LDAP Connection exceptions

### DIFF
--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -85,7 +85,7 @@ class PlgAuthenticationLdap extends CMSPlugin
 
 					$ldap->bind($dn, $this->params->get('password', ''));
 				}
-				catch (ConnectionException|LdapException $exception)
+				catch (ConnectionException | LdapException $exception)
 				{
 					$response->status = Authentication::STATUS_FAILURE;
 					$response->error_message = Text::_('JGLOBAL_AUTH_NOT_CONNECT');

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -85,14 +85,7 @@ class PlgAuthenticationLdap extends CMSPlugin
 
 					$ldap->bind($dn, $this->params->get('password', ''));
 				}
-				catch (ConnectionException $exception) {
-					$response->status = Authentication::STATUS_FAILURE;
-					$response->error_message = Text::_('JGLOBAL_AUTH_NOT_CONNECT');
-
-					return;
-				}
-				catch (LdapException $exception)
-				{
+				catch (ConnectionException|LdapException $exception) {
 					$response->status = Authentication::STATUS_FAILURE;
 					$response->error_message = Text::_('JGLOBAL_AUTH_NOT_CONNECT');
 

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -144,7 +144,7 @@ class PlgAuthenticationLdap extends CMSPlugin
 				{
 					$ldap->bind($ldap->escape($credentials['username'], '', LDAP_ESCAPE_DN), $credentials['password']);
 				}
-				catch (ConnectionException $exception)
+				catch (ConnectionException | LdapException $exception)
 				{
 					$response->status = Authentication::STATUS_FAILURE;
 					$response->error_message = Text::_('JGLOBAL_AUTH_INVALID_PASS');

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -85,7 +85,13 @@ class PlgAuthenticationLdap extends CMSPlugin
 
 					$ldap->bind($dn, $this->params->get('password', ''));
 				}
-				catch (ConnectionException $exception)
+				catch (ConnectionException $exception) {
+					$response->status = Authentication::STATUS_FAILURE;
+					$response->error_message = Text::_('JGLOBAL_AUTH_NOT_CONNECT');
+
+					return;
+				}
+				catch (LdapException $exception)
 				{
 					$response->status = Authentication::STATUS_FAILURE;
 					$response->error_message = Text::_('JGLOBAL_AUTH_NOT_CONNECT');

--- a/plugins/authentication/ldap/ldap.php
+++ b/plugins/authentication/ldap/ldap.php
@@ -85,7 +85,8 @@ class PlgAuthenticationLdap extends CMSPlugin
 
 					$ldap->bind($dn, $this->params->get('password', ''));
 				}
-				catch (ConnectionException|LdapException $exception) {
+				catch (ConnectionException|LdapException $exception)
+				{
 					$response->status = Authentication::STATUS_FAILURE;
 					$response->error_message = Text::_('JGLOBAL_AUTH_NOT_CONNECT');
 


### PR DESCRIPTION
### Summary of Changes

When trying to login, with a username/password that doesnt match the internal Joomla database of users, and with LDAP configured, but the LDAP server is down, Symfony LDAP currently throws an `LdapException` that is not caught

This PR catches that (using PHP 7.1 piped exceptions - thanks @mbabker) and displays a normal Joomla based message instead of a displaying an uncaught exception.

### Testing Instructions

# YOU DONT NEED LDAP EXPERIENCE OR AN LDAP SERVER TO TEST THIS !!

Configure the LDAP Authentication Plugin, making sure that whatever you put in the HOST field is a valid IP or server, but NOT a valid LDAP service running on that host - my settings:

<img width="454" alt="Screenshot 2021-08-24 at 15 50 34" src="https://user-images.githubusercontent.com/400092/130638857-e98e2f95-255b-47c4-bfa5-06bf92dc987c.png">


try to login to Joomla admin with fake credentials.

### Actual result BEFORE applying this Pull Request

<img width="676" alt="Screenshot 2021-08-24 at 15 46 27" src="https://user-images.githubusercontent.com/400092/130638636-5de68f3f-41ed-4911-b94e-a3ccd06abe41.png">

or with debug enabled

<img width="1598" alt="Screenshot 2021-08-24 at 15 45 47" src="https://user-images.githubusercontent.com/400092/130638668-c681259f-5637-4aa6-a7e4-18509827bb5e.png">


### Expected result AFTER applying this Pull Request

<img width="506" alt="Screenshot 2021-08-24 at 15 45 37" src="https://user-images.githubusercontent.com/400092/130638649-292ec0a3-174d-4978-885f-3c24e54f8f58.png">


### Documentation Changes Required

None