### PR TITLE
[4] Include custom fatal page so that any post-processing, alerting, can happen as designed

### DIFF
--- a/templates/system/fatal.php
+++ b/templates/system/fatal.php
@@ -40,7 +40,9 @@ if (file_exists(__DIR__ . '/fatal-error.html'))
  */
 if (file_exists(__DIR__ . '/fatal-error.custom.php'))
 {
-	$template = file_get_contents(__DIR__ . '/fatal-error.custom.php');
+	require __DIR__ . '/fatal-error.custom.php';
+
+	return;
 }
 
 echo str_replace(


### PR DESCRIPTION
My bad again. Sorry. 

### Summary of Changes

In Joomla 3 fatal errors (like cant connect to the db) are shows like this `Error` - yup thats it, one word in black on a white blank page.

In Joomla 4 we moved to handling fatal errors with the Symfony Error Handler (not my work), and more importantly we (I) [implemented a custom template](https://github.com/joomla/joomla-cms/pull/30056) after changes [were merged upstream in Symfony](https://github.com/symfony/symfony/pull/37492#event-3519270830).

Joomla 4.0.0 was the first product to ever be published with a custom Symfony Error Page 🎉

This gave us the (now almost infamous) red page of death when a fatal error happens on the frontend of Joomla 4.

<img width="1485" alt="Screenshot 2021-08-24 at 21 31 56" src="https://user-images.githubusercontent.com/400092/130685813-18bf87dc-38f8-48b2-abcf-1ef504c9b9bd.png">

(Many people are seeing this - when upgrading to Joomla 4 without reading, and with incompatible plugins - thats its job after all! )

One of the principles that was implemented was the introduction of a `fatal-error.custom.php` file that template designers could drop into `templates/system/` which could be used instead of the red screen of death - for the purposes (as documented in `fatal.php`) of:

```
 * Allow overriding Joomla supplied page to prevent changes being wiped on Joomla upgrade.
 * We allow it to be a PHP file so that any post-processing, alerting etc can happen.
```

However, as implemented prior to this PR, any PHP code in the `fatal-error.custom.php` would not actually parse!!!! Doh! as the content of the file was loaded with `file_get_contents` and then `echo` to the response. 

This PR fixes the invalid implementation by correctly including the file, allowing any PHP to parse (This allows the developer to use PHP to call a remote service, display dynamic data, send an email alerting apps, Sentry.io etc)

### Testing Instructions

1) Get a working Joomla 4 site
2) Change your db username to be invalid
3) Visit your home page - see red screen of death
4) create a new `/templates/system/fatal-error.custom.php` file with `<?php echo 'Hello World';` as its content.
5) Visit your home page - see white screen of death, inspect the HTML response and see that `<?php echo 'Hello World';` in unparsed and just output as the response
6) APPLY PR
7) Visit your home page - see `Hello World`

For bonus points, note you can do:

```php
<?php
echo $statusCode;
echo $statusText;
?>
```
and get an output of `HELLO WORLD500Whoops, looks like something went wrong.` this proves that the original status are being passed through for custom template designers to style/place however they like. 

For more bonus points in `configuration.php` set `$debug = true;` and see the Symfony Debug Trace - just to show you what the red page of death is actually "hiding" from your site visitors! 

REMEMBER this "red page of death" is a **FATAL ERROR page, its NOT MEANT to ever be shown in real life. ITS NOT THE ERROR PAGE, its a FATAL error page.** The lowest of the low. Again this is the reason the custom template is NOT in the `template/my_template/` folder but available to be placed in the `templates/system/` folder - because at the FATAL ERROR state  it cannot be assumed that any part of Joomla is available (Eg: a Factory or application or db connection) 

### Actual result BEFORE applying this Pull Request

The content of the `fatal-error.custom.php` would be rendered in the source of the response - even if it was PHP.

PHP would not be parsed, just outputted. 

### Expected result AFTER applying this Pull Request

The PHP in `fatal-error.custom.php` is now parsed, triggered, and runs as expected and as originally designed for this feature. 

Custom template developers can go mad and replace the "Red Screen Of Death" with something else...  and can include PHP which is parsed.

<img width="1366" alt="Screenshot 2021-08-24 at 21 38 23" src="https://user-images.githubusercontent.com/400092/130686676-f390736c-202d-43cf-a8c8-9bbc717d6550.png">


### Documentation Changes Required

None. Joomla 4 is so new I doubt anyone has noticed this is even possible yet :) 

ref: 
@Webdongle https://forum.joomla.org/viewtopic.php?f=810&t=987965&p=3637277#p3637277