### PR TITLE
[4.0] Added clear('order') in _getListCount(Query) of DataBaseModel.php

### DIFF
--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -177,9 +177,8 @@ abstract class BaseDatabaseModel extends BaseModel implements DatabaseModelInter
 		}
 
 		// Otherwise fall back to inefficient way of counting all results.
-
-		// Remove the limit and offset part if it's a DatabaseQuery object
-		// The order part is removed, as it is not needed for counting and could otherwise worsen the performance.
+		
+		// Remove the limit, offset and order parts if it's a DatabaseQuery object
 		if ($query instanceof DatabaseQuery)
 		{
 			$query = clone $query;

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -177,7 +177,7 @@ abstract class BaseDatabaseModel extends BaseModel implements DatabaseModelInter
 		}
 
 		// Otherwise fall back to inefficient way of counting all results.
-		
+
 		// Remove the limit, offset and order parts if it's a DatabaseQuery object
 		if ($query instanceof DatabaseQuery)
 		{

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -182,7 +182,7 @@ abstract class BaseDatabaseModel extends BaseModel implements DatabaseModelInter
 		if ($query instanceof DatabaseQuery)
 		{
 			$query = clone $query;
-			$query->clear('limit')->clear('offset');
+			$query->clear('limit')->clear('offset')->clear('order');
 		}
 
 		$this->getDbo()->setQuery($query);

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -179,6 +179,7 @@ abstract class BaseDatabaseModel extends BaseModel implements DatabaseModelInter
 		// Otherwise fall back to inefficient way of counting all results.
 
 		// Remove the limit and offset part if it's a DatabaseQuery object
+		// The order part is removed, as it is not needed for counting and could otherwise worsen the performance.
 		if ($query instanceof DatabaseQuery)
 		{
 			$query = clone $query;


### PR DESCRIPTION
### Introduction

When creating PR #35341, we noticed that the `_getListCount(Query)` of `DataBaseModel.php` did not clear the order of the query in the second if-statement. Because it is not important for a count function in which order the results are placed and could represent a performance problem in the future when using other queries, so we have added the clear function.

### Summary of Changes

In the method `_getListCount(Query)` of `DataBaseModel.php` the order was also cleared in the second if-statement.

### Testing Instructions

1. Install Joomla 4.0
2. Install Sample Data
3. Activate the Debug Tool *System -> Global Config -> Debug System on*
4. Open the Smart Search
5. Search for a word
6. For example, look for the query as in *Actual result BEFORE applying this Pull Request*
7. Repeat the steps with this PR

### Actual result BEFORE applying this Pull Request

Search Query contains an **Order BY**.

```sql
SELECT l.link_id, l.object,SUM(m.weight) AS ordering
FROM kaftq_finder_links AS l
INNER JOIN `kaftq_finder_links_terms` AS m ON m.link_id = l.link_id
WHERE `l`.`access` IN (:preparedArray1,:preparedArray2,:preparedArray3) AND l.state = 1 AND l.published = 1 AND (l.publish_start_date IS NULL OR l.publish_start_date <= '2021-08-25 08:24:00') AND (l.publish_end_date IS NULL OR l.publish_end_date >= '2021-08-25 08:24:00') AND m.term_id IN (11)
GROUP BY l.link_id,l.object
HAVING SUM(CASE WHEN m.term_id IN (11) THEN 1 ELSE 0 END) > 0
ORDER BY ordering DESC
```

### Expected result AFTER applying this Pull Request

Search Query no longer contains an **Order BY**.

```sql
SELECT l.link_id, l.object,SUM(m.weight) AS ordering
FROM kaftq_finder_links AS l
INNER JOIN `kaftq_finder_links_terms` AS m ON m.link_id = l.link_id
WHERE `l`.`access` IN (:preparedArray1,:preparedArray2,:preparedArray3) AND l.state = 1 AND l.published = 1 AND (l.publish_start_date IS NULL OR l.publish_start_date <= '2021-08-25 08:23:00') AND (l.publish_end_date IS NULL OR l.publish_end_date >= '2021-08-25 08:23:00') AND m.term_id IN (11)
GROUP BY l.link_id,l.object
HAVING SUM(CASE WHEN m.term_id IN (11) THEN 1 ELSE 0 END) > 0
```

### Documentation Changes Required

Probably not.

### Contributers
@scout507 @waleet