### PR TITLE
[4][com_finder] min value zero for Multiplier options

### DIFF
--- a/administrator/components/com_finder/config.xml
+++ b/administrator/components/com_finder/config.xml
@@ -278,6 +278,7 @@
 			type="number"
 			label="COM_FINDER_CONFIG_TITLE_MULTIPLIER_LABEL"
 			default="1.7"
+			min="0"
 		/>
 
 		<field
@@ -293,6 +294,7 @@
 			type="number"
 			label="COM_FINDER_CONFIG_META_MULTIPLIER_LABEL"
 			default="1.2"
+			min="0"
 		/>
 
 		<field
@@ -300,6 +302,7 @@
 			type="number"
 			label="COM_FINDER_CONFIG_PATH_MULTIPLIER_LABEL"
 			default="2.0"
+			min="0"
 		/>
 
 		<field
@@ -307,6 +310,7 @@
 			type="number"
 			label="COM_FINDER_CONFIG_MISC_MULTIPLIER_LABEL"
 			default="0.3"
+			min="0"
 		/>
 
 		<field

--- a/administrator/components/com_finder/config.xml
+++ b/administrator/components/com_finder/config.xml
@@ -285,6 +285,7 @@
 			type="number"
 			label="COM_FINDER_CONFIG_TEXT_MULTIPLIER_LABEL"
 			default="0.7"
+			min="0"
 		/>
 
 		<field


### PR DESCRIPTION
Pull Request for Issue #35365

### Summary of Changes
set min value zero for Multiplier options


### Testing Instructions
index content


### Actual result BEFORE applying this Pull Request
 you can input negative weight multipliers.


### Expected result AFTER applying this Pull Request
 you cannot input negative weight multipliers.


### Documentation Changes Required

