### PR TITLE
[4] Remove check for memory_limit when uploading files

### DIFF
--- a/administrator/components/com_media/src/Controller/ApiController.php
+++ b/administrator/components/com_media/src/Controller/ApiController.php
@@ -366,8 +366,7 @@ class ApiController extends BaseController
 
 		if (($params->get('upload_maxsize', 0) > 0 && $serverlength > ($params->get('upload_maxsize', 0) * 1024 * 1024))
 			|| $serverlength > $helper->toBytes(ini_get('upload_max_filesize'))
-			|| $serverlength > $helper->toBytes(ini_get('post_max_size'))
-			|| $serverlength > $helper->toBytes(ini_get('memory_limit')))
+			|| $serverlength > $helper->toBytes(ini_get('post_max_size')))
 		{
 			throw new \Exception(Text::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'), 403);
 		}


### PR DESCRIPTION
Pull Request for Issue #35360

### Summary of Changes

Remove check to `memory_limit` when uploading files. 

### Testing Instructions

try to upload files bigger than `memory_limit`

Specifically from #35360

 - setup plain joomla4 instance at php 8.0 or 7.3 or 7.4 with mysql 5.7
 - keep standard setup values for uploads
 - set server memory_limit to -1 (=no limit)
 - upload an image via Menu -> Content -> Media

### Actual result BEFORE applying this Pull Request

File uploads would fail if larger than `memory_limit` or if `ini_get('memory_limit) === -1`

### Expected result AFTER applying this Pull Request

File Uploaded, even larger than `memory_limit` upload without issue. 

### Documentation Changes Required

@laoneo 