### PR TITLE
[4.0] Add missing edit action in MM permissions

### DIFF
--- a/administrator/components/com_media/access.xml
+++ b/administrator/components/com_media/access.xml
@@ -6,5 +6,6 @@
 		<action name="core.manage" title="JACTION_MANAGE" />
 		<action name="core.create" title="JACTION_CREATE" />
 		<action name="core.delete" title="JACTION_DELETE" />
+		<action name="core.edit" title="JACTION_EDIT" />
 	</section>
 </access>


### PR DESCRIPTION
### Summary of Changes
The media manager is missing the edit permission in the global options. This pr adds the missing action, as the media manager has proper ACL checks for the CUD operations since version 4.0.1 now.

![image](https://user-images.githubusercontent.com/251072/131158997-39f86a04-79a0-41df-a398-f52a72bbeb18.png)
