### PR TITLE
[4][Security] Translation strings should be treated as UNSAFE

### DIFF
--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -276,7 +276,7 @@ window.Joomla.Modal = window.Joomla.Modal || {
       newDef = newDef === undefined ? newKey : newDef;
       newKey = newKey.toUpperCase();
 
-      return Joomla.Text.strings[newKey] !== undefined ? Joomla.Text.strings[newKey] : newDef;
+      return Joomla.Text.strings[newKey] !== undefined ? Joomla.sanitizeHtml(Joomla.Text.strings[newKey]) : Joomla.sanitizeHtml(newDef);
     },
 
     /**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Pass all the translation strings through the sanitizer

### Why?

The translation strings often have HTML markup and many times are used in combination with `innerHTML`. BAD combo!!!
Also, there is a `load` function that could load any arbitrary JSON into the translation string pool (an object basically). Another backdoor for XSS.

Using the existing sanitizer these backdoors are closed.


### Testing Instructions

Apply the PR
Run `npm ci`
Check that the strings everywhere in the backend/frontend are not affected

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

Yes, there should be a note that inline JS events or any `javascript:` are not allowed anymore and will be discarded.

FWIW I already did a basic search on the languages folders and all strings are **not** affected (eg no funky inline events, etc)

@SniperSister 