### PR TITLE
[4] Calculate the header space correctly

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -2,7 +2,7 @@
 
 .sidebar-wrapper {
   z-index: $zindex-sidebar;
-  min-height: calc(100vh - 69px);
+  min-height: calc(100vh - 66px);
   overflow: hidden;
   background-color: var(--template-sidebar-bg);
   box-shadow: 0 0 20px -10px var(--template-bg-dark-50);


### PR DESCRIPTION
Pull Request for Issue #35262

### Summary of Changes

Kudos to @brianteeman for identifying the root cause and the fix for this - Thanks. 

Correctly calculate the minimum height of the sidebar to avoid any blank space at the bottom of the page

### Testing Instructions

see #35262 - if you can replicate that then try it before and after applying this PR

### Actual result BEFORE applying this Pull Request

A slither of space in at the very bottom when the window size is very large

<img width="352" alt="130267151-2c615645-bc02-454b-845c-b307648eb5ca" src="https://user-images.githubusercontent.com/400092/131232738-2bc1cd72-91e9-45c1-8223-d3cbaa578ef3.png">


### Expected result AFTER applying this Pull Request

sidebar reaches the very bottom

### Documentation Changes Required

