### PR TITLE
[4.0] 3rd party QuickIcon fix

### DIFF
--- a/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
@@ -285,7 +285,7 @@ class QuickIconHelper
 
 					$icon = array_merge($default, $icon);
 
-					if (!\is_null($icon['link']) && !\is_null($icon['text']))
+					if (!\is_null($icon['link']) && (!\is_null($icon['text']) || !\is_null($icon['name'])))
 					{
 						$this->buttons[$key][] = $icon;
 					}


### PR DESCRIPTION
### Summary of Changes
This changes mod_quickicon so it allows the same Quickicon as core uses.
Currently the module requires the buttons to have a `link` and a `text` property, but all core buttons use the `name` property instead of `text`.
This is even needed if you want to show a "+" link as the title of that "+" button is expanded on the `name` string.


### Testing Instructions
Easiest is to install my quickicon plugin and see if the quickicons show up in the "3rd party" quickicons module
[plg_quickicon_sermonspeaker.zip](https://github.com/joomla/joomla-cms/files/7072501/plg_quickicon_sermonspeaker.zip)

### Actual result BEFORE applying this Pull Request
Buttons don't even appear


### Expected result AFTER applying this Pull Request
Buttons appear
![image](https://user-images.githubusercontent.com/1018684/131250779-fe6acf0e-08ff-4b28-aaf3-eaf8d3e29cdb.png)


### Documentation Changes Required
None
