### PR TITLE
Fix Batch Button: Illegal invocation, in joomla.toolbar.batch

### DIFF
--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -23,7 +23,7 @@ Text::script('ERROR');
 $message = "{'error': [Joomla.Text._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
 $alert = "Joomla.renderMessages(" . $message . ")";
 ?>
-<button<?php echo $id; ?> type="button" data-bs-toggle="modal" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $alert; ?>}else{document.getElementById('collapseModal').open(); return true;}" class="btn btn-primary">
+<button<?php echo $id; ?> type="button" onclick="if (document.adminForm.boxchecked.value==0){<?php echo $alert; ?>}else{document.getElementById('collapseModal').open(); return true;}" class="btn btn-primary">
 	<span class="icon-square" aria-hidden="true"></span>
 	<?php echo $title; ?>
 </button>


### PR DESCRIPTION
Pull Request for Issue #35394 .

### Summary of Changes

data-bs-toggle not need here because onclick is used

### Testing Instructions

use this short, inside one of component View::addToolbar()

```php
$title = \JText::_('JTOOLBAR_BATCH');
$layout = new \JLayoutFile('joomla.toolbar.batch');
$dhtml = $layout->render(array('title' => $title));
\JToolbar::getInstance('toolbar')->appendButton('Custom', $dhtml, 'batch');
```
Click that button and watch in browser console for errors


### Actual result BEFORE applying this Pull Request

You get "Illegal invocation" error 


### Expected result AFTER applying this Pull Request

No error

