### PR TITLE
[3.10] Fix misleading Update Required

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1750,7 +1750,7 @@ ENDDATA;
 
 		$downloadUrl = $update->get('downloadurl');
 
-		return !empty($downloadUrl) && !empty($downloadUrl->_data) ? $update->get('version') : false;
+		return !empty($downloadUrl->_data) ? $update->get('minCompatibleVersion') : false;
 	}
 
 	/**

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -66,6 +66,14 @@ class Update extends \JObject
 	protected $version;
 
 	/**
+	 * Update manifest `<version>` element of minimum compatible version
+	 *
+	 * @var    \stdClass
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $minCompatibleVersion;
+
+	/**
 	 * Update manifest `<infourl>` element
 	 *
 	 * @var    string
@@ -411,16 +419,16 @@ class Update extends \JObject
 
 					if ($phpMatch && $stabilityMatch && $dbMatch)
 					{
-						if (isset($this->latest))
-						{
-							if (version_compare($this->currentUpdate->version->_data, $this->latest->version->_data, '>') == 1)
-							{
-								$this->latest = $this->currentUpdate;
-							}
-						}
-						else
+						if (!isset($this->latest)
+							|| version_compare($this->currentUpdate->version->_data, $this->latest->version->_data, '>'))
 						{
 							$this->latest = $this->currentUpdate;
+						}
+
+						if (!isset($this->minCompatibleVersion)
+							|| version_compare($this->currentUpdate->version->_data, $this->minCompatibleVersion->_data, '<'))
+						{
+							$this->minCompatibleVersion = $this->currentUpdate->version;
 						}
 					}
 				}


### PR DESCRIPTION
Pull Request for Issue #35384.

### Summary of Changes
Currently, the pre-update checker compares the current installed version of an extension with the **latest compatible** version (with the Joomla version the site is going to update to) instead of minimum compatible version and it causes the misdleading update required as described in https://github.com/joomla/joomla-cms/issues/35384 . This PR solves that.



### Testing Instructions
1. Install Joomla 3.10.1
2. Set **Update Channel** to **Joomla Next**.
3. Go to Extensions -> Manage -> Install, click on Options button in the toolbar and set **Minimum Stability** to **Release Candidate** (this step is needed because the extension I provide for testing here is in RC release only. If you use a stable extension for testing, please ignore this step)
4. Install weblinks 3.9.10-rc1 in the attachment
[pkg-weblinks-3.9.0-rc1.zip](https://github.com/joomla/joomla-cms/files/7074571/pkg-weblinks-3.9.0-rc1.zip)

5. Go to Components -> Joomla Update, Joomla should prompt you to update to Joomla 4.0.2 like in the screenshot below

![update_to_402](https://user-images.githubusercontent.com/977664/131303473-f9c1e261-328d-4252-813d-1cc286ec9f06.png)

### Actual result BEFORE applying this Pull Request
The pre-update checker still marks the extensions as update required although the extension has indicates that the version is compatible with Joomla 4 already. See update element for 3.9.0-rc1 element
```xml
<targetplatform name="joomla" version="((3\.(9|10))|(4\.0))"/>
``` 

![update_to_402](https://user-images.githubusercontent.com/977664/131303473-f9c1e261-328d-4252-813d-1cc286ec9f06.png)


### Expected result AFTER applying this Pull Request
No update is required. It's green.
![no_update_required](https://user-images.githubusercontent.com/977664/131303494-8921d3dd-fb5f-4399-8e2a-0b16ac6a0d3d.png)
