### PR TITLE
[4.0] Set focus on input field in rename modal

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/audio.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/audio.vue
@@ -193,6 +193,7 @@ export default {
     },
     /* Rename an item */
     openRenameModal() {
+      this.hideActions();
       this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
       this.$store.commit(types.SHOW_RENAME_MODAL);
     },
@@ -214,8 +215,15 @@ export default {
     /* Hide actions dropdown */
     hideActions() {
       this.showActions = false;
-      this.$nextTick(() => this.$refs.actionToggle.focus());
     },
+  },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/audio.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/audio.vue
@@ -175,6 +175,14 @@ export default {
       showActions: false,
     };
   },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if (!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name === this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    },
+  },
   methods: {
     /* Preview an item */
     openPreview() {
@@ -216,14 +224,6 @@ export default {
     hideActions() {
       this.showActions = false;
     },
-  },
-  watch: {
-    // eslint-disable-next-line
-    '$store.state.showRenameModal'(show) {
-      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
-        this.$refs.actionToggle.focus();
-      }
-    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -125,6 +125,7 @@ export default {
     },
     /* Rename an item */
     openRenameModal() {
+      this.hideActions();
       this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
       this.$store.commit(types.SHOW_RENAME_MODAL);
     },
@@ -141,9 +142,15 @@ export default {
     /* Hide actions dropdown */
     hideActions() {
       this.showActions = false;
-      // eslint-disable-next-line no-unused-expressions
-      this.$nextTick(() => { this.$refs.actionToggle ? this.$refs.actionToggle.focus() : false; });
     },
+  },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -112,6 +112,14 @@ export default {
       showActions: false,
     };
   },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if (!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name === this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    },
+  },
   methods: {
     /* Handle the on preview double click event */
     onPreviewDblClick() {
@@ -143,14 +151,6 @@ export default {
     hideActions() {
       this.showActions = false;
     },
-  },
-  watch: {
-    // eslint-disable-next-line
-    '$store.state.showRenameModal'(show) {
-      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
-        this.$refs.actionToggle.focus();
-      }
-    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/document.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/document.vue
@@ -193,6 +193,7 @@ export default {
     },
     /* Rename an item */
     openRenameModal() {
+      this.hideActions();
       this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
       this.$store.commit(types.SHOW_RENAME_MODAL);
     },
@@ -214,8 +215,15 @@ export default {
     /* Hide actions dropdown */
     hideActions() {
       this.showActions = false;
-      this.$nextTick(() => this.$refs.actionToggle.focus());
     },
+  },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/document.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/document.vue
@@ -175,6 +175,14 @@ export default {
       showActions: false,
     };
   },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if (!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name === this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    },
+  },
   methods: {
     /* Preview an item */
     openPreview() {
@@ -216,14 +224,6 @@ export default {
     hideActions() {
       this.showActions = false;
     },
-  },
-  watch: {
-    // eslint-disable-next-line
-    '$store.state.showRenameModal'(show) {
-      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
-        this.$refs.actionToggle.focus();
-      }
-    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
@@ -163,6 +163,7 @@ export default {
     },
     /* Rename an item */
     openRenameModal() {
+      this.hideActions();
       this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
       this.$store.commit(types.SHOW_RENAME_MODAL);
     },
@@ -184,8 +185,15 @@ export default {
     /* Hide actions dropdown */
     hideActions() {
       this.showActions = false;
-      this.$nextTick(() => this.$refs.actionToggle.focus());
     },
+  },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/file.vue
@@ -150,6 +150,14 @@ export default {
       showActions: false,
     };
   },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if (!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name === this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    },
+  },
   methods: {
     /* Preview an item */
     download() {
@@ -186,14 +194,6 @@ export default {
     hideActions() {
       this.showActions = false;
     },
-  },
-  watch: {
-    // eslint-disable-next-line
-    '$store.state.showRenameModal'(show) {
-      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
-        this.$refs.actionToggle.focus();
-      }
-    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -230,6 +230,7 @@ export default {
     },
     /* Rename an item */
     openRenameModal() {
+      this.hideActions();
       this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
       this.$store.commit(types.SHOW_RENAME_MODAL);
     },
@@ -258,8 +259,15 @@ export default {
     /* Hide actions dropdown */
     hideActions() {
       this.showActions = false;
-      this.$nextTick(() => this.$refs.actionToggle.focus());
     },
+  },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -212,6 +212,14 @@ export default {
       return `url(${this.item.thumb_path})`;
     },
   },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if (!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name === this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    },
+  },
   methods: {
     /* Preview an item */
     openPreview() {
@@ -260,14 +268,6 @@ export default {
     hideActions() {
       this.showActions = false;
     },
-  },
-  watch: {
-    // eslint-disable-next-line
-    '$store.state.showRenameModal'(show) {
-      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
-        this.$refs.actionToggle.focus();
-      }
-    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
@@ -193,6 +193,7 @@ export default {
     },
     /* Rename an item */
     openRenameModal() {
+      this.hideActions();
       this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
       this.$store.commit(types.SHOW_RENAME_MODAL);
     },
@@ -214,8 +215,15 @@ export default {
     /* Hide actions dropdown */
     hideActions() {
       this.showActions = false;
-      this.$nextTick(() => this.$refs.actionToggle.focus());
     },
+  },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/video.vue
@@ -175,6 +175,14 @@ export default {
       showActions: false,
     };
   },
+  watch: {
+    // eslint-disable-next-line
+    '$store.state.showRenameModal'(show) {
+      if (!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name === this.item.name) !== undefined) {
+        this.$refs.actionToggle.focus();
+      }
+    },
+  },
   methods: {
     /* Preview an item */
     openPreview() {
@@ -216,14 +224,6 @@ export default {
     hideActions() {
       this.showActions = false;
     },
-  },
-  watch: {
-    // eslint-disable-next-line
-    '$store.state.showRenameModal'(show) {
-      if(!show && this.$refs.actionToggle && this.$store.state.selectedItems.find((item) => item.name == this.item.name) !== undefined) {
-        this.$refs.actionToggle.focus();
-      }
-    }
   },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/modals/rename-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/rename-modal.vue
@@ -119,5 +119,8 @@ export default {
       });
     },
   },
+  updated() {
+    this.$nextTick(() => this.$refs.nameField ? this.$refs.nameField.focus() : null);
+  },
 };
 </script>

--- a/administrator/components/com_media/resources/scripts/components/modals/rename-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/rename-modal.vue
@@ -85,6 +85,9 @@ export default {
       return this.item.extension;
     },
   },
+  updated() {
+    this.$nextTick(() => (this.$refs.nameField ? this.$refs.nameField.focus() : null));
+  },
   methods: {
     /* Check if the form is valid */
     isValid() {
@@ -118,9 +121,6 @@ export default {
         newName,
       });
     },
-  },
-  updated() {
-    this.$nextTick(() => this.$refs.nameField ? this.$refs.nameField.focus() : null);
   },
 };
 </script>


### PR DESCRIPTION
### Summary of Changes
When opening the rename modal in the media manager the input field doesn't get the focus. Not sure if this is a regression of #23950. But it fixes it and also sets the focus back to the element when the dialog is closed.

### Testing Instructions
Rename a folder in the media manager, either by keyboard or mouse and then close it.

### Actual result BEFORE applying this Pull Request
Input has no focus and when closed it is lost.

### Expected result AFTER applying this Pull Request
Focus should be again on the action list toggle.