### PR TITLE
[4.0] Persist search in local storage

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/toolbar/toolbar.vue
+++ b/administrator/components/com_media/resources/scripts/components/toolbar/toolbar.vue
@@ -32,6 +32,7 @@
         type="text"
         :placeholder="translate('COM_MEDIA_SEARCH')"
         @input="changeSearch"
+        :value="search"
       >
     </div>
     <div class="media-view-icons">
@@ -111,6 +112,9 @@ export default {
       // eslint-disable-next-line max-len
       return (this.$store.getters.getSelectedDirectoryContents.length === this.$store.state.selectedItems.length);
     },
+    search() {
+      return this.$store.state.search;
+    }
   },
   watch: {
     // eslint-disable-next-line

--- a/administrator/components/com_media/resources/scripts/components/toolbar/toolbar.vue
+++ b/administrator/components/com_media/resources/scripts/components/toolbar/toolbar.vue
@@ -31,8 +31,8 @@
         class="form-control"
         type="text"
         :placeholder="translate('COM_MEDIA_SEARCH')"
-        @input="changeSearch"
         :value="search"
+        @input="changeSearch"
       >
     </div>
     <div class="media-view-icons">
@@ -114,7 +114,7 @@ export default {
     },
     search() {
       return this.$store.state.search;
-    }
+    },
   },
   watch: {
     // eslint-disable-next-line

--- a/administrator/components/com_media/resources/scripts/store/plugins/persisted-state.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/plugins/persisted-state.es6.js
@@ -7,6 +7,7 @@ export const persistedStateOptions = {
     'showInfoBar',
     'listView',
     'gridSize',
+    'search',
   ],
   storage: window.sessionStorage,
 };

--- a/administrator/components/com_media/resources/scripts/store/state.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/state.es6.js
@@ -69,6 +69,8 @@ export default {
   listView: 'grid',
   // The size of the grid items
   gridSize: 'md',
+  // The search term to filter the elements
+  search: '',
   // The state of confirm delete model
   showConfirmDeleteModal: false,
   // The state of create folder model

--- a/administrator/components/com_media/resources/scripts/store/state.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/state.es6.js
@@ -69,8 +69,6 @@ export default {
   listView: 'grid',
   // The size of the grid items
   gridSize: 'md',
-  // The search term to filter the elements
-  search: '',
   // The state of confirm delete model
   showConfirmDeleteModal: false,
   // The state of create folder model

--- a/tests/Codeception/_support/Page/Acceptance/Administrator/MediaListPage.php
+++ b/tests/Codeception/_support/Page/Acceptance/Administrator/MediaListPage.php
@@ -323,6 +323,14 @@ class MediaListPage extends AdminListPage
 	public static $mediaBrowserTable = ['class' => 'media-browser-table'];
 
 	/**
+	 * The search input field.
+	 *
+	 * @var array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static $searchInputField = ['id' => 'media_search'];
+
+	/**
 	 * The key for the app storage.
 	 *
 	 * @var string

--- a/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
@@ -898,15 +898,18 @@ class MediaListCest
 		$I->assertContains('"showInfoBar":false', $json);
 		$I->assertContains('"listView":"grid"', $json);
 		$I->assertContains('"gridSize":"md"', $json);
+		$I->assertContains('"search":""', $json);
 		$I->clickOnLinkInTree('banners');
 		$I->waitForMediaLoaded();
 		$I->openInfobar();
 		$I->click(MediaListPage::$increaseThumbnailSizeButton);
 		$I->click(MediaListPage::$toggleListViewButton);
+		$I->fillField(MediaListPage::$searchInputField, 'joomla');
 		$json = $I->executeJS('return sessionStorage.getItem("' . MediaListPage::$storageKey . '")');
 		$I->assertContains('"selectedDirectory":"local-images:/banners"', $json);
 		$I->assertContains('"showInfoBar":true', $json);
 		$I->assertContains('"listView":"table"', $json);
 		$I->assertContains('"gridSize":"lg"', $json);
+		$I->assertContains('"search":"joomla"', $json);
 	}
 }


### PR DESCRIPTION
### Summary of Changes
When searching in the media manager and the page got reloaded, then the search should not be cleared and stored in the ~~localStorage~~ sessionStorage of the browser as we do with other parts in the media manager.

![image](https://user-images.githubusercontent.com/251072/131508212-b03446f4-2d91-41b6-897a-ae3b396106cd.png)


### Testing Instructions
Insert "joomla" into the search field in the media manager. And reload the page.

### Actual result BEFORE applying this Pull Request
The whole list is shown without the search term.

### Expected result AFTER applying this Pull Request
The page is loaded with the results filtered with the name joomla.