### PR TITLE
Fixes Debug bar not displaying logs by default #35454

### DIFF
--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -176,7 +176,7 @@ class PlgSystemDebug extends CMSPlugin
 		$this->isAjax = $this->app->input->get('option') === 'com_ajax'
 			&& $this->app->input->get('plugin') === 'debug' && $this->app->input->get('group') === 'system';
 
-		$this->showLogs = (bool) $this->params->get('logs', false);
+		$this->showLogs = (bool) $this->params->get('logs', true);
 
 		// Log deprecated class aliases
 		if ($this->showLogs && $this->app->get('log_deprecated'))


### PR DESCRIPTION
Fixes bug #35454 (Debug plugin: Debug bar doesn't display logs and deprecated tabs by default, while setting's default is ON)

Pull Request for Issue #35454

### Summary of Changes

Makes PHP reflect the default XML setting of the "Logging/Logging/Log entries (display)" setting.

### Testing Instructions

    Fresh Joomla install
    Turn debugging and logging on in global configuration
    Open the debug bar by clicking the joomla logo at bottom left

### Actual result BEFORE applying this Pull Request

Seeing only "J! Info Request Session Profile Queries" tabs.

### Expected result AFTER applying this Pull Request

See "Log", "Deprecated" and "Deprecation notices" tabs on the right of "J! Info Request Session Profile Queries" tabs, as expected by the default Debug system plugin setting "Logging/Logging/Log entries (display)", which is ON by default.

### Documentation Changes Required

None.
