### PR TITLE
[4] void method result used

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -79,7 +79,9 @@ class UpdateModel extends BaseDatabaseModel
 				}
 				else
 				{
-					return Factory::getApplication()->enqueueMessage(Text::_('COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_CUSTOM_ERROR'), 'error');
+					Factory::getApplication()->enqueueMessage(Text::_('COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_CUSTOM_ERROR'), 'error');
+					
+					return;
 				}
 				break;
 

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -80,7 +80,7 @@ class UpdateModel extends BaseDatabaseModel
 				else
 				{
 					Factory::getApplication()->enqueueMessage(Text::_('COM_JOOMLAUPDATE_CONFIG_UPDATESOURCE_CUSTOM_ERROR'), 'error');
-					
+
 					return;
 				}
 				break;


### PR DESCRIPTION
### Summary of Changes

`enqueueMessage` is a method that doesnt return (I.e `void` return type) 

You cannot "return" a `void` it "just is" and therefore this implementation is wrong. 

### Testing Instructions

Code review. Simple

### Actual result BEFORE applying this Pull Request

Everything works. Static analysis complains. phpStorm complains. psalm complains. PHPStan Complains.

### Expected result AFTER applying this Pull Request

Everything works. 

### Documentation Changes Required

None. 