### PR TITLE
[4] Remove attribute thats not allowed here

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/upload/default.php
+++ b/administrator/components/com_joomlaupdate/tmpl/upload/default.php
@@ -77,7 +77,7 @@ $currentJoomlaVersion = isset($this->updateInfo['current']) ? $this->updateInfo[
 		<?php $maxSize = HTMLHelper::_('number.bytes', $maxSizeBytes); ?>
 		<input id="max_upload_size" name="max_upload_size" type="hidden" value="<?php echo $maxSizeBytes; ?>"/>
 		<div class="form-text"><?php echo Text::sprintf('JGLOBAL_MAXIMUM_UPLOAD_SIZE_LIMIT', '&#x200E;' . $maxSize); ?></div>
-		<div class="form-text hidden" id="file_size" name="file_size"><?php echo Text::sprintf('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', '&#x200E;' . ''); ?></div>
+		<div class="form-text hidden" id="file_size"><?php echo Text::sprintf('JGLOBAL_SELECTED_UPLOAD_FILE_SIZE', '&#x200E;' . ''); ?></div>
 		<div class="alert alert-warning hidden" id="max_upload_size_warn">
 			<?php echo Text::_('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG'); ?>
 		</div>


### PR DESCRIPTION
### Summary of Changes

remove `name="file_size"` attribute from a `div` 

Name attributes cannot be added to divs. Reference: https://www.w3schools.com/tags/att_name.asp

### Testing Instructions

Try up upload a Joomla update using the form - see file size 

Code Review if you must. 

Note that the JS is actually using `getElementById` and so is not relying on this name attribute. 
https://github.com/joomla/joomla-cms/blob/1a6f5aeb49bee4ee78b3a245cd30b42bd2786c07/build/media_source/com_joomlaupdate/js/default.es6.js#L28

### Actual result BEFORE applying this Pull Request

Everything works. Invalid HTML. 

### Expected result AFTER applying this Pull Request

Everything works. Valid HTML. 

### Documentation Changes Required

None