### PR TITLE
[4.0] Update deleted files and folders for 4.0.3

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6089,6 +6089,15 @@ class JoomlaInstallerScript
 			'/libraries/vendor/willdurand/negotiation/tests/Negotiation/Tests/NegotiatorTest.php',
 			'/libraries/vendor/willdurand/negotiation/tests/Negotiation/Tests/TestCase.php',
 			'/libraries/vendor/willdurand/negotiation/tests/bootstrap.php',
+			// From 4.0.2 to 4.0.3
+			'/templates/cassiopeia/css/global/fonts-web_fira-sans.css',
+			'/templates/cassiopeia/css/global/fonts-web_fira-sans.min.css',
+			'/templates/cassiopeia/css/global/fonts-web_fira-sans.min.css.gz',
+			'/templates/cassiopeia/css/global/fonts-web_roboto+noto-sans.css',
+			'/templates/cassiopeia/css/global/fonts-web_roboto+noto-sans.min.css',
+			'/templates/cassiopeia/css/global/fonts-web_roboto+noto-sans.min.css.gz',
+			'/templates/cassiopeia/scss/global/fonts-web_fira-sans.scss',
+			'/templates/cassiopeia/scss/global/fonts-web_roboto+noto-sans.scss',
 		);
 
 		$folders = array(


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Update the lists of deleted files in script.php to recently merged PR #34890 .

### Testing Instructions

Either code review or update 4.0.2. or earlier 4.0 version to current 4.0-dev, one time using the latest nightly 4.0 build for the actual result and one time using the update package or URL built by drone for this PR for the expected result.

### Actual result BEFORE applying this Pull Request

The two scss files `templates/cassiopeia/scss/global/fonts-*.scss` which have been deleted with PR #34890 from the sources and their compiled and minified and gzipped css files are still present after the update.

### Expected result AFTER applying this Pull Request

The two scss files `templates/cassiopeia/scss/global/fonts-*.scss` which have been deleted with PR #34890 from the sources and their compiled and minified and gzipped css files have been deleted the update.

### Documentation Changes Required

None.