### PR TITLE
[3] Remove error suppressor to provide better compatibility with JoomlaTools

### DIFF
--- a/libraries/src/Cache/Storage/CacheliteStorage.php
+++ b/libraries/src/Cache/Storage/CacheliteStorage.php
@@ -344,7 +344,12 @@ class CacheliteStorage extends CacheStorage
 	 */
 	public static function isSupported()
 	{
-		@include_once 'Cache/Lite.php';
+		if(!stream_resolve_include_path('Cache/Lite.php'))
+		{
+			return false;
+		}
+
+		include_once 'Cache/Lite.php';
 
 		return class_exists('\Cache_Lite');
 	}

--- a/libraries/src/Cache/Storage/CacheliteStorage.php
+++ b/libraries/src/Cache/Storage/CacheliteStorage.php
@@ -344,7 +344,7 @@ class CacheliteStorage extends CacheStorage
 	 */
 	public static function isSupported()
 	{
-		if(!stream_resolve_include_path('Cache/Lite.php'))
+		if (!stream_resolve_include_path('Cache/Lite.php'))
 		{
 			return false;
 		}


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/35487

### Summary of Changes

Removal of a single error suppressor, in a file thats already deprecated without replacement, to ensure PHP 8 compatibility with the JoomlaTools framework when PHP8 and debug is used

... and "because its better"

### Testing Instructions

Install Joomla 3 and set up caching with Cache Lite, on a PHP 8 server that runs XDebug and DocMan from https://www.joomlatools.com (I know a very specific and very niche set up) 

Attempt to access site. 

### Actual result BEFORE applying this Pull Request

"500 error include_once(Cache/Lite.php): Failed to open stream: No such file or directory"

Enable error reporting/debug mode and then you get a JoomlaTools framework Exception: 

```
KExceptionError | Warning [500]
include_once(Cache/Lite.php): Failed to open stream: No such file or directory
.../libraries/src/Cache/Storage/CacheliteStorage.php:347
```

### Expected result AFTER applying this Pull Request

No errors on loading home page

### Documentation Changes Required

https://github.com/joomla/coding-standards/pull/274