### PR TITLE
[4][CloudFlare Issues] Remove validation of the session by IP address

### DIFF
--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -35,8 +35,6 @@ use Joomla\Session\SessionEvents;
 use Joomla\Session\SessionInterface;
 use Joomla\Session\Storage\RuntimeStorage;
 use Joomla\Session\StorageInterface;
-use Joomla\Session\Validator\AddressValidator;
-use Joomla\Session\Validator\ForwardedValidator;
 
 /**
  * Service provider for the application's session dependency

--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -329,8 +329,6 @@ class Session implements ServiceProviderInterface
 		}
 
 		$session = new \Joomla\CMS\Session\Session($storage, $dispatcher, $options);
-		$session->addValidator(new AddressValidator($input, $session));
-		$session->addValidator(new ForwardedValidator($input, $session));
 
 		return $session;
 	}


### PR DESCRIPTION
Code Review awaiting PLT decisions. 

@wilsonge @nibra @HLeithner 

Part of https://github.com/joomla-framework/session/pull/55 that fixes issues where REMOTE_ADDR changes, which then forces a user to be logged out. 

> Possible solution for https://github.com/joomla-framework/session/issues/54 and thus joomla/joomla-cms#35244 that fixes joomla/joomla-cms#35244 (comment) CloudFlare (and other reverse proxy's that set REMOTE_ADDR as their IP and not the clients IP (which is perfectly valid for a proxy to do that, but causes session logout issues as REMOTE_ADDR frequently changes.