### PR TITLE
[3.10] Fix misleading "Update Required" in the pre-update checker

### DIFF
--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -533,7 +533,9 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 			if ($currentUpdateVersion !== false)
 			{
 				// If there are updates compatible with both CMS versions use these
-				$bothCompatibleVersions = array_values(array_intersect($upgradeCompatibilityStatus->compatibleVersions, $currentCompatibilityStatus->compatibleVersions));
+				$bothCompatibleVersions = array_values(
+					array_intersect($upgradeCompatibilityStatus->compatibleVersions, $currentCompatibilityStatus->compatibleVersions)
+				);
 
 				if (!empty($bothCompatibleVersions))
 				{

--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -509,34 +509,60 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 
 		/** @var JoomlaupdateModelDefault $model */
 		$model = $this->getModel('default');
-		$upgradeCompatibilityStatus = $model->fetchCompatibility($extensionID, $joomlaTargetVersion);
-		$currentCompatibilityStatus = $model->fetchCompatibility($extensionID, $joomlaCurrentVersion);
+		$upgradeCompatibilityStatus  = $model->fetchCompatibility($extensionID, $joomlaTargetVersion);
+		$currentCompatibilityStatus  = $model->fetchCompatibility($extensionID, $joomlaCurrentVersion);
+		$upgradeUpdateVersion        = false;
+		$currentUpdateVersion        = false;
 
 		$upgradeWarning = 0;
-	
-		if ($upgradeCompatibilityStatus->state == 1 && $upgradeCompatibilityStatus->compatibleVersion !== false)
+
+		if ($upgradeCompatibilityStatus->state == 1 && !empty($upgradeCompatibilityStatus->compatibleVersions))
 		{
-			if (version_compare($upgradeCompatibilityStatus->compatibleVersion, $extensionVersion, 'gt'))
+			$upgradeUpdateVersion = end($upgradeCompatibilityStatus->compatibleVersions);
+		}
+
+		if ($currentCompatibilityStatus->state == 1 && !empty($currentCompatibilityStatus->compatibleVersions))
+		{
+			$currentUpdateVersion = end($currentCompatibilityStatus->compatibleVersions);
+		}
+
+		if ($upgradeUpdateVersion !== false)
+		{
+			$upgradeOldestVersion = $upgradeCompatibilityStatus->compatibleVersions[0];
+
+			if ($currentUpdateVersion !== false)
 			{
-				// Extension needs upgrade before upgrading Joomla
+				// If there are updates compatible with both CMS versions use these
+				$bothCompatibleVersions = array_intersect($upgradeCompatibilityStatus->compatibleVersions, $currentCompatibilityStatus->compatibleVersions);
+
+				if (!empty($bothCompatibleVersions))
+				{
+					$upgradeOldestVersion = $bothCompatibleVersions[0];
+					$upgradeUpdateVersion = end($bothCompatibleVersions);
+				}
+			}
+
+			if (version_compare($upgradeOldestVersion, $extensionVersion, '>'))
+			{
+				// Installed version is empty or older than the oldest compatible update: Update required
 				$resultGroup = 2;
 			}
 			else
 			{
-				// Current version is up to date and compatible
+				// Current version is compatible
 				$resultGroup = 3;
 			}
 
-			if ($currentCompatibilityStatus->state == 1)
+			if ($currentUpdateVersion !== false)
 			{
-				if (version_compare($upgradeCompatibilityStatus->compatibleVersion, $currentCompatibilityStatus->compatibleVersion, 'lt'))
+				if (version_compare($upgradeUpdateVersion, $currentUpdateVersion, '<'))
 				{
 					// Special case warning when version compatible with target is lower than current
 					$upgradeWarning = 2;
 				}
 			}
 		}
-		elseif ($currentCompatibilityStatus->state == 1)
+		elseif ($currentUpdateVersion !== false)
 		{
 			// No compatible version for target version but there is a compatible version for current version
 			$resultGroup = 1;
@@ -549,8 +575,14 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 
 		// Do we need to capture
 		$combinedCompatibilityStatus = array(
-			'upgradeCompatibilityStatus' => $upgradeCompatibilityStatus,
-			'currentCompatibilityStatus' => $currentCompatibilityStatus,
+			'upgradeCompatibilityStatus' => (object) array(
+				'state' => $upgradeCompatibilityStatus->state,
+				'compatibleVersion' => $upgradeUpdateVersion
+			),
+			'currentCompatibilityStatus' => (object) array(
+				'state' => $currentCompatibilityStatus->state,
+				'compatibleVersion' => $currentUpdateVersion
+			),
 			'resultGroup' => $resultGroup,
 			'upgradeWarning' => $upgradeWarning,
 		);

--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -533,7 +533,7 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 			if ($currentUpdateVersion !== false)
 			{
 				// If there are updates compatible with both CMS versions use these
-				$bothCompatibleVersions = array_intersect($upgradeCompatibilityStatus->compatibleVersions, $currentCompatibilityStatus->compatibleVersions);
+				$bothCompatibleVersions = array_values(array_intersect($upgradeCompatibilityStatus->compatibleVersions, $currentCompatibilityStatus->compatibleVersions));
 
 				if (!empty($bothCompatibleVersions))
 				{

--- a/administrator/components/com_joomlaupdate/controllers/update.php
+++ b/administrator/components/com_joomlaupdate/controllers/update.php
@@ -553,13 +553,10 @@ class JoomlaupdateControllerUpdate extends JControllerLegacy
 				$resultGroup = 3;
 			}
 
-			if ($currentUpdateVersion !== false)
+			if ($currentUpdateVersion !== false && version_compare($upgradeUpdateVersion, $currentUpdateVersion, '<'))
 			{
-				if (version_compare($upgradeUpdateVersion, $currentUpdateVersion, '<'))
-				{
-					// Special case warning when version compatible with target is lower than current
-					$upgradeWarning = 2;
-				}
+				// Special case warning when version compatible with target is lower than current
+				$upgradeWarning = 2;
 			}
 		}
 		elseif ($currentUpdateVersion !== false)

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1596,15 +1596,9 @@ ENDDATA;
 				{
 					$compatibleVersions = $this->checkCompatibility($updateFileUrl, $joomlaTargetVersion);
 
-					if (!empty($compatibleVersions))
-					{
-						// Return the compatible versions
-						return (object) array('state' => 1, 'compatibleVersions' => $compatibleVersions);
-					}
+					// Return the compatible versions
+					return (object) array('state' => 1, 'compatibleVersions' => $compatibleVersions);
 				}
-
-				// Update server is supported but no compatible version found
-				return (object) array('state' => 1, 'compatibleVersions' => array());
 			}
 			else
 			{

--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -1594,34 +1594,24 @@ ENDDATA;
 
 				foreach ($updateFileUrls as $updateFileUrl)
 				{
-					$compatibleVersion = $this->checkCompatibility($updateFileUrl, $joomlaTargetVersion);
+					$compatibleVersions = $this->checkCompatibility($updateFileUrl, $joomlaTargetVersion);
 
-					if ($compatibleVersion)
+					if (!empty($compatibleVersions))
 					{
-						// Return the compatible version
-						return (object) array('state' => 1, 'compatibleVersion' => $compatibleVersion->_data);
-					}
-					else
-					{
-						// Return the compatible version as false so we can say update server is supported but no compatible version found
-						return (object) array('state' => 1, 'compatibleVersion' => false);
+						// Return the compatible versions
+						return (object) array('state' => 1, 'compatibleVersions' => $compatibleVersions);
 					}
 				}
+
+				// Update server is supported but no compatible version found
+				return (object) array('state' => 1, 'compatibleVersions' => array());
 			}
 			else
 			{
-				$compatibleVersion = $this->checkCompatibility($updateSite['location'], $joomlaTargetVersion);
+				$compatibleVersions = $this->checkCompatibility($updateSite['location'], $joomlaTargetVersion);
 
-				if ($compatibleVersion)
-				{
-					// Return the compatible version
-					return (object) array('state' => 1, 'compatibleVersion' => $compatibleVersion->_data);
-				}
-				else
-				{
-					// Return the compatible version as false so we can say update server is supported but no compatible version found
-					return (object) array('state' => 1, 'compatibleVersion' => false);
-				}
+				// Return the compatible versions
+				return (object) array('state' => 1, 'compatibleVersions' => $compatibleVersions);
 			}
 		}
 
@@ -1735,7 +1725,7 @@ ENDDATA;
 	 * @param   string  $updateFileUrl        The items update XML url.
 	 * @param   string  $joomlaTargetVersion  The Joomla! version to test against
 	 *
-	 * @return  mixed  An array of data items or false.
+	 * @return  array  An array of strings with compatible version numbers
 	 *
 	 * @since   3.10.0
 	 */
@@ -1748,9 +1738,20 @@ ENDDATA;
 		$update->set('jversion.full', $joomlaTargetVersion);
 		$update->loadFromXML($updateFileUrl, $minimumStability);
 
-		$downloadUrl = $update->get('downloadurl');
+		$compatibleVersions = $update->get('compatibleVersions');
 
-		return !empty($downloadUrl) && !empty($downloadUrl->_data) ? $update->get('version') : false;
+		// Check if old version of the updater library
+		if (!isset($compatibleVersions))
+		{
+			$downloadUrl = $update->get('downloadurl');
+			$updateVersion = $update->get('version');
+
+			return empty($downloadUrl) || empty($downloadUrl->_data) || empty($updateVersion) ? array() : array($updateVersion->_data);
+		}
+
+		usort($compatibleVersions, 'version_compare');
+
+		return $compatibleVersions;
 	}
 
 	/**

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -217,6 +217,14 @@ class Update extends \JObject
 	protected $minimum_stability = Updater::STABILITY_STABLE;
 
 	/**
+	 * Array with compatible versions regardless of minimum stability
+	 *
+	 * @var    array
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $compatibleVersions = array();
+
+	/**
 	 * Gets the reference to the current direct parent
 	 *
 	 * @return  object
@@ -411,9 +419,14 @@ class Update extends \JObject
 
 					if ($phpMatch && $stabilityMatch && $dbMatch)
 					{
+						if (!empty($this->currentUpdate->downloadurl) && !empty($this->currentUpdate->downloadurl->_data))
+						{
+							$this->compatibleVersions[] = $this->currentUpdate->version->_data;
+						}
+
 						if (isset($this->latest))
 						{
-							if (version_compare($this->currentUpdate->version->_data, $this->latest->version->_data, '>') == 1)
+							if (version_compare($this->currentUpdate->version->_data, $this->latest->version->_data, '>'))
 							{
 								$this->latest = $this->currentUpdate;
 							}

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -217,7 +217,7 @@ class Update extends \JObject
 	protected $minimum_stability = Updater::STABILITY_STABLE;
 
 	/**
-	 * Array with compatible versions regardless of minimum stability
+	 * Array with compatible versions used by the pre-update check
 	 *
 	 * @var    array
 	 * @since  __DEPLOY_VERSION__

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -424,14 +424,8 @@ class Update extends \JObject
 							$this->compatibleVersions[] = $this->currentUpdate->version->_data;
 						}
 
-						if (isset($this->latest))
-						{
-							if (version_compare($this->currentUpdate->version->_data, $this->latest->version->_data, '>'))
-							{
-								$this->latest = $this->currentUpdate;
-							}
-						}
-						else
+						if (!isset($this->latest)
+							|| version_compare($this->currentUpdate->version->_data, $this->latest->version->_data, '>'))
 						{
 							$this->latest = $this->currentUpdate;
 						}


### PR DESCRIPTION
Pull Request for Issue #35384 .

Alternative to #35419 .

### Summary of Changes

Currently the pre-update checker checks compatibility separately for the current (here 3.10.x) and the target CMS (here 4.0.y) versions, using the latest available, compatible update version for each CMS version.

This means if there is an update which would be compatible with both CMS versions and a later update which is only compatible with the target CMS version, the checker uses the latter and so reports an update to be required (which would be wrong and could even break things). See issue #35384 .

This PR here fixes that by using the latest update version which is compatible with both CMS versions, if there is such, and otherwise still like it is without this PR the latest update for the target CMS version.

In addition, it fixes the compatibility check. Right now, an extension is shown as not compatible with the target CMS version if the latest available update version for the that CMS version is younger than the installed version of the extension, but this is wrong. The extension can be assumed to be compatible with the target if the installed version is not older than the oldest available update for the target CMS version, or in other words, there is at least one update which is known to be compatible and is older than or equal to the installed version.

These both fixes together solve the issue.

In any case the extension versions shown for the two CMS versions in the pre-update checker's details are the latest available versions (with respect to the first change mentioned above), so even for the extensions which have no update required you can see that an update is available by the version numbers.

It could be worth to think about a future PR either extending the pre-update checker by a new category "Update Recommended" for such cases or visualizing in another way that updates are available for compatible extensions.

The change in the Joomla update component has been made in a way so that it works without the change in the updater library like it does now without the PR, so if it needs to release a separate update of the component before the CMS release for some other reason, the updated component will still work before the CMS is updated.

### Testing Instructions

1. Have a clean installation of current 3.10-dev or latest 3.10 nightly or 3.10.1.

2. In the options of the Joomla Update component, set the update channel to "Joomla Next".

3. Install **version 3.9.0 RC1** of the **Weblinks** component from here https://github.com/joomla-extensions/weblinks/releases/download/3.9.0-rc1/pkg-weblinks-3.9.0-rc1.zip . This is the example which we use for checking the issue.

4. In the options of the extensions installer, make sure that you have minimum stability set to "Stable".

5. Go to "Components -> Joomla Update". The pre-update checker should be shown for update to Joomla 4.0.2.

6. Check in which category the "Web Links Extension Package" is shown.
Result: The extension is shown in the category "Update Information Unavailable". This is desired because that extension doesn't have stability "Stable" yet.

7. Go to the extensions installer's options and change minimum stability to "Release Candidate".

8. Go back to "Components -> Joomla Update" and check again in which category the "Web Links Extension Package" is shown.
Result: The extension is shown in the category "Update Required". This is the problem reported with the issue.

9. Check the Joomla 4.0.2 compatible version of the weblinks package.
Result: Version 4.0.0-rc1 is shown, but it should be 3.9.0-rc1.

10. Install some other extensions, e.g. Patchtester 3.0.0 https://github.com/joomla-extensions/patchtester/releases/download/3.0.0/com_patchtester.zip .

11. Go back to "Components -> Joomla Update". Expand all "More Detail" toggles so you can see the version numbers shown in all categories of compatibility and make a screenshot so you can later compare all of them with the results after having applied the changes from this PR.

12. If you have other extensions installed which have different stability levels than "Stable", play a bit with the minimum stability in the extensions installer's options to get different results, and make again screenshots with all "More Detail" toggles being expanded so you can later compare.

13. Go to the extensions installer's options and change minimum stability to "Release Candidate".

14. Make a backup of file "libraries/src/Updater/Update.php".

15. Apply the patch of this PR.

16. Go back to "Components -> Joomla Update" and check again in which category the "Web Links Extension Package" is shown.
Result: The extension is shown in the category "No Update Required".

17. Check the Joomla 4.0.2 compatible version of the weblinks package.
Result: Version 3.9.0-rc1 is shown as it should be.

18. Expand all "More Detail" toggles and compare the details show for all your extensions with the results from step 11.
Result: There should be no changes beside the change for the weblinks package and for other packages having the same or a similar issue. But if there are changes, check if they make sense.

19. Go to the extensions installer's options and change minimum stability to "Stable".

20. Check in which category the "Web Links Extension Package" is shown.
Result: The extension is shown in the category "Update Information Unavailable". This is desired because that extension doesn't have stability "Stable" yet.

21. If you have other extensions installed which have different stability levels than "Stable", play a bit with the minimum stability in the extensions installer's options to get different results, and compare the results with those from step 12.
Result: The minimum stability setting is respected as well as without this PR.

22. Revert the changes of this PR in file "libraries/src/Updater/Update.php" by replacing it with backup file from step 14, but keep the other files changed by this PR.

23. Check that everything works like it does without this PR and there are no PHP errors.
Result: The changes in the Joomla Update component's code made by this PR work also with the old, unchanged version of the updater library, but of course without the issue being fixed, i.e. things work like without this PR.

### Actual result BEFORE applying this Pull Request

See issue #35384 .

![update_to_402](https://user-images.githubusercontent.com/977664/131303473-f9c1e261-328d-4252-813d-1cc286ec9f06.png)

### Expected result AFTER applying this Pull Request

The issue is fixed, everything else works as before or better.

![no_update_required](https://user-images.githubusercontent.com/977664/131303494-8921d3dd-fb5f-4399-8e2a-0b16ac6a0d3d.png)

The changes in the Joomla Update component's code made by this PR work also with the old, unchanged version of the updater library, but of course without the issue being fixed, i.e. things work like without this PR.

### Documentation Changes Required

None.