### PR TITLE
[4] Avoid the EOL underline of the title link

### DIFF
--- a/modules/mod_articles_category/tmpl/default_items.php
+++ b/modules/mod_articles_category/tmpl/default_items.php
@@ -17,7 +17,15 @@ use Joomla\CMS\Layout\LayoutHelper;
 <?php foreach ($items as $item) : ?>
 <li>
 	<?php if ($params->get('link_titles') == 1) : ?>
-		<a class="mod-articles-category-title <?php echo $item->active; ?>" href="<?php echo $item->link; ?>"><?php echo $item->title; ?></a>
+		<?php
+			$attributes = [
+				'class' => 'mod-articles-category-title ' . $item->active
+			];
+			$link = htmlspecialchars($item->link, ENT_COMPAT, 'UTF-8', false);
+			$title = htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8', false);
+
+			echo HTMLHelper::_('link', $link, $title, $attributes);
+		?>
 	<?php else : ?>
 		<?php echo $item->title; ?>
 	<?php endif; ?>

--- a/modules/mod_articles_category/tmpl/default_items.php
+++ b/modules/mod_articles_category/tmpl/default_items.php
@@ -17,9 +17,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 <?php foreach ($items as $item) : ?>
 <li>
 	<?php if ($params->get('link_titles') == 1) : ?>
-		<a class="mod-articles-category-title <?php echo $item->active; ?>" href="<?php echo $item->link; ?>">
-			<?php echo $item->title; ?>
-		</a>
+		<a class="mod-articles-category-title <?php echo $item->active; ?>" href="<?php echo $item->link; ?>"><?php echo $item->title; ?></a>
 	<?php else : ?>
 		<?php echo $item->title; ?>
 	<?php endif; ?>

--- a/modules/mod_articles_category/tmpl/default_items.php
+++ b/modules/mod_articles_category/tmpl/default_items.php
@@ -17,15 +17,10 @@ use Joomla\CMS\Layout\LayoutHelper;
 <?php foreach ($items as $item) : ?>
 <li>
 	<?php if ($params->get('link_titles') == 1) : ?>
-		<?php
-			$attributes = [
-				'class' => 'mod-articles-category-title ' . $item->active
-			];
-			$link = htmlspecialchars($item->link, ENT_COMPAT, 'UTF-8', false);
-			$title = htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8', false);
-
-			echo HTMLHelper::_('link', $link, $title, $attributes);
-		?>
+		<?php $attributes = ['class' => 'mod-articles-category-title ' . $item->active]; ?>
+		<?php $link = htmlspecialchars($item->link, ENT_COMPAT, 'UTF-8', false); ?>
+		<?php $title = htmlspecialchars($item->title, ENT_COMPAT, 'UTF-8', false); ?>
+		<?php echo HTMLHelper::_('link', $link, $title, $attributes); ?>
 	<?php else : ?>
 		<?php echo $item->title; ?>
 	<?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Breaking  lines for an anchor link causes a blank for underline 


### Testing Instructions
Make a module for atricles categoriy on your site. Hover the title and see the underline .


### Actual result BEFORE applying this Pull Request
<img width="228" alt="link-eol" src="https://user-images.githubusercontent.com/1035262/132662974-756b1a8e-e52d-462c-8732-a53d3b35bb50.PNG">



### Expected result AFTER applying this Pull Request
<img width="260" alt="link-eol2" src="https://user-images.githubusercontent.com/1035262/132662992-60a6efdf-36f8-4fe6-8c00-1645a6f5d05a.PNG">



### Documentation Changes Required
no
