### PR TITLE
[4.0] Load search results on suggestion selection

### DIFF
--- a/build/media_source/com_finder/js/finder.es6.js
+++ b/build/media_source/com_finder/js/finder.es6.js
@@ -52,6 +52,14 @@
     }
   };
 
+  // Submits the form programmatically
+  const submitForm = (event) => {
+    const form = event.target.closest('form');
+    if (form) {
+      form.submit();
+    }
+  };
+
   // The boot sequence
   const onBoot = () => {
     const searchWords = [].slice.call(document.querySelectorAll('.js-finder-search-query'));
@@ -63,6 +71,13 @@
 
         // If the current value is empty, set the previous value.
         searchword.addEventListener('input', onInputChange);
+
+        const advanced = searchword.closest('form').querySelector('.js-finder-advanced');
+
+        // Do not submit the form on suggestion selection, in case of advanced form.
+        if (!advanced) {
+          searchword.addEventListener('awesomplete-selectcomplete', submitForm);
+        }
       }
     });
 


### PR DESCRIPTION
### Summary of Changes
The current workflow with the smart search suggestions is to 1st type something, then select the suggestion and then submit the form (pressing enter or clicking on the submit button).

This simplifies the process loading the results, right after a suggestion is selected.

### Testing Instructions
After applying the patch, run `npm install`
Use the smart search with the suggestions enabled and click on a suggestion to get the results straight away.

**DO NOTE: That feature will not work in the advanced form, on purpose, for obvious reasons**

### Actual result BEFORE applying this Pull Request
1st select the suggestion and then submit the form


### Expected result AFTER applying this Pull Request
Get the results after a suggestion is selected.


### Documentation Changes Required
No
