### PR TITLE
[4.0] Show help for system menuitems

### DIFF
--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -1248,7 +1248,7 @@ class ItemModel extends AdminModel
 		else
 		{
 			// We don't have a component. Load the form XML to get the help path
-			$xmlFile = Path::find(JPATH_ADMINISTRATOR . '/components/com_menus/models/forms', $typeFile . '.xml');
+			$xmlFile = Path::find(JPATH_ADMINISTRATOR . '/components/com_menus/forms', $typeFile . '.xml');
 
 			if ($xmlFile)
 			{


### PR DESCRIPTION
When you try to use the "Help" button for a system menuitem like "Menu Heading" or "URL" you get a generic help screen instead of the one for the menuitemtype

### Summary of Changes
The lookup for the XML was looking in the wrong path for system menuitems.


### Testing Instructions
Try the help button for "System Links" menuitem types


### Actual result BEFORE applying this Pull Request
Generic help


### Expected result AFTER applying this Pull Request
Specific help


### Documentation Changes Required

