### PR TITLE
Allow the translation bot to recompile the htmls

### DIFF
--- a/build/build-modules-js/init/cleanup-media.es6.js
+++ b/build/build-modules-js/init/cleanup-media.es6.js
@@ -11,7 +11,7 @@ const RootPath = process.cwd();
  *
  * @returns {Promise}
  */
-module.exports.cleanVendors = async (skip = true) => {
+module.exports.cleanVendors = async () => {
   // eslint-disable-next-line no-console
   console.log('Cleanup the Vendor ');
 

--- a/build/build-modules-js/init/cleanup-media.es6.js
+++ b/build/build-modules-js/init/cleanup-media.es6.js
@@ -12,9 +12,9 @@ const RootPath = process.cwd();
  * @returns {Promise}
  */
 module.exports.cleanVendors = async () => {
-  if (process.env.TRANSLATION_BOT === 'YES') {
+  if (process.env.SKIP_COMPOSER_CHECK === 'YES') {
     // eslint-disable-next-line no-console
-    console.log('Cleanup the Vendor folder skipped');
+    console.log('Skipping the DebugBar assets...');
     return;
   }
 

--- a/build/build-modules-js/init/cleanup-media.es6.js
+++ b/build/build-modules-js/init/cleanup-media.es6.js
@@ -11,28 +11,24 @@ const RootPath = process.cwd();
  *
  * @returns {Promise}
  */
-module.exports.cleanVendors = async () => {
+module.exports.cleanVendors = async (skip = true) => {
   // eslint-disable-next-line no-console
   console.log('Cleanup the Vendor ');
 
-  const mediaFolder = await stat(join(RootPath, 'libraries/vendor/maximebf/debugbar/src/DebugBar/Resources'));
-
-  if (await mediaFolder.isDirectory()) {
-    // Remove the vendor folder
-    // await remove(join(RootPath, 'media'));
-    // eslint-disable-next-line no-console
-    // console.error('/media has been removed.');
-
-    // Recreate the media folder
-    await mkdir(join(RootPath, 'media/vendor/debugbar'), { recursive: true, mode: 0o755 });
-
-    // Copy some assets from a PHP package
-    await copy(join(RootPath, 'libraries/vendor/maximebf/debugbar/src/DebugBar/Resources'), join(RootPath, 'media/vendor/debugbar'), { preserveTimestamps: true });
-    await remove(join(RootPath, 'media/vendor/debugbar/vendor/font-awesome'));
-    await remove(join(RootPath, 'media/vendor/debugbar/vendor/jquery'));
-  } else {
+  try {
+    const mediaFolder = await stat(join(RootPath, 'libraries/vendor/maximebf/debugbar/src/DebugBar/Resources'));
+    await mediaFolder.isDirectory();
+  } catch (e) {
     // eslint-disable-next-line no-console
     console.error('You need to run `npm install` AFTER the command `composer install`!!!. The debug plugin HASN\'T installed all its front end assets');
-    process.exit(1);
+    return;
   }
+
+  // Recreate the media folder
+  await mkdir(join(RootPath, 'media/vendor/debugbar'), { recursive: true, mode: 0o755 });
+
+  // Copy some assets from a PHP package
+  await copy(join(RootPath, 'libraries/vendor/maximebf/debugbar/src/DebugBar/Resources'), join(RootPath, 'media/vendor/debugbar'), { preserveTimestamps: true });
+  await remove(join(RootPath, 'media/vendor/debugbar/vendor/font-awesome'));
+  await remove(join(RootPath, 'media/vendor/debugbar/vendor/jquery'));
 };

--- a/build/build-modules-js/init/cleanup-media.es6.js
+++ b/build/build-modules-js/init/cleanup-media.es6.js
@@ -12,23 +12,33 @@ const RootPath = process.cwd();
  * @returns {Promise}
  */
 module.exports.cleanVendors = async () => {
-  // eslint-disable-next-line no-console
-  console.log('Cleanup the Vendor ');
-
-  try {
-    const mediaFolder = await stat(join(RootPath, 'libraries/vendor/maximebf/debugbar/src/DebugBar/Resources'));
-    await mediaFolder.isDirectory();
-  } catch (e) {
+  if (process.env.TRANSLATION_BOT === 'YES') {
     // eslint-disable-next-line no-console
-    console.error('You need to run `npm install` AFTER the command `composer install`!!!. The debug plugin HASN\'T installed all its front end assets');
+    console.log('Cleanup the Vendor skipped');
     return;
   }
 
-  // Recreate the media folder
-  await mkdir(join(RootPath, 'media/vendor/debugbar'), { recursive: true, mode: 0o755 });
+  // eslint-disable-next-line no-console
+  console.log('Cleanup the Vendor ');
 
-  // Copy some assets from a PHP package
-  await copy(join(RootPath, 'libraries/vendor/maximebf/debugbar/src/DebugBar/Resources'), join(RootPath, 'media/vendor/debugbar'), { preserveTimestamps: true });
-  await remove(join(RootPath, 'media/vendor/debugbar/vendor/font-awesome'));
-  await remove(join(RootPath, 'media/vendor/debugbar/vendor/jquery'));
+  const mediaFolder = await stat(join(RootPath, 'libraries/vendor/maximebf/debugbar/src/DebugBar/Resources'));
+
+  if (await mediaFolder.isDirectory()) {
+    // Remove the vendor folder
+    // await remove(join(RootPath, 'media'));
+    // eslint-disable-next-line no-console
+    // console.error('/media has been removed.');
+
+    // Recreate the media folder
+    await mkdir(join(RootPath, 'media/vendor/debugbar'), { recursive: true, mode: 0o755 });
+
+    // Copy some assets from a PHP package
+    await copy(join(RootPath, 'libraries/vendor/maximebf/debugbar/src/DebugBar/Resources'), join(RootPath, 'media/vendor/debugbar'), { preserveTimestamps: true });
+    await remove(join(RootPath, 'media/vendor/debugbar/vendor/font-awesome'));
+    await remove(join(RootPath, 'media/vendor/debugbar/vendor/jquery'));
+  } else {
+    // eslint-disable-next-line no-console
+    console.error('You need to run `npm install` AFTER the command `composer install`!!!. The debug plugin HASN\'T installed all its front end assets');
+    process.exit(1);
+  }
 };

--- a/build/build-modules-js/init/cleanup-media.es6.js
+++ b/build/build-modules-js/init/cleanup-media.es6.js
@@ -14,7 +14,7 @@ const RootPath = process.cwd();
 module.exports.cleanVendors = async () => {
   if (process.env.TRANSLATION_BOT === 'YES') {
     // eslint-disable-next-line no-console
-    console.log('Cleanup the Vendor skipped');
+    console.log('Cleanup the Vendor folder skipped');
     return;
   }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Do not exit if `composer install` was not executed and there is a system variable `TRANSLATION_BOT` with a value `YES`

Basically, this allows the translation bot to create the error pages by skipping the composer part


### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required


@wilsonge a simple review should be enough here, it solves the issue https://github.com/joomla/joomla-cms/pull/35379#issuecomment-917367450