### PR TITLE
Category custom fields marked as 'subform' act as if they are not

### DIFF
--- a/administrator/components/com_fields/src/Field/SubfieldsField.php
+++ b/administrator/components/com_fields/src/Field/SubfieldsField.php
@@ -68,7 +68,7 @@ class SubfieldsField extends ListField
 		// Check whether we have a result for this context yet
 		if (!isset(static::$customFieldsCache[$this->context]))
 		{
-			static::$customFieldsCache[$this->context] = FieldsHelper::getFields($this->context);
+			static::$customFieldsCache[$this->context] = FieldsHelper::getFields($this->context, null, false, null, true);
 		}
 
 		// Iterate over the custom fields for this context

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -108,13 +108,13 @@ class FieldsHelper
 			self::$fieldsCache->setState('list.limit', 0);
 		}
 
-		if (!$includeSubformFields)
+		if ($includeSubformFields)
 		{
-			self::$fieldsCache->setState('filter.only_use_in_subform', 0);
+			self::$fieldsCache->setState('filter.only_use_in_subform', '');
 		}
 		else
 		{
-			self::$fieldsCache->setState('filter.only_use_in_subform', '');
+			self::$fieldsCache->setState('filter.only_use_in_subform', 0);
 		}
 
 		if (is_array($item))

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -96,7 +96,7 @@ class FieldsHelper
 	 *
 	 * @since   3.7.0
 	 */
-	public static function getFields($context, $item = null, $prepareValue = false, array $valuesToOverride = null)
+	public static function getFields($context, $item = null, $prepareValue = false, array $valuesToOverride = null, bool $includeSubformFields = false)
 	{
 		if (self::$fieldsCache === null)
 		{
@@ -106,6 +106,15 @@ class FieldsHelper
 
 			self::$fieldsCache->setState('filter.state', 1);
 			self::$fieldsCache->setState('list.limit', 0);
+		}
+
+		if (!$includeSubformFields)
+		{
+			self::$fieldsCache->setState('filter.only_use_in_subform', 0);
+		}
+		else
+		{
+			self::$fieldsCache->setState('filter.only_use_in_subform', '');
 		}
 
 		if (is_array($item))

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -87,16 +87,20 @@ class FieldsHelper
 	 * The values of the fields can be overridden by an associative array where the keys
 	 * have to be a name and its corresponding value.
 	 *
-	 * @param   string     $context           The context of the content passed to the helper
-	 * @param   \stdClass  $item              item
-	 * @param   int|bool   $prepareValue      (if int is display event): 1 - AfterTitle, 2 - BeforeDisplay, 3 - AfterDisplay, 0 - OFF
-	 * @param   array      $valuesToOverride  The values to override
+	 * @param   string      $context              The context of the content passed to the helper
+	 * @param   null        $item                 The item being edited in the form
+	 * @param   int|bool    $prepareValue         (if int is display event): 1 - AfterTitle, 2 - BeforeDisplay, 3 - AfterDisplay, 0 - OFF
+	 * @param   array|null  $valuesToOverride     The values to override
+	 * @param   bool        $includeSubformFields Should I include fields marked as Only Use In Subform?
 	 *
 	 * @return  array
 	 *
+	 * @throws \Exception
 	 * @since   3.7.0
 	 */
-	public static function getFields($context, $item = null, $prepareValue = false, array $valuesToOverride = null, bool $includeSubformFields = false)
+	public static function getFields(
+		$context, $item = null, $prepareValue = false, array $valuesToOverride = null, bool $includeSubformFields = false
+	)
 	{
 		if (self::$fieldsCache === null)
 		{

--- a/plugins/fields/subform/subform.php
+++ b/plugins/fields/subform/subform.php
@@ -388,7 +388,7 @@ class PlgFieldsSubform extends FieldsPlugin
 			static::$customFieldsCache = array();
 
 			// Get all custom field instances
-			$customFields = FieldsHelper::getFields('');
+			$customFields = FieldsHelper::getFields('', null, false, null, true);
 
 			foreach ($customFields as $customField)
 			{

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -265,11 +265,7 @@ class PlgSystemFields extends CMSPlugin
 		if (strpos($context, 'com_categories.category') === 0)
 		{
 			$context = str_replace('com_categories.category', '', $context) . '.categories';
-
-			if ($context === 'com_categories.categorycom_content')
-			{
-				$data = $data ?: Factory::getApplication()->input->get('jform', [], 'array');
-			}
+			$data    = $data ?: Factory::getApplication()->input->get('jform', [], 'array');
 
 			// Set the catid on the category to get only the fields which belong to this category
 			if (is_array($data) && array_key_exists('id', $data))

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -266,6 +266,8 @@ class PlgSystemFields extends CMSPlugin
 		{
 			$context = str_replace('com_categories.category', '', $context) . '.categories';
 
+			$data = $data ?: Factory::getApplication()->input->get('jform', [], 'array');
+
 			// Set the catid on the category to get only the fields which belong to this category
 			if (is_array($data) && array_key_exists('id', $data))
 			{

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -266,7 +266,10 @@ class PlgSystemFields extends CMSPlugin
 		{
 			$context = str_replace('com_categories.category', '', $context) . '.categories';
 
-			$data = $data ?: Factory::getApplication()->input->get('jform', [], 'array');
+			if ($context === 'com_categories.categorycom_content')
+			{
+				$data = $data ?: Factory::getApplication()->input->get('jform', [], 'array');
+			}
 
 			// Set the catid on the category to get only the fields which belong to this category
 			if (is_array($data) && array_key_exists('id', $data))


### PR DESCRIPTION
Pull Request for Issue #35543 .

### Summary of Changes

Category custom fields marked as “Use Only In Subform” were loaded as regular fields in all categories. This is a two–part bug (see Technical Notes at the bottom).

As a result I made the following changes:
* I changed `\Joomla\Component\Fields\Administrator\Helper\FieldsHelper::getFields` to only load non–subform–only fields by default with a new option to return all fields, including the subform–only, and made the necessary changes to SubfieldsField and PlgFieldsSubform.
* I changed PlgSystemFields::onContentPrepareForm to load the missing form data when you are saving a com_content category.

### Testing Instructions

* In the backend of your site go to Content, Fields.
* From the dropdown select “Category” and click on New.
* Create a new field with the following parameters:
   - Title: Test
   - Label: Test
   - Required: Yes. **THIS IS IMPORTANT**
   - Only Use In Subform: Yes. **THIS IS IMPORTANT**
   - Filter: Safe HTML. **THIS IS IMPORTANT**
* Click on Save & Close
* Go to Content, Categories
* Edit _any category_
* Click on Save

### Actual result BEFORE applying this Pull Request

You get an error that the Test field is required.

### Expected result AFTER applying this Pull Request

No error; the category is saved correctly.

### Documentation Changes Required

None. I mean, it would be nice if someone documented the “Only Use In Subform” field as now there's no tooltip and no documentation. What does this do? Nobody knows. Even looking at the code it was not obvious, presumably because it did nothing at all to begin with...

### Backwards compatibility notes

The `\Joomla\Component\Fields\Administrator\Helper\FieldsHelper::getFields` method has changed so that, by default, it does not return ALL fields but only those not marked as “Only Use In Subform”. Is this a b/c break? I would say no, because the intent of this option was to make these fields unavailable anywhere EXCEPT the subform custom field. Fixing a bug so that something works as it should, per the meager code documentation, shouldn't be considered a b/c break.

If it is to be considered a b/c break then the “Only Use In Subform“ feature should be removed from 4.0 as it cannot be fixed otherwise (well, just part II of the fix will kinda–sorta fix it but it's an ancillary artefact at best). Then again, removing a feature — even one that never worked — would be a b/c break.

So I am going to ping @wilsonge and @zero-24 and let them sort out the decision–making process of what constitutes a backward compatibility break in this context.

### Technical notes

This is a two part issue.

#### Part I. “Only Use In Subform” doesn't do anything

The new “Only Use In Subform” option in a Custom Field's definition not doing what it's supposed to do.

Supposedly, custom fields with this option enabled would be excluded from everything _except_ defining or rendering a subform custom field.

In reality, this option does nothing useful. It displays a badge in the fields list. Oh, yeah, it also makes the Custom Fields where this option is enabled have a category list of `[-1]`. That's the beginning, middle and end of it. Totally useless.

I changed `\Joomla\Component\Fields\Administrator\Helper\FieldsHelper::getFields` to only load non–subform–only fields by default. If you want to get all fields, including subform–only, you need to pass `true` to a new fifth parameter. Note that the ONLY use case for retrieving all fields, including subform–only, is the SubfieldsField and the subform field itself. Third–party software SHOULD NOT receive those fields outside of the context of a subform custom field, therefore this is not a b/c break.

#### Part II. `PlgSystemFields::onContentPrepareForm` doesn't actually work for com_categories (when saving)

You will see that the system plugin **ALLEGEDLY** has special handling for editing categories in com_categories. Allegedly, because it works on the edit page but NOT when saving! When saving all fields from all categories are loaded since the plugin runs before the form data is loaded from the request, meaning there is no category filter present.

You see, `$data` is an empty array when you the `onContentPrepareForm` event is fired _when saving the form_. I see that  the choice to not populate the form data when loading the form in `\Joomla\CMS\MVC\Controller\FormController::save` dates back to 2010 when Andrew made a commit about fixing some unspecified issue saving plugins.

The problem is that for com_categories _and only this component_ we actually need to load the form data from the request when saving data. Otherwise PlgSystemFields:: onContentPrepareForm sees that $data is empty and doesn't set the category ID. As a result `FieldsHelper::prepareForm` populates `$assignedCatids` to null, therefore it loads all fields from all categories. If any of these fields is required AND has a validator which doesn't accept NULL values — like the ones @crystalenka mentioned — you get a save error.

There are a few options to fix it. One is to override CategoryController::save. However, this results in severe code duplication which will be a pain in the posterior to manage whenever the base FormController::save method is updated.

The other option is to force CategoryModel::getForm to always load the data. However, this may break b/c; I'm especially concerned about third party plugins which may use the empty $data as a signal when figuring out which fields to add to the category edit view.

The final option is to change PlgSystemFields::onContentPrepareForm itself. Since we're doing special handling for com_categories we might just as well populate `data` from the request if we are saving the form. This is what I plan on doing. To keep things b/c this nasty workaround will ONLY apply to com_content categories, not third party extensions' categories. In fact, custom fields SHOULD only apply to com_content categories — which is not the case now — but that's a different bug for a different day, _n'est ce pas_?