### PR TITLE
[4.0] Fix wrong since tag coming from upmerge with deploy version

### DIFF
--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -222,7 +222,7 @@ class Update extends CMSObject
 	 * Array with compatible versions used by the pre-update check
 	 *
 	 * @var    array
-	 * @since  4.0.3
+	 * @since  3.10.2
 	 */
 	protected $compatibleVersions = array();
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

After the upmerge from 3.10-dev into 4.0-dev has been made with this commit https://github.com/joomla/joomla-cms/commit/6615552b8cd4fb48f060aca62a021d358fb6c7a7, the version bump was made on both branches for the RC versions.

Therefore a change has been merged up with a "@since" tag equal to "__DEPLOY_VERSION__", and the version bump after that has created that "@since" tag with two different versions on the two branches for the same thing.

See here https://github.com/joomla/joomla-cms/blob/3.10-dev/libraries/src/Updater/Update.php#L223 for the right tag on 3.10-dev and here https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/src/Updater/Update.php#L225 for the wrong tag in the 4.0-dev branch.

This PR here fixes that.

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

`@since  4.0.3`

### Expected result AFTER applying this Pull Request

`@since  3.10.2`

### Documentation Changes Required

None.