### PR TITLE
[4.0] Check in media field if image is set

### DIFF
--- a/plugins/fields/media/tmpl/media.php
+++ b/plugins/fields/media/tmpl/media.php
@@ -10,7 +10,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 
-if ($field->value == '')
+if (empty($field->value) || empty($field->value['imagefile']))
 {
 	return;
 }


### PR DESCRIPTION
Pull Request for Issue #35227.

### Summary of Changes
Media custom field checks if there is file set.

### Testing Instructions
- Create media custom field.
- Edit an article and open the fields tab.
- Set a description in the media field but NO image.
- Open the article on the front.

### Actual result BEFORE applying this Pull Request
The label of the custom field is shown with the description and an invalid image tag.

### Expected result AFTER applying this Pull Request
Nothing is rendered.