### PR TITLE
Fix underline between icon and link in mod_syndicate

### DIFF
--- a/modules/mod_syndicate/tmpl/default.php
+++ b/modules/mod_syndicate/tmpl/default.php
@@ -9,17 +9,15 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-?>
-<a href="<?php echo $link; ?>" class="mod-syndicate syndicate-module">
-	<span class="icon-feed" aria-hidden="true"></span>
-	<?php $class = $params->get('display_text', 1) ? '' : 'class="visually-hidden"'; ?>
-	<span <?php echo $class; ?>>
-		<?php if (str_replace(' ', '', $text) !== '') : ?>
-			<?php echo $text; ?>
-		<?php else : ?>
-			<?php echo Text::_('MOD_SYNDICATE_DEFAULT_FEED_ENTRIES'); ?>
-		<?php endif; ?>
-	</span>
-</a>
+$text = '<span class="icon-feed mr-1" aria-hidden="true"></span>'
+	. (!empty($text) ? $text :  Text::_('MOD_SYNDICATE_DEFAULT_FEED_ENTRIES'))
+	. ($params->get('display_text', 1) ? '' : 'class="visually-hidden"');
+
+$attribs = [
+	'class' => 'mod-syndicate syndicate-module'
+];
+
+echo HTMLHelper::_('link', $link, $text, $attribs);

--- a/modules/mod_syndicate/tmpl/default.php
+++ b/modules/mod_syndicate/tmpl/default.php
@@ -12,12 +12,13 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-$text = '<span class="icon-feed mr-1" aria-hidden="true"></span>'
-	. (!empty($text) ? $text :  Text::_('MOD_SYNDICATE_DEFAULT_FEED_ENTRIES'))
-	. ($params->get('display_text', 1) ? '' : 'class="visually-hidden"');
+$textClass = ($params->get('display_text', 1) ? '' : 'class="visually-hidden"');
+
+$linkText = '<span class="icon-feed m-1" aria-hidden="true"></span>';
+$linkText .= '<span ' . $textClass . '>' . (!empty($text) ? $text : Text::_('MOD_SYNDICATE_DEFAULT_FEED_ENTRIES')) . '</span>';
 
 $attribs = [
 	'class' => 'mod-syndicate syndicate-module'
 ];
 
-echo HTMLHelper::_('link', $link, $text, $attribs);
+echo HTMLHelper::_('link', $link, $linkText, $attribs);


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/35514#issuecomment-915955830
related to https://github.com/joomla/joomla-cms/issues/35548

### Summary of Changes
We use to code Links where they are needed and for readability we use to break lines. 
This causes errors in the output if a link is followed by a text, as the EOL is part of the link.

In mod_syndication I used HtmlHelper for generating the link. 

### Testing Instructions
See the generated link in the module syndication befor the patch (easy if you have blog sample data).
Apply the patch and the link is underlined properly. 


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/133275782-808648ff-8f0b-4fba-8209-d22946b88ba3.png)


