### PR TITLE
[4.0] pragma header

### DIFF
--- a/administrator/components/com_menus/src/View/Menu/XmlView.php
+++ b/administrator/components/com_menus/src/View/Menu/XmlView.php
@@ -91,7 +91,6 @@ class XmlView extends BaseHtmlView
 		header('content-disposition: attachment; filename="' . $menutype . '.xml"');
 		header("Cache-Control: no-cache, must-revalidate");
 		header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-		header('Pragma: private');
 
 		$dom = new \DOMDocument;
 		$dom->preserveWhiteSpace = true;

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -1096,7 +1096,6 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 					$this->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
 					$this->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
 					$this->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
-					$this->setHeader('Pragma', 'no-cache');
 					$this->sendHeaders();
 
 					$this->redirect((string) $oldUri, 301);
@@ -1162,9 +1161,6 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 		if ($this->allowCache() === false)
 		{
 			$this->setHeader('Cache-Control', 'no-cache', false);
-
-			// HTTP 1.0
-			$this->setHeader('Pragma', 'no-cache');
 		}
 
 		$this->sendHeaders();

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -482,7 +482,6 @@ class PlgSystemLanguageFilter extends CMSPlugin
 				$this->app->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
 				$this->app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
 				$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
-				$this->app->setHeader('Pragma', 'no-cache');
 				$this->app->sendHeaders();
 			}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Pragma is a HTTP/1.0 header.  In HTTP/1.1, Pragma is deprecated and superseded by the Cache-Control header. Remove Pragma to save bandwidth and processing power and it doesn't do anything as it is used after the cache-control header (this was by design to support http/1.0 headers a decade ago)

Mozilla telemetry indicates that there is less than 0.24% still using 1.0 https://mzl.la/3tFMtkA

httparchive didnt even include 1.0 in its 2020 almanac https://almanac.httparchive.org/en/2020/http#fig-3 but in 2019 they reported less than 0.06%


### Testing Instructions
View the http response headers using your browser inspector tools


### Actual result BEFORE applying this Pull Request

pragma response header is present
![image](https://user-images.githubusercontent.com/1296369/133322544-bac3bf6c-5d07-44c7-b6f4-7ddade95bb28.png)

### Expected result AFTER applying this Pull Request
no pragma response header
![image](https://user-images.githubusercontent.com/1296369/133323746-5d725dc8-e4fa-414b-ae59-438f769989fb.png)


There are further header updates for another pr and another day that can/should be made to remove http/1.0 headers such as replace the Expires header with  a Cache-Control header with a max-age directive instead. Cache-Control is more powerful, but also more efficient in that it avoids roundtrips to the origin server.