### PR TITLE
[4] Adapt modal articles to articles

### DIFF
--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -134,13 +134,13 @@ if (!empty($editor))
 							<a class="select-link" href="javascript:void(0)" <?php echo $attribs; ?>>
 								<?php echo $this->escape($item->title); ?>
 							</a>
-							<span class="small break-word">
+							<div class="small break-word">
 								<?php if (empty($item->note)) : ?>
 									<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->alias)); ?>
 								<?php else : ?>
 									<?php echo Text::sprintf('JGLOBAL_LIST_ALIAS_NOTE', $this->escape($item->alias), $this->escape($item->note)); ?>
 								<?php endif; ?>
-							</span>
+							</div>
 							<div class="small">
 								<?php echo Text::_('JCATEGORY') . ': ' . $this->escape($item->category_title); ?>
 							</div>


### PR DESCRIPTION
Pull Request for Issue #35548. 

The issue comes from line break in the title link.
It could be resolved also by writiing the link in one line or by using HtmlHelper.
But it is better when the articles are displayed always in the same format. 

### Summary of Changes
Make a new line for Alias after title, so the article list is the same in list view and modal.


### Testing Instructions
see issue 


### Actual result BEFORE applying this Pull Request
see issue


### Expected result AFTER applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/133331010-d34743c1-84a2-482b-919c-444cec4a6edc.png)



### Documentation Changes Required

