### PR TITLE
[4.0] http request header

### DIFF
--- a/libraries/src/Http/Transport/SocketTransport.php
+++ b/libraries/src/Http/Transport/SocketTransport.php
@@ -90,7 +90,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
 
 		// Build the request payload.
 		$request = array();
-		$request[] = strtoupper($method) . ' ' . ((empty($path)) ? '/' : $path) . ' HTTP/1.0';
+		$request[] = strtoupper($method) . ' ' . ((empty($path)) ? '/' : $path) . ' HTTP/1.1';
 		$request[] = 'Host: ' . $uri->getHost();
 
 		// If an explicit user agent is given use it.


### PR DESCRIPTION
code review

Mozilla telemetry indicates that there is less than 0.24% still using 1.0 https://mzl.la/3tFMtkA

httparchive didnt even include 1.0 in its 2020 almanac https://almanac.httparchive.org/en/2020/http#fig-3 but in 2019 they reported less than 0.06%