### PR TITLE
Incorrect notifications in Update Checker

### DIFF
--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile version="3.9" client="administrator">
 	<name>English (en-GB)</name>
-	<version>3.10.2</version>
+	<version>3.10.3</version>
 	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/language/en-GB/en-GB.xml
+++ b/administrator/language/en-GB/en-GB.xml
@@ -2,7 +2,7 @@
 <metafile version="3.9" client="administrator">
 	<name>English (en-GB)</name>
 	<version>3.10.2</version>
-	<creationDate>August 2021</creationDate>
+	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -3,7 +3,7 @@
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
 	<version>3.10.2</version>
-	<creationDate>August 2021</creationDate>
+	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -2,7 +2,7 @@
 <extension version="3.9" client="administrator" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>3.10.2</version>
+	<version>3.10.3</version>
 	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,7 +6,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>3.10.2-rc1</version>
+	<version>3.10.2-dev</version>
 	<creationDate>September 2021</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,8 +6,8 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>3.10.2-dev</version>
-	<creationDate>August 2021</creationDate>
+	<version>3.10.2-rc1</version>
+	<creationDate>September 2021</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 
 	<scriptfile>administrator/components/com_admin/script.php</scriptfile>

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,7 +6,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>3.10.2</version>
+	<version>3.10.3-dev</version>
 	<creationDate>September 2021</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,7 +6,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>3.10.2-dev</version>
+	<version>3.10.2</version>
 	<creationDate>September 2021</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,7 +2,7 @@
 <extension type="package" version="3.9" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>3.10.2.1</version>
+	<version>3.10.3.1</version>
 	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -3,7 +3,7 @@
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
 	<version>3.10.2.1</version>
-	<creationDate>August 2021</creationDate>
+	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/installation/language/en-GB/en-GB.xml
+++ b/installation/language/en-GB/en-GB.xml
@@ -3,7 +3,7 @@
 	version="3.9"
 	client="installation">
 	<name>English (United Kingdom)</name>
-	<version>3.10.2</version>
+	<version>3.10.3</version>
 	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<copyright>(C) 2005 Open Source Matters, Inc.</copyright>

--- a/installation/language/en-GB/en-GB.xml
+++ b/installation/language/en-GB/en-GB.xml
@@ -4,7 +4,7 @@
 	client="installation">
 	<name>English (United Kingdom)</name>
 	<version>3.10.2</version>
-	<creationDate>August 2021</creationDate>
+	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<copyright>(C) 2005 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -2,7 +2,7 @@
 <metafile version="3.9" client="site">
 	<name>English (en-GB)</name>
 	<version>3.10.2</version>
-	<creationDate>August 2021</creationDate>
+	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/language/en-GB/en-GB.xml
+++ b/language/en-GB/en-GB.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metafile version="3.9" client="site">
 	<name>English (en-GB)</name>
-	<version>3.10.2</version>
+	<version>3.10.3</version>
 	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -3,7 +3,7 @@
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
 	<version>3.10.2</version>
-	<creationDate>August 2021</creationDate>
+	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -2,7 +2,7 @@
 <extension version="3.9" client="site" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>3.10.2</version>
+	<version>3.10.3</version>
 	<creationDate>September 2021</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -220,7 +220,7 @@ class Update extends \JObject
 	 * Array with compatible versions used by the pre-update check
 	 *
 	 * @var    array
-	 * @since  __DEPLOY_VERSION__
+	 * @since  3.10.2
 	 */
 	protected $compatibleVersions = array();
 

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -60,7 +60,7 @@ final class Version
 	 * @var    string
 	 * @since  3.8.0
 	 */
-	const EXTRA_VERSION = 'dev';
+	const EXTRA_VERSION = '';
 
 	/**
 	 * Release version.
@@ -78,7 +78,7 @@ final class Version
 	 * @since  3.5
 	 * @deprecated  4.0  Use separated version constants instead
 	 */
-	const DEV_LEVEL = '2-dev';
+	const DEV_LEVEL = '2';
 
 	/**
 	 * Development status.
@@ -86,7 +86,7 @@ final class Version
 	 * @var    string
 	 * @since  3.5
 	 */
-	const DEV_STATUS = 'Development';
+	const DEV_STATUS = 'Stable';
 
 	/**
 	 * Build number.
@@ -119,7 +119,7 @@ final class Version
 	 * @var    string
 	 * @since  3.5
 	 */
-	const RELTIME = '10:58';
+	const RELTIME = '11:01';
 
 	/**
 	 * Release timezone.

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -60,7 +60,7 @@ final class Version
 	 * @var    string
 	 * @since  3.8.0
 	 */
-	const EXTRA_VERSION = 'rc1';
+	const EXTRA_VERSION = 'dev';
 
 	/**
 	 * Release version.
@@ -78,7 +78,7 @@ final class Version
 	 * @since  3.5
 	 * @deprecated  4.0  Use separated version constants instead
 	 */
-	const DEV_LEVEL = '2-rc1';
+	const DEV_LEVEL = '2-dev';
 
 	/**
 	 * Development status.
@@ -86,7 +86,7 @@ final class Version
 	 * @var    string
 	 * @since  3.5
 	 */
-	const DEV_STATUS = 'Release Candidate';
+	const DEV_STATUS = 'Development';
 
 	/**
 	 * Build number.
@@ -119,7 +119,7 @@ final class Version
 	 * @var    string
 	 * @since  3.5
 	 */
-	const RELTIME = '10:34';
+	const RELTIME = '10:58';
 
 	/**
 	 * Release timezone.

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -49,7 +49,7 @@ final class Version
 	 * @var    integer
 	 * @since  3.8.0
 	 */
-	const PATCH_VERSION = 2;
+	const PATCH_VERSION = 3;
 
 	/**
 	 * Extra release version info.
@@ -60,7 +60,7 @@ final class Version
 	 * @var    string
 	 * @since  3.8.0
 	 */
-	const EXTRA_VERSION = '';
+	const EXTRA_VERSION = 'dev';
 
 	/**
 	 * Release version.
@@ -78,7 +78,7 @@ final class Version
 	 * @since  3.5
 	 * @deprecated  4.0  Use separated version constants instead
 	 */
-	const DEV_LEVEL = '2';
+	const DEV_LEVEL = '3-dev';
 
 	/**
 	 * Development status.
@@ -86,7 +86,7 @@ final class Version
 	 * @var    string
 	 * @since  3.5
 	 */
-	const DEV_STATUS = 'Stable';
+	const DEV_STATUS = 'Development';
 
 	/**
 	 * Build number.
@@ -119,7 +119,7 @@ final class Version
 	 * @var    string
 	 * @since  3.5
 	 */
-	const RELTIME = '11:01';
+	const RELTIME = '11:17';
 
 	/**
 	 * Release timezone.

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -60,7 +60,7 @@ final class Version
 	 * @var    string
 	 * @since  3.8.0
 	 */
-	const EXTRA_VERSION = 'dev';
+	const EXTRA_VERSION = 'rc1';
 
 	/**
 	 * Release version.
@@ -78,7 +78,7 @@ final class Version
 	 * @since  3.5
 	 * @deprecated  4.0  Use separated version constants instead
 	 */
-	const DEV_LEVEL = '2-dev';
+	const DEV_LEVEL = '2-rc1';
 
 	/**
 	 * Development status.
@@ -86,7 +86,7 @@ final class Version
 	 * @var    string
 	 * @since  3.5
 	 */
-	const DEV_STATUS = 'Development';
+	const DEV_STATUS = 'Release Candidate';
 
 	/**
 	 * Build number.
@@ -111,7 +111,7 @@ final class Version
 	 * @var    string
 	 * @since  3.5
 	 */
-	const RELDATE = '22-August-2021';
+	const RELDATE = '12-September-2021';
 
 	/**
 	 * Release time.
@@ -119,7 +119,7 @@ final class Version
 	 * @var    string
 	 * @since  3.5
 	 */
-	const RELTIME = '18:42';
+	const RELTIME = '10:34';
 
 	/**
 	 * Release timezone.


### PR DESCRIPTION
Pull Request for Issue # .Incorrect notifications in Update Checker

### Summary of Changes
If I let the Update Checker show which extensions could cause an update problem, Akeeba also reports.
On Akeeba's site I read that they have all their extensions ready for the transition to Joomla 4.
Still, those extensions show up in the list.
Is there something wrong with recognizing the information about these extensions?

I was hoping this was fixed since the update to Joomla 3.10.2
See :https://github.com/joomla/joomla-cms/pull/35510

This is what they say at Akeeba:  https://www.akeeba.com/support/akeeba-backup-3x/Ticket/35784:questions-about-the-migration-to-joomla-4.html

And here you can read that they are ready for Joomla 4: https://www.akeeba.com/news/1748-joomla-3-10-and-4-0-common-issues.html


### Testing Instructions
The notifications about Akeeba Backup and Akeeba AdminTools should no longer appear in the update checker.


### Actual result BEFORE applying this Pull Request
At the moment there are still notifications about extensions that cannot be updated. But that seems so wrong.


### Expected result AFTER applying this Pull Request
These notifications should no longer appear in the Update Checker if the extensions conform to the most recent version.


### Documentation Changes Required
See above in the Summary of Changes.
