### PR TITLE
[3.10] Fix category data lost on failure save

### DIFF
--- a/administrator/components/com_categories/controllers/category.php
+++ b/administrator/components/com_categories/controllers/category.php
@@ -106,6 +106,47 @@ class CategoriesControllerCategory extends JControllerForm
 	}
 
 	/**
+	 * Override parent save method to store form data with right key as expected by edit category page
+	 *
+	 * @param   string  $key     The name of the primary key of the URL variable.
+	 * @param   string  $urlVar  The name of the URL variable if different from the primary key (sometimes required to avoid router collisions).
+	 *
+	 * @return  boolean  True if successful, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function save($key = null, $urlVar = null)
+	{
+		$result = parent::save($key, $urlVar);
+
+		$oldKey = $this->option . '.edit.category.data';
+		$newKey = $this->option . '.edit.category.' . substr($this->extension, 4) . '.data';
+		$app    = JFactory::getApplication();
+		$app->setUserState($newKey, $app->getUserState($oldKey));
+
+		return $result;
+	}
+
+	/**
+	 * Override cancel method to clear form data for a failed edit action
+	 *
+	 * @param   string  $key  The name of the primary key of the URL variable.
+	 *
+	 * @return  boolean  True if access level checks pass, false otherwise.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function cancel($key = null)
+	{
+		$result = parent::cancel($key);
+
+		$newKey = $this->option . '.edit.category.' . substr($this->extension, 4) . '.data';
+		JFactory::getApplication()->setUserState($newKey, null);
+
+		return $result;
+	}
+
+	/**
 	 * Method to run batch operations.
 	 *
 	 * @param   object  $model  The model.


### PR DESCRIPTION
Pull Request for Issue #35565.

### Summary of Changes
Backport PR https://github.com/joomla/joomla-cms/pull/32959 to 3.10 to prevent data lost when category could not be saved properly for some reasons (for example, use an existing Alias)

### Testing Instructions
1. Create a new category
2. Enter an existing Alias into Alias field (so that category could not be saved)
3. Apply patch
4. Before patch: Error message displayed, but form data lost when you are redirected back to add category screen
5. After patch: Error message displayed, you are redirected back to add category screen but the data you entered before is kept so that you don't have to re-enter.