### PR TITLE
[J4] Adds support for custom class on subforms via xml

### DIFF
--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -28,6 +28,7 @@ extract($displayData);
  * @var   string  $control          The forms control
  * @var   string  $label            The field label
  * @var   string  $description      The field description
+ * @var   string  $class            Classes for the container
  * @var   array   $buttons          Array of the buttons that will be rendered
  * @var   bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
  */
@@ -38,6 +39,8 @@ if ($multiple)
 	Factory::getDocument()->getWebAssetManager()
 		->useScript('webcomponent.field-subform');
 }
+
+$class = $class ? ' ' . $class : '';
 
 // Build heading
 $table_head = '';
@@ -80,7 +83,7 @@ else
 ?>
 
 <div class="subform-repeatable-wrapper subform-table-layout subform-table-sublayout-<?php echo $sublayout; ?>">
-	<joomla-field-subform class="subform-repeatable" name="<?php echo $name; ?>"
+	<joomla-field-subform class="subform-repeatable<?php echo $class; ?>" name="<?php echo $name; ?>"
 		button-add=".group-add" button-remove=".group-remove" button-move="<?php echo empty($buttons['move']) ? '' : '.group-move' ?>"
 		repeatable-element=".subform-repeatable-group"
 		rows-container="tbody.subform-repeatable-container" minimum="<?php echo $min; ?>" maximum="<?php echo $max; ?>">

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -28,6 +28,7 @@ extract($displayData);
  * @var   string  $control          The forms control
  * @var   string  $label            The field label
  * @var   string  $description      The field description
+ * @var   string  $class            Classes for the container
  * @var   array   $buttons          Array of the buttons that will be rendered
  * @var   bool    $groupByFieldset  Whether group the subform fields by it`s fieldset
  */
@@ -39,11 +40,13 @@ if ($multiple)
 		->useScript('webcomponent.field-subform');
 }
 
+$class = $class ? ' ' . $class : '';
+
 $sublayout = empty($groupByFieldset) ? 'section' : 'section-byfieldsets';
 ?>
 
 <div class="subform-repeatable-wrapper subform-layout">
-	<joomla-field-subform class="subform-repeatable" name="<?php echo $name; ?>"
+	<joomla-field-subform class="subform-repeatable<?php echo $class; ?>" name="<?php echo $name; ?>"
 		button-add=".group-add" button-remove=".group-remove" button-move="<?php echo empty($buttons['move']) ? '' : '.group-move' ?>"
 		repeatable-element=".subform-repeatable-group" minimum="<?php echo $min; ?>" maximum="<?php echo $max; ?>">
 		<?php if (!empty($buttons['add'])) : ?>


### PR DESCRIPTION
This PR makes it possible to add a `class="..."` to a subform via the XML of your extension.

```
<field name="foobar" type="subform"
	label="FOO_BAR"
	multiple="true"
	class="my-special-class"
>
...
```

After applying this patch, you should be able to see this in the HTML output:
```
<joomla-field-subform class="subform-repeatable my-special-class" ...
```

Also works on the repeatable table layout, when applying this to the XML field tag:
```
	layout="joomla.form.field.subform.repeatable-table"
```