### PR TITLE
[4.0] Logged in users module

### DIFF
--- a/administrator/modules/mod_logged/tmpl/disabled.php
+++ b/administrator/modules/mod_logged/tmpl/disabled.php
@@ -12,6 +12,9 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 
 ?>
-<p class="card-text">
-	<?php echo Text::_('MOD_LOGGED_NO_SESSION_METADATA'); ?>
-</p>
+<div class="mb-4">
+	<p class="fw-bold text-center text-muted">
+		<span class="icon-users" aria-hidden="true"></span>
+		<?php echo Text::_('MOD_LOGGED_NO_SESSION_METADATA'); ?>
+	</p>
+</div>


### PR DESCRIPTION
If you do not have the track session metadata option enabled in global configuration then the admin module for Logged Users displays an appropriate message.

This PR simply styles the module output correctly to be consistent

### Before
![image](https://user-images.githubusercontent.com/1296369/133835595-739415a8-c075-470b-9eba-c5270fbf2006.png)


### After
![image](https://user-images.githubusercontent.com/1296369/133835528-802a2edb-306e-4619-b7d2-45b86db016c8.png)
