### PR TITLE
Remove the unnecessary space character in $item->text

### DIFF
--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -189,7 +189,7 @@ class JsonapiView extends BaseApiView
 	 */
 	protected function prepareItem($item)
 	{
-		$item->text = $item->introtext . ' ' . $item->fulltext;
+		$item->text = $item->introtext . $item->fulltext;
 
 		// Process the content plugins.
 		PluginHelper::importPlugin('content');

--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -216,7 +216,7 @@ class HtmlView extends BaseHtmlView
 		 */
 		if ($item->params->get('show_intro', '1') == '1')
 		{
-			$item->text = $item->introtext . ' ' . $item->fulltext;
+			$item->text = $item->introtext . $item->fulltext;
 		}
 		elseif ($item->fulltext)
 		{


### PR DESCRIPTION
Found a problem with the addition of an extra space character. For example, if the article contains only introtext (with several paragraphs) and no fulltext. Then `$item->text` will be 1 longer due to the added space character.





### Testing Instructions
`var_dump($article);`


### Actual result BEFORE applying this Pull Request

```
  ["introtext"]=>
  string(780) "<p>***trick.</p>"
  ["fulltext"]=>
  string(0) ""
  ["text"]=>
  string(781) "<p>***trick.</p> "
```


Notice the line length 761 and now the line no longer ends with `</p>`.


