### PR TITLE
[4.1] Add Joomla! Accessibility Team to the code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -70,10 +70,10 @@ plugins/workflow/*	@bembelimen @hleithner
 # Joomla! Accessibility Team
 administrator/*/components/*/tmpl/* @chmst
 administrator/*/modules/*/tmpl/* @chmst
-administrator/templates/atum/html/* @chmst
+administrator/templates/atum/* @chmst
 components/*/tmpl/* @chmst
 modules/*/tmpl/* @chmst
 plugins/*/tmpl/* @chmst
-templates/cassiopeia/html/* @chmst
+templates/cassiopeia/* @chmst
 layouts/* @chmst
 installation/tmpl/* @chmst

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -66,3 +66,13 @@ libraries/src/MVC/Model/Workflow*	@bembelimen @hleithner
 libraries/src/Workflow/*	@bembelimen @hleithner
 build/media_source/com_workflow/*	@bembelimen @hleithner
 plugins/workflow/*	@bembelimen @hleithner
+
+# Joomla! Accessibility Team
+administrator/*/components/*/tmpl/* @chmst
+administrator/*/modules/*/tmpl/* @chmst
+administrator/templates/atum/html/* @chmst
+components/*/tmpl/* @chmst
+modules/*/tmpl/* @chmst
+plugins/*/tmpl/* @chmst
+layouts/* @chmst
+installation/tmpl/* @chmst

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -74,5 +74,6 @@ administrator/templates/atum/html/* @chmst
 components/*/tmpl/* @chmst
 modules/*/tmpl/* @chmst
 plugins/*/tmpl/* @chmst
+templates/cassiopeia/html/* @chmst
 layouts/* @chmst
 installation/tmpl/* @chmst


### PR DESCRIPTION
### Summary of Changes

This PR adds the Joomla! Accessibility Team Lead to the code owners as requested cc @chmst 

### Testing Instructions

Review that i have not missed an layout file folder path

### Actual result BEFORE applying this Pull Request

Joomla! Accessibility Team Lead is not notified on changes to the layout files

### Expected result AFTER applying this Pull Request

Joomla! Accessibility Team Lead is notified on changes to the layout files

### Documentation Changes Required

none