### PR TITLE
[4.0] Fix undefined constant "GLOB_BRACE" error when using TinyMCE on certain OS like e.g. Alpine Linux

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -488,17 +488,16 @@ class PlgEditorTinymce extends CMSPlugin
 						continue;
 					}
 
-					$lang        = Factory::getLanguage();
 					$title       = $filename;
 					$title_upper = strtoupper($filename);
 					$description = ' ';
 
-					if ($lang->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE'))
+					if ($language->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE'))
 					{
 						$title = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE');
 					}
 
-					if ($lang->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC'))
+					if ($language->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC'))
 					{
 						$description = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC');
 					}

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -474,40 +474,40 @@ class PlgEditorTinymce extends CMSPlugin
 			$template_path = $levelParams->get('content_template_path');
 			$template_path = $template_path ? '/templates/' . $template_path : '/media/vendor/tinymce/templates';
 
-			// We need this loop because a single glob call with the GLOB_BRACE flag isn't supported on all OS
-			foreach (['html', 'txt'] as $suffix)
+			$filepaths = Folder::exists(JPATH_ROOT . $template_path)
+				? Folder::files(JPATH_ROOT . $template_path, '\.(html|txt)$', false, true)
+				: [];
+
+			foreach ($filepaths as $filepath)
 			{
-				foreach (glob(JPATH_ROOT . $template_path . '/*.' . $suffix) as $filepath)
+				$fileinfo      = pathinfo($filepath);
+				$filename      = $fileinfo['filename'];
+				$full_filename = $fileinfo['basename'];
+
+				if ($filename === 'index')
 				{
-					$fileinfo      = pathinfo($filepath);
-					$filename      = $fileinfo['filename'];
-					$full_filename = $fileinfo['basename'];
-
-					if ($filename === 'index')
-					{
-						continue;
-					}
-
-					$title       = $filename;
-					$title_upper = strtoupper($filename);
-					$description = ' ';
-
-					if ($language->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE'))
-					{
-						$title = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE');
-					}
-
-					if ($language->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC'))
-					{
-						$description = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC');
-					}
-
-					$templates[] = array(
-						'title' => $title,
-						'description' => $description,
-						'url' => Uri::root(true) . $template_path . '/' . $full_filename,
-					);
+					continue;
 				}
+
+				$title       = $filename;
+				$title_upper = strtoupper($filename);
+				$description = ' ';
+
+				if ($language->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE'))
+				{
+					$title = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE');
+				}
+
+				if ($language->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC'))
+				{
+					$description = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC');
+				}
+
+				$templates[] = array(
+					'title' => $title,
+					'description' => $description,
+					'url' => Uri::root(true) . $template_path . '/' . $full_filename,
+				);
 			}
 		}
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -474,37 +474,41 @@ class PlgEditorTinymce extends CMSPlugin
 			$template_path = $levelParams->get('content_template_path');
 			$template_path = $template_path ? '/templates/' . $template_path : '/media/vendor/tinymce/templates';
 
-			foreach (glob(JPATH_ROOT . $template_path . '/*.{html,txt}', GLOB_BRACE) as $filepath)
+			// We need this loop because a single glob call with the GLOB_BRACE flag isn't supported on all OS
+			foreach (['html', 'txt'] as $suffix)
 			{
-				$fileinfo      = pathinfo($filepath);
-				$filename      = $fileinfo['filename'];
-				$full_filename = $fileinfo['basename'];
-
-				if ($filename === 'index')
+				foreach (glob(JPATH_ROOT . $template_path . '/*.' . $suffix) as $filepath)
 				{
-					continue;
+					$fileinfo      = pathinfo($filepath);
+					$filename      = $fileinfo['filename'];
+					$full_filename = $fileinfo['basename'];
+
+					if ($filename === 'index')
+					{
+						continue;
+					}
+
+					$lang        = Factory::getLanguage();
+					$title       = $filename;
+					$title_upper = strtoupper($filename);
+					$description = ' ';
+
+					if ($lang->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE'))
+					{
+						$title = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE');
+					}
+
+					if ($lang->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC'))
+					{
+						$description = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC');
+					}
+
+					$templates[] = array(
+						'title' => $title,
+						'description' => $description,
+						'url' => Uri::root(true) . $template_path . '/' . $full_filename,
+					);
 				}
-
-				$lang        = Factory::getLanguage();
-				$title       = $filename;
-				$title_upper = strtoupper($filename);
-				$description = ' ';
-
-				if ($lang->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE'))
-				{
-					$title = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_TITLE');
-				}
-
-				if ($lang->hasKey('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC'))
-				{
-					$description = Text::_('PLG_TINY_TEMPLATE_' . $title_upper . '_DESC');
-				}
-
-				$templates[] = array(
-					'title' => $title,
-					'description' => $description,
-					'url' => Uri::root(true) . $template_path . '/' . $full_filename,
-				);
 			}
 		}
 


### PR DESCRIPTION
Pull Request for Issue #35633 .

### Summary of Changes

This pull request (PR) changes the look up for TinyMCE templates so that it doesn't use anymore a single "glob" call using the "GLOB_BRACE" flag.

See https://www.php.net/manual/en/function.glob.php :

> Note: The GLOB_BRACE flag is not available on some non GNU systems, like Solaris or Alpine Linux.

The use of that flag had been introduced with PR #33130 , so we don't have that issue in Joomla 3.

In addition to the above fix, this PR remove a redundant call to `Factory::getLanguage()` from inside the foreach loop. The language object is already fetched here https://github.com/joomla/joomla-cms/blob/4.0-dev/plugins/editors/tinymce/tinymce.php#L178 in the same routine and later not modified, so it can be used.

### Testing Instructions

1. Use the TinyMCE editor on a Joomla 4 installation on an operating system which doesn't support the "GLOB_BRACE" flag, like e.g. Alpine Linux.

2. Check if PR #33130 still works by testing as described in that PR.

### Actual result BEFORE applying this Pull Request

1. See issue #35633 : `error 0: Undefined constant "GLOB_BRACE"`.

2. Cannot be tested if you have error 1.

### Expected result AFTER applying this Pull Request

1. No errors, all works fine.

2. The test from PR #33130 works as it should.

### Documentation Changes Required

None.