### PR TITLE
[4.0] Centered text on emptystater screen is hard to read (a11y).

### DIFF
--- a/layouts/joomla/content/emptystate.php
+++ b/layouts/joomla/content/emptystate.php
@@ -39,7 +39,7 @@ $btnadd     = $displayData['btnadd'] ?? Text::_($textPrefix . '_EMPTYSTATE_BUTTO
 		<span class="fa-8x mb-4 <?php echo $icon; ?>" aria-hidden="true"></span>
 		<h1 class="display-5 fw-bold"><?php echo $title; ?></h1>
 		<div class="col-lg-6 mx-auto">
-			<p class="lead mb-4">
+			<p class="lead mb-4 text-start">
 				<?php echo $content; ?>
 			</p>
 			<div class="d-grid gap-2 d-sm-flex justify-content-sm-center">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Text in paragraphs is hard to read if it is centered. This PR aligns textin emptystate layout for better reading. 

Compare empty page screens screens before and after applying the patch. 

Example here: administrator/index.php?option=com_installer&view=discover

<img width="751" alt="text-before-after" src="https://user-images.githubusercontent.com/1035262/134374187-a1b3349f-16e7-4b29-86e1-2aed0e0f1075.PNG">
### Documentation Changes Required

