### PR TITLE
[4.0] Language Keys may have a : in it.

### DIFF
--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -885,7 +885,7 @@ class Language
 			}
 
 			// Check that the line passes the necessary format.
-			if (!preg_match('#^[A-Z][A-Z0-9_\*\-\.]*\s*=\s*".*"(\s*;.*)?$#', $line))
+			if (!preg_match('#^[A-Z][A-Z0-9_:\*\-\.]*\s*=\s*".*"(\s*;.*)?$#', $line))
 			{
 				$errors[] = $realNumber;
 				continue;


### PR DESCRIPTION
Since the merge of my PR https://github.com/joomla/joomla-cms/pull/35429, the help view now shows errors in the language strings in com_admin.ini if language debug is enabled.

### Summary of Changes
Adjusting the error check so the `:` in the language key now pass the check.


### Testing Instructions
* Enable language debug in the System Configuration
* Go to Help -> Joomla Help
* Check errors


### Actual result BEFORE applying this Pull Request
Some 60+ errors are shown


### Expected result AFTER applying this Pull Request
No error is shown


### Documentation Changes Required
None
