### PR TITLE
[4.0] Don't show help button if no help URL or reference is defined

### DIFF
--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -287,6 +287,9 @@ class HtmlView extends BaseHtmlView
 			$path = Path::clean(JPATH_ADMINISTRATOR . "/components/$component/models/forms/$name.xml");
 		}
 
+		$ref_key = '';
+		$url     = '';
+
 		// Look first in form for help key and url
 		if (file_exists($path))
 		{
@@ -302,9 +305,20 @@ class HtmlView extends BaseHtmlView
 		if (!$ref_key)
 		{
 			// Compute the ref_key if it does exist in the component
-			if (!$lang->hasKey($ref_key = strtoupper($component . ($section ? "_$section" : '')) . '_CATEGORIES_HELP_KEY'))
+			$languageKey = strtoupper($component . ($section ? "_$section" : '')) . '_CATEGORIES_HELP_KEY';
+
+			if ($lang->hasKey($languageKey))
 			{
-				$ref_key = 'JHELP_COMPONENTS_' . strtoupper(substr($component, 4) . ($section ? "_$section" : '')) . '_CATEGORIES';
+				$ref_key = $languageKey;
+			}
+			else
+			{
+				$languageKey = 'JHELP_COMPONENTS_' . strtoupper(substr($component, 4) . ($section ? "_$section" : '')) . '_CATEGORIES';
+
+				if ($lang->hasKey($languageKey))
+				{
+					$ref_key = $languageKey;
+				}
 			}
 		}
 
@@ -325,6 +339,6 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		$toolbar->help($ref_key, ComponentHelper::getParams($component)->exists('helpURL'), $url);
+		ToolbarHelper::help($ref_key, ComponentHelper::getParams($component)->exists('helpURL'), $url);
 	}
 }

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -264,15 +264,23 @@ class HtmlView extends BaseHtmlView
 		// Try with a language string
 		if (!$ref_key)
 		{
-			// Compute the ref_key
-			$ref_key = strtoupper($component . ($section ? "_$section" : '')) . '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT') . '_HELP_KEY';
+			// Compute the ref_key if it does exist in the component
+			$languageKey = strtoupper($component . ($section ? "_$section" : '')) . '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT') . '_HELP_KEY';
 
-			// Check if the computed ref_key does exist in the component
-			if (!$lang->hasKey($ref_key))
+			if ($lang->hasKey($languageKey))
 			{
-				$ref_key = 'JHELP_COMPONENTS_'
+				$ref_key = $languageKey;
+			}
+			else
+			{
+				$languageKey = 'JHELP_COMPONENTS_'
 					. strtoupper(substr($component, 4) . ($section ? "_$section" : ''))
 					. '_CATEGORY_' . ($isNew ? 'ADD' : 'EDIT');
+
+				if ($lang->hasKey($languageKey))
+				{
+					$ref_key = $languageKey;
+				}
 			}
 		}
 

--- a/administrator/components/com_config/src/View/Component/HtmlView.php
+++ b/administrator/components/com_config/src/View/Component/HtmlView.php
@@ -124,7 +124,19 @@ class HtmlView extends BaseHtmlView
 
 		$helpUrl = $this->form->getData()->get('helpURL');
 		$helpKey = (string) $this->form->getXml()->config->help['key'];
-		$helpKey = $helpKey ?: 'JHELP_COMPONENTS_' . strtoupper($this->currentComponent) . '_OPTIONS';
+
+		// Try with legacy language key
+		if (!$helpKey)
+		{
+			$language    = Factory::getApplication()->getLanguage();
+			$languageKey = 'JHELP_COMPONENTS_' . strtoupper($this->currentComponent) . '_OPTIONS';
+
+			if ($language->hasKey($languageKey))
+			{
+				$helpKey = $languageKey;
+			}
+		}
+
 		ToolbarHelper::help($helpKey, (boolean) $helpUrl, null, $this->currentComponent);
 	}
 }

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -145,6 +145,12 @@ abstract class ToolbarHelper
 	 */
 	public static function help($ref, $com = false, $override = null, $component = null)
 	{
+		// Don't show a help button if neither $ref nor $override is given
+		if (!$ref && !$override)
+		{
+			return;
+		}
+
 		$bar = Toolbar::getInstance('toolbar');
 
 		// Add a help button.


### PR DESCRIPTION
Currently, a help button is shown always in com_categories, com_config and com_modules (and maybe other places), regardless if the extension actually has a help page or not.

### Summary of Changes
* Backend Categories list and edit views as well as Component Options view are changed so they check if a language string actually exists before addding it as `ref_key` for the help button
* ToolbarHelper::help() only creates the help button if either `$ref` or `$override` is passed.
* Fixed three notices in the categories view about undefined variables in case no help is specified.

### Testing Instructions
Check with a 3rd party extension if the help button either works (one is specified) or doesn't appear (if none is specified) in:
* Categories list
* Category edit form
* Component Options
* Module Options

### Actual result BEFORE applying this Pull Request
Help button is always shown. If no help is specified, the help page will show a RuntimeException error
![image](https://user-images.githubusercontent.com/1018684/134728530-f5966c2b-6579-4310-a583-2aae9228abe7.png)



### Expected result AFTER applying this Pull Request
Help button doesn't appear when no help is specified
No change to before if help is specified.


### Documentation Changes Required
None
