### PR TITLE
Causing issue in PHP8.0.11 due to BC break in PHP8.0 regarding call_user_func_array and named parameters

### DIFF
--- a/libraries/src/Captcha/Captcha.php
+++ b/libraries/src/Captcha/Captcha.php
@@ -224,7 +224,7 @@ class Captcha implements DispatcherAwareInterface
 	{
 		if (method_exists($this->captcha, $name))
 		{
-			return call_user_func_array(array($this->captcha, $name), $args);
+			return call_user_func_array(array($this->captcha, $name), array_values($args));
 		}
 
 		return null;


### PR DESCRIPTION
Pull Request for Issue #35674 .

### Summary of Changes
Fix issue in Captcha causing a Fatal error in PHP8.0 due to B/C break in PHP8.0 regarding call_user_func_array and named properties
https://github.com/joomla/joomla-cms/issues/35674#issue-1007224748
Added array_values around $params to prevent breaking change behaviour when using assoc arrays and named properties in call_user_func_array in PHP 8.0.11


### Testing Instructions
Use PHP8.0.11
Enable captcha for Joomla 4.0.3 core contact form
Go to the contact form


### Actual result BEFORE applying this Pull Request
Fatal error: Unknown named property $id


### Expected result AFTER applying this Pull Request
The captcha shows up without error


### Documentation Changes Required
I don't think so.
