### PR TITLE
_getUser invalide name fix

### DIFF
--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -421,7 +421,7 @@ class PlgUserJoomla extends CMSPlugin
 		$defaultUserGroup = $params->get('new_usertype', $params->get('guest_usergroup', 1));
 
 		$instance->id = 0;
-		$instance->name = $user['fullname'];
+		$instance->name = $user['name'];
 		$instance->username = $user['username'];
 		$instance->password_clear = $user['password_clear'];
 


### PR DESCRIPTION
"fullname" is undefined, correct key is "name"

tested with joomla 4.0.3