### PR TITLE
 Missing labels on filter fields

### DIFF
--- a/layouts/joomla/searchtools/default/filters.php
+++ b/layouts/joomla/searchtools/default/filters.php
@@ -24,6 +24,7 @@ $filters = $data['view']->filterForm->getGroup('filter');
 				<?php $dataShowOn = " data-showon='" . json_encode(JFormHelper::parseShowOnConditions($field->showon, $field->formControl, $field->group)) . "'"; ?>
 			<?php endif; ?>
 			<div class="js-stools-field-filter"<?php echo $dataShowOn; ?>>
+				<?php echo $field->label; ?>
 				<?php echo $field->input; ?>
 			</div>
 		<?php endif; ?>


### PR DESCRIPTION
https://issues.joomla.org/tracker/joomla-cms/2699
The reported issue is still reproducable on joomla 3.10.1. 
A fix had been added to J4 but missing from J3. 
https://github.com/joomla/joomla-cms/blob/42cfca1b7fc1f03f06ebeed7c147397139fb120a/layouts/joomla/searchtools/default/filters.php#L33

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions
Check the issue. 
https://issues.joomla.org/tracker/joomla-cms/2699


### Actual result BEFORE applying this Pull Request
Labels were not visible of search filters


### Expected result AFTER applying this Pull Request
Shows labels of search filters


### Documentation Changes Required
No
