### PR TITLE
Subform: fix incorrect data-base-name, do not set empty fieldname

### DIFF
--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -196,9 +196,14 @@ class SubformField extends FormField
 			return false;
 		}
 
-		foreach (array('fieldname', 'formsource', 'min', 'max', 'layout', 'groupByFieldset', 'buttons') as $attributeName)
+		foreach (array('formsource', 'min', 'max', 'layout', 'groupByFieldset', 'buttons') as $attributeName)
 		{
 			$this->__set($attributeName, $element[$attributeName]);
+		}
+
+		if ((string) $element['fieldname'])
+		{
+			$this->__set('fieldname', $element['fieldname']);
 		}
 
 		if ($this->value && \is_string($this->value))


### PR DESCRIPTION
Pull Request for Issue #35677 .

### Summary of Changes

After #24711 the `fieldname` is always empty (for subform fields which added in XML), 
that leads to incorrect `data-base-name` attribute.


### Testing Instructions
Please follow #35677
Apply patch,
Add subform somwhere in XML, example in Custom HTML module:

```xml
<field type="subform" name="foobar" label="subform" multiple="true">
  <form>
    <field type="text" name="text" label="text" />
  </form>
</field>
```

And look for `data-base-name` attribute of each section of the field.



### Actual result BEFORE applying this Pull Request
The attribute always like `__fieldX`


### Expected result AFTER applying this Pull Request
The attribute equal to field name like `foobar`


### Documentation Changes Required
none
