### PR TITLE
[4.0] Finder fixes: term length, null category

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -934,6 +934,12 @@ class Indexer
 
 			foreach ($tokens as $token)
 			{
+				// Database size for a term field
+				if ($token->length > 75)
+				{
+					continue;
+				}
+
 				if ($filterCommon && $token->common)
 				{
 					continue;

--- a/plugins/finder/contacts/contacts.php
+++ b/plugins/finder/contacts/contacts.php
@@ -363,7 +363,7 @@ class PlgFinderContacts extends Adapter
 		$category = $categories->get($item->catid);
 
 		// Category does not exist, stop here
-		if ($category)
+		if (!$category)
 		{
 			return;
 		}

--- a/plugins/finder/contacts/contacts.php
+++ b/plugins/finder/contacts/contacts.php
@@ -361,7 +361,11 @@ class PlgFinderContacts extends Adapter
 		// Add the category taxonomy data.
 		$categories = Categories::getInstance('com_contact', ['published' => false, 'access' => false]);
 		$category = $categories->get($item->catid);
-		$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
+
+		if ($category)
+		{
+			$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
+		}
 
 		// Add the language taxonomy data.
 		$item->addTaxonomy('Language', $item->language);

--- a/plugins/finder/contacts/contacts.php
+++ b/plugins/finder/contacts/contacts.php
@@ -362,10 +362,13 @@ class PlgFinderContacts extends Adapter
 		$categories = Categories::getInstance('com_contact', ['published' => false, 'access' => false]);
 		$category = $categories->get($item->catid);
 
+		// Category does not exist, stop here
 		if ($category)
 		{
-			$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
+			return;
 		}
+
+		$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
 
 		// Add the language taxonomy data.
 		$item->addTaxonomy('Language', $item->language);

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -322,7 +322,7 @@ class PlgFinderContent extends Adapter
 		$category = $categories->get($item->catid);
 
 		// Category does not exist, stop here
-		if ($category)
+		if (!$category)
 		{
 			return;
 		}

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -321,10 +321,13 @@ class PlgFinderContent extends Adapter
 		$categories = Categories::getInstance('com_content', ['published' => false, 'access' => false]);
 		$category = $categories->get($item->catid);
 
+		// Category does not exist, stop here
 		if ($category)
 		{
-			$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
+			return;
 		}
+
+		$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
 
 		// Add the language taxonomy data.
 		$item->addTaxonomy('Language', $item->language);

--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -320,7 +320,11 @@ class PlgFinderContent extends Adapter
 		// Add the category taxonomy data.
 		$categories = Categories::getInstance('com_content', ['published' => false, 'access' => false]);
 		$category = $categories->get($item->catid);
-		$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
+
+		if ($category)
+		{
+			$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
+		}
 
 		// Add the language taxonomy data.
 		$item->addTaxonomy('Language', $item->language);

--- a/plugins/finder/newsfeeds/newsfeeds.php
+++ b/plugins/finder/newsfeeds/newsfeeds.php
@@ -298,10 +298,13 @@ class PlgFinderNewsfeeds extends Adapter
 		$categories = Categories::getInstance('com_newsfeeds', ['published' => false, 'access' => false]);
 		$category = $categories->get($item->catid);
 
+		// Category does not exist, stop here
 		if ($category)
 		{
-			$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
+			return;
 		}
+
+		$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
 
 		// Add the language taxonomy data.
 		$item->addTaxonomy('Language', $item->language);

--- a/plugins/finder/newsfeeds/newsfeeds.php
+++ b/plugins/finder/newsfeeds/newsfeeds.php
@@ -299,7 +299,7 @@ class PlgFinderNewsfeeds extends Adapter
 		$category = $categories->get($item->catid);
 
 		// Category does not exist, stop here
-		if ($category)
+		if (!$category)
 		{
 			return;
 		}

--- a/plugins/finder/newsfeeds/newsfeeds.php
+++ b/plugins/finder/newsfeeds/newsfeeds.php
@@ -297,7 +297,11 @@ class PlgFinderNewsfeeds extends Adapter
 		// Add the category taxonomy data.
 		$categories = Categories::getInstance('com_newsfeeds', ['published' => false, 'access' => false]);
 		$category = $categories->get($item->catid);
-		$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
+
+		if ($category)
+		{
+			$item->addNestedTaxonomy('Category', $category, $this->translateState($category->published), $category->access, $category->language);
+		}
 
 		// Add the language taxonomy data.
 		$item->addTaxonomy('Language', $item->language);


### PR DESCRIPTION
### Summary of Changes

Based on  #35676.

Fixes include:
* make sure category exists
* term length check



### Testing Instructions

Create an article with text:
```
LoremipsumdolorsitametcuvimgraeceblanditrecusaboeuesseiuvaretsitusueasinthonestatisEosdolorem accumsan in, 
ex vix stet rebum idque, ad vis utinam graeci percipitur. Sint liber iracundia in est, sea cu enim brute malis. 
Simul intellegam neglegentur ius eu, ullum adipisci splendide mei ne.
```



### Actual result BEFORE applying this Pull Request
Error while saving: `Data too long for column 'term' at row 1`


### Expected result AFTER applying this Pull Request
No error


### Documentation Changes Required
none
