### PR TITLE
[4.0] Update codemirror

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3093,9 +3093,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.62.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.2.tgz",
-      "integrity": "sha512-tVFMUa4J3Q8JUd1KL9yQzQB0/BJt7ZYZujZmTPgo/54Lpuq3ez4C8x/ATUY/wv7b7X3AUq8o3Xd+2C5ZrCGWHw=="
+      "version": "5.63.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.1.tgz",
+      "integrity": "sha512-baivaNZreZOGh1/tYyTvCupC9NeWk7qlZeGUDi4nFKj/J0JU8FYKZND4QqLw70P7HOttlCt4JJAOj9GoIhHEkA=="
     },
     "node_modules/color": {
       "version": "3.1.3",
@@ -12876,9 +12876,9 @@
       }
     },
     "codemirror": {
-      "version": "5.62.2",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.62.2.tgz",
-      "integrity": "sha512-tVFMUa4J3Q8JUd1KL9yQzQB0/BJt7ZYZujZmTPgo/54Lpuq3ez4C8x/ATUY/wv7b7X3AUq8o3Xd+2C5ZrCGWHw=="
+      "version": "5.63.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.1.tgz",
+      "integrity": "sha512-baivaNZreZOGh1/tYyTvCupC9NeWk7qlZeGUDi4nFKj/J0JU8FYKZND4QqLw70P7HOttlCt4JJAOj9GoIhHEkA=="
     },
     "color": {
       "version": "3.1.3",

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_codemirror</name>
-	<version>5.62.2</version>
+	<version>5.63.1</version>
 	<creationDate>28 March 2011</creationDate>
 	<author>Marijn Haverbeke</author>
 	<authorEmail>marijnh@gmail.com</authorEmail>


### PR DESCRIPTION
**29-09-2021: Version 5.63.1:**
Fix an issue with mouse scrolling on Chrome 94 Windows, which made scrolling by wheel move unusably slow.

**20-09-2021: Version 5.63.0:**
Fix scroll position jumping when scrolling a document with very different line heights.
xml mode: Look up HTML element behavior in a case-insensitive way.
vim bindings: Support guu for case-changing.

**20-08-2021: Version 5.62.3:**
Give the editor a translate=no attribute to prevent automatic translation from modifying its content.
Give vim-style cursors a width that matches the character after them.
merge addon: Make buttons keyboard-accessible.
emacs bindings: Fix by-page scrolling keybindings, which were accidentally inverted.
