### PR TITLE
[com_search] Performance Improvement: Removes unnecessary Lower Checks

### DIFF
--- a/plugins/search/content/content.php
+++ b/plugins/search/content/content.php
@@ -142,11 +142,11 @@ class PlgSearchContent extends JPlugin
 				{
 					$word      = $db->quote('%' . $db->escape($word, true) . '%', false);
 					$wheres2   = array();
-					$wheres2[] = 'LOWER(a.title) LIKE LOWER(' . $word . ')';
-					$wheres2[] = 'LOWER(a.introtext) LIKE LOWER(' . $word . ')';
-					$wheres2[] = 'LOWER(a.fulltext) LIKE LOWER(' . $word . ')';
-					$wheres2[] = 'LOWER(a.metakey) LIKE LOWER(' . $word . ')';
-					$wheres2[] = 'LOWER(a.metadesc) LIKE LOWER(' . $word . ')';
+					$wheres2[] = '(a.title) LIKE (' . $word . ')';
+					$wheres2[] = '(a.introtext) LIKE (' . $word . ')';
+					$wheres2[] = '(a.fulltext) LIKE (' . $word . ')';
+					$wheres2[] = '(a.metakey) LIKE (' . $word . ')';
+					$wheres2[] = '(a.metadesc) LIKE (' . $word . ')';
 
 					$relevance[] = ' CASE WHEN ' . $wheres2[0] . ' THEN 5 ELSE 0 END ';
 
@@ -160,7 +160,7 @@ class PlgSearchContent extends JPlugin
 							->where('(f.context IS NULL OR f.context = ' . $db->q('com_content.article') . ')')
 							->where('(f.state IS NULL OR f.state = 1)')
 							->where('(f.access IS NULL OR f.access IN (' . $groups . '))')
-							->where('LOWER(cfv.value) LIKE LOWER(' . $word . ')');
+							->where('(cfv.value) LIKE (' . $word . ')');
 
 						// Filter by language.
 						if ($app->isClient('site') && JLanguageMultilang::isEnabled())
@@ -185,7 +185,7 @@ class PlgSearchContent extends JPlugin
 					}
 					else
 					{
-						$cfwhere[] = 'LOWER(cfv.value) LIKE LOWER(' . $word . ')';
+						$cfwhere[] = '(cfv.value) LIKE (' . $word . ')';
 					}
 
 					$wheres[] = implode(' OR ', $wheres2);


### PR DESCRIPTION
### Summary of Changes

This is a database performance improvement queries used by com_search.

Converting strings to LOWER in the LIKE statements make the queries slower and heavier. Plus, indexes are not used when queries have 'LOWER', which makes things worse.

Those checks are unnecessary as LIKE comparison in MySQL are already case insensitive.
https://tecadmin.net/mysql-case-sensitive-search-with-like/

### Actual result BEFORE applying this Pull Request

Queries are a lot slower and indexes are not used.

### Expected result AFTER applying this Pull Request

Queries are a lot faster. I've done some tests and I've seen some queries go from:

0.5830 seconds
to:
0.0005 seconds

with the same exact results.

### Documentation Changes Required

None