### PR TITLE
[4] Set HTTP_HOST from CLI

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -123,6 +123,9 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 
 		// Register the client name as cli
 		$this->name = 'cli';
+		
+		// Set HTTP_HOST
+		$_SERVER['HTTP_HOST'] = 'localhost';
 
 		$this->setContainer($container);
 		$this->setDispatcher($dispatcher);

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -123,9 +123,6 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 
 		// Register the client name as cli
 		$this->name = 'cli';
-		
-		// Set HTTP_HOST
-		$_SERVER['HTTP_HOST'] = 'localhost';
 
 		$this->setContainer($container);
 		$this->setDispatcher($dispatcher);

--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -100,6 +100,11 @@ class Uri extends \Joomla\Uri\Uri
 					 *
 					 * IIS uses the SCRIPT_NAME variable instead of a REQUEST_URI variable... thanks, MS
 					 */
+					if (Factory::getApplication()->isClient('cli'))
+					{
+						$_SERVER['HTTP_HOST'] = 'localhost';
+					}
+
 					$theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'];
 
 					// If the query string exists append it to the URI string


### PR DESCRIPTION
Pull Request for Issue #35625 .

### Summary of Changes
set a default


### Testing Instructions

> With the command php cli/joomla.php list, you get a list of all available CLI commands.
The script throws a PHP notice if the system plugin "System - Page Cache" is enabled:

### before
Notice: Undefined index: HTTP_HOST in /xxx/libraries/src/Uri/Uri.php on line 103

### after 
No Notice

### Documentation Changes Required
no
