### PR TITLE
[4][com_tags] Created Date cannot change on every save

### DIFF
--- a/administrator/components/com_tags/src/Model/TagModel.php
+++ b/administrator/components/com_tags/src/Model/TagModel.php
@@ -127,19 +127,8 @@ class TagModel extends AdminModel
 			$registry = new Registry($result->urls);
 			$result->urls = $registry->toArray();
 
-			// Convert the created and modified dates to local user time for display in the form.
+			// Convert the modified dates to local user time for display in the form.
 			$tz = new \DateTimeZone(Factory::getApplication()->get('offset'));
-
-			if ((int) $result->created_time)
-			{
-				$date = new Date($result->created_time);
-				$date->setTimezone($tz);
-				$result->created_time = $date->toSql(true);
-			}
-			else
-			{
-				$result->created_time = null;
-			}
 
 			if ((int) $result->modified_time)
 			{


### PR DESCRIPTION
Pull Request for Issue #35670 .

### Summary of Changes
don't change Created Date 


### Testing Instructions


1.   Set your server time (System - Global Configuration - Server) to something different from UTC. Testing this is more intuitive, if your server is actually located in this time zone (e.g. CEST = UTC+2). Otherwise, you'd have to do the appropriate calculations in order to check if the time fits.
2.   Check the time zone setting of your own user (top right: User Menu - Edit Account - Basic Settings) to match your actual time zone (or to compensate for the "wrong" server time zone from step 1 if your server is on UTC).
3.   At Components - Tags, create a new tag and save it.
4.   Edit the tag and look at the created and modified date.
5.   Save the tag multiple times.




### Actual result BEFORE applying this Pull Request
The Created Date is increased on every save.


### Expected result AFTER applying this Pull Request
The Created Date  do not change on every save.


### Documentation Changes Required
No
