### PR TITLE
[4.0] Subform nested: fix incorrect input name

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
@@ -269,9 +269,9 @@
         if (el.nodeName === 'JOOMLA-FIELD-SUBFORM') {
           // Skip self in .closest() call
           return el.parentElement.closest('joomla-field-subform') === this;
-        } else {
-          return el.closest('joomla-field-subform') === this;
         }
+
+        return el.closest('joomla-field-subform') === this;
       });
 
       haveName.forEach((elem) => {

--- a/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-subform.w-c.es6.js
@@ -265,7 +265,14 @@
       const ids = {}; // Collect id for fix checkboxes and radio
 
       // Filter out nested
-      haveName = [].slice.call(haveName).filter((el) => el.closest('joomla-field-subform') === this);
+      haveName = [].slice.call(haveName).filter((el) => {
+        if (el.nodeName === 'JOOMLA-FIELD-SUBFORM') {
+          // Skip self in .closest() call
+          return el.parentElement.closest('joomla-field-subform') === this;
+        } else {
+          return el.closest('joomla-field-subform') === this;
+        }
+      });
 
       haveName.forEach((elem) => {
         const $el = elem;


### PR DESCRIPTION
Pull Request for Issue #35721 .

### Summary of Changes
Fixes incorect name for child subform.


### Testing Instructions
Run `bpm install`
And please follow #35721

Or create a subform somewhere, example in XML for Custom HTML module
```xml
<field
        name="subform_parent"
        label="Subform Parent"
        type="subform"
        multiple="true"
        buttons="add,remove"
>
    <form>
        <field
                name="test_text"
                label="Test Text"
                type="text"
        />
        <field
                name="child_subform"
                label="Child Subform"
                type="subform"
                multiple="true"
        >
            <form>
                <field
                        name="child_text"
                        label="Child Field"
                        type="text"
                />
            </form>
        </field>
    </form>
</field>
```

Add parent field, add children field, and save.

### Actual result BEFORE applying this Pull Request
You got 2 parents instead 1


### Expected result AFTER applying this Pull Request
All saved correctly


### Documentation Changes Required
none
