### PR TITLE
[4.0] Showon: fix for nested subform

### DIFF
--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -262,7 +262,7 @@
 
         // Fix showon field names in a current group
         elements.forEach((element) => {
-          let {showon} = element.dataset;
+          let { showon } = element.dataset;
           search.forEach((pattern, i) => {
             showon = showon.replace(pattern, replace[i]);
           });

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -254,7 +254,7 @@
         const search = [];
         const replace = [];
 
-        // Collect all parent group of changed group
+        // Collect all parent groups of changed group
         getMatchedParents(target, '.subform-repeatable-group').forEach(($parent) => {
           search.push(new RegExp(`\\[${$parent.dataset.baseName}X\\]`, 'g'));
           replace.push(`[${$parent.dataset.group}]`);
@@ -262,7 +262,7 @@
 
         // Fix showon field names in a current group
         elements.forEach((element) => {
-          let showon = element.dataset.showon;
+          let {showon} = element.dataset;
           search.forEach((pattern, i) => {
             showon = showon.replace(pattern, replace[i]);
           });

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -227,7 +227,11 @@
   });
 
   /**
-   * Initialize 'showon' feature when part of the page was updated
+   * Search for matching parents
+   *
+   * @param {HTMLElement} $child
+   * @param {String} selector
+   * @returns {HTMLElement[]}
    */
   const getMatchedParents = ($child, selector) => {
     let $parent = $child;
@@ -245,6 +249,9 @@
     return parents;
   };
 
+  /**
+   * Initialize 'showon' feature when part of the page was updated
+   */
   document.addEventListener('joomla:updated', ({ target }) => {
     // Check is it subform, then wee need to fix some "showon" config
     if (target.classList.contains('subform-repeatable-group')) {

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -229,18 +229,46 @@
   /**
    * Initialize 'showon' feature when part of the page was updated
    */
+  const getMatchedParents = ($child, selector) => {
+    let $parent = $child;
+    let $matchingParent;
+    const parents = [];
+
+    while ($parent) {
+      $matchingParent = $parent.matches && $parent.matches(selector) ? $parent : null;
+      if ($matchingParent) {
+        parents.unshift($matchingParent);
+      }
+      $parent = $parent.parentNode;
+    }
+
+    return parents;
+  };
+
   document.addEventListener('joomla:updated', ({ target }) => {
     // Check is it subform, then wee need to fix some "showon" config
     if (target.classList.contains('subform-repeatable-group')) {
       const elements = [].slice.call(target.querySelectorAll('[data-showon]'));
-      const search = new RegExp(`\\[${target.dataset.baseName}X\\]`, 'g');
-      const replace = `[${target.dataset.group}]`;
 
-      // Fix showon field names in a current group
-      elements.forEach((element) => {
-        const showon = element.dataset.showon.replace(search, replace);
-        element.dataset.showon = showon;
-      });
+      if (elements.length) {
+        const search = [];
+        const replace = [];
+
+        // Collect all parent groups of subform
+        getMatchedParents(target, '.subform-repeatable-group').forEach(($parent) => {
+          search.push(new RegExp(`\\[${$parent.dataset.baseName}X\\]`, 'g'));
+          replace.push(`[${$parent.dataset.group}]`);
+        });
+
+        // Fix showon field names in a current group
+        elements.forEach((element) => {
+          let showon = element.dataset.showon;
+          search.forEach((pattern, i) => {
+            showon = showon.replace(pattern, replace[i]);
+          });
+          element.dataset.showon = showon;
+        });
+      }
     }
 
     Joomla.Showon.initialise(target);

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -254,7 +254,7 @@
         const search = [];
         const replace = [];
 
-        // Collect all parent groups of subform
+        // Collect all parent group of changed group
         getMatchedParents(target, '.subform-repeatable-group').forEach(($parent) => {
           search.push(new RegExp(`\\[${$parent.dataset.baseName}X\\]`, 'g'));
           replace.push(`[${$parent.dataset.group}]`);


### PR DESCRIPTION
### Summary of Changes
Fixing showon to work in nested subform.
Should be applied after #35726


### Testing Instructions

Apply  #35726 patch.
Run `npm install`
Create nested subform field with showon,  example in XML for Custom HTML module:
```xml
<field
  name="subform_parent"
  label="Subform Parent"
  type="subform"
  multiple="true"
  buttons="add,remove"
>
  <form>
    <field
      name="test_text"
      label="Test Text"
      type="text"
    />
    <field
      name="child_subform"
      label="Child Subform"
      type="subform"
      multiple="true"
    >
      <form>
        <field
          name="child_text"
          label="Child Select"
          type="list"
          default="1"
        >
          <option value="1">1</option>
          <option value="2">2</option>
        </field>
        
        <field
          name="child_text2"
          label="Child Text"
          type="text"
          showon="child_text:2"
        />
      </form>
    </field>
  </form>
</field>
```
Add parent field, add children field. Check that field "Child Text" visible only when "Child Select" is 2

### Actual result BEFORE applying this Pull Request
Not works


### Expected result AFTER applying this Pull Request
Works


### Documentation Changes Required
none
