### PR TITLE
[4.0] Don't include restore_finalisation.php in full package for new installation

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -551,6 +551,9 @@ chdir($time);
 // The search package manifest should not be present for new installs, temporarily move it
 system('mv administrator/manifests/packages/pkg_search.xml ../pkg_search.xml');
 
+// The restore_finalisation.php should not be present for new installs, temporarily move it
+system('mv administrator/components/com_joomlaupdate/restore_finalisation.php ../restore_finalisation.php');
+
 // Create full archive packages.
 if (!$excludeBzip2)
 {
@@ -600,6 +603,9 @@ system('rm images/powered_by.png');
 
 // Move the search manifest back
 system('mv ../pkg_search.xml administrator/manifests/packages/pkg_search.xml');
+
+// Move the restore_finalisation.php back
+system('mv ../restore_finalisation.php administrator/components/com_joomlaupdate/restore_finalisation.php');
 
 if (!$excludeBzip2)
 {

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -155,6 +155,7 @@ $foldersDifference = array_diff($previousReleaseFolders, $newReleaseFolders);
 
 // Specific files (e.g. language files) that we want to keep on upgrade
 $filesToKeep = [
+	"'/administrator/components/com_joomlaupdate/restore_finalisation.php',",
 	"'/administrator/language/en-GB/en-GB.com_search.ini',",
 	"'/administrator/language/en-GB/en-GB.com_search.sys.ini',",
 	"'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.ini',",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With pull request (PR) #35388 the server- and client-side code for Joomla Update when applying the update (extracting the update Joomla ZIP file and running the update finalisation code) has been modernised and simplified. Thanks a lot to @nikosdion for that great improvement. The change has been merged after the last 4.0.3 release so it will be included in the upcoming 4.0.4.

Because it can happen that the old "administrator/components/com_joomlaupdate/restore_finalisation.php" is still called when updating a 4.0.3 or earlier to a 4.0.4. or later, this script was changed with that PR so it calls the new "administrator/components/com_joomlaupdate/finalisation.php" and is removed at the end of the update, but not with the files removal in "administrator/components/com_admin/script.php" because that caused trouble in that scenario, so it's later removed in the update model's "cleanUp" method.

That means we don't need that old "restore_finalisation.php" on new installations, we need it only one time when updating from 4.0.3 or earlier versions.

Therefore it should not be included in new installations, similar to the "administrator/manifests/packages/pkg_search.xml" manifest file for the com_search package which we need only on updates from 3.10 and which is removed at the end of the update if no com_search is present.

This PR here changes the "build/build.php" so that the old "restore_finalisation.php" is only included into update packages but not into the full package for new installations, using the same method as for the "pkg_search.xml" file.

In addition it changes the script "build/deleted_file_check.php" so that the "restore_finalisation.php" will not be included into the list of files to be deleted with "script.php" which is generated by "deleted_file_check.php" based on comparisons of full packages. The "restore_finalisation.php" is added to the list of files to be excluded from the comparison.

### Testing Instructions

Requirements: A Joomla 4 development environment (i.e. git, composer, npm and PHP CLI) on Linux (or Windows with WSL) which understands the system command "mv" using slashes "/" as path separator.

1. Download the Joomla 4.0.3 full package for new installations from here https://github.com/joomla/joomla-cms/releases/download/4.0.3/Joomla_4.0.3-Stable-Full_Package.zip .

2. Unzip the downloaded package into a new folder somewhere outside the "build/tmp" folder.
The description in the following steps will use "build/Joomla_4.0.3-Stable-Full_Package".
After that the path to the unpacked "index.php" file should be "build/Joomla_4.0.3-Stable-Full_Package/index.php".
If it is "build/Joomla_4.0.3-Stable-Full_Package/Joomla_4.0.3-Stable-Full_Package/index.php", remove the 2nd "Joomla_4.0.3-Stable-Full_Package" folder and unpack the zip again in the right way.

3. On the curent 4.0-dev branch, open a command shell and change to the Joomla root folder.

4. Run following command in the command shell window and wait until it has completed.
```
php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2
```
Result: There will be 4 packages created in folder "build/tmp/packages", of which one is the full package "Joomla_4.0.4-dev-Development-Full_Package.zip".

5. Unzip the full package "build/tmp/packages/Joomla_4.0.4-dev-Development-Full_Package.zip" into a new folder somewhere outside the "build/tmp" folder in the same way as in step 2.
The description in the following steps will use "build/Joomla_4.0.4-dev-Development-Full_Package".
After that the path to the unpacked "index.php" file should be "build/Joomla_4.0.4-dev-Development-Full_Package/index.php".

6. Run following commands in the command shell window.
```
cd build
php ./deleted_file_check.php --from=./Joomla_4.0.3-Stable-Full_Package --to=./Joomla_4.0.4-dev-Development-Full_Package
mv ./deleted_files.txt ./deleted_files_before.txt
mv ./deleted_folders.txt ./deleted_folders_before.txt
mv ./renamed_files.txt ./renamed_files_before.txt
cd ..
```

7. Save the 4 packages which have been created in folder "build/tmp/packages" somewhere outside the "build/tmp" folder so you can verify them later.

8. Remove the folder in which you had unzipped the full package in step 5, e.g. "build/Joomla_4.0.4-dev-Development-Full_Package".

9. Apply the changes from this PR.

10. Repeat steps 4 and 5.

11. Run following commands in the command shell window.
```
cd build
php ./deleted_file_check.php --from=./Joomla_4.0.3-Stable-Full_Package --to=./Joomla_4.0.4-dev-Development-Full_Package
mv ./deleted_files.txt ./deleted_files_after.txt
mv ./deleted_folders.txt ./deleted_folders_after.txt
mv ./renamed_files.txt ./renamed_files_after.txt
cd ..
```

12. Compare the files `*_after.txt` created in the previous step with the corresponding files `*_before.txt` created in step 6.
Result: No changes, i.e. file "deleted_files_after.txt" is identical with file "deleted_files_before.txt" and so on.

13. Compare the 4 packages created in step 10 with the saved ones from step 5 regarding which files they contain.
Result: The full package from step 10 doesn't contain the "administrator/components/com_joomlaupdate/restore_finalisation.php" file while the one from step 5 does. That's the only difference regarding presence of files.
The update packages haven't changed regarding that, i.e. they still contain that file.

### Actual result BEFORE applying this Pull Request

File "administrator/components/com_joomlaupdate/restore_finalisation.php" is present in the full package for new installations.

After an update, is is not removed by script.php but by the update model here: https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php#L902-L906

### Expected result AFTER applying this Pull Request

File "administrator/components/com_joomlaupdate/restore_finalisation.php" is not present anymore in the full package for new installations but still present in the update packages.

The file will still not be included in the list of files to be deleted.

### Documentation Changes Required

None.