### PR TITLE
[4.0] Fix drag and drop for featured

### DIFF
--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -194,9 +194,7 @@ $assoc = Associations::isEnabled();
 							$transition_ids = ArrayHelper::toInteger($transition_ids);
 
 							?>
-							<tr class="row<?php echo $i % 2; ?>" data-draggable-group="<?php echo $item->catid; ?>"
-								data-transitions="<?php echo implode(',', $transition_ids); ?>"
-							>
+							<tr class="row<?php echo $i % 2; ?>" data-transitions="<?php echo implode(',', $transition_ids); ?>">
 								<td class="text-center">
 									<?php echo HTMLHelper::_('grid.id', $i, $item->id, false, 'cid', 'cb', $item->title); ?>
 								</td>


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/35728

### Summary of Changes
- removed `data-draggable-group="<?php echo $item->catid; ?>"` as this attribute instructs the dragula to respect nested but this view should not respect nested categories as the order is a single entity

### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

No, bug fix