### PR TITLE
[4.1] Enable use of snake_case for form entities

### DIFF
--- a/libraries/src/Form/FormHelper.php
+++ b/libraries/src/Form/FormHelper.php
@@ -206,12 +206,15 @@ class FormHelper
 		// Check if there is a class in the registered namespaces
 		foreach (self::addPrefix($entity) as $prefix)
 		{
-			// Treat underscores as namespace
+			// Normalise type into space separated words
 			$name = Normalise::toSpaceSeparated($type);
+
+			// Treat underscores as namespace
 			$name = str_ireplace(' ', '\\', ucwords($name));
 
 			$subPrefix = '';
 
+			// If type is of form `context.property`, we break-off `context` as sub-prefix
 			if (strpos($name, '.'))
 			{
 				list($subPrefix, $name) = explode('.', $name);
@@ -222,6 +225,15 @@ class FormHelper
 			$class = rtrim($prefix, '\\') . '\\' . $subPrefix . ucfirst($name) . ucfirst($entity);
 
 			// Check if the class exists
+			if (class_exists($class))
+			{
+				return $class;
+			}
+
+			// Try normalising type to CamelCase
+			$name = Normalise::toCamelCase($type);
+			$class = rtrim($prefix, '\\') . '\\' . $subPrefix . $name . ucfirst($entity);
+
 			if (class_exists($class))
 			{
 				return $class;


### PR DESCRIPTION
### Summary of Changes
Enables **use of `snake_case`** style for custom fields (and rules and filters) **in form XML** by adding an additional `class_exists()` checks for entity types normalized to CamelCase. Currently, using `snake_case` is not possible unless a class alias is created through the class map.

With this PR, it will be possible to define a custom field class, for example, in pure CamelCase => `ComplexTypeField` and then use `<field ... type"complex_type"/>` to use it in the XML.

This change should be non-breaking as it only adds additional checks without altering existing code.

### Testing Instructions
For custom fields with CamelClass compliant class names (like `WorkflowComponentSections`), you can replace their usage in forms with snake_case.


### Actual result BEFORE applying this Pull Request
`snake_case` style in XML cannot be used for custom fields with CamelCase compliant class names.


### Expected result AFTER applying this Pull Request
Using `snake_case` for custom fields like the `WorkflowComponentSections` should be possible. Existing forms should work as expected.


### Documentation Changes Required
None I'm aware of.