### PR TITLE
[J4]Add extenstions   parent::getoptions() to field

### DIFF
--- a/libraries/src/Form/Field/HeadertagField.php
+++ b/libraries/src/Form/Field/HeadertagField.php
@@ -36,7 +36,7 @@ class HeadertagField extends ListField
 	 */
 	protected function getOptions()
 	{
-		$options = array();
+		$options = parent::getOptions();
 		$tags = array('h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'p', 'div');
 
 		// Create one new option object for each tag

--- a/libraries/src/Form/Field/ImagelistField.php
+++ b/libraries/src/Form/Field/ImagelistField.php
@@ -36,7 +36,7 @@ class ImagelistField extends FilelistField
 	protected function getOptions()
 	{
 		// Define the image file type filter.
-		$this->fileFilter = '\.png$|\.gif$|\.jpg$|\.bmp$|\.ico$|\.jpeg$|\.psd$|\.eps$';
+		$this->fileFilter = '\.avif$|\.webp$|\.heic$|\.png$|\.gif$|\.jpg$|\.bmp$|\.ico$|\.jpeg$|\.psd$|\.eps$';
 
 		// Get the field options.
 		return parent::getOptions();

--- a/libraries/src/Form/Field/ImagelistField.php
+++ b/libraries/src/Form/Field/ImagelistField.php
@@ -36,7 +36,7 @@ class ImagelistField extends FilelistField
 	protected function getOptions()
 	{
 		// Define the image file type filter.
-		$this->fileFilter = '\.avif$|\.webp$|\.heic$|\.png$|\.gif$|\.jpg$|\.bmp$|\.ico$|\.jpeg$|\.psd$|\.eps$';
+		$this->fileFilter = '\.png$|\.gif$|\.jpg$|\.bmp$|\.ico$|\.jpeg$|\.psd$|\.eps$';
 
 		// Get the field options.
 		return parent::getOptions();

--- a/libraries/src/Form/Field/ModuletagField.php
+++ b/libraries/src/Form/Field/ModuletagField.php
@@ -36,7 +36,7 @@ class ModuletagField extends ListField
 	 */
 	protected function getOptions()
 	{
-		$options = array();
+		$options = parent::getOptions();
 		$tags    = array('address', 'article', 'aside', 'details', 'div', 'footer', 'header', 'main', 'nav', 'section', 'summary');
 
 		// Create one new option object for each tag


### PR DESCRIPTION
I have added extenstions   parent::getoptions()  to tags based on the list tag.
So that you can add your own options to the list tags in the XML file.
It is very often necessary to use your own tags in the module.
You also need to use "Custom HTML Tags"
Without this fix, we are hard-wired to standard tags.

```
<field
                    name="module_tag"
                    type="moduletag"
                    default="fieldset" >
                    <option value="super-calendar">Super Calendar</option> 
                    <option value="custom-tabs">Tabs</option>
                    <option value="fieldset">Fieldset</option>
</field>
```

