### PR TITLE
[4.1] remove static access

### DIFF
--- a/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
@@ -136,7 +136,7 @@ class QuickIconHelper
 					$tmp['ajaxurl'] = 'index.php?option=com_tags&amp;task=tags.getQuickiconContent&amp;format=json';
 				}
 
-				self::$buttons[$key][] = $tmp;
+				$this->buttons[$key][] = $tmp;
 			}
 
 			if ($params->get('show_categories'))


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/35727

Update to Joomla 4.1-dev
![image](https://user-images.githubusercontent.com/400092/136004802-b765360f-a222-40ad-a5cf-d8318fe76e61.jpeg)

```
An error has occurred.
0 Access to undeclared static property: Joomla\Module\Quickicon\Administrator\Helper\QuickIconHelper::$buttons
```




