### PR TITLE
[3.10] Do not run code to load tags twice

### DIFF
--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -348,9 +348,6 @@ class ContactViewContact extends JViewLegacy
 		$this->contacts    = &$contacts;
 		$this->contactUser = $contactUser;
 
-		$item->tags = new JHelperTags;
-		$item->tags->getItemTags('com_contact.contact', $this->item->id);
-
 		// Override the layout only if this is not the active menu item
 		// If it is the active menu item, then the view and item id will match
 		if ((!$active) || ((strpos($active->link, 'view=contact') === false) || (strpos($active->link, '&id=' . (string) $this->item->id) === false)))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Tags for contact is already loaded inside model  https://github.com/joomla/joomla-cms/blob/3.10-dev/components/com_contact/models/contact.php#L252-L256, so we do not need to load it again from view class.

### Testing Instructions
1. Use Joomla 3.10
2. Create a contact. Add some tags for that contact
3. Create a menu item to link to **Single Contact** menu item type of com_contact
4. Access to that menu item

### Actual result BEFORE applying this Pull Request
Tags are being displayed OK, but unnecessary code is executed again inside view class to re-get tags from database.

### Expected result AFTER applying this Pull Request
Tags are being displayed OK, the unnecessary code is removed, so performance is increased a bit.