### PR TITLE
[4.0] Checkbox in Edit module settings

### DIFF
--- a/administrator/components/com_modules/tmpl/module/edit_assignment.php
+++ b/administrator/components/com_modules/tmpl/module/edit_assignment.php
@@ -97,7 +97,7 @@ $this->document->getWebAssetManager()
 									$uselessMenuItem = in_array($link->type, array('separator', 'heading', 'alias', 'url'));
 									$id = 'jform_menuselect';
 									?>
-									<input type="checkbox" class="novalidate" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; echo $uselessMenuItem ? ' disabled="disabled"' : ''; ?>>
+									<input type="checkbox" class="novalidate form-check-input" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : ''; echo $uselessMenuItem ? ' disabled="disabled"' : ''; ?>>
 									<label for="<?php echo $id . $link->value; ?>" class="">
 										<?php echo $link->text; ?>
 										<?php if (Multilanguage::isEnabled() && $link->language != '' && $link->language != '*') : ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Add class `form-check-input`

### Testing Instructions
Menus -> Manage -> click on any modules -> Menu Assignment -> select Only on the pages selected (or next)

![after](https://user-images.githubusercontent.com/61203226/136081979-5fac2346-88de-44a7-b7c6-5643d7fa6ee3.gif)

### Actual result BEFORE applying this Pull Request
![before_pic](https://user-images.githubusercontent.com/61203226/136081989-b8097553-a6da-48f7-a4e4-57f0a0c78d99.JPG)



### Expected result AFTER applying this Pull Request
![after_pic](https://user-images.githubusercontent.com/61203226/136082013-d2eb43e9-7b06-4abd-8b4f-d1a9b48a2d7b.JPG)



### Documentation Changes Required
No
