### PR TITLE
[4.0] pagination lists

### DIFF
--- a/layouts/joomla/pagination/links.php
+++ b/layouts/joomla/pagination/links.php
@@ -63,7 +63,7 @@ if ($currentPage >= $step)
 			<?php endif; ?>
 
 			<?php if ($showPagesLinks) : ?>
-				<ul class="pagination ms-auto mb-4 me-0">
+				<ol class="pagination ms-auto mb-4 me-0">
 					<?php echo LayoutHelper::render('joomla.pagination.link', $pages['start']); ?>
 					<?php echo LayoutHelper::render('joomla.pagination.link', $pages['previous']); ?>
 					<?php foreach ($pages['pages'] as $k => $page) : ?>
@@ -79,7 +79,7 @@ if ($currentPage >= $step)
 					<?php endforeach; ?>
 					<?php echo LayoutHelper::render('joomla.pagination.link', $pages['next']); ?>
 					<?php echo LayoutHelper::render('joomla.pagination.link', $pages['end']); ?>
-				</ul>
+				</ol>
 			<?php endif; ?>
 
 			<?php if ($showLimitStart) : ?>

--- a/layouts/joomla/pagination/list.php
+++ b/layouts/joomla/pagination/list.php
@@ -15,7 +15,7 @@ $list = $displayData['list'];
 
 ?>
 <nav class="pagination__wrapper" aria-label="<?php echo Text::_('JLIB_HTML_PAGINATION'); ?>">
-	<ul class="pagination ms-0 mb-4">
+	<ol class="pagination ms-0 mb-4">
 		<?php echo $list['start']['data']; ?>
 		<?php echo $list['previous']['data']; ?>
 
@@ -25,5 +25,5 @@ $list = $displayData['list'];
 
 		<?php echo $list['next']['data']; ?>
 		<?php echo $list['end']['data']; ?>
-	</ul>
+	</ol>
 </nav>


### PR DESCRIPTION
The pagination lists really should be ol (ordered lists) and not ul (unordered lists) as clearly the items in the list are in a specific order ;)

To test apply pr and then check that the pagination in any admin list view and any site list view still works and is displayed the same
