### PR TITLE
[4.0] Move com_templates css to separate file

### DIFF
--- a/administrator/components/com_templates/tmpl/style/edit_assignment.php
+++ b/administrator/components/com_templates/tmpl/style/edit_assignment.php
@@ -20,7 +20,8 @@ $user      = Factory::getUser();
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
-$wa->useScript('com_templates.admin-template-toggle-assignment');
+$wa->useScript('com_templates.admin-template-toggle-assignment')
+	->useStyle('com_templates.admin-template-toggle-assignment');
 
 ?>
 <label id="jform_menuselect-lbl" for="jform_menuselect"><?php echo Text::_('JGLOBAL_MENU_SELECTION'); ?></label>

--- a/administrator/templates/atum/scss/template.scss
+++ b/administrator/templates/atum/scss/template.scss
@@ -62,7 +62,6 @@
 @import "pages/com_modules";
 @import "pages/com_tags";
 @import "pages/com_privacy";
-@import "pages/com_templates";
 @import "pages/com_users";
 
 // Forcing reduced motion when set in the user OS

--- a/build/media_source/com_templates/joomla.asset.json
+++ b/build/media_source/com_templates/joomla.asset.json
@@ -53,6 +53,11 @@
       }
     },
     {
+      "name": "com_templates.admin-template-toggle-assignment",
+      "type": "style",
+      "uri": "com_templates/admin-template-toggle-assignment.min.css"
+    },
+    {
       "name": "com_templates.admin-template-toggle-switch.es5",
       "type": "script",
       "uri": "com_templates/admin-template-toggle-switch-es5.min.js",

--- a/build/media_source/com_templates/scss/admin-template-toggle-assignment.scss
+++ b/build/media_source/com_templates/scss/admin-template-toggle-assignment.scss
@@ -1,4 +1,9 @@
 // com_templates
+
+@import "../../../../media/vendor/bootstrap/scss/functions";
+@import "../../../../media/vendor/bootstrap/scss/variables";
+@import "../../../../media/vendor/bootstrap/scss/mixins";
+
 .com_templates {
 
   .menu-assignment {


### PR DESCRIPTION
### Summary of Changes

`/atum/scss/pages` contains page specific styling, which should be moved to separate CSS files, so that their only loaded on said specific page, rather than globally.

This PR moves the `com_templates` styling to a separate CSS file

### Testing Instructions

1. Run `npm i`
2. Go to `administrator/index.php?option=com_templates&view=styles`
3. Open the Cassiopeia template
4. Go to the `Menu Assignment` tab

### Expected result AFTER applying this Pull Request

The styling should be the same as before, but you should be able to confirm it derives from the separate CSS file:

![image](https://user-images.githubusercontent.com/2019801/136362867-e831d46f-a380-4484-9829-19bef2cc328b.png)

![image](https://user-images.githubusercontent.com/2019801/136362631-71ce9d7f-630c-435f-b66d-262bf921d058.png)

