### PR TITLE
[4.0] Copy atum template

### DIFF
--- a/administrator/templates/atum/templateDetails.xml
+++ b/administrator/templates/atum/templateDetails.xml
@@ -22,10 +22,9 @@
 		<folder>css</folder>
 		<folder>html</folder>
 		<folder>images</folder>
-		<folder>Service</folder>
 		<folder>scss</folder>
 	</files>
-	<media destination="templates/atum" folder="media">
+	<media destination="templates/administrator/atum" folder="media">
 		<folder>js</folder>
 	</media>
 	<positions>


### PR DESCRIPTION
### Summary of Changes
Correct the file paths in the templateDetails.xml


### Testing Instructions
Go to administrator templates and select atum
Use the copy template button on the toolbar
Give the template a new name

### Actual result BEFORE applying this Pull Request
Failure to copy the template
`-1 Source folder not found`

### Expected result AFTER applying this Pull Request
Template successfully copied


### Documentation Changes Required
none
