### PR TITLE
Fix backend template blog layout setting fields overflow

### DIFF
--- a/administrator/templates/atum/scss/blocks/_form.scss
+++ b/administrator/templates/atum/scss/blocks/_form.scss
@@ -47,7 +47,10 @@
   .form-vertical & {
     flex-direction: column;
   }
+}
 
+.stack .control-label {
+  width: 100%;
 }
 
 .spacer {

--- a/administrator/templates/atum/scss/blocks/_utilities.scss
+++ b/administrator/templates/atum/scss/blocks/_utilities.scss
@@ -46,16 +46,9 @@
     grid-template-columns: repeat(2, 1fr);
   }
 
-  @include media-breakpoint-up(md) {
+  @include media-breakpoint-up(xxl) {
     --span-3: span 3;
     --span-4: span 4;
-    --span-5: span 4;
-
-    grid-template-columns: repeat(4, 1fr);
-    grid-gap: 1rem 2rem;
-  }
-
-  @include media-breakpoint-up(lg) {
     --span-5: span 5;
 
     grid-template-columns: repeat(6, 1fr);
@@ -81,7 +74,11 @@
     grid-column: 1 / var(--span-2);
 
     &-inline {
-      grid-column: var(--span-2);
+      grid-column: var(--span-1);
+
+      @include media-breakpoint-up(xxl) {
+        grid-column: var(--span-2);
+      }
     }
   }
 

--- a/components/com_content/tmpl/category/blog.xml
+++ b/components/com_content/tmpl/category/blog.xml
@@ -222,7 +222,7 @@
 				name="multi_column_order"
 				type="list"
 				label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
-				parentclass="stack span-1-inline"
+				parentclass="stack span-2-inline"
 				useglobal="true"
 				validate="options"
 				>

--- a/components/com_content/tmpl/featured/default.xml
+++ b/components/com_content/tmpl/featured/default.xml
@@ -80,7 +80,7 @@
 				name="multi_column_order"
 				type="list"
 				label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
-				parentclass="stack span-1-inline"
+				parentclass="stack span-2-inline"
 				useglobal="true"
 				validate="options"
 				>


### PR DESCRIPTION
This is a fix for issues: #35816 and #34679

### Summary of Changes
1. Make the field labels as large as possible to accommodate larger text strings. If text strings are simply to lang or an really small breakpoints, wrapping will still occur. But that is due to design philosophy. 
2. Fixes the overflow of the fields in the Blog Layout tab

### Testing Instructions
Test the Articles Category Blog and the Articles Features Articles menu items and see if the overflow of the fields is fixed and the labels have a 100% width.

### Actual result BEFORE applying this Pull Request
See issues.

### Expected result AFTER applying this Pull Request
![Joomla-animatie](https://user-images.githubusercontent.com/5610413/137369945-a0b32084-42d8-4c74-b502-1f0d569d28af.gif)

### Documentation Changes Required
No
