### PR TITLE
[4.0] Hide invisible recapctah label

### DIFF
--- a/libraries/src/Form/Field/CaptchaField.php
+++ b/libraries/src/Form/Field/CaptchaField.php
@@ -37,6 +37,14 @@ class CaptchaField extends FormField
 	protected $_captcha;
 
 	/**
+	 * Hide the field label
+	 *
+	 * @var    boolean
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $hiddenLabel = true;
+
+	/**
 	 * Method to get certain otherwise inaccessible properties from the form field object.
 	 *
 	 * @param   string  $name  The property name for which to get the value.

--- a/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
+++ b/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
@@ -156,23 +156,6 @@ class PlgCaptchaRecaptcha_Invisible extends CMSPlugin
 	}
 
 	/**
-	 * Method to react on the setup of a captcha field. Gives the possibility
-	 * to change the field and/or the XML element for the field.
-	 *
-	 * @param   \Joomla\CMS\Form\Field\CaptchaField  $field    Captcha field instance
-	 * @param   \SimpleXMLElement                    $element  XML form definition
-	 *
-	 * @return void
-	 *
-	 * @since 3.9.0
-	 */
-	public function onSetupField(\Joomla\CMS\Form\Field\CaptchaField $field, \SimpleXMLElement $element)
-	{
-		// Hide the label for the invisible recaptcha type
-		$element['hiddenLabel'] = true;
-	}
-
-	/**
 	 * Get the reCaptcha response.
 	 *
 	 * @param   string  $privatekey  The private key for authentication.


### PR DESCRIPTION
Pull Request for Issue #35814

### Summary of Changes

Hide the invisible captcha label

### Testing Instructions

1. Setup and enable invisible recaptcha
2. Go to the registration form

### Actual result BEFORE applying this Pull Request

The `Captcha` label was visible

### Expected result AFTER applying this Pull Request

The `Captcha` label is hidden