### PR TITLE
[4.0] Fix hiddenLabel for invisiable recaptcha plugin

### DIFF
--- a/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
+++ b/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
@@ -169,7 +169,7 @@ class PlgCaptchaRecaptcha_Invisible extends CMSPlugin
 	public function onSetupField(\Joomla\CMS\Form\Field\CaptchaField $field, \SimpleXMLElement $element)
 	{
 		// Hide the label for the invisible recaptcha type
-		$element['hiddenLabel'] = true;
+		$element['hiddenLabel'] = 'true';
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #35814.

### Summary of Changes
Currently, the label for a Captcha field is always displayed, even if the used plugin is invisible recaptcha. This simple fixes that wrong behavior.

To be honest, I'm unsure if this is a proper fix. Another option is fix this line of code https://github.com/joomla/joomla-cms/blob/4.0-dev/libraries/src/Form/FormField.php#L1052 to something like:

```php
$options['hiddenLabel'] = in_array(strtolower($this->getAttribute('hiddenLabel')), ['true', 'yes', '1'], true);
```

But I don't see we document anywhere what's the possible value of hiddenLabel attribute, so I decided to go with safe option.

### Testing Instructions
1. Use Joomla 4
2. Configure the site to use invisiable recaptcha plugin
3. Access to user registration form or contact form

### Actual result BEFORE applying this Pull Request
The label for captcha field is displayed


### Expected result AFTER applying this Pull Request
The label for captcha field is not being displayed


### Documentation Changes Required
No
