### PR TITLE
[3.10] Use LTR marks for extension versions to fix RTL display of versions which contain characters

### DIFF
--- a/administrator/components/com_installer/views/discover/tmpl/default.php
+++ b/administrator/components/com_installer/views/discover/tmpl/default.php
@@ -98,7 +98,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php echo $item->type_translated; ?>
 						</td>
 						<td class="hidden-phone">
-							<?php echo @$item->version != '' ? $item->version : '&#160;'; ?>
+							<?php echo @$item->version != '' ? '&#x200E;' . $item->version : '&#160;'; ?>
 						</td>
 						<td class="hidden-phone hidden-tablet">
 							<?php echo @$item->creationDate != '' ? $item->creationDate : '&#160;'; ?>

--- a/administrator/components/com_installer/views/languages/tmpl/default.php
+++ b/administrator/components/com_installer/views/languages/tmpl/default.php
@@ -83,9 +83,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 								<?php $minorVersion = $version::MAJOR_VERSION . '.' . $version::MINOR_VERSION; ?>
 								<?php // Display a Note if language pack version is not equal to Joomla version ?>
 								<?php if (strpos($language->version, $minorVersion) !== 0 || strpos($language->version, $currentShortVersion) !== 0) : ?>
-									<span class="label label-warning hasTooltip" title="<?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>"><?php echo $language->version; ?></span>
+									<span class="label label-warning hasTooltip" title="<?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>"><?php echo '&#x200E;' . $language->version; ?></span>
 								<?php else : ?>
-									<span class="label label-success"><?php echo $language->version; ?></span>
+									<span class="label label-success"><?php echo '&#x200E;' . $language->version; ?></span>
 								<?php endif; ?>
 						</td>
 						<td class="small hidden-phone">

--- a/administrator/components/com_installer/views/manage/tmpl/default.php
+++ b/administrator/components/com_installer/views/manage/tmpl/default.php
@@ -111,7 +111,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							<?php echo $item->type_translated; ?>
 						</td>
 						<td class="hidden-phone">
-							<?php echo @$item->version != '' ? $item->version : '&#160;'; ?>
+							<?php echo @$item->version != '' ? '&#x200E;' . $item->version : '&#160;'; ?>
 						</td>
 						<td class="hidden-phone hidden-tablet">
 							<?php echo @$item->creationDate != '' ? $item->creationDate : '&#160;'; ?>

--- a/administrator/components/com_installer/views/update/tmpl/default.php
+++ b/administrator/components/com_installer/views/update/tmpl/default.php
@@ -105,10 +105,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 									<?php echo $item->type_translated; ?>
 								</td>
 								<td class="hidden-phone center">
-									<span class="label label-warning"><?php echo $item->current_version; ?></span>
+									<span class="label label-warning"><?php echo '&#x200E;' . $item->current_version; ?></span>
 								</td>
 								<td class="center">
-									<span class="label label-success"><?php echo $item->version; ?></span>
+									<span class="label label-success"><?php echo '&#x200E;' . $item->version; ?></span>
 								</td>
 								<td class="hidden-phone center">
 									<?php echo $item->folder_translated; ?>

--- a/administrator/components/com_languages/views/installed/tmpl/default.php
+++ b/administrator/components/com_languages/views/installed/tmpl/default.php
@@ -103,9 +103,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 					<?php $minorVersion = $version::MAJOR_VERSION . '.' . $version::MINOR_VERSION; ?>
 					<?php // Display a Note if language pack version is not equal to Joomla version ?>
 					<?php if (strpos($row->version, $minorVersion) !== 0 || strpos($row->version, $currentShortVersion) !== 0) : ?>
-						<span class="label label-warning hasTooltip" title="<?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>"><?php echo $row->version; ?></span>
+						<span class="label label-warning hasTooltip" title="<?php echo JText::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>"><?php echo '&#x200E;' . $row->version; ?></span>
 					<?php else : ?>
-						<span class="label label-success"><?php echo $row->version; ?></span>
+						<span class="label label-success"><?php echo '&#x200E;' . $row->version; ?></span>
 					<?php endif; ?>
 					</td>
 					<td class="hidden-phone">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

_Work in Progress:_ I might replace this PR soon by one doing the same thing in another way. For now I put this one here in draft status.

Preceed version numbers of extensions with LTR marks `'&#x200E;'` in diverse backend views for correct display of versions which contain characters (e.g. development, alpha, beta or RC versions, or versions like "1.2.3.v4" like they are used by some Joomla 4 language pack) with RTL languages, like we do it already in the "Live Update" tab of the Joomla Update component for the installed Joomla version and the latest Joomla version.

Currently such versions are shown wrong when current language in backend has writing direction RTL.

In RTL language version numbers or dates in western formats are still shown with LTR direction, that's the use of the LTR marks `'&#x200E;'`.

### Testing Instructions

The [change in file administrator/components/com_installer/views/languages/tmpl/default.php](https://github.com/joomla/joomla-cms/pull/35838/files#diff-c05c6a5f845659e65d446eae87b975bb3389aec558ca062f75ecc6f8e8e8707f) can be only tested by code review since I haven't found a hack to make the installer find the modified language packs used during the other tests below.

1. On a current 3.10-dev branch or the latest 3.10 nightly build or a 3.10.2, download and install the following modified language packs and weblinks package.

- https://test5.richard-fath.de/de-DE_joomla_lang_full_3.10.1v1.zip
This is an unmodified but older German language pack so you will get an update to a newer version with a "normal" version number. If you have already installed a newer German language pack, uninstall it and then install the one from the link here.
- https://test5.richard-fath.de/de-XX_joomla_lang_full_3.10.1v1_test.zip
This is a modified German language pack which uses a different language tag so it can be installed in parallel to the German language pack mentioned before. It is modified so that both the installed and the available update versions are shown with release candidate "-rcX" version numbers.
- https://test5.richard-fath.de/fa-XX_joomla_lang_full_3.10.2v1_test.zip
This is a modified Persian language which uses a different language tag so it can be installed in parallel to any present Persian language pack. It is modified so that both the installed and the available update versions are shown with version numbers like e.g. "3.10.2v1". The Persian language pack for Joomla 4 currently uses such versions, for the test here with Joomla 3 it needs that modified pack.
- https://test5.richard-fath.de/pkg-weblinks-3.9.0-rc1_test.zip
This is a modified weblinks package to get installed and update versions shown with release candidate "-rcX" version numbers for having test for different extension types than languages.

2. Check in the following views all version numbers which contain strings for both kinds of backend languages LTR and RTL. For RTL you can use the previously installed "Persian (Test)".
- Extensions: Update (Use the "Clear Cache" and then the "Find Updates" button if necessary to find all updates.)
- Extensions: Manage
- Languages: Installed

When using Persian language you can find the views here:
![j3-persian-navigate-2](https://user-images.githubusercontent.com/7413183/137589814-c8350410-e01b-4f84-b2ea-f4382e42231e.png)

3. In database in the extensions table, delete the records for the 'de-DE' and the 'fa-XX' site languages and the weblinks editor button.
- In phpMyAdmin using the GUI:
![j3-extensions-delete-records-for-discover-in-phpmyadmin](https://user-images.githubusercontent.com/7413183/137589671-d3e90806-6873-45bd-8947-0083a8a3d136.png)
- With SQL, replace `#__` with your database prefix.:
```
DELETE FROM `#__extensions` WHERE `type` = 'language' AND `element` = 'de-DE' AND `client_id` = 0;
DELETE FROM `#__extensions` WHERE `type` = 'language' AND `element` = 'fa-XX' AND `client_id` = 0;
DELETE FROM `#__extensions` WHERE `type` = 'plugin' AND `element` = 'weblink' AND `folder` = 'editors-xtd';
```

4. Go to the "Extensions: Discover" view and check the version numbers which contain strings. Use the "Discover" button if necessary to discover all extensions. Check with LTR and RTL backend languages.

5. Select the discovered extensions and install them using the "Install" button.

5. Apply the patch of this PR.

6. Repeat steps 2 to 4.

### Actual result BEFORE applying this Pull Request

#### Extensions: Update

LTR
![j3-extensions-update_ltr](https://user-images.githubusercontent.com/7413183/137588278-74820c3a-7a88-4553-a8ea-09898e0af574.png)

RTL
![j3-extensions-update_rtl-bad](https://user-images.githubusercontent.com/7413183/137587814-1b147955-3fde-476c-a73f-304ded48ef33.png)

#### Extensions: Manage

LTR
![j3-extensions-manage_ltr](https://user-images.githubusercontent.com/7413183/137588285-cc04dcb4-10fc-4c75-85cb-ed0096a2924b.png)

RTL
![j3-extensions-manage_rtl-bad](https://user-images.githubusercontent.com/7413183/137587841-01eb3cb9-8932-4455-8363-343d0a3104f1.png)

#### Extensions: Discover

LTR
![j3-extensions-discover_ltr](https://user-images.githubusercontent.com/7413183/137588287-5f4056ac-b6fe-42f4-bb04-f63772d79058.png)

RTL
![j3-extensions-discover_rtl-bad](https://user-images.githubusercontent.com/7413183/137587865-a504cc02-b9be-492b-9749-50ae64cc8bf9.png)

#### Languages: Installed

LTR
![j3-languages-installed_ltr](https://user-images.githubusercontent.com/7413183/137588293-b1c6df26-1bc8-4eee-ae1c-1cdd809fb2b1.png)

RTL
![j3-languages-installed_rtl-bad](https://user-images.githubusercontent.com/7413183/137587874-c20d5ba0-5d52-426c-a264-d5429746b2cd.png)

### Expected result AFTER applying this Pull Request

For LTR there should be no changes compared to before applying this PR.

For RTL the versions should be the same as for LTR.

#### Extensions: Update

![j3-extensions-update_rtl-ok](https://user-images.githubusercontent.com/7413183/137587984-c7543c11-4319-406e-bcad-99085eab0cb5.png)

#### Extensions: Manage

![j3-extensions-manage_rtl-ok](https://user-images.githubusercontent.com/7413183/137587990-64cbfdb7-b9bd-4437-8761-8128cf391c41.png)

#### Extensions: Discover
![j3-extensions-discover_rtl-ok](https://user-images.githubusercontent.com/7413183/137587999-6a66bf80-0d4f-4c54-b188-f3c0391a6ffe.png)

#### Languages: Installed

![j3-languages-installed_rtl-ok](https://user-images.githubusercontent.com/7413183/137588025-88ba35b9-d423-482c-82db-9a1dc433e544.png)

### Documentation Changes Required

None.