### PR TITLE
Changes to class names of intro_image.php

### DIFF
--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -34,7 +34,7 @@ if ((isset($img->attributes['width']) && (int) $img->attributes['width'] > 0)
 	$extraAttr = ArrayHelper::toString($img->attributes) . ' loading="lazy"';
 }
 ?>
-<figure class="<?php echo htmlspecialchars($imgclass, ENT_COMPAT, 'UTF-8'); ?> item-image">
+<figure class="article__image--full <?php echo htmlspecialchars($imgclass, ENT_COMPAT, 'UTF-8'); ?> | item-image">
 	<?php if ($params->get('link_intro_image') && ($params->get('access-view') || $params->get('show_noauth', '0') == '1')) : ?>
 		<a href="<?php echo Route::_(RouteHelper::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>"
 			itemprop="url" title="<?php echo $this->escape($displayData->title); ?>">
@@ -52,6 +52,6 @@ if ((isset($img->attributes['width']) && (int) $img->attributes['width'] > 0)
 		/>
 	<?php endif; ?>
 	<?php if (isset($images->image_intro_caption) && $images->image_intro_caption !== '') : ?>
-		<figcaption class="caption"><?php echo htmlspecialchars($images->image_intro_caption, ENT_COMPAT, 'UTF-8'); ?></figcaption>
+		<figcaption class="article__caption | caption"><?php echo htmlspecialchars($images->image_intro_caption, ENT_COMPAT, 'UTF-8'); ?></figcaption>
 	<?php endif; ?>
 </figure>


### PR DESCRIPTION
Pull Request for Issue joomla#35342.

### Detailed explanation of the changes:

1. On row 37, the class "item-image" is replaced by "article__image--full" since it represents the full image field of an article. 
The old class name remained for compatibility reasons, separated by the character | to be indicated as deprecated.

2. On row 54, the class "caption" is replaced by "article__caption--full" since it represents the full image caption of an article. 
The old class name remained for compatibility reasons, separated by the character | to be indicated as deprecated.
