### PR TITLE
Add a proper error message if a pack fails to download

### DIFF
--- a/installation/language/en-GB/en-GB.ini
+++ b/installation/language/en-GB/en-GB.ini
@@ -163,6 +163,7 @@ INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU_ITEM="Joomla was unable to automatic
 INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_MENU_MODULE="Joomla was unable to automatically create the %s menu module."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CATEGORY="Joomla was unable to automatically create the %s content category."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_ARTICLE="Joomla was unable to automatically create the %s localised article."
+INSTL_DEFAULTLANGUAGE_COULD_NOT_DOWNLOAD_PACKAGE="Joomla failed to download or unpack the language pack from: %s"
 INSTL_DEFAULTLANGUAGE_COULD_NOT_ENABLE_MODULESWHITCHER_LANGUAGECODE="Joomla was unable to automatically publish the language switcher module."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_ENABLE_PLG_LANGUAGECODE="Joomla was unable to automatically enable the Language Code Plugin."
 INSTL_DEFAULTLANGUAGE_COULD_NOT_ENABLE_PLG_LANGUAGEFILTER="Joomla was unable to automatically enable the Language Filter Plugin."

--- a/installation/model/languages.php
+++ b/installation/model/languages.php
@@ -177,6 +177,13 @@ class InstallationModelLanguages extends JModelBase
 			// Download the package to the tmp folder.
 			$package = $this->downloadPackage($package_url);
 
+			if (!$package)
+			{
+				JFactory::getApplication()->enqueueMessage(JText::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_DOWNLOAD_PACKAGE', $package_url), 'error');
+
+				continue;
+			}
+
 			// Install the package.
 			if (!$installer->install($package['dir']))
 			{


### PR DESCRIPTION
Found because I broke it earlier :) `downloadPackage` returns false in the case the URL isn't available etc. This is a direct backport of https://github.com/joomla/joomla-cms/commit/44ed4113a20dee921c9fdbcf07611da299e3d135 from the 4.0 branch