### PR TITLE
[3.10] Fix double translation of groupText for EOS quickicon

### DIFF
--- a/plugins/quickicon/eos310/eos310.php
+++ b/plugins/quickicon/eos310/eos310.php
@@ -205,7 +205,7 @@ class PlgQuickiconEos310 extends CMSPlugin
 				'messageType'   => 'error',
 				'image'         => 'minus-circle',
 				'messageLink'   => 'https://docs.joomla.org/Special:MyLanguage/Planning_for_Mini-Migration_-_Joomla_3.10.x_to_4.x',
-				'groupText'     => Text::_('PLG_QUICKICON_EOS310_GROUPNAME_EOS'),
+				'groupText'     => 'PLG_QUICKICON_EOS310_GROUPNAME_EOS',
 				'snoozable'     => false,
 			);
 		}
@@ -220,7 +220,7 @@ class PlgQuickiconEos310 extends CMSPlugin
 				'messageType'   => 'warning',
 				'image'         => 'warning-circle',
 				'messageLink'   => 'https://docs.joomla.org/Special:MyLanguage/Planning_for_Mini-Migration_-_Joomla_3.10.x_to_4.x',
-				'groupText'     => Text::_('PLG_QUICKICON_EOS310_GROUPNAME_WARNING'),
+				'groupText'     => 'PLG_QUICKICON_EOS310_GROUPNAME_WARNING',
 				'snoozable'     => true,
 			);
 		}
@@ -235,7 +235,7 @@ class PlgQuickiconEos310 extends CMSPlugin
 				'messageType'   => 'warning',
 				'image'         => 'warning-circle',
 				'messageLink'   => 'https://docs.joomla.org/Special:MyLanguage/Planning_for_Mini-Migration_-_Joomla_3.10.x_to_4.x',
-				'groupText'     => Text::_('PLG_QUICKICON_EOS310_GROUPNAME_WARNING'),
+				'groupText'     => 'PLG_QUICKICON_EOS310_GROUPNAME_WARNING',
 				'snoozable'     => true,
 			);
 		}
@@ -250,7 +250,7 @@ class PlgQuickiconEos310 extends CMSPlugin
 				'messageType'   => 'info',
 				'image'         => 'info-circle',
 				'messageLink'   => 'https://docs.joomla.org/Special:MyLanguage/Pre-Update_Check',
-				'groupText'     => Text::_('PLG_QUICKICON_EOS310_GROUPNAME_INFO'),
+				'groupText'     => 'PLG_QUICKICON_EOS310_GROUPNAME_INFO',
 				'snoozable'     => true,
 			);
 		}
@@ -265,7 +265,7 @@ class PlgQuickiconEos310 extends CMSPlugin
 				'messageType'   => 'info',
 				'image'         => 'info-circle',
 				'messageLink'   => 'https://www.joomla.org/4/#features',
-				'groupText'     => Text::_('PLG_QUICKICON_EOS310_GROUPNAME_INFO'),
+				'groupText'     => 'PLG_QUICKICON_EOS310_GROUPNAME_INFO',
 				'snoozable'     => true,
 			);
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This Pull Request (PR) removes the translation of the `groupText` item used for the group name of the EOS quickicon plugin's message.

If you check for the other quickicon plugins (except of the phpversioncheck which seems to work differently so I could not find any group name there), the group name is not translated either:

https://github.com/joomla/joomla-cms/blob/3.10-dev/plugins/quickicon/extensionupdate/extensionupdate.php#L70

https://github.com/joomla/joomla-cms/blob/3.10-dev/plugins/quickicon/joomlaupdate/joomlaupdate.php#L79

https://github.com/joomla/joomla-cms/blob/3.10-dev/plugins/quickicon/privacycheck/privacycheck.php#L76

### Testing Instructions

1. Code review: Check the changes made by this PR and compare with the places in code of the other quickicon plugins mentioned in the description above.

2. Switch on language debug in Global Configuration.

3. Go to "System -> Control Panel".

4. Check the group name of the EOS quickicon in the side menu. Currently it should be shown as "UPGRADE INFORMATION" on a clean, current 3.10.2 or latest 3.10 nightly or 3.10-dev branch.
Result: The group name shows a double translation `??**UPGRADE INFORMATION**??`, see section "Actual result BEFORE applying this Pull Request" below.

5. Apply the patch from this PR and check again the group name of the EOS quickicon in the side menu.
Result: The group name is shown as properly translated `**UPGRADE INFORMATION**`, see section " Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

![j3-eos-plugin-double-translation](https://user-images.githubusercontent.com/7413183/137627247-ec2b10d2-ab8e-4d85-859c-6e82d0a4bc2b.png)

### Expected result AFTER applying this Pull Request

![j3-eos-plugin-double-translation-fixed](https://user-images.githubusercontent.com/7413183/137627254-edb21741-654e-4c10-b0cd-adb48b4c4a02.png)

### Documentation Changes Required

None.