### PR TITLE
[4.0] Update deleted files and folders for 4.0.4 RC 2

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1456,6 +1456,7 @@ class JoomlaInstallerScript
 			'/administrator/components/com_joomlaupdate/helpers/select.php',
 			'/administrator/components/com_joomlaupdate/joomlaupdate.php',
 			'/administrator/components/com_joomlaupdate/models/default.php',
+			'/administrator/components/com_joomlaupdate/restore.php',
 			'/administrator/components/com_joomlaupdate/views/default/tmpl/complete.php',
 			'/administrator/components/com_joomlaupdate/views/default/tmpl/default.php',
 			'/administrator/components/com_joomlaupdate/views/default/tmpl/default.xml',
@@ -4020,8 +4021,12 @@ class JoomlaInstallerScript
 			'/media/com_contenthistory/js/jquery.pretty-text-diff.js',
 			'/media/com_contenthistory/js/jquery.pretty-text-diff.min.js',
 			'/media/com_finder/js/autocompleter.js',
+			'/media/com_joomlaupdate/js/encryption.js',
+			'/media/com_joomlaupdate/js/encryption.min.js',
 			'/media/com_joomlaupdate/js/json2.js',
 			'/media/com_joomlaupdate/js/json2.min.js',
+			'/media/com_joomlaupdate/js/update.js',
+			'/media/com_joomlaupdate/js/update.min.js',
 			'/media/contacts/images/con_address.png',
 			'/media/contacts/images/con_fax.png',
 			'/media/contacts/images/con_info.png',
@@ -6099,12 +6104,8 @@ class JoomlaInstallerScript
 			'/templates/cassiopeia/scss/global/fonts-web_fira-sans.scss',
 			'/templates/cassiopeia/scss/global/fonts-web_roboto+noto-sans.scss',
 			// From 4.0.3 to 4.0.4
-			'/administrator/components/com_joomlaupdate/restore.php',
-			'/media/com_joomlaupdate/js/encryption.js',
-			'/media/com_joomlaupdate/js/encryption.min.js',
+			'/administrator/templates/atum/scss/_mixin.scss',
 			'/media/com_joomlaupdate/js/encryption.min.js.gz',
-			'/media/com_joomlaupdate/js/update.js',
-			'/media/com_joomlaupdate/js/update.min.js',
 			'/media/com_joomlaupdate/js/update.min.js.gz',
 			'/templates/cassiopeia/images/system/sort_asc.png',
 			'/templates/cassiopeia/images/system/sort_desc.png',
@@ -7365,6 +7366,8 @@ class JoomlaInstallerScript
 			'/libraries/vendor/algo26-matthias/idna-convert/tests/unit',
 			'/libraries/vendor/algo26-matthias/idna-convert/tests/integration',
 			'/libraries/vendor/algo26-matthias/idna-convert/tests',
+			// From 4.0.3 to 4.0.4
+			'/templates/cassiopeia/images/system',
 		);
 
 		$status['files_checked'] = $files;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Update the lists of deleted files in script.php to changes since 4.0.3 and to how the tool "build/deleted_file_check.php" is used. (See this PR for documentation on that: https://github.com/richard67/joomla-cms/pull/19 ).

- The files added with PR #35388 to the deleted files list have been moved from section "// From 4.0.3 to 4.0.4" up to section "// From 3.10 to 4.0".
- File "administrator/templates/atum/scss/_mixin.scss" which has been removed from the sources with PR #35518 has been added to the deleted files list so it is deleted with a CMS update.
- Folder "templates/cassiopeia/images/system" has been added to the list of folders to be removed. The only 2 files in that foldfer have been removed with PR # from the souces, and with commit https://github.com/joomla/joomla-cms/commit/3261b929856096c220e94792248f70c257576fe9 these files have been added to the deleted files list, but the folder has been forgotten so that empty folder will not be deleted with a CMS update.

### Testing Instructions

Either code review or update a 4.0.3 or earlier 4.0 version to current 4.0-dev, one time using the latest nightly 4.0 build for the actual result and one time using the update package or URL built by drone for this PR for the expected result.

### Actual result BEFORE applying this Pull Request

Unused file "administrator/templates/atum/scss/_mixin.scss" and empty folder "templates/cassiopeia/images/system" are still present after the update.

### Expected result AFTER applying this Pull Request

Unused file "administrator/templates/atum/scss/_mixin.scss" and empty folder "templates/cassiopeia/images/system" are not present anymore after the update.

### Documentation Changes Required

None.