### PR TITLE
[4.0] php memory limit

### DIFF
--- a/administrator/components/com_installer/src/Model/WarningsModel.php
+++ b/administrator/components/com_installer/src/Model/WarningsModel.php
@@ -158,13 +158,13 @@ class WarningsModel extends ListModel
 					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_UPLOADBIGGERTHANPOSTDESC'));
 		}
 
-		if ($post_max_size < $minMemory)
+		if ($post_max_size < $minMemory && $memory_limit != -1)
 		{
 			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLPOSTSIZE'),
 					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLPOSTSIZEDESC'));
 		}
 
-		if ($upload_max_filesize < $minMemory)
+		if ($upload_max_filesize < $minMemory && $memory_limit != -1)
 		{
 			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLUPLOADSIZE'),
 					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLUPLOADSIZEDESC'));

--- a/administrator/components/com_media/src/Controller/ApiController.php
+++ b/administrator/components/com_media/src/Controller/ApiController.php
@@ -367,7 +367,7 @@ class ApiController extends BaseController
 		if (($params->get('upload_maxsize', 0) > 0 && $serverlength > ($params->get('upload_maxsize', 0) * 1024 * 1024))
 			|| $serverlength > $helper->toBytes(ini_get('upload_max_filesize'))
 			|| $serverlength > $helper->toBytes(ini_get('post_max_size'))
-			|| $serverlength > $helper->toBytes(ini_get('memory_limit')))
+			|| $serverlength > $helper->toBytes(ini_get('memory_limit')) && $helper->toBytes(ini_get('memory_limit')) != -1)
 		{
 			throw new \Exception(Text::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'), 403);
 		}

--- a/administrator/components/com_media/src/Controller/ApiController.php
+++ b/administrator/components/com_media/src/Controller/ApiController.php
@@ -367,7 +367,7 @@ class ApiController extends BaseController
 		if (($params->get('upload_maxsize', 0) > 0 && $serverlength > ($params->get('upload_maxsize', 0) * 1024 * 1024))
 			|| $serverlength > $helper->toBytes(ini_get('upload_max_filesize'))
 			|| $serverlength > $helper->toBytes(ini_get('post_max_size'))
-			|| $serverlength > $helper->toBytes(ini_get('memory_limit')) && $helper->toBytes(ini_get('memory_limit')) != -1)
+			|| ($serverlength > $helper->toBytes(ini_get('memory_limit')) && $helper->toBytes(ini_get('memory_limit')) != -1))
 		{
 			throw new \Exception(Text::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'), 403);
 		}


### PR DESCRIPTION
It is possible to set the memory limit in php to -1 which means unlimited memory.

Unfortunately this was not accounted for in the maths to check if a file could be uploaded.

To test you will need to change the value in your php.ini to `memory_limit = -1` and restart the web server.

Then try to upload any file in the media manager and you will see an error message that the file is too large.

Apply this PR and the upload will be successful.

PR for #35853
