### PR TITLE
Finder plugins modify component params registry

### DIFF
--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -271,7 +271,7 @@ class PlgFinderContent extends Adapter
 
 		// Initialise the item parameters.
 		$registry = new Registry($item->params);
-		$item->params = ComponentHelper::getParams('com_content', true);
+		$item->params = clone ComponentHelper::getParams('com_content', true);
 		$item->params->merge($registry);
 
 		$item->metadata = new Registry($item->metadata);

--- a/plugins/finder/tags/tags.php
+++ b/plugins/finder/tags/tags.php
@@ -220,7 +220,7 @@ class PlgFinderTags extends Adapter
 
 		// Initialize the item parameters.
 		$registry = new Registry($item->params);
-		$item->params = ComponentHelper::getParams('com_tags', true);
+		$item->params = clone ComponentHelper::getParams('com_tags', true);
 		$item->params->merge($registry);
 
 		$item->metadata = new Registry($item->metadata);


### PR DESCRIPTION
### Summary of Changes

Finder plugins modify component params registry by merging item params. Further code execution occurring during the `onContentAfterSave` event can get the invalid component params data.

### Testing Instructions

Ensure that finder content plugin is enabled.
Edit article and set any setting to non-global, i.e. "Layout", save article.

### Actual result BEFORE applying this Pull Request

Test your custom `onContentAfterSave` event executing after the finder plugin, see that the component param is article param now:
`\JComponentHelper::getComponent('com_content')->getParams()->get('article_layout')`;

### Expected result AFTER applying this Pull Request

Component param value is original.

### Documentation Changes Required

No.