### PR TITLE
Subhead with buttons is removed on certain breakpoints

### DIFF
--- a/build/media_source/templates/administrator/atum/js/template.es6.js
+++ b/build/media_source/templates/administrator/atum/js/template.es6.js
@@ -222,7 +222,7 @@ function subheadScrolling() {
 headerItemsInDropdown();
 reactToResize();
 subheadScrolling();
-if (mobile.matches) {
+if (small.matches) {
   changeLogo('closed');
   if (subhead) {
     subhead.classList.remove('show');


### PR DESCRIPTION
Pull Request for Issue #35792 and  #35630.

### Summary of Changes
On certain screen size the subhead with the buttons get removed.
Take a look at the issue above,

### Testing Instructions
Apply PR and build JS files with "npm run build:js"

### Actual result BEFORE applying this Pull Request
Set screen size to 900px. Go to the articles and refresh the page.
The subhead with the buttons with "+ New" and "Options" is not visible.

### Expected result AFTER applying this Pull Request
The subhead is visible


### Documentation Changes Required

