### PR TITLE
Correct class of div for pagination

### DIFF
--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -189,7 +189,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 		<?php endif; ?>
 
 		<?php if ($this->params->get('show_pagination', 2)) : ?>
-			<div class="com-contact-category__counter w-100">
+			<div class="com-contact-category__pagination w-100">
 				<?php if ($this->params->def('show_pagination_results', 1)) : ?>
 					<p class="com-contact-category__counter counter float-end pt-3 pe-2">
 						<?php echo $this->pagination->getPagesCounter(); ?>


### PR DESCRIPTION
Class of pagination's wrapper div item should be either **com-contact-category__pagination** or **com-contact-category__navigation** isntead of the current 'com-contact-category__**counter**.

Pull Request for Issue # .

### Summary of Changes
Changed class **com-contact-category__counter** to **com-contact-category__pagination** to have some consistency.


### Testing Instructions
Nothing specific. Maybe check it with your template.


### Actual result BEFORE applying this Pull Request
Inconsistent class name compared to other pagination items accross J!.


### Expected result AFTER applying this Pull Request
More consistent class names accross J!.


### Documentation Changes Required
-
