### PR TITLE
[4.0] Missing help

### DIFF
--- a/administrator/components/com_menus/forms/itemadmin_container.xml
+++ b/administrator/components/com_menus/forms/itemadmin_container.xml
@@ -76,5 +76,5 @@
 			filter="array"
 		/>
 	</fields>
-	<help key="JHELP_MENUS_MENU_ITEM_MENU_ITEM_CONTAINER"/>
+	<help key="Menu_Item:_Components_Menu_Container"/>
 </form>


### PR DESCRIPTION
Simple PR to correct the link for he help button on the admin menu type com[onent container

PR for #35555
![image](https://user-images.githubusercontent.com/1296369/138471772-75f1033a-6600-410f-bdf3-725e8fd26c7b.png)
