### PR TITLE
[4.0] Joomla CLI breaks if absolute path is used and System Page Cache plugin is enabled

### DIFF
--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -63,15 +63,13 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	public function __construct(&$subject, $config)
 	{
-		// Disable ourselves if we're running under CLI
-		if (\defined('STDOUT') || \defined('STDIN') || isset($_SERVER['argv']))
-		{
-			$this->isCli = true;
+		parent::__construct($subject, $config);
 
+		// Run only when we're on the public section
+		if (!$this->app->isClient('site'))
+		{
 			return;
 		}
-
-		parent::__construct($subject, $config);
 
 		// Set the cache options.
 		$options = array(
@@ -96,8 +94,8 @@ class PlgSystemCache extends CMSPlugin
 	{
 		static $key;
 
-		// Do not run under CLI
-		if ($this->isCli)
+		// Run only when we're on the public section
+		if (!$this->app->isClient('site'))
 		{
 			return '';
 		}
@@ -124,13 +122,7 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	public function onAfterRoute()
 	{
-		// Do not run under CLI
-		if ($this->isCli)
-		{
-			return;
-		}
-
-		if ($this->app->isClient('administrator') || $this->app->get('offline', '0') || $this->app->getMessageQueue())
+		if (!$this->app->isClient('site') || $this->app->get('offline', '0') || $this->app->getMessageQueue())
 		{
 			return;
 		}
@@ -183,8 +175,8 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	public function onAfterRender()
 	{
-		// Do not run under CLI
-		if ($this->isCli)
+		// Run only when we're on the public section
+		if (!$this->app->isClient('site'))
 		{
 			return;
 		}
@@ -217,8 +209,8 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	public function onAfterRespond()
 	{
-		// Do not run under CLI
-		if ($this->isCli)
+		// Run only when we're on the public section
+		if (!$this->app->isClient('site'))
 		{
 			return;
 		}
@@ -241,8 +233,8 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	protected function isExcluded()
 	{
-		// Do not run under CLI
-		if ($this->isCli)
+		// Run only when we're on the public section
+		if (!$this->app->isClient('site'))
 		{
 			return true;
 		}

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -48,12 +48,6 @@ class PlgSystemCache extends CMSPlugin
 	protected $app;
 
 	/**
-	 * Are we running under a CLI environment?
-	 * @var bool
-	 */
-	private $isCli = false;
-
-	/**
 	 * Constructor.
 	 *
 	 * @param   object  &$subject  The object to observe.

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -59,7 +59,7 @@ class PlgSystemCache extends CMSPlugin
 	{
 		parent::__construct($subject, $config);
 
-		// Run only when we're on the public section
+		// Run only when we're on Site Application side
 		if (!$this->app->isClient('site'))
 		{
 			return;
@@ -88,7 +88,7 @@ class PlgSystemCache extends CMSPlugin
 	{
 		static $key;
 
-		// Run only when we're on the public section
+		// Run only when we're on Site Application side
 		if (!$this->app->isClient('site'))
 		{
 			return '';
@@ -169,7 +169,7 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	public function onAfterRender()
 	{
-		// Run only when we're on the public section
+		// Run only when we're on Site Application side
 		if (!$this->app->isClient('site'))
 		{
 			return;
@@ -203,7 +203,7 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	public function onAfterRespond()
 	{
-		// Run only when we're on the public section
+		// Run only when we're on Site Application side
 		if (!$this->app->isClient('site'))
 		{
 			return;
@@ -227,7 +227,7 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	protected function isExcluded()
 	{
-		// Run only when we're on the public section
+		// Run only when we're on Site Application side
 		if (!$this->app->isClient('site'))
 		{
 			return true;

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -48,6 +48,12 @@ class PlgSystemCache extends CMSPlugin
 	protected $app;
 
 	/**
+	 * Are we running under a CLI environment?
+	 * @var bool
+	 */
+	private $isCli = false;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param   object  &$subject  The object to observe.
@@ -57,6 +63,14 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	public function __construct(&$subject, $config)
 	{
+		// Disable ourselves if we're running under CLI
+		if (\defined('STDOUT') || \defined('STDIN') || isset($_SERVER['argv']))
+		{
+			$this->isCli = true;
+
+			return;
+		}
+
 		parent::__construct($subject, $config);
 
 		// Set the cache options.
@@ -82,6 +96,12 @@ class PlgSystemCache extends CMSPlugin
 	{
 		static $key;
 
+		// Do not run under CLI
+		if ($this->isCli)
+		{
+			return '';
+		}
+
 		if (!$key)
 		{
 			PluginHelper::importPlugin('pagecache');
@@ -104,6 +124,12 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	public function onAfterRoute()
 	{
+		// Do not run under CLI
+		if ($this->isCli)
+		{
+			return;
+		}
+
 		if ($this->app->isClient('administrator') || $this->app->get('offline', '0') || $this->app->getMessageQueue())
 		{
 			return;
@@ -157,6 +183,12 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	public function onAfterRender()
 	{
+		// Do not run under CLI
+		if ($this->isCli)
+		{
+			return;
+		}
+
 		if ($this->_cache->getCaching() === false)
 		{
 			return;
@@ -185,6 +217,12 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	public function onAfterRespond()
 	{
+		// Do not run under CLI
+		if ($this->isCli)
+		{
+			return;
+		}
+
 		if ($this->_cache->getCaching() === false)
 		{
 			return;
@@ -203,6 +241,12 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	protected function isExcluded()
 	{
+		// Do not run under CLI
+		if ($this->isCli)
+		{
+			return true;
+		}
+
 		// Check if menu items have been excluded.
 		if ($exclusions = $this->params->get('exclude_menu_items', array()))
 		{

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -227,12 +227,6 @@ class PlgSystemCache extends CMSPlugin
 	 */
 	protected function isExcluded()
 	{
-		// Run only when we're on Site Application side
-		if (!$this->app->isClient('site'))
-		{
-			return true;
-		}
-
 		// Check if menu items have been excluded.
 		if ($exclusions = $this->params->get('exclude_menu_items', array()))
 		{


### PR DESCRIPTION
If you have the plugin **System - Page Cache** enabled and you use Joomla CLI entry point with an absolute path (as it happens when it's triggered by a CRON job) a fatal error would happen.

### Summary of Changes
This is a side effect caused by enabling the plugin **System - Page Cache**. Once enabled, it's always loaded, even in contexts where cache should never be allowed (ie backend, CLI etc etc).  
In the constructor it tries to parse the current URL; usually this won't cause any harm, beside a warning:  
```
php joomla.php list
PHP Notice:  Undefined index: HTTP_HOST in /var/www/html/joomla/libraries/src/Uri/Uri.php on line 103
```
However, everything breaks if an absolute path is supplied:  
```
php /var/www/html/joomla/cli/joomla.php list

PHP Notice:  Undefined index: HTTP_HOST in /var/www/html/joomla/libraries/src/Uri/Uri.php on line 103

RuntimeException {#539
  #message: "Could not parse the requested URI http:///var/www/html/joomla/cli/joomla.php"
  #code: 0
  #file: "/var/www/html/joomla/libraries/vendor/joomla/uri/src/AbstractUri.php"
  #line: 373
  trace: {
    /var/www/html/joomla/libraries/vendor/joomla/uri/src/AbstractUri.php:373 { …}
    /var/www/html/joomla/libraries/src/Uri/Uri.php:305 {
      Joomla\CMS\Uri\Uri->parse($uri)^
      › {
      › \treturn parent::parse($uri);
      › }
    }
    /var/www/html/joomla/libraries/vendor/joomla/uri/src/AbstractUri.php:111 { …}
    /var/www/html/joomla/libraries/src/Uri/Uri.php:121 { …}
    /var/www/html/joomla/plugins/system/cache/cache.php:71 { …}
    /var/www/html/joomla/libraries/src/Extension/ExtensionManagerTrait.php:242 { …}
    /var/www/html/joomla/libraries/src/Extension/ExtensionManagerTrait.php:160 { …}
    /var/www/html/joomla/libraries/src/Extension/ExtensionManagerTrait.php:94 { …}
    /var/www/html/joomla/libraries/src/Plugin/PluginHelper.php:235 { …}
    /var/www/html/joomla/libraries/src/Plugin/PluginHelper.php:193 { …}
    /var/www/html/joomla/libraries/src/Application/ConsoleApplication.php:228 { …}
    /var/www/html/joomla/cli/joomla.php:76 { …}
  }
}

```
This happens because the absolute path is "converted" into a URL `http:////var/www/html/joomla/cli/joomla.php` (note the 3 slashes) and then it fails to be parsed.  
The proper solution is to let this plugin run only when it makes sense, in the public section of the website.


### Testing Instructions

1 - Enable the **System - Page Cache** plugin
2 - Open a terminal, navigate to the cli folder and type `php joomla.php list`
3 - Only a notice should happen
4 - Now use the full path `php /path/to/cli/joomla.php list`

### Actual result BEFORE applying this Pull Request

A fatal error should happen


### Expected result AFTER applying this Pull Request

Everything should work as expected

### Documentation Changes Required

None