### PR TITLE
[4.0] Do not minify tinymce languages

### DIFF
--- a/build/build-modules-js/javascript/handle-es5.es6.js
+++ b/build/build-modules-js/javascript/handle-es5.es6.js
@@ -13,6 +13,10 @@ module.exports.handleES5File = async (file) => {
     // eslint-disable-next-line no-console
     console.log(`Legacy js file: ${basename(file)}: ✅ copied`);
 
+    // Skip minify on the tinymce language files
+    if (file.includes(`build${sep}media_source${sep}vendor${sep}tinymce${sep}`)) {
+      return;
+    }
     minifyJs(file.replace(`${sep}build${sep}media_source${sep}`, `${sep}media${sep}`).replace('.es5.js', '.js'));
   }
 };


### PR DESCRIPTION
Because of the way that tinymce works it can only use a language file that is named exactly the same as the language. As a result none of the minified files eg de.min.js will ever be used.

They are also listed as a language in the plugin configuration which is obviously also not correct.

this PR stops the minification of these languages files.

To test you  should
1. delete the contents of `media\vendor\tinymce\langs`
2. run `npm run build:js`
3. confirm that there are now no *.min.js in the `media\vendor\tinymce\langs` folder

Pull Request for Issue #35646