### PR TITLE
[4.0] TinyMCE languages fix

### DIFF
--- a/plugins/editors/tinymce/forms/setoptions.xml
+++ b/plugins/editors/tinymce/forms/setoptions.xml
@@ -117,6 +117,7 @@
 			default="en"
 			hide_default="1"
 			fileFilter="\.js$"
+			exclude="\.min\.js$"
 			showon="lang_mode:0"
 			validate="options"
 		/>

--- a/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
+++ b/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
@@ -166,8 +166,8 @@ class TinymcebuilderField extends FormField
 
 		// Check for TinyMCE language file
 		$language      = Factory::getLanguage();
-		$languageFile1 = 'media/vendor/tinymce/langs/' . $language->getTag() . '.js';
-		$languageFile2 = 'media/vendor/tinymce/langs/' . substr($language->getTag(), 0, strpos($language->getTag(), '-')) . '.js';
+		$languageFile1 = 'media/vendor/tinymce/langs/' . $language->getTag() . (JDEBUG ? '.js' : '.min.js');
+		$languageFile2 = 'media/vendor/tinymce/langs/' . substr($language->getTag(), 0, strpos($language->getTag(), '-')) . (JDEBUG ? '.js' : '.min.js');
 
 		$data['languageFile'] = '';
 

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -243,11 +243,11 @@ class PlgEditorTinymce extends CMSPlugin
 
 		if ($langMode)
 		{
-			if (file_exists(JPATH_ROOT . '/media/vendor/tinymce/langs/' . $language->getTag() . '.js'))
+			if (file_exists(JPATH_ROOT . '/media/vendor/tinymce/langs/' . $language->getTag() . (JDEBUG ? '.js' : '.min.js')))
 			{
 				$langPrefix = $language->getTag();
 			}
-			elseif (file_exists(JPATH_ROOT . '/media/vendor/tinymce/langs/' . substr($language->getTag(), 0, strpos($language->getTag(), '-')) . '.js'))
+			elseif (file_exists(JPATH_ROOT . '/media/vendor/tinymce/langs/' . substr($language->getTag(), 0, strpos($language->getTag(), '-')) . (JDEBUG ? '.js' : '.min.js')))
 			{
 				$langPrefix = substr($language->getTag(), 0, strpos($language->getTag(), '-'));
 			}
@@ -580,10 +580,10 @@ class PlgEditorTinymce extends CMSPlugin
 			$scriptOptions,
 			array(
 				'deprecation_warnings' => JDEBUG ? true : false,
-				'suffix'   => '.min',
+				'suffix'   => JDEBUG ? '' : '.min',
 				'baseURL'  => Uri::root(true) . '/media/vendor/tinymce',
 				'directionality' => $text_direction,
-				'language' => $langPrefix,
+				'language' => $langPrefix . (JDEBUG ? '' : '.min'),
 				'autosave_restore_when_empty' => false,
 				'skin'     => $skin,
 				'theme'    => $theme,


### PR DESCRIPTION
Pull Request alternative to #35878

### Summary of Changes

Load either minified or non minified language files depending on the JDEBUG constant (same as the rest scripts/styles in the core)

### Testing Instructions
Same as  #35878


### Actual result BEFORE applying this Pull Request

Broken

### Expected result AFTER applying this Pull Request

Fixed
<img width="1229" alt="Screenshot 2021-10-23 at 20 30 22" src="https://user-images.githubusercontent.com/3889375/138567644-b42e47c9-a3ba-496c-ae19-7f48f3b0f08d.png">

<img width="1368" alt="Screenshot 2021-10-23 at 20 33 31" src="https://user-images.githubusercontent.com/3889375/138567667-bf4697d2-d618-4f83-9ce3-778f07279a56.png">



### Documentation Changes Required

No bug fix

@brianteeman 