### PR TITLE
[4.0] No Articles Message

### DIFF
--- a/components/com_content/tmpl/category/blog.php
+++ b/components/com_content/tmpl/category/blog.php
@@ -66,9 +66,10 @@ $htag    = $this->params->get('show_page_heading') ? 'h2' : 'h1';
 	<?php endif; ?>
 
 	<?php if (empty($this->lead_items) && empty($this->link_items) && empty($this->intro_items)) : ?>
-		<?php if ($this->params->get('show_no_articles', 1)) : ?>
-			<p><?php echo Text::_('COM_CONTENT_NO_ARTICLES'); ?></p>
-		<?php endif; ?>
+		<div class="alert alert-info">
+			<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+				<?php echo Text::_('COM_CONTENT_NO_ARTICLES'); ?>
+		</div>
 	<?php endif; ?>
 
 	<?php $leadingcount = 0; ?>

--- a/components/com_content/tmpl/category/blog.php
+++ b/components/com_content/tmpl/category/blog.php
@@ -66,10 +66,12 @@ $htag    = $this->params->get('show_page_heading') ? 'h2' : 'h1';
 	<?php endif; ?>
 
 	<?php if (empty($this->lead_items) && empty($this->link_items) && empty($this->intro_items)) : ?>
-		<div class="alert alert-info">
-			<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
-				<?php echo Text::_('COM_CONTENT_NO_ARTICLES'); ?>
-		</div>
+		<?php if ($this->params->get('show_no_articles', 1)) : ?>
+			<div class="alert alert-info">
+				<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+					<?php echo Text::_('COM_CONTENT_NO_ARTICLES'); ?>
+			</div>
+		<?php endif; ?>
 	<?php endif; ?>
 
 	<?php $leadingcount = 0; ?>

--- a/components/com_content/tmpl/category/default_articles.php
+++ b/components/com_content/tmpl/category/default_articles.php
@@ -116,10 +116,12 @@ $currentDate = Factory::getDate()->format('Y-m-d H:i:s');
 	<?php endif; ?>
 
 	<?php if (empty($this->items)) : ?>
-		<div class="alert alert-info">
-			<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
-				<?php echo Text::_('COM_CONTENT_NO_ARTICLES'); ?>
-		</div>
+		<?php if ($this->params->get('show_no_articles', 1)) : ?>
+			<div class="alert alert-info">
+				<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+					<?php echo Text::_('COM_CONTENT_NO_ARTICLES'); ?>
+			</div>
+		<?php endif; ?>
 	<?php else : ?>
 		<table class="com-content-category__table category table table-striped table-bordered table-hover">
 			<caption class="visually-hidden">


### PR DESCRIPTION
Both category blog and category list have an option to show or hide a message if there are no articles in the category.

Before this PR the option worked _only_ for a category blog. It was not possible to hide the message for a category list.

In addition the message, when displayed, was not formatted consistently. In some places it was a simple paragraph, in others it was a nicely formatted message. This PR makes the messages display consistently.

![image](https://user-images.githubusercontent.com/1296369/138687308-9863dbb8-0584-4b50-8b56-fb8fbc1b9c9c.png)

Pull Request for #35885 