### PR TITLE
[4.0] Don't blindly try to translate the formfield label

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1198,7 +1198,7 @@ class Form
 			// Define field name for messages
 			if ($field['label'])
 			{
-				$fieldLabel = ($field['label']);
+				$fieldLabel = $field['label'];
 
 				// Try to translate label if not set to false
 				$translate = (string) $field['translateLabel'];

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1198,7 +1198,15 @@ class Form
 			// Define field name for messages
 			if ($field['label'])
 			{
-				$fieldLabel = Text::_($field['label']);
+				$fieldLabel = ($field['label']);
+
+				// Try to translate label if not set to false
+				$translate = (string) $field['translateLabel'];
+
+				if (!($translate === 'false' || $translate === 'off' || $translate === '0'))
+				{
+					$fieldLabel = Text::_($fieldLabel);
+				}
 			}
 			else
 			{

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1209,7 +1209,15 @@ abstract class FormField
 
 		if ($this->element['label'])
 		{
-			$fieldLabel = Text::_($this->element['label']);
+			$fieldLabel = $this->element['label'];
+
+			// Try to translate label if not set to false
+			$translate = (string) $this->element['translateLabel'];
+
+			if (!($translate === 'false' || $translate === 'off' || $translate === '0'))
+			{
+				$fieldLabel = Text::_($fieldLabel);
+			}
 		}
 		else
 		{


### PR DESCRIPTION
Pull Request for Issue https://github.com/infograf768/j4localise/issues/42 .

### Summary of Changes
Adding a check to the form validate code to respect the "translateLabel" attribute of the field.
Currently it always tries to translate the field label. The PR changes this so you can disable the behaviour by setting the attribute "translateLabel" to "false", "off" or "0".
That attribute and the possible values already exist, I just took the same.


### Testing Instructions
I'm not sure how this can be tested. Maybe by leaving a required field empty or entering a non-expected value into a field.
That should give an error with the translated field name both with or without the PR.

With com_localise, the existing error (as stated in the issue) could be prevented by setting the Attribute "translateLabel" to "false". I will add that info to the Issue.

### Documentation Changes Required
None as it just extends the existing feature also to the validation.