### PR TITLE
[4.0] modals invisible tinymce fullscreen

### DIFF
--- a/administrator/templates/atum/scss/vendor/_tinymce.scss
+++ b/administrator/templates/atum/scss/vendor/_tinymce.scss
@@ -16,6 +16,9 @@
   }
 }
 
+.tox-fullscreen {
+  z-index: 1049 !important;
+}
 
 .container-main {
   .mce-panel {

--- a/administrator/templates/atum/scss/vendor/_tinymce.scss
+++ b/administrator/templates/atum/scss/vendor/_tinymce.scss
@@ -17,7 +17,7 @@
 }
 
 .tox-fullscreen {
-  z-index: 1049 !important;
+  z-index: $zindex-modal-backdrop - 1 !important;
 }
 
 .container-main {


### PR DESCRIPTION
Tinymce can be made fullscreen by either the hotkey ctrl-shif-f or by clicking on the icon in the toolbar.

![image](https://user-images.githubusercontent.com/1296369/138866779-f16fbc6e-5e3e-4f43-a93d-f84e0281807e.png)


This sets the z-index of the editor to 1250. As a result the modals generated by the cms content buttons (editor-xtd pluguins) are invisible as they have a z-index of 1050.

This PR changes the tinymce zindex to 1049

