### PR TITLE
[4.0] Close tags on atom documents

### DIFF
--- a/libraries/src/Document/Renderer/Feed/AtomRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/AtomRenderer.php
@@ -104,7 +104,7 @@ class AtomRenderer extends DocumentRenderer
 			}
 		}
 
-		$feed .= "	<link rel=\"alternate\" type=\"text/html\" href=\"" . $url . "\">\n";
+		$feed .= "	<link rel=\"alternate\" type=\"text/html\" href=\"" . $url . "\"/>\n";
 		$feed .= "	<id>" . str_replace(' ', '%20', $data->getBase()) . "</id>\n";
 		$feed .= "	<updated>" . htmlspecialchars($now->toISO8601(true), ENT_COMPAT, 'UTF-8') . "</updated>\n";
 
@@ -130,7 +130,7 @@ class AtomRenderer extends DocumentRenderer
 		}
 
 		$feed .= "	<generator uri=\"https://www.joomla.org\"" . $versionHtmlEscaped . ">" . $data->getGenerator() . "</generator>\n";
-		$feed .= "	<link rel=\"self\" type=\"application/atom+xml\" href=\"" . str_replace(' ', '%20', $url . $syndicationURL) . "\">\n";
+		$feed .= "	<link rel=\"self\" type=\"application/atom+xml\" href=\"" . str_replace(' ', '%20', $url . $syndicationURL) . "\"/>\n";
 
 		for ($i = 0, $count = \count($data->items); $i < $count; $i++)
 		{
@@ -143,7 +143,7 @@ class AtomRenderer extends DocumentRenderer
 
 			$feed .= "	<entry>\n";
 			$feed .= "		<title>" . htmlspecialchars(strip_tags($data->items[$i]->title), ENT_COMPAT, 'UTF-8') . "</title>\n";
-			$feed .= "		<link rel=\"alternate\" type=\"text/html\" href=\"" . $url . $itemlink . "\">\n";
+			$feed .= "		<link rel=\"alternate\" type=\"text/html\" href=\"" . $url . $itemlink . "\"/>\n";
 
 			if ($data->items[$i]->date == '')
 			{
@@ -196,14 +196,14 @@ class AtomRenderer extends DocumentRenderer
 				}
 				else
 				{
-					$feed .= "		<category term=\"" . htmlspecialchars($data->items[$i]->category, ENT_COMPAT, 'UTF-8') . "\" />\n";
+					$feed .= "		<category term=\"" . htmlspecialchars($data->items[$i]->category, ENT_COMPAT, 'UTF-8') . "\"/>\n";
 				}
 			}
 
 			if ($data->items[$i]->enclosure != null)
 			{
 				$feed .= "		<link rel=\"enclosure\" href=\"" . $data->items[$i]->enclosure->url . "\" type=\""
-					. $data->items[$i]->enclosure->type . "\"  length=\"" . $data->items[$i]->enclosure->length . "\">\n";
+					. $data->items[$i]->enclosure->type . "\"  length=\"" . $data->items[$i]->enclosure->length . "\"/>\n";
 			}
 
 			$feed .= "	</entry>\n";

--- a/libraries/src/Document/Renderer/Feed/AtomRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/AtomRenderer.php
@@ -196,7 +196,7 @@ class AtomRenderer extends DocumentRenderer
 				}
 				else
 				{
-					$feed .= "		<category term=\"" . htmlspecialchars($data->items[$i]->category, ENT_COMPAT, 'UTF-8') . "\"/>\n";
+					$feed .= "		<category term=\"" . htmlspecialchars($data->items[$i]->category, ENT_COMPAT, 'UTF-8') . "\" />\n";
 				}
 			}
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/35907

### Summary of Changes

Close all tags on atom documents

### Testing Instructions

- setup a category blog
- open the page in the frontend
- add `?format=feed&type=atom` to the blog URL

### Actual result BEFORE applying this Pull Request

The link tags are not closed

### Expected result AFTER applying this Pull Request

Confirm that the link tags are closed

### Documentation Changes Required

None.