### PR TITLE
[4.0] Add information to the error message

### DIFF
--- a/administrator/language/en-GB/plg_sampledata_blog.ini
+++ b/administrator/language/en-GB/plg_sampledata_blog.ini
@@ -138,6 +138,6 @@ PLG_SAMPLEDATA_BLOG_STEP1_SUCCESS="Step 1: Tags, Articles, Fields and Workflow d
 PLG_SAMPLEDATA_BLOG_STEP2_SUCCESS="Step 2: Menus done!"
 PLG_SAMPLEDATA_BLOG_STEP3_SUCCESS="Step 3: Modules done!"
 PLG_SAMPLEDATA_BLOG_STEP4_SUCCESS="Blog Sample Data has been installed!"
-PLG_SAMPLEDATA_BLOG_STEP_FAILED="Step %1$u Failed: %2$s"
+PLG_SAMPLEDATA_BLOG_STEP_FAILED="Step %1$u Failed with message: %2$s. Please note that you can install Blog Sample Data only once."
 PLG_SAMPLEDATA_BLOG_STEP_SKIPPED="Step %1$u Skipped: '%2$s' is either not installed or disabled."
 PLG_SAMPLEDATA_BLOG_XML_DESCRIPTION="Provides the blog sample data. Can be installed using the sample data module."

--- a/administrator/language/en-GB/plg_sampledata_blog.ini
+++ b/administrator/language/en-GB/plg_sampledata_blog.ini
@@ -138,6 +138,6 @@ PLG_SAMPLEDATA_BLOG_STEP1_SUCCESS="Step 1: Tags, Articles, Fields and Workflow d
 PLG_SAMPLEDATA_BLOG_STEP2_SUCCESS="Step 2: Menus done!"
 PLG_SAMPLEDATA_BLOG_STEP3_SUCCESS="Step 3: Modules done!"
 PLG_SAMPLEDATA_BLOG_STEP4_SUCCESS="Blog Sample Data has been installed!"
-PLG_SAMPLEDATA_BLOG_STEP_FAILED="Step %1$u Failed with message: %2$s Please note that you can install Blog Sample Data only once."
+PLG_SAMPLEDATA_BLOG_STEP_FAILED="Step %1$u Failed with message: %2$s Please note that you can only install Blog Sample Data once."
 PLG_SAMPLEDATA_BLOG_STEP_SKIPPED="Step %1$u Skipped: '%2$s' is either not installed or disabled."
 PLG_SAMPLEDATA_BLOG_XML_DESCRIPTION="Provides the blog sample data. Can be installed using the sample data module."

--- a/administrator/language/en-GB/plg_sampledata_blog.ini
+++ b/administrator/language/en-GB/plg_sampledata_blog.ini
@@ -138,6 +138,6 @@ PLG_SAMPLEDATA_BLOG_STEP1_SUCCESS="Step 1: Tags, Articles, Fields and Workflow d
 PLG_SAMPLEDATA_BLOG_STEP2_SUCCESS="Step 2: Menus done!"
 PLG_SAMPLEDATA_BLOG_STEP3_SUCCESS="Step 3: Modules done!"
 PLG_SAMPLEDATA_BLOG_STEP4_SUCCESS="Blog Sample Data has been installed!"
-PLG_SAMPLEDATA_BLOG_STEP_FAILED="Step %1$u Failed with message: %2$s. Please note that you can install Blog Sample Data only once."
+PLG_SAMPLEDATA_BLOG_STEP_FAILED="Step %1$u Failed with message: %2$s Please note that you can install Blog Sample Data only once."
 PLG_SAMPLEDATA_BLOG_STEP_SKIPPED="Step %1$u Skipped: '%2$s' is either not installed or disabled."
 PLG_SAMPLEDATA_BLOG_XML_DESCRIPTION="Provides the blog sample data. Can be installed using the sample data module."


### PR DESCRIPTION
### Summary of Changes
Blog Sample Data can be installed only once. When the user repeats the installation, the installation fails with a message. 
For new users this message is somehow cryptic. We can add a clearer information. 



### Testing Instructions
Install the Blog Sample Data once, then install again and see the error message. 

### Actual result BEFORE applying this Pull Request
Step 1 Failed with message: Another Tag has the same alias (remember it may be a trashed item).


### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1035262/138951117-ce38e5a8-a2b5-4980-a835-14a97c371598.png)



### Documentation Changes Required

