### PR TITLE
[4.1] Enabled to focus in media files

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/tree/item.vue
+++ b/administrator/components/com_media/resources/scripts/components/tree/item.vue
@@ -73,7 +73,7 @@ export default {
       };
     },
     getTabindex() {
-      return this.isActive ? 0 : -1;
+      return this.isActive ? -1 : 0;
     },
   },
   methods: {

--- a/administrator/components/com_media/resources/scripts/components/tree/item.vue
+++ b/administrator/components/com_media/resources/scripts/components/tree/item.vue
@@ -73,7 +73,7 @@ export default {
       };
     },
     getTabindex() {
-      return this.isActive ? -1 : 0;
+      return 0;
     },
   },
   methods: {


### PR DESCRIPTION
Pull Request for Issue #35229 .

### Summary of Changes
I have enabled focus on media files by changing their `tabindex` from -1 to 0.

### Testing Instructions
Check out issue #35229 for testing and reproducing the PR.

### Actual result BEFORE applying this Pull Request
Unable to focus on media files while using the tab button.

### Expected result AFTER applying this Pull Request
Enabled to focus in media files using the tab button.



