### PR TITLE
Allow to set a value for SubformField

### DIFF
--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -181,7 +181,7 @@ class SubformField extends FormField
 				}
 
 				$this->value = $value !== null ? (array) $value : null;
-			break;
+				break;
 
 			default:
 				parent::__set($name, $value);

--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -15,8 +15,6 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormField;
 use Joomla\Registry\Registry;
 
-use function json_decode;
-
 /**
  * The Field to load the form inside current form
  *
@@ -182,7 +180,7 @@ class SubformField extends FormField
 					$value = json_decode($value, true);
 				}
 
-				$this->value = (array) $value;
+				$this->value = $value;
 			break;
 
 			default:

--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -181,6 +181,7 @@ class SubformField extends FormField
 				}
 
 				$this->value = $value !== null ? (array) $value : null;
+
 				break;
 
 			default:

--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormField;
 use Joomla\Registry\Registry;
 
+use function json_decode;
+
 /**
  * The Field to load the form inside current form
  *
@@ -172,6 +174,16 @@ class SubformField extends FormField
 				}
 
 				break;
+
+			case 'value':
+				// We allow a json encoded string or an array
+				if (is_string($value))
+				{
+					$value = json_decode($value, true);
+				}
+
+				$this->value = (array) $value;
+			break;
 
 			default:
 				parent::__set($name, $value);

--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -180,7 +180,7 @@ class SubformField extends FormField
 					$value = json_decode($value, true);
 				}
 
-				$this->value = $value;
+				$this->value = $value !== null ? (array) $value : null;
 			break;
 
 			default:

--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -183,7 +183,7 @@ class SubformField extends FormField
 				}
 
 				$this->value = (array) $value;
-			break;
+				break;
 
 			default:
 				parent::__set($name, $value);


### PR DESCRIPTION
Subform Field doesn't allow to set a `value` because the supplied `value` is automatically converted to `string` which is the wrong variable type for Subform Field. The Field needs an `array`.

### Summary of Changes
This PR automatically converts a `json` encoded string into an `array` and allows to supply an `array` directly


### Testing Instructions
1. Create a custom field with a subform
2. Test if the field still works in backend and frontend

Testing the new functionally is not so easy. 
Editing the com_content default layout could be the simplest way.

You need to get the subform field from the form and set a value.

For a successful test I would expect that the simple test is enough.

### Actual result BEFORE applying this Pull Request
* Simple test works
* Extended Test doesn't work

### Expected result AFTER applying this Pull Request
* Simple test works
* Extended Test works


