### PR TITLE
[4.0] Fix SQL error 1064 (SQL syntax error) on template overrides table updates when updating extensions

### DIFF
--- a/plugins/installer/override/override.php
+++ b/plugins/installer/override/override.php
@@ -393,6 +393,7 @@ class PlgInstallerOverride extends CMSPlugin
 				],
 				ParameterType::STRING
 			);
+
 			$bindArray = array_merge(
 				$bindArray,
 				$insertQuery->bindArray(
@@ -400,14 +401,18 @@ class PlgInstallerOverride extends CMSPlugin
 						$pk->extension_id,
 						0,
 						(int) $pk->client,
-					]
+					],
+					ParameterType::INTEGER
 				)
 			);
 
 			$insertQuery->values(implode(',', $bindArray));
 		}
 
-		$this->db->setQuery($insertQuery);
-		$this->db->execute();
+		if (!empty($bindArray))
+		{
+			$this->db->setQuery($insertQuery);
+			$this->db->execute();
+		}
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #35427 .

### Summary of Changes

This pull request (PR) fixes an SQL error which happens when you have made some template overrides and now a 3rd party extension or core update makes changes on the overridden files so the override checker finds that change, and then you have another update which again changes the same files but no others files and you haven't made any new overrides in the mean time so all the detected override changes just need to be updated in database and no new one has to be inserted in addition.

Thanks to @stAn47 who suggested the fix.

In addition, this PR adds a `ParameterType::INTEGER` parameter to the 2nd bind call. This could be tested by code review, or test this PR with MySQLi and MySQL (PDO) and PostgreSQL (PDO). The 2 ID columns of the same table are bound with `ParameterType::INTEGER` here https://github.com/joomla/joomla-cms/blob/4.0-dev/plugins/installer/override/override.php#L303-L304 , and the status is given as integer, too.

### Testing Instructions

1. Have a clean, current 4.0-dev or latest 4.0 nightly or 4.0.4 installation which does not have com_weblinks installed.

2. Switch error reporting to maximum in global configuration.

3. Download the Weblinks 4.0.0 RC1 package from here https://github.com/joomla-extensions/weblinks/releases/download/4.0.0-rc1/pkg-weblinks-4.0.0-rc1.zip and install that package.

4. Create a template override for the "category" folder of com_weblinks.
![01-create-override](https://user-images.githubusercontent.com/7413183/139248286-961fdebe-a83e-4fa8-b169-bf4eba37291c.png)

5. Modify the "default_items.php" file of your override.
![02-modify-file](https://user-images.githubusercontent.com/7413183/139248358-5064735d-c20a-403c-bf2a-d75f084fe824.png)

6. Download the special Weblinks 4.0.0 RC2 package which I have created for testing this PR from here https://test5.richard-fath.de/pkg-weblinks-4.0.0-rc2_test.zip and update to that package by uploading and  installing it with the extensions installer.
![03-upload-update-1](https://user-images.githubusercontent.com/7413183/139249119-b7c9d723-9ce1-4ae0-94b7-995936d2f26a.png)

7. Now check for extension updates and update to the (regular, i.e. unmodified) Weblinks 4.0.0 package.
![04-online-update-2](https://user-images.githubusercontent.com/7413183/139249397-36170e67-75fd-4642-a036-8b462b7a6c2e.png)
If you can't use the online update you can download the package from here https://github.com/joomla-extensions/weblinks/releases/download/4.0.0/pkg-weblinks-4.0.0.zip and update to that package in the same way as in the previous step.

Result: See section "Actual result BEFORE applying this Pull Request" below.

8. Uninstall the weblinks package and the weblinks editor button.
![05a-uninstall-weblinks-package](https://user-images.githubusercontent.com/7413183/139252704-af09d496-684a-42e5-8016-88b0eea72a03.png)
Hint: You might see some yellow warning messages about errors e.g. with table not existing, but you can safely ignore that.

9. Delete all override files and folders so there is no "com_weblinks" folder anymore in the template's "html" folder..

10. Make sure that no override changes are shown anymore. If necessary, delete all records in table `#__template_overrides` in database.
![05b-no-overide-changes](https://user-images.githubusercontent.com/7413183/139252913-2c8728cb-5857-4da6-87a5-e4fb17e6c3aa.png)

11. Apply the patch from this PR.

12. Repeat steps 3 to 7.

Result: No SQL error, see section "Expected result AFTER applying this Pull Request" below.

13. Verify that a changed override is shown.
![06-override-changed](https://user-images.githubusercontent.com/7413183/139253132-c8500af0-ad32-4b31-a5c5-b220f49d93f6.png)

14. Verify that your override file still contains your change from step 5.
![07-override-check-1](https://user-images.githubusercontent.com/7413183/139253251-ef1f0867-58f5-4aae-b712-4128a3eb37ad.png)

15. Verify that the comparison also shows the change in the original file from RC1 to the final package.
![07-override-check-2](https://user-images.githubusercontent.com/7413183/139253411-f20c5ce8-c77b-4ddb-9327-cf73debe1e1f.png)

### Actual result BEFORE applying this Pull Request

![05-sql-error](https://user-images.githubusercontent.com/7413183/139249667-cc0c8041-bfb6-4961-b49e-5a98b09617e8.png)

### Expected result AFTER applying this Pull Request

No SQL error. Override checker works as it should.

### Documentation Changes Required

None.