### PR TITLE
[4.0] [webservices] wrong parameter for setting Access-Control-Allow-Headers

### DIFF
--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -363,7 +363,7 @@ final class ApiApplication extends CMSApplication
 		* Obtain allowed CORS headers from Global Settings.
 		* Set to sensible default if not set.
 		*/
-		$allowedHeaders = $this->get('cors_allowed_headers', 'Content-Type,X-Joomla-Token');
+		$allowedHeaders = $this->get('cors_allow_headers', 'Content-Type,X-Joomla-Token');
 
 		/**
 		* Obtain allowed CORS methods from Global Settings.


### PR DESCRIPTION
### Summary of Changes
This PR updates the get parameter for setting Access-Control-Allow-Headers

Similar to PR #35893 

### Testing Instructions
Code review

name `cors_allow_headers` in XML
```xml
<field
	name="cors_allow_headers"
	type="text"
	label="Access-Control-Allow-Headers"
	description="COM_CONFIG_FIELD_WEBSERVICES_CORS_ALLOW_HEADERS_DESC"
	translate_label="false"
	default="Content-Type,X-Joomla-Token"
	showon="cors:1"
/>
```
Get parameter is `cors_allowed_headers`

@alikon 