### PR TITLE
Fixed PHP Warning messages for using uninitialized variables

### DIFF
--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -327,7 +327,7 @@ class HtmlView extends BaseHtmlView
 
 		if (!empty($ref_key) && !empty($url))
 		{
-		    $toolbar->help($ref_key, ComponentHelper::getParams($component)->exists('helpURL'), $url);
+			$toolbar->help($ref_key, ComponentHelper::getParams($component)->exists('helpURL'), $url);
 		}
 	}
 }

--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -299,7 +299,7 @@ class HtmlView extends BaseHtmlView
 			$url     = (string) $xml->listhelp['url'];
 		}
 
-		if (!$ref_key)
+		if (empty($ref_key))
 		{
 			// Compute the ref_key if it does exist in the component
 			if (!$lang->hasKey($ref_key = strtoupper($component . ($section ? "_$section" : '')) . '_CATEGORIES_HELP_KEY'))
@@ -315,7 +315,7 @@ class HtmlView extends BaseHtmlView
 		 * -locally  searching in a component help file if helpURL param exists in the component and is set to ''
 		 * -remotely searching in a component URL if helpURL param exists in the component and is NOT set to ''
 		 */
-		if (!$url)
+		if (empty($url))
 		{
 			if ($lang->hasKey($lang_help_url = strtoupper($component) . '_HELP_URL'))
 			{
@@ -325,6 +325,9 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 
-		$toolbar->help($ref_key, ComponentHelper::getParams($component)->exists('helpURL'), $url);
+		if (!empty($ref_key) && !empty($url))
+		{
+		    $toolbar->help($ref_key, ComponentHelper::getParams($component)->exists('helpURL'), $url);
+		}
 	}
 }


### PR DESCRIPTION
Pull Request for Issue #35941  .
When a third-party component does not use the help buttons on the categories page (or in other words do not have /components/$component/forms/$name.xml file), there are a bunch of PHP warning messages caused by uninitialized variables. 

$ref_key & $url variables are initialized only when the file is available.

### Summary of Changes
Added checks for empty variables so that they do not generate PHP warning messages


### Testing Instructions
Create a component and add categories support. Go to the categories dashboard page of the component.


### Actual result BEFORE applying this Pull Request
There were following PHP errors
Warning: Undefined variable $ref_key in /root../administrator/components/com_categories/src/View/Categories/HtmlView.php on line 302
Warning: Undefined variable $url in /root../administrator/components/com_categories/src/View/Categories/HtmlView.php on line 318
Warning: Undefined variable $url in /root../administrator/components/com_categories/src/View/Categories/HtmlView.php on line 328


### Expected result AFTER applying this Pull Request
No errors


### Documentation Changes Required
None
