### PR TITLE
[4.0] Fix disabled attribute for Radio form field

### DIFF
--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -51,18 +51,13 @@ $blockStart  = $isBtnGroup ? '' : '<div class="form-check">';
 $blockEnd    = $isBtnGroup ? '' : '</div>';
 
 // Add the attributes of the fieldset in an array
-$attribs = ['class="' . trim(
-		$class . ' radio' . ($readonly || $disabled ? ' disabled' : '') . ($readonly ? ' readonly' : '')
-	) . '"',];
+$containerClass = trim($class . ' radio' . ($readonly || $disabled ? ' disabled' : '') . ($readonly ? ' readonly' : ''));
+
+$attribs = ['id="' . $id . '"'];
 
 if (!empty($disabled))
 {
 	$attribs[] = 'disabled';
-}
-
-if (!empty($required))
-{
-	$attribs[] = 'required';
 }
 
 if (!empty($autofocus))
@@ -80,16 +75,16 @@ if ($dataAttribute)
 	$attribs[] = $dataAttribute;
 }
 ?>
-<fieldset id="<?php echo $id; ?>" >
+<fieldset <?php echo implode(' ', $attribs); ?>>
 	<legend class="visually-hidden">
 		<?php echo $label; ?>
 	</legend>
-	<div <?php echo implode(' ', $attribs); ?>>
+	<div <?php echo $containerClass; ?>>
 		<?php foreach ($options as $i => $option) : ?>
 			<?php echo $blockStart; ?>
 				<?php
 				$disabled = !empty($option->disable) ? 'disabled' : '';
-				$style    = $disabled ? 'style="pointer-events: none"' : '';
+				$style    = $disabled ? ' style="pointer-events: none"' : '';
 
 				// Initialize some option attributes.
 				if ($isBtnYesNo)
@@ -118,13 +113,13 @@ if ($dataAttribute)
 				$onchange   = !empty($option->onchange) ? 'onchange="' . $option->onchange . '"' : '';
 				$oid        = $id . $i;
 				$ovalue     = htmlspecialchars($option->value, ENT_COMPAT, 'UTF-8');
-				$attributes = array_filter(array($checked, $disabled, $style, $onchange, $onclick));
+				$attributes = array_filter(array($checked, $disabled, ltrim($style), $onchange, $onclick));
 				?>
 				<?php if ($required) : ?>
 					<?php $attributes[] = 'required'; ?>
 				<?php endif; ?>
 				<input class="<?php echo $classToggle; ?>" type="radio" id="<?php echo $oid; ?>" name="<?php echo $name; ?>" value="<?php echo $ovalue; ?>" <?php echo implode(' ', $attributes); ?>>
-				<label for="<?php echo $oid; ?>" class="<?php echo trim($optionClass . ' ' . $style); ?>"> 
+				<label for="<?php echo $oid; ?>" class="<?php echo trim($optionClass); ?><?php echo $style; ?>">
 					<?php echo $option->text; ?>
 				</label>
 			<?php echo $blockEnd; ?>

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -119,7 +119,7 @@ if ($dataAttribute)
 					<?php $attributes[] = 'required'; ?>
 				<?php endif; ?>
 				<input class="<?php echo $classToggle; ?>" type="radio" id="<?php echo $oid; ?>" name="<?php echo $name; ?>" value="<?php echo $ovalue; ?>" <?php echo implode(' ', $attributes); ?>>
-				<label for="<?php echo $oid; ?>" class="<?php echo trim($optionClass); ?><?php echo $style; ?>">
+				<label for="<?php echo $oid; ?>" class="<?php echo trim($optionClass); ?>"<?php echo $style; ?>>
 					<?php echo $option->text; ?>
 				</label>
 			<?php echo $blockEnd; ?>


### PR DESCRIPTION
Pull Request for Issue #35927.

### Summary of Changes
This PR fixes issue https://github.com/joomla/joomla-cms/issues/35927 and also, some invalid mark up on **buttons** layout of radio form field.

1. Move $attribs back to `fieldset`. It was moved from fieldset to dev by mistake in the PR https://github.com/joomla/joomla-cms/pull/19946
2. Remove **required** attribute from fieldset because required is invalid attribute for fieldset. I think **autofocus** should be removed, too, because it is also invalid. But then how should we handle autofocus for radio options? For now, I leave it there
3. Fix invalid markup for label of disabled option. `style="pointer-events: none"'` should not be used inside class (you can see this by reviewing code)


### Testing Instructions
1. Open administrator/components/com_banners/config.xml, change https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_banners/config.xml#L24-L33 to the below code to make that field disabled and use buttons layout:
```xml
<field
	name="track_impressions"
	type="radio"	
	label="COM_BANNERS_FIELD_TRACKIMPRESSION_LABEL"
	default="0"
	disabled="true"
	>
	<option value="0">JNO</option>
	<option value="1">JYES</option>
</field>
```
2. Login to administrator area of your site, access to Banners component, click on Options button in the toolbar to change setting of the component
3. Press Save button to save the change
### Actual result BEFORE applying this Pull Request
You got fatal error because the value of that disabled field still being submitted to server (causes by invalid mark up for the field)

### Expected result AFTER applying this Pull Request
Change can be saved properly. Also, please make to the appearance of the field is not changed after PR.


### Documentation Changes Required
None.