### PR TITLE
[4.0] Fix exception handling in the database checker's change item

### DIFF
--- a/libraries/src/Schema/ChangeItem.php
+++ b/libraries/src/Schema/ChangeItem.php
@@ -201,7 +201,7 @@ abstract class ChangeItem
 				$this->db->setQuery($this->checkQuery);
 				$rows = $this->db->loadRowList(0);
 			}
-			catch (\Exception $e)
+			catch (\RuntimeException $e)
 			{
 				// Still render the error message from the Exception object
 				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
@@ -252,7 +252,7 @@ abstract class ChangeItem
 					$this->rerunStatus = -2;
 				}
 			}
-			catch (\Exception $e)
+			catch (ExecutionFailureException | \RuntimeException $e)
 			{
 				$this->rerunStatus = -2;
 			}

--- a/libraries/src/Schema/ChangeItem.php
+++ b/libraries/src/Schema/ChangeItem.php
@@ -184,9 +184,8 @@ abstract class ChangeItem
 
 	/**
 	 * Runs the check query and checks that 1 row is returned
-	 * If yes, return true, otherwise return false
 	 *
-	 * @return  boolean  true on success, false otherwise
+	 * @return  integer  1 if success, -1 if skipped, -2 if check failed
 	 *
 	 * @since  2.5
 	 */

--- a/libraries/src/Schema/ChangeItem.php
+++ b/libraries/src/Schema/ChangeItem.php
@@ -196,13 +196,12 @@ abstract class ChangeItem
 
 		if ($this->checkQuery)
 		{
-			$this->db->setQuery($this->checkQuery);
-
 			try
 			{
+				$this->db->setQuery($this->checkQuery);
 				$rows = $this->db->loadRowList(0);
 			}
-			catch (\RuntimeException $e)
+			catch (\Exception $e)
 			{
 				// Still render the error message from the Exception object
 				Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
@@ -238,10 +237,9 @@ abstract class ChangeItem
 			// At this point we have a failed query
 			$query = $this->updateQuery;
 
-			$this->db->setQuery($query);
-
 			try
 			{
+				$this->db->setQuery($query);
 				$this->db->execute();
 
 				if ($this->check())
@@ -254,7 +252,7 @@ abstract class ChangeItem
 					$this->rerunStatus = -2;
 				}
 			}
-			catch (ExecutionFailureException $e)
+			catch (\Exception $e)
 			{
 				$this->rerunStatus = -2;
 			}


### PR DESCRIPTION
Pull Request for Issues #35949 and #35915 .

### Summary of Changes

When an SQL statement in an update SQL script of the core or (new in Joomla 4!) a 3rd party extension has a syntax error in an `ALTER TABLE <tableName> MODIFY <columnName>...` or an `ALTER TABLE <tableName> CHANGE <columnName>...` SQL statement, the check query used by the database checker to check that column will fail with an SQL syntax error.

This error happens already when calling `$this->db->setQuery`, but the try block to handle exceptions does not include that, it handles only the `$this->db->loadRowList` call.

This leads to the database checker being broken, see testing instructions or the issue for details.

This PR fixes it by moving the `$this->db->setQuery` inside the try block in the "check" method of the change item.

The same applies when the database checker would try to fix that problem, so it needs the same fix for the "fix" method.

In addition I've fixed the wrong documentation of the "check" method.

### Testing Instructions

1. Install Weblinks 4.0.0. You can download it from here: https://github.com/joomla-extensions/weblinks/releases/download/4.0.0/pkg-weblinks-4.0.0.zip .

2. Open the following update SQL script of the Weblinks component in a text editor:
- administrator/components/com_weblinks/sql/updates/mysql/4.0.0.sql when using a MySQL or MariaDB database
- administrator/components/com_weblinks/sql/updates/postgresql/4.0.0.sql when using a PostgreSQL database

3. In the first SQL statement, remove the ending names quote for the **table** name and change the **column** name so it looks as follows:
- With MySQL or MariaDB database
```
ALTER TABLE `#__weblinks MODIFY `createdXXX` datetime NOT NULL;
```
- With PostgreSQL database
```
ALTER TABLE "#__weblinks ALTER COLUMN "createdXXX" DROP DEFAULT;
```
After having made the change, save the file.

4. Go to the "System" dashboard and check the icon shown for "Maintenance: Database".
Result: The database check failed.
![2021-10-31_snap-1](https://user-images.githubusercontent.com/7413183/139584636-06dc9bef-7584-40da-a1fc-f710c6e06594.png)

5. Use the link to go to the database checker.
Result: An error alert shows a message about an SQL syntax error, and the database checker doesn't show any rows with the core or extensions, so nothing can be fixed.
Hint: Depending on your database server type and version it might be a different error message which is shown. The important thing is that there is an error message about an SQL error and nothing is shown below it except of the "No matching results" alert.
![2021-10-31_snap-2](https://user-images.githubusercontent.com/7413183/139584688-360683f0-5f02-4879-b250-dade2c9756f9.png)

6. Apply the patch of this PR.

7. Repeat step 4.
Result: The database check shows there is a problem.
![2021-10-31_snap-3](https://user-images.githubusercontent.com/7413183/139584946-65cf5227-fa9c-40ca-8723-b8daacf33e21.png)

8. Repeat step 5.
Result: An error alert shows a message about an SQL syntax error, and the database checker shows rows with the core or extensions. The tool tip shown when moving over the badge with the problem shows which database column in which SQL script has caused the problem.
![2021-11-01_snap-1](https://user-images.githubusercontent.com/7413183/139646844-967c22fe-0ebd-41d0-a68e-957063f7b27c.png)

9. Select the Weblinks component using the check box at the left of the row and use the "Update Structure" button.
Result: No change, but also no uncaught exception like it would happen without the 2nd change in this PR for the "fix" method of the change item.

10. Code review: Check that the changes in the documentation of the "check" method here reflect what the function does.
Note: "Skipped" means that a check item has no check query because it does not change structure, e.g. an INSERT statement, and these will later be reported as "skipped" in the tool tip with the details.

### Actual result BEFORE applying this Pull Request

Database checker broken.

### Expected result AFTER applying this Pull Request

Database checker works.

### Other information

For 3.10 we don't need this fix because when having an SQL error in a core update SQL script like tested here with the Weblinks component, the database checker view is not broken on a 3.10.

### Documentation Changes Required

None for this PR.

But as far as I know our Joomla 4 documentation lacks information about the fact that in Joomla 4 the database schema checker also checks update SQL scripts of 3rd party extensions.