### PR TITLE
[3.10] Fix exception handling in the database checker's change item

### DIFF
--- a/libraries/src/Schema/ChangeItem.php
+++ b/libraries/src/Schema/ChangeItem.php
@@ -192,13 +192,12 @@ abstract class ChangeItem
 
 		if ($this->checkQuery)
 		{
-			$this->db->setQuery($this->checkQuery);
-
 			try
 			{
+				$this->db->setQuery($this->checkQuery);
 				$rows = $this->db->loadRowList(0);
 			}
-			catch (\RuntimeException $e)
+			catch (\Exception $e)
 			{
 				// Still render the error message from the Exception object
 				\JFactory::getApplication()->enqueueMessage($e->getMessage(), 'error');
@@ -233,10 +232,12 @@ abstract class ChangeItem
 		{
 			// At this point we have a failed query
 			$query = $this->db->convertUtf8mb4QueryToUtf8($this->updateQuery);
-			$this->db->setQuery($query);
 
-			if ($this->db->execute())
+			try
 			{
+				$this->db->setQuery($query);
+				$this->db->execute();
+
 				if ($this->check())
 				{
 					$this->checkStatus = 1;
@@ -247,7 +248,7 @@ abstract class ChangeItem
 					$this->rerunStatus = -2;
 				}
 			}
-			else
+			catch (\Exception $e)
 			{
 				$this->rerunStatus = -2;
 			}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This the backport of the J4 PR #35951 .

In opposite to 4.0-dev there is not yet any exception handling in the "fix" method of the change item, so this PR here adds that, too, so at the end it's the same as in 4.0-dev.

### Testing Instructions

Will be added soon.

### Actual result BEFORE applying this Pull Request

Will be added soon.

### Expected result AFTER applying this Pull Request

Will be added soon.

### Documentation Changes Required

None.