### PR TITLE
Display no icons in contact

### DIFF
--- a/components/com_contact/tmpl/contact/default_address.php
+++ b/components/com_contact/tmpl/contact/default_address.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\String\PunycodeHelper;
 
+$icon = ($this->params->get('contact_icons') == 0);
+
 /**
  * Marker_class: Class based on the selection of text, none, or icons
  * jicon-text, jicon-none, jicon-icon
@@ -21,7 +23,7 @@ use Joomla\CMS\String\PunycodeHelper;
 	<?php if (($this->params->get('address_check') > 0) &&
 		($this->item->address || $this->item->suburb  || $this->item->state || $this->item->country || $this->item->postcode)) : ?>
 		<dt>
-			<?php if (!$this->params->get('marker_address')) : ?>
+			<?php if ($icon && !$this->params->get('marker_address')) : ?>
 				<span class="icon-address" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_ADDRESS'); ?></span>
 			<?php else : ?>
 				<span class="<?php echo $this->params->get('marker_class'); ?>">
@@ -70,7 +72,7 @@ use Joomla\CMS\String\PunycodeHelper;
 
 <?php if ($this->item->email_to && $this->params->get('show_email')) : ?>
 	<dt>
-		<?php if (!$this->params->get('marker_email')) : ?>
+		<?php if ($icon && !$this->params->get('marker_email')) : ?>
 			<span class="icon-envelope" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_EMAIL'); ?>"></span>
 		<?php else : ?>
 			<span class="<?php echo $this->params->get('marker_class'); ?>">
@@ -87,7 +89,7 @@ use Joomla\CMS\String\PunycodeHelper;
 
 <?php if ($this->item->telephone && $this->params->get('show_telephone')) : ?>
 	<dt>
-		<?php if (!$this->params->get('marker_telephone')) : ?>
+		<?php if ($icon && !$this->params->get('marker_telephone')) : ?>
 				<span class="icon-phone" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_TELEPHONE'); ?></span>
 		<?php else : ?>
 			<span class="<?php echo $this->params->get('marker_class'); ?>">
@@ -103,7 +105,7 @@ use Joomla\CMS\String\PunycodeHelper;
 <?php endif; ?>
 <?php if ($this->item->fax && $this->params->get('show_fax')) : ?>
 	<dt>
-		<?php if (!$this->params->get('marker_fax')) : ?>
+		<?php if ($icon && !$this->params->get('marker_fax')) : ?>
 			<span class="icon-fax" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_FAX'); ?></span>
 		<?php else : ?>
 			<span class="<?php echo $this->params->get('marker_class'); ?>">
@@ -119,7 +121,7 @@ use Joomla\CMS\String\PunycodeHelper;
 <?php endif; ?>
 <?php if ($this->item->mobile && $this->params->get('show_mobile')) : ?>
 	<dt>
-		<?php if (!$this->params->get('marker_mobile')) : ?>
+		<?php if ($icon && !$this->params->get('marker_mobile')) : ?>
 			<span class="icon-mobile" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_MOBILE'); ?></span>
 		<?php else : ?>
 			<span class="<?php echo $this->params->get('marker_class'); ?>">
@@ -135,7 +137,7 @@ use Joomla\CMS\String\PunycodeHelper;
 <?php endif; ?>
 <?php if ($this->item->webpage && $this->params->get('show_webpage')) : ?>
 	<dt>
-		<?php if (!$this->params->get('marker_webpage')) : ?>
+		<?php if ($icon && !$this->params->get('marker_webpage')) : ?>
 			<span class="icon-home" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_WEBPAGE'); ?></span>
 		<?php else : ?>
 			<span class="<?php echo $this->params->get('marker_class'); ?>">


### PR DESCRIPTION
Pull Request for Issue #35961 .

### Summary of Changes
Check if icons may be shown in a contact. 


### Testing Instructions
You need at least one contact and a menu item to this contact. 

Go to com_contact in Backend, Open the Options and go to Icons settings. 

Set the select to "text": In the frontend. The contact shows text: 
![image](https://user-images.githubusercontent.com/1035262/140190410-87ac57cb-7ff1-4250-a80e-5e9c0ce88a29.png)

Select "none": No icon or text is displayed: 
![image](https://user-images.githubusercontent.com/1035262/140190799-d0dee08e-1ad7-48bb-b062-f383f66917ec.png)

Select "icons" and don't choose an own image: The default icons are displayed.
![image](https://user-images.githubusercontent.com/1035262/140191034-63c4d649-cd89-458e-ad1e-d86fa7c588f2.png)

Select "icons" and choose own images: Own images replace the default icons
![image](https://user-images.githubusercontent.com/1035262/140191366-ec5a69c3-30ab-403a-b516-e0c2212032b0.png)






### Actual result BEFORE applying this Pull Request
Icons were displayed when the selection was "none"


### Expected result AFTER applying this Pull Request
No Icons are displayed when the selection is "none"


### Documentation Changes Required
no, it's a bug
