### PR TITLE
[4.0] [bugfix] Fix popover missing content

### DIFF
--- a/build/media_source/vendor/bootstrap/js/popover.es6.js
+++ b/build/media_source/vendor/bootstrap/js/popover.es6.js
@@ -16,7 +16,6 @@ if (Joomla && Joomla.getOptions) {
       const options = {
         animation: opt.animation ? opt.animation : true,
         container: opt.container ? opt.container : false,
-        content: opt.content ? opt.content : '',
         delay: opt.delay ? opt.delay : 0,
         html: opt.html ? opt.html : false,
         placement: opt.placement ? opt.placement : 'top',
@@ -32,6 +31,9 @@ if (Joomla && Joomla.getOptions) {
         popperConfig: opt.popperConfig ? opt.popperConfig : null,
       };
 
+      if (opt.content) {
+        options.content = opt.content;
+      }
       if (opt.template) {
         options.template = opt.template;
       }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/35966.

### Summary of Changes
The content in the options object should not be false if not passed from the JS


### Testing Instructions
Apply this PR and run `npm i`
edit the atum index.php and paste this:
```html
<?php HTMLHelper::_('bootstrap.popover','#test_popover', [
  'trigger'   => 'hover focus',
  'placement' => 'right',
]); ?>
<span class="badge bg-info" id="test_popover" data-content="Content" data-bs-content="Content" title="Title">Popover Test</span>
```
After `<div class="container-fluid container-main">` ~line #160


### Actual result BEFORE applying this Pull Request

No content
![Screenshot 2021-11-05 at 13 27 22](https://user-images.githubusercontent.com/3889375/140510129-b9408bf5-8f2d-4c8c-9ae0-d6c414654053.png)

### Expected result AFTER applying this Pull Request

Content is taken from the data attribute
![Screenshot 2021-11-05 at 13 26 41](https://user-images.githubusercontent.com/3889375/140510144-ff14f295-f9c3-49ca-97cd-6443efef2f00.png)

### Documentation Changes Required

