### PR TITLE
[4.0] Fix notice about duplicate joomla/mediawiki in composer.json when running composer install

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -88,7 +88,6 @@
         "phpunit/phpunit": "^8.5",
         "joomla/cms-coding-standards": "~2.0.0-alpha2@dev",
         "joomla/coding-standards": "~3.0@dev",
-        "joomla/mediawiki": "dev-master",
         "friendsofphp/php-cs-fixer": "^3.0",
         "squizlabs/php_codesniffer": "~3.0",
         "joomla-projects/joomla-browser": "~4.0@dev",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "52818c07604214e567c5e6d6413a7a3c",
+    "content-hash": "1da875478fc037b5b7b0c997043f2416",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -9827,5 +9827,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Is seem that when PR #33908 was merged, it has added back a line in the composer.json file which had been removed by @wilsonge in the 4.0-dev branch with this commit https://github.com/joomla/joomla-cms/commit/dd22c22c8548c62dc47b5b3060d03649addeb2be .

The result is a duplicate entry for joomla/mediawiki, see the first and the last line of following code part: https://github.com/joomla/joomla-cms/blob/4.0-dev/composer.json#L91-L97

This pull request (PR) here removes the duplicate in line 91 coming from PR #33908 and keeps the one in line 97 from @wilsonge 's commit.

As the resolved version1.0.0 for joomla/mediawiki does not change, there are no changes in the composer.lock file besides the api version and the checksum. But it needs these changes in the lock file in order not to get a warning that it's not updated.

### Testing Instructions

1. On a clean, current 4.0-dev branch, run composer install and note the first line of the output created by composer.
Result: `Key joomla/mediawiki is a duplicate in ./composer.json at line 97`

2. Check in the composer.lock file if the section for dependency "joomla/mediawiki" looks like here regarding the version number, the URLs and checkums and the date and time: https://github.com/joomla/joomla-cms/blob/4.0-dev/composer.lock#L6896-L6956
Result: It's the same.

3. Apply the patch from this PR.

4. Repeat step 1.
Result: `Installing dependencies from lock file (including require-dev)`, i.e. no duplicate reported anymore.

5. Repeat step 2.
Result: It's still the same.

### Actual result BEFORE applying this Pull Request

Notice `Key joomla/mediawiki is a duplicate in ./composer.json at line 97` when running composer install.

### Expected result AFTER applying this Pull Request

No notice `Key joomla/mediawiki is a duplicate in ./composer.json at line 97` when running composer install.

### Documentation Changes Required

None.