### PR TITLE
[4.0] Fix wrong pre-update checker behavior

### DIFF
--- a/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
@@ -168,9 +168,13 @@ class HtmlView extends BaseHtmlView
 			}
 		}
 		// Here we have now two options: preupdatecheck or update
-		elseif ($this->getLayout() != 'update' || $isCritical)
+		elseif ($this->getLayout() != 'update' && ($isCritical || $this->shouldDisplayPreUpdateCheck()))
 		{
 			$this->setLayout('preupdatecheck');
+		}
+		else
+		{
+			$this->setLayout('update');
 		}
 
 		if (in_array($this->getLayout(), ['preupdatecheck', 'update', 'upload']))


### PR DESCRIPTION
Pull Request for Issue #35904.

### Summary of Changes
Currently, when you update from your Joomla 4.0.x installation to latest Joomla version, the pre-update checked is always be displayed. The right behavior is it should only be displayed if:

- You update to next Joomla major release (Joomla 5)
- Or there is a PHP requirement does not meet (all the requirements are checked inside this method https://github.com/joomla/joomla-cms/blob/4.0-dev/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php#L1085)

This PR just fixes that wrong behavior.

### Testing Instructions
1. Go to System ->Update -> Joomla. Click on Options button in the toolbar, set:
- **Update Channel** to **Custom URL**
- **Custom URL** to https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/35972/downloads/48267/pr_list.xml (this is update URL for this PR https://github.com/joomla/joomla-cms/pull/35972)

Save it

2. The system should find a new Joomla update



### Actual result BEFORE applying this Pull Request
Pre-update checker is still being displayed while it should not because you are not updating to new major release (Joomla 5)

![pre_update_checker](https://user-images.githubusercontent.com/977664/140601217-e0eb23d5-f57d-47c9-b129-5893ad1f55ac.png)


### Expected result AFTER applying this Pull Request
Pre-update checker is not being displayed anymore. Update screen is displayed to allow you to perform the update.

![update_screen](https://user-images.githubusercontent.com/977664/140601251-f245e55e-cf8f-4e88-9926-ed1a63c5abe8.png)

### Documentation Changes Required
None.
