### PR TITLE
[3.10] Fix wrong input filter type for extension names of site and admin languages in the extensions installer

### DIFF
--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -149,7 +149,7 @@ class LanguageAdapter extends InstallerAdapter
 
 		// Get the language name
 		// Set the extensions name
-		$name = \JFilterInput::getInstance()->clean((string) $this->getManifest()->name, 'cmd');
+		$name = \JFilterInput::getInstance()->clean((string) $this->getManifest()->name, 'string');
 		$this->set('name', $name);
 
 		// Get the Language tag [ISO tag, eg. en-GB]
@@ -503,7 +503,7 @@ class LanguageAdapter extends InstallerAdapter
 		// Get the language name
 		// Set the extensions name
 		$name = (string) $this->getManifest()->name;
-		$name = \JFilterInput::getInstance()->clean($name, 'cmd');
+		$name = \JFilterInput::getInstance()->clean($name, 'string');
 		$this->set('name', $name);
 
 		// Get the Language tag [ISO tag, eg. en-GB]


### PR DESCRIPTION
Pull Request for Issue #35946 .

Same as #35981 but for 3.10-dev.

### Summary of Changes

This pull request (PR) changes the input filter type from "cmd" to "string" in the extension installer's language adapter so that spaces and parenthesis are not removed anymore from the extension name in database so that error messages show it right.

In opposite to other extension types where language strings might be provided to translate the name, names of languages should never be translated, neither the English name nor the native name.

That's why there is no need to use the "cmd" filter like it would be when using the name to construct a language string constant from it.

### Hint for maintainers

PR #35981 which does the same as this one here but for 4.0-dev has already been merged.

### Testing Instructions

1. On a clean 3.10-dev branch or latest 3.10.3 release or 3.10 nightly build, install an old version of a language pack where the extension names for the site and the admin language contain spaces and/or parenthesis.
You can download e.g. the old French and German packages here:
- https://downloads.joomla.org/language-packs/translations-joomla3/downloads/joomla3-french/3-10-2-2
- https://downloads.joomla.org/language-packs/translations-joomla3/downloads/joomla3-german/3-10-2-1

2. Check the names of the site and the admin languages in database e.g. with phpMyAdmin.
Result: In opposite to the core English languages, the names of the just installed site and admin languages have spaces and parenthesis stripped off.
![j3-db-after-new-install-without-patch](https://user-images.githubusercontent.com/7413183/140614495-e9f822ee-788a-4eb9-8358-cce5193825eb.png)

3. Go to "Extensions - Manage - Manage" and try to uninstall some of the previously installed language packs' admin or site languages.
Result: The warning alert shows the name as it is in database.
![j3-db-try-uninstall-language-without-patch](https://user-images.githubusercontent.com/7413183/140615171-f3325a67-8ea0-49d2-aee5-937394ce9940.png)

4. Apply the patch of this PR.

5. Make sure that you have switched on "Debug System" and set "Error Reporting" to "Maximum" or "Development" in Global Configuration so you would see any errors happening in the next steps.

6. Go to "Extensions - Manage - Update", if necessary use the buttons to clear cache and to check for updates and then update the 2 old language packs.

7. Go to "Extensions - Manage - Install Languages" and install some more language(s) suitable for the test, e.g. French (Canada) and German (Switzerland).

8. Check again the names in database.
Result: The names are as specified in the site and admin language's manifest XML files, no spaces or parenthesis have been stripped off. This is true for both the updated and the newly installed languages.
![j3-db-after-update-with-patch](https://user-images.githubusercontent.com/7413183/140614788-22dce3a6-d608-4053-b8fe-410f79e98aaf.png)

9. Go to "Extensions - Manage - Manage" and try again to uninstall some of the site or admin languages.
Result: The warning alert shows the name as it is in database, and that's ok now.
![j3-db-try-uninstall-language-with-patch](https://user-images.githubusercontent.com/7413183/140615230-7d31415d-00d7-412d-b2bf-1d4cd333417e.png)

### Actual result BEFORE applying this Pull Request

See testing instructions steps 2 and 3.

### Expected result AFTER applying this Pull Request

See testing instructions steps 8 and 9.

### Documentation Changes Required

None.