### PR TITLE
[4.0] Fix wrong input filter type for extension names of site and admin languages in the extensions installer

### DIFF
--- a/libraries/src/Installer/Adapter/LanguageAdapter.php
+++ b/libraries/src/Installer/Adapter/LanguageAdapter.php
@@ -304,7 +304,7 @@ class LanguageAdapter extends InstallerAdapter
 
 		// Get the language name
 		// Set the extensions name
-		$this->name = InputFilter::getInstance()->clean((string) $this->getManifest()->name, 'cmd');
+		$this->name = InputFilter::getInstance()->clean((string) $this->getManifest()->name, 'string');
 
 		// Get the Language tag [ISO tag, eg. en-GB]
 		$tag = (string) $this->getManifest()->tag;
@@ -553,7 +553,7 @@ class LanguageAdapter extends InstallerAdapter
 		// Get the language name
 		// Set the extensions name
 		$name = (string) $this->getManifest()->name;
-		$name = InputFilter::getInstance()->clean($name, 'cmd');
+		$name = InputFilter::getInstance()->clean($name, 'string');
 		$this->name = $name;
 
 		// Get the Language tag [ISO tag, eg. en-GB]


### PR DESCRIPTION
Pull Request for Issue #35946 .

Same as #35980 but for 4.0-dev.

### Summary of Changes

This pull request (PR) changes the input filter type from "cmd" to "string" in the extension installer's language adapter so that spaces and parenthesis are not removed anymore from the extension name in database so that error messages show it right.

In opposite to other extension types where language strings might be provided to translate the name, names of languages should never be translated, neither the English name nor the native name.

That's why there is no need to use the "cmd" filter like it would be when using the name to construct a language string constant from it.

### Hint for maintainers

This PR does the same for 4.0-dev as PR #35980 does for 3.10-dev branch.

If that other PR is merged into 3.10-dev, it will appear in 4.0-dev after the next regular upmerge.

So this PR does not necessarily mean to be merged.

But it can be used to test if the change also works in Joomla 4 and later to verify if the upmerge was right.

### Testing Instructions

1. On a clean 4.0-dev branch or latest 4.0.4 release or 4.0 nightly build, install an old version of a language pack where the extension names for the site and the admin language contain spaces and/or parenthesis.
You can download e.g. the old French and German packages here:
- https://downloads.joomla.org/language-packs/translations-joomla4/downloads/joomla4-french/4-0-3-1
- https://downloads.joomla.org/language-packs/translations-joomla4/downloads/joomla4-german/4-0-3-1

2. Check the names of the site and the admin languages in database e.g. with phpMyAdmin.
Result: In opposite to the core English languages, the names of the just installed site and admin languages have spaces and parenthesis stripped off.
![j4-db-after-new-install-without-patch](https://user-images.githubusercontent.com/7413183/140617310-81e4b2d2-a835-4965-8804-40e92914faf1.png)

3. Go to "System - Manage - Extensions" and try to uninstall some of the previously installed language packs' admin or site languages.
Result: The warning alert shows the name as it is in database.
![j4-db-try-uninstall-language-without-patch](https://user-images.githubusercontent.com/7413183/140617315-8280f3f5-1d43-4d7e-a188-c6897f691cfa.png)
4. Apply the patch of this PR.

5. Make sure that you have switched on "Debug System" and set "Error Reporting" to "Maximum" or "Development" in Global Configuration so you would see any errors happening in the next steps.

6. Go to "System - Update - Extensions", if necessary use the button to check for updates and then update the 2 old language packs.

7. Go to "System - Install - Languages" and install some more language(s) suitable for the test, e.g. German (Switzerland).

8. Check again the names in database.
Result: The names are as specified in the site and admin language's manifest XML files, no spaces or parenthesis have been stripped off. This is true for both the updated and the newly installed languages.
![j4-db-after-update-with-patch](https://user-images.githubusercontent.com/7413183/140617479-9d1918f5-e321-444b-8e64-52604c100df9.png)

9. Go to "System - Manage - Extensions" and try again to uninstall some of the site or admin languages.
Result: The warning alert shows the name as it is in database, and that's ok now.
![j4-db-try-uninstall-language-with-patch](https://user-images.githubusercontent.com/7413183/140617358-b6ceb2ad-9796-4964-977e-4695da37a3ee.png)

### Actual result BEFORE applying this Pull Request

See testing instructions steps 2 and 3.

### Expected result AFTER applying this Pull Request

See testing instructions steps 8 and 9.

### Documentation Changes Required

None.