### PR TITLE
refactor(cache): Reorganize the Page Cache with SubscriberInterface

### DIFF
--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -121,12 +121,15 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 * onAfterRoute.
 	 * Only for BC, not used on J4
 	 *
-	 * @return  void
+	 * @return  	void
 	 *
-	 * @since   4.0.0
+	 * @since   	4.0.0
+	 * @deprecated  5.0 Use \Joomla\Event\SubscriberInterface instead
 	 */
 	public function onAfterRoute()
 	{
+		@trigger_error('The '.__METHOD__.' method is deprecated since version 4.1. Use SubscriberInterface instead.', E_USER_DEPRECATED);
+
 		$this->dumpCachedPage();
 	}
 
@@ -182,12 +185,15 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 * onAfterRender.
 	 * Only for BC, not used on J4.
 	 *
-	 * @return   void
+	 * @return   	void
 	 *
-	 * @since   3.9.12
+	 * @since   	3.9.12
+	 * @deprecated  5.0 Use \Joomla\Event\SubscriberInterface instead
 	 */
 	public function onAfterRender()
 	{
+		@trigger_error('The '.__METHOD__.' method is deprecated since version 4.1. Use SubscriberInterface instead.', E_USER_DEPRECATED);
+
 		$this->verifyThatCurrentPageCanBeCached();
 	}
 
@@ -217,12 +223,15 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 * onAfterRespond.
 	 * Only for BC, not used on J4
 	 *
-	 * @return   void
+	 * @return		void
 	 *
-	 * @since   1.5
+	 * @since	  	1.5
+	 * @deprecated  5.0 Use \Joomla\Event\SubscriberInterface instead
 	 */
 	public function onAfterRespond()
 	{
+		@trigger_error('The '.__METHOD__.' method is deprecated since version 4.1. Use SubscriberInterface instead.', E_USER_DEPRECATED);
+
 		$this->storePage();
 	}
 

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -78,7 +78,7 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 *
 	 * @return  array
 	 *
-	 * @since   4.0.0
+	 * @since   4.1.0
 	 */
 	public static function getSubscribedEvents(): array
 	{

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -78,7 +78,7 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 *
 	 * @return  array
 	 *
-	 * @since   4.1.0
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public static function getSubscribedEvents(): array
 	{
@@ -135,7 +135,7 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 *
 	 * @return  void
 	 *
-	 * @since   4.1
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function dumpCachedPage()
 	{
@@ -196,7 +196,7 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 *
 	 * @return   void
 	 *
-	 * @since   4.1
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function verifyIfCurrentPageCanBeCached()
 	{
@@ -252,7 +252,7 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 *
 	 * @return   boolean  True if the page can be cached
 	 *
-	 * @since    4.1
+	 * @since    __DEPLOY_VERSION__
 	 */
 	private static function canPageBeCached(): bool
 	{
@@ -312,7 +312,7 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 *
 	 * @return   boolean  True if the page is excluded else false
 	 *
-	 * @since    4.1
+	 * @since    __DEPLOY_VERSION__
 	 */
 	private static function isExcludedPage(): bool
 	{
@@ -375,7 +375,7 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 *
 	 * @return   string  The cache key
 	 *
-	 * @since    4.1
+	 * @since    __DEPLOY_VERSION__
 	 */
 	private static function simpleCacheKey(): string
 	{

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -87,7 +87,7 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 		}
 
 		return [
-			'onAfterRender' => 'verifyIfCurrentPageCanBeCached',
+			'onAfterRender' => 'verifyThatCurrentPageCanBeCached',
 			'onAfterRoute' => 'dumpCachedPage',
 			'onAfterRespond' => 'storePage',
 		];
@@ -188,21 +188,20 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 */
 	public function onAfterRender()
 	{
-		$this->verifyIfCurrentPageCanBeCached();
+		$this->verifyThatCurrentPageCanBeCached();
 	}
 
 	/**
-	 * Verify if current page is not excluded from cache.
+	 * Verify that current page is not excluded from cache.
 	 *
 	 * @return   void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function verifyIfCurrentPageCanBeCached()
+	public function verifyThatCurrentPageCanBeCached()
 	{
-		// We need to check if user is guest again here,
-		// 	because auto-login plugins have not been fired before the first aid check.
-		// Page is excluded if excluded in plugin settings.
+		// Check if the user is a guest again because auto-login plugins
+		// 	have not been fired when getSubscribedEvents was called.
 		if (!$this->canPageBeCached())
 		{
 			$this->_cache->setCaching(false);
@@ -237,7 +236,7 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 */
 	public function storePage()
 	{
-		// if it can't be cached due to execution conditions (check verifyIfCurrentPageCanBeCached/canPageBeCached)
+		// if it can't be cached due to execution conditions (check verifyThatCurrentPageCanBeCached/canPageBeCached)
 		if ($this->_cache->getCaching() === false)
 		{
 			return;

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -9,38 +9,28 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Cache\Cache;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Profiler\Profiler;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Event\SubscriberInterface;
-use Joomla\Registry\Registry;
+use Joomla\Plugin\System\Cache\Helpers\PageCacheKeyGenerator;
+use Joomla\Plugin\System\Cache\Helpers\PageCacheStorage;
+use Joomla\Plugin\System\Cache\Helpers\PageCachingChecker;
+
+// Why is not autolading the <namespace path="src">Joomla\Plugin\System\Cache</namespace>?
+require 'src/Helpers/PageCacheKeyGenerator.php';
+require 'src/Helpers/PageCachingChecker.php';
+require 'src/Helpers/PageCacheStorage.php';
 
 /**
  * Joomla! Page Cache Plugin.
  *
  * @since  1.5
  */
-class PlgSystemCache extends CMSPlugin implements SubscriberInterface
+final class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 {
-	/**
-	 * Cache instance.
-	 *
-	 * @var    \Joomla\CMS\Cache\CacheController
-	 * @since  1.5
-	 */
-	public $_cache;
-
-	/**
-	 * Cache key
-	 *
-	 * @var    string
-	 * @since  3.0
-	 */
-	public $_cache_key;
-
 	/**
 	 * Application object.
 	 *
@@ -50,28 +40,12 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	protected $app;
 
 	/**
-	 * Constructor.
+	 * Page Cache Storage
 	 *
-	 * @param   object  &$subject  The object to observe.
-	 * @param   array   $config    An optional associative array of configuration settings.
-	 *
-	 * @since   1.5
+	 * @var    Joomla\Plugin\System\Cache\Helpers\PageCacheStorage
+	 * @since  __DEPLOY_VERSION__
 	 */
-	public function __construct(&$subject, $config)
-	{
-		parent::__construct($subject, $config);
-
-		// Set the cache options.
-		$options = array(
-			'defaultgroup' => 'page',
-			'browsercache' => $this->params->get('browsercache', 0),
-			'caching'      => false,
-		);
-
-		// Instantiate cache with previous options and create the cache key identifier.
-		$this->_cache     = Cache::getInstance('page', $options);
-		$this->_cache_key = self::simpleCacheKey();
-	}
+	protected $cacheStorage;
 
 	/**
 	 * Returns an array of events this subscriber will listen to.
@@ -82,15 +56,99 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 */
 	public static function getSubscribedEvents(): array
 	{
-		if (!self::canPageBeCached()) {
+		$pageCacheKeyGenerator = new PageCacheKeyGenerator(Uri::getInstance());
+		$cacheKey = $pageCacheKeyGenerator->getKey();
+
+		if (!PageCachingChecker::canPageBeCached($cacheKey)) {
 			return [];
 		}
 
+		// Singleton to the PageCacheKeyGenerator.
+		Factory::getContainer()->set(
+			PageCacheKeyGenerator::class,
+			$pageCacheKeyGenerator,
+			true
+		);
+
 		return [
-			'onAfterRender' => 'verifyThatCurrentPageCanBeCached',
-			'onAfterRoute' => 'dumpCachedPage',
+			'onAfterRender' => 'verifyCanBeCached',
+			'onAfterRoute' => 'checkAndDumpPage',
 			'onAfterRespond' => 'storePage',
 		];
+	}
+
+	/**
+	 * Verify that current page is not excluded from cache.
+	 *
+	 * @return   void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function verifyCanBeCached()
+	{
+		// Check if the user is a guest again because auto-login plugins
+		// 	have not been fired when getSubscribedEvents was called.
+		if (!PageCachingChecker::canPageBeCached($this->getCacheKey()))
+		{
+			return;
+		}
+
+		// Disable compression before caching the page.
+		$this->app->set('gzip', false);
+	}
+
+	/**
+	 * After Respond Event.
+	 * Stores page in cache.
+	 *
+	 * @return   void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function storePage()
+	{
+		// if it can't be cached due to execution conditions
+		if (!$this->cacheStorage)
+		{
+			return;
+		}
+
+		// Saves current page in cache.
+		$this->cacheStorage->store($this->app->getBody(), $this->getCacheKey());
+	}
+
+	/**
+	 * Checks if URL exists in cache, if so dumps it directly and closes.
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function checkAndDumpPage()
+	{
+		$cacheKey = $this->getCacheKey();
+
+		// If any pagecache plugins return false for onPageCacheSetCaching, do not use the cache.
+		PluginHelper::importPlugin('pagecache');
+
+		$results = $this->app->triggerEvent('onPageCacheSetCaching');
+		$onPageCacheSetCaching = !in_array(false, $results, true);
+
+		// Double check for BC
+		if (!$onPageCacheSetCaching || !PageCachingChecker::canPageBeCached($cacheKey))
+		{
+			return;
+		}
+
+		$this->cacheStorage = new PageCacheStorage($this->params->get('browsercache', 0));
+		$body = $this->cacheStorage->read($cacheKey);
+
+		if (!$body)
+		{
+			return;
+		}
+
+		$this->dumpCachedPage($body);
 	}
 
 	/**
@@ -102,291 +160,38 @@ class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 */
 	protected function getCacheKey()
 	{
-		static $key;
-
-		if (!$key)
-		{
-			PluginHelper::importPlugin('pagecache');
-
-			$parts = $this->app->triggerEvent('onPageCacheGetKey');
-			$parts[] = Uri::getInstance()->toString();
-
-			$key = md5(serialize($parts));
-		}
-
-		return $key;
+		return Factory::getContainer()->get(PageCacheKeyGenerator::class)->getKey();
 	}
 
 	/**
-	 * onAfterRoute.
-	 * Only for BC, not used on J4
+	 * Dump Cached Page.
 	 *
-	 * @return  	void
-	 *
-	 * @since   	4.0.0
-	 * @deprecated  5.0 Use \Joomla\Event\SubscriberInterface instead
-	 */
-	public function onAfterRoute()
-	{
-		@trigger_error('The '.__METHOD__.' method is deprecated since version 4.1. Use SubscriberInterface instead.', E_USER_DEPRECATED);
-
-		$this->dumpCachedPage();
-	}
-
-	/**
-	 * Checks if URL exists in cache, if so dumps it directly and closes.
+	 * @param   object $body	The cached page body.
 	 *
 	 * @return  void
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function dumpCachedPage()
+	private function dumpCachedPage(string $body)
 	{
-		// If any pagecache plugins return false for onPageCacheSetCaching, do not use the cache.
-		PluginHelper::importPlugin('pagecache');
+		// Set HTML page from cache.
+		$this->app->setBody($body);
 
-		$results = $this->app->triggerEvent('onPageCacheSetCaching');
-		$caching = !in_array(false, $results, true);
+		// Dumps HTML page.
+		echo $this->app->toString((bool) $this->app->get('gzip'));
 
-		// Double check for BC
-		if ($caching && $this->canPageBeCached())
+		// Mark afterCache in debug and run debug onAfterRespond events, e.g. show Joomla Debug Console if debug is active.
+		if (JDEBUG)
 		{
-			$this->_cache->setCaching(true);
+			// Create a document instance and load it into the application.
+			$document = Factory::getContainer()->get('document.factory')->createDocument($this->app->input->get('format', 'html'));
+			$this->app->loadDocument($document);
+
+			Profiler::getInstance('Application')->mark('afterCache');
+			$this->app->triggerEvent('onAfterRespond');
 		}
 
-		$data = $this->_cache->get($this->getCacheKey());
-
-		// If page exist in cache, show cached page.
-		if ($data !== false)
-		{
-			// Set HTML page from cache.
-			$this->app->setBody($data);
-
-			// Dumps HTML page.
-			echo $this->app->toString((bool) $this->app->get('gzip'));
-
-			// Mark afterCache in debug and run debug onAfterRespond events, e.g. show Joomla Debug Console if debug is active.
-			if (JDEBUG)
-			{
-				// Create a document instance and load it into the application.
-				$document = Factory::getContainer()->get('document.factory')->createDocument($this->app->input->get('format', 'html'));
-				$this->app->loadDocument($document);
-
-				Profiler::getInstance('Application')->mark('afterCache');
-				$this->app->triggerEvent('onAfterRespond');
-			}
-
-			// Closes the application.
-			$this->app->close();
-		}
-	}
-
-	/**
-	 * onAfterRender.
-	 * Only for BC, not used on J4.
-	 *
-	 * @return   	void
-	 *
-	 * @since   	3.9.12
-	 * @deprecated  5.0 Use \Joomla\Event\SubscriberInterface instead
-	 */
-	public function onAfterRender()
-	{
-		@trigger_error('The '.__METHOD__.' method is deprecated since version 4.1. Use SubscriberInterface instead.', E_USER_DEPRECATED);
-
-		$this->verifyThatCurrentPageCanBeCached();
-	}
-
-	/**
-	 * Verify that current page is not excluded from cache.
-	 *
-	 * @return   void
-	 *
-	 * @since   __DEPLOY_VERSION__
-	 */
-	public function verifyThatCurrentPageCanBeCached()
-	{
-		// Check if the user is a guest again because auto-login plugins
-		// 	have not been fired when getSubscribedEvents was called.
-		if (!$this->canPageBeCached())
-		{
-			$this->_cache->setCaching(false);
-
-			return;
-		}
-
-		// Disable compression before caching the page.
-		$this->app->set('gzip', false);
-	}
-
-	/**
-	 * onAfterRespond.
-	 * Only for BC, not used on J4
-	 *
-	 * @return		void
-	 *
-	 * @since	  	1.5
-	 * @deprecated  5.0 Use \Joomla\Event\SubscriberInterface instead
-	 */
-	public function onAfterRespond()
-	{
-		@trigger_error('The '.__METHOD__.' method is deprecated since version 4.1. Use SubscriberInterface instead.', E_USER_DEPRECATED);
-
-		$this->storePage();
-	}
-
-	/**
-	 * After Respond Event.
-	 * Stores page in cache.
-	 *
-	 * @return   void
-	 *
-	 * @since   1.5
-	 */
-	public function storePage()
-	{
-		// if it can't be cached due to execution conditions (check verifyThatCurrentPageCanBeCached/canPageBeCached)
-		if ($this->_cache->getCaching() === false)
-		{
-			return;
-		}
-
-		// Saves current page in cache.
-		$this->_cache->store($this->app->getBody(), $this->getCacheKey());
-	}
-
-	/**
-	 * Check if the page can be cached according to all conditions.
-	 *
-	 * @return   boolean  True if the page can be cached
-	 *
-	 * @since    __DEPLOY_VERSION__
-	 */
-	private static function canPageBeCached(): bool
-	{
-		$app = Factory::getApplication();
-
-		// Only GET requests are cached.
-		if ($app->input->getMethod() !== 'GET')
-		{
-			return false;
-		}
-
-		// Run only when we're on Site Application side
-		if (!$app->isClient('site'))
-		{
-			return false;
-		}
-
-		// If the site is offline, don't do anything
-		if ((bool) $app->get('offline', '0'))
-		{
-			return false;
-		}
-
-		// The user is authenticated
-		if (!$app->getIdentity()->guest) {
-			return false;
-		}
-
-		// If there are messages in the queue, don't cache the page
-		if (!empty($app->getMessageQueue()))
-		{
-			return false;
-		}
-
-		if (self::isExcludedPage()) {
-			return false;
-		}
-
-		return true;
-	}
-
-	/**
-	 * onAfterRoute.
-	 * Only for BC, not used on J4
-	 *
-	 * @return   boolean  True if the page is excluded else false
-	 *
-	 * @since    3.5
-	 */
-	protected static function isExcluded()
-	{
-		return self::isExcludedPage();
-	}
-
-	/**
-	 * Check if the page is excluded from the cache or not.
-	 *
-	 * @return   boolean  True if the page is excluded else false
-	 *
-	 * @since    __DEPLOY_VERSION__
-	 */
-	private static function isExcludedPage(): bool
-	{
-		$app = Factory::getApplication();
-		$plugin = PluginHelper::getPlugin('system', 'cache');
-		$params = new Registry($plugin->params);
-
-		// Check if menu items have been excluded.
-		if ($exclusions = $params->get('exclude_menu_items', array()))
-		{
-			// Get the current menu item.
-			$active = $app->getMenu()->getActive();
-
-			if ($active && $active->id && in_array((int) $active->id, (array) $exclusions))
-			{
-				return true;
-			}
-		}
-
-		// Check if regular expressions are being used.
-		if ($exclusions = $params->get('exclude', ''))
-		{
-			// Normalize line endings.
-			$exclusions = str_replace(array("\r\n", "\r"), "\n", $exclusions);
-
-			// Split them.
-			$exclusions = explode("\n", $exclusions);
-
-			// Gets internal URI.
-			$internalUri = '/index.php?' . Uri::getInstance()->buildQuery($app->getRouter()->getVars());
-
-			// Loop through each pattern.
-			if ($exclusions)
-			{
-				foreach ($exclusions as $exclusion)
-				{
-					// Make sure the exclusion has some content
-					if ($exclusion !== '')
-					{
-						// Test both external and internal URI
-						if (preg_match('#' . $exclusion . '#i', self::simpleCacheKey() . ' ' . $internalUri, $match))
-						{
-							return true;
-						}
-					}
-				}
-			}
-		}
-
-		// If any pagecache plugins return true for onPageCacheIsExcluded, exclude.
-		PluginHelper::importPlugin('pagecache');
-
-		$results = $app->triggerEvent('onPageCacheIsExcluded');
-
-		return in_array(true, $results, true);
-	}
-
-	/**
-	 * Generate the cache key.
-	 *
-	 * @return   string  The cache key
-	 *
-	 * @since    __DEPLOY_VERSION__
-	 */
-	private static function simpleCacheKey(): string
-	{
-		return Uri::getInstance()->toString();
+		// Closes the application.
+		$this->app->close();
 	}
 }

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Profiler\Profiler;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Event\Event;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Plugin\System\Cache\Helpers\PageCacheKeyGenerator;
 use Joomla\Plugin\System\Cache\Helpers\PageCacheStorage;
@@ -84,7 +85,7 @@ final class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function verifyCanBeCached()
+	public function verifyCanBeCached(Event $event): void
 	{
 		// Check if the user is a guest again because auto-login plugins
 		// 	have not been fired when getSubscribedEvents was called.
@@ -105,7 +106,7 @@ final class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function storePage()
+	public function storePage(Event $event): void
 	{
 		// if it can't be cached due to execution conditions
 		if (!$this->cacheStorage)
@@ -124,7 +125,7 @@ final class PlgSystemCache extends CMSPlugin implements SubscriberInterface
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
-	public function checkAndDumpPage()
+	public function checkAndDumpPage(Event $event): void
 	{
 		$cacheKey = $this->getCacheKey();
 

--- a/plugins/system/cache/cache.xml
+++ b/plugins/system/cache/cache.xml
@@ -9,6 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>PLG_CACHE_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\System\Cache</namespace>
 	<files>
 		<filename plugin="cache">cache.php</filename>
 	</files>

--- a/plugins/system/cache/src/Helpers/PageCacheKeyGenerator.php
+++ b/plugins/system/cache/src/Helpers/PageCacheKeyGenerator.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  System.cache
+ *
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Plugin\System\Cache\Helpers;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Uri\Uri;
+
+/**
+ * Joomla! Page Cache Plugin - PageCacheKeyGenerator.
+ *
+ * @since  4.1
+ */
+final class PageCacheKeyGenerator
+{
+	/**
+	 * Page Cache Key.
+	 *
+	 * @var		string
+	 * @since	__DEPLOY_VERSION__
+	 */
+	private $key;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param   Uri  $uri  The current Uri.
+	 *
+	 * @since    __DEPLOY_VERSION__
+	 */
+	public function __construct(Uri $uri)
+	{
+		// Get a cache key for the current page based on the url and possible other factors.
+		PluginHelper::importPlugin('pagecache');
+		$parts = Factory::getApplication()->triggerEvent('onPageCacheGetKey');
+		$parts[] = $uri->toString();
+
+		$this->key = md5(serialize($parts));
+	}
+
+	/**
+	 *
+	 *
+	 * @return  string
+	 *
+	 * @since    __DEPLOY_VERSION__
+	 */
+	public function getKey()
+	{
+		return $this->key;
+	}
+}

--- a/plugins/system/cache/src/Helpers/PageCacheKeyGenerator.php
+++ b/plugins/system/cache/src/Helpers/PageCacheKeyGenerator.php
@@ -48,11 +48,9 @@ final class PageCacheKeyGenerator
 	}
 
 	/**
-	 *
-	 *
 	 * @return  string
 	 *
-	 * @since    __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function getKey()
 	{

--- a/plugins/system/cache/src/Helpers/PageCacheStorage.php
+++ b/plugins/system/cache/src/Helpers/PageCacheStorage.php
@@ -40,12 +40,10 @@ final class PageCacheStorage
 	}
 
 	/**
-	 * Store
-	 *
-	 * @param   object $body  		The page body to be stored.
+ 	 * @param   object $body  	The page body to be stored.
 	 * @param   string $cacheKey	Cache Key
 	 *
-	 * @since  __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function store(string $body, string $cacheKey): void
 	{

--- a/plugins/system/cache/src/Helpers/PageCacheStorage.php
+++ b/plugins/system/cache/src/Helpers/PageCacheStorage.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  System.cache
+ *
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Plugin\System\Cache\Helpers;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Cache\Cache;
+use Joomla\CMS\Cache\Controller\PageController;
+
+/**
+ * Joomla! Page Cache Plugin - PageCacheStorage.
+ *
+ * @since  4.1
+ */
+final class PageCacheStorage
+{
+	/**
+	 * Cache instance.
+	 *
+	 * @var    Joomla\CMS\Cache\Controller\PageController
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private $cache;
+
+	/**
+	 * Constructor.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function __construct(int $browsercache)
+	{
+		$this->cache = $this->createCache($browsercache);
+	}
+
+	/**
+	 * Store
+	 *
+	 * @param   object $body  		The page body to be stored.
+	 * @param   string $cacheKey	Cache Key
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function store(string $body, string $cacheKey): void
+	{
+		$this->cache->store($body, $cacheKey);
+	}
+
+	/**
+	 * Read
+	 *
+	 * @param   string $cacheKey 	Cache Key
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function read(string $cacheKey)
+	{
+		return $this->cache->get($cacheKey);
+	}
+
+	/**
+	 * Create Cache
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private function createCache(int $browsercache): PageController
+	{
+		// Set the cache options.
+		$options = array(
+			'defaultgroup' => 'page',
+			'browsercache' => $browsercache,
+			'caching'      => true,
+		);
+
+		// Instantiate cache with previous options and create the cache key identifier.
+		return Cache::getInstance('page', $options);
+	}
+}

--- a/plugins/system/cache/src/Helpers/PageCacheStorage.php
+++ b/plugins/system/cache/src/Helpers/PageCacheStorage.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Cache\Controller\PageController;
 /**
  * Joomla! Page Cache Plugin - PageCacheStorage.
  *
- * @since  4.1
+ * @since  __DEPLOY_VERSION__
  */
 final class PageCacheStorage
 {

--- a/plugins/system/cache/src/Helpers/PageCachingChecker.php
+++ b/plugins/system/cache/src/Helpers/PageCachingChecker.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  System.cache
+ *
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Plugin\System\Cache\Helpers;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Uri\Uri;
+use Joomla\Registry\Registry;
+
+/**
+ * Joomla! Page Cache Plugin - PageCachingChecker.
+ *
+ * @since  4.1
+ */
+final class PageCachingChecker
+{
+	/**
+	 * Check if the page can be cached according to all conditions.
+	 *
+	 * @param   string $cacheKey	Cache Key
+	 *
+	 * @return   boolean  True if the page can be cached
+	 *
+	 * @since    __DEPLOY_VERSION__
+	 */
+	public static function canPageBeCached(string $cacheKey): bool
+	{
+		$app = Factory::getApplication();
+
+		// Only GET requests are cached.
+		if ($app->input->getMethod() !== 'GET')
+		{
+			return false;
+		}
+
+		// Run only when we're on Site Application side
+		if (!$app->isClient('site'))
+		{
+			return false;
+		}
+
+		// If the site is offline, don't do anything
+		if ((bool) $app->get('offline', '0'))
+		{
+			return false;
+		}
+
+		// The user is authenticated
+		if (!$app->getIdentity()->guest) {
+			return false;
+		}
+
+		// If there are messages in the queue, don't cache the page
+		if (!empty($app->getMessageQueue()))
+		{
+			return false;
+		}
+
+		if (self::isExcludedPage($cacheKey)) {
+			return false;
+		}
+
+		return true;
+	}
+
+
+	/**
+	 * Check if the page is excluded from the cache or not.
+	 *
+	 * @param   string $cacheKey	Cache Key
+	 *
+	 * @return   boolean  True if the page is excluded else false
+	 *
+	 * @since    __DEPLOY_VERSION__
+	 */
+	public static function isExcludedPage(string $cacheKey): bool
+	{
+		$app = Factory::getApplication();
+		$plugin = PluginHelper::getPlugin('system', 'cache');
+		$params = new Registry($plugin->params);
+
+		// Check if menu items have been excluded.
+		if ($exclusions = $params->get('exclude_menu_items', array()))
+		{
+			// Get the current menu item.
+			$active = $app->getMenu()->getActive();
+
+			if ($active && $active->id && in_array((int) $active->id, (array) $exclusions))
+			{
+				return true;
+			}
+		}
+
+		// Check if regular expressions are being used.
+		if ($exclusions = $params->get('exclude', ''))
+		{
+			// Normalize line endings.
+			$exclusions = str_replace(array("\r\n", "\r"), "\n", $exclusions);
+
+			// Split them.
+			$exclusions = explode("\n", $exclusions);
+
+			// Gets internal URI.
+			$internalUri = '/index.php?' . Uri::getInstance()->buildQuery($app->getRouter()->getVars());
+
+			// Loop through each pattern.
+			if ($exclusions)
+			{
+				foreach ($exclusions as $exclusion)
+				{
+					// Make sure the exclusion has some content
+					if ($exclusion !== '')
+					{
+						// Test both external and internal URI
+						if (preg_match('#' . $exclusion . '#i', $cacheKey . ' ' . $internalUri, $match))
+						{
+							return true;
+						}
+					}
+				}
+			}
+		}
+
+		// If any pagecache plugins return true for onPageCacheIsExcluded, exclude.
+		PluginHelper::importPlugin('pagecache');
+
+		$results = $app->triggerEvent('onPageCacheIsExcluded');
+
+		return in_array(true, $results, true);
+	}
+}

--- a/plugins/system/cache/src/Helpers/PageCachingChecker.php
+++ b/plugins/system/cache/src/Helpers/PageCachingChecker.php
@@ -19,7 +19,7 @@ use Joomla\Registry\Registry;
 /**
  * Joomla! Page Cache Plugin - PageCachingChecker.
  *
- * @since  4.1
+ * @since  __DEPLOY_VERSION__
  */
 final class PageCachingChecker
 {


### PR DESCRIPTION
Pull Request for Issue #35722 #35625 #35877. 

*This PR for Joomla 4.1 is the follow-up of the previous issues #35722 #35625 #35877 to solve the same problem using the Joomla 4 `SubscriberInterface`. It is the same function but uses the new plugin event subscriber interface.*

### Summary of Changes

This PR refactorizes the original System Page Cache to work based on J4 `SubscriberInterface`. The plugin is an interesting case to use the `SubscriberInterface`. The plugin is not executed if it doesn't subscribe to any event. The plugin must only be run under these conditions:

- GET Method
- Site App
- Site is Live 
- User is Guest
- No messages in the queue
- The current Page is not included in the Exclude URLs settings

On Joomla 3, all event methods are always called, leading to duplicated checks and inconsistencies on all methods.

The plugin refactorization avoids duplicated code.

### Testing Instructions

1. Test that the page is cached and retrieved in the cases detailed above.
1. Test that the page is not cached in these cases: 

- Not GET Method
- CLI/ Administrator/ Api App
- Site is Offline 
- Registered User
- A message in the queue
- The current Page is included in the Exclude URLs settings

### Actual result BEFORE applying this Pull Request

The event methods are called following the Joomla 3 model (`onAfterRoute`, 'onAfterRender', 'onAfterRespond').

The final result of delivering the cached page is the same.

### Expected result AFTER applying this Pull Request

The event methods are called following the Joomla 4 `SubscriberInterface`  (`verifyIfCurrentPageCanBeCached`, 'dumpCachedPage', 'storePage').

The final result of delivering the cached page is the same.

### Documentation Changes Required

As mentioned @HLeithner before here #35877, there is a need to document how to develop a Joomla 4 plugin using the new `SubscriberInterface` and avoid the previous way to define the events methods.

CC: @alikon @HLeithner @Kubik-Rubik @PhilETaylor @tampe125 @nikosdion @brianteeman @richard67 @ceford @ricardo1709 
