### PR TITLE
[4.0] Clear search when a directory is changed in media manager

### DIFF
--- a/administrator/components/com_media/resources/scripts/store/mutations.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/mutations.es6.js
@@ -18,6 +18,7 @@ export default {
      */
   [types.SELECT_DIRECTORY]: (state, payload) => {
     state.selectedDirectory = payload;
+    state.search = '';
   },
 
   /**

--- a/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
@@ -262,6 +262,46 @@ class MediaListCest
 	}
 
 	/**
+	 * Test that search is applied to the current list.
+	 *
+	 * @param   Media  $I
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @throws Exception
+	 */
+	public function searchInFilesAndFolders(Media $I)
+	{
+		$I->wantToTest('that search is applied to the current list.');
+		$I->amOnPage(MediaListPage::$url);
+		$I->waitForMediaLoaded();
+		$I->fillField(MediaListPage::$searchInputField, 'joomla');
+		$I->seeElement(MediaListPage::$items);
+		$I->seeElement(MediaListPage::item('joomla_black.png'));
+		$I->dontSeeElement(MediaListPage::item('banners'));
+	}
+
+	/**
+	 * Test that search is cleared when navigating in the tree.
+	 *
+	 * @param   Media  $I
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @throws Exception
+	 */
+	public function searchIsClearedOnNavigate(Media $I)
+	{
+		$I->wantToTest('that search is cleared when navigating in the tree.');
+		$I->amOnPage(MediaListPage::$url);
+		$I->waitForMediaLoaded();
+		$I->fillField(MediaListPage::$searchInputField, 'banner');
+		$I->doubleClick(MediaListPage::item('banners'));
+		$I->waitForMediaLoaded();
+		$I->seeInField(MediaListPage::$searchInputField, '');
+	}
+
+	/**
 	 * Test the upload of a single file using toolbar button.
 	 *
 	 * @param   Media $I Acceptance Helper Object

--- a/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
+++ b/tests/Codeception/acceptance/administrator/components/com_media/MediaListCest.php
@@ -266,9 +266,9 @@ class MediaListCest
 	 *
 	 * @param   Media  $I
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
 	 *
-	 * @throws Exception
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function searchInFilesAndFolders(Media $I)
 	{
@@ -286,9 +286,9 @@ class MediaListCest
 	 *
 	 * @param   Media  $I
 	 *
-	 * @since   __DEPLOY_VERSION__
+	 * @throws  Exception
 	 *
-	 * @throws Exception
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function searchIsClearedOnNavigate(Media $I)
 	{


### PR DESCRIPTION
Pull Request for discussion https://github.com/joomla/joomla-cms/pull/35453#issuecomment-916261168.

### Summary of Changes
Clears the search in media manager when folder is changed. Similar to a file browser on desktop computer.

@wilsonge and @bembelimen I leave that up to you guys if it should be added to 4.0 or 4.1.

### Testing Instructions
- Open the media manager
- Search for banners
- Double click on the banners folder
- Search input field should be cleared

### Actual result BEFORE applying this Pull Request
Search remains and banners folder is empty.

### Expected result AFTER applying this Pull Request
Search input field is cleared and all items are shown.