### PR TITLE
Adds events on show/hide of showon elements

### DIFF
--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -200,12 +200,12 @@ class Showon {
         if (showfield) {
           field.classList.remove('hidden');
           field.dispatchEvent(new CustomEvent('joomla:showon-show'), {
-            bubbles: true
+            bubbles: true,
           });
         } else {
           field.classList.add('hidden');
           field.dispatchEvent(new CustomEvent('joomla:showon-hide'), {
-            bubbles: true
+            bubbles: true,
           });
         }
       } else {

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -199,8 +199,10 @@ class Showon {
       if (field.tagName !== 'option') {
         if (showfield) {
           field.classList.remove('hidden');
+          document.dispatchEvent(new CustomEvent('showon-show'));
         } else {
           field.classList.add('hidden');
+          document.dispatchEvent(new CustomEvent('showon-hide'));
         }
       } else {
         // TODO: If chosen or choices.js is active we should update them

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -199,10 +199,14 @@ class Showon {
       if (field.tagName !== 'option') {
         if (showfield) {
           field.classList.remove('hidden');
-          field.dispatchEvent(new CustomEvent('showon-show'));
+          field.dispatchEvent(new CustomEvent('joomla:showon-show'), {
+            bubbles: true
+          });
         } else {
           field.classList.add('hidden');
-          field.dispatchEvent(new CustomEvent('showon-hide'));
+          field.dispatchEvent(new CustomEvent('joomla:showon-hide'), {
+            bubbles: true
+          });
         }
       } else {
         // TODO: If chosen or choices.js is active we should update them

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -199,10 +199,10 @@ class Showon {
       if (field.tagName !== 'option') {
         if (showfield) {
           field.classList.remove('hidden');
-          document.dispatchEvent(new CustomEvent('showon-show'));
+          field.dispatchEvent(new CustomEvent('showon-show'));
         } else {
           field.classList.add('hidden');
-          document.dispatchEvent(new CustomEvent('showon-hide'));
+          field.dispatchEvent(new CustomEvent('showon-hide'));
         }
       } else {
         // TODO: If chosen or choices.js is active we should update them


### PR DESCRIPTION
This PR adds events to the showing and hiding of shown elements.

So now you can trigger stuff when elements are dynamically shown or hidden, like:
```
document.addEventListener('showon-show', () => {
	const editor = document.querySelector('.CodeMirror');
	editor && editor.CodeMirror.refresh();
});
```