### PR TITLE
Solved -- To Top button overlaps information

### DIFF
--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -3,7 +3,7 @@
 */
 
 .back-to-top-link {
-  position: fixed;
+  position: absolute;
   right: 1rem;
   bottom: 1rem;
   z-index: 10000;

--- a/templates/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/templates/cassiopeia/scss/blocks/_back-to-top.scss
@@ -4,7 +4,7 @@
 
 .back-to-top-link {
   position: absolute;
-  right: 1rem;
+  inset-inline-end: 1rem;
   bottom: 1rem;
   z-index: 10000;
   padding: $cassiopeia-grid-gutter/2;
@@ -15,11 +15,6 @@
   border-radius: $border-radius;
   opacity: 0;
   transition: opacity 200ms ease-in;
-
-  [dir=rtl] & {
-    right: unset;
-    left: 1rem;
-  }
 
   &.visible {
     opacity: 1;


### PR DESCRIPTION
Pull Request for Issue #35057 .

### Summary of Changes
Changed `back-to-top-link` from fixed to absolute.


### Testing Instructions
1. Enable footer in Joomla Cassiopeia.
2. Add content in the footer.
3. Without this PR the information added will be overlapped by the `back to top` button.
4. After this PR the information added will not be overlapped.

### Actual result BEFORE applying this Pull Request

`back to the top` button overlap the information.

### Expected result AFTER applying this Pull Request
`back to the top` button does not overlap the information.


### Documentation Changes Required
No
