### PR TITLE
[4.1] TinyMCE changes for child templates 3/3

### DIFF
--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -232,7 +232,7 @@ class AdministratorApplication extends CMSApplication
 		$db = Factory::getDbo();
 
 		$query = $db->getQuery(true)
-			->select($db->quoteName(['s.template', 's.params', 's.inheritable', 's.parent']))
+			->select($db->quoteName(['s.template', 's.client_id', 's.params', 's.inheritable', 's.parent']))
 			->from($db->quoteName('#__template_styles', 's'))
 			->join(
 				'LEFT',

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -205,6 +205,7 @@ final class ApiApplication extends CMSApplication
 			$template->params      = new Registry;
 			$template->inheritable = 0;
 			$template->parent      = '';
+			$template->client_id   = 0;
 
 			return $template;
 		}

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -630,6 +630,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 			$template->params      = new Registry;
 			$template->inheritable = 0;
 			$template->parent      = '';
+			$template->client_id   = 0;
 
 			return $template;
 		}

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -470,7 +470,7 @@ final class SiteApplication extends CMSApplication
 			$db = Factory::getDbo();
 
 			$query = $db->getQuery(true)
-				->select($db->quoteName(['id', 'home', 'template', 's.params', 'inheritable', 'parent']))
+				->select($db->quoteName(['id', 'home', 'template', 's.client_id', 's.params', 'inheritable', 'parent']))
 				->from($db->quoteName('#__template_styles', 's'))
 				->where(
 					[

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -349,13 +349,14 @@ abstract class HTMLHelper
 	 * @param   boolean  $relative       Flag if the path to the file is relative to the /media folder (and searches in template).
 	 * @param   boolean  $detectBrowser  Flag if the browser should be detected to include specific browser files.
 	 * @param   boolean  $detectDebug    Flag if debug mode is enabled to include uncompressed files if debug is on.
+	 * @param   object   $template       The template object.
 	 *
 	 * @return  array    files to be included.
 	 *
 	 * @see     Browser
 	 * @since   1.6
 	 */
-	protected static function includeRelativeFiles($folder, $file, $relative, $detectBrowser, $detectDebug)
+	protected static function includeRelativeFiles($folder, $file, $relative, $detectBrowser, $detectDebug, $template)
 	{
 		// Set debug flag
 		$debugMode = false;
@@ -412,13 +413,16 @@ abstract class HTMLHelper
 			// If relative search in template directory or media directory
 			if ($relative)
 			{
-				$app        = Factory::getApplication();
-				$template   = $app->getTemplate(true);
-				$templaPath = JPATH_THEMES;
+				if (!(array) $template)
+				{
+					$template = Factory::getApplication()->getTemplate(true);
+				}
+
+				$templaPath = isset($template->realPath) ? $template->realPath : JPATH_THEMES;
 
 				if ($template->inheritable || !empty($template->parent))
 				{
-					$client     = $app->isClient('administrator') === true ? 'administrator' : 'site';
+					$client     = $template->client_id === 1 ? 'administrator' : 'site';
 					$templaPath = JPATH_ROOT . "/media/templates/$client";
 				}
 
@@ -730,7 +734,7 @@ abstract class HTMLHelper
 
 		if ($returnPath !== -1)
 		{
-			$includes = static::includeRelativeFiles('images', $file, $relative, false, false);
+			$includes = static::includeRelativeFiles('images', $file, $relative, false, false, new \stdClass);
 			$file = \count($includes) ? $includes[0] : null;
 		}
 
@@ -761,8 +765,9 @@ abstract class HTMLHelper
 		$options['pathOnly']      = $options['pathOnly'] ?? false;
 		$options['detectBrowser'] = $options['detectBrowser'] ?? false;
 		$options['detectDebug']   = $options['detectDebug'] ?? true;
+		$options['template']      = $options['template'] ?? new \stdClass;
 
-		$includes = static::includeRelativeFiles('css', $file, $options['relative'], $options['detectBrowser'], $options['detectDebug']);
+		$includes = static::includeRelativeFiles('css', $file, $options['relative'], $options['detectBrowser'], $options['detectDebug'], $options['template']);
 
 		// If only path is required
 		if ($options['pathOnly'])
@@ -813,8 +818,9 @@ abstract class HTMLHelper
 		$options['pathOnly']      = $options['pathOnly'] ?? false;
 		$options['detectBrowser'] = $options['detectBrowser'] ?? false;
 		$options['detectDebug']   = $options['detectDebug'] ?? true;
+		$options['template']      = $options['template'] ?? new \stdClass;
 
-		$includes = static::includeRelativeFiles('js', $file, $options['relative'], $options['detectBrowser'], $options['detectDebug']);
+		$includes = static::includeRelativeFiles('js', $file, $options['relative'], $options['detectBrowser'], $options['detectDebug'], $options['template']);
 
 		// If only path is required
 		if ($options['pathOnly'])

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Modified `HTMLHelper::includeRelativeFiles` to accept the template as an object
- Modified `HTMLHelper::image`, `HTMLHelper::stylesheet` and `HTMLHelper::script` to accept the template as an object in the options
- Modified the `getTemplate()` in the apps to also have the client_id in the returned object
- Finally use `HTMLHelper::stylesheet` in the tinyMCE for the `editor.css` (solves also the .min bug)


### Testing Instructions

Apply the patch in the current 4.1
Verify that the editor.css is loading as expected

Apply #35874 and then this PR
Verify that the editor.css is loading as expected

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request

No debug:
![Screenshot 2021-11-10 at 01 26 14](https://user-images.githubusercontent.com/3889375/141027112-f354fe60-36f6-4104-bbef-e8ddc73b95aa.png)

With debug enabled:
![Screenshot 2021-11-10 at 01 27 30](https://user-images.githubusercontent.com/3889375/141027237-d34ddc71-f27a-4b24-9877-247f37e5749d.png)


### Documentation Changes Required
The changes ARE B/C, nothing is breaking here. The concept of passing the template as an object to the 3 helper functions means that we don't have to replicate the existing relative loading procedure in the tinyMCE (maybe it would be helpful for other scenarios)

@bembelimen @laoneo @wilsonge could you guys review this one? 
