### PR TITLE
Solved -- max-width is overwritten

### DIFF
--- a/templates/cassiopeia/scss/blocks/_css-grid.scss
+++ b/templates/cassiopeia/scss/blocks/_css-grid.scss
@@ -52,7 +52,6 @@ body {
     > [class^="container-"],
     > [class*=" container-"] {
       width: 100%;
-      max-width: none;
       column-gap: $cassiopeia-grid-gutter;
     }
 


### PR DESCRIPTION
Pull Request for Issue #36002 .

### Summary of Changes
Solved `max-width` overwritten problem by removing property `max-width: none`.

### Actual result BEFORE applying this Pull Request
`max-width` was overwritten by `max-width: none`.


### Expected result AFTER applying this Pull Request
`max-width` overwritten problem solved.


### Documentation Changes Required
No
