### PR TITLE
[4.1] Make the getElement function easier to read in PluginAdapter

### DIFF
--- a/libraries/src/Installer/Adapter/PluginAdapter.php
+++ b/libraries/src/Installer/Adapter/PluginAdapter.php
@@ -232,23 +232,27 @@ class PluginAdapter extends InstallerAdapter
 	 */
 	public function getElement($element = null)
 	{
-		if (!$element && $this->getManifest())
+		if ($element || !$this->getManifest())
 		{
-			// Backward Compatibility
-			// @todo Deprecate in future version
-			if (\count($this->getManifest()->files->children()))
+			return $element;
+		}
+
+		// Backward Compatibility
+		// @todo Deprecate in future version
+		if (!\count($this->getManifest()->files->children()))
+		{
+			return $element;
+		}
+
+		$type = (string) $this->getManifest()->attributes()->type;
+
+		foreach ($this->getManifest()->files->children() as $file)
+		{
+			if ((string) $file->attributes()->$type)
 			{
-				$type = (string) $this->getManifest()->attributes()->type;
+				$element = (string) $file->attributes()->$type;
 
-				foreach ($this->getManifest()->files->children() as $file)
-				{
-					if ((string) $file->attributes()->$type)
-					{
-						$element = (string) $file->attributes()->$type;
-
-						break;
-					}
-				}
+				break;
 			}
 		}
 


### PR DESCRIPTION
### Summary of Changes
Simplifies the getElement function in PluginAdapter.

### Testing Instructions
Install any plugin.

### Actual result BEFORE applying this Pull Request
Works no error.

### Expected result AFTER applying this Pull Request
Works no error.