### PR TITLE
[4.1] Tags module limit

### DIFF
--- a/modules/mod_tags_popular/mod_tags_popular.xml
+++ b/modules/mod_tags_popular/mod_tags_popular.xml
@@ -39,6 +39,7 @@
 					label="MOD_TAGS_POPULAR_MAX_LABEL"
 					default="5"
 					filter="integer"
+					min="0"
 				/>
 
 				<field

--- a/modules/mod_tags_popular/mod_tags_popular.xml
+++ b/modules/mod_tags_popular/mod_tags_popular.xml
@@ -35,13 +35,10 @@
 
 				<field
 					name="maximum"
-					type="integer"
+					type="number"
 					label="MOD_TAGS_POPULAR_MAX_LABEL"
 					default="5"
 					filter="integer"
-					first="1"
-					last="20"
-					step="1"
 				/>
 
 				<field

--- a/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
+++ b/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
@@ -38,7 +38,7 @@ abstract class TagsPopularHelper
 		$user        = Factory::getUser();
 		$groups      = $user->getAuthorisedViewLevels();
 		$timeframe   = $params->get('timeframe', 'alltime');
-		$maximum     = $params->get('maximum', 5);
+		$maximum     = (int) $params->get('maximum', 5);
 		$order_value = $params->get('order_value', 'title');
 		$nowDate     = Factory::getDate()->toSql();
 		$nullDate    = $db->getNullDate();
@@ -157,7 +157,7 @@ abstract class TagsPopularHelper
 			}
 		}
 
-		if ($params->get('maximum','5') > 0)
+		if ($maximum > 0)
 		{
 			$query->setLimit((int) $params->get('maximum'));
 		}

--- a/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
+++ b/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
@@ -127,7 +127,6 @@ abstract class TagsPopularHelper
 				// Backup bound parameters array of the original query
 				$bounded = $query->getBounded();
 
-				$query->setLimit($maximum);
 				$query->order($db->quoteName('count') . ' DESC');
 				$equery = $db->getQuery(true)
 					->select(
@@ -158,7 +157,11 @@ abstract class TagsPopularHelper
 			}
 		}
 
-		$query->setLimit($maximum, 0);
+		if ($params->get('maximum','5') > 0)
+		{
+			$query->setLimit((int) $params->get('maximum'));
+		}
+
 		$db->setQuery($query);
 
 		try

--- a/modules/mod_tags_similar/mod_tags_similar.xml
+++ b/modules/mod_tags_similar/mod_tags_similar.xml
@@ -29,6 +29,7 @@
 					label="MOD_TAGS_SIMILAR_MAX_LABEL"
 					default="5"
 					filter="integer"
+					min="0"
 				/>
 
 				<field

--- a/modules/mod_tags_similar/mod_tags_similar.xml
+++ b/modules/mod_tags_similar/mod_tags_similar.xml
@@ -25,13 +25,10 @@
 			<fieldset name="basic">
 				<field
 					name="maximum"
-					type="integer"
+					type="number"
 					label="MOD_TAGS_SIMILAR_MAX_LABEL"
 					default="5"
 					filter="integer"
-					first="1"
-					last="20"
-					step="1"
 				/>
 
 				<field

--- a/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
+++ b/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
@@ -194,7 +194,7 @@ abstract class TagsSimilarHelper
 			$query->order($query->rand());
 		}
 
-		if ($params->get('maximum','5') > 0)
+		if ((int) $params->get('maximum', 5) > 0)
 		{
 			$query->setLimit((int) $params->get('maximum'));
 		}

--- a/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
+++ b/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
@@ -194,7 +194,11 @@ abstract class TagsSimilarHelper
 			$query->order($query->rand());
 		}
 
-		$query->setLimit((int) $params->get('maximum', 5));
+		if ($params->get('maximum','5') > 0)
+		{
+			$query->setLimit((int) $params->get('maximum'));
+		}
+
 		$db->setQuery($query);
 
 		try


### PR DESCRIPTION
Pull Request for Issue #36016.

### Summary of Changes
As title says. For both tag modules. 


### Testing Instructions
Use more than 20 tags to yor articles, 
Set the maximum to a number > 20 and make sure that the tags are displayed corrctly in frontend


### Actual result BEFORE applying this Pull Request
see #36016


### Expected result AFTER applying this Pull Request
Any number is possible 


### Documentation Changes Required

