### PR TITLE
Fix uploadlimits checks

### DIFF
--- a/administrator/components/com_installer/src/Model/WarningsModel.php
+++ b/administrator/components/com_installer/src/Model/WarningsModel.php
@@ -146,7 +146,8 @@ class WarningsModel extends ListModel
 
 		$memory_limit = $this->return_bytes(ini_get('memory_limit'));
 
-		if ($memory_limit > -1) {
+		if ($memory_limit > -1)
+		{
 			if ($memory_limit < $minLimit)
 			{
 				// 16MB

--- a/administrator/components/com_installer/src/Model/WarningsModel.php
+++ b/administrator/components/com_installer/src/Model/WarningsModel.php
@@ -98,76 +98,98 @@ class WarningsModel extends ListModel
 		$messages = [];
 
 		// 16MB
-		$minMemory = 16 * 1024 * 1024;
+		$minLimit = 16 * 1024 * 1024;
 
 		$file_uploads = ini_get('file_uploads');
 
 		if (!$file_uploads)
 		{
-			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_FILEUPLOADSDISABLED'),
-					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_FILEUPLOADISDISABLEDDESC'));
+			$messages[] = [
+				'message'     => Text::_('COM_INSTALLER_MSG_WARNINGS_FILEUPLOADSDISABLED'),
+				'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_FILEUPLOADISDISABLEDDESC'),
+			];
 		}
 
 		$upload_dir = ini_get('upload_tmp_dir');
 
 		if (!$upload_dir)
 		{
-			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_PHPUPLOADNOTSET'),
-					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_PHPUPLOADNOTSETDESC'));
+			$messages[] = [
+				'message'     => Text::_('COM_INSTALLER_MSG_WARNINGS_PHPUPLOADNOTSET'),
+				'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_PHPUPLOADNOTSETDESC'),
+			];
 		}
 		elseif (!is_writable($upload_dir))
 		{
-			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_PHPUPLOADNOTWRITEABLE'),
-					'description' => Text::sprintf('COM_INSTALLER_MSG_WARNINGS_PHPUPLOADNOTWRITEABLEDESC', $upload_dir));
+			$messages[] = [
+				'message'     => Text::_('COM_INSTALLER_MSG_WARNINGS_PHPUPLOADNOTWRITEABLE'),
+				'description' => Text::sprintf('COM_INSTALLER_MSG_WARNINGS_PHPUPLOADNOTWRITEABLEDESC', $upload_dir),
+			];
 		}
 
 		$tmp_path = Factory::getApplication()->get('tmp_path');
 
 		if (!$tmp_path)
 		{
-			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_JOOMLATMPNOTSET'),
-					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_JOOMLATMPNOTSETDESC'));
+			$messages[] = [
+				'message'     => Text::_('COM_INSTALLER_MSG_WARNINGS_JOOMLATMPNOTSET'),
+				'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_JOOMLATMPNOTSETDESC'),
+			];
 		}
 		elseif (!is_writable($tmp_path))
 		{
-			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_JOOMLATMPNOTWRITEABLE'),
-					'description' => Text::sprintf('COM_INSTALLER_MSG_WARNINGS_JOOMLATMPNOTWRITEABLEDESC', $tmp_path));
+			$messages[] = [
+				'message'     => Text::_('COM_INSTALLER_MSG_WARNINGS_JOOMLATMPNOTWRITEABLE'),
+				'description' => Text::sprintf('COM_INSTALLER_MSG_WARNINGS_JOOMLATMPNOTWRITEABLEDESC', $tmp_path),
+			];
 		}
 
 		$memory_limit = $this->return_bytes(ini_get('memory_limit'));
 
-		if ($memory_limit < $minMemory && $memory_limit != -1)
-		{
-			// 16MB
-			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_LOWMEMORYWARN'),
-					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_LOWMEMORYDESC'));
-		}
-		elseif ($memory_limit < ($minMemory * 1.5) && $memory_limit != -1)
-		{
-			// 24MB
-			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_MEDMEMORYWARN'),
-					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_MEDMEMORYDESC'));
+		if ($memory_limit > -1) {
+			if ($memory_limit < $minLimit)
+			{
+				// 16MB
+				$messages[] = [
+					'message'     => Text::_('COM_INSTALLER_MSG_WARNINGS_LOWMEMORYWARN'),
+					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_LOWMEMORYDESC'),
+				];
+			}
+			elseif ($memory_limit < ($minLimit * 1.5))
+			{
+				// 24MB
+				$messages[] = [
+					'message'     => Text::_('COM_INSTALLER_MSG_WARNINGS_MEDMEMORYWARN'),
+					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_MEDMEMORYDESC'),
+				];
+			}
 		}
 
-		$post_max_size = $this->return_bytes(ini_get('post_max_size'));
+		$post_max_size       = $this->return_bytes(ini_get('post_max_size'));
 		$upload_max_filesize = $this->return_bytes(ini_get('upload_max_filesize'));
 
-		if ($post_max_size < $upload_max_filesize)
+		if ($post_max_size > 0 && $post_max_size < $upload_max_filesize)
 		{
-			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_UPLOADBIGGERTHANPOST'),
-					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_UPLOADBIGGERTHANPOSTDESC'));
+			$messages[] = [
+				'message'     => Text::_('COM_INSTALLER_MSG_WARNINGS_UPLOADBIGGERTHANPOST'),
+				'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_UPLOADBIGGERTHANPOSTDESC'),
+			];
 		}
 
-		if ($post_max_size < $minMemory)
+		if ($post_max_size > 0 && $post_max_size < $minLimit)
 		{
-			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLPOSTSIZE'),
-					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLPOSTSIZEDESC'));
+			$messages[] = [
+				'message'     => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLPOSTSIZE'),
+				'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLPOSTSIZEDESC'),
+			];
 		}
 
-		if ($upload_max_filesize < $minMemory)
+		if ($upload_max_filesize > 0 && $upload_max_filesize < $minLimit)
 		{
-			$messages[] = array('message' => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLUPLOADSIZE'),
-					'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLUPLOADSIZEDESC'));
+			$messages[] = [
+				'message'     => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLUPLOADSIZE'),
+				'description' => Text::_('COM_INSTALLER_MSG_WARNINGS_SMALLUPLOADSIZEDESC'),
+			];
 		}
 
 		return $messages;

--- a/administrator/components/com_media/src/Controller/ApiController.php
+++ b/administrator/components/com_media/src/Controller/ApiController.php
@@ -359,15 +359,19 @@ class ApiController extends BaseController
 	 */
 	private function checkContent()
 	{
-		$params = ComponentHelper::getParams('com_media');
+		$helper              = new MediaHelper;
+		$contentLength       = $this->input->server->getInt('CONTENT_LENGTH');
+		$params              = ComponentHelper::getParams('com_media');
+		$paramsUploadMaxsize = $params->get('upload_maxsize', 0) * 1024 * 1024;
+		$uploadMaxFilesize   = $helper->toBytes(ini_get('upload_max_filesize'));
+		$postMaxSize         = $helper->toBytes(ini_get('post_max_size'));
+		$memoryLimit         = $helper->toBytes(ini_get('memory_limit'));
 
-		$helper       = new MediaHelper;
-		$serverlength = $this->input->server->getInt('CONTENT_LENGTH');
-
-		if (($params->get('upload_maxsize', 0) > 0 && $serverlength > ($params->get('upload_maxsize', 0) * 1024 * 1024))
-			|| $serverlength > $helper->toBytes(ini_get('upload_max_filesize'))
-			|| $serverlength > $helper->toBytes(ini_get('post_max_size'))
-			|| $serverlength > $helper->toBytes(ini_get('memory_limit')))
+		if (($paramsUploadMaxsize > 0 && $contentLength > $paramsUploadMaxsize)
+			|| ($uploadMaxFilesize > 0 && $contentLength > $uploadMaxFilesize)
+			|| ($postMaxSize > 0 && $contentLength > $postMaxSize)
+			|| ($memoryLimit > -1 && $contentLength > $memoryLimit)
+		)
 		{
 			throw new \Exception(Text::_('COM_MEDIA_ERROR_WARNFILETOOLARGE'), 403);
 		}


### PR DESCRIPTION
Pull Request for Issue #35853

### Summary of Changes
check if upload, post and memory limit is set to unlimited before checking required minimum limits


### Testing Instructions
Install extensions
Upload file in media manger.
if possible with different values set in for upload_max_filesize, post_max_size, memory_limit in php.ini

### Actual result BEFORE applying this Pull Request
doesn't work if any of the 3 vars is <= 0


### Expected result AFTER applying this Pull Request
works

