### PR TITLE
[4.0] RTL: Correcting sidebar menu

### DIFF
--- a/administrator/templates/atum/scss/blocks/_sidebar.scss
+++ b/administrator/templates/atum/scss/blocks/_sidebar.scss
@@ -215,7 +215,7 @@
 
   .main-nav a:hover .sidebar-item-title {
     position: absolute;
-    left: 100%;
+    inset-inline-start: 100%;
     display: flex;
     align-items: center;
     height: 100%;
@@ -223,12 +223,10 @@
     white-space: nowrap;
     pointer-events: none;
     background-color: var(--template-bg-dark-60);
-    border-radius: 0 $border-radius $border-radius 0;
-    [dir=rtl] & {
-      right: 100%;
-      left: unset;
-      border-radius: $border-radius 0 0 $border-radius;
-    }
+    border-end-start-radius: 0;
+    border-end-end-radius: $border-radius;
+    border-start-end-radius: $border-radius;
+    border-start-start-radius: 0;
   }
 
   .main-nav > li > ul {


### PR DESCRIPTION
This is a replacement to the merged PR #34869

It does exactly the same thing but by using css logical properties we avoid the need to maintain both an LTR and an RTL version

There is no visual change. There is no shorthand for border-radius logical properties

![image](https://user-images.githubusercontent.com/1296369/141660627-bc7a43b1-5b06-4dfc-86c7-66d829ec5f7b.png)
