### PR TITLE
[4.0] Fancy selectbox fix

### DIFF
--- a/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
+++ b/administrator/templates/atum/scss/vendor/choicesjs/choices.scss
@@ -141,21 +141,14 @@
   .choices__button_joomla {
     position: absolute;
     top: 50%;
-    right: 0;
+    inset-inline-end: 0;
     width: 20px;
     height: 20px;
     padding: 0;
-    margin-top: -10px;
-    margin-right: 50px;
+    margin-block-start: -10px;
+    margin-inline-end: 50px;
     border-radius: 10em;
     opacity: .5;
-
-    [dir=rtl] & {
-      right: auto;
-      left: 0;
-      margin-right: 0;
-      margin-left: 50px;
-    }
 
     &:hover,
     &:focus {

--- a/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
+++ b/templates/cassiopeia/scss/vendor/choicesjs/choices.scss
@@ -136,21 +136,14 @@
   .choices__button_joomla {
     position: absolute;
     top: 50%;
-    right: 0;
+    inset-inline-end: 0;
     width: 20px;
     height: 20px;
     padding: 0;
-    margin-top: -10px;
-    margin-right: 50px;
+    margin-block-start: -10px;
+    margin-inline-end: 50px;
     border-radius: 10em;
     opacity: .5;
-
-    [dir=rtl] & {
-      right: auto;
-      left: 0;
-      margin-right: 0;
-      margin-left: 50px;
-    }
 
     &:hover,
     &:focus {


### PR DESCRIPTION
This is a replacement to the merged PR #30739 for atum and to identical code in cassiopeia

It does exactly the same thing but by using css logical properties we avoid the need to maintain both an LTR and an RTL version

There is no visual change.

![image](https://user-images.githubusercontent.com/1296369/141660904-2247d113-b452-45e9-a389-6449b78d6aa6.png)
