### PR TITLE
[4.0] Template tree rtl

### DIFF
--- a/administrator/templates/atum/scss/blocks/_treeselect.scss
+++ b/administrator/templates/atum/scss/blocks/_treeselect.scss
@@ -19,34 +19,23 @@
     &::before {
       position: absolute;
       top: 14px;
-      left: ($treeselect-indent - 15px);
+      inset-inline-start: ($treeselect-indent - 15px);
       width: 10px;
       height: 1px;
       margin: auto;
       content: "";
       background-color: rgba(0, 0, 0, .2);
-
-      [dir=rtl] & {
-        right: ($treeselect-indent - 15px);
-        left: 0;
-        margin: 0;
-      }
     }
 
     &::after {
       position: absolute;
       top: 0;
       bottom: 0;
-      left: ($treeselect-indent - 15px);
+      inset-inline-start: ($treeselect-indent - 15px);
       width: 1px;
       height: 100%;
       content: "";
       background-color: rgba(0, 0, 0, .2);
-
-      [dir=rtl] & {
-        right: ($treeselect-indent - 15px);
-        left: 0;
-      }
     }
 
     &:last-child {
@@ -119,14 +108,8 @@
 
     li::before,
     li::after {
-      left: 8px;
+      inset-inline-start: 8px;
       display: block;
-
-      [dir=rtl] & {
-        right: 8px;
-        left: 0;
-        margin: 0;
-      }
     }
 
     li::before {


### PR DESCRIPTION
This is a replacement to the merged PR #26367

It does exactly the same thing but by using css logical properties we avoid the need to maintain both an LTR and an RTL version

There is no visual change.
![image](https://user-images.githubusercontent.com/1296369/141672489-247c2a5b-899c-4018-9f4a-c77b65457597.png)

