### PR TITLE
[4.0] Atum content quicklinks

### DIFF
--- a/administrator/templates/atum/scss/blocks/_quickicons.scss
+++ b/administrator/templates/atum/scss/blocks/_quickicons.scss
@@ -142,12 +142,5 @@
 
 #content .menu-quicktask {
   position: absolute;
-
-  [dir=ltr] & {
-    right: 1.25rem;
-  }
-
-  [dir=rtl] & {
-    left: 1.25rem;
-  }
+  inset-inline-end: 1.25rem;
 }


### PR DESCRIPTION
This is a partial replacement to part of the merged PR #32336

It does exactly the same thing but by using css logical properties we avoid the need to maintain both an LTR and an RTL version

There is no visual change.
![image](https://user-images.githubusercontent.com/1296369/141672707-7c081859-433d-4933-84ae-e765626b813d.png)
