### PR TITLE
[4.0] Atum alert styling

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -106,7 +106,7 @@
   .joomla-alert-button--close {
     position: absolute;
     top: 0;
-    right: 0;
+    inset-inline-end: 0;
     padding: .75rem .8rem;
     font-size: 2rem;
     line-height: 1rem;
@@ -120,11 +120,6 @@
       text-decoration: none;
       cursor: pointer;
       opacity: .75;
-    }
-
-    [dir=rtl] & {
-      right: auto;
-      left: 0;
     }
   }
 


### PR DESCRIPTION
This is a replacement to part of the merged PR #30294

It does exactly the same thing but by using css logical properties we avoid the need to maintain both an LTR and an RTL version

There is no visual change.
![image](https://user-images.githubusercontent.com/1296369/141672765-c991aec8-a490-46d3-8480-8c30c291385c.png)
