### PR TITLE
[4.0] header.css unused

### DIFF
--- a/administrator/templates/atum/scss/blocks/_header.scss
+++ b/administrator/templates/atum/scss/blocks/_header.scss
@@ -229,24 +229,4 @@
       transform: rotate(180deg);
     }
   }
-
-  .header-item-more {
-    &.active .header-more-menu {
-      left: 0;
-
-      [dir=rtl] & {
-        right: 0;
-        left: auto;
-      }
-    }
-
-    .header-item-content {
-      background: transparent;
-    }
-  }
-
-  .header-more-menu {
-    top: auto;
-    bottom: 100%;
-  }
 }


### PR DESCRIPTION
To the best of my knowledge and testing ability these classes are no longer used and can be safely removed. It looks like they were missed during the numerous refactoring of the atum template.

When testing either confirm they are not used by code review and/or check that the ... menu is still working as desired on smaller screens
