### PR TITLE
[4.0] remove unused fontawesome override

### DIFF
--- a/administrator/templates/atum/scss/vendor/fontawesome-free/fontawesome.scss
+++ b/administrator/templates/atum/scss/vendor/fontawesome-free/fontawesome.scss
@@ -12,8 +12,3 @@ $fa-font-path:                     "../../../../../../media/vendor/fontawesome-f
 
 // B/C for Icomoon
 @import "../../../../../../build/media_source/system/scss/icomoon";
-
-// RTL override
-html[dir=rtl] .float-right {
-  float: left;
-}


### PR DESCRIPTION
This can be safely removed as float-right etc are no longer used

code-review