### PR TITLE
[4.0] Joomla-tabs logical properties

### DIFF
--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -284,10 +284,10 @@ joomla-tab {
         }
 
         .respTable td::before {
-          font-weight: $bold-weight;
-          content: attr(data-label) ":";
           float: inline-start;
           padding-inline-end: 2em;
+          font-weight: $bold-weight;
+          content: attr(data-label) ":";
         }
 
         .respTable td:nth-child(1) {

--- a/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/administrator/templates/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -269,12 +269,8 @@ joomla-tab {
       padding: 0 !important;
 
       @include media-breakpoint-down(lg) {
-        [dir=ltr] & .respTable {
-          text-align: right;
-        }
-
-        [dir=rtl] & .respTable {
-          text-align: left;
+        .respTable {
+          text-align: end;
         }
 
         .respTable, .respTable thead, .respTable tbody, .respTable tr, .respTable th, .respTable td {
@@ -287,22 +283,12 @@ joomla-tab {
           left: -1111px;
         }
 
-        /* stylelint-disable */
         .respTable td::before {
           font-weight: $bold-weight;
           content: attr(data-label) ":";
-
-          [dir=ltr] & {
-            float: left;
-            padding: 0 2em 0 0;
-          }
-
-          [dir=rtl] & {
-            float: right;
-            padding: 0 0 0 2em;
-          }
+          float: inline-start;
+          padding-inline-end: 2em;
         }
-        /* stylelint-enable */
 
         .respTable td:nth-child(1) {
           font-weight: $bold-weight;


### PR DESCRIPTION
It does exactly the same thing but by using css logical properties we avoid the need to maintain both an LTR and an RTL version

There is no visual change.

![image](https://user-images.githubusercontent.com/1296369/141675689-5e01f83b-f222-425d-9e0c-c5e0dc1a2ea8.png)
