### PR TITLE
[4.0] swticher css - rtl

### DIFF
--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -13,18 +13,13 @@ $switcher-height: 28px;
 .switcher input {
   position: absolute;
   top: 0;
-  left: 0;
+  inset-inline-start: 0;
   z-index: 2;
   width: $switcher-width;
   height: $switcher-height;
   margin: 0;
   cursor: pointer;
   opacity: 0;
-
-  [dir=rtl] & {
-    right: 0;
-    left: auto;
-  }
 }
 
 .switcher input:checked {
@@ -48,29 +43,21 @@ $switcher-height: 28px;
 
 .switcher label {
   position: absolute;
-  left: 0;
+  inset-inline-start: 0;
   display: inline-block;
   width: auto;
   min-width: 6rem;
   height: 100%;
   margin-bottom: 0;
-  margin-left: 70px;
+  margin-inline-start: 70px;
   line-height: $switcher-height;
-  text-align: left;
+  text-align: start;
   transition: opacity .25s ease;
-
-  [dir=rtl] & {
-    right: 0;
-    left: auto;
-    margin-right: 70px;
-    margin-left: 0;
-    text-align: right;
-  }
 }
 
 .switcher .toggle-outside {
   position: absolute;
-  left: 0;
+  inset-inline-start: 0;
   box-sizing: border-box;
   width: 58px;
   height: 100%;
@@ -79,11 +66,6 @@ $switcher-height: 28px;
   border: 1px solid rgba(0, 0, 0, .18);
   transition: .2s ease all;
   transform: translate3d(0, 0, 0);
-
-  [dir=rtl] & {
-    right: 0;
-    left: auto;
-  }
 }
 
 .switcher input ~ input:checked ~ .toggle-outside {


### PR DESCRIPTION
Updates the css to use logical properties instead of maintaining LTR and RTL. There is no visible difference

![image](https://user-images.githubusercontent.com/1296369/141679461-bebcaafd-2df9-4c11-b59b-d87938b0b622.png)
