### PR TITLE
[4.0] remove unused atum rtl css

### DIFF
--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -23,12 +23,6 @@ ul {
   margin-left: 0;
 }
 
-// System panel
-.menu-quicktask,
-.menu-badge {
-  float: left;
-}
-
 // Redirect urls fields
 #jform_new_url,
 #jform_old_url,

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -21,13 +21,6 @@ ul {
   direction: ltr;
 }
 
-// skipto
-.skip-to {
-  [role="separator"] {
-    text-align: right !important;
-  }
-}
-
 .input-group > .form-control:not(:last-child),
 .input-group > .form-select:not(:last-child) {
   @include border-start-radius(0);

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -16,11 +16,6 @@ ul {
   }
 }
 
-.sidebar-wrapper {
-  right: 0;
-  left: auto;
-}
-
 .menu-collapse {
   right: 0;
   left: auto;

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -8,14 +8,6 @@ ul {
   padding-right: 0;
 }
 
-.dropdown-menu-end {
-
-  &::after {
-    right: auto;
-    left: .9rem;
-  }
-}
-
 .menu-collapse {
   right: 0;
   left: auto;

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -27,10 +27,6 @@ ul {
   float: right;
 }
 
-.field-user-wrapper {
-  float: none;
-}
-
 // System panel
 .menu-quicktask,
 .menu-badge {

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -23,10 +23,6 @@ ul {
   margin-left: 0;
 }
 
-.form-text {
-  float: right;
-}
-
 // System panel
 .menu-quicktask,
 .menu-badge {

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -23,10 +23,6 @@ ul {
   margin-left: 0;
 }
 
-.field-calendar {
-  float: none;
-}
-
 .form-text {
   float: right;
 }

--- a/administrator/templates/atum/scss/template-rtl.scss
+++ b/administrator/templates/atum/scss/template-rtl.scss
@@ -8,13 +8,6 @@ ul {
   padding-right: 0;
 }
 
-.menu-collapse {
-  right: 0;
-  left: auto;
-  margin-right: -7.5px;
-  margin-left: 0;
-}
-
 // Redirect urls fields
 #jform_new_url,
 #jform_old_url,


### PR DESCRIPTION
Removing these classes from the rtl override as we either no longer need the override or the class itself is no longer present.

code review