### PR TITLE
[4.0] Do not force the change of uploaded mm files to lowercase

### DIFF
--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -92,7 +92,7 @@ class File
 		if (function_exists('transliterator_transliterate') && function_exists('iconv'))
 		{
 			// Using iconv to ignore characters that can't be transliterated
-			$file = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('Any-Latin; Latin-ASCII; Lower()', $file));
+			$file = iconv("UTF-8", "ASCII//TRANSLIT//IGNORE", transliterator_transliterate('Any-Latin; Latin-ASCII', $file));
 		}
 
 		$regex = array('#(\.){2,}#', '#[^A-Za-z0-9\.\_\- ]#', '#^\.#');


### PR DESCRIPTION
Pull Request for Issue #35808.

### Summary of Changes
In the media manager all file names are changed to lower case on upload. This behavior was introduce in #28002 and works only when the INTL extension is installed. Not sure if lower case is intended to be added as well, @infograf768 can shed perhaps some light into this.

This pr reverts the lower case check.

The history of this changes can be traces back to 2016:
- https://github.com/joomla/joomla-cms/pull/28002
- https://github.com/joomla/joomla-cms/pull/12049
- https://github.com/joomla/joomla-cms/issues/7841


### Testing Instructions
- Make sure the INTL extension is installed on your host.
- Upload an image with upper case characters in media manager.

### Actual result BEFORE applying this Pull Request
Image file name is changed to lowercase.

### Expected result AFTER applying this Pull Request
Image file name keeps upper case characters.