### PR TITLE
[4.0]custom-select-color-state update

### DIFF
--- a/components/com_contact/tmpl/categories/default.xml
+++ b/components/com_contact/tmpl/categories/default.xml
@@ -167,7 +167,7 @@
 				type="list"
 				label="COM_CONTACT_NO_CONTACTS_LABEL"
 				useglobal="true"
-				class="custom-select-color-state"
+				class="form-select-color-state"
 				validate="options"
 				>
 				<option value="0">JHIDE</option>
@@ -179,7 +179,7 @@
 				type="list"
 				label="JGLOBAL_SHOW_SUBCATEGORY_HEADING"
 				useglobal="true"
-				class="custom-select-color-state"
+				class="form-select-color-state"
 				validate="options"
 				>
 				<option value="0">JHIDE</option>

--- a/components/com_contact/tmpl/category/default.xml
+++ b/components/com_contact/tmpl/category/default.xml
@@ -106,7 +106,7 @@
 				type="list"
 				label="COM_CONTACT_NO_CONTACTS_LABEL"
 				useglobal="true"
-				class="custom-select-color-state"
+				class="form-select-color-state"
 				validate="options"
 				>
 				<option value="0">JHIDE</option>
@@ -118,7 +118,7 @@
 				type="list"
 				label="JGLOBAL_SHOW_SUBCATEGORY_HEADING"
 				useglobal="true"
-				class="custom-select-color-state"
+				class="form-select-color-state"
 				validate="options"
 				>
 				<option value="0">JHIDE</option>


### PR DESCRIPTION
Replace the last two remaining instances of `class=custom-select-color-state` (bs2-style) with `class-form-select-color-state` (bs5-style)

There is no visible difference so code review only.

Any comment about the class actually doing anything is off-topic. This is just for consistency
