### PR TITLE
[4.0] Pre-update check icon spacing

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
@@ -101,7 +101,7 @@ $updatePossible = true;
 						<?php break; ?>
 					<?php endif; ?>
 				<?php endforeach; ?>
-				<span class="fa fa-<?php echo $labelClass == 'danger' ? 'times' : 'check'; ?> fa-fw py-1 bg-white ms-2 text-<?php echo $labelClass; ?>" aria-hidden="true"></span>
+				<span class="fa fa-<?php echo $labelClass == 'danger' ? 'times' : 'check'; ?> fa-fw py-1 bg-white text-<?php echo $labelClass; ?>" aria-hidden="true"></span>
 			</button>
 			<button class="nav-link d-flex justify-content-between align-items-center" id="joomlaupdate-precheck-recommended-tab" data-bs-toggle="pill" data-bs-target="#joomlaupdate-precheck-recommended-content" type="button" role="tab" aria-controls="joomlaupdate-precheck-recommended-content" aria-selected="false">
 				<?php echo Text::_('COM_JOOMLAUPDATE_PREUPDATE_RECOMMENDED_SETTINGS'); ?>
@@ -112,12 +112,12 @@ $updatePossible = true;
 						<?php break; ?>
 					<?php endif; ?>
 				<?php endforeach; ?>
-				<span class="fa fa-<?php echo $labelClass == 'warning' ? 'exclamation-triangle' : 'check'; ?> fa-fw py-1 bg-white ms-2 text-<?php echo $labelClass; ?>" aria-hidden="true"></span>
+				<span class="fa fa-<?php echo $labelClass == 'warning' ? 'exclamation-triangle' : 'check'; ?> fa-fw py-1 bg-white text-<?php echo $labelClass; ?>" aria-hidden="true"></span>
 			</button>
 			<button class="nav-link d-flex justify-content-between align-items-center" id="joomlaupdate-precheck-extensions-tab" data-bs-toggle="pill" data-bs-target="#joomlaupdate-precheck-extensions-content" type="button" role="tab" aria-controls="joomlaupdate-precheck-extensions-content" aria-selected="false">
 				<?php echo Text::_('COM_JOOMLAUPDATE_PREUPDATE_EXTENSIONS'); ?>
 				<?php $labelClass = 'success'; ?>
-				<span class="fa fa-spinner fa-spin fa-fw py-1 ms-2" aria-hidden="true"></span>
+				<span class="fa fa-spinner fa-spin fa-fw py-1" aria-hidden="true"></span>
 			</button>
 		</div>
 


### PR DESCRIPTION
This PR removes the class ms-2 from the icon (see screenshot). You will not see any change at all in LTR but with RTL you will see the corrections below.

To test you may need to trick the site to see the pre-update check by setting a custom update url such as `https://ci.joomla.org/artifacts/joomla/joomla-cms/4.0-dev/36040/downloads/48447/pr_list.xml`

### before
![image](https://user-images.githubusercontent.com/1296369/142721746-06096d05-fdae-4b15-9763-fde2b7e2996b.png)

### after
![image](https://user-images.githubusercontent.com/1296369/142721757-b5649b32-0414-4342-a3bc-f0a177b47e54.png)
