### PR TITLE
[4.0] Fix invalid closing HTML tags

### DIFF
--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -168,4 +168,4 @@ $this->document->addScriptOptions('associations-modal', ['func' => $function]);
 		<input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'cmd'); ?>">
 		<?php echo HTMLHelper::_('form.token'); ?>
 	</form>
-</div
+</div>

--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -123,7 +123,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 									<span class="list-published badge bg-warning text-light">
 										<?php echo Text::_('JEXPIRED'); ?>
 									</span>
-								</div
+								</div>
 							<?php endif; ?>
 							<?php if ($item->published == -2) : ?>
 								<div>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes invalid HTML markup caused by wrong closing tags in PHP files.

### Testing Instructions

Code review:

1. Check that the changes made by this PR are right.
2. Check that it covers all places in PHP files, e.g. by using following command on Linux in a command shell in your Joomla root folder:
```
find ./ -type f -name "*\.php" -exec grep -EHn "</[A-Za-z0-9]+\s*$" {} \;
```

In addition, check if there are any unwanted visual changes on the views which are fixed by this PR after having applied the patch, which are
- The multilanguage associations modal in backend.
- A list all contacts in a category view (or something like that) in frontend.

### Actual result BEFORE applying this Pull Request

Test 2 finds the 2 places which are fixed by this PR:

```
richard@vmubu01:~/lamp/public_html/joomla-cms-4.0-dev$ find ./ -type f -name "*\.php" -exec grep -EHn "</[A-Za-z0-9]+\s*$" {} \;
./administrator/components/com_associations/tmpl/associations/modal.php:171:</div
./components/com_contact/tmpl/category/default_items.php:126:								</div
richard@vmubu01:~/lamp/public_html/joomla-cms-4.0-dev$
```

### Expected result AFTER applying this Pull Request

Test 2 finds nothing.

There are no visual changes in the views fixed by this PR.

### Documentation Changes Required

None.