### PR TITLE
[4.0] max-width inline style

### DIFF
--- a/administrator/components/com_templates/src/Service/HTML/Templates.php
+++ b/administrator/components/com_templates/src/Service/HTML/Templates.php
@@ -90,7 +90,7 @@ class Templates
 					'width'  => '800px',
 					'footer' => $footer,
 				),
-				$body = '<div><img src="' . $preview . '" style="max-width:100%" alt="' . $template . '"></div>'
+				$body = '<div><img src="' . $preview . '" class="mw-100" alt="' . $template . '"></div>'
 			);
 		}
 

--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -160,7 +160,7 @@ if ($this->type == 'font')
 				</form>
 			<?php elseif ($this->type == 'image') : ?>
 				<legend><?php echo $this->escape(basename($this->image['address'])); ?></legend>
-				<img id="image-crop" src="<?php echo $this->image['address'] . '?' . time(); ?>" style="max-width: 100%">
+				<img id="image-crop" src="<?php echo $this->image['address'] . '?' . time(); ?>" class="mw-100">
 				<form action="<?php echo Route::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm">
 					<fieldset class="adminform">
 						<input type="hidden" id="x" name="x">


### PR DESCRIPTION
This PR replaces the inline style `style="max-width:100%"` with the class `mw-100`

There is no visible difference as they both do the same thing.

To test you can look at the sizing of the template preview

![image](https://user-images.githubusercontent.com/1296369/142759628-38c9158d-0795-4ed2-a0d1-817b88536ad1.png)
