### PR TITLE
[4.0] Convert relative to absolute urls to for HTML Email Body

### DIFF
--- a/administrator/components/com_mails/forms/template.xml
+++ b/administrator/components/com_mails/forms/template.xml
@@ -29,7 +29,8 @@
 			name="htmlbody"
 			type="editor"
 			label="COM_MAILS_FIELD_HTMLBODY_LABEL"
-			buttons="false"
+			buttons="true"
+			hide="fields,pagebreak,readmore,module"
 			class="inputbox"
 			filter="JComponentHelper::filterText"
 		/>

--- a/libraries/src/Mail/MailHelper.php
+++ b/libraries/src/Mail/MailHelper.php
@@ -10,7 +10,9 @@ namespace Joomla\CMS\Mail;
 
 \defined('JPATH_PLATFORM') or die;
 
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\String\PunycodeHelper;
+use Joomla\CMS\Uri\Uri;
 
 /**
  * Email helper class, provides static methods to perform various tasks relevant
@@ -191,5 +193,86 @@ abstract class MailHelper
 		}
 
 		return true;
+	}
+
+	/**
+	 * Convert relative (links, images sources) to absolute urls so that content is accessible in email
+	 *
+	 * @param   string  $content  The content need to convert
+	 *
+	 * @return  string  The converted content which the relative urls are converted to absolute urls
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public static function convertRelativeToAbsoluteUrls($content)
+	{
+		$siteUrl = Uri::root();
+
+		// Replace none SEF URLs by absolute SEF URLs
+		if (strpos($content, 'href="index.php?') !== false)
+		{
+			preg_match_all('#href="index.php\?([^"]+)"#m', $content, $matches);
+
+			foreach ($matches[1] as $urlQueryString)
+			{
+				$content = str_replace(
+					'href="index.php?' . $urlQueryString . '"',
+					'href="' . Route::link('site', 'index.php?' . $urlQueryString, Route::TLS_IGNORE, true) . '"',
+					$content
+				);
+			}
+
+			self::checkContent($content);
+		}
+
+		// Replace relative links, image sources with absolute Urls
+		$protocols  = '[a-zA-Z0-9\-]+:';
+		$attributes = array('href=', 'src=', 'poster=');
+
+		foreach ($attributes as $attribute)
+		{
+			if (strpos($content, $attribute) !== false)
+			{
+				$regex = '#\s' . $attribute . '"(?!/|' . $protocols . '|\#|\')([^"]*)"#m';
+
+				$content = preg_replace($regex, ' ' . $attribute . '"' . $siteUrl . '$1"', $content);
+
+				self::checkContent($content);
+			}
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Check the content after regular expression function call.
+	 *
+	 * @param   string  $content  Content to be checked.
+	 *
+	 * @return  void
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	private static function checkContent($content)
+	{
+		if ($content === null)
+		{
+			switch (preg_last_error())
+			{
+				case PREG_BACKTRACK_LIMIT_ERROR:
+					$message = 'PHP regular expression limit reached (pcre.backtrack_limit)';
+					break;
+				case PREG_RECURSION_LIMIT_ERROR:
+					$message = 'PHP regular expression limit reached (pcre.recursion_limit)';
+					break;
+				case PREG_BAD_UTF8_ERROR:
+					$message = 'Bad UTF8 passed to PCRE function';
+					break;
+				default:
+					$message = 'Unknown PCRE error calling PCRE function';
+			}
+
+			throw new \RuntimeException($message);
+		}
 	}
 }

--- a/libraries/src/Mail/MailHelper.php
+++ b/libraries/src/Mail/MailHelper.php
@@ -251,28 +251,31 @@ abstract class MailHelper
 	 *
 	 * @return  void
 	 *
+	 * @throws  \RuntimeException  If there is an error in previous regular expression function call.
 	 * @since  __DEPLOY_VERSION__
 	 */
 	private static function checkContent($content)
 	{
-		if ($content === null)
+		if ($content !== null)
 		{
-			switch (preg_last_error())
-			{
-				case PREG_BACKTRACK_LIMIT_ERROR:
-					$message = 'PHP regular expression limit reached (pcre.backtrack_limit)';
-					break;
-				case PREG_RECURSION_LIMIT_ERROR:
-					$message = 'PHP regular expression limit reached (pcre.recursion_limit)';
-					break;
-				case PREG_BAD_UTF8_ERROR:
-					$message = 'Bad UTF8 passed to PCRE function';
-					break;
-				default:
-					$message = 'Unknown PCRE error calling PCRE function';
-			}
-
-			throw new \RuntimeException($message);
+			return;
 		}
+
+		switch (preg_last_error())
+		{
+			case PREG_BACKTRACK_LIMIT_ERROR:
+				$message = 'PHP regular expression limit reached (pcre.backtrack_limit)';
+				break;
+			case PREG_RECURSION_LIMIT_ERROR:
+				$message = 'PHP regular expression limit reached (pcre.recursion_limit)';
+				break;
+			case PREG_BAD_UTF8_ERROR:
+				$message = 'Bad UTF8 passed to PCRE function';
+				break;
+			default:
+				$message = 'Unknown PCRE error calling PCRE function';
+		}
+
+		throw new \RuntimeException($message);
 	}
 }

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -257,6 +257,8 @@ class MailTemplate
 				$htmlBody = nl2br($plainBody, false);
 			}
 
+			$htmlBody = MailHelper::convertRelativeToAbsoluteUrls($htmlBody);
+
 			$this->mailer->setBody($htmlBody);
 		}
 
@@ -476,6 +478,8 @@ class MailTemplate
 
 		return $db->execute();
 	}
+
+
 
 	/**
 	 * Check and if necessary fix the file name of an attachment so that the attached file

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -479,8 +479,6 @@ class MailTemplate
 		return $db->execute();
 	}
 
-
-
 	/**
 	 * Check and if necessary fix the file name of an attachment so that the attached file
 	 * has the same extension as the source file, and not a different file extension


### PR DESCRIPTION
Pull Request for Issue #35868.

### Summary of Changes
This PR proposes a solution for issue https://github.com/joomla/joomla-cms/issues/35868. Basically, it does 3 things:

- Convert none self URLs (for example, link to article.., link to menu item... inserted by editor buttons) to absolute sef urls.
- Convert relative URLs (for example, link to an image...) to absolute URLs
- Show editor buttons in editor so to allow easier insert menu item, article... to HTML mail template.

Most of the code is copied from the System - Sef plugin https://github.com/joomla/joomla-cms/blob/4.0-dev/plugins/system/sef/sef.php#L106-L134. I think this should be enough for email content.


### Testing Instructions
1. Go to System -> Mail Templates, click on Options button in the toolbar, change **Mail Format** to **Html**.
2. Apply patch
3. Edit **Global Configuration: Test Mail** email template, try to insert image, menu item, article to the template
4. Go to System -> Global Configuration, try to send test mail. Check the received image, make sure the image is displayed, link to menu item, article is accessible. It is not working before this PR (you can test it by revert PR, then resend the email, these content won't be accessible anymore)


### Actual result BEFORE applying this Pull Request
Images not being displayed, links... are not accessible in the email.


### Expected result AFTER applying this Pull Request
Images are being displayed properly, links... are accessible in the email.


### Documentation Changes Required
None.
