### PR TITLE
[4.0] Recreate namespace map on Joomla! update

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -661,7 +661,7 @@ ENDDATA;
 		}
 
 		// Re-create namespace map. It is needed when updating to a Joomla! version has new extension added
-		(new \JNamespacePsr4Map())->create();
+		(new \JNamespacePsr4Map)->create();
 
 		$installer->manifest = $manifest;
 

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -660,6 +660,9 @@ ENDDATA;
 			return false;
 		}
 
+		// Re-create namespace map. It is needed when updating to a Joomla! version has new extension added
+		(new \JNamespacePsr4Map())->create();
+
 		$installer->manifest = $manifest;
 
 		$installer->setUpgrade(true);


### PR DESCRIPTION
Pull Request for Issue #36089.

### Summary of Changes
This PR makes small modification to update Joomla! process so that namespace map is re-generated during Joomla! update. It is needed because when we update to new Joomla version which has new extension added, we need to register namespace of that new extension so that it can work properly.


### Testing Instructions
1. Apply patch from this PR
2. Download the this update package [Joomla_4.1.0-dev+pr.35143-Development-Update_Package.zip](https://github.com/joomla/joomlacms/files/7589180/Joomla_4.1.0-dev%2Bpr.35143-Development-Update_Package.zip). I had to modify original update package for this PR https://github.com/joomla/joomla-cms/pull/35143 (which introduces new extension for Joomla 4.1) to include the change from this PR so that update process runs smooth.
3. Go to System -> Update -> Joomla, upload and update your Joomla 4 installation with the above downloaded package. Make sure you do not see any error with the update process.


### Actual result BEFORE applying this Pull Request
Without the change from this PR, updating your site to the update package of this PR https://github.com/joomla/joomla-cms/pull/35143 will cause a fatal error:

> 0 Class 'Joomla\Component\Scheduler\Administrator\Extension\SchedulerComponent' not found

### Expected result AFTER applying this Pull Request
Update success. Namespace for new extension is successfully registered in administrator/cache/autoload_psr4.php.

### Documentation Changes Required
No.
