### PR TITLE
[4.0] Change markup of "No matching results" alert

### DIFF
--- a/administrator/components/com_mails/tmpl/templates/default.php
+++ b/administrator/components/com_mails/tmpl/templates/default.php
@@ -28,7 +28,10 @@ $listDirn = $this->escape($this->state->get('list.direction'));
 				echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this));
 				?>
 				<?php if (empty($this->items)) : ?>
-					<joomla-alert type="warning"><?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?></joomla-alert>
+					<div class="alert alert-info">
+						<span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+						<?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+					</div>
 				<?php else : ?>
 					<table class="table" id="templateList">
 						<caption class="visually-hidden">


### PR DESCRIPTION
### Summary of Changes
Change markup of `No matching results` alert for consistency to other instances.


### Testing Instructions
Go to System > Mail Templates.
Type random characters in the search box to return no results.


### Actual result BEFORE applying this Pull Request
![no-matching-results-old](https://user-images.githubusercontent.com/368084/143136560-03765552-6774-4eb7-8b4d-bb2bdceeca7f.jpg)



### Expected result AFTER applying this Pull Request
![no-matching-results-new](https://user-images.githubusercontent.com/368084/143136574-ebc4fbdb-9e56-4b8a-ab01-d1011f2162fc.jpg)
