### PR TITLE
[4.1][webservices] get bearer token on credentials

### DIFF
--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -602,14 +602,15 @@ class UsersModel extends ListModel
 
 		$db->setQuery($query);
 		$result = $db->loadObject();
-		
+
 		if ($result)
 		{
 			$match = UserHelper::verifyPassword($credentials['password'], $result->password, $result->id);
 
 			if ($match === true)
 			{
-				$user = User::getInstance($result->id);			
+				$user = User::getInstance($result->id);
+
 				return [$this->getTokenForDisplay($user->id, $result->profile_value, 'sha256')];
 			}
 			else
@@ -617,7 +618,7 @@ class UsersModel extends ListModel
 				throw new AuthenticationFailed;
 			}
 		}
-	
+
 		throw new AuthenticationFailed;
 	}
 

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -175,4 +175,47 @@ class UsersController extends ApiController
 
 		return parent::displayList();
 	}
+
+	/**
+	 * User list view with filtering of data
+	 *
+	 * @return  static  A BaseController object to support chaining.
+	 *
+	 * @since   4.0.0
+	 * @throws  InvalidParameterException
+	 */
+	public function credentials()
+	{	
+		$viewType   = $this->app->getDocument()->getType();
+		$viewName   = $this->input->get('view', $this->default_view);
+		$viewLayout = $this->input->get('layout', 'default', 'string');
+		$filter     = InputFilter::getInstance();
+
+		try
+		{
+			/** @var JsonapiView $view */
+			$view = $this->getView(
+				$viewName,
+				$viewType,
+				'',
+				['base_path' => $this->basePath, 'layout' => $viewLayout, 'contentType' => $this->contentType]
+			);
+		}
+		catch (\Exception $e)
+		{
+			throw new \RuntimeException($e->getMessage());
+		}
+
+		/** @var \Joomla\Component\Jobs\Administrator\Model\UsersModel $model */
+		$model = $this->getModel();
+		$data  = $this->input->get('data', json_decode($this->input->json->getRaw(), true), 'array');
+
+		$view->setModel($model, true);
+
+		$view->document = $this->app->getDocument();
+
+		$view->credentials($data);
+
+		return $this;
+	}
 }

--- a/api/components/com_users/src/Controller/UsersController.php
+++ b/api/components/com_users/src/Controller/UsersController.php
@@ -185,7 +185,7 @@ class UsersController extends ApiController
 	 * @throws  InvalidParameterException
 	 */
 	public function credentials()
-	{	
+	{
 		$viewType   = $this->app->getDocument()->getType();
 		$viewName   = $this->input->get('view', $this->default_view);
 		$viewLayout = $this->input->get('layout', 'default', 'string');

--- a/api/components/com_users/src/View/Users/JsonapiView.php
+++ b/api/components/com_users/src/View/Users/JsonapiView.php
@@ -124,4 +124,22 @@ class JsonapiView extends BaseApiView
 
 		return parent::prepareItem($item);
 	}
+
+	/**
+	 * Check and get credentials
+	 *
+	 * @param   array  $credentials  The user credentials
+	 *
+	 * @return  object
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public function credentials(array $credentials = null)
+	{
+		/** @var SelectModel $model */
+		$model = $this->getModel();
+		$items = $model->credentials($credentials);
+		return parent::displayList($items);
+	}
+
 }

--- a/api/components/com_users/src/View/Users/JsonapiView.php
+++ b/api/components/com_users/src/View/Users/JsonapiView.php
@@ -139,6 +139,7 @@ class JsonapiView extends BaseApiView
 		/** @var SelectModel $model */
 		$model = $this->getModel();
 		$items = $model->credentials($credentials);
+
 		return parent::displayList($items);
 	}
 

--- a/plugins/webservices/users/users.php
+++ b/plugins/webservices/users/users.php
@@ -57,6 +57,13 @@ class PlgWebservicesUsers extends CMSPlugin
 			'levels',
 			['component' => 'com_users']
 		);
+
+		// A public route for auth
+		$defaults = ['component' => 'com_users', 'public' => true];
+		$routes = [
+			new Route(['POST'], 'v1/users/auth', 'users.credentials', [], $defaults),
+		];
+		$router->addRoutes($routes);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
Add an authorization endpoint


### Testing Instructions
apply patch
create an user that have the API Token
 do a POST `{{base_url}}api/index.php/v1/users/auth`
with this  body
```
{
 "username": "test",
 "password": "123456789012"
}

```


### Actual result BEFORE applying this Pull Request
N/A


### Expected result AFTER applying this Pull Request
it returns the Bearer token  so an app can consume the not public webservices endpoints
![image](https://user-images.githubusercontent.com/181681/143206500-40f36310-f102-44b1-bf56-e98cd4cbb034.png)



### Documentation Changes Required

yes