### PR TITLE
[4.0] codemirror update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "bootstrap": "^5.1.2",
         "choices.js": "^9.0.1",
         "chosen-js": "^1.8.7",
-        "codemirror": "^5.63.1",
+        "codemirror": "^5.64.0",
         "cropperjs": "^1.5.11",
         "diff": "^4.0.2",
         "dragula": "3.7.2",
@@ -2820,9 +2820,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.63.3",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.3.tgz",
-      "integrity": "sha512-1C+LELr+5grgJYqwZKqxrcbPsHFHapVaVAloBsFBASbpLnQqLw1U8yXJ3gT5D+rhxIiSpo+kTqN+hQ+9ialIXw=="
+      "version": "5.64.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.64.0.tgz",
+      "integrity": "sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg=="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -11683,9 +11683,9 @@
       }
     },
     "codemirror": {
-      "version": "5.63.3",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.63.3.tgz",
-      "integrity": "sha512-1C+LELr+5grgJYqwZKqxrcbPsHFHapVaVAloBsFBASbpLnQqLw1U8yXJ3gT5D+rhxIiSpo+kTqN+hQ+9ialIXw=="
+      "version": "5.64.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.64.0.tgz",
+      "integrity": "sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "bootstrap": "^5.1.2",
     "choices.js": "^9.0.1",
     "chosen-js": "^1.8.7",
-    "codemirror": "^5.63.1",
+    "codemirror": "^5.64.0",
     "cropperjs": "^1.5.11",
     "diff": "^4.0.2",
     "dragula": "3.7.2",

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_codemirror</name>
-	<version>5.63.3</version>
+	<version>5.64.0</version>
 	<creationDate>28 March 2011</creationDate>
 	<author>Marijn Haverbeke</author>
 	<authorEmail>marijnh@gmail.com</authorEmail>


### PR DESCRIPTION
Updates codemirror to 5.64.0

Fix a crash that occurred in some situations with replacing marks across line breaks.
Make sure native scrollbars reset their position when hidden and re-shown.
vim bindings: Support C-u to delete back a line.

### Testing Instructions
code review
