### PR TITLE
Solve required field attribute causing rendering error

### DIFF
--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -69,7 +69,7 @@ $disabled     = $disabled ? ' disabled' : '';
 $readonly     = $readonly ? ' readonly' : '';
 $hint         = strlen($hint) ? ' placeholder="' . $this->escape($hint) . '"' : ' placeholder="' . $placeholder . '"';
 $required     = $required ? ' required' : '';
-$autocomplete = !empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '';
+$autocomplete = !empty($autocomplete) ? ' autocomplete="' . $autocomplete . '"' : '';
 
 // Force LTR input value in RTL, due to display issues with rgba/hex colors
 $direction = $lang->isRtl() ? ' dir="ltr" style="text-align:right"' : '';

--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -68,6 +68,7 @@ $validate     = $validate ? ' data-validate="' . $validate . '"' : '';
 $disabled     = $disabled ? ' disabled' : '';
 $readonly     = $readonly ? ' readonly' : '';
 $hint         = strlen($hint) ? ' placeholder="' . $this->escape($hint) . '"' : ' placeholder="' . $placeholder . '"';
+$required     = $required ? ' required aria-required="true"' : '';
 $autocomplete = !empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '';
 
 // Force LTR input value in RTL, due to display issues with rgba/hex colors

--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -68,7 +68,7 @@ $validate     = $validate ? ' data-validate="' . $validate . '"' : '';
 $disabled     = $disabled ? ' disabled' : '';
 $readonly     = $readonly ? ' readonly' : '';
 $hint         = strlen($hint) ? ' placeholder="' . $this->escape($hint) . '"' : ' placeholder="' . $placeholder . '"';
-$required     = $required ? ' required aria-required="true"' : '';
+$required     = $required ? ' required' : '';
 $autocomplete = !empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '';
 
 // Force LTR input value in RTL, due to display issues with rgba/hex colors


### PR DESCRIPTION
Pull Request for Issue #36113 .

### Summary of Changes
Added `$required = $required ? ' required aria-required="true"' : '';` above `$autocomplete`.

### Actual result BEFORE applying this Pull Request
`<input type="text" name="jform[color]" id="jform_color" value="#000000" placeholder="#rrggbb" class="minicolors required hex" data-position="default" data-control="hue"1 data-format="hex"/>`
### Expected result AFTER applying this Pull Request
`<input type="text" name="jform[color]" id="jform_color" value="#000000" placeholder="#rrggbb" class="minicolors required hex" data-position="default" data-control="hue" data-format="hex"/>`

### Documentation Changes Required
No

