### PR TITLE
[4.0] Correctly Namespace class

### DIFF
--- a/components/com_config/src/Dispatcher/Dispatcher.php
+++ b/components/com_config/src/Dispatcher/Dispatcher.php
@@ -28,7 +28,7 @@ class Dispatcher extends ComponentDispatcher
 	 *
 	 * @return  void
 	 *
-	 * @throws  Exception|NotAllowed
+	 * @throws  \Exception|NotAllowed
 	 */
 	protected function checkAccess()
 	{


### PR DESCRIPTION
Code review

Namespace of the class is `Joomla\Component\Config\Site\Dispatcher` and `Joomla\Component\Config\Site\Dispatcher\Exception` is not the correct class `\Exception` is