### PR TITLE
[4.1] 'return' is unnecessary as the last statement in a method

### DIFF
--- a/administrator/components/com_scheduler/src/Task/TaskOption.php
+++ b/administrator/components/com_scheduler/src/Task/TaskOption.php
@@ -85,6 +85,7 @@ class TaskOption
 		{
 			return $this->$name;
 		}
-
+		
+		return null;
 	}
 }

--- a/administrator/components/com_scheduler/src/Task/TaskOption.php
+++ b/administrator/components/com_scheduler/src/Task/TaskOption.php
@@ -85,7 +85,7 @@ class TaskOption
 		{
 			return $this->$name;
 		}
-		
+
 		return null;
 	}
 }

--- a/administrator/components/com_scheduler/src/Task/TaskOption.php
+++ b/administrator/components/com_scheduler/src/Task/TaskOption.php
@@ -86,6 +86,5 @@ class TaskOption
 			return $this->$name;
 		}
 
-		return;
 	}
 }


### PR DESCRIPTION
code review