### PR TITLE
[4.0] template icon

### DIFF
--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -241,7 +241,7 @@ class HtmlView extends BaseHtmlView
 		$explodeArray = explode('.', $this->fileName);
 		$ext = end($explodeArray);
 
-		ToolbarHelper::title(Text::sprintf('COM_TEMPLATES_MANAGER_VIEW_TEMPLATE', ucfirst($this->template->name)), 'paint-brush thememanager');
+		ToolbarHelper::title(Text::sprintf('COM_TEMPLATES_MANAGER_VIEW_TEMPLATE', ucfirst($this->template->name)), 'icon-code thememanager');
 
 		// Only show file edit buttons for global SuperUser
 		if ($isSuperUser)

--- a/administrator/components/com_templates/src/View/Templates/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Templates/HtmlView.php
@@ -135,11 +135,11 @@ class HtmlView extends BaseHtmlView
 		// Set the title.
 		if ((int) $this->get('State')->get('client_id') === 1)
 		{
-			ToolbarHelper::title(Text::_('COM_TEMPLATES_MANAGER_TEMPLATES_ADMIN'), 'paint-brush thememanager');
+			ToolbarHelper::title(Text::_('COM_TEMPLATES_MANAGER_TEMPLATES_ADMIN'), 'icon-code thememanager');
 		}
 		else
 		{
-			ToolbarHelper::title(Text::_('COM_TEMPLATES_MANAGER_TEMPLATES_SITE'), 'paint-brush thememanager');
+			ToolbarHelper::title(Text::_('COM_TEMPLATES_MANAGER_TEMPLATES_SITE'), 'icon-code thememanager');
 		}
 
 		if ($canDo->get('core.admin') || $canDo->get('core.options'))


### PR DESCRIPTION
Use the correct icon for Templates and Template views instead of the icon for styles

![image](https://user-images.githubusercontent.com/1296369/143673195-39d22ed8-fa74-496a-8126-5ea6d3bae733.png)
