### PR TITLE
Fix Codemirror behind tabs

### DIFF
--- a/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
+++ b/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
@@ -12,7 +12,7 @@ class CodemirrorEditor extends HTMLElement {
       if (entries[0].isIntersecting && this.instance) {
         this.instance.refresh();
       }
-    }, {threshold: 0});
+    }, { threshold: 0 });
   }
 
   static get observedAttributes() {

--- a/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
+++ b/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
@@ -6,6 +6,13 @@ class CodemirrorEditor extends HTMLElement {
     this.host = window.location.origin;
     this.element = this.querySelector('textarea');
     this.refresh = this.refresh.bind(this);
+
+    // Observer instance to refresh the Editor when it become visible, eg after Tab switching
+    this.intersectionObserver = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && this.instance) {
+        this.instance.refresh();
+      }
+    }, {threshold: 0});
   }
 
   static get observedAttributes() {
@@ -124,11 +131,17 @@ class CodemirrorEditor extends HTMLElement {
     this.instance = window.CodeMirror.fromTextArea(this.element, this.options);
     this.instance.disable = (disabled) => this.setOption('readOnly', disabled ? 'nocursor' : false);
     Joomla.editors.instances[this.element.id] = this.instance;
+
+    // Watch when the element in viewport, and refresh the editor
+    this.intersectionObserver.observe(this);
   }
 
   disconnectedCallback() {
     // Remove from the Joomla API
     delete Joomla.editors.instances[this.element.id];
+
+    // Remove from observer
+    this.intersectionObserver.unobserve(this);
   }
 
   refresh(element) {


### PR DESCRIPTION
Pull Request for Issue #35096 .

### Summary of Changes
Use IntersectionObserver to refresh Codemirror when it become visible


### Testing Instructions

Apply patch, run `npm install`.
Add editor somewhere in hidden tab, example to Custom HTML module :
```xml
<field type="editor" name="editor_test" editor="codemirror" label="editor test" default="I am a text!"/>
```

Visit the module form, and click on tab with this editor.


### Actual result BEFORE applying this Pull Request
Editor is empty


### Expected result AFTER applying this Pull Request
Editor should display a default text.


### Documentation Changes Required
none
