### PR TITLE
[3.10] Finder plugins modify component params registry / Backport #35855

### DIFF
--- a/plugins/finder/content/content.php
+++ b/plugins/finder/content/content.php
@@ -255,7 +255,7 @@ class PlgFinderContent extends FinderIndexerAdapter
 
 		// Initialise the item parameters.
 		$registry = new Registry($item->params);
-		$item->params = JComponentHelper::getParams('com_content', true);
+		$item->params = clone JComponentHelper::getParams('com_content', true);
 		$item->params->merge($registry);
 
 		$item->metadata = new Registry($item->metadata);

--- a/plugins/finder/tags/tags.php
+++ b/plugins/finder/tags/tags.php
@@ -217,7 +217,7 @@ class PlgFinderTags extends FinderIndexerAdapter
 
 		// Initialize the item parameters.
 		$registry = new Registry($item->params);
-		$item->params =  clone JComponentHelper::getParams('com_tags', true);
+		$item->params = clone JComponentHelper::getParams('com_tags', true);
 		$item->params->merge($registry);
 
 		$item->metadata = new Registry($item->metadata);

--- a/plugins/finder/tags/tags.php
+++ b/plugins/finder/tags/tags.php
@@ -217,7 +217,7 @@ class PlgFinderTags extends FinderIndexerAdapter
 
 		// Initialize the item parameters.
 		$registry = new Registry($item->params);
-		$item->params = JComponentHelper::getParams('com_tags', true);
+		$item->params =  clone JComponentHelper::getParams('com_tags', true);
 		$item->params->merge($registry);
 
 		$item->metadata = new Registry($item->metadata);


### PR DESCRIPTION
Backport #35855

### Summary of Changes

Backports the changes done for J4 here #35855 to 3.10 thanks @Denitz

### Testing Instructions

Ensure that finder content plugin is enabled.
Edit article and set any setting to non-global, i.e. "Layout", save article.

### Actual result BEFORE applying this Pull Request

Test your custom `onContentAfterSave` event executing after the finder plugin, see that the component param is article param now:
`\JComponentHelper::getComponent('com_content')->getParams()->get('article_layout')`;

### Expected result AFTER applying this Pull Request

Component param value is original.

### Documentation Changes Required

No.