### PR TITLE
[4.0] Update deleted files from 4.0.4 to 4.0.5

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6109,6 +6109,8 @@ class JoomlaInstallerScript
 			'/media/com_joomlaupdate/js/update.min.js.gz',
 			'/templates/cassiopeia/images/system/sort_asc.png',
 			'/templates/cassiopeia/images/system/sort_desc.png',
+			// From 4.0.4 to 4.0.5
+			'/media/vendor/codemirror/lib/#codemirror.js#',
 		);
 
 		$folders = array(


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request updates the list of files deleted on update in script.php.

### Testing Instructions

Compare the content of the full packages of releases 4.0.4 and 4.0.5 regarding files deleted from 4.0.4 and 4.0.5.

Result: File "media/vendor/codemirror/lib/#codemirror.js#" is present in the full package for 4.0.4 but not in the one for 4.0.5.

There are no other files or folders to be deleted when updating from 4.0.4 to 4.0.5

### Actual result BEFORE applying this Pull Request

File "media/vendor/codemirror/lib/#codemirror.js#" will not be deleted on update to 4.0.5.

### Expected result AFTER applying this Pull Request

File "media/vendor/codemirror/lib/#codemirror.js#" will be deleted on update to 4.0.5.

### Documentation Changes Required

None.