### PR TITLE
[4.0] Obsolete code for RTL

### DIFF
--- a/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
+++ b/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
@@ -85,12 +85,6 @@ abstract class FieldsPlugin extends CMSPlugin
 			if ($this->app->getLanguage()->hasKey('PLG_FIELDS_' . $key . '_LABEL'))
 			{
 				$data['label'] = Text::sprintf('PLG_FIELDS_' . $key . '_LABEL', strtolower($key));
-
-				// Fix wrongly set parentheses in RTL languages
-				if ($this->app->getLanguage()->isRtl())
-				{
-					$data['label'] = $data['label'] . '&#x200E;';
-				}
 			}
 			else
 			{

--- a/administrator/components/com_languages/src/Model/InstalledModel.php
+++ b/administrator/components/com_languages/src/Model/InstalledModel.php
@@ -177,7 +177,6 @@ class InstalledModel extends ListModel
 		{
 			$this->data = array();
 
-			$isCurrentLanguageRtl = Factory::getLanguage()->isRtl();
 			$params               = ComponentHelper::getParams('com_languages');
 			$installedLanguages   = LanguageHelper::getInstalledLanguages(null, true, true, null, null, null);
 
@@ -200,13 +199,6 @@ class InstalledModel extends ListModel
 					$row->version      = $lang->manifest['version'];
 					$row->published    = $defaultLanguage === $row->language ? 1 : 0;
 					$row->checked_out  = null;
-
-					// Fix wrongly set parentheses in RTL languages
-					if ($isCurrentLanguageRtl)
-					{
-						$row->name       = html_entity_decode($row->name . '&#x200E;', ENT_QUOTES, 'UTF-8');
-						$row->nativeName = html_entity_decode($row->nativeName . '&#x200E;', ENT_QUOTES, 'UTF-8');
-					}
 
 					$this->data[] = $row;
 				}

--- a/administrator/modules/mod_login/src/Helper/LoginHelper.php
+++ b/administrator/modules/mod_login/src/Helper/LoginHelper.php
@@ -46,15 +46,6 @@ abstract class LoginHelper
 			}
 		);
 
-		// Fix wrongly set parentheses in RTL languages
-		if (Factory::getApplication()->getLanguage()->isRtl())
-		{
-			foreach ($languages as &$language)
-			{
-				$language['text'] = $language['text'] . '&#x200E;';
-			}
-		}
-
 		array_unshift($languages, HTMLHelper::_('select.option', '', Text::_('JDEFAULTLANGUAGE')));
 
 		return HTMLHelper::_('select.genericlist', $languages, 'lang', 'class="form-select"', 'value', 'text', null);

--- a/installation/src/Form/Field/Installation/LanguageField.php
+++ b/installation/src/Form/Field/Installation/LanguageField.php
@@ -69,15 +69,6 @@ class LanguageField extends ListField
 		// Get the list of available languages.
 		$options = LanguageHelper::createLanguageList($native);
 
-		// Fix wrongly set parentheses in RTL languages
-		if (Factory::getLanguage()->isRtl())
-		{
-			foreach ($options as &$option)
-			{
-				$option['text'] .= '&#x200E;';
-			}
-		}
-
 		if (!$options || $options instanceof \Exception)
 		{
 			$options = array();


### PR DESCRIPTION
Removes the code that  was added 7 years ago to handle parentheses in RTL being displayed incorrectly in language names

When the code was introduced the LTR text was displayed incorrectly when the document was RTL. Browsers are now better at detection and this code is no longer needed.

To test install any RTL language eg Arabic or Persian Farsi and make that the admin language. Then go to the following links

1. `administrator/index.php?option=com_languages&view=installed&client=1`
2. `administrator/index.php?option=com_languages&view=languages`
3. and the admin login form

Before this PR it should look like the screenshot below. After the PR it should still look the same.

If after applying the PR you see something like `English (en-GB(` please mark this as a failed test and report the exact browser and operating system

![image](https://user-images.githubusercontent.com/1296369/143782427-54699f22-0122-440b-bdad-7946002af87a.png)
