### PR TITLE
[4.0] admin menu RTL

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -13,8 +13,7 @@ use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Language\Text;
 
 $doc       = $app->getDocument();
-$direction = $doc->direction === 'rtl' ? 'float-end' : '';
-$class     = $enabled ? 'nav flex-column main-nav ' . $direction : 'nav flex-column main-nav disabled ' . $direction;
+$class     = $enabled ? 'nav flex-column main-nav' : 'nav flex-column main-nav disabled';
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $doc->getWebAssetManager();


### PR DESCRIPTION
This PR removes code that was required in joomla 3 when the admin menu was horizontal. Now that it is vertical there is no need for this code at all.

To test ensure that the admin menu works and looks the same as before the PR with an RTL language such as arabic or persian
