### PR TITLE
[4.0] media manager infobar

### DIFF
--- a/build/media_source/com_media/scss/components/_media-infobar.scss
+++ b/build/media_source/com_media/scss/components/_media-infobar.scss
@@ -17,7 +17,7 @@ $fa-css-prefix:    fa;
     padding-block-start: 8px;
     padding-block-end: 8px;
     padding-inline-start: ($gutter-width - 5px);
-    padding-inline-end: 8px ($gutter-width + 15px);
+    padding-inline-end: ($gutter-width + 15px);
     margin: (-$gutter-width) (-$gutter-width) $gutter-width;
     font-weight: normal;
     word-wrap: break-word;

--- a/build/media_source/com_media/scss/components/_media-infobar.scss
+++ b/build/media_source/com_media/scss/components/_media-infobar.scss
@@ -4,7 +4,7 @@ $fa-css-prefix:    fa;
 .media-infobar {
   position: absolute;
   top: ($toolbar-height + 1px);
-  right: 0;
+  inset-inline-end: 0;
   bottom: 0;
   z-index: 4;
   float: none;
@@ -14,7 +14,10 @@ $fa-css-prefix:    fa;
   background-color: $info-bg;
   border-inline-start: 1px solid $border-color;
   h2 {
-    padding: 8px ($gutter-width + 15px) 8px ($gutter-width - 5px);
+    padding-block-start: 8px;
+    padding-block-end: 8px;
+    padding-inline-start: ($gutter-width - 5px);
+    padding-inline-end: 8px ($gutter-width + 15px);
     margin: (-$gutter-width) (-$gutter-width) $gutter-width;
     font-weight: normal;
     word-wrap: break-word;
@@ -29,10 +32,14 @@ $fa-css-prefix:    fa;
   }
   dt, dd {
     position: relative;
+    direction: ltr;
     width: 100%;
     min-height: 1px;
     padding-right: ($col-gutter-width / 2);
     padding-left: ($col-gutter-width / 2);
+    [dir=rtl] & {
+      text-align: end;
+    }
   }
   dt {
     font-weight: normal;
@@ -43,7 +50,7 @@ $fa-css-prefix:    fa;
 .infobar-close {
   position: absolute;
   top: 0;
-  right: 0;
+  inset-inline-end: 0;
   z-index: 2;
   padding: 5px $gutter-width;
   font-size: 2.6rem;
@@ -72,26 +79,4 @@ $fa-css-prefix:    fa;
     border: 2px solid #ccc;
     border-radius: 50%;
   }
-}
-
-// RTL override
-
-html[dir=rtl] .media-infobar {
-  right: auto;
-  left: 0;
-}
-
-html[dir=rtl] .infobar-close {
-  right: auto;
-  left: 0;
-}
-
-html[dir=rtl] .media-infobar dd {
-  margin-right: 0;
-  margin-left: auto;
-  direction: ltr;
-  text-align: right;
-}
-html[dir=rtl] .media-infobar h2 {
-  padding: 20px $gutter-width 10px 0;
 }


### PR DESCRIPTION
The RTL specific css was wrong as can be seen in the before screenshot -having a seperate block of css for rtl or even worse a separate file makes this sort of thing all too easy to happen.

This PR removes the RTL specific css (should have been scss) and updates the scss to use logical properties instead.

To test RTL you will need to install arabic or persian.

and dont forget to npm ci

There is no visible change in LTR and the RTL changes are as shown below

## Before LTR
![image](https://user-images.githubusercontent.com/1296369/143859570-de87c3a3-fe36-44d6-8d90-12745c13edc7.png)

## Before RTL
![image](https://user-images.githubusercontent.com/1296369/143859496-f99ad242-fde4-4192-ac97-ff3450c59965.png)

## After LTR
![image](https://user-images.githubusercontent.com/1296369/143859045-c6020ac0-75dd-4ab0-a37c-cc850fd03c64.png)

## After RTL
![image](https://user-images.githubusercontent.com/1296369/143858910-34169a93-e36b-4de6-8d57-a4eff9b3254b.png)
