### PR TITLE
[4.0] Remove _com_joomlaupdate.scss from deleted files in script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -5948,7 +5948,6 @@ class JoomlaInstallerScript
 			'/administrator/components/com_fields/tmpl/field/modal.php',
 			'/administrator/templates/atum/scss/pages/_com_admin.scss',
 			'/administrator/templates/atum/scss/pages/_com_finder.scss',
-			'/administrator/templates/atum/scss/pages/_com_joomlaupdate.scss',
 			'/libraries/src/Error/JsonApi/InstallLanguageExceptionHandler.php',
 			'/libraries/src/MVC/Controller/Exception/InstallLanguage.php',
 			'/media/com_fields/js/admin-field-edit-modal-es5.js',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With PR #34407 file "administrator/templates/atum/scss/pages/_com_joomlaupdate.scss" has been removed from the sources, and so it has been added to section "// 4.0 from RC 1 to RC 2" of the list of files to be deleted on update in script.php .

Later with PR #35076 (same author as the previously mentioned PR), the file was added back, but it has not been removed from script.php, and the "build/deleted_file_check.php" can't know that and will always add it back when creating the list and comparing 4.0 RC 1 and RC 2.

That means on each core update of J4, the file will be deleted.

This PR here fixes this by removing the file from the list of files to be deleted in script.php.

It would also need to add it to the list of files to be kept in "build/deleted_file_check.php" so the tool will not add it back when rebuilding the complete list from scratch.

But in 4.1 the scss file has to be added back to the list in script.php because it will be moved to the media folder due to the child template change.

This means that the the change in "build/deleted_file_check.php" in the 4.0-dev branch would have to be reverted in the 4.10-dev branch, or in other words, the 4.0-dev branch and the 4.1-dev branch would have different versions of "build/deleted_file_check.php".

I want to avoid this and so I don't change "build/deleted_file_check.php" with this PR here.

As I'm the one who currently maintains the files and folders deletion in script.php, I will add information on that to my documentation here https://github.com/richard67/joomla-cms/pull/20 .

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

File "administrator/templates/atum/scss/pages/_com_joomlaupdate.scss" is deleted when updating from 4.0.x to 4.0.y.

### Expected result AFTER applying this Pull Request

File "administrator/templates/atum/scss/pages/_com_joomlaupdate.scss" is not deleted when updating from 4.0.x to 4.0.y.

### Documentation Changes Required

None.