### PR TITLE
[4.0] Fix Hide Article Options

### DIFF
--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -37,17 +37,17 @@ $this->useCoreUI = true;
 $params = clone $this->state->get('params');
 $params->merge(new Registry($this->item->attribs));
 
-$app = Factory::getApplication();
-$input = $app->input;
+$input = Factory::getApplication()->input;
 
-$assoc = Associations::isEnabled();
+$assoc              = Associations::isEnabled();
+$showArticleOptions = $params->get('show_article_options', 1);
 
-if (!$assoc)
+if (!$assoc || !$showArticleOptions)
 {
 	$this->ignore_fieldsets[] = 'frontendassociations';
 }
 
-if (!$params->get('show_article_options', 1))
+if (!$showArticleOptions)
 {
 	// Ignore fieldsets inside Options tab
 	$this->ignore_fieldsets = array_merge($this->ignore_fieldsets, ['attribs', 'basic', 'category', 'author', 'date', 'other']);

--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -47,6 +47,12 @@ if (!$assoc)
 	$this->ignore_fieldsets[] = 'frontendassociations';
 }
 
+if (!$params->get('show_article_options', 1))
+{
+	// Ignore fieldsets inside Options tab
+	$this->ignore_fieldsets = array_merge($this->ignore_fieldsets, ['attribs', 'basic', 'category', 'author', 'date', 'other']);
+}
+
 // In case of modal
 $isModal = $input->get('layout') === 'modal';
 $layout  = $isModal ? 'modal' : 'edit';
@@ -104,9 +110,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 			<?php echo HTMLHelper::_('uitab.endTab'); ?>
 		<?php endif; ?>
 
-		<?php if ($params->get('show_article_options', 1) == 1) : ?>
-			<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
-		<?php endif; ?>
+		<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
 
 		<?php // Do not show the publishing options if the edit form is configured not to. ?>
 		<?php if ($params->get('show_publishing_options', 1) == 1) : ?>


### PR DESCRIPTION
Pull Request for Issue #36121.

### Summary of Changes
This simple PR fixes issue https://github.com/joomla/joomla-cms/issues/36121.

### Testing Instructions
1. Follow instructions at https://github.com/joomla/joomla-cms/issues/36121 , confirm the issue
2. Apply patch, confirm the issue fixed and nothing else is broken.

### Actual result BEFORE applying this Pull Request
Not possible to enter data for custom fields on article edit screen when **Article Options** set to **Hide**

### Expected result AFTER applying this Pull Request
It is still possible to enter data for custom fields on article edit screen when **Article Options** set to **Hide**

### Documentation Changes Required
None.
