### PR TITLE
[4.0] Bootstrap has double imports for alerts and modals

### DIFF
--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -14,7 +14,7 @@ const tasks = [];
 const inputFolder = 'build/media_source/vendor/bootstrap/js';
 const outputFolder = 'media/vendor/bootstrap/js';
 
-const bsVersionA = require(`${process.cwd()}/package.json`);
+const bsVersionA = require(process.cwd() + '/package.json');
 const bsVersion = bsVersionA.dependencies.bootstrap.replace(/^\^/, '');
 
 const createMinified = async (file) => {

--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -14,8 +14,7 @@ const tasks = [];
 const inputFolder = 'build/media_source/vendor/bootstrap/js';
 const outputFolder = 'media/vendor/bootstrap/js';
 
-const bsVersionA = require(process.cwd() + '/package.json');
-const bsVersion = bsVersionA.dependencies.bootstrap.replace(/^\^/, '');
+const bsVersion = require(`${process.cwd()}/package.json`).dependencies.bootstrap.replace(/^\^|~/, '');
 
 const createMinified = async (file) => {
   const initial = await readFile(resolve(outputFolder, file), { encoding: 'utf8' });

--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -14,6 +14,7 @@ const tasks = [];
 const inputFolder = 'build/media_source/vendor/bootstrap/js';
 const outputFolder = 'media/vendor/bootstrap/js';
 
+// eslint-disable-next-line import/no-dynamic-require
 const bsVersion = require(`${process.cwd()}/package.json`).dependencies.bootstrap.replace(/^\^|~/, '');
 
 const createMinified = async (file) => {

--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -28,7 +28,7 @@ const build = async () => {
 
   const domImports = await readdir(resolve('node_modules/bootstrap', 'js/src/dom'));
   const utilImports = await readdir(resolve('node_modules/bootstrap', 'js/src/util'));
- 
+
   const bundle = await rollup.rollup({
     input: resolve(inputFolder, 'index.es6.js'),
     plugins: [

--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -9,17 +9,14 @@ const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const replace = require('@rollup/plugin-replace');
 const { babel } = require('@rollup/plugin-babel');
 const commonjs = require('@rollup/plugin-commonjs');
-
+const bsVersion = require('../../../package.json').dependencies.bootstrap.replace(/^\^|~/, '');
 const tasks = [];
 const inputFolder = 'build/media_source/vendor/bootstrap/js';
 const outputFolder = 'media/vendor/bootstrap/js';
 
-// eslint-disable-next-line import/no-dynamic-require
-const bsVersion = require(`${process.cwd()}/package.json`).dependencies.bootstrap.replace(/^\^|~/, '');
-
 const createMinified = async (file) => {
   const initial = await readFile(resolve(outputFolder, file), { encoding: 'utf8' });
-  const mini = await minify(initial.replace('./popper.js', `./popper.min.js?${bsVersion}`).replace('./dom.js', `./dom.min.js?${bsVersion}`).replace('./alert.js', `./alert.min.js?${bsVersion}`).replace('./modal.js', `./modal.min.js?${bsVersion}`), { sourceMap: false, format: { comments: false } });
+  const mini = await minify(initial.replace('./popper.js', `./popper.min.js?${bsVersion}`).replace('./dom.js', `./dom.min.js?${bsVersion}`), { sourceMap: false, format: { comments: false } });
   await writeFile(resolve(outputFolder, file), initial.replace('./popper.js', `./popper.js?${bsVersion}`).replace('./dom.js', `./dom.js?${bsVersion}`), { encoding: 'utf8', mode: 0o644 });
   await writeFile(resolve(outputFolder, file.replace('.js', '.min.js')), mini.code, { encoding: 'utf8', mode: 0o644 });
 };
@@ -28,6 +25,9 @@ const build = async () => {
   // eslint-disable-next-line no-console
   console.log('Building ES6 Components...');
 
+  const domImports = await readdir(resolve('node_modules/bootstrap', 'js/src/dom'));
+  const utilImports = await readdir(resolve('node_modules/bootstrap', 'js/src/util'));
+  
   const bundle = await rollup.rollup({
     input: resolve(inputFolder, 'index.es6.js'),
     plugins: [
@@ -58,11 +58,9 @@ const build = async () => {
     ],
     external: [
       './base-component.js',
-      './dom/data.js',
-      './event-handler.js',
-      './dom/manipulator.js',
-      './selector-engine.js',
-      './util/index.js',
+      ...domImports.map((file) => `./dom/${file}`),
+      ...domImports.map((file) => `./${file}`),
+      ...utilImports.map((file) => `./util/${file}`),
     ],
     manualChunks: {
       alert: ['build/media_source/vendor/bootstrap/js/alert.es6.js'],
@@ -79,11 +77,8 @@ const build = async () => {
       popper: ['@popperjs/core'],
       dom: [
         'node_modules/bootstrap/js/src/base-component.js',
-        'node_modules/bootstrap/js/src/dom/data.js',
-        'node_modules/bootstrap/js/src/dom/event-handler.js',
-        'node_modules/bootstrap/js/src/dom/manipulator.js',
-        'node_modules/bootstrap/js/src/dom/selector-engine.js',
-        'node_modules/bootstrap/js/src/util/index.js',
+        ...domImports.map((file) => `node_modules/bootstrap/js/src/dom/${file}`),
+        ...utilImports.map((file) => `node_modules/bootstrap/js/src/util/${file}`),
       ],
     },
   });

--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -14,12 +14,13 @@ const tasks = [];
 const inputFolder = 'build/media_source/vendor/bootstrap/js';
 const outputFolder = 'media/vendor/bootstrap/js';
 
-const getCurrentUnixTime = Math.round((new Date()).getTime() / 1000);
+const bsVersionA = require(`${process.cwd()}/package.json`);
+const bsVersion = bsVersionA.dependencies.bootstrap.replace(/^\^/, '');
 
 const createMinified = async (file) => {
   const initial = await readFile(resolve(outputFolder, file), { encoding: 'utf8' });
-  const mini = await minify(initial.replace('./popper.js', `./popper.min.js?${getCurrentUnixTime}`).replace('./dom.js', `./dom.min.js?${getCurrentUnixTime}`), { sourceMap: false, format: { comments: false } });
-  await writeFile(resolve(outputFolder, file), initial.replace('./popper.js', `./popper.js?${getCurrentUnixTime}`).replace('./dom.js', `./dom.js?${getCurrentUnixTime}`), { encoding: 'utf8', mode: 0o644 });
+  const mini = await minify(initial.replace('./popper.js', `./popper.min.js?${bsVersion}`).replace('./dom.js', `./dom.min.js?${bsVersion}`).replace('./alert.js', `./alert.min.js?${bsVersion}`).replace('./modal.js', `./modal.min.js?${bsVersion}`), { sourceMap: false, format: { comments: false } });
+  await writeFile(resolve(outputFolder, file), initial.replace('./popper.js', `./popper.js?${bsVersion}`).replace('./dom.js', `./dom.js?${bsVersion}`), { encoding: 'utf8', mode: 0o644 });
   await writeFile(resolve(outputFolder, file.replace('.js', '.min.js')), mini.code, { encoding: 'utf8', mode: 0o644 });
 };
 

--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -10,6 +10,7 @@ const replace = require('@rollup/plugin-replace');
 const { babel } = require('@rollup/plugin-babel');
 const commonjs = require('@rollup/plugin-commonjs');
 const bsVersion = require('../../../package.json').dependencies.bootstrap.replace(/^\^|~/, '');
+
 const tasks = [];
 const inputFolder = 'build/media_source/vendor/bootstrap/js';
 const outputFolder = 'media/vendor/bootstrap/js';
@@ -27,7 +28,7 @@ const build = async () => {
 
   const domImports = await readdir(resolve('node_modules/bootstrap', 'js/src/dom'));
   const utilImports = await readdir(resolve('node_modules/bootstrap', 'js/src/util'));
-  
+ 
   const bundle = await rollup.rollup({
     input: resolve(inputFolder, 'index.es6.js'),
     plugins: [


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Recent changes in BS have some sharing code from `Alert` and `Modal` for other components. Since Joomla is not distributing a monolith for the JS the build script had to be informed.

EDIT: What happen: The Alert and Modal are now using common code for the close button that lives in the `js/src/util/...` https://github.com/twbs/bootstrap/blob/main/js/src/util/component-functions.js
as it can be clearly seen in https://github.com/twbs/bootstrap/blob/d8999dd5666336dcf6976cc65bc0d562a4baec5a/js/src/alert.js#L11 and https://github.com/twbs/bootstrap/blob/d8999dd5666336dcf6976cc65bc0d562a4baec5a/js/src/modal.js#L23 
To prevent such changes breaking the builds, the build script will automatically add any files in the `src/js/dom` and `src/js/util` to the external scripts and create a chunk with all of them `./dom.js`. This should be future proof as it doesn't have any of these imports hardcoded...


### Testing Instructions
- A broken example that you can test is https://github.com/joomla/joomla-cms/issues/36169
- But also a simple check before and after on the network waterfall is enough:
- - Before, double entries for alert+modal

![Screenshot 2021-12-01 at 17 58 51](https://user-images.githubusercontent.com/3889375/144278826-bc6d630f-68e5-4877-aa05-2728a52c3a13.png)

-  - After, no double entries

![Screenshot 2021-12-01 at 17 57 01](https://user-images.githubusercontent.com/3889375/144278718-967b8274-1bb4-47c2-b769-dc30a4595097.png)


### Actual result BEFORE applying this Pull Request


![Screenshot 2021-12-01 at 17 58 51](https://user-images.githubusercontent.com/3889375/144278826-bc6d630f-68e5-4877-aa05-2728a52c3a13.png)

### Expected result AFTER applying this Pull Request



### Documentation Changes Required

@wilsonge this is a release blocker