### PR TITLE
[4.1] Prevent deleting a parent template if children exist

### DIFF
--- a/administrator/language/en-GB/lib_joomla.ini
+++ b/administrator/language/en-GB/lib_joomla.ini
@@ -630,6 +630,7 @@ JLIB_INSTALLER_ERROR_TPL_REFRESH_MANIFEST_CACHE="Template Refresh manifest cache
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_ERRORUNKOWNEXTENSION="Template Uninstall: Unknown Extension."
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_INVALID_CLIENT="Template Uninstall: Invalid client."
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_INVALID_NOTFOUND_MANIFEST="Template Uninstall: Manifest file invalid or not found."
+JLIB_INSTALLER_ERROR_TPL_UNINSTALL_PARENT_TEMPLATE="Template Uninstall: Can't remove parent template. Please remove all children templates first."
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_TEMPLATE_DEFAULT="Template Uninstall: Can't remove default template."
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_TEMPLATE_DIRECTORY="Template Uninstall: Folder does not exist, can't remove files."
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_TEMPLATE_ID_EMPTY="Template Uninstall: Template ID is empty, can't uninstall files."

--- a/language/en-GB/lib_joomla.ini
+++ b/language/en-GB/lib_joomla.ini
@@ -629,6 +629,7 @@ JLIB_INSTALLER_ERROR_TPL_REFRESH_MANIFEST_CACHE="Template Refresh manifest cache
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_ERRORUNKOWNEXTENSION="Template Uninstall: Unknown Extension."
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_INVALID_CLIENT="Template Uninstall: Invalid client."
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_INVALID_NOTFOUND_MANIFEST="Template Uninstall: Manifest file invalid or not found."
+JLIB_INSTALLER_ERROR_TPL_UNINSTALL_PARENT_TEMPLATE="Template Uninstall: Can't remove parent template. Please remove all children templates first."
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_TEMPLATE_DEFAULT="Template Uninstall: Can't remove default template."
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_TEMPLATE_DIRECTORY="Template Uninstall: Folder does not exist, can't remove files."
 JLIB_INSTALLER_ERROR_TPL_UNINSTALL_TEMPLATE_ID_EMPTY="Template Uninstall: Template ID is empty, can't uninstall files."

--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -464,6 +464,7 @@ class TemplateAdapter extends InstallerAdapter
 	{
 		$this->parent->extension = $this->extension;
 
+		$db       = $this->parent->getDbo();
 		$name     = $this->extension->element;
 		$clientId = $this->extension->client_id;
 
@@ -473,8 +474,26 @@ class TemplateAdapter extends InstallerAdapter
 			throw new \RuntimeException(Text::_('JLIB_INSTALLER_ERROR_TPL_UNINSTALL_TEMPLATE_ID_EMPTY'));
 		}
 
+		// Deny removing a parent template if there are children
+		$query = $db->getQuery(true)
+			->select('COUNT(*)')
+			->from($db->quoteName('#__template_styles'))
+			->where(
+				[
+					$db->quoteName('parent') . ' = :template',
+					$db->quoteName('client_id') . ' = :client_id',
+				]
+			)
+			->bind(':template', $name)
+			->bind(':client_id', $clientId);
+		$db->setQuery($query);
+
+		if ($db->loadResult() != 0)
+		{
+			throw new \RuntimeException(Text::_('JLIB_INSTALLER_ERROR_TPL_UNINSTALL_PARENT_TEMPLATE'));
+		}
+
 		// Deny remove default template
-		$db = $this->parent->getDbo();
 		$query = $db->getQuery(true)
 			->select('COUNT(*)')
 			->from($db->quoteName('#__template_styles'))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
To prevent possible disaster (deleting a parent template but child still around and default) a simple check was added in the installer


### Testing Instructions

- Install  https://github.com/joomla/joomla-cms/files/7235154/cassy_1.0.0.zip
- Create a child template
- try to uninstall Cassy


### Actual result BEFORE applying this Pull Request

The parent template will be removed

### Expected result AFTER applying this Pull Request

Error message and parent template wasn't removed

<img width="966" alt="Screenshot 2021-12-03 at 21 58 28" src="https://user-images.githubusercontent.com/3889375/144672517-d0ea16e5-4d19-49f0-bafc-497a31d1279d.png">


### Documentation Changes Required

