### PR TITLE
[4.1] Prevent disabling a parent template when children exist

### DIFF
--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -145,7 +145,7 @@ class ManageModel extends InstallerModel
 				}
 
 				// Parent template cannot be disabled if there are children
-				if ($style->load(array('parent' => $table->element, 'client_id' => $table->client_id)))
+				if ($style->load(['parent' => $table->element, 'client_id' => $table->client_id]))
 				{
 					Factory::getApplication()->enqueueMessage(Text::_('COM_INSTALLER_ERROR_DISABLE_PARENT_TEMPLATE_NOT_PERMITTED'), 'notice');
 					unset($eid[$i]);

--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -143,6 +143,14 @@ class ManageModel extends InstallerModel
 					unset($eid[$i]);
 					continue;
 				}
+
+				// Parent template cannot be disabled if there are children
+				if ($style->load(array('parent' => $table->element, 'client_id' => $table->client_id)))
+				{
+					Factory::getApplication()->enqueueMessage(Text::_('COM_INSTALLER_ERROR_DISABLE_DEFAULT_TEMPLATE_NOT_PERMITTED'), 'notice');
+					unset($eid[$i]);
+					continue;
+				}
 			}
 
 			if ($table->protected == 1)

--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -147,7 +147,7 @@ class ManageModel extends InstallerModel
 				// Parent template cannot be disabled if there are children
 				if ($style->load(array('parent' => $table->element, 'client_id' => $table->client_id)))
 				{
-					Factory::getApplication()->enqueueMessage(Text::_('COM_INSTALLER_ERROR_DISABLE_DEFAULT_TEMPLATE_NOT_PERMITTED'), 'notice');
+					Factory::getApplication()->enqueueMessage(Text::_('COM_INSTALLER_ERROR_DISABLE_PARENT_TEMPLATE_NOT_PERMITTED'), 'notice');
 					unset($eid[$i]);
 					continue;
 				}

--- a/administrator/language/en-GB/com_installer.ini
+++ b/administrator/language/en-GB/com_installer.ini
@@ -31,6 +31,7 @@ COM_INSTALLER_EMPTYSTATE_CONTENT="You currently have no pending updates to apply
 COM_INSTALLER_EMPTYSTATE_DISCOVER_BUTTON_ADD="Discover extensions to install"
 COM_INSTALLER_EMPTYSTATE_DISCOVER_TITLE="You have no discovered extensions to install."
 COM_INSTALLER_ERROR_DISABLE_DEFAULT_TEMPLATE_NOT_PERMITTED="Disable default template is not permitted."
+COM_INSTALLER_ERROR_DISABLE_PARENT_TEMPLATE_NOT_PERMITTED="Disable parent template is not permitted."
 COM_INSTALLER_ERROR_METHOD="Method Not Implemented"
 COM_INSTALLER_ERROR_NO_EXTENSIONS_DISCOVERED="No extensions discovered."
 COM_INSTALLER_ERROR_NO_EXTENSIONS_SELECTED="No extensions selected."


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

To prevent a possible disaster (disabling a parent template but child still around and default) a simple check was added in the installer component. (FWIW if a parent is disabled the child template is fully functional for the Cassiopeia but if a template also disables some plugins, etc then it might break)

### Testing Instructions

- Install https://github.com/joomla/joomla-cms/files/7235154/cassy_1.0.0.zip
- Create a child template
- try to disable Cassy
- uninstall the child then try to disable Cassy

### Actual result BEFORE applying this Pull Request

A parent template could be disabled although there might be children


### Expected result AFTER applying this Pull Request

Disabling is not possible if children exist

### Documentation Changes Required

