### PR TITLE
Fix Progressive caching to cache modules per custom menu assignment

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -563,7 +563,7 @@ class HtmlDocument extends Document
 			/** @var  \Joomla\CMS\Cache\Controller\OutputController  $cache */
 			$cache = CmsFactory::getContainer()->get(CacheControllerFactoryInterface::class)
 				->createCacheController('output', ['defaultgroup' => 'com_modules']);
-			$itemId = (int) CmsFactory::getApplication()->input->get('Itemid');
+			$itemId = (int) CmsFactory::getApplication()->input->get('Itemid', 0, 'int');
 
 			$hash = md5(
 				serialize(

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -569,7 +569,7 @@ class HtmlDocument extends Document
 						$name,
 						$attribs,
 						null,
-						get_class($renderer),
+						\get_class($renderer),
 						CmsFactory::getApplication()->input->get('Itemid'),
 					]
 				)

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -568,7 +568,6 @@ class HtmlDocument extends Document
 					[
 						$name,
 						$attribs,
-						null,
 						\get_class($renderer),
 						CmsFactory::getApplication()->input->get('Itemid'),
 					]

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -571,7 +571,7 @@ class HtmlDocument extends Document
 						$name,
 						$attribs,
 						\get_class($renderer),
-						CmsFactory::getApplication()->input->get('Itemid'),
+						$itemId,
 					]
 				)
 			);

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -563,6 +563,8 @@ class HtmlDocument extends Document
 			/** @var  \Joomla\CMS\Cache\Controller\OutputController  $cache */
 			$cache = CmsFactory::getContainer()->get(CacheControllerFactoryInterface::class)
 				->createCacheController('output', ['defaultgroup' => 'com_modules']);
+			$itemId = (int) CmsFactory::getApplication()->input->get('Itemid');
+
 			$hash = md5(
 				serialize(
 					[

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -563,13 +563,17 @@ class HtmlDocument extends Document
 			/** @var  \Joomla\CMS\Cache\Controller\OutputController  $cache */
 			$cache = CmsFactory::getContainer()->get(CacheControllerFactoryInterface::class)
 				->createCacheController('output', ['defaultgroup' => 'com_modules']);
-			$hash = md5(serialize(array(
-				$name,
-				$attribs,
-				null,
-				get_class($renderer),
-				CmsFactory::getApplication()->input->get('Itemid'),
-			)));
+			$hash = md5(
+				serialize(
+					[
+						$name,
+						$attribs,
+						null,
+						get_class($renderer),
+						CmsFactory::getApplication()->input->get('Itemid'),
+					]
+				)
+			);
 			$cbuffer = $cache->get('cbuffer_' . $type);
 
 			if (isset($cbuffer[$hash]))

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Document;
 \defined('JPATH_PLATFORM') or die;
 
 use Joomla\CMS\Cache\Cache;
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Factory as CmsFactory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Helper\ModuleHelper;
@@ -559,8 +560,16 @@ class HtmlDocument extends Document
 		if ($this->_caching == true && $type === 'modules' && $name !== 'debug')
 		{
 			/** @var  \Joomla\CMS\Document\Renderer\Html\ModulesRenderer  $renderer */
-			$cache = CmsFactory::getCache('com_modules', '');
-			$hash = md5(serialize(array($name, $attribs, null, get_class($renderer))));
+			/** @var  \Joomla\CMS\Cache\Controller\OutputController  $cache */
+			$cache = CmsFactory::getContainer()->get(CacheControllerFactoryInterface::class)
+				->createCacheController('output', ['defaultgroup' => 'com_modules']);
+			$hash = md5(serialize(array(
+				$name,
+				$attribs,
+				null,
+				get_class($renderer),
+				CmsFactory::getApplication()->input->get('Itemid'),
+			)));
 			$cbuffer = $cache->get('cbuffer_' . $type);
 
 			if (isset($cbuffer[$hash]))


### PR DESCRIPTION
Pull Request for Issue #36102 .

### Summary of Changes

Progressive caching caches the modules per position, however this breaks custom menu assignment for module.
I have add `Itemid` to cache key for Progressive caching, so it works correctly now.

The same issue is for Joomla 3, can be back-ported if this PR is okay.

### Testing Instructions
Apply patch.
Create a custom module, and assign to one specific menu.
Enable Progressive caching, and visit that menu, then visit other pages.


### Actual result BEFORE applying this Pull Request
The module visible on all pages.


### Expected result AFTER applying this Pull Request
The module visible only on selected page.


### Documentation Changes Required
None.
