### PR TITLE
[4.1] Fix deleted files in script.php for 4.1 Beta 1

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -5948,7 +5948,6 @@ class JoomlaInstallerScript
 			'/administrator/components/com_fields/tmpl/field/modal.php',
 			'/administrator/templates/atum/scss/pages/_com_admin.scss',
 			'/administrator/templates/atum/scss/pages/_com_finder.scss',
-			'/administrator/templates/atum/scss/pages/_com_joomlaupdate.scss',
 			'/libraries/src/Error/JsonApi/InstallLanguageExceptionHandler.php',
 			'/libraries/src/MVC/Controller/Exception/InstallLanguage.php',
 			'/media/com_fields/js/admin-field-edit-modal-es5.js',
@@ -6109,7 +6108,9 @@ class JoomlaInstallerScript
 			'/media/com_joomlaupdate/js/update.min.js.gz',
 			'/templates/cassiopeia/images/system/sort_asc.png',
 			'/templates/cassiopeia/images/system/sort_desc.png',
-			// From 4.0.4 to 4.1.0
+			// From 4.0.4 to 4.0.5
+			'/media/vendor/codemirror/lib/#codemirror.js#',
+			// From 4.0.5 to 4.1.0
 			'/administrator/templates/atum/css/system/searchtools/searchtools.css',
 			'/administrator/templates/atum/css/system/searchtools/searchtools.min.css',
 			'/administrator/templates/atum/css/system/searchtools/searchtools.min.css.gz',
@@ -6324,8 +6325,6 @@ class JoomlaInstallerScript
 			'/templates/system/scss/general.scss',
 			'/templates/system/scss/offline.scss',
 			'/templates/system/scss/offline_rtl.scss',
-			// From 4.0.4 to 4.0.5
-			'/media/vendor/codemirror/lib/#codemirror.js#',
 		);
 
 		$folders = array(
@@ -7585,7 +7584,7 @@ class JoomlaInstallerScript
 			'/libraries/vendor/algo26-matthias/idna-convert/tests',
 			// From 4.0.3 to 4.0.4
 			'/templates/cassiopeia/images/system',
-			// From 4.0.4 to 4.1.0
+			// From 4.0.5 to 4.1.0
 			'/templates/system/scss',
 			'/templates/system/css',
 			'/templates/cassiopeia/scss/vendor/metismenu',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) adapts the lists of files and folders to be deleted on update in file "administrator/components/com_admin/script.php" for 4.1.

In detail it changes following on the list of files:

- Remove file "administrator/templates/atum/scss/pages/_com_joomlaupdate.scss" from the list in line 5951 as it appears later again in the list here: https://github.com/richard67/joomla-cms/blob/b9185a9eff0bbea116706ffd32d1ff6c1b4902aa/administrator/components/com_admin/script.php#L6172
This is due to the file having been removed and later added back again in the 4.0-dev branch and now in the 4.1-dev branch it is removed again due to the child template changes.
For details see the description of the recently merged PR #36161 .
- Move section "// From 4.0.4 to 4.0.5" with file "media/vendor/codemirror/lib/#codemirror.js#" to the right place before section for 4.1.
- Change comment of section for 4.1 from "// From 4.0.4 to 4.1.0" to "// From 4.0.5 to 4.1.0".

For the list of folders only the comment of section for 4.1 is changed from "// From 4.0.4 to 4.1.0" to "// From 4.0.5 to 4.1.0".

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

- File "administrator/templates/atum/scss/pages/_com_joomlaupdate.scss" is 2 times in the list, here https://github.com/joomla/joomla-cms/blob/4.1-dev/administrator/components/com_admin/script.php#L5951 and here https://github.com/joomla/joomla-cms/blob/4.1-dev/administrator/components/com_admin/script.php#L6171 .
- Order of sections and section comments are not right. 

### Expected result AFTER applying this Pull Request

- File "administrator/templates/atum/scss/pages/_com_joomlaupdate.scss" is 1 time in the list.
- Order of sections and section comments are right. 

### Documentation Changes Required

None.