### PR TITLE
[4.1] Fix missing class import

### DIFF
--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
+use Joomla\Event\DispatcherInterface;
 use Joomla\Event\EventInterface;
 
 /**


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/pull/35899 added new code that was missing a class import. 

Code review @laoneo 
<img width="1083" alt="Screenshot 2021-12-04 at 18 45 20" src="https://user-images.githubusercontent.com/400092/144721029-c3569b79-9c70-445e-9b36-860b37a4c09a.png">

