### PR TITLE
[4.1] Task manager sort

### DIFF
--- a/administrator/components/com_scheduler/forms/filter_tasks.xml
+++ b/administrator/components/com_scheduler/forms/filter_tasks.xml
@@ -50,16 +50,16 @@
 			validate="options"
 			>
 			<option value="">JGLOBAL_SORT_BY</option>
-			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
-			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
-			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
-			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
-			<option value="j.type_title ASC">COM_SCHEDULER_TASK_TYPE_ASC</option>
-			<option value="j.type_title DESC">COM_SCHEDULER_TASK_TYPE_DESC</option>
 			<option value="a.state ASC">JSTATUS_ASC</option>
 			<option value="a.state DESC">JSTATUS_DESC</option>
 			<option value="a.ordering ASC">JGRID_HEADING_ORDERING_ASC</option>
 			<option value="a.ordering DESC">JGRID_HEADING_ORDERING_DESC</option>
+			<option value="a.title ASC">JGLOBAL_TITLE_ASC</option>
+			<option value="a.title DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="j.type_title ASC">COM_SCHEDULER_TASK_TYPE_ASC</option>
+			<option value="j.type_title DESC">COM_SCHEDULER_TASK_TYPE_DESC</option>
+			<option value="a.id ASC">JGRID_HEADING_ID_ASC</option>
+			<option value="a.id DESC">JGRID_HEADING_ID_DESC</option>
 			<option value="a.priority ASC">COM_SCHEDULER_TASK_PRIORITY_ASC</option>
 			<option value="a.priority DESC">COM_SCHEDULER_TASK_PRIORITY_DESC</option>
 		</field>


### PR DESCRIPTION
All other sort dropdowns are given the same order as the columns. This PR addresses that.

## After
![image](https://user-images.githubusercontent.com/1296369/144744698-a75ce784-6930-46c8-96f0-7d2c9f46a3ab.png)
