### PR TITLE
[4.0][bugfix] Fix Figure misbehaviour in tinyMCE

### DIFF
--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -160,7 +160,7 @@ const insertAsImage = async (media, editor, fieldClass) => {
         }
         alt = attribs.getAttribute('alt-value') ? ` alt="${attribs.getAttribute('alt-value')}"` : appendAlt;
         classes = attribs.getAttribute('img-classes') ? ` class="${attribs.getAttribute('img-classes')}"` : '';
-        figClasses = attribs.getAttribute('fig-classes') ? ` class="image ${attribs.getAttribute('fig-classes')}"` : 'class="image"';
+        figClasses = attribs.getAttribute('fig-classes') ? ` class="image ${attribs.getAttribute('fig-classes')}"` : ' class="image"';
         figCaption = attribs.getAttribute('fig-caption') ? `${attribs.getAttribute('fig-caption')}` : '';
         if (attribs.getAttribute('is-lazy') === 'true') {
           isLazy = ` loading="lazy" width="${Joomla.selectedMediaFile.width}" height="${Joomla.selectedMediaFile.height}"`;

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -160,7 +160,7 @@ const insertAsImage = async (media, editor, fieldClass) => {
         }
         alt = attribs.getAttribute('alt-value') ? ` alt="${attribs.getAttribute('alt-value')}"` : appendAlt;
         classes = attribs.getAttribute('img-classes') ? ` class="${attribs.getAttribute('img-classes')}"` : '';
-        figClasses = attribs.getAttribute('fig-classes') ? ` class="${attribs.getAttribute('fig-classes')}"` : '';
+        figClasses = attribs.getAttribute('fig-classes') ? ` class="image ${attribs.getAttribute('fig-classes')}"` : 'class="image"';
         figCaption = attribs.getAttribute('fig-caption') ? `${attribs.getAttribute('fig-caption')}` : '';
         if (attribs.getAttribute('is-lazy') === 'true') {
           isLazy = ` loading="lazy" width="${Joomla.selectedMediaFile.width}" height="${Joomla.selectedMediaFile.height}"`;


### PR DESCRIPTION
Pull Request for Issue, sorry couldn't found the one...

### Summary of Changes
- Adds a class `image` to the `figure` element as tinyMCE expects that to enable the editing of the `figcaption` text


### Testing Instructions
This Pr needs NPM
- Fetch and run npm install
- Try to select an image using the Joomla dropdown icon and then selecting media
- Add some figure class and some text for the figure caption
- You should have a boxed area around the image and clicking in the caption text you should be able to edit it

![Screenshot 2021-12-05 at 18 56 31](https://user-images.githubusercontent.com/3889375/144757817-8abb74a9-478b-43fc-ba36-d80090cb5da4.png)

![Screenshot 2021-12-05 at 18 56 48](https://user-images.githubusercontent.com/3889375/144757829-d0169983-30b8-4571-afd4-afeabbe6ac3d.png)


### Actual result BEFORE applying this Pull Request

Editing a figure element is kinda broken

### Expected result AFTER applying this Pull Request

Editing a figure element is easier

### Documentation Changes Required

No

@brianteeman @N6REJ 