### PR TITLE
[4.0] Add unit and integration tests for 8.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -58,6 +58,14 @@ steps:
       - php -v
       - ./libraries/vendor/bin/phpunit --testsuite Unit
 
+  - name: php81-unit
+    depends_on: [ phpcs ]
+    image: joomlaprojects/docker-images:php8.1
+    failure: ignore
+    commands:
+      - php -v
+      - ./libraries/vendor/bin/phpunit --testsuite Unit
+
   - name: php72-integration
     depends_on: [ npm ]
     image: joomlaprojects/docker-images:php7.2
@@ -87,6 +95,14 @@ steps:
       - php -v
       - ./libraries/vendor/bin/phpunit --testsuite Integration
 
+  - name: php81-integration
+    depends_on: [ npm ]
+    image: joomlaprojects/docker-images:php8.1
+    failure: ignore
+    commands:
+      - php -v
+      - ./libraries/vendor/bin/phpunit --testsuite Integration
+
   - name: php72-integration-pgsql
     depends_on: [ npm ]
     image: joomlaprojects/docker-images:php7.2
@@ -111,6 +127,14 @@ steps:
   - name: php80-integration-pgsql
     depends_on: [ npm ]
     image: joomlaprojects/docker-images:php8.0
+    failure: ignore
+    commands:
+      - php -v
+      - ./libraries/vendor/bin/phpunit --testsuite Integration --configuration phpunit-pgsql.xml.dist
+
+  - name: php81-integration-pgsql
+    depends_on: [ npm ]
+    image: joomlaprojects/docker-images:php8.1
     failure: ignore
     commands:
       - php -v


### PR DESCRIPTION
Pull Request for Issue #36187.

### Summary of Changes
Adds PHP 8.1 unit and integration tests to automated builds.

System tests need to be done first in the repo https://github.com/joomla-projects/docker-images/tree/systemtests before they can be added here. Perhaps @Hackwar can offer here some insights when the system tests do support PHP 8 as currently they are still running on PHP 7.2.