### PR TITLE
[4.0] Searchtools clear button

### DIFF
--- a/administrator/templates/atum/scss/system/searchtools/searchtools.scss
+++ b/administrator/templates/atum/scss/system/searchtools/searchtools.scss
@@ -28,7 +28,6 @@
 
     .js-stools-btn-clear {
       background-color: var(--template-bg-dark);
-      border: 0;
     }
   }
 


### PR DESCRIPTION
Don't know why but there was a border 0 on the clear button giving undesired results. Maybe as a result of markup changing.

### Before

![image](https://user-images.githubusercontent.com/1296369/144919886-9cc337ca-d0a7-40e9-a280-db228abf3438.png)

### After
![image](https://user-images.githubusercontent.com/1296369/144919930-2c7e72da-073c-41e9-9b91-fb143f5a456c.png)



### Testing Instructions
Dont forget to rebuild the css to test. `npm ci` or `npm run build:css`


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

