### PR TITLE
[4.1][bugfix] Assets should be loaded in the layout

### DIFF
--- a/components/com_config/src/View/Config/HtmlView.php
+++ b/components/com_config/src/View/Config/HtmlView.php
@@ -94,8 +94,6 @@ class HtmlView extends BaseHtmlView
 
 		$this->_prepareDocument();
 
-		Factory::getApplication()->getDocument()->getWebAssetManager()->useScript('inlinehelp');
-
 		parent::display($tpl);
 	}
 

--- a/components/com_config/tmpl/config/default.php
+++ b/components/com_config/tmpl/config/default.php
@@ -17,7 +17,8 @@ use Joomla\CMS\Router\Route;
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
 	->useScript('form.validate')
-	->useScript('com_config.config');
+	->useScript('com_config.config')
+	->useScript('inlinehelp');
 
 ?>
 <?php if ($this->params->get('show_page_heading')) : ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Moved a call for including some JS from the HTML file to the actual layout


### Testing Instructions

Test editing the system settings in the front end.
Ensure that inline help still works as expected


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

No, it's a bug as it forces a script that can only be disabled with a plugin (in the layout anyone can just add/remove whatever they want, not forced!!!)