### PR TITLE
[4.1] Add propper classes to search input

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_form.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_form.scss
@@ -127,11 +127,11 @@ td .form-control {
   display: block;
 }
 
-#filter_search-desc {
+.filter-search-bar__description {
   bottom: 100%;
 }
 
-.container-popup #filter_search-desc {
+.container-popup .filter-search-bar__description {
   top: 100%;
   bottom: auto;
 }

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_form.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_form.scss
@@ -106,7 +106,7 @@ td .form-control {
   display: block;
 }
 
-#filter_search-desc {
+.filter-search-bar__description {
   bottom: 100%;
 }
 
@@ -124,7 +124,7 @@ fieldset {
 .control-group {
   margin: $cassiopeia-grid-gutter 0;
 }
-.container-popup #filter_search-desc {
+.container-popup .filter-search-bar__description {
   top: 100%;
   bottom: auto;
 }

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -27,36 +27,37 @@ $filterButton = $data['options']->get('filterButton', true);
 $searchButton = $data['options']->get('searchButton', true);
 
 $filters = $data['view']->filterForm->getGroup('filter');
+
+if (empty($filters['filter_search']) || !$searchButton)
+{
+	return;
+}
 ?>
 
-<?php if (!empty($filters['filter_search'])) : ?>
-	<?php if ($searchButton) : ?>
-		<div class="btn-group">
-			<div class="input-group">
-				<?php echo $filters['filter_search']->input; ?>
-				<?php if ($filters['filter_search']->description) : ?>
-				<div role="tooltip" id="<?php echo ($filters['filter_search']->id ?: $filters['filter_search']->name) . '-desc'; ?>">
-					<?php echo htmlspecialchars(Text::_($filters['filter_search']->description), ENT_COMPAT, 'UTF-8'); ?>
-				</div>
-				<?php endif; ?>
-				<span class="visually-hidden">
-					<?php echo $filters['filter_search']->label; ?>
-				</span>
-				<button type="submit" class="btn btn-primary" aria-label="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>">
-					<span class="icon-search" aria-hidden="true"></span>
-				</button>
-			</div>
+<div class="filter-search-bar btn-group">
+	<div class="input-group">
+		<?php echo $filters['filter_search']->input; ?>
+		<?php if ($filters['filter_search']->description) : ?>
+		<div role="tooltip" id="<?php echo ($filters['filter_search']->id ?: $filters['filter_search']->name) . '-desc'; ?>" class="filter-search-bar__description">
+			<?php echo htmlspecialchars(Text::_($filters['filter_search']->description), ENT_COMPAT, 'UTF-8'); ?>
 		</div>
-		<div class="btn-group">
-			<?php if ($filterButton) : ?>
-				<button type="button" class="btn btn-primary js-stools-btn-filter">
-					<?php echo Text::_('JFILTER_OPTIONS'); ?>
-					<span class="icon-angle-down" aria-hidden="true"></span>
-				</button>
-			<?php endif; ?>
-			<button type="button" class="btn btn-primary js-stools-btn-clear">
-				<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>
-			</button>
-		</div>
+		<?php endif; ?>
+		<span class="filter-search-bar__label visually-hidden">
+			<?php echo $filters['filter_search']->label; ?>
+		</span>
+		<button type="submit" class="filter-search-bar__button btn btn-primary" aria-label="<?php echo Text::_('JSEARCH_FILTER_SUBMIT'); ?>">
+			<span class="filter-search-bar__button-icon icon-search" aria-hidden="true"></span>
+		</button>
+	</div>
+</div>
+<div class="filter-search-actions btn-group">
+	<?php if ($filterButton) : ?>
+		<button type="button" class="filter-search-actions__button btn btn-primary js-stools-btn-filter">
+			<?php echo Text::_('JFILTER_OPTIONS'); ?>
+			<span class="icon-angle-down" aria-hidden="true"></span>
+		</button>
 	<?php endif; ?>
-<?php endif;
+	<button type="button" class="filter-search-actions__button btn btn-primary js-stools-btn-clear">
+		<?php echo Text::_('JSEARCH_FILTER_CLEAR'); ?>
+	</button>
+</div>


### PR DESCRIPTION
Pull Request for Issue #36254.

### Summary of Changes
Adds proper classes to the search bar layout description element. Additionally it simplifies the code and adds some more classes in BEM style to the other elements.

History:
- #36215
- #36225
- #36254

### Testing Instructions
Go to any search toolbar in the backend and inspect the search field.

### Actual result BEFORE applying this Pull Request
Renders properly.

### Expected result AFTER applying this Pull Request
Renders properly but has new CSS classes.