### PR TITLE
[4.0] Banner Client tips

### DIFF
--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -123,20 +123,40 @@ $params     = $this->state->params ?? new CMSObject;
 										<?php echo $item->contact; ?>
 									</td>
 									<td class="text-center btns d-none d-md-table-cell itemnumber">
-										<a class="btn <?php echo ($item->count_published > 0) ? 'btn-success' : 'btn-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=1'); ?>">
-											<?php echo $item->count_published; ?></a>
+										<a class="btn <?php echo ($item->count_published > 0) ? 'btn-success' : 'btn-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=1'); ?>"
+										aria-describedby="tip-publish<?php echo $i; ?>">
+											<?php echo $item->count_published; ?>
+										</a>
+										<div role="tooltip" id="tip-publish<?php echo $i; ?>">
+											<?php echo Text::_('COM_BANNERS_COUNT_PUBLISHED_ITEMS'); ?>
+										</div>
 									</td>
 									<td class="text-center btns d-none d-md-table-cell itemnumber">
-										<a class="btn <?php echo ($item->count_unpublished > 0) ? 'btn-danger' : 'btn-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=0'); ?>">
-											<?php echo $item->count_unpublished; ?></a>
+										<a class="btn <?php echo ($item->count_unpublished > 0) ? 'btn-danger' : 'btn-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=0'); ?>"
+										aria-describedby="tip-publish<?php echo $i; ?>">
+											<?php echo $item->count_unpublished; ?>
+										</a>
+										<div role="tooltip" id="tip-unpublish<?php echo $i; ?>">
+											<?php echo Text::_('COM_BANNERS_COUNT_UNPUBLISHED_ITEMS'); ?>
+										</div>
 									</td>
 									<td class="text-center btns d-none d-md-table-cell itemnumber">
-										<a class="btn <?php echo ($item->count_archived > 0) ? 'btn-info' : 'btn-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=2'); ?>">
-											<?php echo $item->count_archived; ?></a>
+										<a class="btn <?php echo ($item->count_archived > 0) ? 'btn-info' : 'btn-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=2'); ?>"
+										aria-describedby="tip-archived<?php echo $i; ?>">
+											<?php echo $item->count_archived; ?>
+										</a>
+										<div role="tooltip" id="tip-archived<?php echo $i; ?>">
+											<?php echo Text::_('COM_BANNERS_COUNT_ARCHIVED_ITEMS'); ?>
+										</div>
 									</td>
 									<td class="text-center btns d-none d-md-table-cell itemnumber">
-										<a class="btn <?php echo ($item->count_trashed > 0) ? 'btn-inverse' : 'btn-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=-2'); ?>">
-											<?php echo $item->count_trashed; ?></a>
+										<a class="btn <?php echo ($item->count_trashed > 0) ? 'btn-dark' : 'btn-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=-2'); ?>"
+										aria-describedby="tip-trashed<?php echo $i; ?>">
+											<?php echo $item->count_trashed; ?>
+										</a>
+										<div role="tooltip" id="tip-trashed<?php echo $i; ?>">
+											<?php echo Text::_('COM_BANNERS_COUNT_TRASHED_ITEMS'); ?>
+										</div>
 									</td>
 									<td class="small d-none d-md-table-cell">
 										<?php if ($item->purchase_type < 0) : ?>

--- a/administrator/components/com_banners/tmpl/clients/default.php
+++ b/administrator/components/com_banners/tmpl/clients/default.php
@@ -133,7 +133,7 @@ $params     = $this->state->params ?? new CMSObject;
 									</td>
 									<td class="text-center btns d-none d-md-table-cell itemnumber">
 										<a class="btn <?php echo ($item->count_unpublished > 0) ? 'btn-danger' : 'btn-secondary'; ?>" href="<?php echo Route::_('index.php?option=com_banners&view=banners&filter[client_id]=' . (int) $item->id . '&filter[published]=0'); ?>"
-										aria-describedby="tip-publish<?php echo $i; ?>">
+										aria-describedby="tip-unpublish<?php echo $i; ?>">
 											<?php echo $item->count_unpublished; ?>
 										</a>
 										<div role="tooltip" id="tip-unpublish<?php echo $i; ?>">


### PR DESCRIPTION
Adds a tooltip to the banner client numbers so that they appear the same as category numbers. Also corrects the class on the trashed number so that it has the correct colour

## To test
Create one banner client
Create a banner for the client in each of the published states

### Before
![image](https://user-images.githubusercontent.com/1296369/145197165-924d5a44-e6d9-45eb-b582-2884f1373cf5.png)

### After
![image](https://user-images.githubusercontent.com/1296369/145197085-2734cf61-db74-4687-b8c5-e8837335c064.png)
