### PR TITLE
[4.0] archive icon

### DIFF
--- a/administrator/templates/atum/scss/blocks/_icons.scss
+++ b/administrator/templates/atum/scss/blocks/_icons.scss
@@ -38,7 +38,6 @@
     border-color: $warning;
   }
 
-  .#{$jicon-css-prefix}-archive,
   .#{$jicon-css-prefix}-folder,
   .#{$fa-css-prefix}-folder {
     color: var(--template-text-dark);


### PR DESCRIPTION
All the state icons are grey so that the published icon, which is green, stands out visually.

The archived icon however was black. This PR changes that icon to grey.

### Before
![image](https://user-images.githubusercontent.com/1296369/145203185-2f3d9bcc-b797-4597-99c6-a5c609358710.png)

### After
![image](https://user-images.githubusercontent.com/1296369/145203177-86712608-10e0-4c62-89ca-66dc2b8019cb.png)


As this is an scss change you will need to run `npm ci` or `npm run build:css`