### PR TITLE
[4.0] Full Image class hint

### DIFF
--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -793,6 +793,7 @@
 				name="float_fulltext"
 				type="text"
 				label="COM_CONTENT_FIELD_IMAGE_CLASS_LABEL"
+				description="COM_CONTENT_FIELD_IMAGE_CLASS_DESC"
 				size="20"
 			/>
 

--- a/administrator/language/en-GB/com_content.ini
+++ b/administrator/language/en-GB/com_content.ini
@@ -64,6 +64,7 @@ COM_CONTENT_FIELD_IMAGE_ALT_EMPTY_DESC="Decorative Image - no description requir
 COM_CONTENT_FIELD_IMAGE_ALT_EMPTY_LABEL="No Description"
 COM_CONTENT_FIELD_IMAGE_ALT_LABEL="Image Description (Alt Text)"
 COM_CONTENT_FIELD_IMAGE_CAPTION_LABEL="Caption"
+COM_CONTENT_FIELD_IMAGE_CLASS_DESC="You can add any CSS class for your own styling ideas.<br>For image position use for example float-start and float-end."
 COM_CONTENT_FIELD_IMAGE_CLASS_LABEL="Image Class"
 COM_CONTENT_FIELD_IMAGE_OPTIONS="Image Options"
 COM_CONTENT_FIELD_INFOBLOCK_POSITION_LABEL="Position of Article Info"


### PR DESCRIPTION
Based on feedback and user requests this simple pr adds a hint for the type of class you can add in the image class for the full article image

cc @softforge

![image](https://user-images.githubusercontent.com/1296369/145229510-e69407a2-b26d-42b4-94b5-4888eb966e6e.png)
