### PR TITLE
[4] php 8.1 deprecation

### DIFF
--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -292,7 +292,7 @@ class Date extends \DateTime
 	 *
 	 * @since   1.7.0
 	 */
-	public function format($format, $local = false, $translate = true)
+	public function format($format, $local = false, $translate = true) :string
 	{
 		if ($translate)
 		{
@@ -409,7 +409,7 @@ class Date extends \DateTime
 	 * @since   1.7.0
 	 * @note    This method can't be type hinted due to a PHP bug: https://bugs.php.net/bug.php?id=61483
 	 */
-	public function setTimezone($tz)
+	public function setTimezone($tz) :Date
 	{
 		$this->tz = $tz;
 

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -292,7 +292,7 @@ class Date extends \DateTime
 	 *
 	 * @since   1.7.0
 	 */
-	public function format($format, $local = false, $translate = true) :string
+	public function format($format, $local = false, $translate = true): string
 	{
 		if ($translate)
 		{

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -409,7 +409,7 @@ class Date extends \DateTime
 	 * @since   1.7.0
 	 * @note    This method can't be type hinted due to a PHP bug: https://bugs.php.net/bug.php?id=61483
 	 */
-	public function setTimezone($tz) :Date
+	public function setTimezone($tz): Date
 	{
 		$this->tz = $tz;
 

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -292,7 +292,7 @@ class Date extends \DateTime
 	 *
 	 * @since   1.7.0
 	 */
-        #[\ReturnTypeWillChange]
+	#[\ReturnTypeWillChange]
 	public function format($format, $local = false, $translate = true)
 	{
 		if ($translate)

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -409,7 +409,8 @@ class Date extends \DateTime
 	 * @since   1.7.0
 	 * @note    This method can't be type hinted due to a PHP bug: https://bugs.php.net/bug.php?id=61483
 	 */
-	public function setTimezone($tz): Date
+	#[\ReturnTypeWillChange]
+	public function setTimezone($tz)
 	{
 		$this->tz = $tz;
 

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -292,7 +292,8 @@ class Date extends \DateTime
 	 *
 	 * @since   1.7.0
 	 */
-	public function format($format, $local = false, $translate = true): string
+        #[\ReturnTypeWillChange]
+	public function format($format, $local = false, $translate = true)
 	{
 		if ($translate)
 		{


### PR DESCRIPTION
Pull Request for Issue # .

- PHP Deprecated:  Declaration of Joomla\CMS\Date\Date::format($format, $local = false, $translate = true) should be compatible with DateTime::format(string $format): string in ../joomla-cms/libraries/src/Date/Date.php
- PHP Deprecated:  Declaration of Joomla\CMS\Date\Date::setTimezone($tz) should be compatible with DateTime::setTimezone(DateTimeZone $timezone): DateTime in ../joomla-cms/libraries/src/Date/Date.php  

## Summary of Changes
added annotation `#[\ReturnTypeWillChange]`




