### PR TITLE
[4] php 8.1 Deprecated: strpos(): Passing null to parameter

### DIFF
--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -197,6 +197,8 @@ JS
 	 */
 	private function _getCommand($url)
 	{
+		$url = $url ?? '';
+
 		if (strpos($url, 'http') !== 0)
 		{
 			$url = Uri::base() . $url;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
set a default value


### Testing Instructions
open admin 
edit an user click on close or save


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/181681/145580942-a229e164-48c0-4eb1-80d3-92db252a77f7.png)


### Expected result AFTER applying this Pull Request
No deprecarion on php 8.1

