### PR TITLE
[4] php 8.1 Deprecated: trim(): Passing null to parameter #1

### DIFF
--- a/administrator/components/com_mails/src/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/src/Model/TemplatesModel.php
@@ -129,7 +129,7 @@ class TemplatesModel extends ListModel
 			->where($db->quoteName('a.language') . ' = ' . $db->quote(''));
 
 		// Filter by search in title.
-		if ($search = trim($this->getState('filter.search')))
+		if ($search = trim($this->getState('filter.search', '')))
 		{
 			if (stripos($search, 'id:') === 0)
 			{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
set a default value


### Testing Instructions
admin 
go to Mail Templates


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/181681/145586815-a4afaa97-a840-4f1e-8471-71d39f051e9b.png)


### Expected result AFTER applying this Pull Request
No deprecations

