### PR TITLE
[4.0] PHP 8.1 deprecation notices Feed

### DIFF
--- a/libraries/src/Feed/Feed.php
+++ b/libraries/src/Feed/Feed.php
@@ -191,6 +191,7 @@ class Feed implements \ArrayAccess, \Countable
 	 *
 	 * @return  integer number of entries in the feed.
 	 */
+	#[\ReturnTypeWillChange]
 	public function count()
 	{
 		return \count($this->entries);
@@ -207,6 +208,7 @@ class Feed implements \ArrayAccess, \Countable
 	 * @see     ArrayAccess::offsetExists()
 	 * @since   3.1.4
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetExists($offset)
 	{
 		return isset($this->entries[$offset]);
@@ -222,6 +224,7 @@ class Feed implements \ArrayAccess, \Countable
 	 * @see     ArrayAccess::offsetGet()
 	 * @since   3.1.4
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetGet($offset)
 	{
 		return $this->entries[$offset];
@@ -239,6 +242,7 @@ class Feed implements \ArrayAccess, \Countable
 	 * @since   3.1.4
 	 * @throws  \InvalidArgumentException
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetSet($offset, $value)
 	{
 		if (!($value instanceof FeedEntry))
@@ -267,6 +271,7 @@ class Feed implements \ArrayAccess, \Countable
 	 * @see     ArrayAccess::offsetUnset()
 	 * @since   3.1.4
 	 */
+	#[\ReturnTypeWillChange]
 	public function offsetUnset($offset)
 	{
 		unset($this->entries[$offset]);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Silencing PHP 8.1 deprecation notices.
Not sure if this is the best approach at the moment, but at least there will be a searchable "label" for things that needs looking into later.

### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Deprecated: Return type of Joomla\CMS\Feed\Feed::count() should either be compatible with Countable::count(): int, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /********/src/libraries/src/Feed/Feed.php on line 194

Deprecated: Return type of Joomla\CMS\Feed\Feed::offsetExists($offset) should either be compatible with ArrayAccess::offsetExists(mixed $offset): bool, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /********/src/libraries/src/Feed/Feed.php on line 210

Deprecated: Return type of Joomla\CMS\Feed\Feed::offsetGet($offset) should either be compatible with ArrayAccess::offsetGet(mixed $offset): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /********/src/libraries/src/Feed/Feed.php on line 225

Deprecated: Return type of Joomla\CMS\Feed\Feed::offsetSet($offset, $value) should either be compatible with ArrayAccess::offsetSet(mixed $offset, mixed $value): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /********/src/libraries/src/Feed/Feed.php on line 242

Deprecated: Return type of Joomla\CMS\Feed\Feed::offsetUnset($offset) should either be compatible with ArrayAccess::offsetUnset(mixed $offset): void, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in /********/src/libraries/src/Feed/Feed.php on line 270

### Expected result AFTER applying this Pull Request
No PHP 8.1 deprecation notices from Feed


### Documentation Changes Required
Probably not
