### PR TITLE
PHP 8.1 deprecation fixes

### DIFF
--- a/build/phpcs/Joomla/ruleset.xml
+++ b/build/phpcs/Joomla/ruleset.xml
@@ -86,7 +86,11 @@
 
 	<!-- Include some additional sniffs from the PEAR standard -->
 	<rule ref="PEAR.Classes.ClassDeclaration" />
-	<rule ref="PEAR.Commenting.InlineComment" />
+	<rule ref="PEAR.Commenting.InlineComment">
+		<!-- Files with PHP8 attributes as a PHP Sniffer version doesn't support that (it does in J4) -->
+		<exclude-pattern type="relative">libraries/src/Session/Session.php</exclude-pattern>
+		<exclude-pattern type="relative">libraries/src/Date/Date.php</exclude-pattern>
+	</rule>
 	<rule ref="PEAR.Formatting.MultiLineAssignment" />
 	<rule ref="PEAR.Functions.ValidDefaultValue">
 		<!-- These exceptions are temporary for now -->
@@ -153,6 +157,9 @@
 	</rule>
 
 	<rule ref="Joomla.Commenting.FunctionComment">
+		<!-- Files with PHP8 attributes as a PHP Sniffer version doesn't support that (it does in J4) -->
+		<exclude-pattern type="relative">libraries/src/Session/Session.php</exclude-pattern>
+		<exclude-pattern type="relative">libraries/src/Date/Date.php</exclude-pattern>
 		<!-- We only want this for libraries, language and cli for now -->
 		<exclude-pattern type="relative">templates/*</exclude-pattern>
 		<exclude-pattern type="relative">layouts/*</exclude-pattern>
@@ -168,6 +175,9 @@
 	</rule>
 
 	<rule ref="Joomla.Commenting.SingleComment">
+		<!-- Files with PHP8 attributes as a PHP Sniffer version doesn't support that (it does in J4) -->
+		<exclude-pattern type="relative">libraries/src/Session/Session.php</exclude-pattern>
+		<exclude-pattern type="relative">libraries/src/Date/Date.php</exclude-pattern>
 		<!-- We don't want this in mixed html/php views for now -->
 		<exclude-pattern type="relative">*/tmpl/*</exclude-pattern>
 		<exclude-pattern type="relative">templates/*</exclude-pattern>

--- a/components/com_contact/views/contact/view.html.php
+++ b/components/com_contact/views/contact/view.html.php
@@ -340,7 +340,7 @@ class ContactViewContact extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($item->params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($item->params->get('pageclass_sfx', ''));
 
 		$this->contact     = &$item;
 		$this->params      = &$item->params;

--- a/components/com_contact/views/featured/view.html.php
+++ b/components/com_contact/views/featured/view.html.php
@@ -119,7 +119,7 @@ class ContactViewFeatured extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 		$maxLevel         = $params->get('maxLevel', -1);
 		$this->maxLevel   = &$maxLevel;

--- a/components/com_content/views/archive/view.html.php
+++ b/components/com_content/views/archive/view.html.php
@@ -132,7 +132,7 @@ class ContentViewArchive extends JViewLegacy
 		$form->limitField = $pagination->getLimitBox();
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''));
 
 		$this->filter     = $state->get('list.filter');
 		$this->form       = &$form;

--- a/components/com_content/views/article/view.html.php
+++ b/components/com_content/views/article/view.html.php
@@ -203,7 +203,7 @@ class ContentViewArticle extends JViewLegacy
 		$item->event->afterDisplayContent = trim(implode("\n", $results));
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->item->params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($this->item->params->get('pageclass_sfx', ''));
 
 		$this->_prepareDocument();
 

--- a/components/com_content/views/featured/view.html.php
+++ b/components/com_content/views/featured/view.html.php
@@ -151,7 +151,7 @@ class ContentViewFeatured extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''));
 
 		$this->params     = &$params;
 		$this->items      = &$items;

--- a/components/com_content/views/form/view.html.php
+++ b/components/com_content/views/form/view.html.php
@@ -103,7 +103,7 @@ class ContentViewForm extends JViewLegacy
 		$params = &$this->state->params;
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''));
 
 		$this->params = $params;
 

--- a/components/com_finder/views/search/view.html.php
+++ b/components/com_finder/views/search/view.html.php
@@ -140,7 +140,7 @@ class FinderViewSearch extends JViewLegacy
 		$this->explained = JHtml::_('query.explained', $query);
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''));
 
 		// Check for layout override only if this is not the active menu item
 		// If it is the active menu item, then the view and category id will match

--- a/components/com_newsfeeds/views/category/tmpl/default.php
+++ b/components/com_newsfeeds/views/category/tmpl/default.php
@@ -13,7 +13,7 @@ JHtml::addIncludePath(JPATH_COMPONENT . '/helpers');
 JHtml::_('behavior.caption');
 JHtml::_('formbehavior.chosen', 'select');
 
-$pageClass = $this->params->get('pageclass_sfx');
+$pageClass = $this->params->get('pageclass_sfx', '');
 
 ?>
 <div class="newsfeed-category<?php echo $this->pageclass_sfx; ?>">

--- a/components/com_newsfeeds/views/newsfeed/view.html.php
+++ b/components/com_newsfeeds/views/newsfeed/view.html.php
@@ -170,7 +170,7 @@ class NewsfeedsViewNewsfeed extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''));
 
 		$this->params = $params;
 		$this->newsfeed = $newsfeed;

--- a/components/com_privacy/views/confirm/view.html.php
+++ b/components/com_privacy/views/confirm/view.html.php
@@ -75,7 +75,7 @@ class PrivacyViewConfirm extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 		$this->prepareDocument();
 

--- a/components/com_privacy/views/remind/view.html.php
+++ b/components/com_privacy/views/remind/view.html.php
@@ -75,7 +75,7 @@ class PrivacyViewRemind extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 		$this->prepareDocument();
 

--- a/components/com_privacy/views/request/view.html.php
+++ b/components/com_privacy/views/request/view.html.php
@@ -84,7 +84,7 @@ class PrivacyViewRequest extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 		$this->prepareDocument();
 

--- a/components/com_search/views/search/tmpl/default_form.php
+++ b/components/com_search/views/search/tmpl/default_form.php
@@ -32,7 +32,7 @@ $upper_limit = $lang->getUpperLimitSearchWord();
 		<input type="hidden" name="task" value="search" />
 		<div class="clearfix"></div>
 	</div>
-	<div class="searchintro<?php echo $this->params->get('pageclass_sfx'); ?>">
+	<div class="searchintro<?php echo $this->params->get('pageclass_sfx', ''); ?>">
 		<?php if (!empty($this->searchword)) : ?>
 			<p>
 				<?php echo JText::plural('COM_SEARCH_SEARCH_KEYWORD_N_RESULTS', '<span class="badge badge-info">' . $this->total . '</span>'); ?>

--- a/components/com_search/views/search/view.html.php
+++ b/components/com_search/views/search/view.html.php
@@ -178,7 +178,7 @@ class SearchViewSearch extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''));
 		$this->pagination    = &$pagination;
 		$this->results       = &$results;
 		$this->lists         = &$lists;
@@ -200,7 +200,7 @@ class SearchViewSearch extends JViewLegacy
 	 *
 	 * @param   string  $string       text to be searched
 	 * @param   string  $needle       text to search for
-	 * @param   string  $searchWords  words to be searched  
+	 * @param   string  $searchWords  words to be searched
 	 *
 	 * @return  mixed  A string.
 	 *

--- a/components/com_tags/views/tag/view.html.php
+++ b/components/com_tags/views/tag/view.html.php
@@ -176,7 +176,7 @@ class TagsViewTag extends JViewLegacy
 		$this->item       = $item;
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''));
 
 		// Merge tag params. If this is single-tag view, menu params override tag params
 		// Otherwise, article params override menu item params
@@ -292,8 +292,8 @@ class TagsViewTag extends JViewLegacy
 		}
 
 		$this->document->setTitle($title);
-		
-		$pathway->addItem($title);	
+
+		$pathway->addItem($title);
 
 		foreach ($this->item as $itemElement)
 		{

--- a/components/com_tags/views/tags/view.html.php
+++ b/components/com_tags/views/tags/view.html.php
@@ -76,7 +76,7 @@ class TagsViewTags extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx', ''));
 
 		$active = JFactory::getApplication()->getMenu()->getActive();
 

--- a/components/com_users/views/login/view.html.php
+++ b/components/com_users/views/login/view.html.php
@@ -61,7 +61,7 @@ class UsersViewLogin extends JViewLegacy
 		$this->tfa = is_array($tfa) && count($tfa) > 1;
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 		$this->prepareDocument();
 

--- a/components/com_users/views/profile/view.html.php
+++ b/components/com_users/views/profile/view.html.php
@@ -99,7 +99,7 @@ class UsersViewProfile extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx', ''));
 
 		$this->prepareDocument();
 

--- a/components/com_users/views/registration/view.html.php
+++ b/components/com_users/views/registration/view.html.php
@@ -60,7 +60,7 @@ class UsersViewRegistration extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 		$this->prepareDocument();
 

--- a/components/com_users/views/remind/view.html.php
+++ b/components/com_users/views/remind/view.html.php
@@ -55,7 +55,7 @@ class UsersViewRemind extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 		$this->prepareDocument();
 

--- a/components/com_users/views/reset/view.html.php
+++ b/components/com_users/views/reset/view.html.php
@@ -65,7 +65,7 @@ class UsersViewReset extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
+		$this->pageclass_sfx = htmlspecialchars($this->params->get('pageclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 		$this->prepareDocument();
 

--- a/components/com_wrapper/views/wrapper/view.html.php
+++ b/components/com_wrapper/views/wrapper/view.html.php
@@ -108,7 +108,7 @@ class WrapperViewWrapper extends JViewLegacy
 		}
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''));
 		$this->params        = &$params;
 		$this->wrapper       = &$wrapper;
 

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -1253,7 +1253,7 @@ class WebApplication extends BaseApplication
 		}
 
 		// Check to see if an explicit base URI has been set.
-		$siteUri = trim($this->get('site_uri'));
+		$siteUri = trim($this->get('site_uri', ''));
 
 		if ($siteUri != '')
 		{
@@ -1302,7 +1302,7 @@ class WebApplication extends BaseApplication
 		}
 
 		// Get an explicitly set media URI is present.
-		$mediaURI = trim($this->get('media_uri'));
+		$mediaURI = trim($this->get('media_uri', ''));
 
 		if ($mediaURI)
 		{

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -278,6 +278,7 @@ class Date extends \DateTime
 	 *
 	 * @since   1.7.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function format($format, $local = false, $translate = true)
 	{
 		if ($translate)
@@ -395,6 +396,7 @@ class Date extends \DateTime
 	 * @since   1.7.0
 	 * @note    This method can't be type hinted due to a PHP bug: https://bugs.php.net/bug.php?id=61483
 	 */
+	#[\ReturnTypeWillChange]
 	public function setTimezone($tz)
 	{
 		$this->tz = $tz;

--- a/libraries/src/MVC/View/CategoriesView.php
+++ b/libraries/src/MVC/View/CategoriesView.php
@@ -85,7 +85,7 @@ class CategoriesView extends HtmlView
 		$items = array($parent->id => $items);
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'), ENT_COMPAT, 'UTF-8');
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 		$this->maxLevelcat = $params->get('maxLevelcat', -1) < 0 ? PHP_INT_MAX : $params->get('maxLevelcat', PHP_INT_MAX);
 		$this->params      = &$params;

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -160,7 +160,7 @@ class CategoryView extends HtmlView
 		$children = array($category->id => $children);
 
 		// Escape strings for HTML output
-		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx'));
+		$this->pageclass_sfx = htmlspecialchars($params->get('pageclass_sfx', ''));
 
 		if ($this->runPlugins)
 		{

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -295,6 +295,7 @@ class Session implements \IteratorAggregate
 	 *
 	 * @since   3.0.1
 	 */
+	#[\ReturnTypeWillChange]
 	public function getIterator()
 	{
 		return new \ArrayIterator($this->getData());


### PR DESCRIPTION
### Summary of Changes
Backport several PHP 8.1 deprecation fixes to the 3.10 branch. Not all these fixes are mine - I'm just assembling them together for the backport


### Testing Instructions
Setup PHP 8.1 and run 3.10 on it. Currently install still won't run properly if deprecation warnings are output to screen (as it requires some backports in the framework 1.0 packages for Registry and Input). But there should be significantly less deprecation warnings.

### Documentation Changes Required
None
