### PR TITLE
[4.0] Support to set the location when saving a category through the API

### DIFF
--- a/api/components/com_categories/src/Controller/CategoriesController.php
+++ b/api/components/com_categories/src/Controller/CategoriesController.php
@@ -86,7 +86,15 @@ class CategoriesController extends ApiController
 		/** @var Category $category */
 		$category = $this->getModel('Category')->getTable('Category');
 		$category->load($recordId);
-		$category->setLocation($category->parent_id, $data['location']);
+
+		$reference = $category->parent_id;
+
+		if (!empty($data['location_reference']))
+		{
+			$reference = $data['location_reference'];
+		}
+
+		$category->setLocation($reference, $data['location']);
 		$category->store();
 
 		return $recordId;

--- a/api/components/com_categories/src/Controller/CategoriesController.php
+++ b/api/components/com_categories/src/Controller/CategoriesController.php
@@ -85,13 +85,13 @@ class CategoriesController extends ApiController
 
 		/** @var Category $category */
 		$category = $this->getModel('Category')->getTable('Category');
-		$category->load((int)$recordId);
+		$category->load((int) $recordId);
 
 		$reference = $category->parent_id;
 
 		if (!empty($data['location_reference']))
 		{
-			$reference = (int)$data['location_reference'];
+			$reference = (int) $data['location_reference'];
 		}
 
 		$category->setLocation($reference, $data['location']);

--- a/api/components/com_categories/src/Controller/CategoriesController.php
+++ b/api/components/com_categories/src/Controller/CategoriesController.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Categories\Api\Controller;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\MVC\Controller\ApiController;
+use Joomla\CMS\Table\Category;
 
 /**
  * The categories controller
@@ -55,6 +56,40 @@ class CategoriesController extends ApiController
 		$this->input->set('extension', $extension);
 
 		return $data;
+	}
+
+	/**
+	 * Method to save a record.
+	 *
+	 * @param   integer  $recordKey  The primary key of the item (if exists)
+	 *
+	 * @return  integer  The record ID on success, false on failure
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function save($recordKey = null)
+	{
+		$recordId = parent::save($recordKey);
+
+		if (!$recordId)
+		{
+			return $recordId;
+		}
+
+		$data = $this->input->get('data', json_decode($this->input->json->getRaw(), true), 'array');
+
+		if (empty($data['location']))
+		{
+			return $recordId;
+		}
+
+		/** @var Category $category */
+		$category = $this->getModel('Category')->getTable('Category');
+		$category->load($recordId);
+		$category->setLocation($category->parent_id, $data['location']);
+		$category->store();
+
+		return $recordId;
 	}
 
 	/**

--- a/api/components/com_categories/src/Controller/CategoriesController.php
+++ b/api/components/com_categories/src/Controller/CategoriesController.php
@@ -85,13 +85,13 @@ class CategoriesController extends ApiController
 
 		/** @var Category $category */
 		$category = $this->getModel('Category')->getTable('Category');
-		$category->load($recordId);
+		$category->load((int)$recordId);
 
 		$reference = $category->parent_id;
 
 		if (!empty($data['location_reference']))
 		{
-			$reference = $data['location_reference'];
+			$reference = (int)$data['location_reference'];
 		}
 
 		$category->setLocation($reference, $data['location']);


### PR DESCRIPTION
### Summary of Changes
This PR adds the possibility to define the location of the category while saving it through the API. A location can be one of the following values:
- before
- after
- first-child
- last-child

If `before` or `after` is used it is advisable to also set the location_reference parameter which defines the sibling the category should be located.

### Testing Instructions
Run the following curl command:
```
curl --location --request POST 'https://[your J4 website]/api/index.php/v1/content/categories' \
--header 'Content-Type: application/json' \
--header 'X-Joomla-Token: [your user token]' \
--data-raw '{
    "title": "test",
    "location": "first-child",
    "published": "1",
    "language": "*"
}'
```

### Actual result BEFORE applying this Pull Request
The new category appears as last item in the list in the back end UI.

### Expected result AFTER applying this Pull Request
The new category appears as first item in the list in the back end UI.

### Documentation Changes Required
The new `location` and `location_reference` arguments need to be documented.