### PR TITLE
[4.0] Send the category params in API GET requests

### DIFF
--- a/api/components/com_categories/src/View/Categories/JsonapiView.php
+++ b/api/components/com_categories/src/View/Categories/JsonapiView.php
@@ -53,6 +53,7 @@ class JsonapiView extends BaseApiView
 		'count_unpublished',
 		'count_published',
 		'count_archived',
+		'params',
 	];
 
 	/**
@@ -85,6 +86,7 @@ class JsonapiView extends BaseApiView
 		'count_unpublished',
 		'count_published',
 		'count_archived',
+		'params',
 	];
 
 	/**


### PR DESCRIPTION
### Summary of Changes
When fetching categories by the API, would be nice if the params are contained there as well.

### Testing Instructions
```
curl --location --request GET 'https://[your J4 website]/api/index.php/v1/content/categories' \
--header 'Content-Type: application/json' \
--header 'X-Joomla-Token: [your user token]' \
```

### Actual result BEFORE applying this Pull Request
The result doesn't contains the params field.

### Expected result AFTER applying this Pull Request
The result contains the params field.

### Documentation Changes Required
If the field list is documented, then it needs the params field as well.