### PR TITLE
[4.0] Handle when toggle icon is not available

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -33,10 +33,10 @@
           toggleButton.removeAttribute('disabled');
           toggleButton.addEventListener('click', () => {
             if (Joomla.editors.instances[currentEditor.id].instance.isHidden()) {
-              toggleIcon.setAttribute('class', 'icon-eye');
+              toggleIcon ? toggleIcon.setAttribute('class', 'icon-eye') : null;
               Joomla.editors.instances[currentEditor.id].instance.show();
             } else {
-              toggleIcon.setAttribute('class', 'icon-eye-slash');
+              toggleIcon ? toggleIcon.setAttribute('class', 'icon-eye-slash') : null;
               Joomla.editors.instances[currentEditor.id].instance.hide();
             }
           });

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -33,11 +33,13 @@
           toggleButton.removeAttribute('disabled');
           toggleButton.addEventListener('click', () => {
             if (Joomla.editors.instances[currentEditor.id].instance.isHidden()) {
-              toggleIcon ? toggleIcon.setAttribute('class', 'icon-eye') : null;
               Joomla.editors.instances[currentEditor.id].instance.show();
             } else {
-              toggleIcon ? toggleIcon.setAttribute('class', 'icon-eye-slash') : null;
               Joomla.editors.instances[currentEditor.id].instance.hide();
+            }
+
+            if (toggleIcon) {
+              toggleIcon.setAttribute('class', Joomla.editors.instances[currentEditor.id].instance.isHidden() ? 'icon-eye' : 'icon-eye-slash');
             }
           });
         }


### PR DESCRIPTION
### Summary of Changes
The TinyMCE toggle button does not work when the icon element is not available.

### Testing Instructions
- Put the following content into the file /templates/cassiopeia/html/layouts/joomla/tinymce/togglebutton.php:
  ```
  <div class="toggle-editor btn-toolbar float-end clearfix mt-3">
	  <div class="btn-group">
		  <button type="button" disabled class="btn btn-secondary js-tiny-toggler-button">
			  <?php echo JText::_('PLG_TINY_BUTTON_TOGGLE_EDITOR'); ?>
		  </button>
	  </div>
  </div>
  ```
- Edit an article on the front end
- Click on the toggle editor button

### Actual result BEFORE applying this Pull Request
Javascript error in dev console of the browser:
Uncaught TypeError: toggleIcon is null
    setupEditors http://joomla.box/cms4/media/plg_editors_tinymce/js/tinymce.js?7e502e51b417ca05bec2d8a8aa43adec:33

### Expected result AFTER applying this Pull Request
No error and editor turns into textarea.