### PR TITLE
[4.0] Make routing work in console applications

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -451,15 +451,9 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	 */
 	public static function getRouter($name = null, array $options = array())
 	{
-		if (!isset($name))
+		if (empty($name))
 		{
 			throw new InvalidArgumentException('A router name must be set in console application.');
-		}
-
-		// Fallback to site router when console router is requested
-		if (Factory::getApplication()->getName() === $name)
-		{
-			$name = 'site';
 		}
 
 		$options['mode'] = Factory::getApplication()->get('sef');

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -10,6 +10,7 @@ namespace Joomla\CMS\Application;
 
 \defined('JPATH_PLATFORM') or die;
 
+use InvalidArgumentException;
 use Joomla\CMS\Console;
 use Joomla\CMS\Extension\ExtensionManagerTrait;
 use Joomla\CMS\Factory;
@@ -449,12 +450,18 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	 * @return  Router
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 * @throws  \InvalidArgumentException
 	 */
 	public static function getRouter($name = null, array $options = array())
 	{
-		if (!isset($name) || Factory::getApplication()->getName() === $name)
+		if (!isset($name))
 		{
-			// Use site as default as there is no console router
+			throw new InvalidArgumentException('A router name must be set in console application.');
+		}
+
+		// Fallback to site router when console router is fetched
+		if (Factory::getApplication()->getName() === $name)
+		{
 			$name = 'site';
 		}
 

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -456,7 +456,7 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 			throw new InvalidArgumentException('A router name must be set in console application.');
 		}
 
-		// Fallback to site router when console router is fetched
+		// Fallback to site router when console router is requested
 		if (Factory::getApplication()->getName() === $name)
 		{
 			$name = 'site';

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -12,8 +12,10 @@ namespace Joomla\CMS\Application;
 
 use Joomla\CMS\Console;
 use Joomla\CMS\Extension\ExtensionManagerTrait;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Language;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Router\Router;
 use Joomla\CMS\Version;
 use Joomla\Console\Application;
 use Joomla\DI\Container;
@@ -137,6 +139,9 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 
 		// Set up the environment
 		$this->input->set('format', 'cli');
+
+		// Setting HOST to live site as it is needed when doing some routing
+		$_SERVER['HTTP_HOST'] = $this->get('live_site');
 	}
 
 	/**
@@ -433,5 +438,28 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 	public function setName(string $name): void
 	{
 		throw new \RuntimeException('The console application name cannot be changed');
+	}
+
+	/**
+	 * Returns the application Router object.
+	 *
+	 * @param   string  $name     The name of the application.
+	 * @param   array   $options  An optional associative array of configuration settings.
+	 *
+	 * @return  Router
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	public static function getRouter($name = null, array $options = array())
+	{
+		if (!isset($name) || Factory::getApplication()->getName() === $name)
+		{
+			// Use site as default as there is no console router
+			$name = 'site';
+		}
+
+		$options['mode'] = Factory::getApplication()->get('sef');
+
+		return Router::getInstance($name, $options);
 	}
 }

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -140,9 +140,6 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 
 		// Set up the environment
 		$this->input->set('format', 'cli');
-
-		// Setting HOST to live site as it is needed when doing some routing
-		$_SERVER['HTTP_HOST'] = $this->get('live_site');
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
When working on the console, then routing in Joomla doesn't work propperly. Especially the widely used `Route::_()` code is crashing. This pr adds a function to the console class to get the router object and fills the `HTTP_HOST` server variable with the live site parameter.

### Testing Instructions
- Enable SEF in the Joomla configuration
- Create an article
- Create a blog menu item with the category of the article selected
- Add the following code to the file /libraries/src/Console/ListUserCommand.php somewhere in the `doExecute` function:  
  `$this->ioStyle->success(\JRoute::_('index.php?option=com_content&view=article&id=1&catid=8'));`
  Replace the ids 1 and 8 with the ones from your joomla site.
- In the terminal run `php cli/joomla.php user:list`

### Actual result BEFORE applying this Pull Request
Error in the terminal `Call to undefined method Joomla\CMS\Application\ConsoleApplication::getRouter()`

### Expected result AFTER applying this Pull Request
You see a green OK text with the SEF route to the article.