### PR TITLE
Fix this.searchField is null

### DIFF
--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -125,7 +125,7 @@ Joomla = window.Joomla || {};
       const self = this;
 
       // Get values
-      this.searchString = this.searchField.value;
+      this.searchString = this.searchField ? this.searchField.value : '';
 
       // Do some binding
       this.showFilters = this.showFilters.bind(this);


### PR DESCRIPTION
Pull Request for Issue #36304 .

### Summary of Changes
Fixing searchtool.js error


### Testing Instructions
Apply patch, run `npm install`,

Edit `administrator/components/com_content/forms/filter_articles.xml` remove field with `name="search"`
Open `administrator/index.php?option=com_content&view=articles`
Check browser console.

### Actual result BEFORE applying this Pull Request
You get an error "Uncaught TypeError: this.searchField is null"


### Expected result AFTER applying this Pull Request
No error


### Documentation Changes Required
None
