### PR TITLE
[4.0] codemirror update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2747,9 +2747,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.64.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.64.0.tgz",
-      "integrity": "sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg=="
+      "version": "5.65.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.0.tgz",
+      "integrity": "sha512-gWEnHKEcz1Hyz7fsQWpK7P0sPI2/kSkRX2tc7DFA6TmZuDN75x/1ejnH/Pn8adYKrLEA1V2ww6L00GudHZbSKw=="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -10364,9 +10364,9 @@
       }
     },
     "codemirror": {
-      "version": "5.64.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.64.0.tgz",
-      "integrity": "sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg=="
+      "version": "5.65.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.0.tgz",
+      "integrity": "sha512-gWEnHKEcz1Hyz7fsQWpK7P0sPI2/kSkRX2tc7DFA6TmZuDN75x/1ejnH/Pn8adYKrLEA1V2ww6L00GudHZbSKw=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_codemirror</name>
-	<version>5.64.0</version>
+	<version>5.65.0</version>
 	<creationDate>28 March 2011</creationDate>
 	<author>Marijn Haverbeke</author>
 	<authorEmail>marijnh@gmail.com</authorEmail>


### PR DESCRIPTION
Updates codemirror to 5.65.0

brace-folding addon: Fix broken folding on lines with both braces and square brackets.
vim bindings: Support g0, g$, g<Arrow>.

