### PR TITLE
[4.0] remove deprecated type tag

### DIFF
--- a/plugins/system/debug/src/JavascriptRenderer.php
+++ b/plugins/system/debug/src/JavascriptRenderer.php
@@ -61,7 +61,7 @@ class JavascriptRenderer extends DebugBarJavascriptRenderer
 
 		foreach ($inlineCss as $content)
 		{
-			$html .= sprintf('<style type="text/css">%s</style>' . "\n", $content);
+			$html .= sprintf('<style>%s</style>' . "\n", $content);
 		}
 
 		foreach ($jsFiles as $file)


### PR DESCRIPTION
as per Joomla coding standards and https://developer.mozilla.org/en-US/docs/web/html/element/style#attr-type/contributors.txt
<img width="730" alt="Screenshot 2021-12-23 at 16 51 40" src="https://user-images.githubusercontent.com/400092/147270752-7fba99a2-1d9a-4956-8e69-474698edc368.png">

