### PR TITLE
[4.0] remove redundant check

### DIFF
--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -114,7 +114,7 @@ class PlgUserToken extends CMSPlugin
 		}
 
 		// Get the user ID
-		$userId = isset($data->id) ? intval($data->id) : 0;
+		$userId = intval($data->id);
 
 		// Make sure we have a positive integer user ID
 		if ($userId <= 0)


### PR DESCRIPTION
Removed Condition is always 'true' because '!isset($data->id)' is already 'false' at this point

Code review