### PR TITLE
[4.0] Replace input with button

### DIFF
--- a/modules/mod_login/tmpl/default_logout.php
+++ b/modules/mod_login/tmpl/default_logout.php
@@ -34,7 +34,7 @@ HTMLHelper::_('behavior.keepalive');
 	</ul>
 <?php endif; ?>
 	<div class="mod-login-logout__button logout-button">
-		<input type="submit" name="Submit" class="btn btn-primary" value="<?php echo Text::_('JLOGOUT'); ?>">
+		<button type="submit" name="Submit" class="btn btn-primary"><?php echo Text::_('JLOGOUT'); ?></button>
 		<input type="hidden" name="option" value="com_users">
 		<input type="hidden" name="task" value="user.logout">
 		<input type="hidden" name="return" value="<?php echo $return; ?>">

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -185,7 +185,7 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
 							</div>
 						<?php endforeach; ?>
 
-						<input type="submit" name="Submit" class="btn btn-primary" value="<?php echo Text::_('JLOGIN'); ?>">
+						<button type="submit" name="Submit" class="btn btn-primary"><?php echo Text::_('JLOGIN'); ?></button>
 
 						<input type="hidden" name="option" value="com_users">
 						<input type="hidden" name="task" value="user.login">

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -75,7 +75,7 @@ $twofactormethods = AuthenticationHelper::getTwoFactorMethods();
 			</p>
 		<?php endif; ?>
 		<p id="submit-button">
-			<input type="submit" name="Submit" class="button login"><?php echo Text::_('JLOGIN'); ?></button>
+			<button type="submit" name="Submit" class="button login"><?php echo Text::_('JLOGIN'); ?></button>
 		</p>
 		<input type="hidden" name="option" value="com_users" />
 		<input type="hidden" name="task" value="user.login" />

--- a/templates/system/offline.php
+++ b/templates/system/offline.php
@@ -75,7 +75,7 @@ $twofactormethods = AuthenticationHelper::getTwoFactorMethods();
 			</p>
 		<?php endif; ?>
 		<p id="submit-button">
-			<input type="submit" name="Submit" class="button login" value="<?php echo Text::_('JLOGIN'); ?>" />
+			<input type="submit" name="Submit" class="button login"><?php echo Text::_('JLOGIN'); ?></button>
 		</p>
 		<input type="hidden" name="option" value="com_users" />
 		<input type="hidden" name="task" value="user.login" />


### PR DESCRIPTION
### Summary of Changes

Use an actual button for the "login button", rather than an input.

### Testing Instructions

Make sure you can still logout via `mod_login`
