### PR TITLE
[4.0] Cache-Control post-check and pre-check

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -1095,7 +1095,8 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 
 					$this->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
 					$this->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
-					$this->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
+					$this->setHeader('x-power', 'brian', true);
+					$this->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate', false);
 					$this->sendHeaders();
 
 					$this->redirect((string) $oldUri, 301);

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -1095,7 +1095,6 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 
 					$this->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
 					$this->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
-					$this->setHeader('x-power', 'brian', true);
 					$this->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate', false);
 					$this->sendHeaders();
 

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -481,7 +481,7 @@ class PlgSystemLanguageFilter extends CMSPlugin
 				// We cannot cache this redirect in browser. 301 is cacheable by default so we need to force to not cache it in browsers.
 				$this->app->setHeader('Expires', 'Wed, 17 Aug 2005 00:00:00 GMT', true);
 				$this->app->setHeader('Last-Modified', gmdate('D, d M Y H:i:s') . ' GMT', true);
-				$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, post-check=0, pre-check=0', false);
+				$this->app->setHeader('Cache-Control', 'no-store, no-cache, must-revalidate', false);
 				$this->app->sendHeaders();
 			}
 


### PR DESCRIPTION
This PR (and the associated pr in the framework) kills the references to post-check and pre-check from the headers. These are non-standard directives introduced in ie5 and killed in ie7 and do nothing today except wasting bytes and bandwidth.

Ref: https://www.fastly.com/blog/cache-control-wild

Code review only