### PR TITLE
[4] Ensure message is defined

### DIFF
--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -86,6 +86,8 @@ class ArticlesController extends AdminController
 		if (empty($ids))
 		{
 			$this->app->enqueueMessage(Text::_('JERROR_NO_ITEMS_SELECTED'), 'error');
+			
+			$this->setRedirect(Route::_($redirectUrl, false));
 
 			return;
 		}

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -86,7 +86,7 @@ class ArticlesController extends AdminController
 		if (empty($ids))
 		{
 			$this->app->enqueueMessage(Text::_('JERROR_NO_ITEMS_SELECTED'), 'error');
-			
+
 			$this->setRedirect(Route::_($redirectUrl, false));
 
 			return;

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -86,29 +86,29 @@ class ArticlesController extends AdminController
 		if (empty($ids))
 		{
 			$this->app->enqueueMessage(Text::_('JERROR_NO_ITEMS_SELECTED'), 'error');
+
+			return;
+		}
+
+		// Get the model.
+		/** @var \Joomla\Component\Content\Administrator\Model\ArticleModel $model */
+		$model = $this->getModel();
+
+		// Publish the items.
+		if (!$model->featured($ids, $value))
+		{
+			$this->setRedirect(Route::_($redirectUrl, false), $model->getError(), 'error');
+
+			return;
+		}
+
+		if ($value == 1)
+		{
+			$message = Text::plural('COM_CONTENT_N_ITEMS_FEATURED', count($ids));
 		}
 		else
 		{
-			// Get the model.
-			/** @var \Joomla\Component\Content\Administrator\Model\ArticleModel $model */
-			$model = $this->getModel();
-
-			// Publish the items.
-			if (!$model->featured($ids, $value))
-			{
-				$this->setRedirect(Route::_($redirectUrl, false), $model->getError(), 'error');
-
-				return;
-			}
-
-			if ($value == 1)
-			{
-				$message = Text::plural('COM_CONTENT_N_ITEMS_FEATURED', count($ids));
-			}
-			else
-			{
-				$message = Text::plural('COM_CONTENT_N_ITEMS_UNFEATURED', count($ids));
-			}
+			$message = Text::plural('COM_CONTENT_N_ITEMS_UNFEATURED', count($ids));
 		}
 
 		$this->setRedirect(Route::_($redirectUrl, false), $message);


### PR DESCRIPTION

### Summary of Changes

There is an edge case, where this method can be called with a set of ids, that gets pruned, leaving no ids to feature, which in turn rules a code path that leaves the redirect `$message` undefined. 

### Testing Instructions

Code review. Best viewed with no whitespace https://github.com/joomla/joomla-cms/pull/36404/files?diff=unified&w=1

### Actual result BEFORE applying this Pull Request

`$message` is undefined. 

### Expected result AFTER applying this Pull Request

return early after identifying that we have no `$ids` to process.

### Documentation Changes Required

None