### PR TITLE
[4.0] Correct return type

### DIFF
--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -133,7 +133,7 @@ class ArticlesController extends AdminController
 	/**
 	 * Method to get the JSON-encoded amount of published articles
 	 *
-	 * @return  void  
+	 * @return  void
 	 *
 	 * @since   4.0.0
 	 */

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -131,9 +131,9 @@ class ArticlesController extends AdminController
 	}
 
 	/**
-	 * Method to get the number of published articles for quickicons
+	 * Method to get the JSON-encoded amount of published articles
 	 *
-	 * @return  string  The JSON-encoded amount of published articles
+	 * @return  void  
 	 *
 	 * @since   4.0.0
 	 */


### PR DESCRIPTION
Code review

This method does not return a string, like the other `getQuickiconContent` methods in Joomla, this one also returns `void` and should be documented as such. 