### PR TITLE
[4.1] Correct return type in getQuickiconContent in Tags Controller

### DIFF
--- a/administrator/components/com_tags/src/Controller/TagsController.php
+++ b/administrator/components/com_tags/src/Controller/TagsController.php
@@ -72,9 +72,9 @@ class TagsController extends AdminController
 	}
 
 	/**
-	 * Method to get the number of published tags for quickicons
+	 * Method to get the JSON-encoded amount of published tags for quickicons
 	 *
-	 * @return  string  The JSON-encoded amount of published articles
+	 * @return  void
 	 *
 	 * @since   4.1.0
 	 */


### PR DESCRIPTION
Code review

This method does not return a string, like the other `getQuickiconContent` methods in Joomla, this one also returns `void` and should be documented as such. 