### PR TITLE
[4.0] Fix array to string conversion

### DIFF
--- a/libraries/src/Table/Nested.php
+++ b/libraries/src/Table/Nested.php
@@ -969,7 +969,7 @@ class Nested extends Table
 			// Nothing to set publishing state on, return false.
 			else
 			{
-				$e = new \UnexpectedValueException(sprintf('%s::publish(%s, %d, %d) empty.', \get_class($this), $pks, $state, $userId));
+				$e = new \UnexpectedValueException(sprintf('%s::publish(%s, %d, %d) empty.', \get_class($this), implode(',', $pks), $state, $userId));
 				$this->setError($e);
 
 				return false;


### PR DESCRIPTION
Code Review.

At this location `$pks` is an array, and you are trying to `sprintf` it as if it were a string, which would raise a warning/notice (see https://3v4l.org/lnOBl) 

We know its going to be an array at this point as `$pks    = ArrayHelper::toInteger($pks);` returns an array. 

Ive chosen implode, but json_encode would have been just as good I guess. No one has ever seen this error in real life I doubt 

In PHP 8 this would be a `Warning` whereas before it would be a `Notice` and I bet it will become a `Fatal Error` in later PHP versions probably... who knows... 

https://3v4l.org/lnOBl