### PR TITLE
[4.0] refactor Switch which has only single case

### DIFF
--- a/libraries/src/Changelog/Changelog.php
+++ b/libraries/src/Changelog/Changelog.php
@@ -214,24 +214,19 @@ class Changelog extends CMSObject
 			$this->$tag->data = '';
 		}
 
-		switch ($name)
+		$name = strtolower($name);
+
+		if (!isset($this->currentChangelog->$name))
 		{
-			default:
-				$name = strtolower($name);
+			$this->currentChangelog->$name = new \stdClass;
+		}
 
-				if (!isset($this->currentChangelog->$name))
-				{
-					$this->currentChangelog->$name = new \stdClass;
-				}
+		$this->currentChangelog->$name->data = '';
 
-				$this->currentChangelog->$name->data = '';
-
-				foreach ($attrs as $key => $data)
-				{
-					$key                                 = strtolower($key);
-					$this->currentChangelog->$name->$key = $data;
-				}
-				break;
+		foreach ($attrs as $key => $data)
+		{
+			$key                                 = strtolower($key);
+			$this->currentChangelog->$name->$key = $data;
 		}
 	}
 

--- a/libraries/src/Form/Field/CheckboxField.php
+++ b/libraries/src/Form/Field/CheckboxField.php
@@ -58,10 +58,9 @@ class CheckboxField extends FormField
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		if ($name === 'checked')
 		{
-			case 'checked':
-				return $this->checked;
+			return $this->checked;
 		}
 
 		return parent::__get($name);
@@ -79,16 +78,15 @@ class CheckboxField extends FormField
 	 */
 	public function __set($name, $value)
 	{
-		switch ($name)
+		if ($name === 'checked')
 		{
-			case 'checked':
-				$value = (string) $value;
-				$this->checked = ($value === 'true' || $value == $name || $value === '1');
-				break;
+			$value = (string) $value;
+			$this->checked = ($value === 'true' || $value == $name || $value === '1');
 
-			default:
-				parent::__set($name, $value);
+			return;
 		}
+
+		parent::__set($name, $value);
 	}
 
 	/**

--- a/libraries/src/Form/Field/ChromestyleField.php
+++ b/libraries/src/Form/Field/ChromestyleField.php
@@ -52,10 +52,9 @@ class ChromestyleField extends GroupedlistField
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		if ($name === 'clientId')
 		{
-			case 'clientId':
-				return $this->clientId;
+			return $this->clientId;
 		}
 
 		return parent::__get($name);

--- a/libraries/src/Form/Field/FileField.php
+++ b/libraries/src/Form/Field/FileField.php
@@ -56,10 +56,9 @@ class FileField extends FormField
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		if ($name === 'accept')
 		{
-			case 'accept':
-				return $this->accept;
+			return $this->accept;
 		}
 
 		return parent::__get($name);

--- a/libraries/src/Form/Field/ModuleorderField.php
+++ b/libraries/src/Form/Field/ModuleorderField.php
@@ -47,10 +47,9 @@ class ModuleorderField extends FormField
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		if ($name === 'linked')
 		{
-			case 'linked':
-				return $this->$name;
+			return $this->linked;
 		}
 
 		return parent::__get($name);

--- a/libraries/src/Form/Field/ModulepositionField.php
+++ b/libraries/src/Form/Field/ModulepositionField.php
@@ -50,10 +50,9 @@ class ModulepositionField extends TextField
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		if ($name === 'clientId')
 		{
-			case 'clientId':
-				return $this->clientId;
+			return $this->clientId;
 		}
 
 		return parent::__get($name);

--- a/libraries/src/Form/Field/OrderingField.php
+++ b/libraries/src/Form/Field/OrderingField.php
@@ -51,10 +51,9 @@ class OrderingField extends FormField
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		if ($name === 'contentType')
 		{
-			case 'contentType':
-				return $this->contentType;
+			return $this->contentType;
 		}
 
 		return parent::__get($name);

--- a/libraries/src/Form/Field/PluginsField.php
+++ b/libraries/src/Form/Field/PluginsField.php
@@ -48,10 +48,9 @@ class PluginsField extends ListField
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		if ($name === 'folder')
 		{
-			case 'folder':
-				return $this->folder;
+			return $this->folder;
 		}
 
 		return parent::__get($name);

--- a/libraries/src/Form/Field/TimezoneField.php
+++ b/libraries/src/Form/Field/TimezoneField.php
@@ -54,10 +54,9 @@ class TimezoneField extends GroupedlistField
 	 */
 	public function __get($name)
 	{
-		switch ($name)
+		if ($name === 'keyField')
 		{
-			case 'keyField':
-				return $this->keyField;
+			return $this->keyField;
 		}
 
 		return parent::__get($name);

--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -40,16 +40,7 @@ trait LegacyModelLoaderTrait
 	 */
 	protected static function _createFileName($type, $parts = array())
 	{
-		$filename = '';
-
-		switch ($type)
-		{
-			case 'model':
-				$filename = strtolower($parts['name']) . '.php';
-				break;
-		}
-
-		return $filename;
+		return $type === 'model' ? strtolower($parts['name']) . '.php' : '';
 	}
 
 	/**

--- a/libraries/src/Updater/Adapter/CollectionAdapter.php
+++ b/libraries/src/Updater/Adapter/CollectionAdapter.php
@@ -204,15 +204,10 @@ class CollectionAdapter extends UpdateAdapter
 	{
 		array_pop($this->stack);
 
-		switch ($name)
+		if ($name === 'CATEGORY' && $this->pop_parent)
 		{
-			case 'CATEGORY':
-				if ($this->pop_parent)
-				{
-					$this->pop_parent = 0;
-					array_pop($this->parent);
-				}
-				break;
+			$this->pop_parent = 0;
+			array_pop($this->parent);
 		}
 	}
 


### PR DESCRIPTION
Code review

Refactor of a few `switch` statements which only have a single switch case and therefore are code smell and can be simplified refactored and beautified.

Ok, not beautified,, but they are less complex now