### PR TITLE
[4] Delete lots of code

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Query.php
+++ b/administrator/components/com_finder/src/Indexer/Query.php
@@ -1049,7 +1049,6 @@ class Query
 
 					// Adjust the loop.
 					$i += 2;
-					continue;
 				}
 				// Handle the OR operator.
 				elseif ($op === 'OR' && isset($terms[$i + 2]))
@@ -1119,7 +1118,6 @@ class Query
 
 					// Adjust the loop.
 					$i += 2;
-					continue;
 				}
 			}
 			// Handle an orphaned OR operator.
@@ -1167,7 +1165,6 @@ class Query
 
 				// Adjust the loop.
 				$i++;
-				continue;
 			}
 			// Handle the NOT operator.
 			elseif (isset($terms[$i + 1]) && array_search($terms[$i], $operators, true) === 'NOT')

--- a/administrator/components/com_languages/src/Model/InstalledModel.php
+++ b/administrator/components/com_languages/src/Model/InstalledModel.php
@@ -239,7 +239,6 @@ class InstalledModel extends ListModel
 					&& stripos($installedLanguage->language, $search) === false)
 				{
 					unset($installedLanguages[$key]);
-					continue;
 				}
 			}
 		}

--- a/components/com_content/src/View/Category/HtmlView.php
+++ b/components/com_content/src/View/Category/HtmlView.php
@@ -140,10 +140,6 @@ class HtmlView extends CategoryView
 				{
 					$this->link_items[] = $item;
 				}
-				else
-				{
-					continue;
-				}
 			}
 		}
 

--- a/libraries/src/Adapter/Adapter.php
+++ b/libraries/src/Adapter/Adapter.php
@@ -75,8 +75,8 @@ class Adapter extends CMSObject
 	public function __construct($basepath, $classprefix = null, $adapterfolder = null)
 	{
 		$this->_basepath = $basepath;
-		$this->_classprefix = $classprefix ? $classprefix : 'J';
-		$this->_adapterfolder = $adapterfolder ? $adapterfolder : 'adapters';
+		$this->_classprefix = $classprefix ?: 'J';
+		$this->_adapterfolder = $adapterfolder ?: 'adapters';
 
 		$this->_db = Factory::getDbo();
 	}

--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -182,8 +182,6 @@ class ApplicationHelper
 				}
 			}
 		}
-
-		return;
 	}
 
 	/**

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -1137,8 +1137,6 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 		{
 			return $registry->set($key, $value);
 		}
-
-		return;
 	}
 
 	/**

--- a/libraries/src/Document/FeedDocument.php
+++ b/libraries/src/Document/FeedDocument.php
@@ -203,7 +203,7 @@ class FeedDocument extends Document
 		$type = CmsFactory::getApplication()->input->get('type', 'rss');
 
 		// Instantiate feed renderer and set the mime encoding
-		$renderer = $this->loadRenderer(($type) ?: 'rss');
+		$renderer = $this->loadRenderer($type ?: 'rss');
 
 		if (!($renderer instanceof DocumentRenderer))
 		{

--- a/libraries/src/Document/FeedDocument.php
+++ b/libraries/src/Document/FeedDocument.php
@@ -203,7 +203,7 @@ class FeedDocument extends Document
 		$type = CmsFactory::getApplication()->input->get('type', 'rss');
 
 		// Instantiate feed renderer and set the mime encoding
-		$renderer = $this->loadRenderer(($type) ? $type : 'rss');
+		$renderer = $this->loadRenderer(($type) ?: 'rss');
 
 		if (!($renderer instanceof DocumentRenderer))
 		{

--- a/libraries/src/Document/Renderer/Html/MetasRenderer.php
+++ b/libraries/src/Document/Renderer/Html/MetasRenderer.php
@@ -67,7 +67,7 @@ class MetasRenderer extends DocumentRenderer
 		{
 			$prettyPrint = (JDEBUG && \defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : false);
 			$jsonOptions = json_encode($scriptOptions, $prettyPrint);
-			$jsonOptions = $jsonOptions ? $jsonOptions : '{}';
+			$jsonOptions = $jsonOptions ?: '{}';
 
 			$wa->addInlineScript(
 				$jsonOptions,

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -902,8 +902,6 @@ class Browser
 				return substr($_SERVER['SERVER_PROTOCOL'], $pos + 1);
 			}
 		}
-
-		return;
 	}
 
 	/**

--- a/libraries/src/Feed/FeedParser.php
+++ b/libraries/src/Feed/FeedParser.php
@@ -63,7 +63,7 @@ abstract class FeedParser
 	public function __construct(\XMLReader $stream, InputFilter $inputFilter = null)
 	{
 		$this->stream      = $stream;
-		$this->inputFilter = $inputFilter ? $inputFilter : InputFilter::getInstance(array(), array(), 1, 1);
+		$this->inputFilter = $inputFilter ?: InputFilter::getInstance(array(), array(), 1, 1);
 	}
 
 	/**

--- a/libraries/src/Feed/FeedParser.php
+++ b/libraries/src/Feed/FeedParser.php
@@ -63,7 +63,7 @@ abstract class FeedParser
 	public function __construct(\XMLReader $stream, InputFilter $inputFilter = null)
 	{
 		$this->stream      = $stream;
-		$this->inputFilter = $inputFilter ?: InputFilter::getInstance(array(), array(), 1, 1);
+		$this->inputFilter = $inputFilter ?: InputFilter::getInstance([], [], 1, 1);
 	}
 
 	/**

--- a/libraries/src/Form/Field/ColorField.php
+++ b/libraries/src/Form/Field/ColorField.php
@@ -341,7 +341,7 @@ class ColorField extends FormField
 			}
 		}
 
-		$split = $this->split ? $this->split : 3;
+		$split = $this->split ?: 3;
 
 		return array(
 			'colors' => $colors,

--- a/libraries/src/Form/Field/UserField.php
+++ b/libraries/src/Form/Field/UserField.php
@@ -160,8 +160,6 @@ class UserField extends FormField
 		{
 			return explode(',', $this->element['groups']);
 		}
-
-		return;
 	}
 
 	/**
@@ -177,7 +175,5 @@ class UserField extends FormField
 		{
 			return explode(',', $this->element['exclude']);
 		}
-
-		return;
 	}
 }

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -44,7 +44,7 @@ class Form
 	 * @var    array
 	 * @since  1.7.0
 	 */
-	protected $errors = array();
+	protected $errors = [];
 
 	/**
 	 * The name of the form instance.
@@ -60,7 +60,7 @@ class Form
 	 * @var    array
 	 * @since  1.7.0
 	 */
-	protected $options = array();
+	protected $options = [];
 
 	/**
 	 * The form XML definition.
@@ -76,7 +76,7 @@ class Form
 	 * @var    Form[]
 	 * @since  1.7.0
 	 */
-	protected static $forms = array();
+	protected static $forms = [];
 
 	/**
 	 * Allows extensions to implement repeating elements
@@ -94,7 +94,7 @@ class Form
 	 *
 	 * @since   1.7.0
 	 */
-	public function __construct($name, array $options = array())
+	public function __construct($name, array $options = [])
 	{
 		// Set the name for the form.
 		$this->name = $name;
@@ -277,7 +277,7 @@ class Form
 	 */
 	public function getFieldset($set = null)
 	{
-		$fields = array();
+		$fields = [];
 
 		// Get all of the field elements in the fieldset.
 		if ($set)
@@ -302,7 +302,7 @@ class Form
 		{
 			// Get the field groups for the element.
 			$attrs = $element->xpath('ancestor::fields[@name]/@name');
-			$groups = array_map('strval', $attrs ?: array());
+			$groups = array_map('strval', $attrs ?: []);
 			$group = implode('.', $groups);
 
 			// If the field is successfully loaded add it to the result array.
@@ -326,8 +326,8 @@ class Form
 	 */
 	public function getFieldsets($group = null)
 	{
-		$fieldsets = array();
-		$sets = array();
+		$fieldsets = [];
+		$sets = [];
 
 		// Make sure there is a valid Form XML document.
 		if (!($this->xml instanceof \SimpleXMLElement))
@@ -452,7 +452,7 @@ class Form
 	 */
 	public function getGroup($group, $nested = false)
 	{
-		$fields = array();
+		$fields = [];
 
 		// Get all of the field elements in the field group.
 		$elements = $this->findFieldsByGroup($group, $nested);
@@ -468,7 +468,7 @@ class Form
 		{
 			// Get the field groups for the element.
 			$attrs  = $element->xpath('ancestor::fields[@name]/@name');
-			$groups = array_map('strval', $attrs ?: array());
+			$groups = array_map('strval', $attrs ?: []);
 			$group  = implode('.', $groups);
 
 			// If the field is successfully loaded add it to the result array.
@@ -574,7 +574,7 @@ class Form
 	 *
 	 * @since   3.2.3
 	 */
-	public function renderField($name, $group = null, $default = null, $options = array())
+	public function renderField($name, $group = null, $default = null, $options = [])
 	{
 		$field = $this->getField($name, $group, $default);
 
@@ -596,10 +596,10 @@ class Form
 	 *
 	 * @since   3.2.3
 	 */
-	public function renderFieldset($name, $options = array())
+	public function renderFieldset($name, $options = [])
 	{
 		$fields = $this->getFieldset($name);
-		$html = array();
+		$html = [];
 
 		foreach ($fields as $field)
 		{
@@ -670,7 +670,7 @@ class Form
 		}
 
 		// Get the XML elements to load.
-		$elements = array();
+		$elements = [];
 
 		if ($xpath)
 		{
@@ -697,7 +697,7 @@ class Form
 			{
 				// Get the group names as strings for ancestor fields elements.
 				$attrs = $field->xpath('ancestor::fields[@name]/@name');
-				$groups = array_map('strval', $attrs ?: array());
+				$groups = array_map('strval', $attrs ?: []);
 
 				// Check to see if the field exists in the current form.
 				if ($current = $this->findField((string) $field['name'], implode('.', $groups)))
@@ -1133,7 +1133,7 @@ class Form
 
 			// Get the field groups for the element.
 			$attrs = $field->xpath('ancestor::fields[@name]/@name');
-			$groups = array_map('strval', $attrs ?: array());
+			$groups = array_map('strval', $attrs ?: []);
 			$attrGroup = implode('.', $groups);
 
 			$key = $attrGroup ? $attrGroup . '.' . $name : $name;
@@ -1225,7 +1225,7 @@ class Form
 
 			// Get the field groups for the element.
 			$attrs = $field->xpath('ancestor::fields[@name]/@name');
-			$groups = array_map('strval', $attrs ?: array());
+			$groups = array_map('strval', $attrs ?: []);
 			$attrGroup = implode('.', $groups);
 
 			$key = $attrGroup ? $attrGroup . '.' . $name : $name;
@@ -1292,7 +1292,7 @@ class Form
 
 			// Get the field groups for the element.
 			$attrs = $field->xpath('ancestor::fields[@name]/@name');
-			$groups = array_map('strval', $attrs ?: array());
+			$groups = array_map('strval', $attrs ?: []);
 			$attrGroup = implode('.', $groups);
 
 			$key = $attrGroup ? $attrGroup . '.' . $name : $name;
@@ -1321,7 +1321,7 @@ class Form
 	protected function findField($name, $group = null)
 	{
 		$element = false;
-		$fields = array();
+		$fields = [];
 
 		// Make sure there is a valid Form XML document.
 		if (!($this->xml instanceof \SimpleXMLElement))
@@ -1358,7 +1358,7 @@ class Form
 			{
 				// Get the group names as strings for ancestor fields elements.
 				$attrs = $field->xpath('ancestor::fields[@name]/@name');
-				$names = array_map('strval', $attrs ?: array());
+				$names = array_map('strval', $attrs ?: []);
 
 				// If the field is in the exact group use it and break out of the loop.
 				if ($names == (array) $groupNames)
@@ -1445,7 +1445,7 @@ class Form
 	protected function &findFieldsByGroup($group = null, $nested = false)
 	{
 		$false = false;
-		$fields = array();
+		$fields = [];
 
 		// Make sure there is a valid Form XML document.
 		if (!($this->xml instanceof \SimpleXMLElement))
@@ -1480,7 +1480,7 @@ class Form
 						{
 							// Get the names of the groups that the field is in.
 							$attrs = $field->xpath('ancestor::fields[@name]/@name');
-							$names = array_map('strval', $attrs ?: array());
+							$names = array_map('strval', $attrs ?: []);
 
 							// If the field is in the specific group then add it to the return list.
 							if ($names == (array) $groupNames)
@@ -1518,8 +1518,8 @@ class Form
 	protected function &findGroup($group)
 	{
 		$false = false;
-		$groups = array();
-		$tmp = array();
+		$groups = [];
+		$tmp = [];
 
 		// Make sure there is a valid Form XML document.
 		if (!($this->xml instanceof \SimpleXMLElement))
@@ -1550,7 +1550,7 @@ class Form
 				// Initialise some loop variables.
 				$validNames = \array_slice($group, 0, $i + 1);
 				$current = $tmp;
-				$tmp = array();
+				$tmp = [];
 
 				// Check to make sure that there are no parent groups for each element.
 				foreach ($current as $element)
@@ -1563,7 +1563,7 @@ class Form
 					{
 						// Get the group names as strings for ancestor fields elements.
 						$attrs = $fields->xpath('ancestor-or-self::fields[@name]/@name');
-						$names = array_map('strval', $attrs ?: array());
+						$names = array_map('strval', $attrs ?: []);
 
 						// If the group names for the fields element match the valid names at this
 						// level add the fields element.
@@ -1840,7 +1840,7 @@ class Form
 	 * @throws  \InvalidArgumentException if no data provided.
 	 * @throws  \RuntimeException if the form could not be loaded.
 	 */
-	public static function getInstance($name, $data = null, $options = array(), $replace = true, $xpath = false)
+	public static function getInstance($name, $data = null, $options = [], $replace = true, $xpath = false)
 	{
 		// Reference to array with form instances
 		$forms = &self::$forms;

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -302,7 +302,7 @@ class Form
 		{
 			// Get the field groups for the element.
 			$attrs = $element->xpath('ancestor::fields[@name]/@name');
-			$groups = array_map('strval', $attrs ? $attrs : array());
+			$groups = array_map('strval', $attrs ?: array());
 			$group = implode('.', $groups);
 
 			// If the field is successfully loaded add it to the result array.
@@ -468,7 +468,7 @@ class Form
 		{
 			// Get the field groups for the element.
 			$attrs  = $element->xpath('ancestor::fields[@name]/@name');
-			$groups = array_map('strval', $attrs ? $attrs : array());
+			$groups = array_map('strval', $attrs ?: array());
 			$group  = implode('.', $groups);
 
 			// If the field is successfully loaded add it to the result array.
@@ -697,7 +697,7 @@ class Form
 			{
 				// Get the group names as strings for ancestor fields elements.
 				$attrs = $field->xpath('ancestor::fields[@name]/@name');
-				$groups = array_map('strval', $attrs ? $attrs : array());
+				$groups = array_map('strval', $attrs ?: array());
 
 				// Check to see if the field exists in the current form.
 				if ($current = $this->findField((string) $field['name'], implode('.', $groups)))
@@ -1133,7 +1133,7 @@ class Form
 
 			// Get the field groups for the element.
 			$attrs = $field->xpath('ancestor::fields[@name]/@name');
-			$groups = array_map('strval', $attrs ? $attrs : array());
+			$groups = array_map('strval', $attrs ?: array());
 			$attrGroup = implode('.', $groups);
 
 			$key = $attrGroup ? $attrGroup . '.' . $name : $name;
@@ -1225,7 +1225,7 @@ class Form
 
 			// Get the field groups for the element.
 			$attrs = $field->xpath('ancestor::fields[@name]/@name');
-			$groups = array_map('strval', $attrs ? $attrs : array());
+			$groups = array_map('strval', $attrs ?: array());
 			$attrGroup = implode('.', $groups);
 
 			$key = $attrGroup ? $attrGroup . '.' . $name : $name;
@@ -1292,7 +1292,7 @@ class Form
 
 			// Get the field groups for the element.
 			$attrs = $field->xpath('ancestor::fields[@name]/@name');
-			$groups = array_map('strval', $attrs ? $attrs : array());
+			$groups = array_map('strval', $attrs ?: array());
 			$attrGroup = implode('.', $groups);
 
 			$key = $attrGroup ? $attrGroup . '.' . $name : $name;
@@ -1358,7 +1358,7 @@ class Form
 			{
 				// Get the group names as strings for ancestor fields elements.
 				$attrs = $field->xpath('ancestor::fields[@name]/@name');
-				$names = array_map('strval', $attrs ? $attrs : array());
+				$names = array_map('strval', $attrs ?: array());
 
 				// If the field is in the exact group use it and break out of the loop.
 				if ($names == (array) $groupNames)
@@ -1480,7 +1480,7 @@ class Form
 						{
 							// Get the names of the groups that the field is in.
 							$attrs = $field->xpath('ancestor::fields[@name]/@name');
-							$names = array_map('strval', $attrs ? $attrs : array());
+							$names = array_map('strval', $attrs ?: array());
 
 							// If the field is in the specific group then add it to the return list.
 							if ($names == (array) $groupNames)
@@ -1563,7 +1563,7 @@ class Form
 					{
 						// Get the group names as strings for ancestor fields elements.
 						$attrs = $fields->xpath('ancestor-or-self::fields[@name]/@name');
-						$names = array_map('strval', $attrs ? $attrs : array());
+						$names = array_map('strval', $attrs ?: array());
 
 						// If the group names for the fields element match the valid names at this
 						// level add the fields element.
@@ -1679,7 +1679,7 @@ class Form
 
 		// Get any addfieldpath attributes from the form definition.
 		$paths = $this->xml->xpath('//*[@addfieldpath]/@addfieldpath');
-		$paths = array_map('strval', $paths ? $paths : array());
+		$paths = array_map('strval', $paths ?: []);
 
 		// Add the field paths.
 		foreach ($paths as $path)
@@ -1690,7 +1690,7 @@ class Form
 
 		// Get any addformpath attributes from the form definition.
 		$paths = $this->xml->xpath('//*[@addformpath]/@addformpath');
-		$paths = array_map('strval', $paths ? $paths : array());
+		$paths = array_map('strval', $paths ?: []);
 
 		// Add the form paths.
 		foreach ($paths as $path)
@@ -1701,7 +1701,7 @@ class Form
 
 		// Get any addrulepath attributes from the form definition.
 		$paths = $this->xml->xpath('//*[@addrulepath]/@addrulepath');
-		$paths = array_map('strval', $paths ? $paths : array());
+		$paths = array_map('strval', $paths ?: []);
 
 		// Add the rule paths.
 		foreach ($paths as $path)
@@ -1712,7 +1712,7 @@ class Form
 
 		// Get any addrulepath attributes from the form definition.
 		$paths = $this->xml->xpath('//*[@addfilterpath]/@addfilterpath');
-		$paths = array_map('strval', $paths ? $paths : array());
+		$paths = array_map('strval', $paths ?: []);
 
 		// Add the rule paths.
 		foreach ($paths as $path)
@@ -1723,7 +1723,7 @@ class Form
 
 		// Get any addfieldprefix attributes from the form definition.
 		$prefixes = $this->xml->xpath('//*[@addfieldprefix]/@addfieldprefix');
-		$prefixes = array_map('strval', $prefixes ? $prefixes : array());
+		$prefixes = array_map('strval', $prefixes ?: []);
 
 		// Add the field prefixes.
 		foreach ($prefixes as $prefix)
@@ -1733,7 +1733,7 @@ class Form
 
 		// Get any addformprefix attributes from the form definition.
 		$prefixes = $this->xml->xpath('//*[@addformprefix]/@addformprefix');
-		$prefixes = array_map('strval', $prefixes ? $prefixes : array());
+		$prefixes = array_map('strval', $prefixes ?: []);
 
 		// Add the field prefixes.
 		foreach ($prefixes as $prefix)
@@ -1743,7 +1743,7 @@ class Form
 
 		// Get any addruleprefix attributes from the form definition.
 		$prefixes = $this->xml->xpath('//*[@addruleprefix]/@addruleprefix');
-		$prefixes = array_map('strval', $prefixes ? $prefixes : array());
+		$prefixes = array_map('strval', $prefixes ?: []);
 
 		// Add the field prefixes.
 		foreach ($prefixes as $prefix)
@@ -1753,7 +1753,7 @@ class Form
 
 		// Get any addruleprefix attributes from the form definition.
 		$prefixes = $this->xml->xpath('//*[@addfilterprefix]/@addfilterprefix');
-		$prefixes = array_map('strval', $prefixes ? $prefixes : array());
+		$prefixes = array_map('strval', $prefixes ?: []);
 
 		// Add the field prefixes.
 		foreach ($prefixes as $prefix)

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -302,7 +302,7 @@ class Form
 		{
 			// Get the field groups for the element.
 			$attrs = $element->xpath('ancestor::fields[@name]/@name');
-			$groups = array_map('strval', $attrs ?: array());
+			$groups = array_map('strval', $attrs ?: []);
 			$group = implode('.', $groups);
 
 			// If the field is successfully loaded add it to the result array.

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -489,8 +489,6 @@ abstract class FormField
 					return $this->dataAttributes[$name];
 				}
 		}
-
-		return;
 	}
 
 	/**
@@ -749,11 +747,11 @@ abstract class FormField
 		// If we already have an id segment add the field id/name as another level.
 		if ($id)
 		{
-			$id .= '_' . ($fieldId ? $fieldId : $fieldName);
+			$id .= '_' . ($fieldId ?: $fieldName);
 		}
 		else
 		{
-			$id .= ($fieldId ? $fieldId : $fieldName);
+			$id .= ($fieldId ?: $fieldName);
 		}
 
 		// Clean up any invalid characters.

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -1022,12 +1022,10 @@ class Language
 				return $this->paths[$extension];
 			}
 
-			return;
+			return [];
 		}
-		else
-		{
-			return $this->paths;
-		}
+
+		return $this->paths;
 	}
 
 	/**

--- a/libraries/src/Log/LogEntry.php
+++ b/libraries/src/Log/LogEntry.php
@@ -121,6 +121,6 @@ class LogEntry
 		$this->callStack = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
 
 		// Get the date as a Date object.
-		$this->date = new Date($date ? $date : 'now');
+		$this->date = new Date($date ?: 'now');
 	}
 }

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -375,8 +375,8 @@ class BaseController implements ControllerInterface
 		$this->redirect = null;
 		$this->taskMap = array();
 
-		$this->app   = $app ? $app : Factory::getApplication();
-		$this->input = $input ? $input : $this->app->input;
+		$this->app   = $app ?: Factory::getApplication();
+		$this->input = $input ?: $this->app->input;
 
 		if (\defined('JDEBUG') && JDEBUG)
 		{

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1214,8 +1214,6 @@ abstract class AdminModel extends FormModel
 				if (property_exists($table, $publishedColumnName) && $table->get($publishedColumnName, $value) == $value)
 				{
 					unset($pks[$i]);
-
-					continue;
 				}
 			}
 		}

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -363,7 +363,7 @@ class WebAssetManager implements WebAssetManagerInterface
 				$depName = substr($dependency, 0, $pos);
 			}
 
-			$depType = $depType ? $depType : 'preset';
+			$depType = $depType ?: 'preset';
 
 			// Make sure dependency exists
 			if (!$this->registry->exists($depType, $depName))
@@ -409,7 +409,7 @@ class WebAssetManager implements WebAssetManagerInterface
 				$depName = substr($dependency, 0, $pos);
 			}
 
-			$depType = $depType ? $depType : 'preset';
+			$depType = $depType ?: 'preset';
 
 			// Make sure dependency exists
 			if (!$this->registry->exists($depType, $depName))

--- a/libraries/src/Workflow/Workflow.php
+++ b/libraries/src/Workflow/Workflow.php
@@ -179,8 +179,6 @@ class Workflow
 			if ($workflow_id == 'inherit')
 			{
 				$workflow_id = 0;
-
-				continue;
 			}
 			elseif ($workflow_id == 'use_default')
 			{

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -1188,8 +1188,6 @@ class PlgSampledataMultilang extends CMSPlugin
 			if ($tableLanguage->load(array('lang_code' => $siteLang->language, 'published' => 0)) && !$tableLanguage->publish())
 			{
 				$this->app->enqueueMessage(Text::sprintf('INSTL_DEFAULTLANGUAGE_COULD_NOT_CREATE_CONTENT_LANGUAGE', $siteLang->name), 'warning');
-
-				continue;
 			}
 		}
 


### PR DESCRIPTION
Code review.

Delete all the things. Make them smaller. Prettier. Modern. More Professional. Less Code = Less Bugs

- 'return' is unnecessary as the last statement in a method
- Ternary expression replaced with short version
- Unnecessary 'return' statement
- 'continue' is unnecessary as the last statement in a loop