### PR TITLE
[4] /s/host/command line

### DIFF
--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -16,8 +16,8 @@ if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
 {
 	echo 'Sorry, your PHP version is not supported.' . PHP_EOL;
 	echo 'Your command line php needs to be version ' . JOOMLA_MINIMUM_PHP . ' or newer to run the Joomla! CLI Tools' . PHP_EOL;
-	echo 'Your are command line php is currently running PHP version ' . PHP_VERSION . '.' . PHP_EOL;
-	echo 'The version of PHP available on your command line may be different to the version that is used by your web server to run the Joomla! Web Application' . PHP_EOL;	
+	echo 'The version of PHP currently running this code, at the command line, is PHP version ' . PHP_VERSION . '.' . PHP_EOL;
+	echo 'Please note, the version of PHP running your commands here, may be different to the version that is used by your web server to run the Joomla! Web Application' . PHP_EOL;	
 
 	exit;
 }

--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -17,7 +17,8 @@ if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
 	echo 'Sorry, your PHP version is not supported.' . PHP_EOL;
 	echo 'Your command line php needs to be version ' . JOOMLA_MINIMUM_PHP . ' or newer to run the Joomla! CLI Tools' . PHP_EOL;
 	echo 'The version of PHP currently running this code, at the command line, is PHP version ' . PHP_VERSION . '.' . PHP_EOL;
-	echo 'Please note, the version of PHP running your commands here, may be different to the version that is used by your web server to run the Joomla! Web Application' . PHP_EOL;	
+	echo 'Please note, the version of PHP running your commands here, may be different to the version that is used by ';
+	echo 'your web server to run the Joomla! Web Application' . PHP_EOL;
 
 	exit;
 }

--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -15,7 +15,7 @@ const JOOMLA_MINIMUM_PHP = '7.2.5';
 if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
 {
 	echo 'Sorry, your PHP version is not supported.' . PHP_EOL;
-	echo 'Your host needs to use PHP version ' . JOOMLA_MINIMUM_PHP . ' or newer to run this version of Joomla!' . PHP_EOL;
+	echo 'Your command line php needs to be version ' . JOOMLA_MINIMUM_PHP . ' or newer to run the Joomla! CLI Tools' . PHP_EOL;
 	echo 'You are currently running PHP version ' . PHP_VERSION . '.' . PHP_EOL;
 
 	exit;

--- a/cli/joomla.php
+++ b/cli/joomla.php
@@ -16,7 +16,8 @@ if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<'))
 {
 	echo 'Sorry, your PHP version is not supported.' . PHP_EOL;
 	echo 'Your command line php needs to be version ' . JOOMLA_MINIMUM_PHP . ' or newer to run the Joomla! CLI Tools' . PHP_EOL;
-	echo 'You are currently running PHP version ' . PHP_VERSION . '.' . PHP_EOL;
+	echo 'Your are command line php is currently running PHP version ' . PHP_VERSION . '.' . PHP_EOL;
+	echo 'The version of PHP available on your command line may be different to the version that is used by your web server to run the Joomla! Web Application' . PHP_EOL;	
 
 	exit;
 }


### PR DESCRIPTION
This is the entry point for the CLI commands. 

Saying your "host needs to use PHP version" is ambiguous, as the "web host" could already be running PHP 8.x for apache, Nginx, php-fpm... but the command line PHP version could be 5.2.ish. 

The person with ssh command line access is probably not "your average user" but a "power user" of sorts 

changed terminology slightly 

 