### PR TITLE
Simple class names in articles

### DIFF
--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -98,7 +98,7 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 	<?php if (isset ($this->item->toc)) :
 		echo $this->item->toc;
 	endif; ?>
-	<div itemprop="articleBody" class="article | com-content-article__body">
+	<div itemprop="articleBody" class="content | com-content-article__body">
 		<?php echo $this->item->text; ?>
 	</div>
 

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -33,10 +33,10 @@ $currentDate       = Factory::getDate()->format('Y-m-d H:i:s');
 $isNotPublishedYet = $this->item->publish_up > $currentDate;
 $isExpired         = !is_null($this->item->publish_down) && $this->item->publish_down < $currentDate;
 ?>
-<div class="com-content-article item-page<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="https://schema.org/Article">
+<div class="article <?php echo $this->pageclass_sfx; ?> | com-content-article item-page<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="https://schema.org/Article">
 	<meta itemprop="inLanguage" content="<?php echo ($this->item->language === '*') ? Factory::getApplication()->get('language') : $this->item->language; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
-	<div class="page-header">
+	<div class="title | page-header">
 		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
 	</div>
 	<?php endif;
@@ -50,18 +50,18 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author') || $assocParam; ?>
 
 	<?php if ($params->get('show_title')) : ?>
-	<div class="page-header">
+	<div class="title | page-header">
 		<<?php echo $htag; ?> itemprop="headline">
 			<?php echo $this->escape($this->item->title); ?>
 		</<?php echo $htag; ?>>
 		<?php if ($this->item->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
-			<span class="badge bg-warning text-light"><?php echo Text::_('JUNPUBLISHED'); ?></span>
+			<span class="badge | bg-warning text-light"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>
 		<?php if ($isNotPublishedYet) : ?>
-			<span class="badge bg-warning text-light"><?php echo Text::_('JNOTPUBLISHEDYET'); ?></span>
+			<span class="badge | bg-warning text-light"><?php echo Text::_('JNOTPUBLISHEDYET'); ?></span>
 		<?php endif; ?>
 		<?php if ($isExpired) : ?>
-			<span class="badge bg-warning text-light"><?php echo Text::_('JEXPIRED'); ?></span>
+			<span class="badge | bg-warning text-light"><?php echo Text::_('JEXPIRED'); ?></span>
 		<?php endif; ?>
 	</div>
 	<?php endif; ?>
@@ -98,7 +98,7 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 	<?php if (isset ($this->item->toc)) :
 		echo $this->item->toc;
 	endif; ?>
-	<div itemprop="articleBody" class="com-content-article__body">
+	<div itemprop="articleBody" class="article | com-content-article__body">
 		<?php echo $this->item->text; ?>
 	</div>
 

--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -34,7 +34,7 @@ if ((isset($img->attributes['width']) && (int) $img->attributes['width'] > 0)
 	$extraAttr = ArrayHelper::toString($img->attributes) . ' loading="lazy"';
 }
 ?>
-<figure class="<?php echo htmlspecialchars($imgclass, ENT_COMPAT, 'UTF-8'); ?> item-image">
+<figure class="image <?php echo htmlspecialchars($imgclass, ENT_COMPAT, 'UTF-8'); ?> | item-image">
 	<?php if ($params->get('link_intro_image') && ($params->get('access-view') || $params->get('show_noauth', '0') == '1')) : ?>
 		<a href="<?php echo Route::_(RouteHelper::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>"
 			itemprop="url" title="<?php echo $this->escape($displayData->title); ?>">


### PR DESCRIPTION
Pull Request for Issue #35342.

### Summary of Changes
The proposed changes affect the class names that relate to an article. The purpose is to have simple, short and easy to remember class names in order to create more complex article layouts in an easier way  (with the help of a few changes that I will also propose for custom fields).

Specifically:
- New class names are added (in some cases).
- When new class names are added, the old and not useful class names remained for compatibility reasons.
- The old and not useful class names are separated with the special character | so the developers will distinguish them and not use them.
- (The special character is allowed according to https://stackoverflow.com/questions/448981/which-characters-are-valid-in-css-class-names-selectors.)

### Notes:
- Personally, I would not suggest keeping the old and not useful classes, but some guys want backward compatibility.
- Some guys recommended to use BEM for naming the classes and initially I was using BEM in the proposed changes. But I cancelled using BEM because I don't find it useful. Using BEM, the class names would remain complex and very long.
Also, I think that BEM changed a little some of the naming rules and I think that there are some inconsistencies in the documentation. For example, the class "search-form__button_size_m" should be "search-form__button_size-m".

For many years, I create websites having high quality templates from scratch (only with Joomla of course) and I don't use purchased templates. So I have faced many cases and requirements and I believe that the proposed changes make things way much better.