### PR TITLE
[4.0] Smart Search: let router handle the Itemid

### DIFF
--- a/modules/mod_finder/src/Helper/FinderHelper.php
+++ b/modules/mod_finder/src/Helper/FinderHelper.php
@@ -41,7 +41,6 @@ class FinderHelper
 		$fields = array();
 		$uri = Uri::getInstance(Route::_($route));
 		$uri->delVar('q');
-		$uri->delVar('Itemid');
 
 		// Create hidden input elements for each part of the URI.
 		foreach ($uri->getQuery(true) as $n => $v)

--- a/modules/mod_finder/src/Helper/FinderHelper.php
+++ b/modules/mod_finder/src/Helper/FinderHelper.php
@@ -38,24 +38,15 @@ class FinderHelper
 	 */
 	public static function getGetFields($route = null, $paramItem = 0)
 	{
-		// Determine if there is an item id before routing.
-		$needId = !Uri::getInstance($route)->getVar('Itemid');
-
 		$fields = array();
 		$uri = Uri::getInstance(Route::_($route));
 		$uri->delVar('q');
+		$uri->delVar('Itemid');
 
 		// Create hidden input elements for each part of the URI.
 		foreach ($uri->getQuery(true) as $n => $v)
 		{
 			$fields[] = '<input type="hidden" name="' . $n . '" value="' . $v . '">';
-		}
-
-		// Add a field for Itemid if we need one.
-		if ($needId)
-		{
-			$id       = $paramItem ?: Factory::getApplication()->input->get('Itemid', '0', 'int');
-			$fields[] = '<input type="hidden" name="Itemid" value="' . $id . '">';
 		}
 
 		return implode('', $fields);


### PR DESCRIPTION
Pull Request for Issue  #35497.

### Summary of Changes
The Smart Search module adds all get fields of the form route as additional hidden input fields to the search form. The router always adds the Itemid to the URL and thus will also always add the Itemid as hidden input field. Since the code in line 42 however doesn't check the processed URL, but just the unSEFed URL, it will often enough not contain the Itemid. Long story short: The code in line 42 doesn't find an Itemid and thus adds it in addition, while the code in line 45 adds the Itemid (via the router) and then line 49 adds it a second time. We can simply drop this whole "check for Itemid" code. Either the Itemid is a valid Smart Search menu item, then it will create a nice SEF URL, no Itemid will be in the query in line 49, or the Itemid is part of the get query and will be added as hidden input.


### Testing Instructions
I'm copying the instructions by @brianteeman here, since they are perfect for this.

### Steps to reproduce the issue PART 1
Create a smart search module. Do not create a search menu item or set an ItemID in the module
image

Then visit the front end and perform a search with the module

### Actual result BEFORE applying this Pull Request
The url is example.com/component/finder/search?q=&Itemid=101&Itemid=101

### Expected result AFTER applying this Pull Request
The url is example.com/component/finder/search?q=&Itemid=xxx

### Steps to reproduce the issue PART 2
Repeat the test but this time add a search menu item or set an ItemID in the module

Then visit the front end and perform a search with the module

### Actual result BEFORE applying this Pull Request
The url is example.com/component/finder/search?q=&Itemid=101&Itemid=xxx
where xxx is the id of the search menu item or the id of the menu item selected in the module
where 101 is the id of the default home page

### Expected result AFTER applying this Pull Request
The url is example.com/component/finder/search?q=&Itemid=xxx
where xxx is the id of the search menu item or the id of the menu item selected in the module