### PR TITLE
[4] remove incorrect param in call to posix_getuid

### DIFF
--- a/libraries/src/Application/DaemonApplication.php
+++ b/libraries/src/Application/DaemonApplication.php
@@ -464,7 +464,7 @@ abstract class DaemonApplication extends CliApplication
 		}
 
 		// Change the user id for the process necessary.
-		if ($uid && (posix_getuid($file) != $uid) && (!@ posix_setuid($uid)))
+		if ($uid && (posix_getuid() != $uid) && (!@ posix_setuid($uid)))
 		{
 			Log::add('Unable to change user ownership of the process.', Log::ERROR);
 
@@ -472,7 +472,7 @@ abstract class DaemonApplication extends CliApplication
 		}
 
 		// Change the group id for the process necessary.
-		if ($gid && (posix_getgid($file) != $gid) && (!@ posix_setgid($gid)))
+		if ($gid && (posix_getgid() != $gid) && (!@ posix_setgid($gid)))
 		{
 			Log::add('Unable to change group ownership of the process.', Log::ERROR);
 


### PR DESCRIPTION
Code review

`posix_getuid()` should accept no parameters as per the PHP documentation for this function. 

Docs: https://www.php.net/manual/en/function.posix-getuid.php

Edit: apparently its been this way for 10 years, so, no rush, https://github.com/joomla/joomla-cms/commit/b39a870b891fba091833d80beb2ee11a0cb140df