### PR TITLE
[4.0] Remove all references to old JPrefixed Class in /administrator/

### DIFF
--- a/administrator/components/com_actionlogs/src/Controller/ActionlogsController.php
+++ b/administrator/components/com_actionlogs/src/Controller/ActionlogsController.php
@@ -40,7 +40,7 @@ class ActionlogsController extends AdminController
 	 *                                         Recognized key values include 'name', 'default_task', 'model_path', and
 	 *                                         'view_path' (this list is not meant to be comprehensive).
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   3.9.0

--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Router\Route;
 use Joomla\String\StringHelper;
 
@@ -30,6 +31,7 @@ class ActionlogsHelper
 	 * Array of characters starting a formula
 	 *
 	 * @var    array
+	 *
 	 * @since  3.9.7
 	 */
 	private static $characters = array('=', '+', '-', '@');
@@ -42,6 +44,7 @@ class ActionlogsHelper
 	 * @return  Generator
 	 *
 	 * @since   3.9.0
+	 *
 	 * @throws  \InvalidArgumentException
 	 */
 	public static function getCsvData($data): Generator
@@ -173,8 +176,8 @@ class ActionlogsHelper
 	/**
 	 * Get human readable log message for a User Action Log
 	 *
-	 * @param   stdClass  $log            A User Action log message record
-	 * @param   boolean   $generateLinks  Flag to disable link generation when creating a message
+	 * @param   \stdClass  $log            A User Action log message record
+	 * @param   boolean    $generateLinks  Flag to disable link generation when creating a message
 	 *
 	 * @return  string
 	 *
@@ -233,11 +236,11 @@ class ActionlogsHelper
 	/**
 	 * Get link to an item of given content type
 	 *
-	 * @param   string   $component
-	 * @param   string   $contentType
-	 * @param   integer  $id
-	 * @param   string   $urlVar
-	 * @param   JObject  $object
+	 * @param   string     $component
+	 * @param   string     $contentType
+	 * @param   integer    $id
+	 * @param   string     $urlVar
+	 * @param   CMSObject  $object
 	 *
 	 * @return  string  Link to the content item
 	 *

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -7459,7 +7459,7 @@ class JoomlaInstallerScript
 
 		foreach ($newComponents as $component)
 		{
-			/** @var JTableAsset $asset */
+			/** @var \Joomla\CMS\Table\Asset $asset */
 			$asset = Table::getInstance('Asset');
 
 			if ($asset->loadByName($component))

--- a/administrator/components/com_associations/src/Model/AssociationModel.php
+++ b/administrator/components/com_associations/src/Model/AssociationModel.php
@@ -26,7 +26,7 @@ class AssociationModel extends ListModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  mixed  A \JForm object on success, false on failure
+	 * @return  \Joomla\CMS\Form\Form|boolean  A Form object on success, false on failure
 	 *
 	 * @since  3.7.0
 	 */

--- a/administrator/components/com_banners/src/Controller/BannersController.php
+++ b/administrator/components/com_banners/src/Controller/BannersController.php
@@ -38,7 +38,7 @@ class BannersController extends AdminController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   3.0

--- a/administrator/components/com_banners/src/Model/ClientModel.php
+++ b/administrator/components/com_banners/src/Model/ClientModel.php
@@ -85,7 +85,7 @@ class ClientModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return \Joomla\CMS\Form\Form|boolean A \JForm object on success, false on failure
+	 * @return \Joomla\CMS\Form\Form|boolean A Form object on success, false on failure
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_banners/src/Model/ClientModel.php
+++ b/administrator/components/com_banners/src/Model/ClientModel.php
@@ -85,7 +85,7 @@ class ClientModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  \JForm|boolean  A \JForm object on success, false on failure
+	 * @return \Joomla\CMS\Form\Form|boolean A \JForm object on success, false on failure
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_banners/src/Model/DownloadModel.php
+++ b/administrator/components/com_banners/src/Model/DownloadModel.php
@@ -52,7 +52,7 @@ class DownloadModel extends FormModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  \JForm|boolean  A JForm object on success, false on failure
+	 * @return  \Joomla\CMS\Form\Form|boolean  A Form object on success, false on failure
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_categories/src/Controller/CategoryController.php
+++ b/administrator/components/com_categories/src/Controller/CategoryController.php
@@ -41,7 +41,7 @@ class CategoryController extends FormController
 	 *
 	 * @param   array                     $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface|null  $factory  The factory.
-	 * @param   CMSApplication|null       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication|null       $app      The Application for the dispatcher
 	 * @param   Input|null                $input    Input
 	 *
 	 * @since  1.6

--- a/administrator/components/com_categories/src/Controller/DisplayController.php
+++ b/administrator/components/com_categories/src/Controller/DisplayController.php
@@ -46,7 +46,7 @@ class DisplayController extends BaseController
 	 *
 	 * @param   array                     $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface|null  $factory  The factory.
-	 * @param   CMSApplication|null       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication|null       $app      The Application for the dispatcher
 	 * @param   Input|null                $input    Input
 	 *
 	 * @since   3.0

--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -397,14 +397,16 @@ class CategoryModel extends AdminModel
 	/**
 	 * Method to preprocess the form.
 	 *
-	 * @param   \JForm  $form   A JForm object.
-	 * @param   mixed   $data   The data expected for the form.
-	 * @param   string  $group  The name of the plugin group to import.
+	 * @param   Form    $form  A Form object.
+	 * @param   mixed   $data  The data expected for the form.
+	 * @param   string  $group The name of the plugin group to import.
 	 *
 	 * @return  mixed
 	 *
 	 * @see     \Joomla\CMS\Form\FormField
+	 *
 	 * @since   1.6
+	 *
 	 * @throws  \Exception if there is an error in the form event.
 	 */
 	protected function preprocessForm(Form $form, $data, $group = 'content')

--- a/administrator/components/com_categories/src/Table/CategoryTable.php
+++ b/administrator/components/com_categories/src/Table/CategoryTable.php
@@ -16,7 +16,7 @@ namespace Joomla\Component\Categories\Administrator\Table;
  *
  * @since  1.6
  */
-class CategoryTable extends \JTableCategory
+class CategoryTable extends \Joomla\CMS\Table\Category
 {
 	/**
 	 * Method to delete a node and, optionally, its child nodes from the table.

--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -61,7 +61,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	public $filterForm;
 

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -31,7 +32,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
@@ -45,7 +46,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  CMSObject
 	 */
 	protected $state;
 
@@ -59,7 +60,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var  \JObject
+	 * @var  CMSObject
 	 */
 	protected $canDo;
 

--- a/administrator/components/com_checkin/src/View/Checkin/HtmlView.php
+++ b/administrator/components/com_checkin/src/View/Checkin/HtmlView.php
@@ -41,14 +41,15 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
+	 *
 	 * @since  4.0.0
 	 */
 	public $filterForm;
@@ -57,6 +58,7 @@ class HtmlView extends BaseHtmlView
 	 * The active search filters
 	 *
 	 * @var    array
+	 *
 	 * @since  4.0.0
 	 */
 	public $activeFilters;
@@ -64,7 +66,8 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Is this view an Empty State
 	 *
-	 * @var  boolean
+	 * @var   boolean
+	 *
 	 * @since 4.0.0
 	 */
 	private $isEmptyState = false;

--- a/administrator/components/com_config/src/Controller/ApplicationController.php
+++ b/administrator/components/com_config/src/Controller/ApplicationController.php
@@ -34,7 +34,7 @@ class ApplicationController extends BaseController
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   3.0

--- a/administrator/components/com_config/src/Controller/ComponentController.php
+++ b/administrator/components/com_config/src/Controller/ComponentController.php
@@ -33,7 +33,7 @@ class ComponentController extends FormController
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   3.0

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Filesystem\Path;
+use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\Http\HttpFactory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
@@ -495,7 +496,7 @@ class ApplicationModel extends FormModel
 		// Escape the offline message if present.
 		if (isset($data['offline_message']))
 		{
-			$data['offline_message'] = \JFilterOutput::ampReplace($data['offline_message']);
+			$data['offline_message'] = OutputFilter::ampReplace($data['offline_message']);
 		}
 
 		// Purge the database session table if we are changing to the database handler.

--- a/administrator/components/com_contact/src/Controller/ContactsController.php
+++ b/administrator/components/com_contact/src/Controller/ContactsController.php
@@ -32,7 +32,7 @@ class ContactsController extends AdminController
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   3.0

--- a/administrator/components/com_contact/src/Table/ContactTable.php
+++ b/administrator/components/com_contact/src/Table/ContactTable.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Contact\Administrator\Table;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Table\Table;
@@ -150,7 +151,7 @@ class ContactTable extends Table implements VersionableTableInterface, TaggableT
 
 		$this->default_con = (int) $this->default_con;
 
-		if (\JFilterInput::checkAttribute(array('href', $this->webpage)))
+		if (InputFilter::checkAttribute(array('href', $this->webpage)))
 		{
 			$this->setError(Text::_('COM_CONTACT_WARNING_PROVIDE_VALID_URL'));
 

--- a/administrator/components/com_contact/src/View/Contact/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contact/HtmlView.php
@@ -28,9 +28,9 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
 class HtmlView extends BaseHtmlView
 {
 	/**
-	 * The \JForm object
+	 * The Form object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
@@ -44,7 +44,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 

--- a/administrator/components/com_contact/src/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contacts/HtmlView.php
@@ -37,21 +37,21 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var  \JPagination
+	 * @var  \Joomla\CMS\Pagination\Pagination
 	 */
 	protected $pagination;
 
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	public $filterForm;
 
@@ -65,7 +65,8 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Is this view an Empty State
 	 *
-	 * @var  boolean
+	 * @var   boolean
+	 *
 	 * @since 4.0.0
 	 */
 	private $isEmptyState = false;

--- a/administrator/components/com_content/src/Controller/ArticleController.php
+++ b/administrator/components/com_content/src/Controller/ArticleController.php
@@ -36,7 +36,7 @@ class ArticleController extends FormController
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   3.0

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -34,7 +34,7 @@ class ArticlesController extends AdminController
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   3.0

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -13,6 +13,8 @@ namespace Joomla\Component\Content\Administrator\Model;
 
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\InputFilter;
+use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Helper\TagsHelper;
@@ -685,7 +687,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 	public function save($data)
 	{
 		$input  = Factory::getApplication()->input;
-		$filter = \JFilterInput::getInstance();
+		$filter = InputFilter::getInstance();
 		$db     = $this->getDbo();
 		$user	= Factory::getUser();
 
@@ -805,11 +807,11 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 			{
 				if (Factory::getApplication()->get('unicodeslugs') == 1)
 				{
-					$data['alias'] = \JFilterOutput::stringUrlUnicodeSlug($data['title']);
+					$data['alias'] = OutputFilter::stringUrlUnicodeSlug($data['title']);
 				}
 				else
 				{
-					$data['alias'] = \JFilterOutput::stringURLSafe($data['title']);
+					$data['alias'] = OutputFilter::stringURLSafe($data['title']);
 				}
 
 				$table = Table::getInstance('Content', 'JTable');

--- a/administrator/components/com_content/src/Table/ArticleTable.php
+++ b/administrator/components/com_content/src/Table/ArticleTable.php
@@ -16,6 +16,6 @@ namespace Joomla\Component\Content\Administrator\Table;
  *
  * @since  1.5
  */
-class ArticleTable extends \JTableContent
+class ArticleTable extends \Joomla\CMS\Table\Content
 {
 }

--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -33,7 +33,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var \Joomla\CMS\Form\Form
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
@@ -54,7 +54,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $canDo;
 
@@ -72,8 +72,9 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @return  void
 	 *
-	 * @throws \Exception
 	 * @since   1.6
+	 *
+	 * @throws  \Exception
 	 */
 	public function display($tpl = null)
 	{
@@ -119,8 +120,9 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @return  void
 	 *
-	 * @throws \Exception
 	 * @since   1.6
+	 *
+	 * @throws  \Exception
 	 */
 	protected function addToolbar()
 	{

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -40,21 +40,21 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var  \JPagination
+	 * @var  \Joomla\CMS\Pagination\Pagination
 	 */
 	protected $pagination;
 
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	public $filterForm;
 
@@ -75,7 +75,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Is this view an Empty State
 	 *
-	 * @var  boolean
+	 * @var   boolean
 	 * @since 4.0.0
 	 */
 	private $isEmptyState = false;

--- a/administrator/components/com_content/src/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/src/View/Featured/HtmlView.php
@@ -40,21 +40,21 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var  \JPagination
+	 * @var  \Joomla\CMS\Pagination\Pagination
 	 */
 	protected $pagination;
 
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	public $filterForm;
 

--- a/administrator/components/com_contenthistory/src/View/Compare/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/Compare/HtmlView.php
@@ -31,7 +31,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 

--- a/administrator/components/com_contenthistory/src/View/History/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/History/HtmlView.php
@@ -45,7 +45,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 

--- a/administrator/components/com_contenthistory/src/View/Preview/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/Preview/HtmlView.php
@@ -33,7 +33,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 

--- a/administrator/components/com_fields/src/Controller/FieldController.php
+++ b/administrator/components/com_fields/src/Controller/FieldController.php
@@ -52,7 +52,7 @@ class FieldController extends FormController
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   3.7.0

--- a/administrator/components/com_fields/src/Controller/GroupController.php
+++ b/administrator/components/com_fields/src/Controller/GroupController.php
@@ -50,7 +50,7 @@ class GroupController extends FormController
 	 * Recognized key values include 'name', 'default_task', 'model_path', and
 	 * 'view_path' (this list is not meant to be comprehensive).
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   3.7.0

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -504,7 +504,7 @@ class FieldModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  mixed  A \JForm object on success, false on failure
+	 * @return  Form|bool  A Form object on success, false on failure
 	 *
 	 * @since   3.7.0
 	 */
@@ -985,14 +985,16 @@ class FieldModel extends AdminModel
 	/**
 	 * Method to allow derived classes to preprocess the form.
 	 *
-	 * @param   \JForm  $form   A JForm object.
+	 * @param   Form    $form   A Form object.
 	 * @param   mixed   $data   The data expected for the form.
 	 * @param   string  $group  The name of the plugin group to import (defaults to "content").
 	 *
 	 * @return  void
 	 *
 	 * @see     \Joomla\CMS\Form\FormField
+	 *
 	 * @since   3.7.0
+	 *
 	 * @throws  \Exception if there is an error in the form event.
 	 */
 	protected function preprocessForm(Form $form, $data, $group = 'content')

--- a/administrator/components/com_fields/src/Model/FieldsModel.php
+++ b/administrator/components/com_fields/src/Model/FieldsModel.php
@@ -449,7 +449,7 @@ class FieldsModel extends ListModel
 	 * @param   array    $data      data
 	 * @param   boolean  $loadData  load current data
 	 *
-	 * @return  \JForm|false  the JForm object or false
+	 * @return  \Joomla\CMS\Form\Form|bool  The JForm object or false.
 	 *
 	 * @since   3.7.0
 	 */

--- a/administrator/components/com_fields/src/View/Field/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Field/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -27,21 +28,21 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
 class HtmlView extends BaseHtmlView
 {
 	/**
-	 * @var  \JForm
+	 * @var     \Joomla\CMS\Form\Form
 	 *
 	 * @since   3.7.0
 	 */
 	protected $form;
 
 	/**
-	 * @var  \JObject
+	 * @var     CMSObject
 	 *
 	 * @since   3.7.0
 	 */
 	protected $item;
 
 	/**
-	 * @var  \JObject
+	 * @var     CMSObject
 	 *
 	 * @since   3.7.0
 	 */
@@ -55,6 +56,7 @@ class HtmlView extends BaseHtmlView
 	 * @return  void
 	 *
 	 * @see     HtmlView::loadTemplate()
+	 *
 	 * @since   3.7.0
 	 */
 	public function display($tpl = null)

--- a/administrator/components/com_fields/src/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Fields/HtmlView.php
@@ -32,7 +32,7 @@ use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 class HtmlView extends BaseHtmlView
 {
 	/**
-	 * @var  \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 *
 	 * @since  3.7.0
 	 */
@@ -53,14 +53,14 @@ class HtmlView extends BaseHtmlView
 	protected $items;
 
 	/**
-	 * @var  \JPagination
+	 * @var    \Joomla\CMS\Pagination\Pagination
 	 *
 	 * @since  3.7.0
 	 */
 	protected $pagination;
 
 	/**
-	 * @var  \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 *
 	 * @since  3.7.0
 	 */
@@ -73,7 +73,8 @@ class HtmlView extends BaseHtmlView
 	 *
 	 * @return  void
 	 *
-	 * @see     JViewLegacy::loadTemplate()
+	 * @see     \Joomla\CMS\MVC\View\HtmlView::loadTemplate()
+	 *
 	 * @since   3.7.0
 	 */
 	public function display($tpl = null)

--- a/administrator/components/com_fields/src/View/Group/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Group/HtmlView.php
@@ -28,21 +28,21 @@ use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 class HtmlView extends BaseHtmlView
 {
 	/**
-	 * @var  \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 *
 	 * @since  3.7.0
 	 */
 	protected $form;
 
 	/**
-	 * @var  \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 *
 	 * @since  3.7.0
 	 */
 	protected $item;
 
 	/**
-	 * @var  \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 *
 	 * @since  3.7.0
 	 */
@@ -51,7 +51,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var  \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 *
 	 * @since  3.7.0
 	 */
@@ -66,6 +66,7 @@ class HtmlView extends BaseHtmlView
 	 * @return  void
 	 *
 	 * @see     JViewLegacy::loadTemplate()
+	 *
 	 * @since   3.7.0
 	 */
 	public function display($tpl = null)

--- a/administrator/components/com_fields/src/View/Groups/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Groups/HtmlView.php
@@ -32,35 +32,35 @@ use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 class HtmlView extends BaseHtmlView
 {
 	/**
-	 * @var  \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 *
 	 * @since  3.7.0
 	 */
 	public $filterForm;
 
 	/**
-	 * @var  array
+	 * @var    array
 	 *
 	 * @since  3.7.0
 	 */
 	public $activeFilters;
 
 	/**
-	 * @var  array
+	 * @var    array
 	 *
 	 * @since  3.7.0
 	 */
 	protected $items;
 
 	/**
-	 * @var  \JPagination
+	 * @var    \Joomla\CMS\Pagination\Pagination
 	 *
 	 * @since  3.7.0
 	 */
 	protected $pagination;
 
 	/**
-	 * @var  \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 *
 	 * @since  3.7.0
 	 */
@@ -74,6 +74,7 @@ class HtmlView extends BaseHtmlView
 	 * @return  void
 	 *
 	 * @see     HtmlView::loadTemplate()
+	 *
 	 * @since   3.7.0
 	 */
 	public function display($tpl = null)

--- a/administrator/components/com_finder/src/Model/FilterModel.php
+++ b/administrator/components/com_finder/src/Model/FilterModel.php
@@ -98,7 +98,7 @@ class FilterModel extends AdminModel
 	 * @param   array    $data      Data for the form. [optional]
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not. [optional]
 	 *
-	 * @return  Form|boolean  A \JForm object on success, false on failure
+	 * @return  Form|boolean  A Form object on success, false on failure
 	 *
 	 * @since   2.5
 	 */

--- a/administrator/components/com_finder/src/Model/IndexModel.php
+++ b/administrator/components/com_finder/src/Model/IndexModel.php
@@ -337,7 +337,7 @@ class IndexModel extends ListModel
 	 * @param   string  $prefix  A prefix for the table class name. [optional]
 	 * @param   array   $config  Configuration array for model. [optional]
 	 *
-	 * @return  \JTable  A database object
+	 * @return  \Joomla\CMS\Table\Table  A database object
 	 *
 	 * @since   2.5
 	 */

--- a/administrator/components/com_finder/src/Model/StatisticsModel.php
+++ b/administrator/components/com_finder/src/Model/StatisticsModel.php
@@ -26,7 +26,7 @@ class StatisticsModel extends BaseDatabaseModel
 	/**
 	 * Method to get the component statistics
 	 *
-	 * @return  \JObject  The component statistics
+	 * @return  CMSObject The component statistics
 	 *
 	 * @since   2.5
 	 */

--- a/administrator/components/com_finder/src/View/Filter/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Filter/HtmlView.php
@@ -29,6 +29,7 @@ class HtmlView extends BaseHtmlView
 	 * The filter object
 	 *
 	 * @var  \Joomla\Component\Finder\Administrator\Table\FilterTable
+	 *
 	 * @since  3.6.2
 	 */
 	protected $filter;
@@ -36,7 +37,8 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var    \Joomla\CMS\Form\Form
+	 *
 	 * @since  3.6.2
 	 */
 	protected $form;
@@ -44,7 +46,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The active item
 	 *
-	 * @var  \JObject|boolean
+	 * @var    \Joomla\CMS\Object\CMSObject|boolean
 	 *
 	 * @since  3.6.2
 	 */
@@ -53,7 +55,8 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
+	 *
 	 * @since  3.6.2
 	 */
 	protected $state;
@@ -62,6 +65,7 @@ class HtmlView extends BaseHtmlView
 	 * The total indexed items
 	 *
 	 * @var    integer
+	 *
 	 * @since  3.8.0
 	 */
 	protected $total;

--- a/administrator/components/com_finder/src/View/Filters/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Filters/HtmlView.php
@@ -28,7 +28,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * An array of items
 	 *
-	 * @var  array
+	 * @var    array
 	 *
 	 * @since  3.6.1
 	 */
@@ -37,7 +37,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var  \Joomla\CMS\Pagination\Pagination
+	 * @var    \Joomla\CMS\Pagination\Pagination
 	 *
 	 * @since  3.6.1
 	 */
@@ -46,7 +46,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 *
 	 * @since  3.6.1
 	 */
@@ -64,7 +64,8 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
+	 *
 	 * @since  4.0.0
 	 */
 	public $filterForm;
@@ -73,12 +74,13 @@ class HtmlView extends BaseHtmlView
 	 * The active search filters
 	 *
 	 * @var    array
+	 *
 	 * @since  4.0.0
 	 */
 	public $activeFilters;
 
 	/**
-	 * @var boolean
+	 * @var    boolean
 	 *
 	 * @since  4.0.0
 	 */

--- a/administrator/components/com_finder/src/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Index/HtmlView.php
@@ -41,7 +41,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var  \Joomla\CMS\Pagination\Pagination
+	 * @var    \Joomla\CMS\Pagination\Pagination
 	 *
 	 * @since  3.6.1
 	 */
@@ -60,6 +60,7 @@ class HtmlView extends BaseHtmlView
 	 * The id of the content - finder plugin in mysql
 	 *
 	 * @var    integer
+	 *
 	 * @since  4.0.0
 	 */
 	protected $finderPluginId = 0;
@@ -67,7 +68,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  mixed
+	 * @var    mixed
 	 *
 	 * @since  3.6.1
 	 */
@@ -76,7 +77,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The total number of items
 	 *
-	 * @var  integer
+	 * @var    integer
 	 *
 	 * @since  3.6.1
 	 */
@@ -85,7 +86,8 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
+	 *
 	 * @since  4.0.0
 	 */
 	public $filterForm;
@@ -94,6 +96,7 @@ class HtmlView extends BaseHtmlView
 	 * The active search filters
 	 *
 	 * @var    array
+	 *
 	 * @since  4.0.0
 	 */
 	public $activeFilters;

--- a/administrator/components/com_finder/src/View/Maps/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Maps/HtmlView.php
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var  \Joomla\CMS\Pagination\Pagination
+	 * @var    \Joomla\CMS\Pagination\Pagination
 	 *
 	 * @since  3.6.1
 	 */
@@ -47,7 +47,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 *
 	 * @since  3.6.1
 	 */
@@ -65,7 +65,8 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
+	 *
 	 * @since  4.0.0
 	 */
 	public $filterForm;
@@ -74,12 +75,13 @@ class HtmlView extends BaseHtmlView
 	 * The active search filters
 	 *
 	 * @var    array
+	 *
 	 * @since  4.0.0
 	 */
 	public $activeFilters;
 
 	/**
-	 * @var boolean
+	 * @var   boolean
 	 *
 	 * @since 4.0.0
 	 */

--- a/administrator/components/com_finder/src/View/Searches/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Searches/HtmlView.php
@@ -46,21 +46,21 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var    \Joomla\CMS\Pagination\Pagination
+	 * @var  \Joomla\CMS\Pagination\Pagination
 	 */
 	protected $pagination;
 
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;
@@ -76,7 +76,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var    \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 * @since  4.0.0
 	 */
 	protected $canDo;

--- a/administrator/components/com_finder/src/View/Statistics/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Statistics/HtmlView.php
@@ -24,7 +24,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The index statistics
 	 *
-	 * @var  \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 *
 	 * @since  3.6.1
 	 */

--- a/administrator/components/com_installer/src/Controller/ManageController.php
+++ b/administrator/components/com_installer/src/Controller/ManageController.php
@@ -33,7 +33,7 @@ class ManageController extends BaseController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since  1.6

--- a/administrator/components/com_installer/src/Controller/UpdatesitesController.php
+++ b/administrator/components/com_installer/src/Controller/UpdatesitesController.php
@@ -41,7 +41,7 @@ class UpdatesitesController extends AdminController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since  1.6

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -14,6 +14,7 @@ namespace Joomla\Component\Installer\Administrator\Model;
 use Joomla\CMS\Extension\ExtensionHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
+use Joomla\CMS\Form\Form;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Installer\InstallerHelper;
 use Joomla\CMS\Language\Text;
@@ -530,16 +531,16 @@ class UpdateModel extends ListModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  mixed  A \JForm object on success, false on failure
+	 * @return  Form|bool  A Form object on success, false on failure
 	 *
 	 * @since	2.5.2
 	 */
 	public function getForm($data = array(), $loadData = true)
 	{
 		// Get the form.
-		\JForm::addFormPath(JPATH_COMPONENT . '/models/forms');
-		\JForm::addFieldPath(JPATH_COMPONENT . '/models/fields');
-		$form = \JForm::getInstance('com_installer.update', 'update', array('load_data' => $loadData));
+		Form::addFormPath(JPATH_COMPONENT . '/models/forms');
+		Form::addFieldPath(JPATH_COMPONENT . '/models/fields');
+		$form = Form::getInstance('com_installer.update', 'update', array('load_data' => $loadData));
 
 		// Check for an error.
 		if ($form == false)

--- a/administrator/components/com_installer/src/View/Installer/HtmlView.php
+++ b/administrator/components/com_installer/src/View/Installer/HtmlView.php
@@ -27,7 +27,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var    \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 * @since  4.0.0
 	 */
 	public $state;

--- a/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
@@ -64,7 +64,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var    \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 * @since  4.0.0
 	 */
 	protected $state;

--- a/administrator/components/com_languages/src/Model/LanguageModel.php
+++ b/administrator/components/com_languages/src/Model/LanguageModel.php
@@ -136,7 +136,7 @@ class LanguageModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  mixed  A \JForm object on success, false on failure.
+	 * @return  \Joomla\CMS\Form\Form|bool  A Form object on success, false on failure.
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_languages/src/Model/OverrideModel.php
+++ b/administrator/components/com_languages/src/Model/OverrideModel.php
@@ -31,7 +31,7 @@ class OverrideModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  mixed A \JForm object on success, false on failure.
+	 * @return  \Joomla\CMS\Form\Form|bool  A Form object on success, false on failure.
 	 *
 	 * @since   2.5
 	 */

--- a/administrator/components/com_languages/src/View/Installed/HtmlView.php
+++ b/administrator/components/com_languages/src/View/Installed/HtmlView.php
@@ -49,7 +49,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var    \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 * @since  4.0.0
 	 */
 	protected $state;
@@ -57,7 +57,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_languages/src/View/Language/HtmlView.php
+++ b/administrator/components/com_languages/src/View/Language/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -33,23 +34,23 @@ class HtmlView extends BaseHtmlView
 	public $item;
 
 	/**
-	 * The \JForm object
+	 * The Form object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	public $form;
 
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  CMSObject
 	 */
 	public $state;
 
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var    \JObject
+	 * @var    CMSObject
 	 * @since  4.0.0
 	 */
 	protected $canDo;

--- a/administrator/components/com_languages/src/View/Languages/HtmlView.php
+++ b/administrator/components/com_languages/src/View/Languages/HtmlView.php
@@ -42,7 +42,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var    \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 * @since  4.0.0
 	 */
 	protected $state;
@@ -50,7 +50,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_mails/src/Controller/TemplateController.php
+++ b/administrator/components/com_mails/src/Controller/TemplateController.php
@@ -34,7 +34,7 @@ class TemplateController extends FormController
 	 *                                         Recognized key values include 'name', 'default_task', 'model_path', and
 	 *                                         'view_path' (this list is not meant to be comprehensive).
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   4.0.0

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -329,7 +329,7 @@ class TemplateModel extends AdminModel
 		$isNew = true;
 
 		// Include the plugins for the save events.
-		\JPluginHelper::importPlugin($this->events_map['save']);
+		\Joomla\CMS\Plugin\PluginHelper::importPlugin($this->events_map['save']);
 
 		// Allow an exception to be thrown.
 		try

--- a/administrator/components/com_media/src/Event/OAuthCallbackEvent.php
+++ b/administrator/components/com_media/src/Event/OAuthCallbackEvent.php
@@ -32,7 +32,7 @@ class OAuthCallbackEvent extends AbstractEvent
 	/**
 	 * The event input.
 	 *
-	 * @var \JInput
+	 * @var    Input
 	 * @since  4.0.0
 	 */
 	private $input = null;

--- a/administrator/components/com_menus/src/Controller/ItemsController.php
+++ b/administrator/components/com_menus/src/Controller/ItemsController.php
@@ -32,7 +32,7 @@ class ItemsController extends AdminController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since  1.6

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -492,7 +492,7 @@ class MenusHelper extends ContentHelper
 
 		foreach ($items as $item)
 		{
-			/** @var  \JTableMenu  $table */
+			/** @var \Joomla\CMS\Table\Menu $table */
 			$table = Table::getInstance('Menu');
 
 			$item->alias = $menutype . '-' . $item->title;

--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -959,7 +959,7 @@ class ItemModel extends AdminModel
 	 * A protected method to get the where clause for the reorder.
 	 * This ensures that the row will be moved relative to a row with the same menutype.
 	 *
-	 * @param   \JTableMenu  $table  instance.
+	 * @param   \Joomla\CMS\Table\Menu  $table
 	 *
 	 * @return  array  An array of conditions to add to add to ordering queries.
 	 *

--- a/administrator/components/com_menus/src/Model/MenuModel.php
+++ b/administrator/components/com_menus/src/Model/MenuModel.php
@@ -78,7 +78,7 @@ class MenuModel extends FormModel
 	 * @param   string  $prefix  A prefix for the table class name. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  \JTable    A database object
+	 * @return  Table A database object
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_menus/src/Model/MenutypesModel.php
+++ b/administrator/components/com_menus/src/Model/MenutypesModel.php
@@ -138,7 +138,7 @@ class MenutypesModel extends BaseDatabaseModel
 	 * Method to create the reverse lookup for link-to-name.
 	 * (can be used from onAfterGetMenuTypeOptions handlers)
 	 *
-	 * @param   \JObject  $option  with request array or string and title public variables
+	 * @param   CMSObject $option  With request array or string and title public variables.
 	 *
 	 * @return  void
 	 *

--- a/administrator/components/com_menus/src/Table/MenuTable.php
+++ b/administrator/components/com_menus/src/Table/MenuTable.php
@@ -20,7 +20,7 @@ use Joomla\Database\ParameterType;
  *
  * @since  1.6
  */
-class MenuTable extends \JTableMenu
+class MenuTable extends \Joomla\CMS\Table\Menu
 {
 	/**
 	 * Method to delete a node and, optionally, its child nodes from the table.

--- a/administrator/components/com_menus/src/Table/MenuTypeTable.php
+++ b/administrator/components/com_menus/src/Table/MenuTypeTable.php
@@ -16,7 +16,7 @@ namespace Joomla\Component\Menus\Administrator\Table;
  *
  * @since  1.6
  */
-class MenuTypeTable extends \JTableMenuType
+class MenuTypeTable extends \Joomla\CMS\Table\MenuType
 {
 
 }

--- a/administrator/components/com_menus/src/View/Item/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Item/HtmlView.php
@@ -30,14 +30,14 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
 	/**
 	 * The active item
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $item;
 
@@ -49,14 +49,14 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var    \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 * @since  3.7.0
 	 */
 	protected $canDo;

--- a/administrator/components/com_menus/src/View/Items/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Items/HtmlView.php
@@ -53,14 +53,14 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_menus/src/View/Menu/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menu/HtmlView.php
@@ -28,7 +28,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
@@ -42,14 +42,14 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $canDo;
 

--- a/administrator/components/com_menus/src/View/Menu/XmlView.php
+++ b/administrator/components/com_menus/src/View/Menu/XmlView.php
@@ -33,7 +33,7 @@ class XmlView extends BaseHtmlView
 	protected $items;
 
 	/**
-	 * @var  \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 *
 	 * @since  3.8.0
 	 */

--- a/administrator/components/com_menus/src/View/Menus/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menus/HtmlView.php
@@ -48,14 +48,14 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_menus/src/View/Menutypes/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menutypes/HtmlView.php
@@ -36,7 +36,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Array of menu types
 	 *
-	 * @var    \JObject[]
+	 * @var    CMSObject[]
 	 * @since  3.7.0
 	 */
 	protected $types;

--- a/administrator/components/com_messages/src/Model/ConfigModel.php
+++ b/administrator/components/com_messages/src/Model/ConfigModel.php
@@ -101,7 +101,7 @@ class ConfigModel extends FormModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  \JForm	 A \JForm object on success, false on failure
+	 * @return  \Joomla\CMS\Form\Form|bool  A Form object on success, false on failure
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_messages/src/Model/MessageModel.php
+++ b/administrator/components/com_messages/src/Model/MessageModel.php
@@ -218,7 +218,7 @@ class MessageModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  \JForm   A \JForm object on success, false on failure
+	 * @return  \Joomla\CMS\Form\Form|bool  A Form object on success, false on failure
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_messages/src/View/Config/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Config/HtmlView.php
@@ -27,7 +27,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
@@ -41,7 +41,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 

--- a/administrator/components/com_messages/src/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Message/HtmlView.php
@@ -28,7 +28,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
@@ -42,7 +42,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 

--- a/administrator/components/com_messages/src/View/Messages/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Messages/HtmlView.php
@@ -42,14 +42,14 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -542,7 +542,7 @@ class ModuleModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  \JForm  A \JForm object on success, false on failure
+	 * @return  Form|bool  A Form object on success, false on failure
 	 *
 	 * @since   1.6
 	 */
@@ -847,7 +847,7 @@ class ModuleModel extends AdminModel
 	/**
 	 * Method to preprocess the form
 	 *
-	 * @param   \JForm  $form   A form object.
+	 * @param   Form    $form   A form object.
 	 * @param   mixed   $data   The data expected for the form.
 	 * @param   string  $group  The name of the plugin group to import (defaults to "content").
 	 *

--- a/administrator/components/com_modules/src/View/Module/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Module/HtmlView.php
@@ -28,7 +28,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
@@ -42,14 +42,14 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var    \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 * @since  4.0.0
 	 */
 	protected $canDo;

--- a/administrator/components/com_modules/src/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Modules/HtmlView.php
@@ -38,21 +38,21 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var  \JPagination
+	 * @var  \Joomla\CMS\Pagination\Pagination
 	 */
 	protected $pagination;
 
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_modules/src/View/Select/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Select/HtmlView.php
@@ -28,7 +28,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
@@ -102,7 +102,7 @@ class NewsfeedModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  \JForm    A \JForm object on success, false on failure
+	 * @return  Form|bool  A Form object on success, false on failure
 	 *
 	 * @since   1.6
 	 */
@@ -305,7 +305,7 @@ class NewsfeedModel extends AdminModel
 	/**
 	 * Prepare and sanitise the table prior to saving.
 	 *
-	 * @param   \JTable  $table  The table object
+	 * @param   \Joomla\CMS\Table\Table  $table  The table object
 	 *
 	 * @return  void
 	 */
@@ -390,7 +390,7 @@ class NewsfeedModel extends AdminModel
 	/**
 	 * A protected method to get a set of ordering conditions.
 	 *
-	 * @param   \JForm  $form   The form object.
+	 * @param   Form    $form   The form object.
 	 * @param   array   $data   The data to be injected into the form
 	 * @param   string  $group  The plugin group to process
 	 *

--- a/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -30,7 +30,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The item object for the newsfeed
 	 *
-	 * @var    \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 * @since  1.6
 	 */
 	protected $item;
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The form object for the newsfeed
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  1.6
 	 */
 	protected $form;
@@ -46,7 +46,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state of the newsfeed
 	 *
-	 * @var    \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 * @since  1.6
 	 */
 	protected $state;

--- a/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
@@ -30,7 +30,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The list of newsfeeds
 	 *
-	 * @var    \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 * @since  1.6
 	 */
 	protected $items;
@@ -46,7 +46,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var    \JObject
+	 * @var    \Joomla\CMS\Object\CMSObject
 	 * @since  1.6
 	 */
 	protected $state;
@@ -54,8 +54,8 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Is this view an Empty State
 	 *
-	 * @var  boolean
-	 * @since 4.0.0
+	 * @var    boolean
+	 * @since  4.0.0
 	 */
 	private $isEmptyState = false;
 

--- a/administrator/components/com_plugins/src/Helper/PluginsHelper.php
+++ b/administrator/components/com_plugins/src/Helper/PluginsHelper.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Installer\Installer;
+use Joomla\CMS\Object\CMSObject;
 
 /**
  * Plugins component helper.
@@ -101,11 +102,11 @@ class PluginsHelper
 	 * @param   string  $templateBaseDir  Base path to the template directory.
 	 * @param   string  $templateDir      Template directory.
 	 *
-	 * @return  \JObject
+	 * @return CMSObject|bool
 	 */
 	public function parseXMLTemplateFile($templateBaseDir, $templateDir)
 	{
-		$data = new \JObject;
+		$data = new CMSObject;
 
 		// Check of the xml file exists.
 		$filePath = Path::clean($templateBaseDir . '/templates/' . $templateDir . '/templateDetails.xml');

--- a/administrator/components/com_plugins/src/Model/PluginModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginModel.php
@@ -237,7 +237,7 @@ class PluginModel extends AdminModel
 	/**
 	 * Preprocess the form.
 	 *
-	 * @param \Joomla\CMS\Form\Form $form A form object.
+	 * @param   \Joomla\CMS\Form\Form  $form A form object.
 	 * @param   mixed   $data   The data expected for the form.
 	 * @param   string  $group  Cache group name.
 	 *

--- a/administrator/components/com_plugins/src/Model/PluginModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginModel.php
@@ -78,7 +78,7 @@ class PluginModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  \JForm    A \JForm object on success, false on failure.
+	 * @return  Form|bool  A Form object on success, false on failure.
 	 *
 	 * @since   1.6
 	 */
@@ -237,7 +237,7 @@ class PluginModel extends AdminModel
 	/**
 	 * Preprocess the form.
 	 *
-	 * @param   \JForm  $form   A form object.
+	 * @param \Joomla\CMS\Form\Form $form A form object.
 	 * @param   mixed   $data   The data expected for the form.
 	 * @param   string  $group  Cache group name.
 	 *

--- a/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
@@ -28,21 +28,21 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The item object for the newsfeed
 	 *
-	 * @var    \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $item;
 
 	/**
 	 * The form object for the newsfeed
 	 *
-	 * @var    \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
 	/**
 	 * The model state of the newsfeed
 	 *
-	 * @var    \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 

--- a/administrator/components/com_plugins/src/View/Plugins/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugins/HtmlView.php
@@ -42,14 +42,14 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var    \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_redirect/src/Model/LinkModel.php
+++ b/administrator/components/com_redirect/src/Model/LinkModel.php
@@ -56,7 +56,7 @@ class LinkModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  \JForm   A JForm object on success, false on failure
+	 * @return  \Joomla\CMS\Form\Form A JForm object on success, false on failure
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_redirect/src/View/Link/HtmlView.php
+++ b/administrator/components/com_redirect/src/View/Link/HtmlView.php
@@ -35,14 +35,14 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
 	/**
 	 * The model state
 	 *
-	 * @var    \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 

--- a/administrator/components/com_redirect/src/View/Links/HtmlView.php
+++ b/administrator/components/com_redirect/src/View/Links/HtmlView.php
@@ -67,7 +67,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
@@ -81,7 +81,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_tags/src/Model/TagModel.php
+++ b/administrator/components/com_tags/src/Model/TagModel.php
@@ -151,7 +151,7 @@ class TagModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  mixed  A \JForm object on success, false on failure
+	 * @return  bool|\Joomla\CMS\Form\Form  A Form object on success, false on failure
 	 *
 	 * @since   3.1
 	 */

--- a/administrator/components/com_tags/src/View/Tag/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tag/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -29,7 +30,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
@@ -43,7 +44,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  CMSObject
 	 */
 	protected $state;
 
@@ -57,7 +58,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var    \JObject
+	 * @var    CMSObject
 	 * @since  4.0.0
 	 */
 	protected $canDo;

--- a/administrator/components/com_tags/src/View/Tags/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tags/HtmlView.php
@@ -44,14 +44,14 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_templates/src/Controller/TemplateController.php
+++ b/administrator/components/com_templates/src/Controller/TemplateController.php
@@ -35,7 +35,7 @@ class TemplateController extends BaseController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since  1.6

--- a/administrator/components/com_templates/src/Helper/TemplatesHelper.php
+++ b/administrator/components/com_templates/src/Helper/TemplatesHelper.php
@@ -29,7 +29,7 @@ class TemplatesHelper
 	/**
 	 * Get a list of filter options for the application clients.
 	 *
-	 * @return  array  An array of \JHtmlOption elements.
+	 * @return  array  An array of HtmlOption elements.
 	 */
 	public static function getClientOptions()
 	{
@@ -46,7 +46,7 @@ class TemplatesHelper
 	 *
 	 * @param   mixed  $clientId  The CMS client id (0:site | 1:administrator) or '*' for all.
 	 *
-	 * @return  array  An array of \JHtmlOption elements.
+	 * @return  array
 	 */
 	public static function getTemplateOptions($clientId = '*')
 	{
@@ -77,12 +77,10 @@ class TemplatesHelper
 	}
 
 	/**
-	 * TODO
+	 * @param   string  $templateBaseDir
+	 * @param   string  $templateDir
 	 *
-	 * @param   string  $templateBaseDir  TODO
-	 * @param   string  $templateDir      TODO
-	 *
-	 * @return  boolean|\JObject
+	 * @return boolean|CMSObject
 	 */
 	public static function parseXMLTemplateFile($templateBaseDir, $templateDir)
 	{
@@ -110,10 +108,8 @@ class TemplatesHelper
 	}
 
 	/**
-	 * TODO
-	 *
-	 * @param   integer  $clientId     TODO
-	 * @param   string   $templateDir  TODO
+	 * @param   integer  $clientId
+	 * @param   string   $templateDir
 	 *
 	 * @return  boolean|array
 	 *

--- a/administrator/components/com_templates/src/View/Style/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Style/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -26,30 +27,30 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
 class HtmlView extends BaseHtmlView
 {
 	/**
-	 * The \JObject (on success, false on failure)
+	 * The Object (on success, false on failure)
 	 *
-	 * @var   \JObject
+	 * @var  CMSObject
 	 */
 	protected $item;
 
 	/**
 	 * The form object
 	 *
-	 * @var   \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
 	/**
 	 * The model state
 	 *
-	 * @var   \JObject
+	 * @var  CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * The actions the user is authorised to perform
 	 *
-	 * @var    \JObject
+	 * @var    CMSObject
 	 * @since  4.0.0
 	 */
 	protected $canDo;

--- a/administrator/components/com_templates/src/View/Style/JsonView.php
+++ b/administrator/components/com_templates/src/View/Style/JsonView.php
@@ -22,23 +22,23 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 class JsonView extends BaseHtmlView
 {
 	/**
-	 * The \JObject (on success, false on failure)
+	 * The Object (on success, false on failure)
 	 *
-	 * @var   \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $item;
 
 	/**
 	 * The form object
 	 *
-	 * @var   \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
 	/**
 	 * The model state
 	 *
-	 * @var   \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 

--- a/administrator/components/com_templates/src/View/Styles/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Styles/HtmlView.php
@@ -42,14 +42,14 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var  \JObject
+	 * @var  \Joomla\CMS\Object\CMSObject
 	 */
 	protected $state;
 
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_templates/src/View/Templates/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Templates/HtmlView.php
@@ -59,7 +59,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_users/src/Model/GroupModel.php
+++ b/administrator/components/com_users/src/Model/GroupModel.php
@@ -78,7 +78,7 @@ class GroupModel extends AdminModel
 	 * @param   array    $data      An optional array of data for the form to interrogate.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  \JForm	A \JForm object on success, false on failure
+	 * @return  Form|bool  A Form object on success, false on failure
 	 *
 	 * @since   1.6
 	 */
@@ -121,7 +121,7 @@ class GroupModel extends AdminModel
 	/**
 	 * Override preprocessForm to load the user plugin group instead of content.
 	 *
-	 * @param   \JForm  $form   A form object.
+	 * @param   Form    $form   A form object.
 	 * @param   mixed   $data   The data expected for the form.
 	 * @param   string  $group  The name of the plugin group to import (defaults to "content").
 	 *

--- a/administrator/components/com_users/src/Model/LevelModel.php
+++ b/administrator/components/com_users/src/Model/LevelModel.php
@@ -173,7 +173,7 @@ class LevelModel extends AdminModel
 	 * @param   array    $data      An optional array of data for the form to interrogate.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  Form|bool	A \JForm object on success, false on failure
+	 * @return  Form|bool  A Form object on success, false on failure
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_users/src/Model/MailModel.php
+++ b/administrator/components/com_users/src/Model/MailModel.php
@@ -37,7 +37,7 @@ class MailModel extends AdminModel
 	 * @param   array    $data      An optional array of data for the form to interrogate.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  Form	A \JForm object on success, false on failure
+	 * @return  Form	A Form object on success, false on failure
 	 *
 	 * @since   1.6
 	 */
@@ -75,7 +75,7 @@ class MailModel extends AdminModel
 	/**
 	 * Method to preprocess the form
 	 *
-	 * @param   \JForm  $form   A form object.
+	 * @param   Form    $form   A form object.
 	 * @param   mixed   $data   The data expected for the form.
 	 * @param   string  $group  The name of the plugin group to import (defaults to "content").
 	 *

--- a/administrator/components/com_users/src/Model/NoteModel.php
+++ b/administrator/components/com_users/src/Model/NoteModel.php
@@ -39,7 +39,7 @@ class NoteModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  mixed  A \JForm object on success, false on failure
+	 * @return  \Joomla\CMS\Form\Form|bool  A Form object on success, false on failure
 	 *
 	 * @since   2.5
 	 */

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -116,7 +116,7 @@ class UserModel extends AdminModel
 	 * @param   array    $data      An optional array of data for the form to interrogate.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return  mixed  A \JForm object on success, false on failure
+	 * @return  Form|bool  A Form object on success, false on failure
 	 *
 	 * @since   1.6
 	 */
@@ -201,7 +201,7 @@ class UserModel extends AdminModel
 	/**
 	 * Override Joomla\CMS\MVC\Model\AdminModel::preprocessForm to ensure the correct plugin group is loaded.
 	 *
-	 * @param   \JForm  $form   A \JForm object.
+	 * @param   Form    $form   A Form object.
 	 * @param   mixed   $data   The data expected for the form.
 	 * @param   string  $group  The name of the plugin group to import (defaults to "content").
 	 *

--- a/administrator/components/com_users/src/View/Debuggroup/HtmlView.php
+++ b/administrator/components/com_users/src/View/Debuggroup/HtmlView.php
@@ -69,7 +69,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	public $filterForm;
 

--- a/administrator/components/com_users/src/View/Debuguser/HtmlView.php
+++ b/administrator/components/com_users/src/View/Debuguser/HtmlView.php
@@ -69,7 +69,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	public $filterForm;
 

--- a/administrator/components/com_users/src/View/Group/HtmlView.php
+++ b/administrator/components/com_users/src/View/Group/HtmlView.php
@@ -29,7 +29,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 

--- a/administrator/components/com_users/src/View/Groups/HtmlView.php
+++ b/administrator/components/com_users/src/View/Groups/HtmlView.php
@@ -52,7 +52,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_users/src/View/Level/HtmlView.php
+++ b/administrator/components/com_users/src/View/Level/HtmlView.php
@@ -29,7 +29,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 

--- a/administrator/components/com_users/src/View/Levels/HtmlView.php
+++ b/administrator/components/com_users/src/View/Levels/HtmlView.php
@@ -52,7 +52,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_users/src/View/Mail/HtmlView.php
+++ b/administrator/components/com_users/src/View/Mail/HtmlView.php
@@ -27,7 +27,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The \JForm object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 

--- a/administrator/components/com_users/src/View/Note/HtmlView.php
+++ b/administrator/components/com_users/src/View/Note/HtmlView.php
@@ -30,7 +30,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The edit form.
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  2.5
 	 */
 	protected $form;

--- a/administrator/components/com_users/src/View/Notes/HtmlView.php
+++ b/administrator/components/com_users/src/View/Notes/HtmlView.php
@@ -63,7 +63,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;

--- a/administrator/components/com_users/src/View/User/HtmlView.php
+++ b/administrator/components/com_users/src/View/User/HtmlView.php
@@ -27,9 +27,9 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
 class HtmlView extends BaseHtmlView
 {
 	/**
-	 * The \JForm object
+	 * The Form object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 

--- a/administrator/components/com_users/src/View/Users/HtmlView.php
+++ b/administrator/components/com_users/src/View/Users/HtmlView.php
@@ -53,9 +53,9 @@ class HtmlView extends BaseHtmlView
 	protected $state;
 
 	/**
-	 * A \JForm instance with filter fields.
+	 * A Form instance with filter fields.
 	 *
-	 * @var    \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  3.6.3
 	 */
 	public $filterForm;

--- a/administrator/components/com_workflow/src/Controller/DisplayController.php
+++ b/administrator/components/com_workflow/src/Controller/DisplayController.php
@@ -55,7 +55,7 @@ class DisplayController extends BaseController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   4.0.0

--- a/administrator/components/com_workflow/src/Controller/StageController.php
+++ b/administrator/components/com_workflow/src/Controller/StageController.php
@@ -52,7 +52,7 @@ class StageController extends FormController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   4.0.0

--- a/administrator/components/com_workflow/src/Controller/StagesController.php
+++ b/administrator/components/com_workflow/src/Controller/StagesController.php
@@ -62,7 +62,7 @@ class StagesController extends AdminController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   4.0.0

--- a/administrator/components/com_workflow/src/Controller/TransitionController.php
+++ b/administrator/components/com_workflow/src/Controller/TransitionController.php
@@ -52,7 +52,7 @@ class TransitionController extends FormController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   4.0.0

--- a/administrator/components/com_workflow/src/Controller/TransitionsController.php
+++ b/administrator/components/com_workflow/src/Controller/TransitionsController.php
@@ -60,7 +60,7 @@ class TransitionsController extends AdminController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   4.0.0

--- a/administrator/components/com_workflow/src/Controller/WorkflowController.php
+++ b/administrator/components/com_workflow/src/Controller/WorkflowController.php
@@ -46,7 +46,7 @@ class WorkflowController extends FormController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   4.0.0

--- a/administrator/components/com_workflow/src/Controller/WorkflowsController.php
+++ b/administrator/components/com_workflow/src/Controller/WorkflowsController.php
@@ -46,7 +46,7 @@ class WorkflowsController extends AdminController
 	 *
 	 * @param   array                $config   An optional associative array of configuration settings.
 	 * @param   MVCFactoryInterface  $factory  The factory.
-	 * @param   CMSApplication       $app      The JApplication for the dispatcher
+	 * @param   CMSApplication       $app      The Application for the dispatcher
 	 * @param   Input                $input    Input
 	 *
 	 * @since   4.0.0

--- a/administrator/components/com_workflow/src/Model/StageModel.php
+++ b/administrator/components/com_workflow/src/Model/StageModel.php
@@ -210,7 +210,7 @@ class StageModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return \JForm|boolean  A JForm object on success, false on failure
+	 * @return  Form|boolean A Form object on success, false on failure
 	 *
 	 * @since  4.0.0
 	 */
@@ -369,9 +369,9 @@ class StageModel extends AdminModel
 	/**
 	 * Method to preprocess the form.
 	 *
-	 * @param   \JForm  $form   A \JForm object.
-	 * @param   mixed   $data   The data expected for the form.
-	 * @param   string  $group  The name of the plugin group to import (defaults to "content").
+	 * @param   Form    $form  A Form object.
+	 * @param   mixed   $data  The data expected for the form.
+	 * @param   string  $group The name of the plugin group to import (defaults to "content").
 	 *
 	 * @return  void
 	 *

--- a/administrator/components/com_workflow/src/Model/TransitionModel.php
+++ b/administrator/components/com_workflow/src/Model/TransitionModel.php
@@ -217,7 +217,7 @@ class TransitionModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return \JForm|boolean  A JForm object on success, false on failure
+	 * @return  \Joomla\CMS\Form\Form|boolean  A Form object on success, false on failure
 	 *
 	 * @since  4.0.0
 	 */

--- a/administrator/components/com_workflow/src/Model/TransitionsModel.php
+++ b/administrator/components/com_workflow/src/Model/TransitionsModel.php
@@ -211,7 +211,7 @@ class TransitionsModel extends ListModel
 	 * @param   array    $data      data
 	 * @param   boolean  $loadData  load current data
 	 *
-	 * @return  \JForm|boolean  The \JForm object or false on error
+	 * @return  \Joomla\CMS\Form\Form|boolean The Form object or false on error
 	 *
 	 * @since  4.0.0
 	 */

--- a/administrator/components/com_workflow/src/Model/WorkflowModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowModel.php
@@ -223,7 +223,7 @@ class WorkflowModel extends AdminModel
 	/**
 	 * Method to preprocess the form.
 	 *
-	 * @param \Joomla\CMS\Form\Form $form A Form object.
+	 * @param   \Joomla\CMS\Form\Form  $form  A Form object.
 	 * @param   mixed   $data   The data expected for the form.
 	 * @param   string  $group  The name of the plugin group to import (defaults to "content").
 	 *

--- a/administrator/components/com_workflow/src/Model/WorkflowModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowModel.php
@@ -149,7 +149,7 @@ class WorkflowModel extends AdminModel
 	 * @param   array    $data      Data for the form.
 	 * @param   boolean  $loadData  True if the form is to load its own data (default case), false if not.
 	 *
-	 * @return \JForm|boolean  A JForm object on success, false on failure
+	 * @return  \Joomla\CMS\Form\Form|boolean A Form object on success, false on failure
 	 *
 	 * @since  4.0.0
 	 */
@@ -223,7 +223,7 @@ class WorkflowModel extends AdminModel
 	/**
 	 * Method to preprocess the form.
 	 *
-	 * @param   \JForm  $form   A \JForm object.
+	 * @param \Joomla\CMS\Form\Form $form A Form object.
 	 * @param   mixed   $data   The data expected for the form.
 	 * @param   string  $group  The name of the plugin group to import (defaults to "content").
 	 *

--- a/administrator/components/com_workflow/src/Model/WorkflowsModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowsModel.php
@@ -123,7 +123,7 @@ class WorkflowsModel extends ListModel
 	 * @param   array    $data      data
 	 * @param   boolean  $loadData  load current data
 	 *
-	 * @return  \JForm|false  the JForm object or false
+	 * @return  \Joomla\CMS\Form\Form|false the Form object or false
 	 *
 	 * @since   4.0.0
 	 */

--- a/administrator/components/com_workflow/src/View/Stage/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Stage/HtmlView.php
@@ -35,7 +35,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * From object to generate fields
 	 *
-	 * @var     \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	protected $form;
@@ -43,7 +43,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Items array
 	 *
-	 * @var     object
+	 * @var    object
 	 * @since  4.0.0
 	 */
 	protected $item;

--- a/administrator/components/com_workflow/src/View/Stages/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Stages/HtmlView.php
@@ -30,7 +30,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * An array of stages
 	 *
-	 * @var     array
+	 * @var    array
 	 * @since  4.0.0
 	 */
 	protected $stages;
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model stage
 	 *
-	 * @var     object
+	 * @var    object
 	 * @since  4.0.0
 	 */
 	protected $stage;
@@ -46,7 +46,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The HTML for displaying sidebar
 	 *
-	 * @var     string
+	 * @var    string
 	 * @since  4.0.0
 	 */
 	protected $sidebar;
@@ -54,7 +54,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var     \JPagination
+	 * @var    \Joomla\CMS\Pagination\Pagination
 	 * @since  4.0.0
 	 */
 	protected $pagination;
@@ -62,7 +62,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var     \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;
@@ -70,7 +70,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The active search filters
 	 *
-	 * @var     array
+	 * @var    array
 	 * @since  4.0.0
 	 */
 	public $activeFilters;
@@ -78,7 +78,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The current workflow
 	 *
-	 * @var     object
+	 * @var    object
 	 * @since  4.0.0
 	 */
 	protected $workflow;
@@ -86,7 +86,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The ID of current workflow
 	 *
-	 * @var     integer
+	 * @var    integer
 	 * @since  4.0.0
 	 */
 	protected $workflowID;
@@ -94,7 +94,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The name of current extension
 	 *
-	 * @var     string
+	 * @var    string
 	 * @since  4.0.0
 	 */
 	protected $extension;

--- a/administrator/components/com_workflow/src/View/Transition/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Transition/HtmlView.php
@@ -35,7 +35,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * From object to generate fields
 	 *
-	 * @var     \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	protected $form;
@@ -43,7 +43,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Items array
 	 *
-	 * @var     object
+	 * @var    object
 	 * @since  4.0.0
 	 */
 	protected $item;
@@ -67,7 +67,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The ID of current workflow
 	 *
-	 * @var     integer
+	 * @var    integer
 	 * @since  4.0.0
 	 */
 	protected $workflowID;
@@ -75,7 +75,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The name of current extension
 	 *
-	 * @var     string
+	 * @var    string
 	 * @since  4.0.0
 	 */
 	protected $extension;

--- a/administrator/components/com_workflow/src/View/Transitions/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Transitions/HtmlView.php
@@ -29,7 +29,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * An array of transitions
 	 *
-	 * @var     array
+	 * @var    array
 	 * @since  4.0.0
 	 */
 	protected $transitions;
@@ -37,7 +37,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var     object
+	 * @var    object
 	 * @since  4.0.0
 	 */
 	protected $state;
@@ -45,7 +45,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The HTML for displaying sidebar
 	 *
-	 * @var     string
+	 * @var    string
 	 * @since  4.0.0
 	 */
 	protected $sidebar;
@@ -53,7 +53,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var     \JPagination
+	 * @var    \Joomla\CMS\Pagination\Pagination
 	 * @since  4.0.0
 	 */
 	protected $pagination;
@@ -61,7 +61,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var     \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;
@@ -69,7 +69,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The active search filters
 	 *
-	 * @var     array
+	 * @var    array
 	 * @since  4.0.0
 	 */
 	public $activeFilters;
@@ -77,7 +77,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The current workflow
 	 *
-	 * @var     object
+	 * @var    object
 	 * @since  4.0.0
 	 */
 	protected $workflow;
@@ -85,7 +85,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The ID of current workflow
 	 *
-	 * @var     integer
+	 * @var    integer
 	 * @since  4.0.0
 	 */
 	protected $workflowID;
@@ -93,7 +93,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The name of current extension
 	 *
-	 * @var     string
+	 * @var    string
 	 * @since  4.0.0
 	 */
 	protected $extension;

--- a/administrator/components/com_workflow/src/View/Workflow/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Workflow/HtmlView.php
@@ -27,15 +27,15 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var     object
+	 * @var    object
 	 * @since  4.0.0
 	 */
 	protected $state;
 
 	/**
-	 * The \JForm object
+	 * The Form object
 	 *
-	 * @var  \JForm
+	 * @var  \Joomla\CMS\Form\Form
 	 */
 	protected $form;
 
@@ -49,7 +49,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The ID of current workflow
 	 *
-	 * @var     integer
+	 * @var    integer
 	 * @since  4.0.0
 	 */
 	protected $workflowID;
@@ -57,7 +57,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The name of current extension
 	 *
-	 * @var     string
+	 * @var    string
 	 * @since  4.0.0
 	 */
 	protected $extension;

--- a/administrator/components/com_workflow/src/View/Workflows/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Workflows/HtmlView.php
@@ -28,7 +28,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * An array of workflows
 	 *
-	 * @var     array
+	 * @var    array
 	 * @since  4.0.0
 	 */
 	protected $workflows;
@@ -36,7 +36,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The model state
 	 *
-	 * @var     object
+	 * @var    object
 	 * @since  4.0.0
 	 */
 	protected $state;
@@ -44,7 +44,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The pagination object
 	 *
-	 * @var     \JPagination
+	 * @var    \Joomla\CMS\Pagination\Pagination
 	 * @since  4.0.0
 	 */
 	protected $pagination;
@@ -52,7 +52,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The HTML for displaying sidebar
 	 *
-	 * @var     string
+	 * @var    string
 	 * @since  4.0.0
 	 */
 	protected $sidebar;
@@ -60,7 +60,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * Form object for search filters
 	 *
-	 * @var     \JForm
+	 * @var    \Joomla\CMS\Form\Form
 	 * @since  4.0.0
 	 */
 	public $filterForm;
@@ -68,7 +68,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The active search filters
 	 *
-	 * @var     array
+	 * @var    array
 	 * @since  4.0.0
 	 */
 	public $activeFilters;
@@ -76,7 +76,7 @@ class HtmlView extends BaseHtmlView
 	/**
 	 * The name of current extension
 	 *
-	 * @var     string
+	 * @var    string
 	 * @since  4.0.0
 	 */
 	protected $extension;

--- a/administrator/includes/app.php
+++ b/administrator/includes/app.php
@@ -34,7 +34,7 @@ if (!file_exists(JPATH_LIBRARIES . '/vendor/autoload.php') || !is_dir(JPATH_ROOT
 require_once JPATH_BASE . '/includes/framework.php';
 
 // Set profiler start time and memory usage and mark afterLoad in the profiler.
-JDEBUG ? JProfiler::getInstance('Application')->setStart($startTime, $startMem)->mark('afterLoad') : null;
+JDEBUG ? \Joomla\CMS\Profiler\Profiler::getInstance('Application')->setStart($startTime, $startMem)->mark('afterLoad') : null;
 
 // Boot the DI container
 $container = \Joomla\CMS\Factory::getContainer();

--- a/api/includes/app.php
+++ b/api/includes/app.php
@@ -26,7 +26,7 @@ if (!defined('_JDEFINES'))
 require_once JPATH_BASE . '/includes/framework.php';
 
 // Set profiler start time and memory usage and mark afterLoad in the profiler.
-JDEBUG ? JProfiler::getInstance('Application')->setStart($startTime, $startMem)->mark('afterLoad') : null;
+JDEBUG ? \Joomla\CMS\Profiler\Profiler::getInstance('Application')->setStart($startTime, $startMem)->mark('afterLoad') : null;
 
 // Boot the DI container
 $container = \Joomla\CMS\Factory::getContainer();

--- a/includes/app.php
+++ b/includes/app.php
@@ -34,7 +34,7 @@ if (!file_exists(JPATH_LIBRARIES . '/vendor/autoload.php') || !is_dir(JPATH_ROOT
 require_once JPATH_BASE . '/includes/framework.php';
 
 // Set profiler start time and memory usage and mark afterLoad in the profiler.
-JDEBUG ? JProfiler::getInstance('Application')->setStart($startTime, $startMem)->mark('afterLoad') : null;
+JDEBUG ? \Joomla\CMS\Profiler\Profiler::getInstance('Application')->setStart($startTime, $startMem)->mark('afterLoad') : null;
 
 // Boot the DI container
 $container = \Joomla\CMS\Factory::getContainer();


### PR DESCRIPTION
Code Review Removing Technical Debt.

Remove reference to old JPrefixed Class + other small cleanups of doc blocks. 

Nothing here is controversial and should be a quick test and merge.

These changes are manually made and reviewed, over several hours, and are restricted to the /administrator/ folder only.

This PR is not exhaustive.