### PR TITLE
Ensure returned getAuthorisedViewLevels array has only unique values

### DIFF
--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -1044,9 +1044,9 @@ class Access
 					}
 				}
 			}
-			
+	
 			$authorised = array_unique($authorised);
-			
+
 			return $authorised;
 		}
 
@@ -1071,7 +1071,7 @@ class Access
 				}
 			}
 		}
-		
+
 		$authorised = array_unique($authorised);
 
 		return $authorised;

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -1044,7 +1044,9 @@ class Access
 					}
 				}
 			}
-
+			
+			$authorised = array_unique($authorised);
+			
 			return $authorised;
 		}
 
@@ -1069,6 +1071,8 @@ class Access
 				}
 			}
 		}
+		
+		$authorised = array_unique($authorised);
 
 		return $authorised;
 	}

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -1044,7 +1044,7 @@ class Access
 					}
 				}
 			}
-	
+
 			$authorised = array_unique($authorised);
 
 			return $authorised;

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -1045,9 +1045,7 @@ class Access
 				}
 			}
 
-			$authorised = array_unique($authorised);
-
-			return $authorised;
+			return array_unique($authorised);
 		}
 
 		// Get all groups that the user is mapped to recursively.
@@ -1072,9 +1070,7 @@ class Access
 			}
 		}
 
-		$authorised = array_unique($authorised);
-
-		return $authorised;
+		return array_unique($authorised);
 	}
 
 	/**


### PR DESCRIPTION
I stumbled over this on a site I was debugging. The system sends the following query:

```
SELECT `folder` AS `type`,`element` AS `name`,`params` AS `params`,`extension_id` AS `id`

  FROM #__extensions

  WHERE enabled = 1 
  AND type = 'plugin' 
  AND state IN (0,1) 
  AND access IN (1,1,5)

  ORDER BY ordering
```

Notice the ```AND access IN (1,1,5)``` the extra 1 comes from the fact that this method hardcodes the 1 on line 1027 and then later also finds in the database. This does not really break anything but is just proper data management. For instance if someone wanted to count how many groups have access to something and used this method and counted the entries would get the answer 3 and not 2. It also leads to "wasted" time with developers who are curious where this comes from and spends time hunting down the source.

Pull Request for Issue # .

### Summary of Changes

Added array_unique before returning values

### Testing Instructions

Not totally sure how to test this as I am sure this method is called many many places. But if you enable debug and look at executed queries and find one that starts with:

```
SELECT `folder` AS `type`,`element` AS `name`,`params` AS `params`,`extension_id` AS `id`
```
Then ensure the parenthesis in ACCESS IN statement only has unique values

### Actual result BEFORE applying this Pull Request

There could be duplicates

### Expected result AFTER applying this Pull Request

There can not be duplicates

### Documentation Changes Required

No