### PR TITLE
Add KEY to table structure to prevent filesort

### DIFF
--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -412,7 +412,7 @@ CREATE TABLE IF NOT EXISTS `#__languages` (
   UNIQUE KEY `idx_sef` (`sef`),
   UNIQUE KEY `idx_langcode` (`lang_code`),
   KEY `idx_access` (`access`),
-  KEY `idx_ordering` (`ordering`)
+  KEY `idx_ordering` (`ordering`),
 KEY `idx_published_ordering` (`published`, `ordering`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -413,7 +413,7 @@ CREATE TABLE IF NOT EXISTS `#__languages` (
   UNIQUE KEY `idx_langcode` (`lang_code`),
   KEY `idx_access` (`access`),
   KEY `idx_ordering` (`ordering`)
-	KEY `idx_published_ordering` (`published`, `ordering`)
+KEY `idx_published_ordering` (`published`, `ordering`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 --

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -413,6 +413,7 @@ CREATE TABLE IF NOT EXISTS `#__languages` (
   UNIQUE KEY `idx_langcode` (`lang_code`),
   KEY `idx_access` (`access`),
   KEY `idx_ordering` (`ordering`)
+	KEY `idx_published_ordering` (`published`, `ordering`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;
 
 --


### PR DESCRIPTION
This is more to open a discussion, I guess. When reviewing performance issues with a site, I noticed that even loading the core language selector triggers a filesort in MariaDB which is not ideal. As there will only ever be a few languages on a site this will most likely never be a huge performance issue, but every little optimization we can do, we should do, right? In order to not have a filesort for the query:

```
SELECT *
  FROM #__languages
  WHERE published=1
  ORDER BY ordering ASC
```
We need to add a composite key for both published and ordering. 

This does speed up loading very minutely and if done throughout the app so that at least there are keys for core functionality would have a real impact (although small) on performance.

### Summary of Changes
Add KEY to table structure to prevent filesort

