### PR TITLE
[4.0] Uninstalled components with leftover menu records appear in the Components Dashboard

### DIFF
--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -61,10 +61,6 @@ abstract class Menu
 				{
 					$item->link = 'index.php?option=com_admin&amp;view=help&amp;layout=langforum';
 				}
-				elseif ($special === 'custom-forum')
-				{
-					$item->link = $this->params->get('forum_url');
-				}
 			}
 
 			$uri   = new Uri($item->link);

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\MenuItem;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 use Joomla\Utilities\ArrayHelper;
 
@@ -52,6 +53,33 @@ abstract class Menu
 
 		foreach ($children as $item)
 		{
+			if (substr($item->link, 0, 8) === 'special:')
+			{
+				$special = substr($item->link, 8);
+
+				if ($special === 'language-forum')
+				{
+					$item->link = 'index.php?option=com_admin&amp;view=help&amp;layout=langforum';
+				}
+				elseif ($special === 'custom-forum')
+				{
+					$item->link = $this->params->get('forum_url');
+				}
+			}
+
+			$uri   = new Uri($item->link);
+			$query = $uri->getQuery(true);
+
+			/**
+			 * This is needed to populate the element property when the component is no longer
+			 * installed but its core menu items are left behind.
+			 */
+			if ($option = $uri->getVar('option'))
+			{
+				$item->element = $option;
+			}
+
+			// Exclude item if is not enabled
 			if ($item->element && !ComponentHelper::isEnabled($item->element))
 			{
 				$parent->removeChild($item);
@@ -158,7 +186,7 @@ abstract class Menu
 					continue;
 				}
 
-				list($assetName) = isset($query['extension']) ? explode('.', $query['extension'], 2) : array('com_workflow');
+				[$assetName] = isset($query['extension']) ? explode('.', $query['extension'], 2) : array('com_workflow');
 			}
 			// Special case for components which only allow super user access
 			elseif (\in_array($item->element, array('com_config', 'com_privacy', 'com_actionlogs'), true) && !$user->authorise('core.admin'))


### PR DESCRIPTION
### Summary of Changes

Fixes the Components Dashboard to work equivalently to the backend Main Menu with regards to uninstalled / disabled components.

### Testing Instructions

* Install a component, ANY component, e.g. JCE, com_weblinks, whatever.
* Delete the `#__extensions` record of the component to simulate a botched component uninstallation which leaves the component menu items behind

### Actual result BEFORE applying this Pull Request

The main menu (sidebar) does not display links to the component.

However, the Components Dashboard (four squares icon next to the “Components” menu item name in the main menu) displays the missing component's links, untranslated. Clicking on them results in a 404 Component Not Found error page as expected.

### Expected result AFTER applying this Pull Request

The main menu (sidebar) does not display links to the component.

The Components Dashboard (four squares icon next to the “Components” menu item name in the main menu) does not display links to the component.

### Documentation Changes Required

None.

### Further information

This problem was observed on a live site a while after after we uninstalled a (paid) extension. Due to an internal error in the extension's script the uninstallation didn't complete. Unbeknownst to us at the time, the extension record was removed from the `#__extensions` table, the files were removed from the filesystem **BUT** the `#__menu` records were left behind.

We didn't think much of this uninstallation issue until a few weeks later when we started doing the final, detailed inspection of the site to get it ready for delivery. @crystalenka noticed that the Components Dashboard would display links to the extension whereas the sidebar Main Menu wouldn't. I took a 5' look and found the discrepancy between how mod_submenu and mod_menu post-process the loaded menu items. This PR addresses this discrepancy.

No, the offending component was NOT mine, NEITHER was it JCE or WebLinks. :trollface: In any case the problem is not extension-specific, it can happen if the uninstallation is interrupted before the `#__menu` entries are removed for any reason.

Ideally, the common post-processing logic should be moved outside of `Joomla\Module\Submenu\Administrator\Menu\Menu` and `Joomla\Module\Menu\Administrator\Menu\CssMenu` and into `Joomla\Component\Menus\Administrator\Helper\MenusHelper` so it can be reused by third party menu modules.

Please note that this is supposed to be my week off. I may not be very responsive until January 3rd when I'm back at the office. I don't even know how I got suckered into fixing this in my week off. Something something something can't say no to my wife and Joomla being Hotel California... Anyway, Merry Christmas / Happy Holidays and Happy New Year, y'all!