### PR TITLE
[4.0] Remove reference to old JPrefixed Class + Cleanup (JTable etc)

### DIFF
--- a/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
@@ -269,7 +269,7 @@ class ActionlogsModel extends ListModel
 	}
 
 	/**
-	 * Get logs data into JTable object
+	 * Get logs data into Table object
 	 *
 	 * @param   integer[]|null  $pks  An optional array of log record IDs to load
 	 *

--- a/administrator/components/com_associations/src/Field/Modal/AssociationField.php
+++ b/administrator/components/com_associations/src/Field/Modal/AssociationField.php
@@ -41,7 +41,7 @@ class AssociationField extends FormField
 	 */
 	protected function getInput()
 	{
-		// @TODO USE JLayouts here!!!
+		// @todo USE Layouts here!!!
 		// The active item id field.
 		$value = (int) $this->value ?: '';
 

--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -150,7 +150,7 @@ class CategoryModel extends AdminModel
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  \Joomla\CMS\Table\Table  A JTable object
+	 * @return  \Joomla\CMS\Table\Table  A Table object
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_contenthistory/src/Model/CompareModel.php
+++ b/administrator/components/com_contenthistory/src/Model/CompareModel.php
@@ -150,7 +150,7 @@ class CompareModel extends ListModel
 	/**
 	 * Method to test whether a record is editable
 	 *
-	 * @param   ContentHistory  $record  A \JTable object.
+	 * @param   ContentHistory  $record  A Table object.
 	 *
 	 * @return  boolean  True if allowed to edit the record. Defaults to the permission set in the component.
 	 *

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -414,7 +414,7 @@ class FieldModel extends AdminModel
 	 * @param   string  $prefix   The class prefix. Optional.
 	 * @param   array   $options  Configuration array for model. Optional.
 	 *
-	 * @return  Table  A JTable object
+	 * @return  Table  A Table object
 	 *
 	 * @since   3.7.0
 	 * @throws  \Exception
@@ -895,7 +895,7 @@ class FieldModel extends AdminModel
 	/**
 	 * A protected method to get a set of ordering conditions.
 	 *
-	 * @param   Table  $table  A JTable object.
+	 * @param   Table  $table  A Table object.
 	 *
 	 * @return  array  An array of conditions to add to ordering queries.
 	 *

--- a/administrator/components/com_fields/src/Model/GroupModel.php
+++ b/administrator/components/com_fields/src/Model/GroupModel.php
@@ -74,7 +74,7 @@ class GroupModel extends AdminModel
 	 * @param   string  $prefix   The class prefix. Optional.
 	 * @param   array   $options  Configuration array for model. Optional.
 	 *
-	 * @return  Table  A JTable object
+	 * @return  Table  A Table object
 	 *
 	 * @since   3.7.0
 	 * @throws  \Exception

--- a/administrator/components/com_fields/src/Table/FieldTable.php
+++ b/administrator/components/com_fields/src/Table/FieldTable.php
@@ -269,7 +269,7 @@ class FieldTable extends Table
 	 * The extended class can define a table and id to lookup.  If the
 	 * asset does not exist it will be created.
 	 *
-	 * @param   Table    $table  A JTable object for the asset parent.
+	 * @param   Table    $table  A Table object for the asset parent.
 	 * @param   integer  $id     Id to look up
 	 *
 	 * @return  integer

--- a/administrator/components/com_fields/src/Table/GroupTable.php
+++ b/administrator/components/com_fields/src/Table/GroupTable.php
@@ -195,7 +195,7 @@ class GroupTable extends Table
 	 * The extended class can define a table and id to lookup.  If the
 	 * asset does not exist it will be created.
 	 *
-	 * @param   Table    $table  A JTable object for the asset parent.
+	 * @param   Table    $table  A Table object for the asset parent.
 	 * @param   integer  $id     Id to look up
 	 *
 	 * @return  integer

--- a/administrator/components/com_finder/src/Model/IndexModel.php
+++ b/administrator/components/com_finder/src/Model/IndexModel.php
@@ -331,7 +331,7 @@ class IndexModel extends ListModel
 	}
 
 	/**
-	 * Returns a \JTable object, always creating it.
+	 * Returns a Table object, always creating it.
 	 *
 	 * @param   string  $type    The table type to instantiate. [optional]
 	 * @param   string  $prefix  A prefix for the table class name. [optional]

--- a/administrator/components/com_finder/src/Model/MapsModel.php
+++ b/administrator/components/com_finder/src/Model/MapsModel.php
@@ -275,7 +275,7 @@ class MapsModel extends ListModel
 	}
 
 	/**
-	 * Returns a \JTable object, always creating it.
+	 * Returns a Table object, always creating it.
 	 *
 	 * @param   string  $type    The table type to instantiate. [optional]
 	 * @param   string  $prefix  A prefix for the table class name. [optional]

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -251,7 +251,7 @@ class TemplateModel extends AdminModel
 	 * @param   string  $prefix   The class prefix. Optional.
 	 * @param   array   $options  Configuration array for model. Optional.
 	 *
-	 * @return  Table  A JTable object
+	 * @return  Table  A Table object
 	 *
 	 * @since   4.0.0
 	 * @throws  \Exception
@@ -403,7 +403,7 @@ class TemplateModel extends AdminModel
 	/**
 	 * Prepare and sanitise the table data prior to saving.
 	 *
-	 * @param   Table  $table  A reference to a \JTable object.
+	 * @param   Table  $table  A reference to a Table object.
 	 *
 	 * @return  void
 	 *

--- a/administrator/components/com_menus/src/Model/MenuModel.php
+++ b/administrator/components/com_menus/src/Model/MenuModel.php
@@ -78,7 +78,7 @@ class MenuModel extends FormModel
 	 * @param   string  $prefix  A prefix for the table class name. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  Table A database object
+	 * @return  Table   A database object
 	 *
 	 * @since   1.6
 	 */

--- a/administrator/components/com_plugins/src/Model/PluginsModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginsModel.php
@@ -295,7 +295,7 @@ class PluginsModel extends ListModel
 	{
 		$data = parent::loadFormData();
 
-		// Set the selected filter values for pages that use the \JLayouts for filtering
+		// Set the selected filter values for pages that use the Layouts for filtering
 		$data->list['sortTable'] = $this->state->get('list.ordering');
 		$data->list['directionTable'] = $this->state->get('list.direction');
 

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -520,7 +520,7 @@ class TemplateModel extends FormModel
 		}
 		elseif (stristr($type, 'layouts') !== false)
 		{
-			// For Jlayouts
+			// For Layouts
 			$subtype = $explodeArray['3'];
 
 			if (stristr($subtype, 'com_'))

--- a/administrator/components/com_workflow/src/Model/StagesModel.php
+++ b/administrator/components/com_workflow/src/Model/StagesModel.php
@@ -107,7 +107,7 @@ class StagesModel extends ListModel
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  \Joomla\CMS\Table\Table  A JTable object
+	 * @return  \Joomla\CMS\Table\Table  A Table object
 	 *
 	 * @since  4.0.0
 	 */

--- a/administrator/components/com_workflow/src/Model/TransitionsModel.php
+++ b/administrator/components/com_workflow/src/Model/TransitionsModel.php
@@ -92,7 +92,7 @@ class TransitionsModel extends ListModel
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  \Joomla\CMS\Table\Table  A JTable object
+	 * @return  \Joomla\CMS\Table\Table  A Table object
 	 *
 	 * @since  4.0.0
 	 */

--- a/administrator/components/com_workflow/src/Model/WorkflowsModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowsModel.php
@@ -89,7 +89,7 @@ class WorkflowsModel extends ListModel
 	 * @param   string  $prefix  The class prefix. Optional.
 	 * @param   array   $config  Configuration array for model. Optional.
 	 *
-	 * @return  \Joomla\CMS\Table\Table  A JTable object
+	 * @return  \Joomla\CMS\Table\Table  A Table object
 	 *
 	 * @since  4.0.0
 	 */

--- a/administrator/components/com_workflow/src/Table/StageTable.php
+++ b/administrator/components/com_workflow/src/Table/StageTable.php
@@ -262,8 +262,8 @@ class StageTable extends Table
 	/**
 	 * Get the parent asset id for the record
 	 *
-	 * @param   Table    $table  A JTable object for the asset parent.
-	 * @param   integer  $id     The id for the asset
+	 * @param   Table|null    $table  A Table object for the asset parent.
+	 * @param   integer|null  $id     The id for the asset
 	 *
 	 * @return  integer  The id of the asset's parent
 	 *

--- a/administrator/components/com_workflow/src/Table/TransitionTable.php
+++ b/administrator/components/com_workflow/src/Table/TransitionTable.php
@@ -114,7 +114,7 @@ class TransitionTable extends Table
 	/**
 	 * Get the parent asset id for the record
 	 *
-	 * @param   Table    $table  A JTable object for the asset parent.
+	 * @param   Table    $table  A Table object for the asset parent.
 	 * @param   integer  $id     The id for the asset
 	 *
 	 * @return  integer  The id of the asset's parent

--- a/administrator/components/com_workflow/src/Table/WorkflowTable.php
+++ b/administrator/components/com_workflow/src/Table/WorkflowTable.php
@@ -292,7 +292,7 @@ class WorkflowTable extends Table
 	/**
 	 * Get the parent asset id for the record
 	 *
-	 * @param   Table    $table  A JTable object for the asset parent.
+	 * @param   Table    $table  A Table object for the asset parent.
 	 * @param   integer  $id     The id for the asset
 	 *
 	 * @return  integer  The id of the asset's parent

--- a/components/com_privacy/src/Model/RemindModel.php
+++ b/components/com_privacy/src/Model/RemindModel.php
@@ -168,7 +168,7 @@ class RemindModel extends AdminModel
 	 * @param   string  $prefix   The class prefix. Optional.
 	 * @param   array   $options  Configuration array for model. Optional.
 	 *
-	 * @return  Table  A JTable object
+	 * @return  Table  A Table object
 	 *
 	 * @throws  \Exception
 	 * @since   3.9.0

--- a/components/com_privacy/src/Model/RequestModel.php
+++ b/components/com_privacy/src/Model/RequestModel.php
@@ -231,7 +231,7 @@ class RequestModel extends AdminModel
 	 * @param   string  $prefix   The class prefix. Optional.
 	 * @param   array   $options  Configuration array for model. Optional.
 	 *
-	 * @return  Table  A JTable object
+	 * @return  Table  A Table object
 	 *
 	 * @throws  \Exception
 	 * @since   3.9.0

--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\FileLayout;
 
 extract($displayData);
 
@@ -52,7 +53,7 @@ extract($displayData);
  * @var   array        $setsNames      List of Sets names
  * @var   Form[]       $setsForms      Form with extra options for an each set
  * @var   string       $languageFile   TinyMCE language file to translate the buttons
- * @var   JLayoutFile  $this           Context
+ * @var   FileLayout   $this           Context
  */
 
 /** @var HtmlDocument $doc */

--- a/libraries/src/Event/Table/AbstractEvent.php
+++ b/libraries/src/Event/Table/AbstractEvent.php
@@ -13,7 +13,6 @@ namespace Joomla\CMS\Event\Table;
 use BadMethodCallException;
 use Joomla\CMS\Event\AbstractImmutableEvent;
 use Joomla\CMS\Table\TableInterface;
-use JTableInterface;
 
 /**
  * Event class for the Table's events

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1110,7 +1110,7 @@ abstract class AdminModel extends FormModel
 	/**
 	 * A protected method to get a set of ordering conditions.
 	 *
-	 * @param   Table  $table  A \JTable object.
+	 * @param   Table  $table  A Table object.
 	 *
 	 * @return  array  An array of conditions to add to ordering queries.
 	 *
@@ -1145,7 +1145,7 @@ abstract class AdminModel extends FormModel
 	/**
 	 * Prepare and sanitise the table data prior to saving.
 	 *
-	 * @param   Table  $table  A reference to a \JTable object.
+	 * @param   Table  $table  A reference to a Table object.
 	 *
 	 * @return  void
 	 *

--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -85,7 +85,7 @@ class Category extends Nested implements VersionableTableInterface, TaggableTabl
 	/**
 	 * Get the parent asset id for the record
 	 *
-	 * @param   Table    $table  A JTable object for the asset parent.
+	 * @param   Table    $table  A Table object for the asset parent.
 	 * @param   integer  $id     The id for the asset
 	 *
 	 * @return  integer  The id of the asset's parent

--- a/libraries/src/UCM/UCMContent.php
+++ b/libraries/src/UCM/UCMContent.php
@@ -181,7 +181,7 @@ class UCMContent extends UCMBase
 	 * Store data to the appropriate table
 	 *
 	 * @param   array           $data        Data to be stored
-	 * @param   TableInterface  $table       JTable Object
+	 * @param   TableInterface  $table       Table Object
 	 * @param   boolean         $primaryKey  Flag that is true for data that are using #__ucm_content as their primary table
 	 *
 	 * @return  boolean  true on success

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -126,4 +126,4 @@ spl_autoload_register([new \Joomla\CMS\Autoload\ClassLoader($loader), 'loadClass
 require_once JPATH_LIBRARIES . '/classmap.php';
 
 // Define the Joomla version if not already defined.
-defined('JVERSION') or define('JVERSION', (new JVersion)->getShortVersion());
+defined('JVERSION') or define('JVERSION', (new \Joomla\CMS\Version)->getShortVersion());


### PR DESCRIPTION
Code Review Removing Technical Debt.

Remove reference to old JPrefixed Class + other small cleanups of doc blocks.

Nothing here is controversial and should be a quick test and merge.

These changes are manually made and reviewed, over several hours, and are mainly JTable 

This PR is not exhaustive.