### PR TITLE
[4.0] Mail Templates language files

### DIFF
--- a/administrator/components/com_mails/src/View/Template/HtmlView.php
+++ b/administrator/components/com_mails/src/View/Template/HtmlView.php
@@ -88,7 +88,9 @@ class HtmlView extends BaseHtmlView
 		$this->templateData = array();
 		$language = Factory::getLanguage();
 		$language->load($component, JPATH_SITE, $this->item->language, true);
+		$language->load($component, JPATH_SITE . '/components/' . $component, $this->item->language, true);
 		$language->load($component, JPATH_ADMINISTRATOR, $this->item->language, true);
+		$language->load($component, JPATH_ADMINISTRATOR . '/components/' . $component, $this->item->language, true);
 
 		$this->master->subject = Text::_($this->master->subject);
 		$this->master->body    = Text::_($this->master->body);


### PR DESCRIPTION
Adds support for component language files located in the component folder not the languages folder

Pull Request for Issue #36462 .

See original issue for test instructions and sample component