### PR TITLE
[4.0] Input bs5 for installation page

### DIFF
--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -60,7 +60,7 @@ HTMLHelper::_('behavior.formvalidator');
 				<tr>
 					<td>
 						<input
-						        class="form-check-input"
+							class="form-check-input"
 							id="admin-language-cb<?php echo $i; ?>"
 							type="radio"
 							name="administratorlang"
@@ -100,7 +100,7 @@ HTMLHelper::_('behavior.formvalidator');
 				<tr>
 					<td>
 						<input
-						        class="form-check-input"
+							class="form-check-input"
 							id="site-language-cb<?php echo $i; ?>"
 							type="radio"
 							name="frontendlang"

--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -60,6 +60,7 @@ HTMLHelper::_('behavior.formvalidator');
 				<tr>
 					<td>
 						<input
+						        class="form-check-input"
 							id="admin-language-cb<?php echo $i; ?>"
 							type="radio"
 							name="administratorlang"
@@ -99,6 +100,7 @@ HTMLHelper::_('behavior.formvalidator');
 				<tr>
 					<td>
 						<input
+						        class="form-check-input"
 							id="site-language-cb<?php echo $i; ?>"
 							type="radio"
 							name="frontendlang"
@@ -246,7 +248,7 @@ HTMLHelper::_('behavior.formvalidator');
 						<?php $language->code = $element[1]; ?>
 						<tr>
 							<td>
-								<input type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $language->update_id; ?>">
+								<input class="form-check-input" type="checkbox" id="cb<?php echo $i; ?>" name="cid[]" value="<?php echo $language->update_id; ?>">
 							</td>
 							<th scope="row">
 								<label for="cb<?php echo $i; ?>"><?php echo $language->name; ?></label>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Small change for the language installation page when installing Joomla (by analogy with https://github.com/joomla/joomla-cms/pull/34759). 

**Before / After**

![Screenshot_1](https://user-images.githubusercontent.com/8440661/147568687-e24a09d1-af65-4bf2-a3aa-307aa4922b59.png)
![Screenshot_2](https://user-images.githubusercontent.com/8440661/147568689-86990f89-4de0-410c-9fdd-8e3860852dfa.png)

![Screenshot_3](https://user-images.githubusercontent.com/8440661/147568690-68e9399f-e6d4-49b1-b950-9f4ba3b069b2.png)
![Screenshot_4](https://user-images.githubusercontent.com/8440661/147568693-471c000d-0592-41f7-832c-021833a76627.png)

