### PR TITLE
[4][com_finder] - php 8.1 serializable-deprecated

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Result.php
+++ b/administrator/components/com_finder/src/Indexer/Result.php
@@ -555,4 +555,19 @@ class Result implements \Serializable
 			}
 		}
 	}
+
+	/**
+	 * Magic method used for serializing.
+	 */
+	public function __serialize()
+	{
+	}
+
+	/**
+	 * Magic method used for unserializing.
+	 */
+	public function __unserialize($serialized)
+	{
+	}
+
 }


### PR DESCRIPTION

https://php.watch/versions/8.1/serializable-deprecated

### Summary of Changes
added magic method


### Testing Instructions
php 8.1
on frontend do a search
check the log


### Actual result BEFORE applying this Pull Request
` PHP Deprecated:  The Serializable interface is deprecated. Implement __serialize() and __unserialize() instead (or in addition, if support for old PHP versions is necessary)`


### Expected result AFTER applying this Pull Request
no more deprecation


