### PR TITLE
[4.0] PHP 8 ReturnTypeWillChange JsonapiDocument::jsonSerialize

### DIFF
--- a/libraries/src/Document/JsonapiDocument.php
+++ b/libraries/src/Document/JsonapiDocument.php
@@ -159,6 +159,7 @@ class JsonapiDocument extends JsonDocument implements \JsonSerializable
 	 *
 	 * @since  4.0.0
 	 */
+	#[\ReturnTypeWillChange]
 	public function jsonSerialize()
 	{
 		return $this->toArray();


### PR DESCRIPTION
Backport of #36394 to Joomla 4.0 as requested

Code review 

<img width="1981" alt="Screenshot 2021-12-24 at 17 49 56" src="https://user-images.githubusercontent.com/400092/147367636-3a8fda61-2c45-49cb-a4c6-fbfab89195e8.png">


```
  <b>Deprecated</b>:  Return type of Joomla\CMS\Document\JsonapiDocument::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice in <b>/tests/www/postgres/libraries/src/Document/JsonapiDocument.php</b> on line <b>162</b><br />
39s
240	  <br />
```

