### PR TITLE
[4.0] If the Mail Template was not found in the db, return false

### DIFF
--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -376,7 +376,7 @@ class MailTemplate
 	 * @param   string  $key       Template identifier
 	 * @param   string  $language  Language code of the template
 	 *
-	 * @return  object  An object with the data of the mail
+	 * @return  object|null  An object with the data of the mail, or null if the template not found in the db.
 	 *
 	 * @since   4.0.0
 	 */

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -28,7 +28,7 @@ use PHPMailer\PHPMailer\Exception as phpmailerException;
 class MailTemplate
 {
 	/**
-	 * Mailer object to send the actual mail..
+	 * Mailer object to send the actual mail.
 	 *
 	 * @var    \Joomla\CMS\Mail\Mail
 	 * @since  4.0.0

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -28,7 +28,7 @@ use PHPMailer\PHPMailer\Exception as phpmailerException;
 class MailTemplate
 {
 	/**
-	 * Mailer object to send the actual mail.
+	 * Mailer object to send the actual mail..
 	 *
 	 * @var    \Joomla\CMS\Mail\Mail
 	 * @since  4.0.0

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -190,6 +190,12 @@ class MailTemplate
 
 		$mail = self::getTemplate($this->template_id, $this->language);
 
+		// If the Mail Template was not found in the db, we cannot send an email.
+		if ($mail === null)
+		{
+			return false;
+		}
+
 		/** @var Registry $params */
 		$params = $mail->params;
 		$app    = Factory::getApplication();


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/36478

### Summary of Changes

If the Mail Template was not found in the db, we cannot send an email, therefore return false before trying to do lots of things based on the template that doesnt exist and avoid error messages

### Testing Instructions

Code review

```php
$mailer = new MailTemplate('com_bftest.invalidtemplateid', 'en-GB');
// ...
$sent = $mailer->send();
```

### Actual result BEFORE applying this Pull Request

Load of PHP notices and a 'Message body empty' warning.

### Expected result AFTER applying this Pull Request

```php
// $sent === false
$sent = $mailer->send();
```

### Documentation Changes Required

None