### PR TITLE
[4.0] RTL Version number in log file

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -44,7 +44,7 @@ class UpdateController extends BaseController
 
 		try
 		{
-			Log::add(Text::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_START', $user->id, $user->name, '&#x200E;' . \JVERSION), Log::INFO, 'Update');
+			Log::add(Text::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_START', $user->id, $user->name, \JVERSION), Log::INFO, 'Update');
 		}
 		catch (\RuntimeException $exception)
 		{


### PR DESCRIPTION
### Summary of Changes
PR #28549 added a _force ltr_ character before the version number is displayed to prevent issues when using an rtl language.

It should not have been added to this instance as it is only used for the update log file which is always in english and therefore LTR and the special character is not recognised in plain text


### Testing Instructions
code review as its an obvious fix


### Actual result BEFORE applying this Pull Request
the logs\joomla_update.php file will contain a line similar to
`2021-12-30T08:12:30+00:00	INFO ::1	update	Update started by user Brian Teeman (608). Old version is &#x200E;4.0.6-dev.`



### Expected result AFTER applying this Pull Request
the logs\joomla_update.php file will contain a line similar to
`2021-12-30T08:12:30+00:00	INFO ::1	update	Update started by user Brian Teeman (608). Old version is 4.0.6-dev.`



### Documentation Changes Required
none
