### PR TITLE
[4] remove Factory::getDbo() deprecated

### DIFF
--- a/administrator/components/com_modules/src/Helper/ModulesHelper.php
+++ b/administrator/components/com_modules/src/Helper/ModulesHelper.php
@@ -66,7 +66,7 @@ abstract class ModulesHelper
 	 */
 	public static function getPositions($clientId, $editPositions = false)
 	{
-		$db       = Factory::getDbo();
+		$db       = Factory::getContainer()->get('DatabaseDriver');
 		$clientId = (int) $clientId;
 		$query    = $db->getQuery(true)
 			->select('DISTINCT ' . $db->quoteName('position'))
@@ -122,7 +122,7 @@ abstract class ModulesHelper
 	 */
 	public static function getTemplates($clientId = 0, $state = '', $template = '')
 	{
-		$db       = Factory::getDbo();
+		$db       = Factory::getContainer()->get('DatabaseDriver');
 		$clientId = (int) $clientId;
 
 		// Get the database object and a new query object.
@@ -164,7 +164,7 @@ abstract class ModulesHelper
 	 */
 	public static function getModules($clientId)
 	{
-		$db    = Factory::getDbo();
+		$db    = Factory::getContainer()->get('DatabaseDriver');
 		$query = $db->getQuery(true)
 			->select('element AS value, name AS text')
 			->from('#__extensions as e')

--- a/administrator/components/com_workflow/src/Field/ComponentsWorkflowField.php
+++ b/administrator/components/com_workflow/src/Field/ComponentsWorkflowField.php
@@ -43,7 +43,7 @@ class ComponentsWorkflowField extends ListField
 	protected function getOptions()
 	{
 		// Initialise variable.
-		$db = Factory::getDbo();
+		$db = Factory::getContainer()->get('DatabaseDriver');
 
 		$query = $db->getQuery(true)
 			->select('DISTINCT a.name AS text, a.element AS value')

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -202,7 +202,7 @@ class HtmlView extends BaseHtmlView
 		$this->items      = &$items;
 		$this->pagination = &$pagination;
 		$this->user       = &$user;
-		$this->db         = Factory::getDbo();
+		$this->db         = Factory::getContainer()->get('DatabaseDriver');
 
 		$this->_prepareDocument();
 

--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -119,7 +119,7 @@ class HtmlView extends BaseHtmlView
 		$this->twofactorform    = $this->get('Twofactorform');
 		$this->twofactormethods = UsersHelper::getTwoFactorMethods();
 		$this->otpConfig        = $this->get('OtpConfig');
-		$this->db               = Factory::getDbo();
+		$this->db               = Factory::getContainer()->get('DatabaseDriver');
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -718,7 +718,7 @@ class HtmlDocument extends Document
 
 		if (!isset($children))
 		{
-			$db = CmsFactory::getDbo();
+			$db = CmsFactory::getContainer()->get('DatabaseDriver');
 			$app = CmsFactory::getApplication();
 			$menu = $app->getMenu();
 			$active = $menu->getActive();

--- a/libraries/src/Form/Field/TransitionField.php
+++ b/libraries/src/Form/Field/TransitionField.php
@@ -101,7 +101,7 @@ class TransitionField extends ListField
 		$jinput = Factory::getApplication()->input;
 
 		// Initialise variable.
-		$db = Factory::getDbo();
+		$db = Factory::getContainer()->get('DatabaseDriver');
 		$extension = $this->extension;
 		$workflowStage = (int) $this->workflowStage;
 

--- a/libraries/src/Form/Field/WorkflowstageField.php
+++ b/libraries/src/Form/Field/WorkflowstageField.php
@@ -92,7 +92,7 @@ class WorkflowstageField extends GroupedlistField
 	 */
 	protected function getGroups()
 	{
-		$db    = Factory::getDbo();
+		$db    = Factory::getContainer()->get('DatabaseDriver');
 		$query = $db->getQuery(true);
 
 		// Select distinct stages for existing articles

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -1036,7 +1036,7 @@ class Installer extends Adapter
 	{
 		if ($eid && $schema)
 		{
-			$db = Factory::getDbo();
+			$db = Factory::getContainer()->get('DatabaseDriver');
 			$schemapaths = $schema->children();
 
 			if (!$schemapaths)
@@ -1108,7 +1108,7 @@ class Installer extends Adapter
 		// Ensure we have an XML element and a valid extension id
 		if ($eid && $schema)
 		{
-			$db = Factory::getDbo();
+			$db = Factory::getContainer()->get('DatabaseDriver');
 			$schemapaths = $schema->children();
 
 			if (\count($schemapaths))
@@ -2087,7 +2087,7 @@ class Installer extends Adapter
 	 */
 	public function cleanDiscoveredExtension($type, $element, $folder = '', $client = 0)
 	{
-		$db = Factory::getDbo();
+		$db = Factory::getContainer()->get('DatabaseDriver');
 		$query = $db->getQuery(true)
 			->delete($db->quoteName('#__extensions'))
 			->where('type = :type')

--- a/libraries/src/MVC/Factory/MVCFactory.php
+++ b/libraries/src/MVC/Factory/MVCFactory.php
@@ -215,7 +215,7 @@ class MVCFactory implements MVCFactoryInterface, FormFactoryAwareInterface
 		}
 		else
 		{
-			$db = Factory::getDbo();
+			$db = Factory::getContainer()->get('DatabaseDriver');
 		}
 
 		return new $className($db);

--- a/libraries/src/Menu/SiteMenu.php
+++ b/libraries/src/Menu/SiteMenu.php
@@ -63,7 +63,9 @@ class SiteMenu extends AbstractMenu
 	{
 		// Extract the internal dependencies before calling the parent constructor since it calls $this->load()
 		$this->app      = isset($options['app']) && $options['app'] instanceof CMSApplication ? $options['app'] : Factory::getApplication();
-		$this->db       = isset($options['db']) && $options['db'] instanceof DatabaseDriver ? $options['db'] : Factory::getContainer()->get('DatabaseDriver');
+		$this->db       = isset($options['db']) && $options['db'] instanceof DatabaseDriver
+			? $options['db']
+			: Factory::getContainer()->get('DatabaseDriver');
 		$this->language = isset($options['language']) && $options['language'] instanceof Language ? $options['language'] : Factory::getLanguage();
 
 		parent::__construct($options);

--- a/libraries/src/Menu/SiteMenu.php
+++ b/libraries/src/Menu/SiteMenu.php
@@ -63,8 +63,8 @@ class SiteMenu extends AbstractMenu
 	{
 		// Extract the internal dependencies before calling the parent constructor since it calls $this->load()
 		$this->app      = isset($options['app']) && $options['app'] instanceof CMSApplication ? $options['app'] : Factory::getApplication();
-		$this->db       = isset($options['db']) && $options['db'] instanceof DatabaseDriver ? $options['db'] : Factory::getDbo();
-		$this->language = isset($options['language']) && $options['language'] instanceof Language ? $options['language'] : Factory::getLanguage();
+		$this->db       = isset($options['db']) && $options['db'] instanceof DatabaseDriver ? $options['db'] : Factory::getContainer()->get('DatabaseDriver');;
+		$this->language = isset($options['language']) && $options['language'] instanceof Language ? $options['language'] : Factory::getContainer()->get('DatabaseDriver');;
 
 		parent::__construct($options);
 	}

--- a/libraries/src/Menu/SiteMenu.php
+++ b/libraries/src/Menu/SiteMenu.php
@@ -63,8 +63,8 @@ class SiteMenu extends AbstractMenu
 	{
 		// Extract the internal dependencies before calling the parent constructor since it calls $this->load()
 		$this->app      = isset($options['app']) && $options['app'] instanceof CMSApplication ? $options['app'] : Factory::getApplication();
-		$this->db       = isset($options['db']) && $options['db'] instanceof DatabaseDriver ? $options['db'] : Factory::getContainer()->get('DatabaseDriver');;
-		$this->language = isset($options['language']) && $options['language'] instanceof Language ? $options['language'] : Factory::getContainer()->get('DatabaseDriver');;
+		$this->db       = isset($options['db']) && $options['db'] instanceof DatabaseDriver ? $options['db'] : Factory::getContainer()->get('DatabaseDriver');
+		$this->language = isset($options['language']) && $options['language'] instanceof Language ? $options['language'] : Factory::getLanguage();
 
 		parent::__construct($options);
 	}

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -392,7 +392,7 @@ class Updater extends Adapter
 	 */
 	private function getSitesWithUpdates($timestamp = 0)
 	{
-		$db        = Factory::getDbo();
+		$db        = Factory::getContainer()->get('DatabaseDriver');
 		$timestamp = (int) $timestamp;
 
 		$query = $db->getQuery(true)
@@ -438,7 +438,7 @@ class Updater extends Adapter
 	private function updateLastCheckTimestamp($updateSiteId)
 	{
 		$timestamp    = time();
-		$db           = Factory::getDbo();
+		$db           = Factory::getContainer()->get('DatabaseDriver');
 		$updateSiteId = (int) $updateSiteId;
 
 		$query = $db->getQuery(true)

--- a/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
+++ b/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
@@ -40,7 +40,7 @@ abstract class ArticlesLatestHelper
 	public static function getList(Registry $params, ArticlesModel $model)
 	{
 		// Get the Dbo and User object
-		$db   = Factory::getDbo();
+		$db   = Factory::getContainer()->get('DatabaseDriver');
 		$user = Factory::getUser();
 
 		// Set application parameters in model


### PR DESCRIPTION
### Summary of Changes
get DatabaseDriver from container


### Testing Instructions
code review


### Actual result BEFORE applying this Pull Request
@deprecated 5.0 — Load the database service from the dependency injection container


### Expected result AFTER applying this Pull Request
no more `Factory::getDbo(); @deprecated 5.0 
`

