### PR TITLE
[3] Remove reference & in usort callback function

### DIFF
--- a/libraries/joomla/utilities/arrayhelper.php
+++ b/libraries/joomla/utilities/arrayhelper.php
@@ -358,15 +358,15 @@ abstract class JArrayHelper
 	/**
 	 * Callback function for sorting an array of objects on a key
 	 *
-	 * @param   array  &$a  An array of objects
-	 * @param   array  &$b  An array of objects
+	 * @param   array  $a  An array of objects
+	 * @param   array  $b  An array of objects
 	 *
 	 * @return  integer  Comparison status
 	 *
 	 * @see     JArrayHelper::sortObjects()
 	 * @since   1.7.0
 	 */
-	protected static function _sortObjects(&$a, &$b)
+	protected static function _sortObjects($a, $b)
 	{
 		$key = self::$sortKey;
 


### PR DESCRIPTION
usort throws an error when callback functions requires a reference.

`JArrayHelper::_sortObjects(): Argument #1 ($a) must be passed by reference, value given`

### Summary of Changes
Removed & from _sortObjects parameter signature


### Testing Instructions
Use JArrayHelper::sortObjects


### Actual result BEFORE applying this Pull Request
* error message on php 8+


### Expected result AFTER applying this Pull Request
No error message



