### PR TITLE
[4] Fix pass-by-reference regression in PlgContentEmailcloak

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -46,7 +46,10 @@ class PlgContentEmailcloak extends CMSPlugin
 			return;
 		}
 
-		$this->_cloak(is_object($row) ? $row->text : $row, $params);
+		// Convert to a parameter, so we can pass-by-reference into `_clock` method
+		$text = is_object($row) ? $row->text : $row;
+
+		$this->_cloak( $text, $params);
 	}
 
 	/**

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -46,10 +46,14 @@ class PlgContentEmailcloak extends CMSPlugin
 			return;
 		}
 
-		// Convert to a parameter, so we can pass-by-reference into `_clock` method
-		$text = is_object($row) ? $row->text : $row;
+		if (is_object($row))
+		{
+			$this->_cloak($row->text, $params);
 
-		$this->_cloak($text, $params);
+			return;
+		}
+
+		$this->_cloak($row, $params);
 	}
 
 	/**

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -49,7 +49,7 @@ class PlgContentEmailcloak extends CMSPlugin
 		// Convert to a parameter, so we can pass-by-reference into `_clock` method
 		$text = is_object($row) ? $row->text : $row;
 
-		$this->_cloak( $text, $params);
+		$this->_cloak($text, $params);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #36501 fixes regression from my PR https://github.com/joomla/joomla-cms/pull/36442

### Summary of Changes

Only parameters can be passed by reference - doh. 

### Testing Instructions

Create an article with an email address in it - view article on frontend 

### Actual result BEFORE applying this Pull Request

```
PlgContentEmailcloak::_cloak(): Argument #1 ($text) cannot be passed by reference
```

### Expected result AFTER applying this Pull Request

Article loads fine. 

### Documentation Changes Required

None