### PR TITLE
[4.1] Fix asset table sequence next value for PostgreSQL after upmerge from 4.0-dev

### DIFF
--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -115,7 +115,7 @@ INSERT INTO "#__assets" ("id", "parent_id", "lft", "rgt", "level", "name", "titl
 (89, 18, 128, 129, 2, 'com_modules.module.90', 'Login Support', '{}'),
 (90, 1, 163, 164, 1, 'com_scheduler', 'com_scheduler', '{}');
 
-SELECT setval('#__assets_id_seq', 90, false);
+SELECT setval('#__assets_id_seq', 91, false);
 
 --
 -- Table structure for table `#__extensions`


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix the sequence number next value for the assets table in base.sql for PostgreSQL after the last upmerge from 4.0-dev.

### Testing Instructions

Either code review by someone who knows what a sequence means in PostgreSQL, or:

1. Make a new Joomla installation using a PostgreSQL database with the 4.1-dev branch as it is right now, i.e. since after the upmerge from 4.0-dev a few hours ago.
2. Try to install blog sample data.

### Actual result BEFORE applying this Pull Request

Creating anything which requires assets fails, and so does e.g. installing Blog Sample Data.

In the log file of the database server:

```
ERROR:  duplicate key value violates unique constraint "j4ux0_assets_pkey"
DETAIL:  Key (id)=(90) already exists.
STATEMENT:  INSERT INTO "j4ux0_assets"
	("name","title","rules","parent_id","level","lft","rgt") VALUES 
	('com_content.fieldgroup.1','The Author','{}',8,2,38,39)
	RETURNING id
ERROR:  current transaction is aborted, commands ignored until end of transaction block
STATEMENT:  SELECT 1
ERROR:  current transaction is aborted, commands ignored until end of transaction block
STATEMENT:  DEALLOCATE pdo_stmt_00000196
```

### Expected result AFTER applying this Pull Request

No such problem.

### Documentation Changes Required

None.