### PR TITLE
[4] add isSite/isAdmin as deprecated trait

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -49,6 +49,15 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 	use ContainerAwareTrait, ExtensionManagerTrait, ExtensionNamespaceMapper, SessionAwareWebApplicationTrait;
 
 	/**
+	 * Allow calling of isAdmin and isSite in Joomla 4.x
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 *
+	 * @deprecated  5.0  Will be removed in Joomla 5.0 - you have been warned!
+	 */
+	use DeprecatedClientAwareHelper;
+
+	/**
 	 * Array of options for the \JDocument object
 	 *
 	 * @var    array

--- a/libraries/src/Application/DeprecatedClientAwareHelper.php
+++ b/libraries/src/Application/DeprecatedClientAwareHelper.php
@@ -20,9 +20,9 @@ namespace Joomla\CMS\Application;
 trait DeprecatedClientAwareHelper
 {
 	/**
-	 * @return bool
+	 * @return  boolean
 	 *
-	 * @since  __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function isAdmin(): bool
 	{
@@ -32,9 +32,9 @@ trait DeprecatedClientAwareHelper
 	}
 
 	/**
-	 * @return bool
+	 * @return  boolean
 	 *
-	 * @since  __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function isSite(): bool
 	{
@@ -44,9 +44,9 @@ trait DeprecatedClientAwareHelper
 	}
 
 	/**
-	 * @return bool
+	 * @return  boolean
 	 *
-	 * @since  __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function isCLI(): bool
 	{
@@ -56,9 +56,9 @@ trait DeprecatedClientAwareHelper
 	}
 
 	/**
-	 * @return bool
+	 * @return  boolean
 	 *
-	 * @since  __DEPLOY_VERSION__
+	 * @since   __DEPLOY_VERSION__
 	 */
 	public function isApi(): bool
 	{
@@ -68,9 +68,9 @@ trait DeprecatedClientAwareHelper
 	}
 
 	/**
-	 * @param string $function The function that is deprecated
+	 * @param   string  $function  The function that is deprecated
 	 *
-	 * @return void
+	 * @return  void
 	 */
 	private function _raiseDeprecatedNotice($function){
 		@trigger_error(

--- a/libraries/src/Application/DeprecatedClientAwareHelper.php
+++ b/libraries/src/Application/DeprecatedClientAwareHelper.php
@@ -72,7 +72,8 @@ trait DeprecatedClientAwareHelper
 	 *
 	 * @return  void
 	 */
-	private function _raiseDeprecatedNotice($function){
+	private function _raiseDeprecatedNotice($function)
+	{
 		@trigger_error(
 			sprintf(
 				'%s() is deprecated and will be removed in Joomla 5.0',

--- a/libraries/src/Application/DeprecatedClientAwareHelper.php
+++ b/libraries/src/Application/DeprecatedClientAwareHelper.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE
+ */
+
+namespace Joomla\CMS\Application;
+
+\defined('JPATH_PLATFORM') or die;
+
+/**
+ * Trait for allowing calls that should have been deprecated in 4.0 but are still used.
+ *
+ * @since  __DEPLOY_VERSION__
+ *
+ * @deprecated  5.0  Will be removed in Joomla 5.0 - You have been warned!
+ */
+trait DeprecatedClientAwareHelper
+{
+	/**
+	 * @return bool
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function isAdmin(): bool
+	{
+		$this->_raiseDeprecatedNotice(__METHOD__);
+
+		return ($this instanceof AdministratorApplication);
+	}
+
+	/**
+	 * @return bool
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function isSite(): bool
+	{
+		$this->_raiseDeprecatedNotice(__METHOD__);
+
+		return ($this instanceof SiteApplication);
+	}
+
+	/**
+	 * @return bool
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function isCLI(): bool
+	{
+		$this->_raiseDeprecatedNotice(__METHOD__);
+
+		return ($this instanceof ConsoleApplication);
+	}
+
+	/**
+	 * @return bool
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function isApi(): bool
+	{
+		$this->_raiseDeprecatedNotice(__METHOD__);
+
+		return ($this instanceof ApiApplication);
+	}
+
+	/**
+	 * @param string $function The function that is deprecated
+	 *
+	 * @return void
+	 */
+	private function _raiseDeprecatedNotice($function){
+		@trigger_error(
+			sprintf(
+				'%s() is deprecated and will be removed in Joomla 5.0',
+				$function
+			),
+			E_USER_DEPRECATED
+		);
+	}
+}

--- a/libraries/src/Application/DeprecatedClientAwareHelper.php
+++ b/libraries/src/Application/DeprecatedClientAwareHelper.php
@@ -23,6 +23,8 @@ trait DeprecatedClientAwareHelper
 	 * @return  boolean
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @deprecated  5.0  Will be removed in Joomla 5.0 - You have been warned!
 	 */
 	public function isAdmin(): bool
 	{
@@ -35,6 +37,8 @@ trait DeprecatedClientAwareHelper
 	 * @return  boolean
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @deprecated  5.0  Will be removed in Joomla 5.0 - You have been warned!
 	 */
 	public function isSite(): bool
 	{
@@ -47,6 +51,8 @@ trait DeprecatedClientAwareHelper
 	 * @return  boolean
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @deprecated  5.0  Will be removed in Joomla 5.0 - You have been warned!
 	 */
 	public function isCLI(): bool
 	{
@@ -59,6 +65,8 @@ trait DeprecatedClientAwareHelper
 	 * @return  boolean
 	 *
 	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @deprecated  5.0  Will be removed in Joomla 5.0 - You have been warned!
 	 */
 	public function isApi(): bool
 	{
@@ -71,6 +79,8 @@ trait DeprecatedClientAwareHelper
 	 * @param   string  $function  The function that is deprecated
 	 *
 	 * @return  void
+	 *
+	 * @deprecated  5.0  Will be removed in Joomla 5.0 - You have been warned!
 	 */
 	private function _raiseDeprecatedNotice($function)
 	{


### PR DESCRIPTION
First PR of 2022 - Happy New Year.. 

Pull Request for Issue .. well countless issues.

Yes I know this is **_controversial_** ... but.. like @brianteeman says, its the real world verses the perfect world. 

### Summary of Changes

Implement a deprecated trait to the CMS Application to allow calls to `isSite` and `isAdmin` application methods for the Joomla 4 series. 

### Testing Instructions

you can now call `$app->isSite()` or `$app->isAdmin()` and get a `bool` back

### Actual result BEFORE applying this Pull Request

Some old extensions that did not pay attention to Joomla 4 development bombed out on missing methods.

### Expected result AFTER applying this Pull Request

A deprecated trait that allows the continued calling of these methods - but logs a deprecated message 

### Documentation Changes Required

Educate developers to NOT use this code in this PR ;-) 