### PR TITLE
[4.1] Protect Manual/Test Runs of Tasks against CSRF

### DIFF
--- a/administrator/components/com_scheduler/tmpl/tasks/default.php
+++ b/administrator/components/com_scheduler/tmpl/tasks/default.php
@@ -10,6 +10,7 @@
 // Restrict direct access
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Application\CMSWebApplicationInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -37,8 +38,10 @@ Text::script('JLIB_JS_AJAX_ERROR_PARSE');
 
 try
 {
+	/** @var CMSWebApplicationInterface $app */
 	$app = Factory::getApplication();
-} catch (Exception $e)
+}
+catch (Exception $e)
 {
 	die('Failed to get app');
 }
@@ -57,7 +60,9 @@ if ($saveOrder && !empty($this->items))
 	HTMLHelper::_('draggablelist.draggable');
 }
 
-$app->getDocument()->getWebAssetManager()->useScript('com_scheduler.test-task');
+$document = $app->getDocument();
+$document->addScriptOptions('com_scheduler.test-task.token', Session::getFormToken());
+$document->getWebAssetManager()->useScript('com_scheduler.test-task');
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_scheduler&view=tasks'); ?>" method="post" name="adminForm"

--- a/build/media_source/com_scheduler/js/admin-view-run-test-task.es6.js
+++ b/build/media_source/com_scheduler/js/admin-view-run-test-task.es6.js
@@ -17,7 +17,8 @@ if (!window.Joomla) {
 
 const initRunner = () => {
   const paths = Joomla.getOptions('system.paths');
-  const uri = `${paths ? `${paths.base}/index.php` : window.location.pathname}?option=com_ajax&format=json&plugin=RunSchedulerTest&group=system&id=%d`;
+  const token = Joomla.getOptions('com_scheduler.test-task.token');
+  const uri = `${paths ? `${paths.base}/index.php` : window.location.pathname}?option=com_ajax&format=json&plugin=RunSchedulerTest&group=system&id=%d${token ? `&${token}=1` : ``}`;
   const modal = document.getElementById('scheduler-test-modal');
 
   // Task output template

--- a/build/media_source/com_scheduler/js/admin-view-run-test-task.es6.js
+++ b/build/media_source/com_scheduler/js/admin-view-run-test-task.es6.js
@@ -18,7 +18,7 @@ if (!window.Joomla) {
 const initRunner = () => {
   const paths = Joomla.getOptions('system.paths');
   const token = Joomla.getOptions('com_scheduler.test-task.token');
-  const uri = `${paths ? `${paths.base}/index.php` : window.location.pathname}?option=com_ajax&format=json&plugin=RunSchedulerTest&group=system&id=%d${token ? `&${token}=1` : ``}`;
+  const uri = `${paths ? `${paths.base}/index.php` : window.location.pathname}?option=com_ajax&format=json&plugin=RunSchedulerTest&group=system&id=%d${token ? `&${token}=1` : ''}`;
   const modal = document.getElementById('scheduler-test-modal');
 
   // Task output template
@@ -42,7 +42,7 @@ const initRunner = () => {
     const id = parseInt(button.dataset.id, 10);
     const { title } = button.dataset;
 
-    modal.querySelector('.modal-title').innerHTML = Joomla.Text._('COM_SCHEDULER_TEST_RUN_TITLE').replace('%d', id);
+    modal.querySelector('.modal-title').innerHTML = Joomla.Text._('COM_SCHEDULER_TEST_RUN_TITLE').replace('%d', id.toString());
     modal.querySelector('.modal-body > div').innerHTML = template.replace('%s', title);
 
     Joomla.request({

--- a/plugins/system/schedulerunner/schedulerunner.php
+++ b/plugins/system/schedulerunner/schedulerunner.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\Session\Session;
 use Joomla\CMS\Table\Extension;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Component\Scheduler\Administrator\Scheduler\Scheduler;
@@ -253,6 +254,11 @@ class PlgSystemSchedulerunner extends CMSPlugin implements SubscriberInterface
 	 */
 	public function runTestCron(Event $event)
 	{
+		if (!Session::checkToken('GET'))
+		{
+			return;
+		}
+
 		$id = (int) $this->app->input->getInt('id');
 		$allowConcurrent = $this->app->input->getBool('allowConcurrent', false);
 


### PR DESCRIPTION
Pull Request for Issue #36454.

### Summary of Changes
Adds CSRF protection for  task "test" trigger endpoint. Token is injected in the list template.


### Testing Instructions
- Create Scheduled Task, note ID.
- Goto `http://example.com/administrator/index.php?option=com_ajax&format=json&plugin=RunSchedulerTest&group=system&id={TaskID}` in another tab.


### Actual result BEFORE applying this Pull Request
Task is executed.


### Expected result AFTER applying this Pull Request
Task is not executed since request lacks token.


### Documentation Changes Required
\-
