### PR TITLE
Take workflow extension into account when setting a default

### DIFF
--- a/administrator/components/com_workflow/src/Model/WorkflowModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowModel.php
@@ -297,7 +297,13 @@ class WorkflowModel extends AdminModel
 		if ($value)
 		{
 			// Unset other default item
-			if ($table->load(array('default' => '1')))
+			if ($table->load(
+				[
+					'default' => '1',
+					'extension' => $table->get('extension')
+				]
+			)
+			)
 			{
 				$table->default = 0;
 				$table->modified = $date;

--- a/administrator/components/com_workflow/src/Model/WorkflowModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowModel.php
@@ -302,8 +302,7 @@ class WorkflowModel extends AdminModel
 					'default' => '1',
 					'extension' => $table->get('extension')
 				]
-			)
-			)
+			))
 			{
 				$table->default = 0;
 				$table->modified = $date;

--- a/administrator/components/com_workflow/src/Table/WorkflowTable.php
+++ b/administrator/components/com_workflow/src/Table/WorkflowTable.php
@@ -227,8 +227,7 @@ class WorkflowTable extends Table
 					'default' => '1',
 					'extension' => $this->extension
 				]
-			)
-			)
+			))
 			{
 				$table->default = 0;
 				$table->store();

--- a/administrator/components/com_workflow/src/Table/WorkflowTable.php
+++ b/administrator/components/com_workflow/src/Table/WorkflowTable.php
@@ -144,7 +144,7 @@ class WorkflowTable extends Table
 		}
 		else
 		{
-			$db = $this->getDbo();
+			$db    = $this->getDbo();
 			$query = $db->getQuery(true);
 
 			$query
@@ -192,7 +192,7 @@ class WorkflowTable extends Table
 		{
 			// Existing item
 			$this->modified_by = $user->id;
-			$this->modified = $date->toSql();
+			$this->modified    = $date->toSql();
 		}
 		else
 		{
@@ -219,10 +219,16 @@ class WorkflowTable extends Table
 			$this->modified_by = $this->created_by;
 		}
 
-		if ($this->default == '1')
+		if ((int) $this->default === 1)
 		{
 			// Verify that the default is unique for this workflow
-			if ($table->load(array('default' => '1')))
+			if ($table->load(
+				[
+					'default' => '1',
+					'extension' => $this->extension
+				]
+			)
+			)
 			{
 				$table->default = 0;
 				$table->store();


### PR DESCRIPTION
### Summary of Changes
When using the workflow extension in a custom component with more than 1 view using the workflow you cannot set a default work flow per section. The default is considered across all workflows, regardless which workflow is being used.

### Testing Instructions
1. Go to Content -> Articles
2. Click on Options
3. Click on the Integration tab
4. Set `Enable Workflow` to `Yes`
5. Save the changes
6. Under `Content` click on `Workflows`
7. Make sure to see that the `Basic Workflow` is set as Default
8. Go to the URL `https://YOURSITE/administrator/index.php?option=com_workflow&view=workflows&extension=com_banners.banner`
9. Click on New
10. Give it a name
11. Make sure to set the `Default` to `Yes`
12. Save the changes
13. Go to Content -> Workflows
14. Notice that the `Basic Workflow` is no longer Default
15. Apply the patch
16. Go to Content -> Workflows
17. Click on the Default button to make the workflow default
18. Go to the URL `https://YOURSITE/administrator/index.php?option=com_workflow&view=workflows&extension=com_banners.banner`
19. Notice that the banner workflow is still default


### Actual result BEFORE applying this Pull Request
A default workflow was set across all workflows


### Expected result AFTER applying this Pull Request
A default workflow is applied per section


### Documentation Changes Required
None
