### PR TITLE
[4.0] Fix example in cleanImageURL docblock

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -664,7 +664,7 @@ abstract class HTMLHelper
 	 *             url: 'string',
 	 *             attributes: [
 	 *               width:  integer,
-	 *               height: integer
+	 *               height: integer,
 	 *             ]
 	 *           }
 	 *

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -657,13 +657,15 @@ abstract class HTMLHelper
 	/**
 	 * Gets a URL, cleans the Joomla specific params and returns an object
 	 *
-	 * @param    string        $url        The relative or absolute URL to use for the src attribute.
+	 * @param    string $url  The relative or absolute URL to use for the src attribute.
 	 *
 	 * @return   object
 	 * @example  {
-	 *             url:    'string',
-	 *             width:  integer,
-	 *             height: integer,
+	 *             url: 'string',
+	 *             attributes: [
+	 *               width:  integer,
+	 *               height: integer
+	 *             ]
 	 *           }
 	 *
 	 * @since    4.0.0

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -657,7 +657,7 @@ abstract class HTMLHelper
 	/**
 	 * Gets a URL, cleans the Joomla specific params and returns an object
 	 *
-	 * @param    string $url  The relative or absolute URL to use for the src attribute.
+	 * @param    string  $url  The relative or absolute URL to use for the src attribute.
 	 *
 	 * @return   object
 	 * @example  {


### PR DESCRIPTION
### Summary of Changes
Fix the example in the docblock to reflect the structure of the object.


### Testing Instructions
Code review.

@dgrammatiko

