### PR TITLE
Impressionestudio patch: simple article classes

### DIFF
--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -98,7 +98,7 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 	<?php if (isset ($this->item->toc)) :
 		echo $this->item->toc;
 	endif; ?>
-	<div itemprop="articleBody" class="article | com-content-article__body">
+	<div itemprop="articleBody" class="content | com-content-article__body">
 		<?php echo $this->item->text; ?>
 	</div>
 

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -33,10 +33,10 @@ $currentDate       = Factory::getDate()->format('Y-m-d H:i:s');
 $isNotPublishedYet = $this->item->publish_up > $currentDate;
 $isExpired         = !is_null($this->item->publish_down) && $this->item->publish_down < $currentDate;
 ?>
-<div class="com-content-article item-page<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="https://schema.org/Article">
+<div class="article <?php echo $this->pageclass_sfx; ?> | com-content-article item-page<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="https://schema.org/Article">
 	<meta itemprop="inLanguage" content="<?php echo ($this->item->language === '*') ? Factory::getApplication()->get('language') : $this->item->language; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
-	<div class="page-header">
+	<div class="title | page-header">
 		<h1> <?php echo $this->escape($this->params->get('page_heading')); ?> </h1>
 	</div>
 	<?php endif;
@@ -50,18 +50,18 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 	|| $params->get('show_hits') || $params->get('show_category') || $params->get('show_parent_category') || $params->get('show_author') || $assocParam; ?>
 
 	<?php if ($params->get('show_title')) : ?>
-	<div class="page-header">
+	<div class="title | page-header">
 		<<?php echo $htag; ?> itemprop="headline">
 			<?php echo $this->escape($this->item->title); ?>
 		</<?php echo $htag; ?>>
 		<?php if ($this->item->state == ContentComponent::CONDITION_UNPUBLISHED) : ?>
-			<span class="badge bg-warning text-light"><?php echo Text::_('JUNPUBLISHED'); ?></span>
+			<span class="badge | bg-warning text-light"><?php echo Text::_('JUNPUBLISHED'); ?></span>
 		<?php endif; ?>
 		<?php if ($isNotPublishedYet) : ?>
-			<span class="badge bg-warning text-light"><?php echo Text::_('JNOTPUBLISHEDYET'); ?></span>
+			<span class="badge | bg-warning text-light"><?php echo Text::_('JNOTPUBLISHEDYET'); ?></span>
 		<?php endif; ?>
 		<?php if ($isExpired) : ?>
-			<span class="badge bg-warning text-light"><?php echo Text::_('JEXPIRED'); ?></span>
+			<span class="badge | bg-warning text-light"><?php echo Text::_('JEXPIRED'); ?></span>
 		<?php endif; ?>
 	</div>
 	<?php endif; ?>
@@ -98,7 +98,7 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 	<?php if (isset ($this->item->toc)) :
 		echo $this->item->toc;
 	endif; ?>
-	<div itemprop="articleBody" class="com-content-article__body">
+	<div itemprop="articleBody" class="article | com-content-article__body">
 		<?php echo $this->item->text; ?>
 	</div>
 

--- a/components/com_content/tmpl/article/default_links.php
+++ b/components/com_content/tmpl/article/default_links.php
@@ -18,8 +18,8 @@ $urls = json_decode($this->item->urls);
 $params = $this->item->params;
 if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))) :
 ?>
-<div class="com-content-article__links content-links">
-	<ul class="com-content-article__links content-list">
+<div class="links | com-content-article__links content-links">
+	<ul class="links | com-content-article__links content-list">
 		<?php
 			$urlarray = array(
 			array($urls->urla, $urls->urlatext, $urls->targeta, 'a'),
@@ -42,7 +42,7 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 				// If no target is present, use the default
 				$target = $target ?: $params->get('target' . $id);
 				?>
-			<li class="com-content-article__link content-links-<?php echo $id; ?>">
+			<li class="link link-<?php echo $id; ?> | com-content-article__link content-links-<?php echo $id; ?>">
 				<?php
 					// Compute the correct link
 
@@ -73,7 +73,7 @@ if ($urls && (!empty($urls->urla) || !empty($urls->urlb) || !empty($urls->urlc))
 									'width'  => '100%',
 									'modalWidth'  => '500',
 									'bodyHeight'  => '500',
-									'footer' => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-hidden="true">'
+									'footer' => '<button type="button" class="btn | btn-secondary" data-bs-dismiss="modal" aria-hidden="true">'
 										. \Joomla\CMS\Language\Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
 								)
 							);

--- a/layouts/joomla/content/full_image.php
+++ b/layouts/joomla/content/full_image.php
@@ -32,7 +32,7 @@ if ((isset($img->attributes['width']) && (int) $img->attributes['width'] > 0)
 	$extraAttr = ArrayHelper::toString($img->attributes) . ' loading="lazy"';
 }
 ?>
-<figure class="<?php echo htmlspecialchars($imgclass, ENT_COMPAT, 'UTF-8'); ?> item-image">
+<figure class="image <?php echo htmlspecialchars($imgclass, ENT_COMPAT, 'UTF-8'); ?> | item-image">
 	<img src="<?php echo htmlspecialchars($img->url, ENT_COMPAT, 'UTF-8'); ?>"
 			 <?php echo $alt; ?>
 			 itemprop="image"

--- a/layouts/joomla/content/icons.php
+++ b/layouts/joomla/content/icons.php
@@ -17,10 +17,6 @@ $articleId = $displayData['item']->id;
 
 <?php if ($canEdit) : ?>
 	<div class="icons">
-		<div class="float-end">
-			<div>
-				<?php echo HTMLHelper::_('icon.edit', $displayData['item'], $displayData['params']); ?>
-			</div>
-		</div>
+		<?php echo HTMLHelper::_('icon.edit', $displayData['item'], $displayData['params']); ?>
 	</div>
 <?php endif; ?>

--- a/layouts/joomla/content/info_block.php
+++ b/layouts/joomla/content/info_block.php
@@ -14,13 +14,13 @@ use Joomla\CMS\Language\Text;
 $blockPosition = $displayData['params']->get('info_block_position', 0);
 
 ?>
-<dl class="article-info text-muted">
+<dl class="info | article-info text-muted">
 
 	<?php if ($displayData['position'] === 'above' && ($blockPosition == 0 || $blockPosition == 2)
 			|| $displayData['position'] === 'below' && ($blockPosition == 1)
 			) : ?>
 
-		<dt class="article-info-term">
+		<dt class="info-title | article-info-term">
 			<?php if ($displayData['params']->get('info_block_show_title', 1)) : ?>
 				<?php echo Text::_('COM_CONTENT_ARTICLE_INFO'); ?>
 			<?php endif; ?>

--- a/layouts/joomla/content/info_block/associations.php
+++ b/layouts/joomla/content/info_block/associations.php
@@ -19,18 +19,23 @@ use Joomla\CMS\Router\Route;
 <?php $associations = $displayData['item']->associations; ?>
 
 <dd class="association">
-	<span class="icon-globe icon-fw" aria-hidden="true"></span>
+	<span class="info-icon icon-globe icon-fw" aria-hidden="true"></span>
+	<span class="info-label">
 	<?php echo Text::_('JASSOCIATIONS'); ?>
+	</span>
+	<span class="info-value">
 	<?php foreach ($associations as $association) : ?>
 		<?php if ($displayData['item']->params->get('flags', 1) && $association['language']->image) : ?>
 			<?php $flag = HTMLHelper::_('image', 'mod_languages/' . $association['language']->image . '.gif', $association['language']->title_native, array('title' => $association['language']->title_native), true); ?>
-			<a href="<?php echo Route::_($association['item']); ?>"><?php echo $flag; ?></a>
+			<a class="<?php echo strtolower($association['language']->lang_code); ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo $flag; ?></a>
 		<?php else : ?>
-			<?php $class = 'btn btn-secondary btn-sm btn-' . strtolower($association['language']->lang_code); ?>
-			<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>"><?php echo $association['language']->lang_code; ?>
-				<span class="visually-hidden"><?php echo $association['language']->title_native; ?></span>
+			<?php $class = 'btn btn-' . strtolower($association['language']->lang_code).' | btn-secondary btn-sm'; ?>
+			<a class="<?php echo $class; ?>" title="<?php echo $association['language']->title_native; ?>" href="<?php echo Route::_($association['item']); ?>">
+				<span class="lang-code"><?php echo $association['language']->lang_code; ?></span>
+				<span class="lang-title"><?php echo $association['language']->title_native; ?></span>
 			</a>
 		<?php endif; ?>
 	<?php endforeach; ?>
+	</span>
 </dd>
 <?php endif; ?>

--- a/layouts/joomla/content/info_block/author.php
+++ b/layouts/joomla/content/info_block/author.php
@@ -14,12 +14,18 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <dd class="createdby" itemprop="author" itemscope itemtype="https://schema.org/Person">
-	<span class="icon-user icon-fw" aria-hidden="true"></span>
+	<span class="info-icon icon-user icon-fw" aria-hidden="true"></span>
 	<?php $author = ($displayData['item']->created_by_alias ?: $displayData['item']->author); ?>
-	<?php $author = '<span itemprop="name">' . $author . '</span>'; ?>
+	<?php $author = '<span class="info-value" itemprop="name">' . $author . '</span>'; ?>
 	<?php if (!empty($displayData['item']->contact_link ) && $displayData['params']->get('link_author') == true) : ?>
-		<?php echo Text::sprintf('COM_CONTENT_WRITTEN_BY', HTMLHelper::_('link', $displayData['item']->contact_link, $author, array('itemprop' => 'url'))); ?>
+		<span class="info-label">
+		<?php echo Text::sprintf('COM_CONTENT_WRITTEN_BY', ''); ?>
+		</span>
+		<?php echo HTMLHelper::_('link', $displayData['item']->contact_link, $author, array('class' => 'info-value', 'itemprop' => 'url')); ?>
 	<?php else : ?>
-		<?php echo Text::sprintf('COM_CONTENT_WRITTEN_BY', $author); ?>
+		<span class="info-label">
+		<?php echo Text::sprintf('COM_CONTENT_WRITTEN_BY', ''); ?>
+		</span>
+		<?php echo $author; ?>
 	<?php endif; ?>
 </dd>

--- a/layouts/joomla/content/info_block/category.php
+++ b/layouts/joomla/content/info_block/category.php
@@ -15,16 +15,22 @@ use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 ?>
-<dd class="category-name">
-	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'icon-folder-open icon-fw']); ?>
+<dd class="category | category-name">
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info-icon icon-folder-open icon-fw']); ?>
 	<?php $title = $this->escape($displayData['item']->category_title); ?>
 	<?php if ($displayData['params']->get('link_category') && !empty($displayData['item']->catid)) : ?>
-		<?php $url = '<a href="' . Route::_(
+		<?php $url = '<a class="info-value" href="' . Route::_(
 			RouteHelper::getCategoryRoute($displayData['item']->catid, $displayData['item']->category_language)
 			)
 			. '" itemprop="genre">' . $title . '</a>'; ?>
-		<?php echo Text::sprintf('COM_CONTENT_CATEGORY', $url); ?>
+		<span class="info-label">
+		<?php echo Text::sprintf('COM_CONTENT_CATEGORY', ''); ?>	
+		</span>
+		<?php echo $url; ?>
 	<?php else : ?>
-		<?php echo Text::sprintf('COM_CONTENT_CATEGORY', '<span itemprop="genre">' . $title . '</span>'); ?>
+		<span class="info-label">
+		<?php echo Text::sprintf('COM_CONTENT_CATEGORY', ''); ?>	
+		</span>
+		<span class="info-value" itemprop="genre"><?php echo $title; ?></span>
 	<?php endif; ?>
 </dd>

--- a/layouts/joomla/content/info_block/create_date.php
+++ b/layouts/joomla/content/info_block/create_date.php
@@ -14,8 +14,11 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <dd class="create">
-	<span class="icon-calendar icon-fw" aria-hidden="true"></span>
-	<time datetime="<?php echo HTMLHelper::_('date', $displayData['item']->created, 'c'); ?>" itemprop="dateCreated">
-		<?php echo Text::sprintf('COM_CONTENT_CREATED_DATE_ON', HTMLHelper::_('date', $displayData['item']->created, Text::_('DATE_FORMAT_LC3'))); ?>
-	</time>
+	<span class="info-icon icon-calendar icon-fw" aria-hidden="true"></span>
+	<span class="info-label">
+		<?php echo Text::sprintf('COM_CONTENT_CREATED_DATE_ON', ''); ?>
+	</span>
+	<span class="info-value">
+		<?php echo HTMLHelper::_('date', $displayData['item']->created, Text::_('DATE_FORMAT_LC3')); ?>
+	</span>
 </dd>

--- a/layouts/joomla/content/info_block/create_date.php
+++ b/layouts/joomla/content/info_block/create_date.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Language\Text;
 	<span class="info-label">
 		<?php echo Text::sprintf('COM_CONTENT_CREATED_DATE_ON', ''); ?>
 	</span>
-	<span class="info-value">
+	<time class="info-value" datetime="<?php echo HTMLHelper::_('date', $displayData['item']->created, 'c'); ?>" itemprop="dateCreated">
 		<?php echo HTMLHelper::_('date', $displayData['item']->created, Text::_('DATE_FORMAT_LC3')); ?>
-	</span>
+	</time>
 </dd>

--- a/layouts/joomla/content/info_block/hits.php
+++ b/layouts/joomla/content/info_block/hits.php
@@ -13,7 +13,12 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <dd class="hits">
-	<span class="icon-eye icon-fw" aria-hidden="true"></span>
+	<span class="info-icon icon-eye icon-fw" aria-hidden="true"></span>
 	<meta itemprop="interactionCount" content="UserPageVisits:<?php echo $displayData['item']->hits; ?>">
-	<?php echo Text::sprintf('COM_CONTENT_ARTICLE_HITS', $displayData['item']->hits); ?>
+	<span class="info-label">
+		<?php echo Text::sprintf('COM_CONTENT_ARTICLE_HITS', ''); ?>
+	</span>
+	<span class="info-value">
+		<?php echo $displayData['item']->hits; ?>
+	</span>
 </dd>

--- a/layouts/joomla/content/info_block/modify_date.php
+++ b/layouts/joomla/content/info_block/modify_date.php
@@ -14,8 +14,11 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <dd class="modified">
-	<span class="icon-calendar icon-fw" aria-hidden="true"></span>
-	<time datetime="<?php echo HTMLHelper::_('date', $displayData['item']->modified, 'c'); ?>" itemprop="dateModified">
-		<?php echo Text::sprintf('COM_CONTENT_LAST_UPDATED', HTMLHelper::_('date', $displayData['item']->modified, Text::_('DATE_FORMAT_LC3'))); ?>
+	<span class="info-icon icon-calendar icon-fw" aria-hidden="true"></span>
+	<span class="info-label">
+		<?php echo Text::sprintf('COM_CONTENT_LAST_UPDATED', ''); ?>
+	</span>
+	<time class="info-value" datetime="<?php echo HTMLHelper::_('date', $displayData['item']->modified, 'c'); ?>" itemprop="dateModified">
+		<?php echo HTMLHelper::_('date', $displayData['item']->modified, Text::_('DATE_FORMAT_LC3')); ?>
 	</time>
 </dd>

--- a/layouts/joomla/content/info_block/parent_category.php
+++ b/layouts/joomla/content/info_block/parent_category.php
@@ -10,19 +10,29 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 ?>
-<dd class="parent-category-name">
+<dd class="parent-category">
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'info-icon icon-folder-open icon-fw']); ?>
 	<?php $title = $this->escape($displayData['item']->parent_title); ?>
 	<?php if ($displayData['params']->get('link_parent_category') && !empty($displayData['item']->parent_id)) : ?>
-		<?php $url = '<a href="' . Route::_(
+		<span class="info-label">
+			<?php echo Text::sprintf('COM_CONTENT_PARENT', ''); ?>
+		</span>
+		<?php $url = '<a class="info-value" href="' . Route::_(
 			RouteHelper::getCategoryRoute($displayData['item']->parent_id, $displayData['item']->parent_language)
 			)
 			. '" itemprop="genre">' . $title . '</a>'; ?>
-		<?php echo Text::sprintf('COM_CONTENT_PARENT', $url); ?>
+		<?php echo $url; ?>
 	<?php else : ?>
-		<?php echo Text::sprintf('COM_CONTENT_PARENT', '<span itemprop="genre">' . $title . '</span>'); ?>
+		<span class="info-label">
+			<?php echo Text::sprintf('COM_CONTENT_PARENT', ''); ?>
+		</span>
+		<span class="info-value" itemprop="genre">
+		<?php echo $title; ?>
+		</span>
 	<?php endif; ?>
 </dd>

--- a/layouts/joomla/content/info_block/publish_date.php
+++ b/layouts/joomla/content/info_block/publish_date.php
@@ -14,8 +14,11 @@ use Joomla\CMS\Language\Text;
 
 ?>
 <dd class="published">
-	<span class="icon-calendar icon-fw" aria-hidden="true"></span>
-	<time datetime="<?php echo HTMLHelper::_('date', $displayData['item']->publish_up, 'c'); ?>" itemprop="datePublished">
-		<?php echo Text::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', HTMLHelper::_('date', $displayData['item']->publish_up, Text::_('DATE_FORMAT_LC3'))); ?>
+	<span class="info-icon icon-calendar icon-fw" aria-hidden="true"></span>
+	<span class="info-label">
+		<?php echo Text::sprintf('COM_CONTENT_PUBLISHED_DATE_ON', ''); ?>
+	</span>
+	<time class="info-value" datetime="<?php echo HTMLHelper::_('date', $displayData['item']->publish_up, 'c'); ?>" itemprop="datePublished">
+		<?php echo HTMLHelper::_('date', $displayData['item']->publish_up, Text::_('DATE_FORMAT_LC3')); ?>
 	</time>
 </dd>

--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -34,7 +34,7 @@ if ((isset($img->attributes['width']) && (int) $img->attributes['width'] > 0)
 	$extraAttr = ArrayHelper::toString($img->attributes) . ' loading="lazy"';
 }
 ?>
-<figure class="<?php echo htmlspecialchars($imgclass, ENT_COMPAT, 'UTF-8'); ?> item-image">
+<figure class="image <?php echo htmlspecialchars($imgclass, ENT_COMPAT, 'UTF-8'); ?> | item-image">
 	<?php if ($params->get('link_intro_image') && ($params->get('access-view') || $params->get('show_noauth', '0') == '1')) : ?>
 		<a href="<?php echo Route::_(RouteHelper::getArticleRoute($displayData->slug, $displayData->catid, $displayData->language)); ?>"
 			itemprop="url" title="<?php echo $this->escape($displayData->title); ?>">

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -20,12 +20,12 @@ $direction = Factory::getLanguage()->isRtl() ? 'left' : 'right';
 
 <p class="readmore">
 	<?php if (!$params->get('access-view')) : ?>
-		<a class="btn btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo Text::_('JGLOBAL_REGISTER_TO_READ_MORE') . ' ' . $this->escape($item->title); ?>">
+		<a class="btn | btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo Text::_('JGLOBAL_REGISTER_TO_READ_MORE') . ' ' . $this->escape($item->title); ?>">
 			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
 			<?php echo Text::_('JGLOBAL_REGISTER_TO_READ_MORE'); ?>
 		</a>
 	<?php elseif ($readmore = $item->alternative_readmore) : ?>
-		<a class="btn btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo $this->escape($readmore . ' ' . $item->title); ?>">
+		<a class="btn | btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo $this->escape($readmore . ' ' . $item->title); ?>">
 			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
 			<?php echo $readmore; ?>
 			<?php if ($params->get('show_readmore_title', 0) != 0) : ?>
@@ -33,12 +33,12 @@ $direction = Factory::getLanguage()->isRtl() ? 'left' : 'right';
 			<?php endif; ?>
 		</a>
 	<?php elseif ($params->get('show_readmore_title', 0) == 0) : ?>
-		<a class="btn btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo Text::sprintf('JGLOBAL_READ_MORE_TITLE', $this->escape($item->title)); ?>">
+		<a class="btn | btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo Text::sprintf('JGLOBAL_READ_MORE_TITLE', $this->escape($item->title)); ?>">
 			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
 			<?php echo Text::_('JGLOBAL_READ_MORE'); ?>
 		</a>
 	<?php else : ?>
-		<a class="btn btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo Text::sprintf('JGLOBAL_READ_MORE_TITLE', $this->escape($item->title)); ?>">
+		<a class="btn | btn-secondary" href="<?php echo $displayData['link']; ?>" aria-label="<?php echo Text::sprintf('JGLOBAL_READ_MORE_TITLE', $this->escape($item->title)); ?>">
 			<?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
 			<?php echo Text::sprintf('JGLOBAL_READ_MORE_TITLE', HTMLHelper::_('string.truncate', $item->title, $params->get('readmore_limit'))); ?>
 		</a>

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -18,13 +18,13 @@ $authorised = Factory::getUser()->getAuthorisedViewLevels();
 
 ?>
 <?php if (!empty($displayData)) : ?>
-	<ul class="tags list-inline">
+	<ul class="tags | list-inline">
 		<?php foreach ($displayData as $i => $tag) : ?>
 			<?php if (in_array($tag->access, $authorised)) : ?>
 				<?php $tagParams = new Registry($tag->params); ?>
 				<?php $link_class = $tagParams->get('tag_link_class', 'btn-info'); ?>
-				<li class="list-inline-item tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i; ?>" itemprop="keywords">
-					<a href="<?php echo Route::_(RouteHelper::getTagRoute($tag->tag_id . ':' . $tag->alias)); ?>" class="btn btn-sm <?php echo $link_class; ?>">
+				<li class="tag tag-<?php echo $tag->tag_id; ?> tag-index-<?php echo $i; ?> | list-inline-item tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i; ?>" itemprop="keywords">
+					<a href="<?php echo Route::_(RouteHelper::getTagRoute($tag->tag_id . ':' . $tag->alias)); ?>" class="btn <?php echo $link_class; ?> | btn-sm">
 						<?php echo $this->escape($tag->title); ?>
 					</a>
 				</li>


### PR DESCRIPTION
Pull Request for Issue #35342.

### Summary of Changes
The proposed changes affect the class names that relate to an article. The purpose is to have simple, short and easy to remember class names in order to create more complex article layouts in an easier way (with the help of a few changes that I will also propose for custom fields).

Specifically:
- New class names are added (in some cases).
- When new class names are added, the old and not useful class names remained for compatibility reasons.
- The old and not useful class names are separated with the special character | so the developers will distinguish them and not use them. (The special character is allowed according to https://stackoverflow.com/questions/448981/which-characters-are-valid-in-css-class-names-selectors.)

### Notes:
- Personally, I would not suggest keeping the old and not useful classes, but some guys want backward compatibility.
- Some guys recommended to use BEM for naming the classes and initially I was using BEM in the proposed changes. But I cancelled using BEM because I don't find it useful. Using BEM, the class names would remain complex and very long.
Also, I think that BEM changed a little some naming rules and I think that there are some inconsistencies in the documentation. For example, the class "search-form__button_size_m" should be "search-form__button_size-m" since the proposed pattern is "block-name__element-name_modifier-name_modifier-value". 
It seems, to me, that BEM has a lot of rules that are not straight. So the final rule I use is: if it is not simple, I do not use it.

For many years, I create websites with high quality templates from scratch (only with Joomla of course) and I don't use purchased templates. So I have faced many cases and requirements and I believe that the proposed changes make things way much better.

(At the bottom of the following closed pull request, you can find a useful chat: https://github.com/joomla/joomla-cms/pull/36422)