### PR TITLE
[J4] Category edit form should use return url

### DIFF
--- a/administrator/components/com_categories/tmpl/category/edit.php
+++ b/administrator/components/com_categories/tmpl/category/edit.php
@@ -124,6 +124,7 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
 
 		<?php echo $this->form->getInput('extension'); ?>
 		<input type="hidden" name="task" value="">
+		<input type="hidden" name="return" value="<?php echo $input->getBase64('return'); ?>">
 		<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">
 		<?php echo HTMLHelper::_('form.token'); ?>
 	</div>


### PR DESCRIPTION
### Summary of Changes
Currently the article edit form respects return URLs; the category edit form does not. Adding it here makes for a more consistent editing experience.


### Testing Instructions
In the Joomla 4 back end, navigate to this link: `index.php?option=com_categories&view=category&layout=edit&extension=com_content&return=aW5kZXgucGhw`

This will open a new category edit page, with the return url as 'index.php' (base64 encoded)

Either create a new category and save and close, or hit cancel to exit the form.


### Actual result BEFORE applying this Pull Request
Joomla ignores the return URL and takes you to the category list.


### Expected result AFTER applying this Pull Request
Joomla sees the return url and takes you to the home dashboard instead.


### Documentation Changes Required
None that I'm aware of.
