### PR TITLE
[4.0] - Fixes location where manifest script is looked for when uninstalling library

### DIFF
--- a/libraries/src/Installer/Adapter/LibraryAdapter.php
+++ b/libraries/src/Installer/Adapter/LibraryAdapter.php
@@ -372,8 +372,8 @@ class LibraryAdapter extends InstallerAdapter
 		// Set the library root path
 		$this->parent->setPath('extension_root', JPATH_PLATFORM . '/' . $manifest->libraryname);
 
-		// Set the source path to the manifests directory so the manifest script may be found
-		$this->parent->setPath('source', JPATH_MANIFESTS . '/libraries/' . $manifest->libraryname);
+		// Set the source path to the library root, the manifest script may be found
+		$this->parent->setPath('source', $this->parent->getPath('extension_root'));
 
 		$xml = simplexml_load_file($manifestFile);
 


### PR DESCRIPTION
Pull Request for Issue #36569.

### Summary of Changes

Changes the location where the manifest `script.php` file is looked for during uninstall, to the library root directory as opposed to the manifests directory

### Testing Instructions

For testing purposes use the attached package, which does nothing really useful, other than proving uninstall of library packages is erroneous. It creates a text file named `JPATH_LIBRARIES/lib_foo_script.txt`, containing a line for each `preflight()` and `postflight()` method being executed  in `script.php`, showing the performed installer action (install, uninstall, uograde).

- Install the attached library package in a clean Joomla! 4.0.x site,  
- Upgrade the library by installing the same package a second time.
- Uninstall the library.
- Inspect the created text file.

**Beware!** If after the first test run, before applying the patch and running the second run, the text file is still there, results for the second run will be appended to the existing file!

### Actual result BEFORE applying this Pull Request

File `JPATH_LIBRARIES/lib_foo_script.txt` contains the following:

```
preflight: install
postflight: install
preflight: update
postflight: update
```

As can be seen,  `preflight()` and `postflight()` methods are _neither_ triggered as part of the update process _nor_ during uninstall.

### Expected result AFTER applying this Pull Request

File `JPATH_LIBRARIES/lib_foo_script.txt` contains the following:

```
preflight: install
postflight: install
preflight: uninstall
postflight: uninstall
preflight: update
postflight: update
preflight: uninstall
postflight: uninstall
```

As can be seen,  `preflight()` and `postflight()` methods _are_ triggered both as part of the update process and during uninstall.

### Documentation Changes Required

None

[lib_foo.zip](https://github.com/joomla/joomla-cms/files/7814170/lib_foo.zip)
