### PR TITLE
[3.10] TinyMCE editor buttons work with single field instance only

### DIFF
--- a/media/editors/tinymce/js/tinymce.js
+++ b/media/editors/tinymce/js/tinymce.js
@@ -44,10 +44,10 @@
 		 * @since 3.7.0
 		 */
 		setupEditor: function ( element, pluginOptions ) {
-			var name = element ? element.getAttribute('name').replace(/\[\]|\]/g, '').split('[').pop() : 'default', // Get Editor name
-			    tinyMCEOptions = pluginOptions ? pluginOptions.tinyMCE || {} : {},
-			    defaultOptions = tinyMCEOptions['default'] || {},
-			    options = tinyMCEOptions[name] ? tinyMCEOptions[name] : defaultOptions; // Check specific options by the name
+			var name = element ? element.getAttribute('id') : 'default', // Get Editor name
+				tinyMCEOptions = pluginOptions ? pluginOptions.tinyMCE || {} : {},
+				defaultOptions = tinyMCEOptions['default'] || {},
+				options = tinyMCEOptions[name] ? tinyMCEOptions[name] : defaultOptions; // Check specific options by the name
 
 			// Avoid an unexpected changes, and copy the options object
 			if (options.joomlaMergeDefaults) {

--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -162,8 +162,7 @@ class PlgEditorTinymce extends JPlugin
 		}
 
 		$id            = preg_replace('/(\s|[^A-Za-z0-9_])+/', '_', $id);
-		$nameGroup     = explode('[', preg_replace('/\[\]|\]/', '', $name));
-		$fieldName     = end($nameGroup);
+		$fieldName     = $id;
 		$scriptOptions = array();
 
 		// Check for existing options
@@ -1233,8 +1232,7 @@ class PlgEditorTinymce extends JPlugin
 		}
 
 		$id            = preg_replace('/(\s|[^A-Za-z0-9_])+/', '_', $id);
-		$nameGroup     = explode('[', preg_replace('/\[\]|\]/', '', $name));
-		$fieldName     = end($nameGroup);
+		$fieldName     = $id;
 		$scriptOptions = array();
 
 		// Check for existing options


### PR DESCRIPTION
Pull Request for Issue #36571 .

### Summary of Changes

Joomla TimyMCE editor instances should be identified by full-featured ID but not by JForm field `name` attribute, otherwise fields with the same name use the single editor instance.

Joomla 4 is also affected, not sure if this patch will go into 4.0-dev, somebody please advise.

### Testing Instructions

If a form has multiple editor fields with the same name but within different groups, all XTD button actions are applied in first editor only.

I.e. in item has top-level field `<field name="description" type="editor"...` + a field with the same `name` but inside the another group like `<fields name="params"> <field name="description" type="editor"...`

If you click any XTD buttons in the editor field of `params` group, all actions are actually applied in the first field.
I.e. Readmore is inserted in the first field etc.

Test:

Edit admin article.xml form of com_content and add these code after `<fieldset name="basic" ...` line:

```
<field
	name="articletext"
	type="editor"
	label="COM_CONTENT_FIELD_ARTICLETEXT_LABEL"
	description="COM_CONTENT_FIELD_ARTICLETEXT_DESC"
	filter="JComponentHelper::filterText"
	buttons="true"
	/>
```
Now we have two fields with the name `articletext`, the first one is original article text in Content tab, the second one is displayed in Options tab and has the field group `attribs`, these are two different fields even with the same `name` attribute.

Try to use any buttons in this second field, see that actually all actions are applied in the main editor field displayed in Content tab.

### Actual result BEFORE applying this Pull Request

Button actions are executed on first field only.

### Expected result AFTER applying this Pull Request

Button actions should be executed separately for each editor instance.

### Documentation Changes Required

No.