### PR TITLE
[4.0] Add CORS for all Google Fonts

### DIFF
--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -33,10 +33,10 @@ if ($paramsFontScheme)
 {
 	if (stripos($paramsFontScheme, 'https://') === 0)
 	{
-		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', []);
-		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', []);
-		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style']);
-		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
+		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', ['crossorigin' => 'anonymous']);
+		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', ['crossorigin' => 'anonymous']);
+		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style', 'crossorigin' => 'anonymous']);
+		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'', 'crossorigin' => 'anonymous']);
 
 		if (preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches) > 0)
 		{

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -45,10 +45,10 @@ if ($paramsFontScheme)
 {
 	if (stripos($paramsFontScheme, 'https://') === 0)
 	{
-		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', []);
-		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', []);
-		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style']);
-		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
+		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', ['crossorigin' => 'anonymous']);
+		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', ['crossorigin' => 'anonymous']);
+		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style', 'crossorigin' => 'anonymous']);
+		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'', 'crossorigin' => 'anonymous']);
 
 		if (preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches) > 0)
 		{

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -50,10 +50,10 @@ if ($paramsFontScheme)
 {
 	if (stripos($paramsFontScheme, 'https://') === 0)
 	{
-		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', []);
-		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', []);
-		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style']);
-		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
+		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', ['crossorigin' => 'anonymous']);
+		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', ['crossorigin' => 'anonymous']);
+		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style', 'crossorigin' => 'anonymous']);
+		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'', 'crossorigin' => 'anonymous']);
 
 		if (preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches) > 0)
 		{

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -41,10 +41,10 @@ if ($paramsFontScheme)
 {
 	if (stripos($paramsFontScheme, 'https://') === 0)
 	{
-		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', []);
-		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', []);
-		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style']);
-		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'']);
+		$this->getPreloadManager()->preconnect('https://fonts.googleapis.com/', ['crossorigin' => 'anonymous']);
+		$this->getPreloadManager()->preconnect('https://fonts.gstatic.com/', ['crossorigin' => 'anonymous']);
+		$this->getPreloadManager()->preload($paramsFontScheme, ['as' => 'style', 'crossorigin' => 'anonymous']);
+		$wa->registerAndUseStyle('fontscheme.current', $paramsFontScheme, [], ['media' => 'print', 'rel' => 'lazy-stylesheet', 'onload' => 'this.media=\'all\'', 'crossorigin' => 'anonymous']);
 
 		if (preg_match_all('/family=([^?:]*):/i', $paramsFontScheme, $matches) > 0)
 		{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Adds `crossorigin="anonymous"` to all the prefetch, preload and the actual CSS link for the Google Fonts
- Info about crossorigin https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/crossorigin
- Info about CORS https://developer.mozilla.org/en-US/docs/Glossary/CORS


### Testing Instructions
- Select one of the Google fonts in the Caasiopeia
- Check the front end using the browser inspector and the Network tab
- Check the Request for the document that the crossorigin is used for the prefetch/preload
<img width="1792" alt="Screenshot 2022-01-07 at 01 14 40" src="https://user-images.githubusercontent.com/3889375/148470464-2390f37b-bce5-46ae-b9de-66ebae151de9.png">

- Check the CSS for the font
<img width="1788" alt="Screenshot 2022-01-07 at 01 18 07" src="https://user-images.githubusercontent.com/3889375/148470723-4c0fa742-133c-44df-baeb-462008dedfd3.png">



### Actual result BEFORE applying this Pull Request

Cassiopeia using Google Fonts has privacy issues

### Expected result AFTER applying this Pull Request

No privacy issues

### Documentation Changes Required


@wilsonge this is kinda important...