### PR TITLE
[4.0] Load the subform data correctly

### DIFF
--- a/libraries/src/Form/Field/MediaField.php
+++ b/libraries/src/Form/Field/MediaField.php
@@ -321,7 +321,7 @@ class MediaField extends FormField
 				$this->folder = 'local-' . $adapterName . ':/' . implode('/', $paths);
 			}
 		}
-		elseif ($this->directory && strpos(':', $this->directory))
+		elseif ($this->directory && strpos($this->directory, ':'))
 		{
 			/**
 			 * Directory contains adapter information and path, for example via programming or directly defined in xml

--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -231,7 +231,7 @@ class SubformField extends FormField
 	protected function getInput()
 	{
 		// Prepare data for renderer
-		$data    = parent::getLayoutData();
+		$data    = $this->getLayoutData();
 		$tmpl    = null;
 		$control = $this->name;
 


### PR DESCRIPTION
### Summary of Changes
The `FormField` should load the form data from the actual aclass and not the parent. With the current code it is not possible to overload the from data.

### Testing Instructions
- Add the following code to the file /libraries/src/Form/Field/AccessiblemediaField.php:  
```
protected function getLayoutData()
{
    $data = parent::getLayoutData();
    $data['class'] .= ' test';
    return $data;
}
```
- Replace the line 19 in the file /layouts/joomla/form/field/media/accessiblemedia.php with:  
```
<div class="subform-wrapper <?php echo $class;?>">
```
- Create a media custom field
- Open the article form

### Actual result BEFORE applying this Pull Request
The root container of the media custom field has no class test.

### Expected result AFTER applying this Pull Request
The root container of the media custom field has the class test.