### PR TITLE
[3] don't remove <joomla-hidden-mail> from module

### DIFF
--- a/modules/mod_articles_category/helper.php
+++ b/modules/mod_articles_category/helper.php
@@ -324,7 +324,7 @@ abstract class ModArticlesCategoryHelper
 	public static function _cleanIntrotext($introtext)
 	{
 		$introtext = str_replace(array('<p>','</p>'), ' ', $introtext);
-		$introtext = strip_tags($introtext, '<a><em><strong>');
+		$introtext = strip_tags($introtext, '<a><em><strong><joomla-hidden-mail>');
 		$introtext = trim($introtext);
 
 		return $introtext;


### PR DESCRIPTION
Pull Request for Issue #13522.

### Summary of Changes
don't remove `<joomla-hidden-mail>`


### Testing Instructions

-   Add an "Articles Category" module on the sample site
-   Under "Display Options" tab: everything on Hide, except "Introtext= show" and "Show Read More=show"
-   Create an article with the below html:

```
<p>Intro text <a href="mailto:sample@example.com">sample@example.com</a> - more more more</p>
<hr id="system-readmore" />
<p><br />Paragraph 1<br />1<br />2<br />3<br />4<br />5</p>
<p>Paragraph 2<br />1<br />2<br />3<br />4<br />5</p>
<p>Paragraph 3<br />1<br />2<br />3<br />4<br />5</p>
<p>End</p>
```



### Actual result BEFORE applying this Pull Request
This email address is being protected from spambots. You need JavaScript enabled to... 


### Expected result AFTER applying this Pull Request

Introtext shows the email address



