### PR TITLE
[3.10] Backport the image Layout

### DIFF
--- a/layouts/joomla/html/image.php
+++ b/layouts/joomla/html/image.php
@@ -18,7 +18,7 @@ defined('_JEXEC') or die;
 
 if (isset($displayData['src']))
 {
-	$displayData['src'] = $this->escape($img->url);
+	$displayData['src'] = $this->escape($displayData['src']);
 }
 
 if (isset($displayData['alt']))

--- a/layouts/joomla/html/image.php
+++ b/layouts/joomla/html/image.php
@@ -6,6 +6,7 @@
  * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+defined('_JEXEC') or die;
 
 /**
  * Layout variables
@@ -14,7 +15,6 @@
  *                             Eg: src, class, alt, width, height, loading, decoding, style, data-*
  *                             Note: only the alt and src attributes are escaped by default!
  */
-defined('_JEXEC') or die;
 
 if (isset($displayData['src']))
 {

--- a/layouts/joomla/html/image.php
+++ b/layouts/joomla/html/image.php
@@ -16,8 +16,6 @@
  */
 defined('_JEXEC') or die;
 
-use Joomla\Utilities\ArrayHelper;
-
 if (isset($displayData['alt']))
 {
 	$displayData['src'] = $this->escape($img->url);
@@ -31,4 +29,4 @@ if (isset($displayData['alt'])) {
 	}
 }
 
-echo '<img ' . ArrayHelper::toString($displayData) . '>';
+echo '<img ' . JArrayHelper::toString($displayData) . '>';

--- a/layouts/joomla/html/image.php
+++ b/layouts/joomla/html/image.php
@@ -21,10 +21,14 @@ if (isset($displayData['alt']))
 	$displayData['src'] = $this->escape($img->url);
 }
 
-if (isset($displayData['alt'])) {
-	if ($displayData['alt'] === false) {
+if (isset($displayData['alt']))
+{
+	if ($displayData['alt'] === false)
+	{
 		unset($displayData['alt']);
-	} else {
+	}
+	else
+	{
 		$displayData['alt'] = $this->escape($displayData['alt']);
 	}
 }

--- a/layouts/joomla/html/image.php
+++ b/layouts/joomla/html/image.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   array  $displayData  Array with all the given attributes for the image element.
+ *                             Eg: src, class, alt, width, height, loading, decoding, style, data-*
+ *                             Note: only the alt and src attributes are escaped by default!
+ */
+defined('_JEXEC') or die;
+
+use Joomla\Utilities\ArrayHelper;
+
+if (isset($displayData['alt']))
+{
+	$displayData['src'] = $this->escape($img->url);
+}
+
+if (isset($displayData['alt'])) {
+	if ($displayData['alt'] === false) {
+		unset($displayData['alt']);
+	} else {
+		$displayData['alt'] = $this->escape($displayData['alt']);
+	}
+}
+
+echo '<img ' . ArrayHelper::toString($displayData) . '>';

--- a/layouts/joomla/html/image.php
+++ b/layouts/joomla/html/image.php
@@ -3,7 +3,7 @@
  * @package     Joomla.Site
  * @subpackage  Layout
  *
- * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/layouts/joomla/html/image.php
+++ b/layouts/joomla/html/image.php
@@ -16,7 +16,7 @@
  */
 defined('_JEXEC') or die;
 
-if (isset($displayData['alt']))
+if (isset($displayData['src']))
 {
 	$displayData['src'] = $this->escape($img->url);
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This PR backports the `image.php` JLayout so Devs could use it even if their extensions are targeting both 3.10 and 4.x

### Testing Instructions

in the protostar index.php add before the `<Jdoc:include type="component"` the following

```php

<?php echo JLayoutHelper::render(
 'joomla.html.image',
 [
 	'src' => JUri:root() . 'images/joomla_black.png',
 	'alt' => 'Some Alt tag',
 ]
); ?>

<?php echo JLayoutHelper::render(
 'joomla.html.image',
 [
 	'src' => JUri:root() . 'iimages/powered_by.png',
 	'alt' => false,
 ]
); ?>
```

You should be able to see the 2 Joomla banners, one with alt: Some Alt tag and the other one without any alt tag

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

Yes, this needs to be communicated, eg: this is the preferred way to handle images.
I'm preparing something...

@zero-24 this is a backport of #35780