### PR TITLE
[4.0] Fix error in article model

### DIFF
--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -417,7 +417,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 			$registry = new Registry($item->urls);
 			$item->urls = $registry->toArray();
 
-			$item->articletext = ($item->fulltext === null || trim($item->fulltext) != '') ? $item->introtext . "<hr id=\"system-readmore\">" . $item->fulltext : $item->introtext;
+			$item->articletext = ($item->fulltext !== null && trim($item->fulltext) != '') ? $item->introtext . "<hr id=\"system-readmore\">" . $item->fulltext : $item->introtext;
 
 			if (!empty($item->id))
 			{


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/commit/67215a7dd6648b4dcf3731603b57cc375389e276#r63168677 .

### Summary of Changes

Fix error from the above commit.

I have no idea yet if we have more such errors in the 4.0-dev branch.

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

Wrong condition. On PHP 8.1+ it will raise an error due to trim with null argument, and (regardless of PHP version) the read more will be shown when the full text is null.

### Expected result AFTER applying this Pull Request

Right condition. The read more and the full text are only added if the full text is not null and the trimmed full text is not an empty string.

### Documentation Changes Required

None.