### PR TITLE
[4.0] Fix deprecation notice on PHP 8.1 when creating category

### DIFF
--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -345,7 +345,7 @@ class CategoryModel extends AdminModel
 			if (!$data->id)
 			{
 				// Check for which extension the Category Manager is used and get selected fields
-				$extension = substr($app->getUserState('com_categories.categories.filter.extension'), 4);
+				$extension = substr($app->getUserState('com_categories.categories.filter.extension', ''), 4);
 				$filters = (array) $app->getUserState('com_categories.categories.' . $extension . '.filter');
 
 				$data->set(


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix a deprecation notice which you get on PHP 8.1 when creating a new category of any kind.

### Testing Instructions

Use the latest 4.0-dev branch on PHP 8.1. Make a new installation if you haven't done yet.

Create a new category of any kind.

### Actual result BEFORE applying this Pull Request

![2022-01-09_1](https://user-images.githubusercontent.com/7413183/148687329-f0642bed-63c5-49c7-ac59-b6ceb816bb7b.png)

### Expected result AFTER applying this Pull Request

![2022-01-09_2](https://user-images.githubusercontent.com/7413183/148687333-9e880c0f-eee9-417b-bc63-70f88438677e.png)

### Documentation Changes Required

None.