### PR TITLE
[4.0] Access the getRouter function statically

### DIFF
--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -160,7 +160,7 @@ class HtmlView extends BaseHtmlView
 		if (strpos($this->query->input, '"'))
 		{
 			// Get the application router.
-			$router = $app->getRouter();
+			$router = $app::getRouter();
 
 			// Fix the q variable in the URL.
 			if ($router->getVar('q') !== $this->query->input)

--- a/libraries/src/Router/Route.php
+++ b/libraries/src/Router/Route.php
@@ -132,7 +132,7 @@ class Route
 		{
 			$app = Factory::getApplication();
 
-			self::$_router[$client] = $app->getRouter($client);
+			self::$_router[$client] = $app::getRouter($client);
 		}
 
 		// Make sure that we have our router

--- a/plugins/system/cache/cache.php
+++ b/plugins/system/cache/cache.php
@@ -249,7 +249,7 @@ class PlgSystemCache extends CMSPlugin
 			$exclusions = explode("\n", $exclusions);
 
 			// Gets internal URI.
-			$internal_uri	= '/index.php?' . Uri::getInstance()->buildQuery($this->app->getRouter()->getVars());
+			$internal_uri	= '/index.php?' . Uri::getInstance()->buildQuery($this->app::getRouter()->getVars());
 
 			// Loop through each pattern.
 			if ($exclusions)

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -155,7 +155,7 @@ class PlgSystemLanguageFilter extends CMSPlugin
 		$this->app->item_associations = $this->params->get('item_associations', 0);
 
 		// We need to make sure we are always using the site router, even if the language plugin is executed in admin app.
-		$router = CMSApplication::getInstance('site')->getRouter('site');
+		$router = $this->app::getRouter('site');
 
 		// Attach build rules for language SEF.
 		$router->attachBuildRule(array($this, 'preprocessBuildRule'), Router::PROCESS_BEFORE);
@@ -764,7 +764,7 @@ class PlgSystemLanguageFilter extends CMSPlugin
 			$remove_default_prefix = $this->params->get('remove_default_prefix', 0);
 			$server                = Uri::getInstance()->toString(array('scheme', 'host', 'port'));
 			$is_home               = false;
-			$currentInternalUrl    = 'index.php?' . http_build_query($this->app->getRouter()->getVars());
+			$currentInternalUrl    = 'index.php?' . http_build_query($this->app::getRouter()->getVars());
 
 			if ($active)
 			{


### PR DESCRIPTION
Pull Request for pr #36562.

### Summary of Changes
This is a result of the discussion in #36562 to keep static function `getRouter` in 4 and make it none static in 5. So in 4 all calls should be on the static function.

### Testing Instructions
- Enable the language filter plugin
- Enable preview in the global template options
- Click on the preview link in the back end template styles list for the site

### Actual result BEFORE applying this Pull Request
Works

### Expected result AFTER applying this Pull Request
Works