### PR TITLE
[4.0] PHP 8.1 deprecation notice com_joomlaupdate

### DIFF
--- a/administrator/components/com_joomlaupdate/extract.php
+++ b/administrator/components/com_joomlaupdate/extract.php
@@ -525,7 +525,7 @@ class ZIPExtraction
 			return;
 		}
 
-		$sleepMillisec = $minExecTime - $elapsed;
+		$sleepMillisec = intval($minExecTime - $elapsed);
 
 		/**
 		 * If we need to sleep for more than 1 second we should be using sleep() or time_sleep_until() to prevent high


### PR DESCRIPTION
Pull Request for Issue # .

Deprecated:  Implicit conversion from float 555470.9434509277 to int loses precision in ..\administrator\components\com_joomlaupdate\extract.php on line 542
Stack trace:
1. {main}() ..\administrator\components\com_joomlaupdate\extract.php:0
2. ZIPExtraction->enforceMinimumExecutionTime() ..\administrator\components\com_joomlaupdate\extract.php:2038
3. usleep($microseconds = 555470.94345093) ..\administrator\components\com_joomlaupdate\extract.php:542

Win10, WAMP64, PHP 8.1.1



### Testing Instructions
Code review



### Documentation Changes Required
No.
