### PR TITLE
[3.10] Use the correct namespace for the taggable trait

### DIFF
--- a/libraries/src/Tag/TaggableTableTrait.php
+++ b/libraries/src/Tag/TaggableTableTrait.php
@@ -6,7 +6,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-namespace Joomla\CMS\Versioning;
+namespace Joomla\CMS\Tag;
 
 defined('JPATH_PLATFORM') or die;
 


### PR DESCRIPTION
The `TaggableTableTrait` has the wrong namespace.

ping here @zero-24 and @wilsonge