### PR TITLE
Changed the 'position' property of the 'media-tree' to 'fixed' in 4.1.dev

### DIFF
--- a/build/media_source/com_media/scss/components/_media-tree.scss
+++ b/build/media_source/com_media/scss/components/_media-tree.scss
@@ -15,6 +15,7 @@ ul.media-tree {
 
 .media-disk {
   margin-bottom: 10px;
+  position: fixed;
 }
 
 .media-drive {


### PR DESCRIPTION
…-dev

Pull Request for Issue # 36545.

### Summary of Changes
Changed the 'position' property of the 'media-tree' to 'fixed' in 4.1.dev
this helps the user to access the media-tree even if the user has scrolled down the page as it fixes the media-tree at its place even while scrolling up and down


### Testing Instructions
try to upload as many images in your media tab and try scrolling up and down, if the browsing directory is visible even as you scroll down the media, the test is successful


### Actual result BEFORE applying this Pull Request
The media-tree is not fixed and if a user scrolls down, he/she has to scroll all the way up to again access the directory 


### Expected result AFTER applying this Pull Request
helps the user to access the media-tree even if the user has scrolled down the page as it fixes the media-tree at its place even while scrolling up and down



### Documentation Changes Required

no changes required