### PR TITLE
Changed the 'position' property of the 'media-tree' to 'fixed' in 4.1-dev

### DIFF
--- a/build/media_source/com_media/scss/components/_media-tree.scss
+++ b/build/media_source/com_media/scss/components/_media-tree.scss
@@ -15,6 +15,7 @@ ul.media-tree {
 
 .media-disk {
   margin-bottom: 10px;
+  position: fixed;
 }
 
 .media-drive {


### PR DESCRIPTION
…-dev

Pull Request for Issue #36545 .

### Summary of Changes
Changed the 'position' property of the 'media-tree' to 'fixed' in 4.1-dev


### Testing Instructions
Upload as many media files you can in the media tab of joomla administrator control then try scrolling down, if the media-tree on the side remains on the screen then it means its position is fixed that is you still access it if you scroll down the media


### Actual result BEFORE applying this Pull Request
before the change, if a user scrolled down the media he/she had to scroll all the way up to access the media tree


### Expected result AFTER applying this Pull Request
after the change, the user can now access the tree even if he/she has scrolled down the page.


### Documentation Changes Required

No changes required.