### PR TITLE
FileLayout instantiation limitation in ToolbarButton::renderButton() removed

### DIFF
--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -211,7 +211,7 @@ abstract class ToolbarButton
 		$options['btnClass'] = 'button-' . $buttonClass . ' ' . $iconclass;
 
 		// Instantiate a new LayoutFile instance and render the layout
-		$layout = new FileLayout($this->layout);
+		$layout = $this->getLayoutInstance($this->layout);
 
 		return $layout->render($options);
 	}
@@ -246,7 +246,14 @@ abstract class ToolbarButton
 
 		return $layout->render(array('icon' => $identifier));
 	}
+	/*
+	This will allow any class which extends Joomla\CMS\Toolbar\ToobarButton and/or Joomla\CMS\Toolbar\popupButton to customise the FileLayout object (or even extend that class) in any way required.
+	*/
 
+	protected function getLayoutInstance($layoutId, $basePath = null, $options = null)
+		{
+		return new FileLayout($layoutId, $basePath, $options);
+	}	
 	/**
 	 * Get the button
 	 *

--- a/libraries/src/Toolbar/ToolbarButton.php
+++ b/libraries/src/Toolbar/ToolbarButton.php
@@ -247,13 +247,12 @@ abstract class ToolbarButton
 		return $layout->render(array('icon' => $identifier));
 	}
 	/*
-	This will allow any class which extends Joomla\CMS\Toolbar\ToobarButton and/or Joomla\CMS\Toolbar\popupButton to customise the FileLayout object (or even extend that class) in any way required.
+	This will allow any class which extends Joomla\CMS\Toolbar\ToobarButton and/or Joomla\CMS\Toolbar\popupButton to customise the FileLayout object in any way required.
 	*/
 
-	protected function getLayoutInstance($layoutId, $basePath = null, $options = null)
-		{
-		return new FileLayout($layoutId, $basePath, $options);
-	}	
+	protected function getLayoutInstance( $layoutId, $basepath = null, $options = null ) {
+		return new FileLayout($layoutId, $basepath, $options);
+	}
 	/**
 	 * Get the button
 	 *


### PR DESCRIPTION


Pull Request for Issue #36597.

### Summary of Changes
override the renderButton() method in ToolbarButton to remove the limitations of FileLayout Instantiation in modules tab


### Testing Instructions
Create a module that uses button layout from a component
if you are able to access the component button layout, the test is successful.


### Actual result BEFORE applying this Pull Request
Firstly, create a module that uses button layout from a component
Earlier, you were unable to access the component button layout.

### Expected result AFTER applying this Pull Request
after the commit, you will be able to access the component button layout. 


### Documentation Changes Required
No major changes required
