### PR TITLE
[4.0] PHP 8.1 deprecation notice in libraries/src/Filesystem/Path.php

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1073,7 +1073,7 @@ ENDDATA;
 
 		foreach ($files as $file)
 		{
-			if (File::exists($file))
+			if ($file !== null && File::exists($file))
 			{
 				File::delete($file);
 			}


### PR DESCRIPTION
Pull Request for Issue # .
Deprecation notice Joomla update.
### Summary of Changes
Deprecation notice in libraries/src/Filesystem/Path.php fixed in ..\administrator\components\com_joomlaupdate\src\Model\UpdateModel.php as agreed in #36355 


### Testing Instructions
Open Joomla update when on PHP 8.1.


### Actual result BEFORE applying this Pull Request
Deprecated:  trim(): Passing null to parameter #1 ($string) of type string is deprecated in D:\virtualhosts\clean40\libraries\src\Filesystem\Path.php on line 219


### Expected result AFTER applying this Pull Request
No notice.


### Documentation Changes Required
No
