### PR TITLE
Updated MediaHelper::canUpload function

### DIFF
--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -246,7 +246,7 @@ class MediaHelper
 		// Remove allowed executables from array
 		if (count($allowedExecutables))
 		{
-			$executable = array_diff($executables, $allowedExecutables);
+			$executables = array_diff($executables, $allowedExecutables);
 		}
 
 		$check = array_intersect($filetypes, $executables);


### PR DESCRIPTION
Pull Request for Issue #36674.

### Summary of Changes
In libraries/src/Helper/MediaHelper
changed 
`if (count($allowedExecutables))
		{
			$executable = array_diff($executables, $allowedExecutables);
		}`

to
`if (count($allowedExecutables))
		{
			$executables = array_diff($executables, $allowedExecutables);
		}`
to allow only some permitted executable file type to be uploaded in the media tab
### Testing Instructions
In the media tab, try uploading executable file types that are not permitted by the cms
for reference,
`/**
	 * A special list of blocked executable extensions, skipping executables that are
	 * typically executable in the webserver context as those are fetched from
	 * Joomla\CMS\Filter\InputFilter
	 *
	 * @var    string[]
	 * @since  4.0.0
	 */
	public const EXECUTABLES = array(
		'js', 'exe', 'dll', 'go', 'ade', 'adp', 'bat', 'chm', 'cmd', 'com', 'cpl', 'hta',
		'ins', 'isp', 'jse', 'lib', 'mde', 'msc', 'msp', 'mst', 'pif', 'scr', 'sct', 'shb',
		'sys', 'vb', 'vbe', 'vbs', 'vxd', 'wsc', 'wsf', 'wsh', 'html', 'htm', 'msi'
	);`
if you are unable to execute/run the files, the test is successful.


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required
No major Changes
