### PR TITLE
[4.1] Admin Template Preview/Screenshot

### DIFF
--- a/administrator/components/com_templates/src/Service/HTML/Templates.php
+++ b/administrator/components/com_templates/src/Service/HTML/Templates.php
@@ -158,7 +158,7 @@ class Templates
 
 				if (file_exists(JPATH_ROOT . '/media/templates/' . $client->name . '/' . $template->name . '/images/template_preview.png'))
 				{
-					$preview = ($template->client_id == 0 ? Uri::root(true) : Uri::root(true) . '/administrator') . '/media/templates/' . $client->name . '/' . $template->name . '/images/template_preview.png';
+					$preview = Uri::root(true) . '/media/templates/' . $client->name . '/' . $template->name . '/images/template_preview.png';
 				}
 			}
 		}


### PR DESCRIPTION
The path is not correct for the preview/screenshot (not thumbnail) of the admin template. It is ok for the site template

## Before
![image](https://user-images.githubusercontent.com/1296369/149660416-cb86c8f1-6833-4974-bd20-8a02e8ba3ad4.png)

## After
![image](https://user-images.githubusercontent.com/1296369/149660399-64a1ecbd-8817-410f-9b1d-53323dcf190d.png)

NOTE
I have not tested all the other variants of loading the atum template preview

Pull Request for Issue #36581
