### PR TITLE
Text field without xml element for layout rendering

### DIFF
--- a/libraries/src/Form/Field/TextField.php
+++ b/libraries/src/Form/Field/TextField.php
@@ -50,6 +50,14 @@ class TextField extends FormField
 	protected $inputmode;
 
 	/**
+	 * The field option objects.
+	 *
+	 * @var    array
+	 * @since  3.2
+	 */
+	protected $options;
+
+	/**
 	 * The name of the form field direction (ltr or rtl).
 	 *
 	 * @var    string
@@ -192,6 +200,19 @@ class TextField extends FormField
 
 			$this->addonBefore = (string) $this->element['addonBefore'];
 			$this->addonAfter  = (string) $this->element['addonAfter'];
+			$this->useglobal = (bool) $this->element['useglobal'];
+			
+			foreach ($this->element->children() as $option)
+			{
+				// Only add <option /> elements.
+				if ($option->getName() !== 'option')
+				{
+					continue;
+				}
+
+				// Create a new option element in list options.
+				$this->options[] = ['value' => (string) $option['value'], 'text' => (string) $option];
+			}
 		}
 
 		return $result;
@@ -206,7 +227,7 @@ class TextField extends FormField
 	 */
 	protected function getInput()
 	{
-		if ($this->element['useglobal'])
+		if ($this->useglobal)
 		{
 			$component = Factory::getApplication()->input->getCmd('option');
 
@@ -253,16 +274,15 @@ class TextField extends FormField
 	 */
 	protected function getOptions()
 	{
+		if(empty($this->options))
+		{
+			return [];
+		}
+
 		$options = array();
 
-		foreach ($this->element->children() as $option)
+		foreach ($this->options as $option)
 		{
-			// Only add <option /> elements.
-			if ($option->getName() !== 'option')
-			{
-				continue;
-			}
-
 			// Create a new option object based on the <option /> element.
 			$options[] = HTMLHelper::_(
 				'select.option', (string) $option['value'],

--- a/libraries/src/Form/Field/TextField.php
+++ b/libraries/src/Form/Field/TextField.php
@@ -53,9 +53,9 @@ class TextField extends FormField
 	 * The field option objects.
 	 *
 	 * @var    array
-	 * @since  3.2
+	 * @since  4.0
 	 */
-	protected $options;
+	protected $options = [];
 
 	/**
 	 * The name of the form field direction (ltr or rtl).
@@ -201,7 +201,7 @@ class TextField extends FormField
 			$this->addonBefore = (string) $this->element['addonBefore'];
 			$this->addonAfter  = (string) $this->element['addonAfter'];
 			$this->useglobal = (bool) $this->element['useglobal'];
-			
+
 			foreach ($this->element->children() as $option)
 			{
 				// Only add <option /> elements.

--- a/libraries/src/Form/Field/TextField.php
+++ b/libraries/src/Form/Field/TextField.php
@@ -274,7 +274,7 @@ class TextField extends FormField
 	 */
 	protected function getOptions()
 	{
-		if(empty($this->options))
+		if (empty($this->options))
 		{
 			return [];
 		}

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -688,7 +688,7 @@ abstract class FormField
 		$this->layout = !empty($this->element['layout']) ? (string) $this->element['layout'] : $this->layout;
 
 		$this->parentclass = isset($this->element['parentclass']) ? (string) $this->element['parentclass'] : $this->parentclass;
-		
+
 		$this->labelElement = $this->element['label'] ? (string) $this->element['label'] : null;
 
 		// Add required to class list if field is required.

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -808,7 +808,7 @@ abstract class FormField
 		}
 
 		// Get the label text from the XML element, defaulting to the element name.
-		$title = $this->element['label'] ? (string) $this->element['label'] : (string) $this->element['name'];
+		$title = $this->label ? (string) $this->label : (string) $this->fieldname;
 		$title = $this->translateLabel ? Text::_($title) : $title;
 
 		return $title;
@@ -831,7 +831,7 @@ abstract class FormField
 		$data = $this->getLayoutData();
 
 		// Forcing the Alias field to display the tip below
-		$position = $this->element['name'] === 'alias' ? ' data-bs-placement="bottom" ' : '';
+		$position = $this->fieldname === 'alias' ? ' data-bs-placement="bottom" ' : '';
 
 		// Here mainly for B/C with old layouts. This can be done in the layouts directly
 		$extraData = array(
@@ -1319,7 +1319,7 @@ abstract class FormField
 	protected function getLayoutData()
 	{
 		// Label preprocess
-		$label = !empty($this->element['label']) ? (string) $this->element['label'] : null;
+		$label = !empty($this->label) ? (string) $this->label : null;
 		$label = $label && $this->translateLabel ? Text::_($label) : $label;
 
 		// Description preprocess

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -688,6 +688,8 @@ abstract class FormField
 		$this->layout = !empty($this->element['layout']) ? (string) $this->element['layout'] : $this->layout;
 
 		$this->parentclass = isset($this->element['parentclass']) ? (string) $this->element['parentclass'] : $this->parentclass;
+		
+		$this->labelElement = $this->element['label'] ? (string) $this->element['label'] : null;
 
 		// Add required to class list if field is required.
 		if ($this->required)
@@ -808,7 +810,7 @@ abstract class FormField
 		}
 
 		// Get the label text from the XML element, defaulting to the element name.
-		$title = $this->label ? (string) $this->label : (string) $this->fieldname;
+		$title = $this->labelElement ? (string) $this->labelElement : (string) $this->fieldname;
 		$title = $this->translateLabel ? Text::_($title) : $title;
 
 		return $title;
@@ -1319,7 +1321,7 @@ abstract class FormField
 	protected function getLayoutData()
 	{
 		// Label preprocess
-		$label = !empty($this->label) ? (string) $this->label : null;
+		$label = !empty($this->labelElement) ? (string) $this->labelElement : null;
 		$label = $label && $this->translateLabel ? Text::_($label) : $label;
 
 		// Description preprocess


### PR DESCRIPTION
Each field must be created using XML or using PHP. 
But this text field cannot be created using PHP.
Examples:
1.`<field name="user" type="text"/>`
2. 
```
$textfield = Joomla\CMS\Form\FormHelper::loadFieldType('text');
$textfield->name = 'user';
$textfield->renderField();
```
This not working.
instead of this method, you can use another method 
`$textfield->render($textfield->renderLayout,[]);`
It doesn't work either.
These methods call the text field method `$textfield->getLayoutData()`
Inside this method there is a method call `$textfield->getOptions()`
And inside this method, data is collected from `$textfield->element` which has the type SimpleXMLElement.
This functionality should be called in the `$textfield->Setup()` method. 
But it is not called there, but is called when called `->renderField();` and `->render();`.
Thus, it is not possible to create fields in PHP.
[		foreach ($this->element->children() as $option)](https://github.com/joomla/joomla-cms/blob/50685f9147ed458be421e544591444e27ca4613b/libraries/src/Form/Field/TextField.php#L258)

Of course, this can be solved with crutches and props by creating a separate pseudo element with the `SimpleXMLElement` type. or by creating a Layout object separately from the text field object. But this is not normal at all. This is NOT observed in other fields. Moreover, the text field is the base class for many other fields. It is necessary to transfer the call `$textfield->getOptions()` to the method `$textfield->Setup()`