### PR TITLE
[4.0] Required fields [a11y]

### DIFF
--- a/layouts/plugins/system/privacyconsent/label.php
+++ b/layouts/plugins/system/privacyconsent/label.php
@@ -91,6 +91,6 @@ else
 }
 
 // Add the label text and star.
-$label = $link . '<span class="star">&#160;*</span>';
+$label = $link . '<span class="star" aria-hidden="true">&#160;*</span>';
 
 echo $label;

--- a/layouts/plugins/user/terms/label.php
+++ b/layouts/plugins/user/terms/label.php
@@ -90,6 +90,6 @@ else
 }
 
 // Add the label text and star.
-$label = $link . '<span class="star">&#160;*</span>';
+$label = $link . '<span class="star" aria-hidden="true">&#160;*</span>';
 
 echo $label;

--- a/plugins/user/profile/src/Field/TosField.php
+++ b/plugins/user/profile/src/Field/TosField.php
@@ -144,7 +144,7 @@ class TosField extends RadioField
 		}
 
 		// Add the label text and closing tag.
-		$label .= '>' . $link . '<span class="star">&#160;*</span></label>';
+		$label .= '>' . $link . '<span class="star" aria-hidden="true">&#160;*</span></label>';
 
 		return $label;
 	}


### PR DESCRIPTION
Asterisks are helpful cues for someone looking at a webpage, but aren’t as helpful when browsing via screen reader. `aria-hidden="true"` should be used to hide an asterisk from a screen reader.

We are only using this for fields rendered with the form layout and this PR adds it to the three plugins with a required field that do not use that layout.
