### PR TITLE
Fix PHP Warning: Undefined array key 0 in lugins\system\debug\src\DataFormatter.php on line 54 and line 79 #36716

### DIFF
--- a/plugins/system/debug/src/DataFormatter.php
+++ b/plugins/system/debug/src/DataFormatter.php
@@ -51,7 +51,7 @@ class DataFormatter extends DebugBarDataFormatter
 			// If entry has Class/Method print it.
 			$string .= htmlspecialchars($call['class'] . $call['type'] . $call['function']) . '()';
 		}
-		elseif (isset($call['args']) && \is_array($call['args'][0]))
+		elseif (isset($call['args'][0]) && \is_array($call['args'][0]))
 		{
 			$string .= htmlspecialchars($call['function']) . ' (';
 

--- a/plugins/system/debug/src/DataFormatter.php
+++ b/plugins/system/debug/src/DataFormatter.php
@@ -74,7 +74,7 @@ class DataFormatter extends DebugBarDataFormatter
 
 			$string = rtrim($string, ', ') . ')';
 		}
-		elseif (isset($call['args']))
+		elseif (isset($call['args'][0]))
 		{
 			$string .= htmlspecialchars($call['function']) . ' ' . $call['args'][0];
 		}


### PR DESCRIPTION
…-40-dev\plugins\system\debug\src\DataFormatter.php on line 79 #36716

Pull Request for Issue #36716 .

### Summary of Changes

Obvious source-code bug-fix.

### Testing Instructions

Btw, This is a so obvious bug that it could be merged on source-code review.

Reported by Kunena team: When Kunena and CB are installed and debug is enabled, and as reported by Kunena "to reproduce the issue you need to enable the CB integration plugin into Kunena. You need to have too the debug and debug enabled into Joomla! configuration."

### Actual result BEFORE applying this Pull Request

PHP Warning: Undefined array key 0 in C:\Users\flo\git\joomla-cms-40-dev\plugins\system\debug\src\DataFormatter.php on line 79

### Expected result AFTER applying this Pull Request

No warnings

### Documentation Changes Required

None.