### PR TITLE
[3.10] [PHP 8.1] deprecated header() in WebApplication

### DIFF
--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -1103,6 +1103,7 @@ class WebApplication extends BaseApplication
 		{
 			$code = 0;
 		}
+
 		header($string, $replace, $code);
 	}
 

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -1098,6 +1098,11 @@ class WebApplication extends BaseApplication
 	protected function header($string, $replace = true, $code = null)
 	{
 		$string = str_replace(chr(0), '', $string);
+
+		if ($code === null)
+		{
+			$code = 0;
+		}
 		header($string, $replace, $code);
 	}
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fixes PHP 8.1 deprecation warning in Joomla 3.10.

**Note** in Joomla 4.0: Same PHP 8.1 deprecated issue is in libraries/vendor/joomla/application/src/AbstractWebApplication.php line 886 but it doesn't appear.

### Testing Instructions

Use PHP 8.1 in Joomla 3.10
Enable debug mode (without Debug plugin enabled!) (not sure if CB also imight be needed to reproduce).
Go to administration home page

### Actual result BEFORE applying this Pull Request

`Deprecated: header(): Passing null to parameter #3 ($response_code) of type int is deprecated in libraries/src/Application/WebApplication.php on line 1101`

### Expected result AFTER applying this Pull Request

No warning.

### Documentation Changes Required

None.