### PR TITLE
[4.0] Disabled Update Sites message

### DIFF
--- a/administrator/components/com_installer/src/Controller/UpdateController.php
+++ b/administrator/components/com_installer/src/Controller/UpdateController.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Installer\Administrator\Controller;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Response\JsonResponse;
@@ -109,14 +108,14 @@ class UpdateController extends BaseController
 		if ($disabledUpdateSites)
 		{
 			$updateSitesUrl = Route::_('index.php?option=com_installer&view=updatesites');
-			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_INSTALLER_MSG_UPDATE_SITES_COUNT_CHECK', $updateSitesUrl), 'warning');
+			$this->app->enqueueMessage(Text::sprintf('COM_INSTALLER_MSG_UPDATE_SITES_COUNT_CHECK', $updateSitesUrl), 'warning');
 		}
 
 		$model->findUpdates(0, $cache_timeout, $minimum_stability);
 
 		if (0 === $model->getTotal())
 		{
-			Factory::getApplication()->enqueueMessage(Text::_('COM_INSTALLER_MSG_UPDATE_NOUPDATES'), 'info');
+			$this->app->enqueueMessage(Text::_('COM_INSTALLER_MSG_UPDATE_NOUPDATES'), 'info');
 		}
 
 		$this->setRedirect(Route::_('index.php?option=com_installer&view=update', false));

--- a/administrator/components/com_installer/src/Controller/UpdateController.php
+++ b/administrator/components/com_installer/src/Controller/UpdateController.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Installer\Administrator\Controller;
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Response\JsonResponse;
@@ -108,14 +109,14 @@ class UpdateController extends BaseController
 		if ($disabledUpdateSites)
 		{
 			$updateSitesUrl = Route::_('index.php?option=com_installer&view=updatesites');
-			$this->setMessage(Text::sprintf('COM_INSTALLER_MSG_UPDATE_SITES_COUNT_CHECK', $updateSitesUrl), 'warning');
+			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_INSTALLER_MSG_UPDATE_SITES_COUNT_CHECK', $updateSitesUrl), 'warning');
 		}
 
 		$model->findUpdates(0, $cache_timeout, $minimum_stability);
 
 		if (0 === $model->getTotal())
 		{
-			$this->setMessage(Text::_('COM_INSTALLER_MSG_UPDATE_NOUPDATES'), 'info');
+			Factory::getApplication()->enqueueMessage(Text::_('COM_INSTALLER_MSG_UPDATE_NOUPDATES'), 'info');
 		}
 
 		$this->setRedirect(Route::_('index.php?option=com_installer&view=update', false));


### PR DESCRIPTION
### Summary of Changes
The message "Some update sites are disabled. You may want to check the Update Sites Manager." was not being displayed


### Testing Instructions
Go to the list of update sites and if you have an extension installed disable the update site. If you dont have an extension installed then you can disabled the accredited translations update site
Go to Extensions Update and click on the Check Updates button in the toolbar


### Actual result BEFORE applying this Pull Request
No warning about the disabled updates sites
![image](https://user-images.githubusercontent.com/1296369/149935194-fee1d9d3-315c-4c0b-b690-a15fe6eab080.png)


### Expected result AFTER applying this Pull Request
Warning and link is displayed
![image](https://user-images.githubusercontent.com/1296369/149935207-f9b41667-6bcb-44d3-809a-02ee7bab8b64.png)



### Documentation Changes Required
none

###  Notes
Assuming I read the code correctly the problem was due to the use of setmessage and the second message overwriting the first. So I changed the code to use enqueueMessage instead
