### PR TITLE
Removed hard limit of 20 to the module tags

### DIFF
--- a/modules/mod_tags_popular/mod_tags_popular.xml
+++ b/modules/mod_tags_popular/mod_tags_popular.xml
@@ -35,13 +35,12 @@
 
 				<field
 					name="maximum"
-					type="integer"
+					type="number"
 					label="MOD_TAGS_POPULAR_MAX_LABEL"
 					default="5"
 					filter="integer"
-					first="1"
-					last="20"
-					step="1"
+					min="0"
+					validate="number"
 				/>
 
 				<field

--- a/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
+++ b/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
@@ -126,6 +126,12 @@ abstract class TagsPopularHelper
 			{
 				// Backup bound parameters array of the original query
 				$bounded = $query->getBounded();
+
+				if ($maximum > 0)
+				{
+					$query->setLimit($maximum);
+				}
+				
 				$query->order($db->quoteName('count') . ' DESC');
 				$equery = $db->getQuery(true)
 					->select(

--- a/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
+++ b/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
@@ -38,7 +38,7 @@ abstract class TagsPopularHelper
 		$user        = Factory::getUser();
 		$groups      = $user->getAuthorisedViewLevels();
 		$timeframe   = $params->get('timeframe', 'alltime');
-		$maximum =     (int) $params->get('maximum', 5);
+		$maximum     = (int) $params->get('maximum', 5);
 		$order_value = $params->get('order_value', 'title');
 		$nowDate     = Factory::getDate()->toSql();
 		$nullDate    = $db->getNullDate();

--- a/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
+++ b/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
@@ -38,7 +38,7 @@ abstract class TagsPopularHelper
 		$user        = Factory::getUser();
 		$groups      = $user->getAuthorisedViewLevels();
 		$timeframe   = $params->get('timeframe', 'alltime');
-		$maximum     = $params->get('maximum', 5);
+		$maximum =     (int) $params->get('maximum', 5);
 		$order_value = $params->get('order_value', 'title');
 		$nowDate     = Factory::getDate()->toSql();
 		$nullDate    = $db->getNullDate();
@@ -126,8 +126,6 @@ abstract class TagsPopularHelper
 			{
 				// Backup bound parameters array of the original query
 				$bounded = $query->getBounded();
-
-				$query->setLimit($maximum);
 				$query->order($db->quoteName('count') . ' DESC');
 				$equery = $db->getQuery(true)
 					->select(
@@ -158,7 +156,11 @@ abstract class TagsPopularHelper
 			}
 		}
 
-		$query->setLimit($maximum, 0);
+		if ($maximum > 0)
+		{
+			$query->setLimit($maximum);
+		}
+
 		$db->setQuery($query);
 
 		try

--- a/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
+++ b/modules/mod_tags_popular/src/Helper/TagsPopularHelper.php
@@ -131,7 +131,7 @@ abstract class TagsPopularHelper
 				{
 					$query->setLimit($maximum);
 				}
-				
+
 				$query->order($db->quoteName('count') . ' DESC');
 				$equery = $db->getQuery(true)
 					->select(

--- a/modules/mod_tags_similar/mod_tags_similar.xml
+++ b/modules/mod_tags_similar/mod_tags_similar.xml
@@ -25,13 +25,12 @@
 			<fieldset name="basic">
 				<field
 					name="maximum"
-					type="integer"
+					type="number"
 					label="MOD_TAGS_SIMILAR_MAX_LABEL"
 					default="5"
 					filter="integer"
-					first="1"
-					last="20"
-					step="1"
+					min="0"
+					validate="number"
 				/>
 
 				<field

--- a/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
+++ b/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
@@ -200,7 +200,7 @@ abstract class TagsSimilarHelper
 		{
 			$query->setLimit($maximum);
 		}
-		
+
 		$db->setQuery($query);
 
 		try

--- a/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
+++ b/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
@@ -194,7 +194,13 @@ abstract class TagsSimilarHelper
 			$query->order($query->rand());
 		}
 
-		$query->setLimit((int) $params->get('maximum', 5));
+		$maximum = (int) $params->get('maximum', 5);
+
+		if ($maximum > 0)
+		{
+			$query->setLimit($maximum);
+		}
+		
 		$db->setQuery($query);
 
 		try


### PR DESCRIPTION
Pull Request for Issue #36016.

### Summary of Changes
Removed the hard limit for Module Tags-Popular and Module Tags-Similar.


### Testing Instructions

#### For tags popular :
1. Site modules--> New-->Tags-Popular.
2. Set the maximum tags to a number > 20 and make sure that the tags are displayed correctly in the frontend.

#### For tags similar :
1.Site modules--> New-->Tags-similar.
2. Set the maximum items to a number > 20 and make sure that the tags are displayed correctly in the frontend



### Actual result BEFORE applying this Pull Request

see #36016 

### Expected result AFTER applying this Pull Request
Any number is possible for both tags-popular and tags-similar.

### Documentation Changes Required

