### PR TITLE
[4.x] Fix error from last upmerge from 3.10-dev causing issue 36730

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -240,7 +240,7 @@ class PlgSystemRedirect extends CMSPlugin implements SubscriberInterface
 
 				try
 				{
-					$db->updateObject('#__redirect_links', $redirect, 'id');
+					$this->db->updateObject('#__redirect_links', $redirect, 'id');
 				}
 				catch (Exception $e)
 				{


### PR DESCRIPTION
Pull Request for Issue #36730 .

### Summary of Changes

Fix the error not using the injected database object but an undefined $db variable coming from the upmerge of PR #34640 from 3.10-dev into 4.0-dev 10 days ago.

Thanks to @SniperSister for the hint.

### Testing Instructions

Either just code review, or have a site updated from 4.0.5 to 4.0.6 where you can reproduce issue #36730 and check if this fix solves it.

### Actual result BEFORE applying this Pull Request

Unhandled PHP error in file "plugins/system/redirect/redirect.php", line 243 causes a server error when having redirects.

### Expected result AFTER applying this Pull Request

No unhandled PHP error in file "plugins/system/redirect/redirect.php", line 243 causes a server error when having redirects.

### Documentation Changes Required

None.