### PR TITLE
Media fields in non-repeatable subforms are broken

### DIFF
--- a/libraries/src/Form/Field/AccessiblemediaField.php
+++ b/libraries/src/Form/Field/AccessiblemediaField.php
@@ -131,6 +131,19 @@ class AccessiblemediaField extends SubformField
 	public function setup(\SimpleXMLElement $element, $value, $group = null)
 	{
 		/**
+		 * When you have subforms which are not repeatable (i.e. a subform custom field with the
+		 * repeat attribute set to 0) you get an array here. This happens because the subform data,
+		 * including the inner data of the media field, is stored as JSON and decoded as an
+		 * associative array. Since the code below only expects a string (JSON or legacy single
+		 * image file) or an object it thinks there's invalid data which causes the media field to
+		 * not save its data and, on the next page load, not render at all.
+		 *
+		 * Typecasting that array back to the expected object value solves the discrepancy between
+		 * provided data and expected data, solving the issue.
+		 */
+		$value = is_array($value) ? (object) $value : $value;
+
+		/**
 		 * If the value is not a string, it is
 		 * most likely within a custom field of type subform
 		 * and the value is a stdClass with properties

--- a/libraries/src/Form/Field/AccessiblemediaField.php
+++ b/libraries/src/Form/Field/AccessiblemediaField.php
@@ -132,14 +132,11 @@ class AccessiblemediaField extends SubformField
 	{
 		/**
 		 * When you have subforms which are not repeatable (i.e. a subform custom field with the
-		 * repeat attribute set to 0) you get an array here. This happens because the subform data,
-		 * including the inner data of the media field, is stored as JSON and decoded as an
-		 * associative array. Since the code below only expects a string (JSON or legacy single
-		 * image file) or an object it thinks there's invalid data which causes the media field to
-		 * not save its data and, on the next page load, not render at all.
+		 * repeat attribute set to 0) you get an array here since the data comes from decoding the
+		 * JSON into an associative array, including the media subfield's data.
 		 *
-		 * Typecasting that array back to the expected object value solves the discrepancy between
-		 * provided data and expected data, solving the issue.
+		 * However, this method expects an object or a string, not an array. Typecasting the array
+		 * to an object solves the data format discrepancy.
 		 */
 		$value = is_array($value) ? (object) $value : $value;
 


### PR DESCRIPTION
Pull Request for Issue #36734 .

### Summary of Changes

Addresses the data format discrepancy between what `Joomla\CMS\Form\Field\AccessiblemediaField` expects and what a non-repeatable subform custom field provides.

### Testing Instructions

Per issue #36734:

1. Create a media custom field. Configuration doesn't matter.
2. Create another custom field, any type but media. Configuration doesn't matter.
3. Create a subform with those two fields. Set the "Repeatable" toggle to no. (This is important!)
4. Open an article with the subform field. Fill out the fields, or don't. It doesn't matter.
5. Save the article.

### Actual result BEFORE applying this Pull Request

The media field _disappears_ every other save. Any images you set in the field is ignored; the field appears in its default (empty) state when it reappears.

### Expected result AFTER applying this Pull Request

The media field still displays in the subform, and if any value was added to the media field, it remains.

### Documentation Changes Required

None

### Technical information

This problem happens because Joomla is playing fast and loose with data types.

The subform custom field stores its value as a JSON document. This includes the values of each and every subfield contained in it. It is always decoded to an associative array, including the subfields' data.

The Media custom field's value is meant to be either an object or a string (which can be a JSON-serialised object or a legacy image file path without alt text). That's how the setup() method of the AccessiblemediaField class expects its values.

When combining the two you create the observed problem.

When you load a custom field it decodes the JSON value into an associative array. This means that the internal data of the Media custom field is also decoded as an array. Since the AccessiblemediaField does not accept an array it considers the data invalid, setup() returns false and the field is removed from the form. Therefore its data is removed when you save the content (e.g. article) again. The next page load has no value for this field stored so the field falls back to its default empty state due to the fall-through of the setup() method's opening if-block and displays, albeit empty.

The dead simple solution is to check if the incoming value is an array and type cast it to an object. This satisfies the if-block's conditions and the field displays correctly.