### PR TITLE
[4.1] plg_webservices_media missing on update

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.1.0-2022-01-19.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.1.0-2022-01-19.sql
@@ -1,0 +1,2 @@
+INSERT INTO `#__extensions` (`name`, `type`, `element`, `folder`, `client_id`, `enabled`, `access`, `protected`, `locked`, `manifest_cache`, `params`, `custom_data`, `checked_out`, `checked_out_time`, `ordering`, `state`) VALUES
+('plg_webservices_media', 'plugin', 'media', 'webservices', 0, 1, 1, 0, 1, '', '{}', '', NULL, NULL, 0, 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.1.0-2022-01-19.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.1.0-2022-01-19.sql
@@ -1,0 +1,2 @@
+INSERT INTO "#__extensions" ("name", "type", "element", "folder", "client_id", "enabled", "access", "protected", "locked", "manifest_cache", "params", "custom_data", "checked_out", "checked_out_time", "ordering", "state") VALUES
+('plg_webservices_media', 'plugin', 'media', 'webservices', 0, 1, 1, 0, 1, '', '{}', '', NULL, NULL, 0, 0);


### PR DESCRIPTION
There was no sql to install this plugin on update from 4.0 to 4.1

### Steps to reproduce the issue
On a clean 4.0.6 set the update channel to testing and perform an update to RC1


### Expected result
No extensions found by discover


### Actual result
1 extension found
![image](https://user-images.githubusercontent.com/1296369/150101929-dc5273b6-4554-43be-b7fa-4549d50cbfa5.png)

This was missing from the original PR #35788 by @laoneo 