### PR TITLE
[3.10] Set a timeout on update package downloads

### DIFF
--- a/administrator/components/com_joomlaupdate/models/default.php
+++ b/administrator/components/com_joomlaupdate/models/default.php
@@ -443,7 +443,7 @@ class JoomlaupdateModelDefault extends JModelLegacy
 		// Download the package
 		try
 		{
-			$result = $http->get($url);
+			$result = $http->get($url, [], 30);
 		}
 		catch (RuntimeException $e)
 		{


### PR DESCRIPTION
### Summary of Changes
Downloading the Joomla update package runs on some web sites into a timeout for the main Joomla download server and crashes the update. This should be catched and then the fallback download servers used instead.

The timeout is set to 30 seconds. Not sure if this is too short on slower hostings. Any recommendations?

[UPDATE]: As this here is more of a hot fix. End goal should be to fetch the update package in an ajax request as came out in the discussion of this pr.