### PR TITLE
[4.0] Implement FormFactoryAwareInterface in ListModel

### DIFF
--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -14,6 +14,7 @@ use Exception;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\FormFactoryAwareInterface;
 use Joomla\CMS\Form\FormFactoryAwareTrait;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Pagination\Pagination;
@@ -24,7 +25,7 @@ use Joomla\Database\DatabaseQuery;
  *
  * @since  1.6
  */
-class ListModel extends BaseDatabaseModel implements ListModelInterface
+class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, ListModelInterface
 {
 	use FormBehaviorTrait;
 	use FormFactoryAwareTrait;


### PR DESCRIPTION
### Summary of Changes

Implement FormFactoryAwareInterface in ListModel to inject FormFactory

### Testing Instructions

Open any list view (e.g. list of articles, contacts, extensions) and verify that the search form is displayed as before

### Actual result BEFORE applying this Pull Request

`UnexpectedValueException: FormFactory not set in Joomla\CMS\MVC\Model\ListModel`

And fallback to `Factory::getContainer()->get(FormFactoryInterface::class)` to get the FormFactory

### Expected result AFTER applying this Pull Request

FormFactory is now set in MVCFactory by `setFormFactoryOnObject` since Model now implements `FormFactoryAwareInterface`

### Documentation Changes Required

none