### PR TITLE
Included the title attribute to the image area and image name in media manager.

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -4,7 +4,8 @@
     @dblclick="openPreview()"
     @mouseleave="hideActions()"
   >
-    <div class="media-browser-item-preview">
+    <div class="media-browser-item-preview"
+    :title="item.name">
       <div class="image-background">
         <div
           class="image-cropped"
@@ -12,7 +13,8 @@
         />
       </div>
     </div>
-    <div class="media-browser-item-info">
+    <div class="media-browser-item-info"
+    :title="item.name">
       {{ item.name }} {{ item.filetype }}
     </div>
     <span


### PR DESCRIPTION
Pull Request for Issue #36302


### Summary of Changes

Included the "title" attribute to the image area and image name in the media manager.

### Testing Instructions:
1. Home dashboard--> Media manager.
2. Hover over any image and notice that the file name is not displayed on hovering over the image before applying this pull request.
3. Apply the patch and confirm that the full file name is displayed on hovering over the image in the media manager.


### Actual result BEFORE applying this Pull Request

see #36302


### Expected result AFTER applying this Pull Request

see #36302
