### PR TITLE
[3.10] [PHP 8.1] Fixes mod_menu/menu.php type null instead of string

### DIFF
--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -380,7 +380,7 @@ class JAdminCssMenu
 			}
 
 			// Exclude if link is invalid
-			if (!in_array($item->type, array('separator', 'heading', 'container')) && trim((string) $item->link) === '')
+			if (is_null($item->link) || (!in_array($item->type, array('separator', 'heading', 'container')) && trim($item->link) === ''))
 			{
 				continue;
 			}

--- a/administrator/modules/mod_menu/menu.php
+++ b/administrator/modules/mod_menu/menu.php
@@ -380,7 +380,7 @@ class JAdminCssMenu
 			}
 
 			// Exclude if link is invalid
-			if (!in_array($item->type, array('separator', 'heading', 'container')) && trim($item->link) === '')
+			if (!in_array($item->type, array('separator', 'heading', 'container')) && trim((string) $item->link) === '')
 			{
 				continue;
 			}


### PR DESCRIPTION
Fixes Deprecated: trim(): `Passing null to parameter #1 ($string) of type string is deprecated in administrator/modules/mod_menu/menu.php on line 383`

Pull Request for Issue # none

### Summary of Changes

Sometimes item is null, but in PHP 8.1, trim accepts only string type, not null.

### Testing Instructions

Code-review could perfectly be enough as it's obvious.

Look at admin area of 3.10, and see error.

### Actual result BEFORE applying this Pull Request

Passing null to parameter #1 ($string) of type string is deprecated in administrator/modules/mod_menu/menu.php on line 383

### Expected result AFTER applying this Pull Request

That warning disappears.

### Documentation Changes Required

None.