### PR TITLE
[3.10] [PHP 8.1] Fix HtmlDocument preg_split(): Passing null to $limit of type int

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -592,7 +592,7 @@ class HtmlDocument extends Document
 	public function countModules($condition)
 	{
 		$operators = '(\+|\-|\*|\/|==|\!=|\<\>|\<|\>|\<=|\>=|and|or|xor)';
-		$words = preg_split('# ' . $operators . ' #', $condition, null, PREG_SPLIT_DELIM_CAPTURE);
+		$words = preg_split('# ' . $operators . ' #', $condition, -1, PREG_SPLIT_DELIM_CAPTURE);
 
 		if (count($words) === 1)
 		{


### PR DESCRIPTION
Pull Request for Issue # none, found and fixed directly here.

### Summary of Changes

Fixes PHP 8.1 incompatibility `Deprecated: preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in libraries/src/Document/HtmlDocument.php on line 595`

Actually, null would converts to 0, but it's the same as the function's default value of -1 that was expected there.

See https://www.php.net/manual/en/function.preg-split.php : 

>  limit
>  If specified, then only substrings up to limit are returned with the rest of the string being placed in the last substring. A limit of -1 or 0 means "no limit".

### Testing Instructions

Open administrator backend in debug mode (with all incl. deprecation warnings turned on), and see this warning, then apply patch and see it disappear.

### Actual result BEFORE applying this Pull Request

`Deprecated: preg_split(): Passing null to parameter #3 ($limit) of type int is deprecated in libraries/src/Document/HtmlDocument.php on line 595`

### Expected result AFTER applying this Pull Request

warning disappeared.

### Documentation Changes Required

none.
