### PR TITLE
[3.10] [PHP 8.1] Fix Editor Passing null to $string line 258

### DIFF
--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -255,7 +255,7 @@ class Editor extends \JObject
 
 		foreach ($results as $result)
 		{
-			if (trim($result))
+			if (trim((string) $result))
 			{
 				// @todo remove code: $return .= $result;
 				$return = $result;

--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -255,7 +255,7 @@ class Editor extends \JObject
 
 		foreach ($results as $result)
 		{
-			if (trim((string) $result))
+			if (!is_null($result) && trim($result))
 			{
 				// @todo remove code: $return .= $result;
 				$return = $result;


### PR DESCRIPTION
Pull Request for Issue # none, directly fixed here.

### Summary of Changes

Fixes `Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in libraries/src/Editor/Editor.php on line 258`

### Testing Instructions

Obvious source-code review should be enough.

Otherwise go into admin with PHP 8.1 and debug on, with deprecation warnings turned on.

### Actual result BEFORE applying this Pull Request

Displays warning `Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in libraries/src/Editor/Editor.php on line 258`

### Expected result AFTER applying this Pull Request

warning disappears.

### Documentation Changes Required

None.
