### PR TITLE
[3.10] [PHP 8.1] Mysqli database driver escape function fix

### DIFF
--- a/libraries/joomla/database/driver/mysql.php
+++ b/libraries/joomla/database/driver/mysql.php
@@ -154,12 +154,12 @@ class JDatabaseDriverMysql extends JDatabaseDriverMysqli
 		if (is_float($text))
 		{
 			// Force the dot as a decimal point.
-			return str_replace(',', '.', $text);
+			return str_replace(',', '.', (string) $text);
 		}
 
 		$this->connect();
 
-		$result = mysql_real_escape_string($text, $this->getConnection());
+		$result = mysql_real_escape_string((string) $text, $this->getConnection());
 
 		if ($extra)
 		{

--- a/libraries/joomla/database/driver/mysqli.php
+++ b/libraries/joomla/database/driver/mysqli.php
@@ -246,12 +246,12 @@ class JDatabaseDriverMysqli extends JDatabaseDriver
 		if (is_float($text))
 		{
 			// Force the dot as a decimal point.
-			return str_replace(',', '.', $text);
+			return str_replace(',', '.', (string) $text);
 		}
 
 		$this->connect();
 
-		$result = mysqli_real_escape_string($this->getConnection(), $text);
+		$result = mysqli_real_escape_string($this->getConnection(), (string) $text);
 
 		if ($extra)
 		{

--- a/libraries/joomla/database/driver/pdo.php
+++ b/libraries/joomla/database/driver/pdo.php
@@ -349,10 +349,10 @@ abstract class JDatabaseDriverPdo extends JDatabaseDriver
 		if (is_float($text))
 		{
 			// Force the dot as a decimal point.
-			return str_replace(',', '.', $text);
+			return str_replace(',', '.', (string) $text);
 		}
 
-		$text = str_replace("'", "''", $text);
+		$text = str_replace("'", "''", (string) $text);
 
 		return addcslashes($text, "\000\n\r\\\032");
 	}

--- a/libraries/joomla/database/driver/pdomysql.php
+++ b/libraries/joomla/database/driver/pdomysql.php
@@ -464,7 +464,7 @@ class JDatabaseDriverPdomysql extends JDatabaseDriverPdo
 		if (is_float($text))
 		{
 			// Force the dot as a decimal point.
-			return str_replace(',', '.', $text);
+			return str_replace(',', '.', (string) $text);
 		}
 
 		$this->connect();

--- a/libraries/joomla/database/driver/postgresql.php
+++ b/libraries/joomla/database/driver/postgresql.php
@@ -212,12 +212,12 @@ class JDatabaseDriverPostgresql extends JDatabaseDriver
 		if (is_float($text))
 		{
 			// Force the dot as a decimal point.
-			return str_replace(',', '.', $text);
+			return str_replace(',', '.', (string) $text);
 		}
 
 		$this->connect();
 
-		$result = pg_escape_string($this->connection, $text);
+		$result = pg_escape_string($this->connection, (string) $text);
 
 		if ($extra)
 		{


### PR DESCRIPTION
Pull Request for Issue # none.

### Summary of Changes

Fixes `Deprecated: mysqli_real_escape_string(): Passing null to parameter #2 ($string) of type string is deprecated in libraries/joomla/database/driver/mysqli.php on line 254`

### Testing Instructions

Source-code review should be enough here.

Just test that site continues to work.
I saw this error while saving a user in admin aera with CB.

### Actual result BEFORE applying this Pull Request

`Deprecated: mysqli_real_escape_string(): Passing null to parameter #2 ($string) of type string is deprecated in libraries/joomla/database/driver/mysqli.php on line 254`

### Expected result AFTER applying this Pull Request

That warning is not displayed

### Documentation Changes Required

None.
