### PR TITLE
[3.10] [PHP 8.1] Fixing mod_search Passing null to type string

### DIFF
--- a/modules/mod_search/mod_search.php
+++ b/modules/mod_search/mod_search.php
@@ -41,7 +41,7 @@ $width           = (int) $params->get('width');
 $maxlength       = $upper_limit;
 $text            = htmlspecialchars($params->get('text', JText::_('MOD_SEARCH_SEARCHBOX_TEXT')), ENT_COMPAT, 'UTF-8');
 $label           = htmlspecialchars($params->get('label', JText::_('MOD_SEARCH_LABEL_TEXT')), ENT_COMPAT, 'UTF-8');
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 if ($imagebutton)
 {


### PR DESCRIPTION
Pull Request for Issue # none

### Summary of Changes

Fixes `Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/modules/mod_search/mod_search.php on line 44`

### Testing Instructions

Code review is enough.

But to reproduce, use PHP 8.1 with Debug ON and all (incl. deprecation) php warnings on, in fronted see warning with mod_search enabled.

### Actual result BEFORE applying this Pull Request

`Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/modules/mod_search/mod_search.php on line 44`

### Expected result AFTER applying this Pull Request

that warning disappears

### Documentation Changes Required

none.
