### PR TITLE
[3.10] [PHP 8.1] Make templates/system/html/modules.php PHP 8.1 compatible

### DIFF
--- a/templates/beez3/html/modules.php
+++ b/templates/beez3/html/modules.php
@@ -18,7 +18,7 @@ function modChrome_beezDivision($module, &$params, &$attribs)
 {
 	$headerLevel = isset($attribs['headerLevel']) ? (int) $attribs['headerLevel'] : 3;
 	if (!empty ($module->content)) : ?>
-		<div class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8'); ?>">
+		<div class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8'); ?>">
 		<?php if ($module->showtitle) : ?>
 			<h<?php echo $headerLevel; ?>><?php echo $module->title; ?></h<?php echo $headerLevel; ?>>
 		<?php endif; ?>
@@ -39,7 +39,7 @@ function modChrome_beezHide($module, &$params, &$attribs)
 	if (!empty ($module->content)) { ?>
 
 <div
-	class="moduletable_js <?php echo htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');?>"><?php if ($module->showtitle) : ?>
+	class="moduletable_js <?php echo htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');?>"><?php if ($module->showtitle) : ?>
 <h<?php echo $headerLevel; ?> class="js_heading"> <?php echo $module->title; ?> <a href="#"
 	title="<?php echo JText::_('TPL_BEEZ3_CLICK'); ?>"
 	onclick="auf('module_<?php echo $module->id; ?>'); return false"

--- a/templates/protostar/html/modules.php
+++ b/templates/protostar/html/modules.php
@@ -44,7 +44,7 @@ function modChrome_well($module, &$params, &$attribs)
 
 	if ($module->content)
 	{
-		echo '<' . $moduleTag . ' class="well ' . htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8') . $moduleClass . '">';
+		echo '<' . $moduleTag . ' class="well ' . htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8') . $moduleClass . '">';
 
 			if ($module->showtitle)
 			{

--- a/templates/system/html/modules.php
+++ b/templates/system/html/modules.php
@@ -32,7 +32,7 @@ function modChrome_html5($module, &$params, &$attribs)
 	$headerClass    = !empty($headerClass) ? ' class="' . htmlspecialchars($headerClass, ENT_COMPAT, 'UTF-8') . '"' : '';
 
 	if (!empty ($module->content)) : ?>
-		<<?php echo $moduleTag; ?> class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8') . $moduleClass; ?>">
+		<<?php echo $moduleTag; ?> class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8') . $moduleClass; ?>">
 
 		<?php if ((bool) $module->showtitle) :?>
 			<<?php echo $headerTag . $headerClass . '>' . $module->title; ?></<?php echo $headerTag; ?>>
@@ -50,7 +50,7 @@ function modChrome_html5($module, &$params, &$attribs)
  */
 function modChrome_table($module, &$params, &$attribs)
 { ?>
-	<table cellpadding="0" cellspacing="0" class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8'); ?>">
+	<table cellpadding="0" cellspacing="0" class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8'); ?>">
 	<?php if ((bool) $module->showtitle) : ?>
 		<tr>
 			<th>
@@ -98,7 +98,7 @@ function modChrome_xhtml($module, &$params, &$attribs)
 	$headerClass    = $headerClass ? ' class="' . htmlspecialchars($headerClass, ENT_COMPAT, 'UTF-8') . '"' : '';
 
 	if (!empty ($module->content)) : ?>
-		<<?php echo $moduleTag; ?> class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8') . $moduleClass; ?>">
+		<<?php echo $moduleTag; ?> class="moduletable<?php echo htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8') . $moduleClass; ?>">
 			<?php if ((bool) $module->showtitle) : ?>
 				<<?php echo $headerTag . $headerClass . '>' . $module->title; ?></<?php echo $headerTag; ?>>
 			<?php endif; ?>
@@ -112,7 +112,7 @@ function modChrome_xhtml($module, &$params, &$attribs)
  */
 function modChrome_rounded($module, &$params, &$attribs)
 { ?>
-		<div class="module<?php echo htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8'); ?>">
+		<div class="module<?php echo htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8'); ?>">
 			<div>
 				<div>
 					<div>


### PR DESCRIPTION
Pull Request for Issue # none

### Summary of Changes

Fixes `Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/templates/system/html/modules.php on line 101` and a few more (line 35, line 53, line 115)
and same in Protostar and Beez modules.php

### Testing Instructions

Code review.

Or see front-end with PHP 8.1, debug ON, and all PHP errors on.

### Actual result BEFORE applying this Pull Request

`Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/templates/system/html/modules.php on line 101`
and in some other cases:
`Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/templates/system/html/modules.php on line 35`
`Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/templates/system/html/modules.php on line 53`
`Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/templates/system/html/modules.php on line 115`

### Expected result AFTER applying this Pull Request

not those warnings anymore.

### Documentation Changes Required

None.
