### PR TITLE
[3.10] [PHP 8.1] fixes all modules Deprecated: htmlspecialchars(): Passing null to type string

### DIFF
--- a/administrator/modules/mod_feed/mod_feed.php
+++ b/administrator/modules/mod_feed/mod_feed.php
@@ -26,6 +26,6 @@ if (empty ($rssurl))
 }
 
 $feed            = ModFeedHelper::getFeed($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_feed', $params->get('layout', 'default'));

--- a/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.php
+++ b/administrator/modules/mod_privacy_dashboard/mod_privacy_dashboard.php
@@ -25,6 +25,6 @@ JHtml::addIncludePath(JPATH_ADMINISTRATOR . '/components/com_privacy/helpers/htm
 JLoader::register('ModPrivacyDashboardHelper', __DIR__ . '/helper.php');
 
 $list            = ModPrivacyDashboardHelper::getData();
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_privacy_dashboard', $params->get('layout', 'default'));

--- a/administrator/modules/mod_stats_admin/mod_stats_admin.php
+++ b/administrator/modules/mod_stats_admin/mod_stats_admin.php
@@ -15,6 +15,6 @@ JLoader::register('ModStatsHelper', __DIR__ . '/helper.php');
 $serverinfo      = $params->get('serverinfo');
 $siteinfo        = $params->get('siteinfo');
 $list            = ModStatsHelper::getStats($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_stats_admin', $params->get('layout', 'default'));

--- a/modules/mod_articles_archive/mod_articles_archive.php
+++ b/modules/mod_articles_archive/mod_articles_archive.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 JLoader::register('ModArchiveHelper', __DIR__ . '/helper.php');
 
 $params->def('count', 10);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 $list            = ModArchiveHelper::getList($params);
 
 require JModuleHelper::getLayoutPath('mod_articles_archive', $params->get('layout', 'default'));

--- a/modules/mod_articles_categories/mod_articles_categories.php
+++ b/modules/mod_articles_categories/mod_articles_categories.php
@@ -29,7 +29,7 @@ $list = JModuleHelper::moduleCache($module, $params, $cacheparams);
 
 if (!empty($list))
 {
-	$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+	$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 	$startLevel      = reset($list)->getParent()->level;
 
 	require JModuleHelper::getLayoutPath('mod_articles_categories', $params->get('layout', 'default'));

--- a/modules/mod_articles_category/mod_articles_category.php
+++ b/modules/mod_articles_category/mod_articles_category.php
@@ -65,7 +65,7 @@ if (!empty($list))
 	$grouped                    = false;
 	$article_grouping           = $params->get('article_grouping', 'none');
 	$article_grouping_direction = $params->get('article_grouping_direction', 'ksort');
-	$moduleclass_sfx            = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+	$moduleclass_sfx            = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 	$item_heading               = $params->get('item_heading');
 
 	if ($article_grouping !== 'none')

--- a/modules/mod_articles_latest/mod_articles_latest.php
+++ b/modules/mod_articles_latest/mod_articles_latest.php
@@ -13,6 +13,6 @@ defined('_JEXEC') or die;
 JLoader::register('ModArticlesLatestHelper', __DIR__ . '/helper.php');
 
 $list            = ModArticlesLatestHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_articles_latest', $params->get('layout', 'default'));

--- a/modules/mod_articles_news/mod_articles_news.php
+++ b/modules/mod_articles_news/mod_articles_news.php
@@ -13,6 +13,6 @@ defined('_JEXEC') or die;
 JLoader::register('ModArticlesNewsHelper', __DIR__ . '/helper.php');
 
 $list            = ModArticlesNewsHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_articles_news', $params->get('layout', 'horizontal'));

--- a/modules/mod_articles_popular/mod_articles_popular.php
+++ b/modules/mod_articles_popular/mod_articles_popular.php
@@ -13,6 +13,6 @@ defined('_JEXEC') or die;
 JLoader::register('ModArticlesPopularHelper', __DIR__ . '/helper.php');
 
 $list = ModArticlesPopularHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_articles_popular', $params->get('layout', 'default'));

--- a/modules/mod_banners/mod_banners.php
+++ b/modules/mod_banners/mod_banners.php
@@ -18,6 +18,6 @@ $footerText = trim($params->get('footer_text', ''));
 JLoader::register('BannersHelper', JPATH_ADMINISTRATOR . '/components/com_banners/helpers/banners.php');
 BannersHelper::updateReset();
 $list = &ModBannersHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_banners', $params->get('layout', 'default'));

--- a/modules/mod_breadcrumbs/mod_breadcrumbs.php
+++ b/modules/mod_breadcrumbs/mod_breadcrumbs.php
@@ -18,6 +18,6 @@ $count = count($list);
 
 // Set the default separator
 $separator = ModBreadCrumbsHelper::setSeparator($params->get('separator'));
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_breadcrumbs', $params->get('layout', 'default'));

--- a/modules/mod_custom/mod_custom.php
+++ b/modules/mod_custom/mod_custom.php
@@ -15,6 +15,6 @@ if ($params->def('prepare_content', 1))
 	$module->content = JHtml::_('content.prepare', $module->content, '', 'mod_custom.content');
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_custom', $params->get('layout', 'default'));

--- a/modules/mod_feed/mod_feed.php
+++ b/modules/mod_feed/mod_feed.php
@@ -26,6 +26,6 @@ if (empty ($rssurl))
 }
 
 $feed = ModFeedHelper::getFeed($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_feed', $params->get('layout', 'default'));

--- a/modules/mod_footer/mod_footer.php
+++ b/modules/mod_footer/mod_footer.php
@@ -34,6 +34,6 @@ else
 	$lineone = $line1;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_footer', $params->get('layout', 'default'));

--- a/modules/mod_languages/mod_languages.php
+++ b/modules/mod_languages/mod_languages.php
@@ -15,6 +15,6 @@ JLoader::register('ModLanguagesHelper', __DIR__ . '/helper.php');
 $headerText      = $params->get('header_text');
 $footerText      = $params->get('footer_text');
 $list            = ModLanguagesHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_languages', $params->get('layout', 'default'));

--- a/modules/mod_menu/mod_menu.php
+++ b/modules/mod_menu/mod_menu.php
@@ -20,7 +20,7 @@ $active_id  = $active->id;
 $default_id = $default->id;
 $path       = $base->tree;
 $showAll    = $params->get('showAllChildren', 1);
-$class_sfx  = htmlspecialchars($params->get('class_sfx'), ENT_COMPAT, 'UTF-8');
+$class_sfx  = htmlspecialchars($params->get('class_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 if (count($list))
 {

--- a/modules/mod_random_image/mod_random_image.php
+++ b/modules/mod_random_image/mod_random_image.php
@@ -24,6 +24,6 @@ if (!count($images))
 }
 
 $image           = ModRandomImageHelper::getRandomImage($params, $images);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_random_image', $params->get('layout', 'default'));

--- a/modules/mod_related_items/mod_related_items.php
+++ b/modules/mod_related_items/mod_related_items.php
@@ -26,7 +26,7 @@ if (!count($list))
 	return;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 $showDate        = $params->get('showDate', 0);
 
 require JModuleHelper::getLayoutPath('mod_related_items', $params->get('layout', 'default'));

--- a/modules/mod_stats/mod_stats.php
+++ b/modules/mod_stats/mod_stats.php
@@ -15,6 +15,6 @@ JLoader::register('ModStatsHelper', __DIR__ . '/helper.php');
 $serverinfo      = $params->get('serverinfo', 0);
 $siteinfo        = $params->get('siteinfo', 0);
 $list            = ModStatsHelper::getList($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_stats', $params->get('layout', 'default'));

--- a/modules/mod_syndicate/mod_syndicate.php
+++ b/modules/mod_syndicate/mod_syndicate.php
@@ -21,7 +21,7 @@ if ($link === null)
 	return;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
-$text            = htmlspecialchars($params->get('text'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
+$text            = htmlspecialchars($params->get('text', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_syndicate', $params->get('layout', 'default'));

--- a/modules/mod_tags_popular/mod_tags_popular.php
+++ b/modules/mod_tags_popular/mod_tags_popular.php
@@ -26,7 +26,7 @@ if (!count($list) && !$params->get('no_results_text'))
 	return;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 $display_count   = $params->get('display_count', 0);
 
 require JModuleHelper::getLayoutPath('mod_tags_popular', $params->get('layout', 'default'));

--- a/modules/mod_tags_similar/mod_tags_similar.php
+++ b/modules/mod_tags_similar/mod_tags_similar.php
@@ -26,6 +26,6 @@ if (!count($list))
 	return;
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_tags_similar', $params->get('layout', 'default'));

--- a/modules/mod_users_latest/mod_users_latest.php
+++ b/modules/mod_users_latest/mod_users_latest.php
@@ -14,6 +14,6 @@ JLoader::register('ModUsersLatestHelper', __DIR__ . '/helper.php');
 
 $shownumber      = $params->get('shownumber', 5);
 $names           = ModUsersLatestHelper::getUsers($params);
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_users_latest', $params->get('layout', 'default'));

--- a/modules/mod_whosonline/mod_whosonline.php
+++ b/modules/mod_whosonline/mod_whosonline.php
@@ -24,6 +24,6 @@ if ($showmode > 0)
 	$names = ModWhosonlineHelper::getOnlineUserNames($params);
 }
 
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
 
 require JModuleHelper::getLayoutPath('mod_whosonline', $params->get('layout', 'default'));

--- a/modules/mod_wrapper/mod_wrapper.php
+++ b/modules/mod_wrapper/mod_wrapper.php
@@ -15,13 +15,13 @@ JLoader::register('ModWrapperHelper', __DIR__ . '/helper.php');
 $params = ModWrapperHelper::getParams($params);
 
 $load            = $params->get('load');
-$url             = htmlspecialchars($params->get('url'), ENT_COMPAT, 'UTF-8');
-$target          = htmlspecialchars($params->get('target'), ENT_COMPAT, 'UTF-8');
-$width           = htmlspecialchars($params->get('width'), ENT_COMPAT, 'UTF-8');
-$height          = htmlspecialchars($params->get('height'), ENT_COMPAT, 'UTF-8');
-$scroll          = htmlspecialchars($params->get('scrolling'), ENT_COMPAT, 'UTF-8');
-$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx'), ENT_COMPAT, 'UTF-8');
-$frameborder     = htmlspecialchars($params->get('frameborder'), ENT_COMPAT, 'UTF-8');
+$url             = htmlspecialchars($params->get('url', ''), ENT_COMPAT, 'UTF-8');
+$target          = htmlspecialchars($params->get('target', ''), ENT_COMPAT, 'UTF-8');
+$width           = htmlspecialchars($params->get('width', ''), ENT_COMPAT, 'UTF-8');
+$height          = htmlspecialchars($params->get('height', ''), ENT_COMPAT, 'UTF-8');
+$scroll          = htmlspecialchars($params->get('scrolling', ''), ENT_COMPAT, 'UTF-8');
+$moduleclass_sfx = htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_COMPAT, 'UTF-8');
+$frameborder     = htmlspecialchars($params->get('frameborder', ''), ENT_COMPAT, 'UTF-8');
 $ititle          = $module->title;
 $id              = $module->id;
 


### PR DESCRIPTION
Pull Request for Issue # none

### Summary of Changes

Fixes in all modules errors like:
`Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/modules/mod_tags_popular/mod_tags_popular.php on line 29`
`Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/modules/mod_breadcrumbs/mod_breadcrumbs.php on line 21`

### Testing Instructions

View front-end and backend in PHP 8.1 while debug on and all PHP errors.

### Actual result BEFORE applying this Pull Request

`Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/modules/mod_tags_popular/mod_tags_popular.php on line 29`
`Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/modules/mod_breadcrumbs/mod_breadcrumbs.php on line 21`
### Expected result AFTER applying this Pull Request

No such warnings

### Documentation Changes Required

None.