### PR TITLE
[3.10] [PHP 8.1] Fixes com_finder/indexer/query

### DIFF
--- a/administrator/components/com_finder/helpers/indexer/query.php
+++ b/administrator/components/com_finder/helpers/indexer/query.php
@@ -730,7 +730,7 @@ class FinderIndexerQuery
 	protected function processString($input, $lang, $mode)
 	{
 		// Clean up the input string.
-		$input = html_entity_decode($input, ENT_QUOTES, 'UTF-8');
+		$input = html_entity_decode((string) $input, ENT_QUOTES, 'UTF-8');
 		$input = StringHelper::strtolower($input);
 		$input = preg_replace('#\s+#mi', ' ', $input);
 		$input = trim($input);

--- a/administrator/components/com_finder/helpers/indexer/query.php
+++ b/administrator/components/com_finder/helpers/indexer/query.php
@@ -172,7 +172,7 @@ class FinderIndexerQuery
 	public function __construct($options)
 	{
 		// Get the input string.
-		$this->input = isset($options['input']) ? $options['input'] : null;
+		$this->input = isset($options['input']) ? $options['input'] : '';
 
 		// Get the empty query setting.
 		$this->empty = isset($options['empty']) ? (bool) $options['empty'] : false;
@@ -730,7 +730,7 @@ class FinderIndexerQuery
 	protected function processString($input, $lang, $mode)
 	{
 		// Clean up the input string.
-		$input = html_entity_decode((string) $input, ENT_QUOTES, 'UTF-8');
+		$input = html_entity_decode($input, ENT_QUOTES, 'UTF-8');
 		$input = StringHelper::strtolower($input);
 		$input = preg_replace('#\s+#mi', ' ', $input);
 		$input = trim($input);


### PR DESCRIPTION
Pull Request for Issue # none

### Summary of Changes

Fixes `Fixes `Deprecated: html_entity_decode(): Passing null to parameter #1 ($string) of type string is deprecated in administrator/components/com_finder/helpers/indexer/query.php on line 733`

### Testing Instructions

Code review should be enough.

Look in frontend in PHP 8.1 with all errors on and Joomla debug on, while finder is re-indexing.

### Actual result BEFORE applying this Pull Request

`Deprecated: html_entity_decode(): Passing null to parameter #1 ($string) of type string is deprecated in administrator/components/com_finder/helpers/indexer/query.php on line 733`

### Expected result AFTER applying this Pull Request

warning disappeared.

### Documentation Changes Required

none.