### PR TITLE
[3.10] [PHP 8.1] Fixes MVC BaseController Deprecated ucfirst() and Deprecated strtolower() null to string type warnings

### DIFF
--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -273,7 +273,7 @@ class BaseController extends \JObject
 		else
 		{
 			// Base controller.
-			$type = null;
+			$type = '';
 
 			// Define the controller filename and path.
 			$file       = self::createFileName('controller', array('name' => 'controller', 'format' => $format));
@@ -681,7 +681,7 @@ class BaseController extends \JObject
 	{
 		$this->task = $task;
 
-		$task = strtolower($task);
+		$task = strtolower((string) $task);
 
 		if (isset($this->taskMap[$task]))
 		{


### PR DESCRIPTION
Pull Request for Issue # none

### Summary of Changes

Fixes MVC BaseController for warnings:

`Deprecated: ucfirst(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/libraries/src/MVC/Controller/BaseController.php on line 286`
and
`Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/libraries/src/MVC/Controller/BaseController.php on line 684`

### Testing Instructions

Code review is probably enough, as trivial.

Check frontend with PHP 8.1 with all errors on and Joomla Debug ON.

### Actual result BEFORE applying this Pull Request

`Deprecated: ucfirst(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/libraries/src/MVC/Controller/BaseController.php on line 286`
`Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/j/libraries/src/MVC/Controller/BaseController.php on line 684`

### Expected result AFTER applying this Pull Request

Those warnings disappeared.

### Documentation Changes Required

None.
