### PR TITLE
[3.10] [PHP 8.1] Fixes Router/Route.php deprecated null to string in strpos()

### DIFF
--- a/libraries/src/Router/Route.php
+++ b/libraries/src/Router/Route.php
@@ -121,7 +121,7 @@ class Route
 	public static function link($client, $url, $xhtml = true, $tls = self::TLS_IGNORE, $absolute = false)
 	{
 		// If we cannot process this $url exit early.
-		if (!is_array($url) && (strpos((string) $url, '&') !== 0) && (strpos((string) $url, 'index.php') !== 0))
+		if (is_null($url) || (!is_array($url) && (strpos($url, '&') !== 0) && (strpos($url, 'index.php') !== 0)))
 		{
 			return $url;
 		}

--- a/libraries/src/Router/Route.php
+++ b/libraries/src/Router/Route.php
@@ -121,7 +121,7 @@ class Route
 	public static function link($client, $url, $xhtml = true, $tls = self::TLS_IGNORE, $absolute = false)
 	{
 		// If we cannot process this $url exit early.
-		if (is_null($url) || (!is_array($url) && (strpos($url, '&') !== 0) && (strpos($url, 'index.php') !== 0)))
+		if (!is_array($url) && (strpos($url, '&') !== 0) && (strpos($url, 'index.php') !== 0))
 		{
 			return $url;
 		}

--- a/libraries/src/Router/Route.php
+++ b/libraries/src/Router/Route.php
@@ -121,7 +121,7 @@ class Route
 	public static function link($client, $url, $xhtml = true, $tls = self::TLS_IGNORE, $absolute = false)
 	{
 		// If we cannot process this $url exit early.
-		if (!is_array($url) && (strpos($url, '&') !== 0) && (strpos($url, 'index.php') !== 0))
+		if (!is_array($url) && (strpos((string) $url, '&') !== 0) && (strpos((string) $url, 'index.php') !== 0))
 		{
 			return $url;
 		}

--- a/modules/mod_breadcrumbs/helper.php
+++ b/modules/mod_breadcrumbs/helper.php
@@ -51,7 +51,7 @@ class ModBreadCrumbsHelper
 		{
 			$crumbs[$i]       = new stdClass;
 			$crumbs[$i]->name = stripslashes(htmlspecialchars($items[$i]->name, ENT_COMPAT, 'UTF-8'));
-			$crumbs[$i]->link = JRoute::_($items[$i]->link);
+			$crumbs[$i]->link = !is_null($items[$i]->link) ? JRoute::_($items[$i]->link) : '';
 		}
 
 		if ($params->get('showHome', 1))


### PR DESCRIPTION
Pull Request for Issue # none

### Summary of Changes

Fixes `Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in libraries/src/Router/Route.php on line 124`

### Testing Instructions

Source-code review should be enough.

Otherwise on PHP 8.1 with all errors on and Joomla Debug ON, go to frontend in registration page (of CB if needed)

### Actual result BEFORE applying this Pull Request

`Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in libraries/src/Router/Route.php on line 124`

### Expected result AFTER applying this Pull Request

Warning disappears.

### Documentation Changes Required

None.
