### PR TITLE
[3.10] [PHP 8.1] Fixes Table User for Date/Date.php warning on login

### DIFF
--- a/libraries/src/Table/User.php
+++ b/libraries/src/Table/User.php
@@ -478,7 +478,7 @@ class User extends Table
 		}
 
 		// If no timestamp value is passed to function, than current time is used.
-		$date = \JFactory::getDate($timeStamp);
+		$date = \JFactory::getDate($timeStamp === null ? 'now' : $timeStamp);
 
 		// Update the database row for the user.
 		$db = $this->_db;


### PR DESCRIPTION
Pull Request for Issue # none

### Summary of Changes

Fixes `Deprecated: DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in /home/beat/www/j/libraries/src/Date/Date.php on line 112` error on login

A `new \Joomla\Date\Date($date, $tz);` requires a `string` as $date, and defaults to `'now'`. It does not treat the special case of null, which in PHP 8.1 warns deprecation, so I think that the correct place to fix the null parameter is just above where the default for "now" is NULL, in the call of the below where the default is 'now' and doesn't treat null.

### Testing Instructions

Code-review or test;

PHP 8.1 with all errors on, and joomla debug on. Then login in front-end, and before redirect it has that warning (at least when CB is installed as CB pauses redirects when there is an error). 

### Actual result BEFORE applying this Pull Request

`Deprecated: DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated in /home/beat/www/j/libraries/src/Date/Date.php on line 112` error on login

### Expected result AFTER applying this Pull Request

That warning disappears.

### Documentation Changes Required

None.
