### PR TITLE
[3.10] [PHP 8.1] compatibility of htmlentities types in tinymce.php (fixes Deprecated tinymce.php on line 603)

### DIFF
--- a/plugins/editors/tinymce/tinymce.php
+++ b/plugins/editors/tinymce/tinymce.php
@@ -600,7 +600,7 @@ class PlgEditorTinymce extends JPlugin
 
 			if ($app->isClient('site'))
 			{
-				$uploadUrl = htmlentities($uploadUrl, null, 'UTF-8', null);
+				$uploadUrl = htmlentities((string) $uploadUrl, null, 'UTF-8', null);
 			}
 
 			// Is Joomla installed in subdirectory


### PR DESCRIPTION
Pull Request for Issue # none.

### Summary of Changes

Fixes `Deprecated: htmlentities(): Passing null to parameter #2 ($flags) of type int is deprecated in plugins/editors/tinymce/tinymce.php on line 603`
Joomla 3.10 version of Joomla 4.0 #36761

In PHP, `htmlentities()` has following parameters types: 2nd is a non-null int, 4th is à non-null bool.
```
 htmlentities(
    string $string,
    int $flags = ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401,
    ?string $encoding = null,
    bool $double_encode = true
): string
```

ref.: https://www.php.net/manual/en/function.htmlentities.php

This PR does replace null by their type-conversions: (int) null -> 0, and (bool) null -> false.

**Disclaimer:** I'm only fixing PHP 8.1 compatibility here.

### Testing Instructions

A code-review should be enough here.

I found it with CB internal PMS / New Message, but I guess PHP 8.1 with all errors on and joomla debug on on any tinymce window should show it too.

### Actual result BEFORE applying this Pull Request

`Deprecated: htmlentities(): Passing null to parameter #2 ($flags) of type int is deprecated in plugins/editors/tinymce/tinymce.php on line 603`

### Expected result AFTER applying this Pull Request

No errors.

### Documentation Changes Required

None.