### PR TITLE
[4.1] codemirror update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2765,9 +2765,9 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.64.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.64.0.tgz",
-      "integrity": "sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg=="
+      "version": "5.65.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.1.tgz",
+      "integrity": "sha512-s6aac+DD+4O2u1aBmdxhB7yz2XU7tG3snOyQ05Kxifahz7hoxnfxIRHxiCSEv3TUC38dIVH8G+lZH9UWSfGQxA=="
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -10400,9 +10400,9 @@
       }
     },
     "codemirror": {
-      "version": "5.64.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.64.0.tgz",
-      "integrity": "sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg=="
+      "version": "5.65.1",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.1.tgz",
+      "integrity": "sha512-s6aac+DD+4O2u1aBmdxhB7yz2XU7tG3snOyQ05Kxifahz7hoxnfxIRHxiCSEv3TUC38dIVH8G+lZH9UWSfGQxA=="
     },
     "color-convert": {
       "version": "1.9.3",

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_codemirror</name>
-	<version>5.64.0</version>
+	<version>5.65.1</version>
 	<creationDate>28 March 2011</creationDate>
 	<author>Marijn Haverbeke</author>
 	<authorEmail>marijnh@gmail.com</authorEmail>


### PR DESCRIPTION
## Changelog
5.65.1 Fix miscalculation of vertical positions in lines that have both line widgets and replaced newlines.

5.65.0
Bug fixes
brace-folding addon: Fix broken folding on lines with both braces and square brackets.

New features
vim bindings: Support g0, g$, g.
