### PR TITLE
Removed unnecessary left join and distinct

### DIFF
--- a/libraries/src/Form/Field/TagField.php
+++ b/libraries/src/Form/Field/TagField.php
@@ -122,9 +122,8 @@ class TagField extends \JFormFieldList
 
 		$db    = Factory::getDbo();
 		$query = $db->getQuery(true)
-			->select('DISTINCT a.id AS value, a.path, a.title AS text, a.level, a.published, a.lft')
-			->from('#__tags AS a')
-			->join('LEFT', $db->qn('#__tags') . ' AS b ON a.lft > b.lft AND a.rgt < b.rgt');
+			->select('a.id AS value, a.path, a.title AS text, a.level, a.published, a.lft')
+			->from($db->qn('#__tags') . ' AS a');			
 
 		// Limit Options in multilanguage
 		if ($app->isClient('site') && Multilanguage::isEnabled())


### PR DESCRIPTION
### Summary of Changes
left joined table b is not used in query at all, it just generates multiple same rows, which are solved by distinct. Removing both gives the same result and removes 'using temporary table' and 'Range checked for each record' from query explain, which could cause high performance issues on some servers.

Plus add quoting on table name.

### Testing Instructions
Enable Debug mode, open list of articles, see generated Explain for query 
```
SELECT DISTINCT a.id AS value, a.path, a.title AS text, a.level, a.published, a.lft 
FROM sdx54_tags AS a 
LEFT JOIN `sdx54_tags` AS b ON a.lft > b.lft AND a.rgt < b.rgt 
WHERE `a`.`lft` > 0 AND a.published IN (0, 1) ORDER BY a.lft ASC
```

### Actual result BEFORE applying this Pull Request
Tags in filetr field for Tags are displayed, sorted by it ordering
Explain of query shows 
```
Using where; Using temporary; Using filesort
Range checked for each record (index map: 0x10); Distinct
```
![before](https://user-images.githubusercontent.com/979699/150793133-3e74b934-50be-4227-89e8-020a2dbac4be.jpg)

### Expected result AFTER applying this Pull Request
Tags in filetr field for Tags are displayed, sorted by it ordering
Query is simplified to 
```
SELECT a.id AS value, a.path, a.title AS text, a.level, a.published, a.lft 
FROM `sdx54_tags` AS a 
WHERE `a`.`lft` > 0 AND a.published IN (0, 1) ORDER BY a.lft ASC
```
Explain shows
```
Using where; Using filesort
```
![after](https://user-images.githubusercontent.com/979699/150793163-0797fef9-e64e-45af-a4c5-263b11c5ee5b.jpg)


### Documentation Changes Required
No

### Additional info
This issue remains in 4.0 and 4.1, If accepted I could prepare PR there also.

In my case this becomes issue after moving from MySQL 5 to MySQL 8 on some server. the original query took aprox. 8s, new one is aprox 5ms.