### PR TITLE
improving Menus: Edit Item - moving Publishing fields v2 #36918

### DIFF
--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -144,11 +144,11 @@ if ($clientId === 1)
 						'menuordering',
 						'published',
 						'home',
-						'publish_up',
-						'publish_down',
 						'access',
 						'language',
 						'note',
+						'publish_up',
+						'publish_down',
 					);
 
 					if ($this->item->type != 'component')


### PR DESCRIPTION
PR for issue https://github.com/joomla/joomla-cms/issues/36918

This PR moves in the **Menus: Edit Item** the **Start Publishing** and **Finish Publishing** date to the bottom,
so that the **Access** and **Language** are easier to use (like in Joomla 3.x)

## Test instructions

### Before PR
On a multilingual website, go to Menus > Main Menu (en-GB) > Create a new menu item.
You have to scroll a lot to reach the **Access** and **Language** fields:

![menu_item](https://user-images.githubusercontent.com/1217850/152164834-7719c8ca-d3c2-4309-bb15-dc281867eaf7.png)

### After PR
After the PR the **Access** and **Language** fields are easier to use because you don't have to scroll past the **Start Publishing** and **Finish Publishing** fields:

![details-v2](https://user-images.githubusercontent.com/1217850/152164938-c3d0f103-f856-4bf2-bf3b-bf0f17e12b4d.png)
