### PR TITLE
[4.1] MediaRSS link

### DIFF
--- a/libraries/src/Feed/Parser/Rss/MediaRssParser.php
+++ b/libraries/src/Feed/Parser/Rss/MediaRssParser.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Feed\Parser\NamespaceParserInterface;
 /**
  * RSS Feed Parser Namespace handler for MediaRSS.
  *
- * @link   http://video.search.yahoo.com/mrss
+ * @link   https://www.rssboard.org/media-rss
  * @since  3.1.4
  */
 class MediaRssParser implements NamespaceParserInterface


### PR DESCRIPTION
This PR doesnt do anything that is testable it just corrects the link in the comments

> Editor's Note: This is version 1.5.1 of the Media RSS specification, a namespace for RSS 2.0 published on Dec. 11, 2009. This is the official specification, which used to be at http://video.search.yahoo.com/mrss before the rights were transferred to the RSS Advisory Board in 2009. The current version always will be available at this link. Public comments are welcomed at RSS-Media.
