### PR TITLE
[4.2] Turn background image in MM into an img element

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -17,8 +17,8 @@
           loading="lazy"
           :width="width"
           :height="height"
-        />
-        <span v-if="!getURL" class="icon-eye-slash image-placeholder"></span>
+        >
+        <span v-if="!getURL" class="icon-eye-slash image-placeholder" aria-hidden="true"></span>
       </div>
     </div>
     <div

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -45,22 +45,12 @@ import { api } from '../../../app/Api.es6';
 export default {
   name: 'MediaBrowserItemImage',
   props: {
-    item: {
-      type: Object,
-      required: true,
-    },
-    focused: {
-      type: Boolean,
-      required: true,
-      default: false,
-    },
+    item: { type: Object, required: true, },
+    focused: { type: Boolean, required: true, default: false, },
   },
   data() {
     return {
-      showActions: {
-        type: Boolean,
-        default: false,
-      },
+      showActions: { type: Boolean, default: false, },
     };
   },
   computed: {

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -7,10 +7,14 @@
     <div class="media-browser-item-preview"
     :title="item.name">
       <div class="image-background">
-        <div
+        <img
           class="image-cropped"
-          :style="{ backgroundImage: getHashedURL }"
-        />
+          :src="getURL"
+          :alt="altTag"
+          loading="lazy"
+          :width="width"
+          :height="height"
+        >
       </div>
     </div>
     <div class="media-browser-item-info"
@@ -40,20 +44,39 @@ import { api } from '../../../app/Api.es6';
 
 export default {
   name: 'MediaBrowserItemImage',
-  // eslint-disable-next-line vue/require-prop-types
-  props: ['item', 'focused'],
+  props: {
+    item: {
+      type: Object,
+      required: true,
+    },
+    focused: {
+      type: Boolean,
+      required: true,
+      default: false,
+    },
+  },
   data() {
     return {
-      showActions: false,
+      showActions: {
+        type: Boolean,
+        default: false,
+      },
     };
   },
   computed: {
-    /* Get the hashed URL */
-    getHashedURL() {
-      if (this.item.adapter.startsWith('local-')) {
-        return `url(${this.item.thumb_path}?${api.mediaVersion})`;
-      }
-      return `url(${this.item.thumb_path})`;
+    getURL() {
+      return this.item.thumb_path.split(Joomla.getOptions('system.paths').rootFull).length > 1
+        ? `${this.item.thumb_path}?${api.mediaVersion}`
+        : `${this.item.thumb_path}`;
+    },
+    width() {
+      return this.item.width;
+    },
+    height() {
+      return this.item.height;
+    },
+    altTag() {
+      return this.item.name;
     },
   },
   methods: {

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -10,13 +10,15 @@
     >
       <div class="image-background">
         <img
+          v-if="getURL"
           class="image-cropped"
           :src="getURL"
           :alt="altTag"
           loading="lazy"
           :width="width"
           :height="height"
-        >
+        />
+        <span v-if="!getURL" class="icon-eye-slash image-placeholder"></span>
       </div>
     </div>
     <div

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -4,8 +4,10 @@
     @dblclick="openPreview()"
     @mouseleave="hideActions()"
   >
-    <div class="media-browser-item-preview"
-    :title="item.name">
+    <div
+      class="media-browser-item-preview"
+      :title="item.name"
+    >
       <div class="image-background">
         <img
           class="image-cropped"
@@ -17,8 +19,10 @@
         >
       </div>
     </div>
-    <div class="media-browser-item-info"
-    :title="item.name">
+    <div
+      class="media-browser-item-info"
+      :title="item.name"
+    >
       {{ item.name }} {{ item.filetype }}
     </div>
     <span
@@ -45,17 +49,17 @@ import { api } from '../../../app/Api.es6';
 export default {
   name: 'MediaBrowserItemImage',
   props: {
-    item: { type: Object, required: true, },
-    focused: { type: Boolean, required: true, default: false, },
+    item: { type: Object, required: true },
+    focused: { type: Boolean, required: true, default: false },
   },
   data() {
     return {
-      showActions: { type: Boolean, default: false, },
+      showActions: { type: Boolean, default: false },
     };
   },
   computed: {
     getURL() {
-      if(!this.item.thumb_path) {
+      if (!this.item.thumb_path) {
         return '';
       }
 

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -65,6 +65,10 @@ export default {
   },
   computed: {
     getURL() {
+      if(!this.item.thumb_path) {
+        return '';
+      }
+
       return this.item.thumb_path.split(Joomla.getOptions('system.paths').rootFull).length > 1
         ? `${this.item.thumb_path}?${api.mediaVersion}`
         : `${this.item.thumb_path}`;

--- a/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/image.vue
@@ -74,7 +74,7 @@ export default {
     },
   },
   methods: {
-    /* Check if the item is a document to edit */
+    /* Check if the item is an image to edit */
     canEdit() {
       return ['jpg', 'jpeg', 'png'].includes(this.item.extension.toLowerCase());
     },

--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -213,8 +213,8 @@
 
 .image-placeholder {
   display: flex;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   aspect-ratio: 1/1;
   max-width: 100%;
   height: auto;

--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -211,6 +211,16 @@
   border-radius: $grid-item-border-radius;
 }
 
+.image-placeholder {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  aspect-ratio: 1/1;
+  max-width: 100%;
+  height: auto;
+  color: #9d9d9d;
+}
+
 .file-background, .folder-background {
   padding-bottom: 100%;
   background-color: hsl(var(--hue), 20%, 97%);

--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -204,10 +204,10 @@
 }
 
 .image-cropped {
-  padding-bottom: 100%;
-  background-repeat: no-repeat;
-  background-position: center;
-  background-size: contain;
+  aspect-ratio: 1/1;
+  max-width: 100%;
+  height: auto;
+  object-fit: contain;
   border-radius: $grid-item-border-radius;
 }
 


### PR DESCRIPTION
Partial pull Request for Issue #36533.

### Summary of Changes
Turns the element which shows an image in the media manager from a background div into a propper image element. Full credit for this pr goes to @dgrammatiko as he is the original author in #36550.

### Testing Instructions
- Open the media manager list with the local adapter.
- Optionally you can also install the FTP adapter from DPmedia to test it with an external adapter.

### Actual result BEFORE applying this Pull Request
Image is shown as background image.

### Expected result AFTER applying this Pull Request
Image is shown as normal image with loading lazy attribute.