### PR TITLE
[4.1] empty state duplicated variables

### DIFF
--- a/layouts/joomla/content/emptystate.php
+++ b/layouts/joomla/content/emptystate.php
@@ -28,8 +28,6 @@ $title      = $displayData['title'] ?? Text::_($textPrefix . '_EMPTYSTATE_TITLE'
 $content    = $displayData['content'] ?? Text::_($textPrefix . '_EMPTYSTATE_CONTENT');
 $icon       = $displayData['icon'] ?? 'icon-copy article';
 $append     = $displayData['formAppend'] ?? '';
-$title      = $displayData['title'] ?? Text::_($textPrefix . '_EMPTYSTATE_TITLE');
-$content    = $displayData['content'] ?? Text::_($textPrefix . '_EMPTYSTATE_CONTENT');
 $btnadd     = $displayData['btnadd'] ?? Text::_($textPrefix . '_EMPTYSTATE_BUTTON_ADD');
 ?>
 


### PR DESCRIPTION
PR for #36935 

$title and $content were defined twice. Can be merged on code review
