### PR TITLE
 PHP 8.1 deprecation: strtolower()

### DIFF
--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -709,7 +709,7 @@ class BaseController implements ControllerInterface
 	{
 		$this->task = $task;
 
-		$task = strtolower($task);
+		$task = (isset($task) && $task) ? strtolower($task) : '';
 
 		if (isset($this->taskMap[$task]))
 		{


### PR DESCRIPTION
Problem like: #34952

This should fix the message:

Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in [..]/BaseController.php on line 712

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions

Check for set and not null before use, fallback empty string.

### Actual result BEFORE applying this Pull Request

php 8.1 warning

### Expected result AFTER applying this Pull Request

Be ready for future php versions.

### Documentation Changes Required

