### PR TITLE
[4.1] Remove readonly on media fields

### DIFF
--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -181,7 +181,7 @@ if (count($doc->getScriptOptions('media-picker')) === 0) {
 		</div>
 	<?php endif; ?>
 	<div class="input-group">
-		<input type="text" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" readonly="readonly" <?php echo $attr; ?>>
+		<input type="text" name="<?php echo $name; ?>" id="<?php echo $id; ?>" value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>" <?php echo $attr; ?>>
 		<?php if ($disabled != true) : ?>
 			<button type="button" class="btn btn-success button-select"><?php echo Text::_('JLIB_FORM_BUTTON_SELECT'); ?></button>
 			<button type="button" class="btn btn-danger button-clear"><span class="icon-times" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('JLIB_FORM_BUTTON_CLEAR'); ?></span></button>


### PR DESCRIPTION
PR for #28852 

The field was readonly for the reasons states by @dgrammatiko and I respect those views. But the request for the ability to paste an image url directly into the field by @coolcat-creations and others also makes sense.

As you can see its a super simple PR to achieve this. All the features of the media field are maintained and you can paste an image url directly. However when pasting a url you do not get the data attributes and lazy loading. I believe this to be an acceptable solution.

To test try to use the full article image or a custom media field and make sure you can still select an image and that you can now paste an image url