### PR TITLE
[4.1] template previews need size restrictions

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/pages/_com_templates.scss
+++ b/build/media_source/templates/administrator/atum/scss/pages/_com_templates.scss
@@ -45,4 +45,9 @@
       }
     }
   }
+
+  .thumbnail > img {
+    max-width: 100%;
+    max-height: 100%;
+  }
 }


### PR DESCRIPTION
pr for #35498

If a template developer supplies a template_thumbnail.jpg that is oversized then it _breaks_ the layout of the page.

## To Test
1. Delete media\templates\site\cassiopeia\images\template_thumbnail.png
2. Copy media\templates\site\cassiopeia\images\template_preview.png to template_thumbnail.png
3. Visit administrator/index.php?option=com_templates&view=templates&client_id=0 and you will see the oversized image
4. Apply this pr (and `npm run build:css` or use a prebuilt package
5. Visit the url in step 3 and you will see the image displayed resized to fit the column
