### PR TITLE
[3.10] Fix redirect updating new_url value

### DIFF
--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -278,11 +278,11 @@ class PlgSystemRedirect extends JPlugin
 
 				if ($urlQuery !== '' && empty($oldUrlParts['query']))
 				{
-					$new_url .= '?' . $urlQuery;
+					$newUrl .= '?' . $urlQuery;
 				}
 
-				$dest = JUri::isInternal($new_url) || strpos($new_url, 'http') === false ?
-					JRoute::_($new_url) : $new_url;
+				$dest = JUri::isInternal($newUrl) || strpos($newUrl, 'http') === false ?
+					JRoute::_($newUrl) : $newUrl;
 
 				// In case the url contains double // lets remove it
 				$destination = str_replace(JUri::root() . '/', JUri::root(), $dest);

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -274,13 +274,15 @@ class PlgSystemRedirect extends JPlugin
 
 				$oldUrlParts = parse_url($redirect->old_url);
 
+				$newUrl = $redirect->new_url;
+
 				if ($urlQuery !== '' && empty($oldUrlParts['query']))
 				{
-					$redirect->new_url .= '?' . $urlQuery;
+					$new_url .= '?' . $urlQuery;
 				}
 
-				$dest = JUri::isInternal($redirect->new_url) || strpos($redirect->new_url, 'http') === false ?
-					JRoute::_($redirect->new_url) : $redirect->new_url;
+				$dest = JUri::isInternal($new_url) || strpos($new_url, 'http') === false ?
+					JRoute::_($new_url) : $new_url;
 
 				// In case the url contains double // lets remove it
 				$destination = str_replace(JUri::root() . '/', JUri::root(), $dest);


### PR DESCRIPTION
Pull Request for Issue #36862 original work done by @[tonypartridge](https://github.com/tonypartridge) here: https://github.com/joomla/joomla-cms/pull/36873

### Summary of Changes
Remove the direct changes to the redirect object and updating of new_url 

### Testing Instructions

Without this PR add a redirect and publish it into com_redirects, for example:

Source:
/my-custom-error 
Destination
/my-real-live-page

access 
/my-custom-error?query_junk_here

### Actual result BEFORE applying this Pull Request

you are redirected to:
/my-real-live-page?query_junk_here

Try it again and you will see you are redirected to:
/my-real-live-page?query_junk_here?query_junk_here

Because before this PR the DB is updated.

### Expected result AFTER applying this Pull Request

You are redirected to: /my-custom-error?query_junk_here 
But your redirect in the database is not changed.

### Documentation Changes Required

None. But it has to be merged up to J4 once tested against 3.10