### PR TITLE
[4.1] storage of the e-mail address in com_privacy

### DIFF
--- a/components/com_privacy/src/Model/RequestModel.php
+++ b/components/com_privacy/src/Model/RequestModel.php
@@ -88,7 +88,7 @@ class RequestModel extends AdminModel
 			return false;
 		}
 
-		$email = Factory::getUser()->email;
+		$data['email'] = Factory::getUser()->email;
 
 		// Search for an open information request matching the email and type
 		$db    = $this->getDbo();
@@ -98,7 +98,7 @@ class RequestModel extends AdminModel
 			->where($db->quoteName('email') . ' = :email')
 			->where($db->quoteName('request_type') . ' = :requesttype')
 			->whereIn($db->quoteName('status'), [0, 1])
-			->bind(':email', $email)
+			->bind(':email', $data['email'])
 			->bind(':requesttype', $data['request_type']);
 
 		try
@@ -139,7 +139,7 @@ class RequestModel extends AdminModel
 
 		$messageModel->notifySuperUsers(
 			Text::_('COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_SUBJECT'),
-			Text::sprintf('COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_MESSAGE', $email)
+			Text::sprintf('COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_MESSAGE', $data['email'])
 		);
 
 		// The mailer can be set to either throw Exceptions or return boolean false, account for both
@@ -174,7 +174,7 @@ class RequestModel extends AdminModel
 			}
 
 			$mailer->addTemplateData($templateData);
-			$mailer->addRecipient($email);
+			$mailer->addRecipient($data['email']);
 
 			$mailer->send();
 


### PR DESCRIPTION
### Summary of Changes



### Testing Instructions

Steps to Reproduce:

1. Create a new menu item of the type Privacy -> Create Request
2. Log in to the frontend
3. Click on the menu item 'Create Request
4. Submit export or deletion request
5. check your mails -> there should be an email request
6. Click confirmation link
7. Confirm request on the website

### Actual result BEFORE applying this Pull Request

No e-mail address is stored in com_privacy when confirm the privacy request.
There is no matching between the sent e-mail with the token and the database entry!

![empty](https://user-images.githubusercontent.com/1752513/153047192-1f6d2517-b711-4a8b-91b6-13667f9435a4.jpg)

### Expected result AFTER applying this Pull Request

e-mail address is stored

![email-not-empty](https://user-images.githubusercontent.com/1752513/153047247-11af1810-e1ee-4888-8d14-4823bf7d8643.jpg)

### Documentation Changes Required

.