### PR TITLE
[4.1] [release blocker] The http head call returns a different structure than in J3

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -385,7 +385,7 @@ class UpdateModel extends BaseDatabaseModel
 		// Follow the Location headers until the actual download URL is known
 		while (isset($head->headers['location']))
 		{
-			$packageURL = $head->headers['location'];
+			$packageURL = (string) $head->headers['location'][0];
 
 			try
 			{


### PR DESCRIPTION
Pull Request for Issue reported by Jenn Gress

This is an release blocker as without a patch for this issue no update is possible anymore.

### Summary of Changes

The http head call returns a different structure than in J3
Within J3 it returns an string:
![image](https://user-images.githubusercontent.com/2596554/153075728-33271b17-6e0f-4258-a25b-6cb75a89e484.png)

On J4 it returns an array of strings while that header can only have one value?
![image](https://user-images.githubusercontent.com/2596554/153075987-97c63004-4323-46ac-9329-2d81a8aff51c.png)

### Testing Instructions

- Install 4.1.0-rc3
- set the update server to testing
- try to to reinistall 4.1.0-rc using the updater component

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/2596554/153076182-4257978c-7725-4e54-b663-98680c24012b.png)

### Expected result AFTER applying this Pull Request

Update works

### Documentation Changes Required

none

cc @bembelimen 