### PR TITLE
E-Mail Cloak: part of the TLD will not be truncated

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -102,8 +102,9 @@ class PlgContentEmailcloak extends CMSPlugin
 		$mode = (int) $this->params->def('mode', 1);
 		$mode = $mode === 1;
 
+		
 		// Example: any@example.org
-		$searchEmail = '([\w\.\'\-\+]+\@(?:[a-z0-9\.\-]+\.)+(?:[a-zA-Z0-9\-]{2,10}))';
+		$searchEmail = '([a-zA-Z0-9._-]+@([a-zA-Z0-9_-]+\.)+[a-zA-Z0-9_-]+)';
 
 		// Example: any@example.org?subject=anyText
 		$searchEmailLink = $searchEmail . '([?&][\x20-\x7f][^"<>]+)';


### PR DESCRIPTION
Pull Request for Issue  #36981 

**###Summary Of Changes**
$searchEmail = '([\w\.\'\-\+]+\@(?:[a-z0-9\.\-]+\.)+(?:[a-zA-Z0-9\-]{2,10}))'; 
This accepts only 10 characters due to which some emails were not picked by server and hence people were facing problem.

### Actual result BEFORE applying this Pull Request
Once the plugin(email-cloak) is activated, part of the TLD will be truncated. Example:
office@some.international
becomes:
office@some.internatio

### Expected result AFTER applying this Pull Request
E-mail will not be truncated
