### PR TITLE
Removed depriciation warnings in scss

### DIFF
--- a/build/media_source/com_media/scss/components/_layout.scss
+++ b/build/media_source/com_media/scss/components/_layout.scss
@@ -27,8 +27,8 @@
   position: relative;
   width: 100%;
   min-height: 1px;
-  padding-right: ($col-gutter-width / 2);
-  padding-left: ($col-gutter-width / 2);
+  padding-right: calc($col-gutter-width / 2);
+  padding-left: calc($col-gutter-width / 2);
 }
 
 @media (min-width: var(--breakpoint-md)) {

--- a/build/media_source/com_media/scss/components/_media-infobar.scss
+++ b/build/media_source/com_media/scss/components/_media-infobar.scss
@@ -27,8 +27,9 @@ $fa-css-prefix:    fa;
   dl {
     display: flex;
     flex-wrap: wrap;
-    margin-right: -($col-gutter-width / 2);
-    margin-left: -($col-gutter-width / 2);
+    // margin-right: calc((-$col-gutter-width) / 2);
+    margin-right: calc(calc($col-gutter-width / 2) * -1);
+    margin-left: calc(calc($col-gutter-width / 2) * -1);
   }
   dt, dd {
     position: relative;

--- a/build/media_source/com_media/scss/components/_media-infobar.scss
+++ b/build/media_source/com_media/scss/components/_media-infobar.scss
@@ -35,8 +35,8 @@ $fa-css-prefix:    fa;
     direction: ltr;
     width: 100%;
     min-height: 1px;
-    padding-right: ($col-gutter-width / 2);
-    padding-left: ($col-gutter-width / 2);
+    padding-right: calc($col-gutter-width / 2);
+    padding-left: calc($col-gutter-width / 2);
     [dir=rtl] & {
       text-align: end;
     }

--- a/build/media_source/com_media/scss/components/_media-infobar.scss
+++ b/build/media_source/com_media/scss/components/_media-infobar.scss
@@ -27,7 +27,6 @@ $fa-css-prefix:    fa;
   dl {
     display: flex;
     flex-wrap: wrap;
-    // margin-right: calc((-$col-gutter-width) / 2);
     margin-right: calc(calc($col-gutter-width / 2) * -1);
     margin-left: calc(calc($col-gutter-width / 2) * -1);
   }

--- a/build/media_source/com_media/scss/components/_media-tree.scss
+++ b/build/media_source/com_media/scss/components/_media-tree.scss
@@ -41,7 +41,7 @@ ul.media-tree {
   display: block;
   &::before {
     position: absolute;
-    top: ($sidebar-tree-line-height / 2);
+    top: calc($sidebar-tree-line-height / 2);
     left: 0;
     width: 10px;
     height: 1px;
@@ -61,7 +61,7 @@ ul.media-tree {
   }
   &:last-child {
     &::after {
-      height: ($sidebar-tree-line-height / 2);
+      height: calc($sidebar-tree-line-height / 2);
     }
   }
   li {

--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -75,12 +75,12 @@ $switcher-height: 28px;
 .switcher .toggle-inside {
   position: absolute;
   left: 0;
-  width: calc(($switcher-width - 6) / 2);
+  width: calc((calc($switcher-width - 6px)) / 2);
   height: $switcher-height;
   background: #fff;
   transition: .4s ease all;
 }
 
 .switcher input ~ input:checked ~ .toggle-outside .toggle-inside {
-  left: calc(($switcher-width / 2) - 1);
+  left: calc(($switcher-width / 2) - 1px);
 }

--- a/build/media_source/system/scss/fields/switcher.scss
+++ b/build/media_source/system/scss/fields/switcher.scss
@@ -75,12 +75,12 @@ $switcher-height: 28px;
 .switcher .toggle-inside {
   position: absolute;
   left: 0;
-  width: ($switcher-width - 6) / 2;
+  width: calc(($switcher-width - 6) / 2);
   height: $switcher-height;
   background: #fff;
   transition: .4s ease all;
 }
 
 .switcher input ~ input:checked ~ .toggle-outside .toggle-inside {
-  left: ($switcher-width / 2) - 1;
+  left: calc(($switcher-width / 2) - 1);
 }

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_back-to-top.scss
@@ -7,7 +7,7 @@
   inset-inline-end: 1rem;
   bottom: 1rem;
   z-index: 10000;
-  padding: $cassiopeia-grid-gutter/2;
+  padding: calc($cassiopeia-grid-gutter/2);
   color: var(--cassiopeia-color-primary, $standard-color-primary);
   pointer-events: all;
   background-color: var(--white, $white);

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_footer.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_footer.scss
@@ -9,7 +9,7 @@
   .grid-child {
     align-items: center;
     justify-content: space-between;
-    padding: 2.5rem ($cassiopeia-grid-gutter/2);
+    padding: 2.5rem calc($cassiopeia-grid-gutter/2);
   }
 
   a {

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_global.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_global.scss
@@ -84,7 +84,7 @@ a {
 .btn-group {
   margin-bottom: $cassiopeia-grid-gutter;
   > input {
-    padding: $cassiopeia-grid-gutter/2;
+    padding: calc($cassiopeia-grid-gutter/2);
     border: 1px solid $gray-400;
     @include border-start-radius($border-radius);
     @include border-end-radius(0);

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
@@ -12,12 +12,12 @@
   }
 
   .grid-child {
-    padding: ($cassiopeia-grid-gutter / 2);
+    padding: calc($cassiopeia-grid-gutter / 2);
   }
 
   nav {
     padding: 0;
-    margin-top: $cassiopeia-grid-gutter / 2;
+    margin-top: calc($cassiopeia-grid-gutter / 2);
   }
 
   .site-description {


### PR DESCRIPTION
Pull Request for Issue #36991 .

### Summary of Changes

included "calc" before every bracket where warning occured in scss files

### Testing Instructions

hit "npm run build:css" in the root folder the warnings of depriciation will appear

### Actual result BEFORE applying this Pull Request

there will be warnings of depreciation in scss

### Expected result AFTER applying this Pull Request

only few warnings related to fontawsome will remain in the directory of media\vendor rest all warnings will be cleared

### Documentation Changes Required
no