### PR TITLE
[4.1] [PHP 8.1] Fix Deprecated notice: strtolower(): Passing null to string in components/com_ajax/ajax.php on line 39

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -36,7 +36,7 @@ $app->setHeader('X-Robots-Tag', 'noindex, nofollow');
 $input = $app->input;
 
 // Requested format passed via URL
-$format = strtolower($input->getWord('format'));
+$format = strtolower($input->getWord('format', ''));
 
 // Initialize default response and module name
 $results = null;


### PR DESCRIPTION
Pull Request for Issue # none

### Summary of Changes

Fixes `Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in components/com_ajax/ajax.php on line 39`

### Testing Instructions

Code-review or

With PHP 8.1 try accessing:
`http://localhost/.../index.php/component/ajax/?plugin=RunSchedulerWebcron&group=system&hash=ERoRNEvIxx8cLCIho0T2`

(without `&format=raw`)

### Actual result BEFORE applying this Pull Request

Error `Deprecated: strtolower(): Passing null to parameter #1 ($string) of type string is deprecated in components/com_ajax/ajax.php on line 39`

### Expected result AFTER applying this Pull Request

This error disappears.

### Documentation Changes Required

None.
