### PR TITLE
[4.1] [Scheduler] [BugFix] WebCron failing when no scheduled tasks are defined, with "message":"A key is required" and Fatal error "Table '#_users' was not locked with LOCK TABLES"

### DIFF
--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -399,11 +399,13 @@ class TaskModel extends AdminModel
 			}
 			catch (\RuntimeException $e)
 			{
+				$db->unlockTables();
 				return null;
 			}
 
 			if ($runningCount !== 0)
 			{
+				$db->unlockTables();
 				return null;
 			}
 		}
@@ -470,6 +472,13 @@ class TaskModel extends AdminModel
 			}
 			catch (\RuntimeException $e)
 			{
+				$db->unlockTables();
+				return null;
+			}
+
+			if (count($ids) === 0)
+			{
+				$db->unlockTables();
 				return null;
 			}
 

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -400,12 +400,14 @@ class TaskModel extends AdminModel
 			catch (\RuntimeException $e)
 			{
 				$db->unlockTables();
+
 				return null;
 			}
 
 			if ($runningCount !== 0)
 			{
 				$db->unlockTables();
+
 				return null;
 			}
 		}
@@ -473,12 +475,14 @@ class TaskModel extends AdminModel
 			catch (\RuntimeException $e)
 			{
 				$db->unlockTables();
+
 				return null;
 			}
 
 			if (count($ids) === 0)
 			{
 				$db->unlockTables();
+
 				return null;
 			}
 


### PR DESCRIPTION
Pull Request for Issue # none

### Summary of Changes

This is due to `throw new \InvalidArgumentException('A key is required');` in `DatabaseQuery` because there are no tasks ids in the WHERE clause of the query.

Additionally, it was triggering a second bug:
`Fatal error: Uncaught mysqli_sql_exception: Table '#_users' was not locked with LOCK TABLES in 4.1/libraries/vendor/joomla/database/src/Mysqli/MysqliStatement.php on line 137`

This also fixes other `return` statements that did not unlock the table, blocking it for further processings.

### Testing Instructions

In System/Scheduled Tasks, Options, Enable WebCron without having set any scheduled tasks. Then copy URL of webcron, and access it.

### Actual result BEFORE applying this Pull Request

```
{"success":false,"message":"A key is required","messages":null,"data":null}<br />
<font size='1'><table class='xdebug-error xe-uncaught-exception' dir='ltr' border='1' cellspacing='0' cellpadding='1'>
<tr><th align='left' bgcolor='#f57900' colspan="5"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> Fatal error: Uncaught mysqli_sql_exception: Table 'j40b5_users' was not locked with LOCK TABLES in /home/beat/www/4.1/libraries/vendor/joomla/database/src/Mysqli/MysqliStatement.php on line <i>137</i></th></tr>
<tr><th align='left' bgcolor='#f57900' colspan="5"><span style='background-color: #cc0000; color: #fce94f; font-size: x-large;'>( ! )</span> mysqli_sql_exception: Table 'j40b5_users' was not locked with LOCK TABLES in /home/beat/www/4.1/libraries/vendor/joomla/database/src/Mysqli/MysqliStatement.php on line <i>137</i></th></tr>
<tr><th align='left' bgcolor='#e9b96e' colspan='5'>Call Stack</th></tr>
<tr><th align='center' bgcolor='#eeeeec'>#</th><th align='left' bgcolor='#eeeeec'>Time</th><th align='left' bgcolor='#eeeeec'>Memory</th><th align='left' bgcolor='#eeeeec'>Function</th><th align='left' bgcolor='#eeeeec'>Location</th></tr>
<tr><td bgcolor='#eeeeec' align='center'>1</td><td bgcolor='#eeeeec' align='center'>0.1191</td><td bgcolor='#eeeeec' align='right'>2032256</td><td bgcolor='#eeeeec'>Joomla\CMS\Session\Storage\JoomlaStorage->close(  )</td><td title='/home/beat/www/4.1/libraries/src/Session/Storage/JoomlaStorage.php' bgcolor='#eeeeec'>.../JoomlaStorage.php<b>:</b>0</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>2</td><td bgcolor='#eeeeec' align='center'>0.1191</td><td bgcolor='#eeeeec' align='right'>2032728</td><td bgcolor='#eeeeec'>Joomla\Registry\Registry->__clone(  )</td><td title='/home/beat/www/4.1/libraries/src/Session/Storage/JoomlaStorage.php' bgcolor='#eeeeec'>.../JoomlaStorage.php<b>:</b>133</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>3</td><td bgcolor='#eeeeec' align='center'>0.1191</td><td bgcolor='#eeeeec' align='right'>2036824</td><td bgcolor='#eeeeec'><a href='http://www.php.net/function.unserialize' target='_new'>unserialize</a>( <span>$data = </span><span>&#39;O:8:&quot;stdClass&quot;:3:{s:7:&quot;session&quot;;O:8:&quot;stdClass&quot;:3:{s:7:&quot;counter&quot;;i:101;s:5:&quot;timer&quot;;O:8:&quot;stdClass&quot;:3:{s:5:&quot;start&quot;;i:1643824340;s:4:&quot;last&quot;;i:1644622963;s:3:&quot;now&quot;;i:1644623430;}s:5:&quot;token&quot;;s:32:&quot;e71c60635cf8a71d0e7e80587ff8aeec&quot;;}s:8:&quot;registry&quot;;O:24:&quot;Joomla\\Registry\\Registry&quot;:3:{s:7:&quot;\000*\000data&quot;;O:8:&quot;stdClass&quot;:0:{}s:14:&quot;\000*\000initialized&quot;;b:0;s:9:&quot;separator&quot;;s:1:&quot;.&quot;;}s:4:&quot;user&quot;;O:20:&quot;Joomla\\CMS\\User\\User&quot;:1:{s:2:&quot;id&quot;;i:915;}}&#39;</span> )</td><td title='/home/beat/www/4.1/libraries/vendor/joomla/registry/src/Registry.php' bgcolor='#eeeeec'>.../Registry.php<b>:</b>80</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>4</td><td bgcolor='#eeeeec' align='center'>0.1191</td><td bgcolor='#eeeeec' align='right'>2056936</td><td bgcolor='#eeeeec'>Joomla\CMS\User\User->__wakeup(  )</td><td title='/home/beat/www/4.1/libraries/vendor/joomla/registry/src/Registry.php' bgcolor='#eeeeec'>.../Registry.php<b>:</b>80</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>5</td><td bgcolor='#eeeeec' align='center'>0.1191</td><td bgcolor='#eeeeec' align='right'>2057072</td><td bgcolor='#eeeeec'>Joomla\CMS\User\User->load( <span>$id = </span><span>915</span> )</td><td title='/home/beat/www/4.1/libraries/src/User/User.php' bgcolor='#eeeeec'>.../User.php<b>:</b>920</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>6</td><td bgcolor='#eeeeec' align='center'>0.1193</td><td bgcolor='#eeeeec' align='right'>2059136</td><td bgcolor='#eeeeec'>Joomla\CMS\Table\User->load( <span>$userId = </span><span>915</span>, <span>$reset = </span>??? )</td><td title='/home/beat/www/4.1/libraries/src/User/User.php' bgcolor='#eeeeec'>.../User.php<b>:</b>858</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>7</td><td bgcolor='#eeeeec' align='center'>0.1195</td><td bgcolor='#eeeeec' align='right'>2062160</td><td bgcolor='#eeeeec'>Joomla\Database\DatabaseDriver->setQuery( <span>$query = </span><span>class Joomla\Database\Mysqli\MysqliQuery { protected $bounded = [&#39;:userid&#39; =&gt; class stdClass { ... }]; protected $parameterMapping = [&#39;boolean&#39; =&gt; &#39;boolean&#39;, &#39;int&#39; =&gt; &#39;int&#39;, &#39;lob&#39; =&gt; &#39;lob&#39;, &#39;null&#39; =&gt; &#39;null&#39;, &#39;string&#39; =&gt; &#39;string&#39;]; protected $db = class Joomla\Database\Mysqli\MysqliDriver { private ${Joomla\Database\DatabaseDriver}database = &#39;j4&#39;; public $name = &#39;mysqli&#39;; public $serverType = &#39;mysql&#39;; protected $connection = class mysqli { ... }; protected $count = 18; protected $cursor = NULL; protected $executed = FALSE; protected $limit = 1; protected $nameQuote = &#39;`&#39;; protected $nullDate = &#39;0000-00-00 00:00:00&#39;; protected $offset = 0; protected $options = [...]; protected $sql = class Joomla\Database\Mysqli\MysqliQuery { ... }; protected $statement = class Joomla\Database\Mysqli\MysqliStatement { ... }; protected $tablePrefix = &#39;j40b5_&#39;; protected $utf = TRUE; protected $errorNum = 0; protected $errorMsg = NULL; protected $transactionDepth = 0; protected $factory = class Joomla\Database\DatabaseFactory { ... }; protected $monitor = class Joomla\Database\Monitor\DebugMonitor { ... }; private ${Joomla\Database\DatabaseDriver}dispatcher = class Joomla\Event\Dispatcher { ... }; protected $utf8mb4 = TRUE; protected $mariadb = FALSE }; protected $sql = NULL; protected $type = &#39;select&#39;; protected $alias = NULL; protected $element = NULL; protected $select = class Joomla\Database\Query\QueryElement { protected $name = &#39;SELECT&#39;; protected $elements = [...]; protected $glue = &#39;,&#39; }; protected $delete = NULL; protected $update = NULL; protected $insert = NULL; protected $from = class Joomla\Database\Query\QueryElement { protected $name = &#39;FROM&#39;; protected $elements = [...]; protected $glue = &#39;,&#39; }; protected $join = NULL; protected $set = NULL; protected $where = class Joomla\Database\Query\QueryElement { protected $name = &#39;WHERE&#39;; protected $elements = [...]; protected $glue = &#39; AND &#39; }; protected $group = NULL; protected $having = NULL; protected $columns = NULL; protected $values = NULL; protected $order = NULL; protected $autoIncrementField = FALSE; protected $call = NULL; protected $exec = NULL; protected $merge = NULL; protected $querySet = NULL; protected $selectRowNumber = NULL; protected $nullDatetimeList = [0 =&gt; &#39;0000-00-00 00:00:00&#39;, 1 =&gt; &#39;1000-01-01 00:00:00&#39;]; protected $offset = 0; protected $limit = 0; protected $preparedIndex = 0 }</span>, <span>$offset = </span>???, <span>$limit = </span>??? )</td><td title='/home/beat/www/4.1/libraries/src/Table/User.php' bgcolor='#eeeeec'>.../User.php<b>:</b>104</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>8</td><td bgcolor='#eeeeec' align='center'>0.1195</td><td bgcolor='#eeeeec' align='right'>2062240</td><td bgcolor='#eeeeec'>Joomla\Database\Mysqli\MysqliDriver->prepareStatement( <span>$query = </span><span>&#39;SELECT *\nFROM `j40b5_users`\nWHERE `id` = :userid&#39;</span> )</td><td title='/home/beat/www/4.1/libraries/vendor/joomla/database/src/DatabaseDriver.php' bgcolor='#eeeeec'>.../DatabaseDriver.php<b>:</b>1900</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>9</td><td bgcolor='#eeeeec' align='center'>0.1195</td><td bgcolor='#eeeeec' align='right'>2062464</td><td bgcolor='#eeeeec'>Joomla\Database\Mysqli\MysqliStatement->__construct( <span>$connection = </span><span>class mysqli { public $affected_rows = -1; public $client_info = &#39;mysqlnd 8.1.2&#39;; public $client_version = 80102; public $connect_errno = 0; public $connect_error = NULL; public $errno = 1100; public $error = &#39;Table \&#39;j40b5_users\&#39; was not locked with LOCK TABLES&#39;; public $error_list = [0 =&gt; [...]]; public $field_count = 1; public $host_info = &#39;Localhost via UNIX socket&#39;; public $info = NULL; public $insert_id = 0; public $server_info = &#39;8.0.28-0ubuntu0.20.04.3&#39;; public $server_version = 80028; public $sqlstate = &#39;HY000&#39;; public $protocol_version = 10; public $thread_id = 200; public $warning_count = 0 }</span>, <span>$query = </span><span>&#39;SELECT *\nFROM `j40b5_users`\nWHERE `id` = :userid&#39;</span> )</td><td title='/home/beat/www/4.1/libraries/vendor/joomla/database/src/Mysqli/MysqliDriver.php' bgcolor='#eeeeec'>.../MysqliDriver.php<b>:</b>1048</td></tr>
<tr><td bgcolor='#eeeeec' align='center'>10</td><td bgcolor='#eeeeec' align='center'>0.1196</td><td bgcolor='#eeeeec' align='right'>2062952</td><td bgcolor='#eeeeec'><a href='http://www.php.net/mysqli.prepare' target='_new'>prepare</a>( <span>$query = </span><span>&#39;SELECT *\nFROM `j40b5_users`\nWHERE `id` = ?&#39;</span> )</td><td title='/home/beat/www/4.1/libraries/vendor/joomla/database/src/Mysqli/MysqliStatement.php' bgcolor='#eeeeec'>.../MysqliStatement.php<b>:</b>137</td></tr>
</table></font>
```

### Expected result AFTER applying this Pull Request

{"success":true,"message":null,"messages":null,"data":[]}

### Documentation Changes Required

None.
