### PR TITLE
Update README.md instruction to use https for github cloning instead of ssh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Joomla! CMS™ 
+Joomla! CMS™
 ====================
 
 Build Status
@@ -39,7 +39,7 @@ You will need:
 **Steps to setup the local environment:**
 - Clone the repository:
 ```bash
-git clone git@github.com:joomla/joomla-cms.git
+git clone https://github.com/joomla/joomla-cms.git
 ```
 - Go to the joomla-cms folder:
 ```bash


### PR DESCRIPTION
Pull Request for Issue # none

### Summary of Changes

github https read access is public, while ssh access [requires a Github account with an active SSH key](https://docs.github.com/en/get-started/getting-started-with-git/about-remote-repositories))

https github remote access does not require creating and confirming a github account, generating a ssh key-pair and uploading the public key to be able to just clone, like ssh does. Additionally these first steps are **not** described in the current README.md.

This lowers a bit the barrier to test from sources, without having negative effects.

Only Joomla main repository code committers have advantages with ssh, and they know that github also provides ssh access, so no documentation needed for those in the README.md.

This separates PR #37019 into 2 parts, this being the trivial one.

### Testing Instructions

- By testing:
Just install git and try `git clone https://github.com/joomla/joomla-cms.git` from the instructions you get a joomla-cms folder with joomla in it (it will only be runnable after having applying the other parts.

- Or by change-review:
Just check that the cloning path of this MR (`https://github.com/joomla/joomla-cms.git`) is identical to the public cloning path on this Github repository, in the "Code v" button -> clone-> using https link.

### Actual result BEFORE applying this Pull Request

If you only install git, but don't create/have a github account and ssh keys uploaded with local private key, and follow the README.md, you get following result:

```
git clone git@github.com:joomla/joomla-cms.git
Cloning into 'joomla-cms'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

### Expected result AFTER applying this Pull Request

If, with same setup you use the new instruction, success:

```
$ git clone https://github.com/joomla/joomla-cms.git
Cloning into 'joomla-cms'...
remote: Enumerating objects: 859132, done.
remote: Counting objects: 100% (74/74), done.
remote: Compressing objects: 100% (47/47), done.
remote: Total 859132 (delta 43), reused 27 (delta 27), pack-reused 859058
Receiving objects: 100% (859132/859132), 291.49 MiB | 16.43 MiB/s, done.
Resolving deltas: 100% (573592/573592), done.

$ ls joomla-cms/
administrator       composer.json  libraries               README.txt
api                 composer.lock  LICENSE.txt             robots.txt.dist
build               htaccess.txt   modules                 templates
build.xml           images         package.json            tests
cache               includes       package-lock.json       tmp
cli                 index.php      phpunit-pgsql.xml.dist  web.config.txt
codeception.yml     installation   phpunit.xml.dist
CODE_OF_CONDUCT.md  language       plugins
components          layouts        README.md
```


### Documentation Changes Required

