### PR TITLE
Fix immediate fatal error on CLI scheduler:run --all

### DIFF
--- a/libraries/src/Console/TasksRunCommand.php
+++ b/libraries/src/Console/TasksRunCommand.php
@@ -106,7 +106,7 @@ class TasksRunCommand extends AbstractCommand
 		foreach ($records as $record)
 		{
 			$cStart   = microtime(true);
-			$task     = $scheduler->runTask(['id' => $record->id, 'allowDisabled' => true, 'allowConcurrent' => true]);
+			$task     = $scheduler->runTask(['id' => (int) $record->id, 'allowDisabled' => true, 'allowConcurrent' => true]);
 			$exit     = empty($task) ? Status::NO_RUN : $task->getContent()['status'];
 			$duration = microtime(true) - $cStart;
 			$key      = (\array_key_exists($exit, $outTextMap)) ? $exit : 'N/A';


### PR DESCRIPTION
### Summary of Changes

Fix the following immediate fatal error when running `php ./joomla.php scheduler:run --all`:

```
In OptionsResolver.php line 1060:
                                                                               
  The option "id" with value "1" is expected to be of type "int", but is of type "string".                                                                
```

Tagging @bembelimen

### Testing Instructions

Create a scheduled task

From a terminal go to your site's CLI directory and run `php ./joomla.php scheduler:run --all`

### Actual result BEFORE applying this Pull Request

Fatal error:
```
In OptionsResolver.php line 1060:
                                                                               
  The option "id" with value "1" is expected to be of type "int", but is of type "string".                                                                
```

### Expected result AFTER applying this Pull Request

The task runs correctly.

### Documentation Changes Required

None.

### Further information

While this solves the immediate problem observed I believe a better place to address it is `Joomla\Component\Scheduler\Administrator\Scheduler\Scheduler::runTask`. Since the ID will always have to be an integer shouldn't you check if it's a numeric value and type–cast to integer?

PS: Yes, I have now started writing real-world code for Joomla's scheduled tasks. Sorry it took me so long, everything got pushed back by a month while our kid was sick and out of school. We are finally back to normal and trying to catch up!