### PR TITLE
Fix tasks never running when using the PDO MySQL driver

### DIFF
--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -498,10 +498,12 @@ class TaskModel extends AdminModel
 		}
 		finally
 		{
+			$affectedRows = $db->getAffectedRows();
+
 			$db->unlockTables();
 		}
 
-		if ($db->getAffectedRows() != 1)
+		if ($affectedRows != 1)
 		{
 			/*
 			 // @todo


### PR DESCRIPTION
### Summary of Changes

Scheduled Tasks never run when using the PDO MySQL database driver in Joomla. The CLI script replies with 
`<warning>Task#01 'CLI only backup at midnight' failed to run. Is it already running?</warning>`

That's because you are trying to find the number of affected rows after unlocking the tables once you have tried to set a lock timestamp on the task row. However, this means that you trying to find out how many rows where affected by unlocking the tables, not how many tasks were affected by the UPDATE command which sets the lock timestamp! Therefore tasks remained locked without running.

This problem does not happen with the MySQLi driver because it operates differently under the hood. Fun times!

Tagging @bembelimen since this is a release blocker!

### Testing Instructions

Make sure your site is using the PDO MySQL database driver. **THIS IS NOT REPRODUCIBLE WITH THE mysqli DRIVER**.

Create a new scheduled task.

Try to execute it with `php ./joomla.php scheduler:run --all` (AFTER applying my other PR https://github.com/joomla/joomla-cms/pull/37034 which solves yet another issue with scheduled tasks).

### Actual result BEFORE applying this Pull Request

You get the error
`<warning>Task#01 'CLI only backup at midnight' failed to run. Is it already running?</warning>`

### Expected result AFTER applying this Pull Request

The task runs!

### Documentation Changes Required

None.