### PR TITLE
[4.1] updated language filenames to non-prefixed names

### DIFF
--- a/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
+++ b/administrator/modules/mod_multilangstatus/mod_multilangstatus.xml
@@ -15,8 +15,8 @@
 	</files>
 
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.mod_multilangstatus.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.mod_multilangstatus.sys.ini</language>
+		<language tag="en-GB">language/en-GB/mod_multilangstatus.ini</language>
+		<language tag="en-GB">language/en-GB/mod_multilangstatus.sys.ini</language>
 	</languages>
 
 	<help key="Admin_Modules:_Multilingual_Status" />

--- a/administrator/modules/mod_version/mod_version.xml
+++ b/administrator/modules/mod_version/mod_version.xml
@@ -16,8 +16,8 @@
 		<folder>tmpl</folder>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.mod_version.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.mod_version.sys.ini</language>
+		<language tag="en-GB">language/en-GB/mod_version.ini</language>
+		<language tag="en-GB">language/en-GB/mod_version.sys.ini</language>
 	</languages>
 	<help key="Admin_Modules:_Joomla_Version_Information" />
 	<config>

--- a/modules/mod_finder/mod_finder.xml
+++ b/modules/mod_finder/mod_finder.xml
@@ -16,8 +16,8 @@
 		<folder>tmpl</folder>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.mod_finder.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.mod_finder.sys.ini</language>
+		<language tag="en-GB">language/en-GB/mod_finder.ini</language>
+		<language tag="en-GB">language/en-GB/mod_finder.sys.ini</language>
 	</languages>
 	<help key="Site_Modules:_Smart_Search" />
 	<config>

--- a/plugins/filesystem/local/local.xml
+++ b/plugins/filesystem/local/local.xml
@@ -16,8 +16,8 @@
 	</files>
 
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_filesystem_local.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_filesystem_local.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_filesystem_local.ini</language>
+		<language tag="en-GB">language/en-GB/plg_filesystem_local.sys.ini</language>
 	</languages>
 
 	<config>

--- a/plugins/finder/categories/categories.xml
+++ b/plugins/finder/categories/categories.xml
@@ -13,7 +13,7 @@
 		<filename plugin="categories">categories.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_finder_categories.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_finder_categories.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_finder_categories.ini</language>
+		<language tag="en-GB">language/en-GB/plg_finder_categories.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/finder/contacts/contacts.xml
+++ b/plugins/finder/contacts/contacts.xml
@@ -13,7 +13,7 @@
 		<filename plugin="contacts">contacts.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_finder_contacts.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_finder_contacts.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_finder_contacts.ini</language>
+		<language tag="en-GB">language/en-GB/plg_finder_contacts.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/finder/content/content.xml
+++ b/plugins/finder/content/content.xml
@@ -13,7 +13,7 @@
 		<filename plugin="content">content.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_finder_content.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_finder_content.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_finder_content.ini</language>
+		<language tag="en-GB">language/en-GB/plg_finder_content.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/finder/newsfeeds/newsfeeds.xml
+++ b/plugins/finder/newsfeeds/newsfeeds.xml
@@ -13,7 +13,7 @@
 		<filename plugin="newsfeeds">newsfeeds.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_finder_newsfeeds.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_finder_newsfeeds.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_finder_newsfeeds.ini</language>
+		<language tag="en-GB">language/en-GB/plg_finder_newsfeeds.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/finder/tags/tags.xml
+++ b/plugins/finder/tags/tags.xml
@@ -13,7 +13,7 @@
 		<filename plugin="tags">tags.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_finder_tags.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_finder_tags.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_finder_tags.ini</language>
+		<language tag="en-GB">language/en-GB/plg_finder_tags.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/system/highlight/highlight.xml
+++ b/plugins/system/highlight/highlight.xml
@@ -13,7 +13,7 @@
 		<filename plugin="highlight">highlight.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_system_highlight.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_system_highlight.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_system_highlight.ini</language>
+		<language tag="en-GB">language/en-GB/plg_system_highlight.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/system/languagecode/languagecode.xml
+++ b/plugins/system/languagecode/languagecode.xml
@@ -13,8 +13,8 @@
 		<filename plugin="languagecode">languagecode.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_system_languagecode.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_system_languagecode.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_system_languagecode.ini</language>
+		<language tag="en-GB">language/en-GB/plg_system_languagecode.sys.ini</language>
 	</languages>
 	<config>
 		<fields name="params">

--- a/plugins/webservices/banners/banners.xml
+++ b/plugins/webservices/banners/banners.xml
@@ -13,7 +13,7 @@
 		<filename plugin="banners">banners.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_banners.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_banners.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_banners.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_banners.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/config/config.xml
+++ b/plugins/webservices/config/config.xml
@@ -13,7 +13,7 @@
 		<filename plugin="config">config.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_config.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_config.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_config.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_config.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/contact/contact.xml
+++ b/plugins/webservices/contact/contact.xml
@@ -13,7 +13,7 @@
 		<filename plugin="contact">contact.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_contact.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_contact.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_contact.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_contact.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/content/content.xml
+++ b/plugins/webservices/content/content.xml
@@ -13,7 +13,7 @@
 		<filename plugin="content">content.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_content.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_content.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_content.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_content.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/languages/languages.xml
+++ b/plugins/webservices/languages/languages.xml
@@ -13,7 +13,7 @@
 		<filename plugin="languages">languages.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_languages.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_languages.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_languages.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_languages.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/media/media.xml
+++ b/plugins/webservices/media/media.xml
@@ -13,7 +13,7 @@
 		<filename plugin="media">media.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_media.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_media.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_media.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_media.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/menus/menus.xml
+++ b/plugins/webservices/menus/menus.xml
@@ -13,7 +13,7 @@
 		<filename plugin="menus">menus.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_menus.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_menus.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_menus.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_menus.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/messages/messages.xml
+++ b/plugins/webservices/messages/messages.xml
@@ -13,7 +13,7 @@
 		<filename plugin="messages">messages.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_messages.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_messages.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_messages.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_messages.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/modules/modules.xml
+++ b/plugins/webservices/modules/modules.xml
@@ -13,7 +13,7 @@
 		<filename plugin="modules">modules.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_modules.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_modules.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_modules.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_modules.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/newsfeeds/newsfeeds.xml
+++ b/plugins/webservices/newsfeeds/newsfeeds.xml
@@ -13,7 +13,7 @@
 		<filename plugin="newsfeeds">newsfeeds.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_newsfeeds.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_newsfeeds.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_newsfeeds.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_newsfeeds.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/plugins/plugins.xml
+++ b/plugins/webservices/plugins/plugins.xml
@@ -13,7 +13,7 @@
 		<filename plugin="plugins">plugins.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_plugins.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_plugins.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_plugins.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_plugins.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/privacy/privacy.xml
+++ b/plugins/webservices/privacy/privacy.xml
@@ -13,7 +13,7 @@
 		<filename plugin="privacy">privacy.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_privacy.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_privacy.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_privacy.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_privacy.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/redirect/redirect.xml
+++ b/plugins/webservices/redirect/redirect.xml
@@ -13,7 +13,7 @@
 		<filename plugin="redirect">redirect.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_redirect.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_redirect.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_redirect.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_redirect.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/tags/tags.xml
+++ b/plugins/webservices/tags/tags.xml
@@ -13,7 +13,7 @@
 		<filename plugin="tags">tags.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_tags.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_tags.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_tags.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_tags.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/templates/templates.xml
+++ b/plugins/webservices/templates/templates.xml
@@ -13,7 +13,7 @@
 		<filename plugin="templates">templates.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_templates.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_templates.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_templates.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_templates.sys.ini</language>
 	</languages>
 </extension>

--- a/plugins/webservices/users/users.xml
+++ b/plugins/webservices/users/users.xml
@@ -13,7 +13,7 @@
 		<filename plugin="users">users.php</filename>
 	</files>
 	<languages>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_users.ini</language>
-		<language tag="en-GB">language/en-GB/en-GB.plg_webservices_users.sys.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_users.ini</language>
+		<language tag="en-GB">language/en-GB/plg_webservices_users.sys.ini</language>
 	</languages>
 </extension>


### PR DESCRIPTION
At https://joomla.stackexchange.com/a/31948/13472 Sharky wrote that we should use non-prefixed filenames in Joomla 4.x and that some core manifest files haven't been updated yet. Hence this PR to update them.

### Summary of Changes

This PR updates the core manifest files and removes the language prefix from the file names. For example:
``<language tag="en-GB">language/en-GB/en-GB.mod_multilangstatus.ini</language>``
has been changed to
``<language tag="en-GB">language/en-GB/mod_multilangstatus.ini</language>``
