### PR TITLE
[4.1] page class not suffix

### DIFF
--- a/components/com_contact/tmpl/form/edit.php
+++ b/components/com_contact/tmpl/form/edit.php
@@ -22,7 +22,7 @@ $this->tab_name         = 'com-contact-form';
 $this->ignore_fieldsets = array('details', 'item_associations', 'language');
 $this->useCoreUI        = true;
 ?>
-<div class="edit item-page <?php echo $this->pageclass_sfx; ?>">
+<div class="edit item-page<?php echo $this->pageclass_sfx ? ' ' . $this->pageclass_sfx : ''; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>

--- a/components/com_contact/tmpl/form/edit.php
+++ b/components/com_contact/tmpl/form/edit.php
@@ -22,7 +22,7 @@ $this->tab_name         = 'com-contact-form';
 $this->ignore_fieldsets = array('details', 'item_associations', 'language');
 $this->useCoreUI        = true;
 ?>
-<div class="edit item-page<?php echo $this->pageclass_sfx; ?>">
+<div class="edit item-page <?php echo $this->pageclass_sfx; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -33,7 +33,7 @@ $currentDate       = Factory::getDate()->format('Y-m-d H:i:s');
 $isNotPublishedYet = $this->item->publish_up > $currentDate;
 $isExpired         = !is_null($this->item->publish_down) && $this->item->publish_down < $currentDate;
 ?>
-<div class="com-content-article item-page<?php echo $this->pageclass_sfx; ?>" itemscope itemtype="https://schema.org/Article">
+<div class="com-content-article item-page <?php echo $this->pageclass_sfx; ?>" itemscope itemtype="https://schema.org/Article">
 	<meta itemprop="inLanguage" content="<?php echo ($this->item->language === '*') ? Factory::getApplication()->get('language') : $this->item->language; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 	<div class="page-header">

--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -33,7 +33,7 @@ $currentDate       = Factory::getDate()->format('Y-m-d H:i:s');
 $isNotPublishedYet = $this->item->publish_up > $currentDate;
 $isExpired         = !is_null($this->item->publish_down) && $this->item->publish_down < $currentDate;
 ?>
-<div class="com-content-article item-page <?php echo $this->pageclass_sfx; ?>" itemscope itemtype="https://schema.org/Article">
+<div class="com-content-article item-page<?php echo $this->pageclass_sfx ? ' ' . $this->pageclass_sfx : ''; ?>" itemscope itemtype="https://schema.org/Article">
 	<meta itemprop="inLanguage" content="<?php echo ($this->item->language === '*') ? Factory::getApplication()->get('language') : $this->item->language; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 	<div class="page-header">

--- a/components/com_privacy/tmpl/confirm/default.php
+++ b/components/com_privacy/tmpl/confirm/default.php
@@ -19,7 +19,7 @@ HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');
 
 ?>
-<div class="request-confirm <?php echo $this->pageclass_sfx; ?>">
+<div class="request-confirm<?php echo $this->pageclass_sfx ? ' ' . $this->pageclass_sfx : ''; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>

--- a/components/com_privacy/tmpl/confirm/default.php
+++ b/components/com_privacy/tmpl/confirm/default.php
@@ -19,7 +19,7 @@ HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');
 
 ?>
-<div class="request-confirm<?php echo $this->pageclass_sfx; ?>">
+<div class="request-confirm <?php echo $this->pageclass_sfx; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>

--- a/components/com_privacy/tmpl/remind/default.php
+++ b/components/com_privacy/tmpl/remind/default.php
@@ -19,7 +19,7 @@ HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');
 
 ?>
-<div class="remind-confirm<?php echo $this->pageclass_sfx; ?>">
+<div class="remind-confirm <?php echo $this->pageclass_sfx; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>

--- a/components/com_privacy/tmpl/remind/default.php
+++ b/components/com_privacy/tmpl/remind/default.php
@@ -19,7 +19,7 @@ HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');
 
 ?>
-<div class="remind-confirm <?php echo $this->pageclass_sfx; ?>">
+<div class="remind-confirm<?php echo $this->pageclass_sfx ? ' ' . $this->pageclass_sfx : ''; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>

--- a/components/com_privacy/tmpl/request/default.php
+++ b/components/com_privacy/tmpl/request/default.php
@@ -19,7 +19,7 @@ HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');
 
 ?>
-<div class="request-form<?php echo $this->pageclass_sfx; ?>">
+<div class="request-form <?php echo $this->pageclass_sfx; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>

--- a/components/com_privacy/tmpl/request/default.php
+++ b/components/com_privacy/tmpl/request/default.php
@@ -19,7 +19,7 @@ HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');
 
 ?>
-<div class="request-form <?php echo $this->pageclass_sfx; ?>">
+<div class="request-form<?php echo $this->pageclass_sfx ? ' ' . $this->pageclass_sfx : ''; ?>">
 	<?php if ($this->params->get('show_page_heading')) : ?>
 		<div class="page-header">
 			<h1>

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -51,7 +51,7 @@ if (substr($className, -1) === 's')
 
 $tagsData = $category->tags->itemTags;
 ?>
-<div class="<?php echo $className . '-category' . $displayData->pageclass_sfx; ?>">
+<div class="<?php echo $className . '-category' . ' ' . $displayData->pageclass_sfx; ?>">
 	<?php if ($params->get('show_page_heading')) : ?>
 		<h1>
 			<?php echo $displayData->escape($params->get('page_heading')); ?>

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -51,7 +51,7 @@ if (substr($className, -1) === 's')
 
 $tagsData = $category->tags->itemTags;
 ?>
-<div class="<?php echo $className . '-category' . ' ' . $displayData->pageclass_sfx; ?>">
+<div class="<?php echo $className . '-category'; ?><?php echo $displayData->pageclass_sfx ? ' ' . $displayData->pageclass_sfx : ''; ?>">
 	<?php if ($params->get('show_page_heading')) : ?>
 		<h1>
 			<?php echo $displayData->escape($params->get('page_heading')); ?>


### PR DESCRIPTION
Pull Request for Issue #37047 .



The option to set a page class on a menu item sets a class on the body tag. But in some places it is also used on the container div of the component. As it is a class and not a suffix now (despite the name which wasnt changed for bc) this PR ensures that it is used as a class and not a suffix. ie there is a space before the page class.

PS not sure if this page class should even be used here so an alternative would be to remove it from these files