### PR TITLE
[3.10][PHP 8.1] Remove properties of legacy extension class (#37035)

### DIFF
--- a/libraries/legacy/exception/exception.php
+++ b/libraries/legacy/exception/exception.php
@@ -27,24 +27,6 @@ class JException extends Exception
 	protected $level = null;
 
 	/**
-	 * Error code.
-	 *
-	 * @var    string
-	 * @since  1.5
-	 * @deprecated  1.7
-	 */
-	protected $code = null;
-
-	/**
-	 * Error message.
-	 *
-	 * @var    string
-	 * @since  1.5
-	 * @deprecated  1.7
-	 */
-	protected $message = null;
-
-	/**
 	 * Additional info about the error relevant to the developer,
 	 * for example, if a database connect fails, the dsn used
 	 *
@@ -53,24 +35,6 @@ class JException extends Exception
 	 * @deprecated  1.7
 	 */
 	protected $info = '';
-
-	/**
-	 * Name of the file the error occurred in [Available if backtrace is enabled]
-	 *
-	 * @var    string
-	 * @since  1.5
-	 * @deprecated  1.7
-	 */
-	protected $file = null;
-
-	/**
-	 * Line number the error occurred in [Available if backtrace is enabled]
-	 *
-	 * @var    integer
-	 * @since  1.5
-	 * @deprecated  1.7
-	 */
-	protected $line = 0;
 
 	/**
 	 * Name of the method the error occurred in [Available if backtrace is enabled]


### PR DESCRIPTION
Pull Request for Issue #37035 . 404 pages throw a blank page / 500 status code instead of displaying the default 404 page. This is due to a compile time error in the legacy exception class used internally to create the 404 error page.

### Summary of Changes

The legacy extension class re-declares properties already declared in PHP's default exception class.
Starting with PHP 8.1, all the protected properties got type hints in the upstream definition and thus cannot be redeclared without specifying type hints in the overriding class. Adding those type hints would be of course no viable solution, as this is not possible with php 5.x (no type hint support) and would even be a compile time error on all PHP versions up to PHP 8.0.

(This is a b/c break between PHP 8.0 and 8.1, though this should not occur between two minor versions. In the [relevant discussion](https://externals.io/message/115683) on the PHP mailing list, the re-declaration of already defined core properties was just defined as unsupported...)

Removing the re-declared properties from Joomla's legacy exception class should fix the issue. After some research, this fix should work on all PHP versions supported by Joomla 3.10, but I did not test old PHP versions manually.

### Testing Instructions
1. Install Joomla 3.10.x on a host with PHP 8.1 or any lower version, use template protostar.
2. Try to access a non-existing page on the frontend while running PHP 8.1, see no 404 error page
3. Apply this patch
4. Try again with (still with PHP 8.1), a 404 page should show as expected.

### Actual result BEFORE applying this Pull Request
Accessing a non-existent page in the frontend displays a white page / 500 error instead of a 404 page.


### Expected result AFTER applying this Pull Request
Accessing a non-existent page in the frontend displays a standard 404 page.

### Documentation Changes Required

