### PR TITLE
[4.1] Fileinfo check

### DIFF
--- a/administrator/components/com_admin/src/Model/SysinfoModel.php
+++ b/administrator/components/com_admin/src/Model/SysinfoModel.php
@@ -261,6 +261,7 @@ class SysinfoModel extends BaseDatabaseModel
 			'zlib'                => \extension_loaded('zlib'),
 			'zip'                 => \function_exists('zip_open') && \function_exists('zip_read'),
 			'mbstring'            => \extension_loaded('mbstring'),
+			'fileinfo'            => \extension_loaded('fileinfo'),
 			'gd'                  => \extension_loaded('gd'),
 			'iconv'               => \function_exists('iconv'),
 			'intl'                => \function_exists('transliterator_transliterate'),

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
@@ -145,7 +145,7 @@ use Joomla\CMS\Language\Text;
 			</tr>
 			<tr>
 				<th scope="row">
-				<?php echo Text::sprintf('COM_ADMIN_EXTENSION_AVAILABLE', 'Fileinfo'); ?>
+					<?php echo Text::sprintf('COM_ADMIN_EXTENSION_AVAILABLE', 'Fileinfo'); ?>
 				</th>
 				<td class="break-word">
 					<?php echo HTMLHelper::_('phpsetting.set', $this->phpSettings['fileinfo']); ?>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
@@ -145,6 +145,14 @@ use Joomla\CMS\Language\Text;
 			</tr>
 			<tr>
 				<th scope="row">
+				<?php echo Text::sprintf('COM_ADMIN_EXTENSION_AVAILABLE', 'Fileinfo'); ?>
+				</th>
+				<td class="break-word">
+					<?php echo HTMLHelper::_('phpsetting.set', $this->phpSettings['fileinfo']); ?>
+				</td>
+			</tr>
+			<tr>
+				<th scope="row">
 					<?php echo Text::_('COM_ADMIN_MBSTRING_ENABLED'); ?>
 				</th>
 				<td>

--- a/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
+++ b/administrator/components/com_admin/tmpl/sysinfo/default_phpsettings.php
@@ -147,7 +147,7 @@ use Joomla\CMS\Language\Text;
 				<th scope="row">
 					<?php echo Text::sprintf('COM_ADMIN_EXTENSION_AVAILABLE', 'Fileinfo'); ?>
 				</th>
-				<td class="break-word">
+				<td>
 					<?php echo HTMLHelper::_('phpsetting.set', $this->phpSettings['fileinfo']); ?>
 				</td>
 			</tr>


### PR DESCRIPTION
Despite the php extension fileinfo being enabled by default in php we have had quite a few users who are discovering that media manager will not load. This is because they have fileinfo disabled on the server.

This PR adds fileinfo to the list of php settings shown in the system information.

To test
Install the PR and check the php settings page of the system information and you will see the new line "Fileinfo Available" which hopefully has a setting of yes.

In your php.ini file locate the line with `extension=fileinfo` and comment it out by placing at ; at the beginning of the line.

Then restart apache

Now when you go to media manager you will see the reported error.

![image](https://user-images.githubusercontent.com/1296369/154492343-3eb9943f-4374-4179-a883-45ce1574fbfe.png)

Check the php settings page of the system information and you will see that fileinfo is not available

![image](https://user-images.githubusercontent.com/1296369/154492549-4403f523-1f4a-4496-b516-323751e2693a.png)

Now go back to php.ini and uncomment that line

Restart apache

And check that media manager works and the system setting shows fileinfo is available

![image](https://user-images.githubusercontent.com/1296369/154492695-c9acb6bc-6a34-4bc3-98cd-9d4828aa2a16.png)
