### PR TITLE
[4.1] Fix:  "Undefined variable $id"

### DIFF
--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -34,7 +34,7 @@ if (!empty($options['showonEnabled']))
 
 $class           = empty($options['class']) ? '' : ' ' . $options['class'];
 $rel             = empty($options['rel']) ? '' : ' ' . $options['rel'];
-$id              = ($id ?: $name) . '-desc';
+$id              = ($id ?? $name) . '-desc';
 $hideLabel       = !empty($options['hiddenLabel']);
 $hideDescription = empty($options['hiddenDescription']) ? false : $options['hiddenDescription'];
 $descClass       = ($options['descClass'] ?? '') ?: 'hide-aware-inline-help';


### PR DESCRIPTION
Regression of #35610.

### Summary of Changes

This pull request changes from "elvis operator" to "null coalescing operator", which automatically includes an isset() and "not null" check.

"null coalescing operator" was introduced in PHP7.0 - as Joomla 4.1 requires min PHP7.2.5 this change should not break anything.

### Testing Instructions

Joomla 4.1 / PHP8.0.15 in combination with iCagenda pro 3.8.0-beta2 custom fields.

### Actual result BEFORE applying this Pull Request

Warning Message with custom fields from iCagenda:
> Warning: Undefined variable $id in layouts/joomla/form/renderfield.php on line 37

Other extensions may be affected too.

### Expected result AFTER applying this Pull Request

No warning message anymore

### Documentation Changes Required

No
