### PR TITLE
[4.1] Module "Articles - Categories" - Make the category selection optional

### DIFF
--- a/modules/mod_articles_categories/mod_articles_categories.xml
+++ b/modules/mod_articles_categories/mod_articles_categories.xml
@@ -30,7 +30,6 @@
 					extension="com_content"
 					filter="integer"
 					published=""
-					required="true"
 					select="true"
 					new="true"
 					edit="true"


### PR DESCRIPTION
The module "Articles - Categories" requires to select a parent category. But that means you can't have the module show *all* categories, you can only show a subset.

I think this is a requirement which is not needed. The code itself already falls back to "root" if no category is selected.

### Summary of Changes
Removing the "required" flag from the parent category field.


### Testing Instructions
Test the module "Articles - Categories" and make especially sure nothing breaks when no category is selected.


### Actual result BEFORE applying this Pull Request
You always need to select a category and the module shows only subset of the article categories.


### Expected result AFTER applying this Pull Request
You don't need to select a category and the module can show all categories.


### Documentation Changes Required
None