### PR TITLE
Module caching breaks WebAssetsManager

### DIFF
--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -700,6 +700,52 @@ class Cache
 								}
 							}
 						}
+
+						// Special treatment for the WebAssetManager assets
+						if ($now === 'assetManager'
+							&& \is_array($newvalue)
+							&& \is_array($options['headerbefore'][$now])
+							&& isset($newvalue['assets'])
+							&& \is_array($newvalue['assets'])
+							&& isset($options['headerbefore'][$now]['assets'])
+							&& \is_array($options['headerbefore'][$now]['assets'])
+						)
+						{
+							$newAssets = $newvalue['assets'];
+							$oldAssets = $options['headerbefore'][$now]['assets'];
+
+							foreach ($newAssets as $type => &$listOfNewAssets)
+							{
+								if (!array_key_exists($type, $oldAssets)
+									|| !\is_array($oldAssets[$type])
+									|| empty($oldAssets[$type] ?? [])
+									|| !\is_array($listOfNewAssets)
+									|| empty($listOfNewAssets)
+								)
+								{
+									continue;
+								}
+
+								$filter = function ($asset) use ($oldAssets, $type) {
+									return !in_array($asset, $oldAssets[$type]);
+								};
+								$listOfNewAssets = array_filter($listOfNewAssets, $filter);
+							}
+
+							$filter = function ($inner) {
+								return !empty($inner);
+							};
+							$newAssets = array_filter($newAssets, $filter);
+
+							if (empty($newAssets))
+							{
+								unset($newvalue['assets']);
+							}
+							else
+							{
+								$newvalue['assets'] = $newAssets;
+							}
+						}
 					}
 					else
 					{


### PR DESCRIPTION
Pull Request for Issue #37122.

### Summary of Changes

Modified the `Joomla\CMS\Cache\Cache::setWorkarounds` to do a special treatment of the WebAssetManager assets before they are cached when caching a module.

### Testing Instructions

* Install a new Joomla 4.1 site (I used the latest 4.1-dev as of February 23rd, 2022)
* Do NOT install any sample data
* Components, Contacts, Contacts, Add Your First Contact and create a contact in the Uncategorised group
* Menus, Main Menu, New
	- Menu item type: Contacts, List All Categories in a Contact category Tree
	- Title: Contacts
	- Alias: contacts
* Save & Close
* System, Global Configuration and set the following in the System tab
	- System Cache: ON - Conservative Caching (VERY IMPORTANT! Do not use Progressive, that caching type makes it harder to reproduce the issue as I explain in the very long technical explanation below)
	- Cache Handler: File
	- Platform Specific Caching: No
	- Cache Time (minutes): 60
* Click on Save & Close
* System, Clear Cache, Delete All

Go to the frontend of your site and click through **IN THIS EXACT ORDER**:
* Contacts
* Uncategorised

### Actual result BEFORE applying this Pull Request

Unsatisfied dependency "com_categories.shared-categories-accordion.es5" for an asset "com_categories.shared-categories-accordion" of type "script"

### Expected result AFTER applying this Pull Request

I can see the contacts

### Documentation Changes Required

None.

### Important

Please look at the referenced issue's “Additional comments”. This can be a security issue for some sites.