### PR TITLE
[4.1] fields in users dashboard

### DIFF
--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -156,7 +156,7 @@ abstract class Menu
 					$createFields = ComponentHelper::getParams(strstr($query['context'], '.', true))->get('custom_fields_enable', 1);
 				}
 
-				if (!$createFields)
+				if (!$createFields || !$user->authorise('core.manage', 'com_users'))
 				{
 					$parent->removeChild($item);
 					continue;


### PR DESCRIPTION
If a user has access to com_messages but not to com_users then the user dashboard still displays the fields options which all lead to a 403.

This PR check to make sure the user has permission

## before
![image](https://user-images.githubusercontent.com/1296369/155532470-16dd1ad1-2081-4f2b-b5cd-97a0e69d9d45.png)

## after
![image](https://user-images.githubusercontent.com/1296369/155532397-ffdbc116-a503-4cc0-b8d5-606659dc2935.png)
