### PR TITLE
Better module cache

### DIFF
--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -656,75 +656,38 @@ class Cache
 		{
 			if ($loptions['modulemode'] == 1)
 			{
-				$headnow = $document->getHeadData();
-				$unset   = array('title', 'description', 'link', 'links', 'metaTags');
+				$headNow = $document->getHeadData();
+				$unset   = ['title', 'description', 'link', 'links', 'metaTags'];
 
-				foreach ($unset as $un)
+				foreach ($unset as $key)
 				{
-					unset($headnow[$un]);
-					unset($options['headerbefore'][$un]);
+					unset($headNow[$key]);
 				}
 
-				$cached['head'] = [];
-
-				// Only store what this module has added
-				foreach ($headnow as $now => $value)
+				// Sanitize empty data
+				foreach (\array_keys($headNow) as $key)
 				{
-					if (isset($options['headerbefore'][$now]))
+					if (!isset($headNow[$key]) || $headNow[$key] === [])
 					{
-						// We have to serialize the content of the arrays because the may contain other arrays which is a notice in PHP 5.4 and newer
-						$nowvalue    = array_map('serialize', $headnow[$now]);
-						$beforevalue = array_map('serialize', $options['headerbefore'][$now]);
-
-						$newvalue = array_diff_assoc($nowvalue, $beforevalue);
-						$newvalue = array_map('unserialize', $newvalue);
-
-						// Special treatment for script and style declarations.
-						if (($now === 'script' || $now === 'style') && \is_array($newvalue) && \is_array($options['headerbefore'][$now]))
-						{
-							foreach ($newvalue as $type => $currentScriptStr)
-							{
-								if (isset($options['headerbefore'][$now][strtolower($type)]))
-								{
-									$oldScriptStr = $options['headerbefore'][$now][strtolower($type)];
-
-									// Save only the appended declaration.
-									if (\is_array($oldScriptStr) && \is_array($currentScriptStr))
-									{
-										$newvalue[strtolower($type)] = array_diff_key($currentScriptStr, $oldScriptStr);
-									}
-									else
-									{
-										$newvalue[strtolower($type)] = StringHelper::substr($currentScriptStr, StringHelper::strlen($oldScriptStr));
-									}
-								}
-							}
-						}
-					}
-					else
-					{
-						$newvalue = $headnow[$now];
-					}
-
-					if (!empty($newvalue))
-					{
-						$cached['head'][$now] = $newvalue;
+						unset($headNow[$key]);
 					}
 				}
+
+				$cached['head'] = $headNow;
 			}
 			else
 			{
 				$cached['head'] = $document->getHeadData();
+
+				// Document MIME encoding
+				$cached['mime_encoding'] = $document->getMimeEncoding();
 			}
 		}
-
-		// Document MIME encoding
-		$cached['mime_encoding'] = $document->getMimeEncoding();
 
 		// Pathway data
 		if ($app->isClient('site') && $loptions['nopathway'] != 1)
 		{
-			$cached['pathway'] = \is_array($data) && isset($data['pathway']) ? $data['pathway'] : $app->getPathway()->getPathway();
+			$cached['pathway'] = $data['pathway'] ?? $app->getPathway()->getPathway();
 		}
 
 		if ($loptions['nomodules'] != 1)

--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Cache\Exception\CacheExceptionInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Path;
 use Joomla\CMS\Session\Session;
-use Joomla\String\StringHelper;
 
 /**
  * Joomla! Cache base object

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -18,7 +18,6 @@ use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Utility\Utility;
-use Joomla\CMS\WebAsset\WebAssetManager;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -173,10 +173,7 @@ class HtmlDocument extends Document
 		{
 			foreach ($assetNames as $assetName => $assetState)
 			{
-				if ($assetState === WebAssetManager::ASSET_STATE_ACTIVE)
-				{
-					$waState['assets'][$assetType][] = $wa->getAsset($assetType, $assetName);
-				}
+				$waState['assets'][$assetType][] = $wa->getAsset($assetType, $assetName);
 			}
 		}
 

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -154,6 +154,20 @@ class WebAssetManager implements WebAssetManagerInterface
 	}
 
 	/**
+	 * Clears all collected items.
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	public function reset(): WebAssetManagerInterface
+	{
+		$this->activeAssets = [];
+		$this->locked = false;
+		$this->dependenciesIsActual = false;
+
+		return $this;
+	}
+
+	/**
 	 * Adds support for magic method calls
 	 *
 	 * @param   string  $method     A method name

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -156,6 +156,8 @@ class WebAssetManager implements WebAssetManagerInterface
 	/**
 	 * Clears all collected items.
 	 *
+	 * @return self
+	 *
 	 * @since  __DEPLOY_VERSION__
 	 */
 	public function reset(): WebAssetManagerInterface

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -162,8 +162,12 @@ class WebAssetManager implements WebAssetManagerInterface
 	 */
 	public function reset(): WebAssetManagerInterface
 	{
+		if ($this->locked)
+		{
+			throw new InvalidActionException('WebAssetManager is locked');
+		}
+
 		$this->activeAssets = [];
-		$this->locked = false;
 		$this->dependenciesIsActual = false;
 
 		return $this;

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -163,7 +163,6 @@ class WebAssetManager implements WebAssetManagerInterface
 	public function reset(): WebAssetManagerInterface
 	{
 		$this->activeAssets = [];
-		$this->locked = false;
 		$this->dependenciesIsActual = false;
 
 		return $this;

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -163,6 +163,7 @@ class WebAssetManager implements WebAssetManagerInterface
 	public function reset(): WebAssetManagerInterface
 	{
 		$this->activeAssets = [];
+		$this->locked = false;
 		$this->dependenciesIsActual = false;
 
 		return $this;


### PR DESCRIPTION
### Summary of Changes

Please check https://github.com/joomla/joomla-cms/issues/37122 and https://github.com/joomla/joomla-cms/pull/35776

Now, before rendering the cached module, we empty the document and WebAssetmanager data, hence the module cache contains all data added by a module.

### Testing Instructions

Apply patch, enable Joomla caching, load page with cached modules

### Actual result BEFORE applying this Pull Request

Module cache doesn't have own assets if they were also added before module render.

### Expected result AFTER applying this Pull Request

Module cache always have own assets in cache.

### Documentation Changes Required

No.