### PR TITLE
Made items in the media tree of media manager keyboard accessible

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/tree/item.vue
+++ b/administrator/components/com_media/resources/scripts/components/tree/item.vue
@@ -6,7 +6,7 @@
     :aria-level="level"
     :aria-setsize="size"
     :aria-posinset="counter"
-    :tabindex="getTabindex"
+    :tabindex="0"
   >
     <a @click.stop.prevent="onItemClick()">
       <span class="item-icon"><span :class="iconClass" /></span>

--- a/administrator/components/com_media/resources/scripts/components/tree/item.vue
+++ b/administrator/components/com_media/resources/scripts/components/tree/item.vue
@@ -6,9 +6,8 @@
     :aria-level="level"
     :aria-setsize="size"
     :aria-posinset="counter"
-    :tabindex="0"
   >
-    <a @click.stop.prevent="onItemClick()">
+    <a tabindex="0" @click.stop.prevent="onItemClick()" @keyup.right="onItemClick()">
       <span class="item-icon"><span :class="iconClass" /></span>
       <span class="item-name">{{ item.name }}</span>
     </a>


### PR DESCRIPTION
Pull Request for Issue #37117.

### Summary of Changes
solved the first issue from the issue #37117, i.e. made the items in the media tree of the media manager, keyboard accessible 



### Testing Instructions
open the media manger of Joomla-CMS then click in the media tree section and press tab key
Press the right arrow key on any node to open it



### Actual result BEFORE applying this Pull Request
You were not able to access any item of the media tree section using tab key


### Expected result AFTER applying this Pull Request
You are able to access each item of the media tree section using tab key


<img width="272" alt="Screenshot 2022-02-26 at 8 48 04 PM" src="https://user-images.githubusercontent.com/78909027/155848506-a2065d4a-8e1c-4e20-aa12-73c82b57fdcb.png">


### Documentation Changes Required
No changes required.
