### PR TITLE
[4.1] Fix wrong sequence next values in PostgreSQL installation SQL scripts

### DIFF
--- a/installation/sql/postgresql/extensions.sql
+++ b/installation/sql/postgresql/extensions.sql
@@ -790,7 +790,7 @@ INSERT INTO "#__action_logs_extensions" ("id", "extension") VALUES
 (18, 'com_checkin'),
 (19, 'com_scheduler');
 
-SELECT setval('#__action_logs_extensions_id_seq', 19, false);
+SELECT setval('#__action_logs_extensions_id_seq', 20, false);
 -- --------------------------------------------------------
 
 --
@@ -833,7 +833,7 @@ INSERT INTO "#__action_log_config" ("id", "type_title", "type_alias", "id_holder
 (20, 'task', 'com_scheduler.task', 'id', 'title', '#__scheduler_tasks', 'PLG_ACTIONLOG_JOOMLA');
 
 
-SELECT setval('#__action_log_config_id_seq', 20, false);
+SELECT setval('#__action_log_config_id_seq', 21, false);
 
 --
 -- Table structure for table `#__action_logs_users`


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes the next sequence values in PostgreSQL installation SQL scripts which have been forgotten to change when new records for the task scheduler were added with PR #35143 .

Some more wrong values from that PR e.g. for the assets table have already been fixed by someone with some other PR.

### Testing Instructions

Code review by someone who knows how sequences work on PostgreSQL, or make a new installation using a PostgreSQL database and then try to insert new records into tables "#__action_logs_extensions" or "#__action_log_config".

### Actual result BEFORE applying this Pull Request

Inserting a new record fails with error about duplicate primary key, e.g.:

> ERROR: duplicate key value violates unique constraint "j4ux0_action_logs_extensions_pkey" DETAIL: Key (id)=(19) already exists.

### Expected result AFTER applying this Pull Request

Inserting a new record works, and the new ID has the right value.

### Documentation Changes Required

None.