### PR TITLE
[4.1] Fix the update version fix of the database fix for 3rd party extensions

### DIFF
--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -650,7 +650,7 @@ class DatabaseModel extends InstallerModel
 				$table->get('element'),
 				$table->get('type'),
 				$table->get('client_id'),
-				$table->get('element') === 'plugin' ? $table->get('folder') : null
+				$table->get('type') === 'plugin' ? $table->get('folder') : null
 			);
 			$extensionVersion = (string) $installationXML->version;
 		}

--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -646,7 +646,12 @@ class DatabaseModel extends InstallerModel
 		}
 		else
 		{
-			$installationXML  = InstallerHelper::getInstallationXML($table->get('element'), $table->get('type'));
+			$installationXML = InstallerHelper::getInstallationXML(
+					$table->get('element'),
+					$table->get('type'),
+					$table->get('client_id'),
+					$table->get('element') === 'plugin' ? $table->get('folder') : null
+			);
 			$extensionVersion = (string) $installationXML->version;
 		}
 

--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -647,10 +647,10 @@ class DatabaseModel extends InstallerModel
 		else
 		{
 			$installationXML = InstallerHelper::getInstallationXML(
-					$table->get('element'),
-					$table->get('type'),
-					$table->get('client_id'),
-					$table->get('element') === 'plugin' ? $table->get('folder') : null
+				$table->get('element'),
+				$table->get('type'),
+				$table->get('client_id'),
+				$table->get('element') === 'plugin' ? $table->get('folder') : null
 			);
 			$extensionVersion = (string) $installationXML->version;
 		}


### PR DESCRIPTION
Pull Request for Issue #37124 .

### Summary of Changes

This pull request (PR) fixes the database checker's method for fixing the update version so it finds the manifest XML in all cases and so uses the right extension version and not an empty string when being used for 3rd party extensions.

At other places in the same source file it is already done in the right way, e.g. here
https://github.com/joomla/joomla-cms/blob/4.1-dev/administrator/components/com_installer/src/Model/DatabaseModel.php#L192-L196
or here
https://github.com/joomla/joomla-cms/blob/4.1-dev/administrator/components/com_installer/src/Model/DatabaseModel.php#L563-L568

The issue is only relevant for J4 because the functionality of the database checker to check not only the CMS core but also 3rd party extensions is a new J4 feature.

### Testing Instructions

1. Install a plugin which includes an `<update>` tag in its manifest XML and has some update SQL scripts.
You can use the following dummy plugin: https://test5.richard-fath.de/plg_test_pr_37160.zip

2. Go to "System - Manage - Database".

3. Check that there is no problem shown for that plugin.

4. Select the row of the plugin and use the "Fix Structure" button regardless of no problems being shown.
Result: Now there is one problem shown for the plugin.

5. Hover over the badge with the "1 problem" to see the details.
Result: The problem is about not matching versions, of which one is an empty string.
See screenshot in section "Actual result BEFORE applying this Pull Request" below.

6. Apply the patch of this PR.

7. Go back to "System - Manage - Database".
Result: The problem from step 4 is still shown.

8. Select the row of that plugin (check box) and use the "Fix structure" button.
Result: No problem shown.

9. Repeat step 8 a few times to be sure it works well now.

10. Finally test if there is no issue with using the fix button for any other kind of extension which has update SQL scripts. You can use the patchtester extension for this test.

### Actual result BEFORE applying this Pull Request

When using the "Fix structure" button of the database checker for a 3rd party plugin or a 3rd party backend module which come with own update SQL scripts so they are shown in the checker, the version in the manifest cache is set to an empty string, so after the fix you have this database problem:

![pr-37160_1](https://user-images.githubusercontent.com/7413183/156150269-3d5ca600-aeb2-4fac-b831-e8376e5ddbe7.png)

### Expected result AFTER applying this Pull Request

When using the "Fix structure" button of the database checker for a 3rd party plugin or a 3rd party backend module which come with own update SQL scripts so they are shown in the checker, the version in the manifest cache is set to the right value from the manifest XML file, so there are no problems shown after using the "Fix Structure" button..

![pr-37160_2](https://user-images.githubusercontent.com/7413183/156153745-5fc5e21e-283e-43c1-9a9d-5b493f08dc53.png)

### Documentation Changes Required

None.