### PR TITLE
[4.1] com_users login div

### DIFF
--- a/components/com_users/tmpl/login/default_login.php
+++ b/components/com_users/tmpl/login/default_login.php
@@ -113,8 +113,6 @@ $usersConfig = ComponentHelper::getParams('com_users');
 			<?php echo HTMLHelper::_('form.token'); ?>
 		</fieldset>
 	</form>
-</div>
-<div>
 	<div class="com-users-login__options list-group">
 		<a class="com-users-login__reset list-group-item" href="<?php echo Route::_('index.php?option=com_users&view=reset'); ?>">
 			<?php echo Text::_('COM_USERS_LOGIN_RESET'); ?>


### PR DESCRIPTION
Every view has a single containing div except for the login page which has two divs.

This creates issues when styling if for example you wanted to put a border around the div or a background. Every page but this one will have one box. This one will have two.

To test add the following code immediately after the head in the site template

	`<style>main>[class^="com-"]{background-color:grey; border:5px solid black;}</style>`

### Before
![image](https://user-images.githubusercontent.com/1296369/156263708-4dbf93e4-485a-4fd7-8f3d-1aa1725ac91e.png)


### After
![image](https://user-images.githubusercontent.com/1296369/156263766-eb6d7a5e-f7ec-4c18-897f-bbc0e33d013b.png)
