### PR TITLE
Add support ID with 0 for value CheckboxField.php

### DIFF
--- a/libraries/src/Form/Field/CheckboxField.php
+++ b/libraries/src/Form/Field/CheckboxField.php
@@ -138,7 +138,7 @@ class CheckboxField extends FormField
 	protected function getLayoutData()
 	{
 		$data            = parent::getLayoutData();
-		$data['value']   = $this->default ?: '1';
+		$data['value']	 = $this->default || $this->default === '0' ? $this->default : '1';
 		$data['checked'] = $this->checked || $this->value;
 
 		return $data;


### PR DESCRIPTION
This amendment concerns to use this field to pass ID as an argument. If we use this field not in an XML file but in a dynamic table of fields.  In each row of the table, we use the Checkbox to select a row number or select an ID in the list. After activating these checkboxes, we mark which of the parameter lists with which ID we have activated. 
I believe that the original code implied the use of checkboxes as just a parameter in the static configuration of the settings page, not to select an ID, but simply to select certain settings. 
Therefore, such a subtlety as using the value '0' as a value was not taken into account. 
My change does not violate compatibility and does not violate the default settings. 
And of course it would be stupid on the part of external developers to use the value '0' of the attribute to get an activated checkbox. 
Because the value '0' is interpreted as an empty value and we get an active checkbox. In this way, it is stupid to mark activity using unreadable, this is a stupid approach to activate the checkbox.
Therefore, I suggest using the value '0' as the value for ID selection.