### PR TITLE
[4.2] Remove PHP 5.3 compatibility code in HTMLHelper

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -286,15 +286,7 @@ abstract class HTMLHelper
 	 */
 	protected static function call(callable $function, $args)
 	{
-		// PHP 5.3 workaround
-		$temp = array();
-
-		foreach ($args as &$arg)
-		{
-			$temp[] = &$arg;
-		}
-
-		return \call_user_func_array($function, $temp);
+		return \call_user_func_array($function, $args);
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
Removes some PHP 5.3 compatibility code in the `HTMLHelper` class. Should probably go into 5.0.

### Testing Instructions
Browse Joomla.

### Actual result BEFORE applying this Pull Request
All works.

### Expected result AFTER applying this Pull Request
All works.