### PR TITLE
[4.1] remove db prefix from action logs

### DIFF
--- a/plugins/actionlog/joomla/joomla.php
+++ b/plugins/actionlog/joomla/joomla.php
@@ -992,7 +992,7 @@ class PlgActionlogJoomla extends ActionLogPlugin
 			'userid'      => $user->id,
 			'username'    => $user->username,
 			'accountlink' => 'index.php?option=com_users&task=user.edit&id=' . $user->id,
-			'table'       => $table,
+			'table'       => str_replace($this->db->getPrefix(), '#__', $table),
 		);
 
 		$this->addLog(array($message), 'PLG_ACTIONLOG_JOOMLA_USER_CHECKIN', $context, $user->id);


### PR DESCRIPTION
When performing a checkin of an article from the article manager then the log says `performed a check in to table #__content`
When performing a checkin using the global checkin then the log says` performed a check in to table jos_content`

This pr standardises and remove the jos_ from the action logs

(obviously the jos_ is yur own db prefix)

Pull Request for Issue #36889

### before

![image](https://user-images.githubusercontent.com/1296369/156622238-db34d77e-00ec-4915-8cb0-be6a73e1ced9.png)


### after 

![image](https://user-images.githubusercontent.com/1296369/156622338-07f44357-095c-41fb-be9e-732f583ce16e.png)
