### PR TITLE
[4.1] com_scheduler reset task counters

### DIFF
--- a/administrator/components/com_scheduler/forms/task.xml
+++ b/administrator/components/com_scheduler/forms/task.xml
@@ -57,17 +57,13 @@
 			/>
 			<field
 				name="times_executed"
-				type="number"
+				type="executed"
 				label="COM_SCHEDULER_LABEL_TIMES_EXEC"
-				disabled="true"
-				filter="unset"
 			/>
 			<field
 				name="times_failed"
-				type="number"
+				type="failed"
 				label="COM_SCHEDULER_LABEL_TIMES_FAIL"
-				disabled="true"
-				filter="unset"
 			/>
 		</fieldset>
 

--- a/administrator/components/com_scheduler/src/Field/ExecutedField.php
+++ b/administrator/components/com_scheduler/src/Field/ExecutedField.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_scheduler
+ *
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Scheduler\Administrator\Field;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Form\FormField;
+use Joomla\CMS\Language\Text;
+
+/**
+ * Count executed field.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ExecutedField extends FormField
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $type = 'Executed';
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @return  string  The field input markup.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getInput()
+	{
+		$onclick = ' onclick="document.getElementById(\'' . $this->id . '\').value=\'0\';"';
+
+		return '<div class="input-group"><input class="form-control" type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly">'
+			. '<button type="button" class="btn btn-secondary" ' . $onclick . '>'
+			. '<span class="icon-sync" aria-hidden="true"></span> ' . Text::_('JRESET') . '</button></div>';
+	}
+}

--- a/administrator/components/com_scheduler/src/Field/FailedField.php
+++ b/administrator/components/com_scheduler/src/Field/FailedField.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_scheduler
+ *
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Scheduler\Administrator\Field;
+
+\defined('_JEXEC') or die;
+
+use Joomla\CMS\Form\FormField;
+use Joomla\CMS\Language\Text;
+
+/**
+ * Count failed field.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class FailedField extends FormField
+{
+	/**
+	 * The form field type.
+	 *
+	 * @var    string
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $type = 'Failed';
+
+	/**
+	 * Method to get the field input markup.
+	 *
+	 * @return  string  The field input markup.
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	protected function getInput()
+	{
+		$onclick = ' onclick="document.getElementById(\'' . $this->id . '\').value=\'0\';"';
+
+		return '<div class="input-group"><input class="form-control" type="text" name="' . $this->name . '" id="' . $this->id . '" value="'
+			. htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" readonly="readonly">'
+			. '<button type="button" class="btn btn-secondary" ' . $onclick . '>'
+			. '<span class="icon-sync" aria-hidden="true"></span> ' . Text::_('JRESET') . '</button></div>';
+	}
+}


### PR DESCRIPTION
Pull Request for Issue #36457 .

### Summary of Changes
> So lets say my task has been constantly failing and I have 3123 Times Failed. I have fixed the problem and want to reset the stats to that I can keep an eye on it, there is no way to do that without deleting the task and creating a new one.

Add reset button to the counter for times executed and times failed


### Testing Instructions
Apply the pr
Create a task and run it a few times (or update the db directly)
Press the reset button and save the task
Check the task again and the counts have been reset to 0


### Actual result BEFORE applying this Pull Request
Not possible

