### PR TITLE
[4.1] remove unused rtl css

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_toolbar.scss
@@ -180,10 +180,3 @@
     }
   }
 }
-
-// In Microsoft Edge, sticky positioning doesn't work when combined with dir "rtl" attribute
-@supports (-ms-ime-align: auto) {
-  [dir=rtl] .subhead {
-    position: relative;
-  }
-}


### PR DESCRIPTION
This css was a special case for a bug in the old edge.

The bug is no longer present and that non-chromium version of edge is no longer supported.

code review

Spotted while checking some rtl issues