### PR TITLE
[4.1] Fix wrong checked out values for update sites table

### DIFF
--- a/administrator/components/com_installer/src/Table/UpdatesiteTable.php
+++ b/administrator/components/com_installer/src/Table/UpdatesiteTable.php
@@ -22,6 +22,15 @@ use Joomla\Database\DatabaseDriver;
 class UpdatesiteTable extends Table
 {
 	/**
+	 * Indicates that columns fully support the NULL value in the database
+	 *
+	 * @var    boolean
+	 *
+	 * @since  __DEPLOY_VERSION__
+	 */
+	protected $_supportNullValue = true;
+
+	/**
 	 * Constructor
 	 *
 	 * @param   DatabaseDriver  $db  Database connector object


### PR DESCRIPTION
Pull Request for Issue #37204 .

### Summary of Changes

Add null value support to the "UpdatesiteTable" class to fix the issue with column "checked_out" being 0 and "checked_out_time" being  '0000-00-00 00:00:00' after having saved an update site in backend e.g. for changing the download key or after a checked out update site was checked in with the icon in the update sites view and not in Global Checkin.

### Testing Instructions

#### Test 1: Edit update site

For this test it does not even need an extension with a download key like it was in the reported issue, but if you want to test that, too, you can use this fake [ "paid download" ](http://updates.myoldsite.com/file_null-1.0.zip)extension Null file which was used for testing several PRs in past, e.g. #34419 or #34386 . Thanks @nikosdion for the file.

1. Make sure that there are no checked out items shown in the System Dashboard beside "Global Check-in" in the "Maintenance" section, i.e. a green check mark is shown and not a number in a yellow box. If there are items checked out, i.e.. a number is shown, go to Global Check-in and check in all checked out items.

2. Go to "Update Sites" go to the edit view of any update site by selecting its title.
Note that if the update site doesn't have any download key, there is nothing to edit and only a button to close.

3. Use the close button. Alternatively, if you have an extension which uses a download key, update that key to some value and save and close.

4. Check if there is a checked-out icon left beside the title of the previously "edited" update site.
Result: There is no checked-out icon for that update site.

5. Check Global Check-in if something is shown as checked out.
Result:
- Without this PR see section "Actual result BEFORE applying this Pull Request" below.
- With this PR see section "Expected result AFTER applying this Pull Request" below.

6. Check the values of columns "checked_out" and "checked_out_time" of that update site in database, e.g. with phpMyAdmin.
Result:
- Without this PR see section "Actual result BEFORE applying this Pull Request" below.
- With this PR see section "Expected result AFTER applying this Pull Request" below.

#### Test 2: Check-in an update site using the icon

1. Make sure that there are no checked out items shown in the System Dashboard beside "Global Check-in" in the "Maintenance" section, i.e. a green check mark is shown and not a number in a yellow box. If there are items checked out, i.e.. a number is shown, go to Global Check-in and check in all checked out items.

2. Go to "Update Sites" go to the edit view of any update site by selecting its title.

3. Use the "back" button of your browser to leave the view and cause the item to be checked out.
Result: The update site has a checked-out icon left beside the title.

4. Click the checked-out icon to check in the update site.
Result: The update site doesn't have a checked-out icon anymore left beside the title.

5. Check Global Check-in if something is shown as checked out.
- Without this PR see section "Actual result BEFORE applying this Pull Request" below.
- With this PR see section "Expected result AFTER applying this Pull Request" below.

6. Check the values of columns "checked_out" and "checked_out_time" of that update site in database, e.g. with phpMyAdmin.
Result:
- Without this PR see section "Actual result BEFORE applying this Pull Request" below.
- With this PR see section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

#### Test 1: Edit update site

In Global Check-in there is one checked out item shown for the update sites table.

In database "checked_out" is 0 and "checked_out_time" is '0000-00-00 00:00:00' for that update site.

#### Test 2: Check-in an update site using the icon

Same as Test 1.

### Expected result AFTER applying this Pull Request

#### Test 1: Edit update site

In Global Check-in there is no checked out icon shown.

In database "checked_out" and "checked_out_time" are both NULL for that update site.

#### Test 2: Check-in an update site using the icon

Same as Test 1.

### Questions

There is also a table class for the update sites table here: https://github.com/joomla/joomla-cms/blob/4.1-dev/libraries/src/Table/UpdateSite.php .

Theoretically the same change as made here with this PR in file "administrator/components/com_installer/src/Table/UpdatesiteTable.php" should also be made there.

Practically I have done that but it did not have any effect.

From reading our code I would expect it to be vice versa, the "UpdateSite.php" being used but not the "UpdatesiteTable.php", but as said, it is the "UpdatesiteTable.php" where the fix from this PR helps. 

@bembelimen @wilsonge Do you have any idea? And should I make the same change in the "UpdateSite.php" anyway because it is the same database table and so should be handled in the same way here and there?

### Documentation Changes Required

None.