### PR TITLE
[4] use correct object to get message from

### DIFF
--- a/administrator/components/com_finder/src/Field/ContenttypesField.php
+++ b/administrator/components/com_finder/src/Field/ContenttypesField.php
@@ -60,7 +60,7 @@ class ContenttypesField extends ListField
 		}
 		catch (\RuntimeException $e)
 		{
-			Factory::getApplication()->enqueueMessage($db->getMessage(), 'error');
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 		}
 
 		// Translate.

--- a/administrator/components/com_finder/src/Service/HTML/Finder.php
+++ b/administrator/components/com_finder/src/Service/HTML/Finder.php
@@ -89,7 +89,7 @@ class Finder
 		}
 		catch (\RuntimeException $e)
 		{
-			Factory::getApplication()->enqueueMessage($db->getMessage(), 'error');
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 		}
 
 		// Translate.

--- a/administrator/components/com_newsfeeds/src/Field/NewsfeedsField.php
+++ b/administrator/components/com_newsfeeds/src/Field/NewsfeedsField.php
@@ -60,7 +60,7 @@ class NewsfeedsField extends ListField
 		}
 		catch (\RuntimeException $e)
 		{
-			Factory::getApplication()->enqueueMessage($db->getMessage(), 'error');
+			Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 		}
 
 		// Merge any additional options in the XML definition.


### PR DESCRIPTION
### Summary of Changes


There is no such method as `$db->getMessage()` - one assumes you are trying to get the exception message?


### Testing Instructions

Code review 

### Actual result BEFORE applying this Pull Request

The code would fatal error if this exception block was ever invoked

### Expected result AFTER applying this Pull Request

The exception would be correctly reported 

### Documentation Changes Required

none