### PR TITLE
Remove Unused Method Again After Merge Error

### DIFF
--- a/components/com_content/src/Model/ArchiveModel.php
+++ b/components/com_content/src/Model/ArchiveModel.php
@@ -130,34 +130,6 @@ class ArchiveModel extends ArticlesModel
 	}
 
 	/**
-	 * Method to get the archived article list
-	 *
-	 * @access public
-	 * @return array
-	 */
-	public function getData()
-	{
-		$app = Factory::getApplication();
-
-		// Lets load the content if it doesn't already exist
-		if (empty($this->_data))
-		{
-			// Get the page/component configuration
-			$params = $app->getParams();
-
-			// Get the pagination request variables
-			$limit      = $app->input->get('limit', $params->get('display_num', 20), 'uint');
-			$limitstart = $app->input->get('limitstart', 0, 'uint');
-
-			$query = $this->_buildQuery();
-
-			$this->_data = $this->_getList($query, $limitstart, $limit);
-		}
-
-		return $this->_data;
-	}
-
-	/**
 	 * Gets the archived articles years
 	 *
 	 * @return   array


### PR DESCRIPTION
https://github.com/joomla/joomla-cms/issues/37212

> So ignoring the "Files Changed" Tab ... look at the commits tab on the older PRs.

> #34060 = I remove the method `getData` which was merged by you at 8:38pm

> #34118 = I remove the method `_getList` https://github.com/joomla/joomla-cms/pull/34118/commits/f6effc70192f804ff116eb3c4ed15a51e6a59e5c

> You then merge 4.0-dev incorrectly at 8:41pm - thus resulting in adding back some code... leading to the +/- we see in the Files Changed Tab here: https://github.com/joomla/joomla-cms/pull/34118/files

> So, my PRs were to remove `getData` and `getList` methods from this file, and thus we need to do that again... by removing the `getData` 


//cc @joomdonation @richard67 
