### PR TITLE
[4] Page of errors when trying to load deleted template file

### DIFF
--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -156,6 +156,12 @@ class HtmlView extends BaseHtmlView
 	public function display($tpl = null)
 	{
 		$app               = Factory::getApplication();
+
+		if (false === $this->template = $this->get('Template'))
+		{
+			return;
+		}
+
 		$this->file        = $app->input->get('file');
 		$this->fileName    = InputFilter::getInstance()->clean(base64_decode($this->file), 'string');
 		$explodeArray      = explode('.', $this->fileName);
@@ -163,7 +169,6 @@ class HtmlView extends BaseHtmlView
 		$this->files       = $this->get('Files');
 		$this->mediaFiles  = $this->get('MediaFiles');
 		$this->state       = $this->get('State');
-		$this->template    = $this->get('Template');
 		$this->preview     = $this->get('Preview');
 		$this->pluginState = PluginHelper::isEnabled('installer', 'override');
 		$this->updatedList = $this->get('UpdatedList');


### PR DESCRIPTION
Pull Request for Issue Page of errors when trying to load deleted template file. #29345

### Summary of Changes

Check template exists before running off and attempting anything else

### Testing Instructions

Try to edit a template that has been deleted using a bookmark or cached url in your browser (or try to hack yourself by loading an invalid template id) .

The easiest way to replicate is to go to edit the templates files

http://example.com/administrator/index.php?option=com_templates&view=templates

Select administrator

Click Atum Details and Files

gets you a url like this

https://example.com/administrator/index.php?option=com_templates&view=template&id=210&file=aG9tZQ==

Change 210 to lets say 666

### Actual result BEFORE applying this Pull Request

A page of errors or more recently just bool

<img width="935" alt="Screen Shot 2022-03-06 at 22 09 03" src="https://user-images.githubusercontent.com/400092/156944191-4e76c628-ce3b-4104-afb1-aa075ae9da37.png">

### Expected result AFTER applying this Pull Request


<img width="854" alt="Screen Shot 2022-03-06 at 21 44 59" src="https://user-images.githubusercontent.com/400092/156943400-4be96be3-9f77-4c12-ad6b-216b44d3442b.png">

### Documentation Changes Required

none