### PR TITLE
Solved the problem of little space at blue sidebar issue #37171

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -231,7 +231,7 @@ label {
 .com_login .sidebar-wrapper #sidebar p {
   margin-bottom: .2rem;
 }
-.com_login #wrapper{
+.com_login #wrapper {
   flex-grow: 1;
 }
 

--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -231,6 +231,9 @@ label {
 .com_login .sidebar-wrapper #sidebar p {
   margin-bottom: .2rem;
 }
+.com_login #wrapper{
+  flex-grow: 1;
+}
 
 .com_login .sidebar-wrapper .main-brand a,
 .com_login .sidebar-wrapper #sidebar,

--- a/build/media_source/templates/administrator/atum/scss/blocks/_sidebar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_sidebar.scss
@@ -2,7 +2,7 @@
 
 .sidebar-wrapper {
   z-index: $zindex-sidebar;
-  min-height: calc(100vh - 66px);
+  min-height: calc(103vh - 66px);
   overflow: hidden;
   background-color: var(--template-sidebar-bg);
   box-shadow: 0 0 20px -10px var(--template-bg-dark-50);


### PR DESCRIPTION
Pull Request for Issue #37171
Backend Login page -> There's a little space below the left blue bar. I believe this only shows when there are NO buttons in the top header. We have disabled all those buttons for not logged in users

### Summary of Changes
Just changed the viewport height so after disabling the login button at the top of bar.


### Testing Instructions
I made changes in scss folder so after recreating the media folder(creating CSS files) the changes will be reflected on the localhost.


### Actual result BEFORE applying this Pull Request
![](https://user-images.githubusercontent.com/4346247/156353618-ce094f9a-a74a-4db0-ac44-532c86b8b7de.png)


### Expected result AFTER applying this Pull Request
This space has been filled 


### Documentation Changes Required
No changes required
