### PR TITLE
[4.1][bug] Retain hidden info when saving as a style

### DIFF
--- a/administrator/components/com_templates/forms/style.xml
+++ b/administrator/components/com_templates/forms/style.xml
@@ -39,5 +39,16 @@
 			type="hidden"
 		/>
 
+				<field
+			name="inheritable"
+			type="hidden"
+			readonly="true"
+		/>
+
+		<field
+			name="parent"
+			type="hidden"
+			readonly="true"
+		/>
 	</fieldset>
 </form>

--- a/administrator/components/com_templates/forms/style.xml
+++ b/administrator/components/com_templates/forms/style.xml
@@ -39,7 +39,7 @@
 			type="hidden"
 		/>
 
-				<field
+		<field
 			name="inheritable"
 			type="hidden"
 			readonly="true"

--- a/administrator/components/com_templates/tmpl/style/edit.php
+++ b/administrator/components/com_templates/tmpl/style/edit.php
@@ -72,6 +72,8 @@ $user = Factory::getUser();
 				);
 				?>
 				<?php echo LayoutHelper::render('joomla.edit.global', $this); ?>
+				<?php echo $this->form->renderField('inheritable'); ?>
+				<?php echo $this->form->renderField('parent'); ?>
 			</div>
 		</div>
 		<?php echo HTMLHelper::_('uitab.endTab'); ?>


### PR DESCRIPTION
Pull Request for Issue #37246.

### Summary of Changes
- include 2 hidden form fields for the db columns inheritable and parent

### Testing Instructions

Go to Template Style Site
Open Cassiopeia - Default
Save as copy
Assign Style via Menu or just make it default style

### Actual result BEFORE applying this Pull Request

No CSS loaded, just HTML on website

### Expected result AFTER applying this Pull Request



### Documentation Changes Required

No, this is a bug