### PR TITLE
[4.1] Change a conditional to check on the first character

### DIFF
--- a/libraries/src/Form/Field/FilelistField.php
+++ b/libraries/src/Form/Field/FilelistField.php
@@ -187,14 +187,22 @@ class FilelistField extends ListField
 	 */
 	protected function getOptions()
 	{
-		$options = [];
-
-		$path = Path::clean(strpos($this->directory, '/') === 0 ? $this->directory : (JPATH_ROOT . '/' . $this->directory));
+		$path = $this->directory;
 
 		if (!is_dir($path))
 		{
-			return $options;
+			if (is_dir(JPATH_ROOT . '/' . $path))
+			{
+				$path = JPATH_ROOT . '/' . $path;
+			}
+			else
+			{
+				return [];
+			}
 		}
+
+		$path    = Path::clean($path);
+		$options = [];
 
 		// Prepend some default options based on field attributes.
 		if (!$this->hideNone)

--- a/libraries/src/Form/Field/FilelistField.php
+++ b/libraries/src/Form/Field/FilelistField.php
@@ -190,7 +190,7 @@ class FilelistField extends ListField
 		$options = [];
 		$path    = $this->directory;
 
-		if (strpos($path, '/') === 0)
+		if (strpos($path, '/') !== 0)
 		{
 			$path = JPATH_ROOT . '/' . $path;
 		}

--- a/libraries/src/Form/Field/FilelistField.php
+++ b/libraries/src/Form/Field/FilelistField.php
@@ -189,7 +189,14 @@ class FilelistField extends ListField
 	{
 		$options = [];
 
-		$path = Path::clean(strpos($this->directory, '/') === 0 ? $this->directory : (JPATH_ROOT . '/' . $this->directory));
+		$path = $this->directory;
+		
+		if (strpos($path, '/') === 0)
+		{
+			$path = JPATH_ROOT . '/' . $path;
+		}
+		
+		$path = Path::clean($path);
 
 		if (!is_dir($path))
 		{

--- a/libraries/src/Form/Field/FilelistField.php
+++ b/libraries/src/Form/Field/FilelistField.php
@@ -187,22 +187,14 @@ class FilelistField extends ListField
 	 */
 	protected function getOptions()
 	{
-		$path = $this->directory;
-
-		if (!is_dir($path))
-		{
-			if (is_dir(JPATH_ROOT . '/' . $path))
-			{
-				$path = JPATH_ROOT . '/' . $path;
-			}
-			else
-			{
-				return [];
-			}
-		}
-
-		$path    = Path::clean($path);
 		$options = [];
+
+ 		$path = Path::clean(strpos($this->directory, '/') === 0 ? $this->directory : (JPATH_ROOT . '/' . $this->directory));
+
+ 		if (!is_dir($path))
+ 		{
+ 			return $options;
+ 		}
 
 		// Prepend some default options based on field attributes.
 		if (!$this->hideNone)

--- a/libraries/src/Form/Field/FilelistField.php
+++ b/libraries/src/Form/Field/FilelistField.php
@@ -188,9 +188,8 @@ class FilelistField extends ListField
 	protected function getOptions()
 	{
 		$options = [];
+		$path    = $this->directory;
 
-		$path = $this->directory;
-		
 		if (strpos($path, '/') === 0)
 		{
 			$path = JPATH_ROOT . '/' . $path;

--- a/libraries/src/Form/Field/FilelistField.php
+++ b/libraries/src/Form/Field/FilelistField.php
@@ -187,16 +187,14 @@ class FilelistField extends ListField
 	 */
 	protected function getOptions()
 	{
-		$options = array();
+		$options = [];
 
-		$path = $this->directory;
+		$path = Path::clean(strpos($this->directory, '/') === 0 ? $this->directory : (JPATH_ROOT . '/' . $this->directory));
 
 		if (!is_dir($path))
 		{
-			$path = JPATH_ROOT . '/' . $path;
+			return $options;
 		}
-
-		$path = Path::clean($path);
 
 		// Prepend some default options based on field attributes.
 		if (!$this->hideNone)

--- a/libraries/src/Form/Field/FilelistField.php
+++ b/libraries/src/Form/Field/FilelistField.php
@@ -194,7 +194,7 @@ class FilelistField extends ListField
 		{
 			$path = JPATH_ROOT . '/' . $path;
 		}
-		
+
 		$path = Path::clean($path);
 
 		if (!is_dir($path))

--- a/libraries/src/Form/Field/FilelistField.php
+++ b/libraries/src/Form/Field/FilelistField.php
@@ -189,12 +189,12 @@ class FilelistField extends ListField
 	{
 		$options = [];
 
- 		$path = Path::clean(strpos($this->directory, '/') === 0 ? $this->directory : (JPATH_ROOT . '/' . $this->directory));
+		$path = Path::clean(strpos($this->directory, '/') === 0 ? $this->directory : (JPATH_ROOT . '/' . $this->directory));
 
- 		if (!is_dir($path))
- 		{
- 			return $options;
- 		}
+		if (!is_dir($path))
+		{
+			return $options;
+		}
 
 		// Prepend some default options based on field attributes.
 		if (!$this->hideNone)

--- a/libraries/src/Form/Field/FolderlistField.php
+++ b/libraries/src/Form/Field/FolderlistField.php
@@ -185,12 +185,12 @@ class FolderlistField extends ListField
 	{
 		$options = [];
 		$path    = $this->directory;
-		
+
 		if (strpos($path, '/') === 0)
 		{
 			$path = JPATH_ROOT . '/' . $path;
 		}
-		
+
 		$path = Path::clean($path);
 
 		if (!is_dir($path))

--- a/libraries/src/Form/Field/FolderlistField.php
+++ b/libraries/src/Form/Field/FolderlistField.php
@@ -186,7 +186,7 @@ class FolderlistField extends ListField
 		$options = [];
 		$path    = $this->directory;
 
-		if (strpos($path, '/') === 0)
+		if (strpos($path, '/') !== 0)
 		{
 			$path = JPATH_ROOT . '/' . $path;
 		}

--- a/libraries/src/Form/Field/FolderlistField.php
+++ b/libraries/src/Form/Field/FolderlistField.php
@@ -185,12 +185,12 @@ class FolderlistField extends ListField
 	{
 		$options = [];
 
- 		$path = Path::clean(strpos($this->directory, '/') === 0 ? $this->directory : (JPATH_ROOT . '/' . $this->directory));
+		$path = Path::clean(strpos($this->directory, '/') === 0 ? $this->directory : (JPATH_ROOT . '/' . $this->directory));
 
- 		if (!is_dir($path))
- 		{
- 			return $options;
- 		}
+		if (!is_dir($path))
+		{
+			return $options;
+		}
 
 		// Prepend some default options based on field attributes.
 		if (!$this->hideNone)

--- a/libraries/src/Form/Field/FolderlistField.php
+++ b/libraries/src/Form/Field/FolderlistField.php
@@ -184,8 +184,7 @@ class FolderlistField extends ListField
 	protected function getOptions()
 	{
 		$options = [];
-
-		$path = $this->directory;
+		$path    = $this->directory;
 		
 		if (strpos($path, '/') === 0)
 		{

--- a/libraries/src/Form/Field/FolderlistField.php
+++ b/libraries/src/Form/Field/FolderlistField.php
@@ -183,23 +183,14 @@ class FolderlistField extends ListField
 	 */
 	protected function getOptions()
 	{
-		$options = array();
+		$options = [];
 
-		$path = $this->directory;
+ 		$path = Path::clean(strpos($this->directory, '/') === 0 ? $this->directory : (JPATH_ROOT . '/' . $this->directory));
 
-		if (!is_dir($path))
-		{
-			if (is_dir(JPATH_ROOT . '/' . $path))
-			{
-				$path = JPATH_ROOT . '/' . $path;
-			}
-			else
-			{
-				return [];
-			}
-		}
-
-		$path = Path::clean($path);
+ 		if (!is_dir($path))
+ 		{
+ 			return $options;
+ 		}
 
 		// Prepend some default options based on field attributes.
 		if (!$this->hideNone)

--- a/libraries/src/Form/Field/FolderlistField.php
+++ b/libraries/src/Form/Field/FolderlistField.php
@@ -185,7 +185,14 @@ class FolderlistField extends ListField
 	{
 		$options = [];
 
-		$path = Path::clean(strpos($this->directory, '/') === 0 ? $this->directory : (JPATH_ROOT . '/' . $this->directory));
+		$path = $this->directory;
+		
+		if (strpos($path, '/') === 0)
+		{
+			$path = JPATH_ROOT . '/' . $path;
+		}
+		
+		$path = Path::clean($path);
 
 		if (!is_dir($path))
 		{


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/37241#issuecomment-1066110623 .

### Summary of Changes

- Change the conditional from checking if a folder exists to determine if it's a relative or absolute path to checking the first character


### Testing Instructions

- Goto administrator/index.php?option=com_languages&view=language&layout=edit&lang_id=1 and check that the selector for the language images still works
- Edit https://github.com/joomla/joomla-cms/blob/cb07dbda22c8a8a8f4ced200ff9c079fec8a2f27/administrator/components/com_languages/forms/language.xml#L47-L59 to something like (provide a folder outside of Joomla's root that has some files)
```xml
<field
	name="image"
	type="filelist"
	label="COM_LANGUAGES_FIELD_IMAGE_LABEL"
	stripext="1"
	directory="/Users/dgrammatiko/Downloads"
	hide_none="1"
	hide_default="1"
	>
	<option value="">JNONE</option>
</field>
```

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request
- Relative path:
<img width="1665" alt="Screenshot 2022-03-13 at 16 15 39" src="https://user-images.githubusercontent.com/3889375/158066502-442227e7-eaa1-467f-b30c-de2bd3092fe0.png">


- Absolute path: 
<img width="1636" alt="Screenshot 2022-03-13 at 16 14 07" src="https://user-images.githubusercontent.com/3889375/158066533-08a54199-f9fa-4413-b25f-c5dafe428422.png">

### Documentation Changes Required

