### PR TITLE
[4.1] cpanel add module permissions

### DIFF
--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -62,7 +62,7 @@ echo HTMLHelper::_(
 			echo ModuleHelper::renderModule($module, array('style' => 'well'));
 		}
 		?>
-		<?php if ($user->authorise('core.manage', 'com_modules')) : ?>
+		<?php if ($user->authorise('core.create', 'com_modules')) : ?>
 			<div class="module-wrapper">
 				<div class="card">
 					<button type="button" data-bs-toggle="modal" data-bs-target="#moduleDashboardAddModal" class="cpanel-add-module">


### PR DESCRIPTION
The permission to decide which user will see the add new module on the admin cpanel was wrong. It should have been create not manage

Pull Request for Issue #37267 

## Steps to reproduce the issue
Create a new usergroup. Give this group acces (only) to the modules. No 'create' rights. Then log in with a user in this usergroup on the backend.

### Expected result
There should not be an 'Add module to the dashboard' button on the backend control panel.

### Actual result
There is an 'Add module to the dashboard' button on the control panel. It is not possible to add a module, but I think the button to add a module should not be there when creating a module is not possible (because of ACL)..
