### PR TITLE
Fix advanced search mod_finder in header

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
@@ -223,5 +223,13 @@
         color: darken($white, 10%);
       }
     }
+
+    .awesomplete {
+      color: var(--body-color);
+
+      > ul {
+        background: linear-gradient(to bottom right, white, hsla(0,0%,100%,.9));
+      }
+    }
   }
 }

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
@@ -228,7 +228,7 @@
       color: var(--body-color);
 
       > ul {
-        background: linear-gradient(to bottom right, white, hsla(0,0%,100%,.9));
+        background: linear-gradient(to bottom right, $white, hsla(0,0%,100%,.9));
       }
     }
   }

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
@@ -1,6 +1,7 @@
 // Header
 
 .container-header {
+  color: $white;
   position: relative;
   z-index: 10;
   background-color: var(--cassiopeia-color-primary);
@@ -9,6 +10,14 @@
 
   @include media-breakpoint-down(lg) {
     position: relative !important;
+  }
+
+  a {
+    color: $white;
+
+    &:hover, &:focus {
+      color: darken($white, 10%);
+    }
   }
 
   .grid-child {
@@ -211,16 +220,5 @@
 
   .container-search {
     margin-top: $cassiopeia-grid-gutter / 2;
-  }
-
-  .mod-finder {
-    position: relative;
-    display: flex;
-    flex: 1 0 20rem;
-    max-width: 100%;
-
-    > label {
-      @include visually-hidden();
-    }
   }
 }

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
@@ -1,9 +1,9 @@
 // Header
 
 .container-header {
-  color: $white;
   position: relative;
   z-index: 10;
+  color: $white;
   background-color: var(--cassiopeia-color-primary);
   background-image: $cassiopeia-header-grad;
   box-shadow: 0 5px 5px hsla(0, 0%, 0%, .03) inset;

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
@@ -3,21 +3,12 @@
 .container-header {
   position: relative;
   z-index: 10;
-  color: $white;
   background-color: var(--cassiopeia-color-primary);
   background-image: $cassiopeia-header-grad;
   box-shadow: 0 5px 5px hsla(0, 0%, 0%, .03) inset;
 
   @include media-breakpoint-down(lg) {
     position: relative !important;
-  }
-
-  a {
-    color: $white;
-
-    &:hover, &:focus {
-      color: darken($white, 10%);
-    }
   }
 
   .grid-child {
@@ -220,5 +211,17 @@
 
   .container-search {
     margin-top: $cassiopeia-grid-gutter / 2;
+  }
+
+  .mod-finder {
+    color: $white;
+
+    a {
+      color: $white;
+
+      &:hover, &:focus {
+        color: darken($white, 10%);
+      }
+    }
   }
 }


### PR DESCRIPTION
This is a proposal Pull Request for Issue #37263 

### Summary of Changes
The styling of the advanced search is broken when used in the header. This PR adds the same styling als used in the left and right position. @brianteeman please review and comment.

### Testing Instructions
Add PR and build the CSS. For testing see issue mentioned above.

### Actual result BEFORE applying this Pull Request
Search button is stretchend and colors are wrong.

### Expected result AFTER applying this Pull Request

### Documentation Changes Required

