### PR TITLE
# Fix maximum media modal width

### DIFF
--- a/build/media_source/com_media/scss/components/_media-modal.scss
+++ b/build/media_source/com_media/scss/components/_media-modal.scss
@@ -52,7 +52,7 @@
     background-color: #fff;
     box-shadow: $modal-box-shadow;
     img {
-      max-width: 200%;
+      max-width: 100%;
     }
   }
   .modal-footer {


### PR DESCRIPTION
Pull Request for Issue # 
https://github.com/joomla/joomla-cms/issues/37277

### Summary of Changes
When using the modal preview for images with large images, images gets cut off. 

### Testing Instructions
- Upload a width-wise large image to your Joomla images folder. 
- Go to Joomla media manager and select said image.
- Preview the image; it's cut off.

### Actual result BEFORE applying this Pull Request
Images only partly visible.

### Expected result AFTER applying this Pull Request
Images fully visible, because of proper width.

### Documentation Changes Required
-

