### PR TITLE
[4.1] Composer update maximebf/debugbar to fix PHP 8.1 deprecations of the debug bar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
         "symfony/yaml": "~5.0",
         "typo3/phar-stream-wrapper": "~3.1",
         "wamania/php-stemmer": "^2.0",
-        "maximebf/debugbar": "^1.17",
+        "maximebf/debugbar": "^1.18",
         "tobscure/json-api": "dev-joomla-backports",
         "willdurand/negotiation": "^3.0",
         "ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1bc051f8327d43f2ea9ff9aca3cccef3",
+    "content-hash": "5d3606db6081658d68430d7ea9aa7a5c",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -2380,25 +2380,26 @@
         },
         {
             "name": "maximebf/debugbar",
-            "version": "v1.17.3",
+            "version": "v1.18.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maximebf/php-debugbar.git",
-                "reference": "e8ac3499af0ea5b440908e06cc0abe5898008b3c"
+                "reference": "0d44b75f3b5d6d41ae83b79c7a4bceae7fbc78b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/e8ac3499af0ea5b440908e06cc0abe5898008b3c",
-                "reference": "e8ac3499af0ea5b440908e06cc0abe5898008b3c",
+                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/0d44b75f3b5d6d41ae83b79c7a4bceae7fbc78b6",
+                "reference": "0d44b75f3b5d6d41ae83b79c7a4bceae7fbc78b6",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.1|^8",
                 "psr/log": "^1|^2|^3",
-                "symfony/var-dumper": "^2.6|^3|^4|^5"
+                "symfony/var-dumper": "^2.6|^3|^4|^5|^6"
             },
             "require-dev": {
-                "phpunit/phpunit": "^7.5.20 || ^9.4.2"
+                "phpunit/phpunit": "^7.5.20 || ^9.4.2",
+                "twig/twig": "^1.38|^2.7|^3.0"
             },
             "suggest": {
                 "kriswallsmith/assetic": "The best way to manage assets",
@@ -2439,9 +2440,9 @@
             ],
             "support": {
                 "issues": "https://github.com/maximebf/php-debugbar/issues",
-                "source": "https://github.com/maximebf/php-debugbar/tree/v1.17.3"
+                "source": "https://github.com/maximebf/php-debugbar/tree/v1.18.0"
             },
-            "time": "2021-10-19T12:33:27+00:00"
+            "time": "2021-12-27T18:49:48+00:00"
         },
         {
             "name": "nyholm/psr7",


### PR DESCRIPTION
Pull Request for Issue #37274 (part).

Replaces PR #37278 .

### Summary of Changes

This pull requests updates the composer dependency "maximebf/debugbar" to their latest version 1.18 which fixes a lot of PHP 8.1 deprecations.

It should fix almost all of the deprecation notices reported in the issue except of the 2 mentioned in this comment here: https://github.com/joomla/joomla-cms/issues/37274#issuecomment-1068413464 .

These are already fixed in the upstream repository with this PR, which has been merged on February 11: https://github.com/maximebf/php-debugbar/pull/498 , i.e. one day after their latest version 1.18 was released. So for these 2 we have to wait for the next version.

### Testing Instructions

See issue #37274 .

### Actual result BEFORE applying this Pull Request

Lots of deprecation notices about the debug bar with PHP 8.1, and one for the calendar field.

### Expected result AFTER applying this Pull Request

Deprecation notices about the debug bar disappeared.

### Documentation Changes Required

None.