### PR TITLE
[4.1] Update deleted files and folders for 4.1.1

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -638,7 +638,7 @@ class JoomlaInstallerScript
 		];
 
 		$files = array(
-			// From 3.10 to 4.0
+			// From 3.10 to 4.1
 			'/administrator/components/com_actionlogs/actionlogs.php',
 			'/administrator/components/com_actionlogs/controller.php',
 			'/administrator/components/com_actionlogs/controllers/actionlogs.php',
@@ -705,6 +705,7 @@ class JoomlaInstallerScript
 			'/administrator/components/com_admin/sql/updates/mysql/3.1.5.sql',
 			'/administrator/components/com_admin/sql/updates/mysql/3.10.0-2020-08-10.sql',
 			'/administrator/components/com_admin/sql/updates/mysql/3.10.0-2021-05-28.sql',
+			'/administrator/components/com_admin/sql/updates/mysql/3.10.7-2022-02-20.sql',
 			'/administrator/components/com_admin/sql/updates/mysql/3.2.0.sql',
 			'/administrator/components/com_admin/sql/updates/mysql/3.2.1.sql',
 			'/administrator/components/com_admin/sql/updates/mysql/3.2.2-2013-12-22.sql',
@@ -827,6 +828,7 @@ class JoomlaInstallerScript
 			'/administrator/components/com_admin/sql/updates/postgresql/3.1.5.sql',
 			'/administrator/components/com_admin/sql/updates/postgresql/3.10.0-2020-08-10.sql',
 			'/administrator/components/com_admin/sql/updates/postgresql/3.10.0-2021-05-28.sql',
+			'/administrator/components/com_admin/sql/updates/postgresql/3.10.7-2022-02-20.sql.sql',
 			'/administrator/components/com_admin/sql/updates/postgresql/3.2.0.sql',
 			'/administrator/components/com_admin/sql/updates/postgresql/3.2.1.sql',
 			'/administrator/components/com_admin/sql/updates/postgresql/3.2.2-2013-12-22.sql',
@@ -951,6 +953,7 @@ class JoomlaInstallerScript
 			'/administrator/components/com_admin/sql/updates/sqlazure/3.1.5.sql',
 			'/administrator/components/com_admin/sql/updates/sqlazure/3.10.0-2021-05-28.sql',
 			'/administrator/components/com_admin/sql/updates/sqlazure/3.10.1-2021-08-17.sql',
+			'/administrator/components/com_admin/sql/updates/sqlazure/3.10.7-2022-02-20.sql.sql',
 			'/administrator/components/com_admin/sql/updates/sqlazure/3.2.0.sql',
 			'/administrator/components/com_admin/sql/updates/sqlazure/3.2.1.sql',
 			'/administrator/components/com_admin/sql/updates/sqlazure/3.2.2-2013-12-22.sql',
@@ -6332,10 +6335,52 @@ class JoomlaInstallerScript
 			'/templates/system/scss/offline_rtl.scss',
 			// From 4.1.0-beta3 to 4.1.0-rc1
 			'/api/components/com_media/src/Helper/AdapterTrait.php',
+			// From 4.1.0 to 4.1.1
+			'/libraries/vendor/tobscure/json-api/.git/HEAD',
+			'/libraries/vendor/tobscure/json-api/.git/ORIG_HEAD',
+			'/libraries/vendor/tobscure/json-api/.git/config',
+			'/libraries/vendor/tobscure/json-api/.git/description',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/applypatch-msg.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/commit-msg.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/fsmonitor-watchman.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/post-update.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/pre-applypatch.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/pre-commit.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/pre-merge-commit.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/pre-push.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/pre-rebase.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/pre-receive.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/prepare-commit-msg.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/push-to-checkout.sample',
+			'/libraries/vendor/tobscure/json-api/.git/hooks/update.sample',
+			'/libraries/vendor/tobscure/json-api/.git/index',
+			'/libraries/vendor/tobscure/json-api/.git/info/exclude',
+			'/libraries/vendor/tobscure/json-api/.git/info/refs',
+			'/libraries/vendor/tobscure/json-api/.git/logs/HEAD',
+			'/libraries/vendor/tobscure/json-api/.git/logs/refs/heads/joomla-backports',
+			'/libraries/vendor/tobscure/json-api/.git/logs/refs/remotes/origin/HEAD',
+			'/libraries/vendor/tobscure/json-api/.git/objects/info/packs',
+			'/libraries/vendor/tobscure/json-api/.git/objects/pack/pack-51530cba04703b17f3c11b9e8458a171092cf5e3.idx',
+			'/libraries/vendor/tobscure/json-api/.git/objects/pack/pack-51530cba04703b17f3c11b9e8458a171092cf5e3.pack',
+			'/libraries/vendor/tobscure/json-api/.git/packed-refs',
+			'/libraries/vendor/tobscure/json-api/.git/refs/heads/joomla-backports',
+			'/libraries/vendor/tobscure/json-api/.git/refs/remotes/origin/HEAD',
+			'/libraries/vendor/tobscure/json-api/.php_cs',
+			'/libraries/vendor/tobscure/json-api/tests/AbstractSerializerTest.php',
+			'/libraries/vendor/tobscure/json-api/tests/AbstractTestCase.php',
+			'/libraries/vendor/tobscure/json-api/tests/CollectionTest.php',
+			'/libraries/vendor/tobscure/json-api/tests/DocumentTest.php',
+			'/libraries/vendor/tobscure/json-api/tests/ErrorHandlerTest.php',
+			'/libraries/vendor/tobscure/json-api/tests/Exception/Handler/FallbackExceptionHandlerTest.php',
+			'/libraries/vendor/tobscure/json-api/tests/Exception/Handler/InvalidParameterExceptionHandlerTest.php',
+			'/libraries/vendor/tobscure/json-api/tests/LinksTraitTest.php',
+			'/libraries/vendor/tobscure/json-api/tests/ParametersTest.php',
+			'/libraries/vendor/tobscure/json-api/tests/ResourceTest.php',
+			'/libraries/vendor/tobscure/json-api/tests/UtilTest.php',
 		);
 
 		$folders = array(
-			// From 3.10 to 4.0
+			// From 3.10 to 4.1
 			'/templates/system/images',
 			'/templates/system/html',
 			'/templates/protostar/less',
@@ -7644,6 +7689,27 @@ class JoomlaInstallerScript
 			'/administrator/templates/atum/css',
 			// From 4.1.0-beta3 to 4.1.0-rc1
 			'/api/components/com_media/src/Helper',
+			// From 4.1.0 to 4.1.1
+			'/libraries/vendor/tobscure/json-api/tests/Exception/Handler',
+			'/libraries/vendor/tobscure/json-api/tests/Exception',
+			'/libraries/vendor/tobscure/json-api/tests',
+			'/libraries/vendor/tobscure/json-api/.git/refs/tags',
+			'/libraries/vendor/tobscure/json-api/.git/refs/remotes/origin',
+			'/libraries/vendor/tobscure/json-api/.git/refs/remotes',
+			'/libraries/vendor/tobscure/json-api/.git/refs/heads',
+			'/libraries/vendor/tobscure/json-api/.git/refs',
+			'/libraries/vendor/tobscure/json-api/.git/objects/pack',
+			'/libraries/vendor/tobscure/json-api/.git/objects/info',
+			'/libraries/vendor/tobscure/json-api/.git/objects',
+			'/libraries/vendor/tobscure/json-api/.git/logs/refs/remotes/origin',
+			'/libraries/vendor/tobscure/json-api/.git/logs/refs/remotes',
+			'/libraries/vendor/tobscure/json-api/.git/logs/refs/heads',
+			'/libraries/vendor/tobscure/json-api/.git/logs/refs',
+			'/libraries/vendor/tobscure/json-api/.git/logs',
+			'/libraries/vendor/tobscure/json-api/.git/info',
+			'/libraries/vendor/tobscure/json-api/.git/hooks',
+			'/libraries/vendor/tobscure/json-api/.git/branches',
+			'/libraries/vendor/tobscure/json-api/.git',
 		);
 
 		$status['files_checked'] = $files;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Update the lists of deleted files and folders in script.php to recent changes for the upcoming 4.1.1:

- Delete new 3.10 update SQL scripts "3.10.7-2022-02-20.sql" which were added to 3.10 with #36861 and later renamed with this commit https://github.com/joomla/joomla-cms/commit/a73ee4556765dba6a705ec8feab5f2ee0643f892 .
- Delete files and folders which are not included anymore after the change of the Tobscure library from 3rd party to our backport, see this commit https://github.com/joomla/joomla-cms/commit/1ac91f5bc64ee2697e76b425c9050c4c1010d786 .

### Testing Instructions

Code review, or update from current 3.10-dev or latest 3.10 nightly to current 4.1-dev or latest nightly, and update from 4.0.5 or an earlier 4.0.x version to current 4.1-dev or latest nightly.

### Actual result BEFORE applying this Pull Request

Update SQL scripts "3.10.7-2022-02-20.sql" are not deleted with update from 3.10.

In folder "libraries/vendor/tobscure/json-api", file ".php_cs" and subfolders ".git" and "tests" and their files are not deleted with an update from 4.0.5 or an earlier 4.0.x version.

### Expected result AFTER applying this Pull Request

Update SQL scripts "3.10.7-2022-02-20.sql" are deleted with update from 3.10.

In folder "libraries/vendor/tobscure/json-api", file ".php_cs" and subfolders ".git" and "tests" and their files are deleted with an update from 4.0.5 or an earlier 4.0.x version.

### Documentation Changes Required

None.