### PR TITLE
[4.1] TinyMCE wrong name for the highlight Plus plugin

### DIFF
--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -366,7 +366,7 @@ trait DisplayTrait
 		}
 
 		// Use CodeMirror in the code view instead of plain text to provide syntax highlighting
-		if ($levelParams->get('highlightPlus', 1))
+		if ($levelParams->get('sourcecode', 1))
 		{
 			$externalPlugins['highlightPlus'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/highlighter/plugin-es5.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
 		}


### PR DESCRIPTION
Pull Request for Issue [#37294] (https://github.com/joomla/joomla-cms/issues/37294#issuecomment-1069484191)

### Summary of Changes

- Change the name of a parameter

### Testing Instructions

Try disabling the `Source Code Highlighting`

### Actual result BEFORE applying this Pull Request

No effect

### Expected result AFTER applying this Pull Request

Source Code Highlighting disabled

### Documentation Changes Required

