### PR TITLE
Logo collapsed position

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_header.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_header.scss
@@ -45,6 +45,7 @@
           height: 20px;
           object-fit: contain;
           object-position: center center;
+          margin-left: 0.65rem;
         }
       }
     }


### PR DESCRIPTION
Pull Request for UI Improvement

### Summary of Changes
Just change the position of the side logo after collapsing it is not aligned with the rest icon present bottom to it if we align the logo with the rest icons it looks good I think! 



### Testing Instructions
just login to your dashboard and see the logo position after collapsing it.


### Actual result BEFORE applying this Pull Request
![WhatsApp Image 2022-03-17 at 12 03 56 PM (1)](https://user-images.githubusercontent.com/88332977/158751249-2f31b56e-b16e-4b51-b672-d5039e86b8be.jpeg)



### Expected result AFTER applying this Pull Request
![WhatsApp Image 2022-03-17 at 12 03 56 PM](https://user-images.githubusercontent.com/88332977/158751264-a9e8c5af-63bc-4334-918f-4e3b7afbb205.jpeg)



### Documentation Changes Required
No document changes.
