### PR TITLE
[4.1] Check if string is null in hasKey function

### DIFF
--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -1178,9 +1178,12 @@ class Language
 	 */
 	public function hasKey($string)
 	{
-		$key = $string ? strtoupper($string) : '';
+		if ($string === null)
+		{
+			return false;
+		}
 
-		return isset($this->strings[$key]);
+		return isset($this->strings[strtoupper($string)]);
 	}
 
 	/**

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -1178,7 +1178,7 @@ class Language
 	 */
 	public function hasKey($string)
 	{
-		$key = strtoupper($string);
+		$key = $string ? strtoupper($string) : '';
 
 		return isset($this->strings[$key]);
 	}


### PR DESCRIPTION
### Summary of Changes
When editing a plugin a deprecated warning is displayed on PHP 8.1.

### Testing Instructions
In the back end open a plugin form.

### Actual result BEFORE applying this Pull Request
The following deprecated message is shown:
_Deprecated: strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated in /libraries/src/Language/Language.php on line 1181_

### Expected result AFTER applying this Pull Request
No warning.