### PR TITLE
[4.1] Check if links are not null in menu item

### DIFF
--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -732,8 +732,12 @@ class ItemModel extends AdminModel
 				$table->type = 'component';
 
 				// Ensure the integrity of the component_id field is maintained, particularly when changing the menu item type.
-				$args = array();
-				parse_str(parse_url($table->link, PHP_URL_QUERY), $args);
+				$args = [];
+
+				if ($table->link)
+				{
+					parse_str(parse_url($table->link, PHP_URL_QUERY), $args);
+				}
 
 				if (isset($args['option']))
 				{
@@ -1138,11 +1142,15 @@ class ItemModel extends AdminModel
 		// Initialise form with component view params if available.
 		if ($type == 'component')
 		{
-			$link = htmlspecialchars_decode($link);
+			$link = $link ? htmlspecialchars_decode($link) : '';
 
 			// Parse the link arguments.
-			$args = array();
-			parse_str(parse_url(htmlspecialchars_decode($link), PHP_URL_QUERY), $args);
+			$args = [];
+
+			if ($link)
+			{
+				parse_str(parse_url(htmlspecialchars_decode($link), PHP_URL_QUERY), $args);
+			}
 
 			// Confirm that the option is defined.
 			$option = '';


### PR DESCRIPTION
### Summary of Changes
Ads some checks in menu items if the links are not null. These checks are needed on PHP 8.1 as it will throw a deprecated message.

### Testing Instructions
Open the new menu item form.

### Actual result BEFORE applying this Pull Request
Following error is thrown:
_Deprecated: parse_str(): Passing null to parameter #1 ($string) of type string is deprecated in /administrator/components/com_menus/src/Model/ItemModel.php on line 1150_

### Expected result AFTER applying this Pull Request
No error.