### PR TITLE
[4.1] Check if value is not null in menu item

### DIFF
--- a/administrator/components/com_menus/src/Field/MenutypeField.php
+++ b/administrator/components/com_menus/src/Field/MenutypeField.php
@@ -75,15 +75,19 @@ class MenutypeField extends ListField
 
 			default:
 				$link = $this->form->getValue('link');
+				$value = '';
 
-				$model = Factory::getApplication()->bootComponent('com_menus')
-					->getMVCFactory()->createModel('Menutypes', 'Administrator', array('ignore_request' => true));
-				$model->setState('client_id', $clientId);
+				if ($link !== null)
+				{
+					$model = Factory::getApplication()->bootComponent('com_menus')
+						->getMVCFactory()->createModel('Menutypes', 'Administrator', array('ignore_request' => true));
+					$model->setState('client_id', $clientId);
 
-				$rlu   = $model->getReverseLookup();
+					$rlu   = $model->getReverseLookup();
 
-				// Clean the link back to the option, view and layout
-				$value = Text::_(ArrayHelper::getValue($rlu, MenusHelper::getLinkKey($link)));
+					// Clean the link back to the option, view and layout
+					$value = Text::_(ArrayHelper::getValue($rlu, MenusHelper::getLinkKey($link)));
+				}
 				break;
 		}
 


### PR DESCRIPTION
### Summary of Changes

This PR will fix the 'Deprecated' message under PHP 8.1 while creating a new menu item.

### Testing Instructions

Create a new menu item

### Actual result BEFORE applying this Pull Request

`Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in libraries/src/Language/Text.php on line 96`

### Expected result AFTER applying this Pull Request

No message.

### Documentation Changes Required

.