### PR TITLE
[4.1] Check if model has a value for direction

### DIFF
--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -631,7 +631,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
 				// Check if the ordering direction is valid, otherwise use the incoming value.
 				$value = $app->getUserStateFromRequest($this->context . '.orderdirn', 'filter_order_Dir', $direction);
 
-				if (!\in_array(strtoupper($value), array('ASC', 'DESC', '')))
+				if (!$value || !\in_array(strtoupper($value), array('ASC', 'DESC', '')))
 				{
 					$value = $direction;
 					$app->setUserState($this->context . '.orderdirn', $value);


### PR DESCRIPTION
### Summary of Changes
The base model throws a deprecate message in PHP 8.1 when no direction is set.

### Testing Instructions
In the back end go to /administrator/index.php?option=com_scheduler&view=select&layout=default.

### Actual result BEFORE applying this Pull Request
The following deprecate message is shown:
_Deprecated: strtoupper(): Passing null to parameter #1 ($string) of type string is deprecated in /libraries/src/MVC/Model/ListModel.php on line 634_

### Expected result AFTER applying this Pull Request
No error.