### PR TITLE
[4.1] Check if the output to escape is null in BaseLayout

### DIFF
--- a/libraries/src/Layout/BaseLayout.php
+++ b/libraries/src/Layout/BaseLayout.php
@@ -116,12 +116,7 @@ class BaseLayout implements LayoutInterface
 	 */
 	public function escape($output)
 	{
-		if ($output === null)
-		{
-			return '';
-		}
-
-		return htmlspecialchars($output, ENT_QUOTES, 'UTF-8');
+		return $output === null ? '' : htmlspecialchars($output, ENT_QUOTES, 'UTF-8');
 	}
 
 	/**

--- a/libraries/src/Layout/BaseLayout.php
+++ b/libraries/src/Layout/BaseLayout.php
@@ -116,6 +116,11 @@ class BaseLayout implements LayoutInterface
 	 */
 	public function escape($output)
 	{
+		if ($output === null)
+		{
+			return '';
+		}
+
 		return htmlspecialchars($output, ENT_QUOTES, 'UTF-8');
 	}
 


### PR DESCRIPTION
### Summary of Changes
When a contact is edited, the form shows a deprecated notice around the user field in PHP 8.1

### Testing Instructions
Create a contact without a linked user and edit it.

### Actual result BEFORE applying this Pull Request
The following error is shown:
_Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in /libraries/src/Layout/BaseLayout.php on line 119_

### Expected result AFTER applying this Pull Request
No error.