### PR TITLE
[4.1] Json decode can't handle null in login view

### DIFF
--- a/components/com_users/tmpl/login/default_login.php
+++ b/components/com_users/tmpl/login/default_login.php
@@ -108,7 +108,7 @@ $usersConfig = ComponentHelper::getParams('com_users');
 				</div>
 			</div>
 
-			<?php $return = $this->form->getValue('return', '', $this->params->get('login_redirect_url', $this->params->get('login_redirect_menuitem'))); ?>
+			<?php $return = $this->form->getValue('return', '', $this->params->get('login_redirect_url', $this->params->get('login_redirect_menuitem', ''))); ?>
 			<input type="hidden" name="return" value="<?php echo base64_encode($return); ?>">
 			<?php echo HTMLHelper::_('form.token'); ?>
 		</fieldset>

--- a/components/com_users/tmpl/login/default_logout.php
+++ b/components/com_users/tmpl/login/default_logout.php
@@ -50,9 +50,9 @@ use Joomla\CMS\Router\Route;
 			</div>
 		</div>
 		<?php if ($this->params->get('logout_redirect_url')) : ?>
-			<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('logout_redirect_url', $this->form->getValue('return'))); ?>">
+			<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('logout_redirect_url', $this->form->getValue('return', null, ''))); ?>">
 		<?php else : ?>
-			<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('logout_redirect_menuitem', $this->form->getValue('return'))); ?>">
+			<input type="hidden" name="return" value="<?php echo base64_encode($this->params->get('logout_redirect_menuitem', $this->form->getValue('return', null, ''))); ?>">
 		<?php endif; ?>
 		<?php echo HTMLHelper::_('form.token'); ?>
 	</form>


### PR DESCRIPTION
### Summary of Changes
In PHP 8.1, the return value must be a string, otherwise we get a null deprecated message.

### Testing Instructions
Open the url /index.php?option=com_users&view=login

### Actual result BEFORE applying this Pull Request
The following error is in the source of the page:
_Deprecated:  base64_encode(): Passing null to parameter #1 ($string) of type string is deprecated in /components/com_users/tmpl/login/default_login.php on line 112_

### Expected result AFTER applying this Pull Request
No error.