### PR TITLE
[4.1] Check if attributes have a value before trimming in menu table

### DIFF
--- a/libraries/src/Table/Menu.php
+++ b/libraries/src/Table/Menu.php
@@ -117,7 +117,7 @@ class Menu extends Nested
 		}
 
 		// Check for a title.
-		if (trim($this->title) === '')
+		if (!$this->title || trim($this->title) === '')
 		{
 			$this->setError(Text::_('JLIB_DATABASE_ERROR_MUSTCONTAIN_A_TITLE_MENUITEM'));
 
@@ -125,19 +125,19 @@ class Menu extends Nested
 		}
 
 		// Check for a path.
-		if (trim($this->path) === '')
+		if (!$this->path || trim($this->path) === '')
 		{
 			$this->path = $this->alias;
 		}
 
 		// Check for params.
-		if (trim($this->params) === '')
+		if (!$this->params || trim($this->params) === '')
 		{
 			$this->params = '{}';
 		}
 
 		// Check for img.
-		if (trim($this->img) === '')
+		if (!$this->img || trim($this->img) === '')
 		{
 			$this->img = ' ';
 		}

--- a/libraries/src/Table/Menu.php
+++ b/libraries/src/Table/Menu.php
@@ -117,7 +117,7 @@ class Menu extends Nested
 		}
 
 		// Check for a title.
-		if (!$this->title || trim($this->title) === '')
+		if ($this->title === null || trim($this->title) === '')
 		{
 			$this->setError(Text::_('JLIB_DATABASE_ERROR_MUSTCONTAIN_A_TITLE_MENUITEM'));
 
@@ -125,19 +125,19 @@ class Menu extends Nested
 		}
 
 		// Check for a path.
-		if (!$this->path || trim($this->path) === '')
+		if ($this->path === null || trim($this->path) === '')
 		{
 			$this->path = $this->alias;
 		}
 
 		// Check for params.
-		if (!$this->params || trim($this->params) === '')
+		if ($this->params === null || trim($this->params) === '')
 		{
 			$this->params = '{}';
 		}
 
 		// Check for img.
-		if (!$this->img || trim($this->img) === '')
+		if ($this->img === null || trim($this->img) === '')
 		{
 			$this->img = ' ';
 		}


### PR DESCRIPTION
### Summary of Changes
The menu table adds some checks if the values are empty. On PHP 8.1 these checks do throw a deprecated message when the value is null. For example on:
_trim(): Passing null to parameter 1 ($string) of type string is deprecated in /libraries/src/Table/Menu.php on line 128_

This happens only when doing a discover install with DPDocker, so it can be merged as code review.
