### PR TITLE
[4.1] Fix warning on HTMLHelper::_('select.integerlist')

### DIFF
--- a/libraries/src/HTML/Helpers/Select.php
+++ b/libraries/src/HTML/Helpers/Select.php
@@ -326,7 +326,7 @@ abstract class Select
 	public static function integerlist($start, $end, $inc, $name, $attribs = null, $selected = null, $format = '')
 	{
 		// Set default options
-		$options = array_merge(HTMLHelper::$formatOptions, array('format.depth' => 0, 'option.format' => '', 'id' => null));
+		$options = array_merge(HTMLHelper::$formatOptions, array('format.depth' => 0, 'option.format' => '', 'id' => false));
 
 		if (is_array($attribs) && func_num_args() === 5)
 		{


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR fixes Deprecated warning on HTMLHelper::_('select.integerlist') method


### Testing Instructions
1. Use Joomla 4 website on PHP 8.1
2. Go to Global Configuration, set **Error Reporting** to **Maximum**
2. Edit the file templates/cassiopeia/index.php, add this line of code:

```php
echo HTMLHelper::_('select.integerlist', 1, 10, 1, 'integer_list');
```

### Actual result BEFORE applying this Pull Request
There is Deprecated warning:

>Deprecated
: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in
D:\www\joomla4\libraries\src\HTML\Helpers\Select.php


### Expected result AFTER applying this Pull Request
No warning anymore.
