### PR TITLE
[4.1] Fix Deprecated warning on plugin page

### DIFF
--- a/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
@@ -101,7 +101,7 @@ class HtmlView extends BaseHtmlView
 
 		$help = $this->get('Help');
 
-		if ($lang->hasKey($help->url))
+		if ($help->url && $lang->hasKey($help->url))
 		{
 			$debug = $lang->setDebug(false);
 			$url = Text::_($help->url);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Alternative solution to PR https://github.com/joomla/joomla-cms/pull/37324 . I think we should not pass a null or empty value to $lang->hasKey method.


### Testing Instructions
1. Use Joomla 4 on PHP 8.1
2. Go to System -> Plugins, click on a plugin.


### Actual result BEFORE applying this Pull Request
See message

> Deprecated: strtoupper(): Passing null to parameter https://github.com/joomla/joomla-cms/pull/1 ($string) of type string is deprecated in /libraries/src/Language/Language.php on line 1181


### Expected result AFTER applying this Pull Request
No deprecated message anymore.
