### PR TITLE
[4.1] Do not pass null to base64 decode in front form models

### DIFF
--- a/components/com_contact/src/Model/FormModel.php
+++ b/components/com_contact/src/Model/FormModel.php
@@ -138,7 +138,7 @@ class FormModel extends \Joomla\Component\Contact\Administrator\Model\ContactMod
 	 */
 	public function getReturnPage()
 	{
-		return base64_encode($this->getState('return_page'));
+		return base64_encode($this->getState('return_page', ''));
 	}
 
 	/**
@@ -190,7 +190,7 @@ class FormModel extends \Joomla\Component\Contact\Administrator\Model\ContactMod
 
 		$this->setState('contact.catid', $app->input->getInt('catid'));
 
-		$return = $app->input->get('return', null, 'base64');
+		$return = $app->input->get('return', '', 'base64');
 		$this->setState('return_page', base64_decode($return));
 
 		// Load the parameters.

--- a/components/com_content/src/Model/FormModel.php
+++ b/components/com_content/src/Model/FormModel.php
@@ -68,7 +68,7 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
 
 		$this->setState('article.catid', $app->input->getInt('catid', $catId));
 
-		$return = $app->input->get('return', null, 'base64');
+		$return = $app->input->get('return', '', 'base64');
 		$this->setState('return_page', base64_decode($return));
 
 		$this->setState('layout', $app->input->getString('layout'));
@@ -178,7 +178,7 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
 	 */
 	public function getReturnPage()
 	{
-		return base64_encode($this->getState('return_page'));
+		return base64_encode($this->getState('return_page', ''));
 	}
 
 	/**


### PR DESCRIPTION
### Summary of Changes
There are deprecated warnings on PHP 8.1 in the front end form models for contacts and articles when no return parameter is set in the url.

### Testing Instructions
- Create a new "Create Article" menu item
- Open the menu item on the front end

### Actual result BEFORE applying this Pull Request
The following error is shown:
_Deprecated: base64_decode(): Passing null to parameter #1 ($string) of type string is deprecated in /components/com_content/src/Model/FormModel.php on line 72_

### Expected result AFTER applying this Pull Request
No error.