### PR TITLE
[4.1] Fix some null errors in contact list

### DIFF
--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -119,7 +119,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
 									</span>
 								</div>
 							<?php endif; ?>
-							<?php if (strtotime($item->publish_up) > strtotime(Factory::getDate())) : ?>
+							<?php if ($item->publish_up && strtotime($item->publish_up) > strtotime(Factory::getDate())) : ?>
 								<div>
 									<span class="list-published badge bg-warning text-light">
 										<?php echo Text::_('JNOTPUBLISHEDYET'); ?>

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -185,7 +185,7 @@ class CategoryView extends HtmlView
 				$itemElement->event = new \stdClass;
 
 				// For some plugins.
-				!empty($itemElement->description) ? $itemElement->text = $itemElement->description : $itemElement->text = null;
+				!empty($itemElement->description) ? $itemElement->text = $itemElement->description : $itemElement->text = '';
 
 				Factory::getApplication()->triggerEvent('onContentPrepare', [$this->extension . '.category', &$itemElement, &$itemElement->params, 0]);
 


### PR DESCRIPTION
### Summary of Changes
The contacts front end list shows some deprecated messages on PHP 8.1.

### Testing Instructions
- Create a "List Contacts in a Category" menu item
- On the front open the new menu item
- Click on "New Contact"
- Set only a title in the form
- Click "Save"

### Actual result BEFORE applying this Pull Request
A lot of different messages are shown like:
_Deprecated: strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated in /components/com_contact/tmpl/category/default_items.php on line 122_

### Expected result AFTER applying this Pull Request
No error.