### PR TITLE
[4.2] Handle extensions when the installer script doesn't return a boolean

### DIFF
--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -1040,10 +1040,17 @@ abstract class InstallerAdapter implements ContainerAwareInterface
 		$installer = null;
 
 		// Load the installer from the file
-		if (file_exists($manifestScriptFile))
+		if (!file_exists($manifestScriptFile))
 		{
-			require_once $manifestScriptFile;
+			@trigger_error(
+				'Installer file must exist when defined. In version 5.0 this will crash.',
+				E_USER_DEPRECATED
+			);
+
+			return;
 		}
+
+		require_once $manifestScriptFile;
 
 		// When the instance is a service provider, then register the container with it
 		if ($installer instanceof ServiceProviderInterface)

--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -1037,8 +1037,13 @@ abstract class InstallerAdapter implements ContainerAwareInterface
 		// The real location of the file
 		$manifestScriptFile = $this->parent->getPath('source') . '/' . $manifestScript;
 
-		// Load the file
-		$installer = require_once $manifestScriptFile;
+		$installer = null;
+
+		// Load the installer from the file
+		if (file_exists($manifestScriptFile))
+		{
+			require_once $manifestScriptFile;
+		}
 
 		// When the instance is a service provider, then register the container with it
 		if ($installer instanceof ServiceProviderInterface)

--- a/libraries/src/Installer/LegacyInstallerScript.php
+++ b/libraries/src/Installer/LegacyInstallerScript.php
@@ -42,12 +42,7 @@ class LegacyInstallerScript implements InstallerScriptInterface
 	 */
 	public function install(InstallerAdapter $adapter): bool
 	{
-		if (!method_exists($this->installerScript, 'install'))
-		{
-			return true;
-		}
-
-		return (bool) $this->installerScript->install($adapter);
+		return $this->callOnScript('install', [$adapter]);
 	}
 
 	/**
@@ -61,12 +56,7 @@ class LegacyInstallerScript implements InstallerScriptInterface
 	 */
 	public function update(InstallerAdapter $adapter): bool
 	{
-		if (!method_exists($this->installerScript, 'update'))
-		{
-			return true;
-		}
-
-		return (bool) $this->installerScript->update($adapter);
+		return $this->callOnScript('update', [$adapter]);
 	}
 
 	/**
@@ -80,12 +70,7 @@ class LegacyInstallerScript implements InstallerScriptInterface
 	 */
 	public function uninstall(InstallerAdapter $adapter): bool
 	{
-		if (!method_exists($this->installerScript, 'uninstall'))
-		{
-			return true;
-		}
-
-		return (bool) $this->installerScript->uninstall($adapter);
+		return $this->callOnScript('uninstall', [$adapter]);
 	}
 
 	/**
@@ -100,12 +85,7 @@ class LegacyInstallerScript implements InstallerScriptInterface
 	 */
 	public function preflight(string $type, InstallerAdapter $adapter): bool
 	{
-		if (!method_exists($this->installerScript, 'preflight'))
-		{
-			return true;
-		}
-
-		return (bool) $this->installerScript->preflight($type, $adapter);
+		return $this->callOnScript('preflight', [$type, $adapter]);
 	}
 
 	/**
@@ -120,12 +100,7 @@ class LegacyInstallerScript implements InstallerScriptInterface
 	 */
 	public function postflight(string $type, InstallerAdapter $adapter): bool
 	{
-		if (!method_exists($this->installerScript, 'postflight'))
-		{
-			return true;
-		}
-
-		return (bool) $this->installerScript->postflight($type, $adapter);
+		return $this->callOnScript('postflight', [$type, $adapter]);
 	}
 
 	/**
@@ -158,17 +133,47 @@ class LegacyInstallerScript implements InstallerScriptInterface
 	}
 
 	/**
-	 * Calls the function with the given name on the internal script.
+	 * Calls the function with the given name on the internal script with
+	 * the given name and arguments.
 	 *
 	 * @param   string $name       The name of the function
 	 * @param   array  $arguments  The arguments
 	 *
-	 * @return  void
+	 * @return  mixed
 	 *
 	 * @since   __DEPLOY_VERSION__
 	 */
 	public function __call(string $name, array $arguments)
 	{
-		return call_user_func([$this->installerScript, $name], $arguments);
+		return call_user_func_array([$this->installerScript, $name], $arguments);
+	}
+
+	/**
+	 * Calls the function with the given name on the internal script with
+	 * some condition checking.
+	 *
+	 * @param   string $name       The name of the function
+	 * @param   array  $arguments  The arguments
+	 *
+	 * @return  bool
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 */
+	private function callOnScript(string $name, array $arguments): bool
+	{
+		if (!method_exists($this->installerScript, $name))
+		{
+			return true;
+		}
+
+		$return = $this->__call($name, $arguments);
+
+		// When function doesn't have a return value, assume it succeeded
+		if ($return === null)
+		{
+			return true;
+		}
+
+		return (bool)$return;
 	}
 }

--- a/libraries/src/Installer/LegacyInstallerScript.php
+++ b/libraries/src/Installer/LegacyInstallerScript.php
@@ -174,6 +174,6 @@ class LegacyInstallerScript implements InstallerScriptInterface
 			return true;
 		}
 
-		return (bool)$return;
+		return (bool) $return;
 	}
 }


### PR DESCRIPTION
Pull Request for comment https://github.com/joomla/joomla-cms/pull/37091#issuecomment-1079101363.

### Summary of Changes
Adds an extra check if the extension installer script returns a boolean in the routines.

### Testing Instructions
Install any extension.

### Actual result BEFORE applying this Pull Request
Some which do not return a boolean do fail like acymailing.

### Expected result AFTER applying this Pull Request
All extension can be installed.