### PR TITLE
[4.1] Order of elements in tag layout

### DIFF
--- a/components/com_tags/tmpl/tag/default.xml
+++ b/components/com_tags/tmpl/tag/default.xml
@@ -121,11 +121,11 @@
 				useglobal="true"
 				validate="options"
 				>
-				<option value="c.core_title">JGLOBAL_TITLE</option>
+				<option value="title">JGLOBAL_TITLE</option>
 				<option value="match_count">COM_TAGS_MATCH_COUNT</option>
-				<option value="c.core_created_time">JGLOBAL_CREATED_DATE</option>
-				<option value="c.core_modified_time">JGLOBAL_MODIFIED_DATE</option>
-				<option value="c.core_publish_up">JGLOBAL_PUBLISHED_DATE</option>
+				<option value="created_time">JGLOBAL_CREATED_DATE</option>
+				<option value="modified_time">JGLOBAL_MODIFIED_DATE</option>
+				<option value="publish_up">JGLOBAL_PUBLISHED_DATE</option>
 			</field>
 
 			<field

--- a/components/com_tags/tmpl/tag/list.xml
+++ b/components/com_tags/tmpl/tag/list.xml
@@ -120,11 +120,11 @@
 				useglobal="true"
 				validate="options"
 				>
-				<option value="c.core_title">JGLOBAL_TITLE</option>
+				<option value="title">JGLOBAL_TITLE</option>
 				<option value="match_count">COM_TAGS_MATCH_COUNT</option>
-				<option value="c.core_created_time">JGLOBAL_CREATED_DATE</option>
-				<option value="c.core_modified_time">JGLOBAL_MODIFIED_DATE</option>
-				<option value="c.core_publish_up">JGLOBAL_PUBLISHED_DATE</option>
+				<option value="created_time">JGLOBAL_CREATED_DATE</option>
+				<option value="modified_time">JGLOBAL_MODIFIED_DATE</option>
+				<option value="publish_up">JGLOBAL_PUBLISHED_DATE</option>
 			</field>
 
 			<field


### PR DESCRIPTION
### Summary of Changes
Install Joomla 4.1 build.

Create menu items: **Tags - Compact List of Tagged Items** OR **Tags - Tagged Items**. On the "Options" tab for the "Order" parameter, the global variable will be "incorrectly passed".

The error is clearly visible if you use a language in the admin panel that is clearly different from English.

**Before / After**

![Screenshot_1](https://user-images.githubusercontent.com/8440661/160156579-c48463dc-dc27-41d2-b7d1-0e99862c4acd.png)

