### PR TITLE
[4.2] Remove duplicate WebAssetManager

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -59,10 +59,6 @@ if ($saveOrder && !empty($this->items))
 	HTMLHelper::_('draggablelist.draggable');
 }
 
-/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
-$wa = $this->document->getWebAssetManager();
-$wa->useScript('multiselect');
-
 $workflow_enabled  = ComponentHelper::getParams('com_content')->get('workflow_enabled');
 $workflow_state    = false;
 $workflow_featured = false;

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -60,10 +60,6 @@ if ($saveOrder && !empty($this->items))
 	HTMLHelper::_('draggablelist.draggable');
 }
 
-/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
-$wa = $this->document->getWebAssetManager();
-$wa->useScript('multiselect');
-
 $workflow_enabled  = ComponentHelper::getParams('com_content')->get('workflow_enabled');
 $workflow_state    = false;
 $workflow_featured = false;

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -18,7 +18,8 @@ use Joomla\CMS\Uri\Uri;
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')
-	->useScript('multiselect');
+	->useScript('multiselect')
+	->useScript('com_menus.admin-menus');
 
 $uri       = Uri::getInstance();
 $return    = base64_encode($uri);
@@ -37,12 +38,6 @@ foreach ($this->items as $item)
 }
 
 $this->document->addScriptOptions('menus-default', ['items' => $itemIds]);
-
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-$wa = $this->document->getWebAssetManager();
-$wa->useScript('multiselect')
-	->useScript('com_menus.admin-menus');
-
 ?>
 <form action="<?php echo Route::_('index.php?option=com_menus&view=menus'); ?>" method="post" name="adminForm" id="adminForm">
 	<div class="row">

--- a/administrator/components/com_scheduler/tmpl/tasks/default.php
+++ b/administrator/components/com_scheduler/tmpl/tasks/default.php
@@ -25,7 +25,9 @@ use Joomla\Component\Scheduler\Administrator\View\Tasks\HtmlView;
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')
-	->useScript('multiselect');
+	->useScript('multiselect')
+	->useScript('com_scheduler.test-task')
+	->useStyle('com_scheduler.admin-view-tasks-css');
 
 Text::script('COM_SCHEDULER_TEST_RUN_TITLE');
 Text::script('COM_SCHEDULER_TEST_RUN_TASK');
@@ -65,12 +67,6 @@ if ($saveOrder && !empty($this->items))
 }
 
 $this->document->addScriptOptions('com_scheduler.test-task.token', Session::getFormToken());
-
-/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-$wa = $this->document->getWebAssetManager();
-$wa->useScript('multiselect')
-	->useScript('com_scheduler.test-task')
-	->useStyle('com_scheduler.admin-view-tasks-css');
 ?>
 
 <form action="<?php echo Route::_('index.php?option=com_scheduler&view=tasks'); ?>" method="post" name="adminForm"


### PR DESCRIPTION
### Summary of Changes

Remove duplicate access to WebAssetManager

Caused by conflicts in #36591 due #36373

### Testing Instructions

- open articles: test multiselect
- open featured articles: test multiselect
- open menues: test multiselect and site reload after position modal closed
- open scheduler: test multiselect, test run and display failed task

### Actual result BEFORE applying this Pull Request

Everything works

### Expected result AFTER applying this Pull Request

Everything works

### Documentation Changes Required

None