### PR TITLE
PHP 8.1: Fixes Deprecated: null to string in MailTemplate.php

### DIFF
--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -294,7 +294,7 @@ class MailTemplate
 			$this->mailer->addReplyTo($this->replyto->mail, $this->replyto->name);
 		}
 
-		if (trim($config->get('attachment_folder')))
+		if (trim($config->get('attachment_folder', '')))
 		{
 			$folderPath = rtrim(Path::check(JPATH_ROOT . '/' . $config->get('attachment_folder')), \DIRECTORY_SEPARATOR);
 


### PR DESCRIPTION
Fixes `Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in libraries/src/Mail/MailTemplate.php on line 297`

Pull Request for Issue # none.

### Summary of Changes

Obvious fix to avoid a default null (instead of empty string) passed to trim() which generates a deprecated warning in PHP 8.1.

### Testing Instructions

Code review is enough imho.

To reproduce:
- PHP 8.1 + debug ON + deprecated warnings on in php.ini
- Make sure that you never edited the Joomla mail template
- Make Joomla send an email in admin area (e.g. for new version available)
- See deprecation warning displayed (or not anymore after fix)

### Actual result BEFORE applying this Pull Request

```
Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /home/beat/www/4.1/libraries/src/Mail/MailTemplate.php on line 297

# | Time | Memory | Function | Location
-- | -- | -- | -- | --
1 | 0.0058 | 364520 | {main}(  ) | .../index.php:0
2 | 0.0223 | 365880 | require_once( '/home/beat/www/4.1/administrator/includes/app.php ) | .../index.php:32
3 | 0.2463 | 1853712 | Joomla\CMS\Application\CMSApplication->execute(  ) | .../app.php:63
4 | 2.2751 | 6298176 | Joomla\CMS\Application\AdministratorApplication->render(  ) | .../CMSApplication.php:284
5 | 2.2752 | 6298216 | Joomla\CMS\Application\CMSApplication->render(  ) | .../AdministratorApplication.php:514
6 | 2.5000 | 8513024 | Joomla\CMS\Application\WebApplication->triggerEvent( $eventName = 'onAfterRender', $args = ??? ) | .../CMSApplication.php:1045
7 | 2.5000 | 8513120 | Joomla\Event\Dispatcher->dispatch( $name = 'onAfterRender', $event = class Joomla\Event\Event { protected $name = 'onAfterRender'; protected $arguments = []; protected $stopped = FALSE } ) | .../EventAware.php:111
8 | 2.5002 | 8513768 | Joomla\CMS\Plugin\CMSPlugin->Joomla\CMS\Plugin\{closure:/home/beat/www/4.1/libraries/src/Plugin/CMSPlugin.php:267-296}( $event = class Joomla\Event\Event { protected $name = 'onAfterRender'; protected $arguments = []; protected $stopped = FALSE } ) | .../Dispatcher.php:486
9 | 2.5002 | 8513768 | PlgSystemUpdatenotification->onAfterRender(  ) | .../CMSPlugin.php:285
10 | 3.0070 | 8978392 | Joomla\CMS\Mail\MailTemplate->send(  ) | .../updatenotification.php:271
11 | 3.0117 | 8993992 | trim( $string = NULL ) | .../MailTemplate.php:297
```

### Expected result AFTER applying this Pull Request

No error.

### Documentation Changes Required

None.