### PR TITLE
[4.1] Add label for notification tab in workflow transition form

### DIFF
--- a/plugins/workflow/notification/forms/action.xml
+++ b/plugins/workflow/notification/forms/action.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
 	<fields name="options">
-		<fieldset name="notification">
+		<fieldset name="notification" label="COM_WORKFLOW_NOTIFICATION_FIELDSET_LABEL">
 			<field
 				name="notification_send_mail"
 				type="radio"


### PR DESCRIPTION
Pull Request for Issue #37390 part 2 .

### Summary of Changes

Add a label attribute to the notifications fieldset in the edit workflow transition form.

### Testing Instructions

Switch on "Debug Language" in Global Configuration.

Edit a workflow transition and go to the 3rd tab for the notifications setting.

### Actual result BEFORE applying this Pull Request

![2022-03-28_workflow-transition-notification_2](https://user-images.githubusercontent.com/7413183/160417749-b0870790-3af8-4216-8354-b405a80b7621.png)

### Expected result AFTER applying this Pull Request

![2022-03-28_workflow-transition-notification_3](https://user-images.githubusercontent.com/7413183/160417793-a7c76de9-eaf3-4fa9-a4f2-d1ce8d2d2601.png)

### Documentation Changes Required

None.