### PR TITLE
[4.1] s\preset\present

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -8651,7 +8651,7 @@ class JoomlaInstallerScript
 	}
 
 	/**
-	 * Add the user Auth Provider Column as it could be preset from 3.10 already
+	 * Add the user Auth Provider Column as it could be present from 3.10 already
 	 *
 	 * @return  void
 	 *


### PR DESCRIPTION
Fix copy [paste error. Corrects the copyright date as its a new file.

Looks like all the `@since ` values also need to be corrected as well
