### PR TITLE
[4.1] Refactoring Appveyor test setup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,89 +1,63 @@
+image: Visual Studio 2022
 build: false
 platform:
   - x64
 clone_folder: C:\projects\joomla-cms
 
-branches:
-  except:
-    - /l10n_*/
-
 ## Build matrix for lowest and highest possible targets
 environment:
   PHPBuild: "x64"
-  VC: "vc15"
-  WINCACHE: "2.0.0.8"
   matrix:
   - php_ver_target: 7.2
   - php_ver_target: 7.3
   - php_ver_target: 7.4
+  - php_ver_target: 8.0
+  - php_ver_target: 8.1
+
+matrix:
+  allow_failures:
+    - php_ver_target: 8.1
 
 init:
-  - SET PATH=C:\Program Files\OpenSSL;C:\tools\php;%PATH%
+  - SET PATH=C:\Tools\php;%PATH%
   - SET COMPOSER_NO_INTERACTION=1
-  - SET PHP=1 # This var relates to caching the php install
   - SET ANSICON=121x90 (121x90)
 services:
   - mysql
-  - postgresql94
   - iis
 
 ## Install PHP and composer, and run the appropriate composer command
 install:
-    - IF EXIST C:\tools\php (SET PHP=0)
-    # @todo: This is a workaround for https://github.com/chocolatey/choco/issues/1843. Once this is fixed we
-    #       should go back to latest version in appveyor saving ourselves test time
-    - ps: choco upgrade chocolatey -y --version 0.10.13 --allow-downgrade --no-progress
     - ps: >-
-        If ($env:PHP -eq "1") {
-          appveyor-retry cinst --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
-        }
+        appveyor-retry choco install --no-progress --params '""/InstallDir:C:\tools\php""' --ignore-checksums -y php --version ((choco search php --exact --all-versions -r | select-string -pattern $env:php_ver_target | sort { [version]($_ -split '\|' | select -last 1) } -Descending | Select-Object -first 1) -replace '[php|]','')
     - cd C:\tools\php
-    - IF %PHP%==1 copy php.ini-production php.ini /Y
-    - IF %PHP%==1 echo date.timezone="UTC" >> php.ini
-    - IF %PHP%==1 echo extension_dir=ext >> php.ini
-    - IF %PHP%==1 echo extension=php_openssl.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_mbstring.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_fileinfo.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_gd2.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_gmp.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_pgsql.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_pdo_pgsql.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_pdo_mysql.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_mysqli.dll >> php.ini
-    - IF %PHP_VER_TARGET%==5.6 IF %PHP%==1 echo extension=php_mysql.dll >> php.ini
-    - IF %PHP%==1 echo extension=php_curl.dll >> php.ini
-    # Get the Wincache DLLs
-    - ps: >-
-        If ($env:PHP -eq "1" -and $env:WINCACHE) {
-          cd c:\tools\php\ext
-          $source = "https://windows.php.net/downloads/pecl/releases/wincache/$($env:WINCACHE)/php_wincache-$($env:WINCACHE)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-          $destination = "c:\tools\php\ext\php_wincache-$($env:WINCACHE)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip"
-          Invoke-WebRequest $source -OutFile $destination
-          #appveyor-retry appveyor DownloadFile https://windows.php.net/downloads/pecl/releases/wincache/$($env:WINCACHE)/php_wincache-$($env:WINCACHE)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip
-          7z x -y php_wincache-$($env:WINCACHE)-$($env:php_ver_target)-nts-$($env:VC)-$($env:PHPBuild).zip > $null
-          Remove-Item C:\tools\php\ext* -include .zip
-          cd c:\tools\php
-          Add-Content php.ini "`nextension=php_wincache.dll"
-          Add-Content php.ini "`wincache.enablecli = 1"
-          Add-Content php.ini "`n"
-        }
-    - IF %PHP%==1 echo zend_extension=php_opcache.dll >> php.ini
-    - IF %PHP%==1 echo opcache.enable_cli=1 >> php.ini
-    - IF %PHP%==1 echo extension=php_ldap.dll >> php.ini
-    - IF %PHP%==1 echo @php %%~dp0composer.phar %%* > composer.bat
-    - IF %PHP%==1 appveyor-retry appveyor DownloadFile https://getcomposer.org/download/latest-1.x/composer.phar
+    - copy php.ini-production php.ini /Y
+    - echo date.timezone="UTC" >> php.ini
+    - echo extension_dir=ext >> php.ini
+    - echo extension=php_openssl.dll >> php.ini
+    - echo extension=php_mbstring.dll >> php.ini
+    - echo extension=php_fileinfo.dll >> php.ini
+    - IF %php_ver_target% LSS 8 echo extension=php_gd2.dll >> php.ini
+    - IF %php_ver_target% GEQ 8 echo extension=gd >> php.ini
+    - echo extension=php_gmp.dll >> php.ini
+    - echo extension=php_pgsql.dll >> php.ini
+    - echo extension=php_pdo_pgsql.dll >> php.ini
+    - echo extension=php_pdo_mysql.dll >> php.ini
+    - echo extension=php_mysqli.dll >> php.ini
+    - echo extension=php_curl.dll >> php.ini
+    - echo zend_extension=php_opcache.dll >> php.ini
+    - echo opcache.enable_cli=1 >> php.ini
+    - echo extension=php_ldap.dll >> php.ini
+    - choco install composer
     - cd C:\projects\joomla-cms
-    - appveyor-retry composer install --no-progress --profile
+    - refreshenv
+    - composer install --no-progress --profile
 before_test:
 #  Database setup for MySQL via PowerShell tools
   - >
-    "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql" -u root -p"Password12!" -e "CREATE DATABASE IF NOT EXISTS joomla_ut;"
-#  Database setup for PostgreSQL
-  - SET PGUSER=postgres
-  - SET PGPASSWORD=Password12!
-  - PATH=C:\Program Files\PostgreSQL\9.4\bin\;%PATH%
-  - createdb joomla_ut
+    "C:\Program Files\MySQL\MySQL Server 5.7\bin\mysql" -u root -p"Password12!" -e "CREATE DATABASE IF NOT EXISTS test_joomla;"
 
 test_script:
   - cd C:\projects\joomla-cms
   - libraries/vendor/bin/phpunit --testsuite Unit
+  - libraries/vendor/bin/phpunit --testsuite Integration  --configuration tests/phpunit-appveyor.xml.dist

--- a/tests/phpunit-appveyor.xml.dist
+++ b/tests/phpunit-appveyor.xml.dist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="Unit/bootstrap.php" colors="false">
+	<testsuites>
+		<testsuite name="Unit">
+			<directory suffix="Test.php">./Unit/Libraries</directory>
+		</testsuite>
+		<testsuite name="Integration">
+			<directory suffix="Test.php">./Integration/Libraries</directory>
+		</testsuite>
+	</testsuites>
+	<php>
+		<const name="JTEST_DB_ENGINE" value="mysqli" />
+		<const name="JTEST_DB_HOST" value="localhost" />
+		<const name="JTEST_DB_NAME" value="test_joomla" />
+		<const name="JTEST_DB_USER" value="root" />
+		<const name="JTEST_DB_PASSWORD" value="Password12!" />
+	</php>
+</phpunit>


### PR DESCRIPTION
The Appveyor setup was pretty outdated and did rarely any tests. This PR refactors all of this and hopefully improves this for the future. The following changes were done:
- Updated the system image to run off of from Visual Studio 2015 to Visual Studio 2022
- Removed the limitations for branches. We haven't had l10n branches for years...
- Added PHP 8.0 and 8.1 (where 8.1 is allowed to still fail right now)
- Removed the "caching" of the PHP installation. That stuff never worked. We are always starting with a clean image.
- Using built in chocolatey instead of downgrading to an earlier version. The bug that required that was fixed a year ago.
- Removed WinCache setup. First of all, we never ran any tests with WinCache and second of all, WinCache seems to be dead for several years already. I'm going to create PRs to deprecate it for Joomla 5 soon.
- Removed PostgreSQL. Up till now we didn't run any database tests and Postgres didn't work out of the box in my tests. So for now I've removed that.
- Added the Integration tests.

These changes mean that while we run 5 jobs instead of 3, it doesn't take longer than before, maybe it is even quicker. This can be merged when the Appveyor tests pass, no tests by humans needed.