### PR TITLE
Fix bug use value 1 as TRUE - Workflowcondition Field

### DIFF
--- a/libraries/src/Form/Field/WorkflowconditionField.php
+++ b/libraries/src/Form/Field/WorkflowconditionField.php
@@ -75,7 +75,7 @@ class WorkflowconditionField extends ListField
 
 			if (\strlen($element['hide_all']))
 			{
-				$this->hideAll = (string) $element['hide_all'] === 'true' || (string) $element['hide_all'] === 'yes';
+				$this->hideAll = (string) $element['hide_all'] === 'true' || (string) $element['hide_all'] === 'yes' || (string) $element['hide_all'] === '1';
 			}
 		}
 


### PR DESCRIPTION
Correcting a gross mistake. Obviously, the value 1 of the field attribute is always used equivalent to TRUE. We always use the values 1 and 0 for lists and radio buttons to make switches.