### PR TITLE
[4.1] Remove composer dependencies' development artifacts from packages and from installations on updates

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6384,10 +6384,6 @@ class JoomlaInstallerScript
 			'/libraries/vendor/tobscure/json-api/tests/ResourceTest.php',
 			'/libraries/vendor/tobscure/json-api/tests/UtilTest.php',
 			// From 4.1.2 to 4.1.3
-			'libraries/vendor/sebastian/code-unit-reverse-lookup/.php_cs',
-			'libraries/vendor/sebastian/object-enumerator/.php_cs',
-			'libraries/vendor/sebastian/object-reflector/.php_cs',
-			'libraries/vendor/sebastian/version/.php_cs',
 			'libraries/vendor/webmozart/assert/.php_cs',
 		);
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6383,6 +6383,12 @@ class JoomlaInstallerScript
 			'/libraries/vendor/tobscure/json-api/tests/ParametersTest.php',
 			'/libraries/vendor/tobscure/json-api/tests/ResourceTest.php',
 			'/libraries/vendor/tobscure/json-api/tests/UtilTest.php',
+			// From 4.1.2 to 4.1.3
+			'libraries/vendor/sebastian/code-unit-reverse-lookup/.php_cs',
+			'libraries/vendor/sebastian/object-enumerator/.php_cs',
+			'libraries/vendor/sebastian/object-reflector/.php_cs',
+			'libraries/vendor/sebastian/version/.php_cs',
+			'libraries/vendor/webmozart/assert/.php_cs',
 		);
 
 		$folders = array(

--- a/build/build.php
+++ b/build/build.php
@@ -87,6 +87,7 @@ function clean_checkout(string $dir)
 	system('find libraries/vendor -name UPGRADING.md | xargs rm -rf -');
 	system('find libraries/vendor -name SUMMARY.md | xargs rm -rf -');
 	system('find libraries/vendor -name .travis.yml | xargs rm -rf -');
+	system('find libraries/vendor -name .git | xargs rm -rf -');
 	system('find libraries/vendor -name .gitignore | xargs rm -rf -');
 	system('find libraries/vendor -name .gitmodules | xargs rm -rf -');
 	system('find libraries/vendor -name ISSUE_TEMPLATE | xargs rm -rf -');
@@ -102,6 +103,7 @@ function clean_checkout(string $dir)
 	system('find libraries/vendor -name .editorconfig | xargs rm -rf -');
 	system('find libraries/vendor -name appveyor.yml | xargs rm -rf -');
 	system('find libraries/vendor -name phpunit.xml.dist | xargs rm -rf -');
+	system('find libraries/vendor -name .php_cs | xargs rm -rf -');
 	system('find libraries/vendor -name .php_cs.dist | xargs rm -rf -');
 	system('find libraries/vendor -name phpcs.xsd | xargs rm -rf -');
 	system('find libraries/vendor -name phpcs.xml | xargs rm -rf -');
@@ -161,8 +163,6 @@ function clean_checkout(string $dir)
 	system('rm -rf libraries/vendor/symfony/console/Resources');
 
 	// tobscure/json-api
-	system('rm -rf libraries/vendor/tobscure/json-api/.git');
-	system('rm -rf libraries/vendor/tobscure/json-api/.php_cs');
 	system('rm -rf libraries/vendor/tobscure/json-api/tests');
 
 	// wamania/php-stemmer

--- a/build/build.php
+++ b/build/build.php
@@ -160,6 +160,11 @@ function clean_checkout(string $dir)
 	system('rm -rf libraries/vendor/symfony/*/Tests');
 	system('rm -rf libraries/vendor/symfony/console/Resources');
 
+	// tobscure/json-api
+	system('rm -rf libraries/vendor/tobscure/json-api/.git');
+	system('rm -rf libraries/vendor/tobscure/json-api/.php_cs');
+	system('rm -rf libraries/vendor/tobscure/json-api/tests');
+
 	// wamania/php-stemmer
 	system('rm -rf libraries/vendor/wamania/php-stemmer/test');
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) adds removal of .git folders and .php_cs files from 3rd party libraries in general and of the "tests" folder or the composer dependency "tobscure/json-api" in particular to the build script "build/build.php" so that these files and folders which are not needed on a J4 installation will not be included in the full installation or update packages.

It also adds the "libraries/vendor/webmozart/assert/.php_cs" file to the list of files to be deleted on update in administrator/components/com_admin/script.php.

### Reasons for Changes

When having updated the list of files and folders to be deleted on update with my PR #37287 before the 4.0.1 release, I had done that as usual based on a comparison of a full package built with the build script on the 4.1-dev branch at that time and the full installation package of the previous 4.0.0 release (and of course also another comparison with a 3.10-dev package, but that doesn't matter here).

The result was that the file ".php_cs" and subfolders ".git" and "tests" of the "tobscure/json-api" dependency were detected as removed and so added to script.php with PR #37287 as this file and these folders are not needed on a J4 installation.

See here

https://github.com/joomla/joomla-cms/blob/4.1-dev/administrator/components/com_admin/script.php#L6344-L6385

and here

https://github.com/joomla/joomla-cms/blob/4.1-dev/administrator/components/com_admin/script.php#L7698-L7718

It's development stuff from of this dependency and so it was right to remove it.

But now the same check for the current 4.1-dev branch and the 4.0.2 release has shown that this stuff was included again in the release packages, while the 4.1-dev nightly builds and also the 4.2-dev nightly builds and the 4.2.0-alpha1 packages do not include that.

See here a comparison of the latest 4.1-dev nightly installation package (left side) with the 4.0.2 release installation package (right side):

![2022-04-02_j4 1-tobscure-json-api-files](https://user-images.githubusercontent.com/7413183/161383508-b5850629-c927-4f64-8679-d198b9972c3f.png)

The ".git" and "tests" subfolders are not expanded in the above image, they contain a lot of files.

With the 4.1 update packages it's the same.

The 4.2 packages are all ok, regardless if nightly or latest alpha.

So it seems to depend on the build environment if that stuff is in the package or not. I was never able to get it into a package when I made local builds with `php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2`, so up to now only @bembelimen could reproduce the issue.

I have now decided to do it like we did with other vendor stuff in past and added code to the build script for removing these files and folders from the build result before we pack the packages.

For the ".git" subfolder and the ".php_cs" file I've decided to do that in general for all vendor libraries and not only that one. This results in one more file "libraries/vendor/webmozart/assert/.php_cs" which is detected by the comparison mentioned at the beginning for the list of files to be deleted on update, and so this PR here adds that file to the list.

### Testing Instructions

**Requirement:** It needs a development environment with Linux or WSL on Windows because the build/build.php script doesn't work on Windows without WSL.

1. On a clean, current 4.1-dev branch in a command shell in the Joomla root folder, run `php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2`.

2. Check the content of the "build/tmp/packages/Joomla_4.1.3-dev-Development-Full_Package.zip" package if it contains the following folders and files:
- Folder "libraries/vendor/tobscure/json-api/.git" with files in it
- File "libraries/vendor/tobscure/json-api/.php_cs"
- Folder "libraries/vendor/tobscure/json-api/tests" with files in it
- File "libraries/vendor/webmozart/assert/.php_cs"
Result: See section "Actual result BEFORE applying this Pull Request" below.

4. Revert all local changes:
`git clean -d -x -f`
`git checkout .`

5. Fetch the changes of this PR into a new branch named "test-pr-37458":
`git fetch upstream pull/37458/head:test-pr-37458`
with "upstream" being the remote for this repository here. If you don't have such a remote, you can add it with
`git remote add upstream https://github.com/joomla/joomla-cms.git`
before executing the above "fetch" command.

6. Checkout the new branch from step 4:
`git checkout test-pr-37458`

7. Run `php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2`.

8. Check the content of the "build/tmp/packages/Joomla_4.1.3-dev-Development-Full_Package.zip" package like in step 2 above.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

File "libraries/vendor/webmozart/assert/.php_cs" is in the package.

Depending on your build environment and which parameters you have used for the build script, the following files and folders might be in the package:
- Folder "libraries/vendor/tobscure/json-api/.git" with files in it
- File "libraries/vendor/tobscure/json-api/.php_cs"
- Folder "libraries/vendor/tobscure/json-api/tests" with files in it

### Expected result AFTER applying this Pull Request

File "libraries/vendor/webmozart/assert/.php_cs" is not in the package.

The following files and folders are not in the package:
- Folder "libraries/vendor/tobscure/json-api/.git" with files in it
- File "libraries/vendor/tobscure/json-api/.php_cs"
- Folder "libraries/vendor/tobscure/json-api/tests" with files in it

### Documentation Changes Required

None.