### PR TITLE
[4.1-dev] Fix DB query in `Scheduler::getTaskRecords()`

### DIFF
--- a/administrator/components/com_scheduler/src/Scheduler/Scheduler.php
+++ b/administrator/components/com_scheduler/src/Scheduler/Scheduler.php
@@ -330,7 +330,7 @@ class Scheduler
 			throw new \RuntimeException('JLIB_APPLICATION_ERROR_MODEL_CREATE');
 		}
 
-		$model->setState('list.select', '*');
+		$model->setState('list.select', 'a.*');
 
 		// Default to only enabled tasks
 		if (!isset($filters['state']))


### PR DESCRIPTION
### Summary of Changes
Something broke the `SELECT *` query, resulting in a NULL id when
it was finally evaluated against the DB in TasksModel. This broke
the `scheduler:run` console command which is fixed by this commit.

### Testing Instructions
- Create a scheduled task.
- Trigger the scheduler from the CLI: `php joomla.php scheduler:run`.


### Actual result BEFORE applying this Pull Request
```
Run tasks
=========


In OptionsResolver.php line 1060:

  The option "id" with value null is expected to be of type "numeric", but is of type "null".

```


### Expected result AFTER applying this Pull Request
```
Run tasks
=========

Task#02 'Some Task' processed in 5.12 seconds.

Finished running 1 tasks in 5.12 seconds.
```

### Documentation Changes Required
None

