### PR TITLE
[4.1] Language sort

### DIFF
--- a/administrator/components/com_languages/forms/filter_installed.xml
+++ b/administrator/components/com_languages/forms/filter_installed.xml
@@ -36,8 +36,8 @@
 			<option value="name DESC">COM_LANGUAGES_HEADING_LANGUAGE_DESC</option>
 			<option value="nativeName ASC">COM_LANGUAGES_HEADING_TITLE_NATIVE_ASC</option>
 			<option value="nativeName DESC">COM_LANGUAGES_HEADING_TITLE_NATIVE_DESC</option>
-			<option value="language ASC" requires="multilanguage">COM_LANGUAGES_HEADING_LANG_TAG_ASC</option>
-			<option value="language DESC" requires="multilanguage">COM_LANGUAGES_HEADING_LANG_TAG_DESC</option>
+			<option value="language ASC">COM_LANGUAGES_HEADING_LANG_TAG_ASC</option>
+			<option value="language DESC">COM_LANGUAGES_HEADING_LANG_TAG_DESC</option>
 			<option value="published ASC">COM_LANGUAGES_HEADING_DEFAULT_ASC</option>
 			<option value="published DESC">COM_LANGUAGES_HEADING_DEFAULT_DESC</option>
 			<option value="version ASC">COM_LANGUAGES_HEADING_VERSION_ASC</option>


### PR DESCRIPTION
Removes the multilanguage check as it is not correct for the list of installed languages

PARTIAL Pull Request for Issue #37499 .

To test install more than one language and go to the list of installed languages (do NOT enable the language filter plugin)

Click on the Language tag column header to sort by this column

### Before
![image](https://user-images.githubusercontent.com/1296369/162079748-a7ca6524-9500-4d8a-831a-a5342fa85f82.png)

### After
![image](https://user-images.githubusercontent.com/1296369/162079590-27c7badf-0dba-4ae0-b98c-2410389ec924.png)
