### PR TITLE
[4.1] com_scheduler columns

### DIFF
--- a/administrator/components/com_scheduler/tmpl/tasks/default.php
+++ b/administrator/components/com_scheduler/tmpl/tasks/default.php
@@ -133,12 +133,12 @@ $wa->useScript('multiselect')
 					</th>
 
 					<!-- Test task -->
-					<th scope="col">
+					<th scope="col" class="d-none d-md-table-cell">
 						<?php echo Text::_('COM_SCHEDULER_TEST_TASK'); ?>
 					</th>
 
 					<!-- Priority -->
-					<th scope="col">
+					<th scope="col" class="d-none d-lg-table-cell">
 						<?php echo HTMLHelper::_('searchtools.sort', 'COM_SCHEDULER_TASK_PRIORITY', 'a.priority', $listDirn, $listOrder) ?>
 					</th>
 


### PR DESCRIPTION
The display of the columns in a row did not match the display of the headers at responsive breakpoints


## Before
![zoom](https://user-images.githubusercontent.com/1296369/162144212-51675306-bba7-42f5-ae92-5ee1a1eb3c2d.gif)


## After
![zoom](https://user-images.githubusercontent.com/1296369/162144003-5f117fad-7497-4bd6-a180-1666002d22de.gif)
