### PR TITLE
[4.1] Joomla Update Component update site

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.1.3-2022-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.1.3-2022-04-08.sql
@@ -1,0 +1,3 @@
+UPDATE `#__update_sites`
+   SET `name` = 'Joomla! Update Component'
+ WHERE `name`= 'Joomla! Update Component Update Site';

--- a/administrator/components/com_admin/sql/updates/mysql/4.1.3-2022-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.1.3-2022-04-08.sql
@@ -1,3 +1,3 @@
 UPDATE `#__update_sites`
    SET `name` = 'Joomla! Update Component'
- WHERE `name`= 'Joomla! Update Component Update Site';
+ WHERE `name` = 'Joomla! Update Component Update Site';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.1.3-2022-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.1.3-2022-04-08.sql
@@ -1,3 +1,3 @@
 UPDATE "#__update_sites"
    SET "name" = 'Joomla! Update Component'
- WHERE "name"= 'Joomla! Update Component Update Site';
+ WHERE "name" = 'Joomla! Update Component Update Site';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.1.3-2022-04-08.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.1.3-2022-04-08.sql
@@ -1,0 +1,3 @@
+UPDATE "#__update_sites"
+   SET "name" = 'Joomla! Update Component'
+ WHERE "name"= 'Joomla! Update Component Update Site';

--- a/administrator/components/com_joomlaupdate/joomlaupdate.xml
+++ b/administrator/components/com_joomlaupdate/joomlaupdate.xml
@@ -28,6 +28,6 @@
 		</languages>
 	</administration>
 	<updateservers>
-		<server type="extension" name="Joomla! Update Component Update Site">https://update.joomla.org/core/extensions/com_joomlaupdate.xml</server>
+		<server type="extension" name="Joomla! Update Component">https://update.joomla.org/core/extensions/com_joomlaupdate.xml</server>
 	</updateservers>
 </extension>

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -864,7 +864,7 @@ CREATE TABLE IF NOT EXISTS `#__update_sites` (
 INSERT INTO `#__update_sites` (`update_site_id`, `name`, `type`, `location`, `enabled`, `last_check_timestamp`) VALUES
 (1, 'Joomla! Core', 'collection', 'https://update.joomla.org/core/list.xml', 1, 0),
 (2, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_4.xml', 1, 0),
-(3, 'Joomla! Update Component Update Site', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
+(3, 'Joomla! Update Component', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
 
 -- --------------------------------------------------------
 

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -881,7 +881,7 @@ COMMENT ON TABLE "#__update_sites" IS 'Update Sites';
 INSERT INTO "#__update_sites" ("update_site_id", "name", "type", "location", "enabled", "last_check_timestamp") VALUES
 (1, 'Joomla! Core', 'collection', 'https://update.joomla.org/core/list.xml', 1, 0),
 (2, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_4.xml', 1, 0),
-(3, 'Joomla! Update Component Update Site', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
+(3, 'Joomla! Update Component', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
 
 SELECT setval('#__update_sites_update_site_id_seq', 4, false);
 


### PR DESCRIPTION
### Summary of Changes
Simple PR to change the name of the update site for the Joomla Update Component.

It doesn't really make sense to have Update Site in the name


### Testing Instructions
Update using the prebuilt updates
Clean install using the prebuilt full package


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/162159087-535db7e2-dd40-4065-9717-26b87feabcc4.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/162158916-f8800e93-dae3-438b-8513-0db00b7d6651.png)



### Documentation Changes Required

none