### PR TITLE
[4.1] configuration.php-dist debug

### DIFF
--- a/installation/configuration.php-dist
+++ b/installation/configuration.php-dist
@@ -130,7 +130,7 @@ class JConfig
 	public $proxy_pass = '';
 
 	/* Debug Settings */
-	public $debug = true;
+	public $debug = false;
 	public $debug_lang = false;
 	public $debug_lang_const = true;
 


### PR DESCRIPTION
The file configuration.php-dist should have values that match the standard installation. 
This pr sets the value for debug to false from true

code review only