### PR TITLE
[4.1] Manual Update links underline [a11y]

### DIFF
--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
@@ -352,7 +352,7 @@ if (version_compare($this->updateInfo['latest'], Version::MAJOR_VERSION + 1, '>=
 	</form>
 
 	<?php if (Factory::getUser()->authorise('core.admin')) : ?>
-		<div class="text-center">
+		<div class="text-center text-decoration-underline">
 		<?php echo HTMLHelper::_('link', Route::_('index.php?option=com_joomlaupdate&view=upload'), Text::_('COM_JOOMLAUPDATE_EMPTYSTATE_APPEND')); ?>
 		</div>
 	<?php endif; ?>

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/reinstall.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/reinstall.php
@@ -46,7 +46,7 @@ if (isset($this->updateInfo['object']) && isset($this->updateInfo['object']->get
 endif;
 
 if (Factory::getApplication()->getIdentity()->authorise('core.admin', 'com_joomlaupdate')) :
-	$displayData['formAppend'] = '<div class="text-center">' . HTMLHelper::_('link', $uploadLink, Text::_('COM_JOOMLAUPDATE_EMPTYSTATE_APPEND')) . '</div>';
+	$displayData['formAppend'] = '<div class="text-center text-decoration-underline">' . HTMLHelper::_('link', $uploadLink, Text::_('COM_JOOMLAUPDATE_EMPTYSTATE_APPEND')) . '</div>';
 endif;
 
 echo '<div id="joomlaupdate-wrapper">';

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/update.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/update.php
@@ -55,7 +55,7 @@ $displayData['content'] .= '<div class="form-check d-flex justify-content-center
 	</div>';
 
 if (Factory::getApplication()->getIdentity()->authorise('core.admin', 'com_joomlaupdate')) :
-	$displayData['formAppend'] = '<div class="text-center">' . HTMLHelper::_('link', $uploadLink, Text::_('COM_JOOMLAUPDATE_EMPTYSTATE_APPEND')) . '</div>';
+	$displayData['formAppend'] = '<div class="text-center text-decoration-underline">' . HTMLHelper::_('link', $uploadLink, Text::_('COM_JOOMLAUPDATE_EMPTYSTATE_APPEND')) . '</div>';
 endif;
 
 echo '<div id="joomlaupdate-wrapper">';


### PR DESCRIPTION
This finishes the work started in #36134 which was incomplete.

 Making sure that the class is added to ALL the instances of the link and not just the instance on the default page.

Testing is tricky as you will need to force the updater to see a new release so it is probably best to test by code review only.

