### PR TITLE
[4.2] Deprecate the CMS filesystem package in favor of the framework

### DIFF
--- a/libraries/src/Client/ClientHelper.php
+++ b/libraries/src/Client/ClientHelper.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Factory;
  * Client helper class
  *
  * @since  1.7.0
+ *
+ * @deprecated  5.0 No replacement
  */
 class ClientHelper
 {

--- a/libraries/src/Client/FtpClient.php
+++ b/libraries/src/Client/FtpClient.php
@@ -85,6 +85,8 @@ if (!\defined('FTP_NATIVE'))
  * FTP client class
  *
  * @since  1.5
+ *
+ * @deprecated  5.0 Use the filesystem package from the framework
  */
 class FtpClient
 {

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -805,6 +805,7 @@ abstract class Factory
 	 *
 	 * @see     Stream
 	 * @since   1.7.0
+	 * @deprecated  5.0 Use the native PHP streams or build one from the framework package
 	 */
 	public static function getStream($usePrefix = true, $useNetwork = true, $userAgentSuffix = 'Joomla', $maskUserAgent = false)
 	{

--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -21,6 +21,8 @@ use Joomla\CMS\Log\Log;
  * A File handling class
  *
  * @since  1.7.0
+ *
+ * @deprecated  5.0 Use the filesystem package from the framework
  */
 class File
 {

--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -40,6 +40,8 @@ class File
 	 * @return  string  The file extension
 	 *
 	 * @since   1.7.0
+	 *
+	 * @deprecated  5.0 Use native pathinfo
 	 */
 	public static function getExt($file)
 	{
@@ -665,6 +667,8 @@ class File
 	 * @return  boolean  True if path is a file
 	 *
 	 * @since   1.7.0
+	 *
+	 * @deprecated  5.0 Use native is_file instead
 	 */
 	public static function exists($file)
 	{

--- a/libraries/src/Filesystem/FilesystemHelper.php
+++ b/libraries/src/Filesystem/FilesystemHelper.php
@@ -16,6 +16,8 @@ namespace Joomla\CMS\Filesystem;
  * Holds support functions for the filesystem, particularly the stream
  *
  * @since  1.7.0
+ *
+ * @deprecated  5.0 Use the filesystem package from the framework
  */
 class FilesystemHelper
 {

--- a/libraries/src/Filesystem/Folder.php
+++ b/libraries/src/Filesystem/Folder.php
@@ -480,6 +480,8 @@ abstract class Folder
 	 * @return  boolean  True if path is a folder
 	 *
 	 * @since   1.7.0
+	 *
+	 * @deprecated  5.0 Use native is_dir
 	 */
 	public static function exists($path)
 	{

--- a/libraries/src/Filesystem/Folder.php
+++ b/libraries/src/Filesystem/Folder.php
@@ -20,6 +20,8 @@ use Joomla\CMS\Log\Log;
  * A Folder handling class
  *
  * @since  1.7.0
+ *
+ * @deprecated  5.0 Use the filesystem package from the framework
  */
 abstract class Folder
 {

--- a/libraries/src/Filesystem/Patcher.php
+++ b/libraries/src/Filesystem/Patcher.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Language\Text;
  *
  * @link   http://sourceforge.net/projects/phppatcher/ This has been derived from the PhpPatcher version 0.1.1 written by Giuseppe Mazzotta
  * @since  3.0.0
+ *
+ * @deprecated  5.0 Use the filesystem package from the framework
  */
 class Patcher
 {

--- a/libraries/src/Filesystem/Path.php
+++ b/libraries/src/Filesystem/Path.php
@@ -22,6 +22,8 @@ if (!\defined('JPATH_ROOT'))
  * A Path handling class
  *
  * @since  1.7.0
+ *
+ * @deprecated  5.0 Use the filesystem package from the framework
  */
 class Path
 {

--- a/libraries/src/Filesystem/Stream.php
+++ b/libraries/src/Filesystem/Stream.php
@@ -27,6 +27,8 @@ use Joomla\CMS\Object\CMSObject;
  * @link   https://www.php.net/manual/en/filters.php Stream Filters
  * @link   https://www.php.net/manual/en/transports.php Socket Transports (used by some options, particularly HTTP proxy)
  * @since  1.7.0
+ *
+ * @deprecated  5.0 Use the filesystem package from the framework
  */
 class Stream extends CMSObject
 {

--- a/libraries/src/Filesystem/Streams/StreamString.php
+++ b/libraries/src/Filesystem/Streams/StreamString.php
@@ -19,6 +19,8 @@ use Joomla\CMS\Filesystem\Support\StringController;
  * you would normally use a regular stream wrapper
  *
  * @since  1.7.0
+ *
+ * @deprecated  5.0 Use the filesystem package from the framework
  */
 class StreamString
 {

--- a/libraries/src/Filesystem/Support/StringController.php
+++ b/libraries/src/Filesystem/Support/StringController.php
@@ -14,6 +14,8 @@ namespace Joomla\CMS\Filesystem\Support;
  * String Controller
  *
  * @since  1.7.0
+ *
+ * @deprecated  5.0 Use the filesystem package from the framework
  */
 class StringController
 {


### PR DESCRIPTION
### Summary of Changes
This pr deprecates the CMS filesystem package in favor of the framework one. Replacing the references of the CMS filesystem library should be done in followup pr's as a search and replace doesn't really work on all classes and functions.

Followup of #33390.

Only code review.