### PR TITLE
Fix error in empty state screen, remove add button

### DIFF
--- a/administrator/components/com_installer/tmpl/discover/emptystate.php
+++ b/administrator/components/com_installer/tmpl/discover/emptystate.php
@@ -11,17 +11,14 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\Session\Session;
 
 $displayData = [
 	'textPrefix' => 'COM_INSTALLER',
 	'formURL'    => 'index.php?option=com_installer&task=discover.refresh',
 	'helpURL'    => 'https://docs.joomla.org/Special:MyLanguage/Help4.x:Extensions:_Discover',
 	'icon'       => 'icon-puzzle-piece install',
-	'createURL'  => 'index.php?option=com_installer&task=discover.refresh&' . Session::getFormToken() . '=1',
 	'content'    => Text::_('COM_INSTALLER_MSG_DISCOVER_DESCRIPTION'),
 	'title'      => Text::_('COM_INSTALLER_EMPTYSTATE_DISCOVER_TITLE'),
-	'btnadd'     => Text::_('COM_INSTALLER_EMPTYSTATE_DISCOVER_BUTTON_ADD'),
 ];
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);

--- a/administrator/language/en-GB/com_installer.ini
+++ b/administrator/language/en-GB/com_installer.ini
@@ -28,7 +28,6 @@ COM_INSTALLER_DOWNLOADKEY_MISSING_TIP="Updates for this extension will not work 
 COM_INSTALLER_EMPTYSTATE_TITLE="Check For Updates"
 COM_INSTALLER_EMPTYSTATE_BUTTON_ADD="Check For Updates"
 COM_INSTALLER_EMPTYSTATE_CONTENT="You currently have no pending updates to apply. Check regularly for new updates to keep your site up to date and secure."
-COM_INSTALLER_EMPTYSTATE_DISCOVER_BUTTON_ADD="Discover extensions to install"
 COM_INSTALLER_EMPTYSTATE_DISCOVER_TITLE="You have no discovered extensions to install."
 COM_INSTALLER_ERROR_DISABLE_DEFAULT_TEMPLATE_NOT_PERMITTED="Disabling the default template is not permitted."
 COM_INSTALLER_ERROR_DISABLE_PARENT_TEMPLATE_NOT_PERMITTED="Disabling the parent template is not permitted."


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Remove the add button from discover, as ther is nothing to add. Technically it is the add-button, even if the text suggests a second discover button.

### Testing Instructions

Use an application where is nothing to discover, Go to system-discover and activate the botton. 

### Actual result BEFORE applying this Pull Request

![grafik](https://user-images.githubusercontent.com/1035262/162614317-021bb546-52f1-497a-9dbe-e4a6498adc2a.png)


### Expected result AFTER applying this Pull Request

![grafik](https://user-images.githubusercontent.com/1035262/162614644-3d3d4c86-f815-4c2a-b332-75490eedee23.png)

