### PR TITLE
Fix empty state buttons in discover and update

### DIFF
--- a/administrator/components/com_installer/src/Controller/DiscoverController.php
+++ b/administrator/components/com_installer/src/Controller/DiscoverController.php
@@ -32,7 +32,7 @@ class DiscoverController extends BaseController
 	 */
 	public function refresh()
 	{
-		$this->checkToken('get');
+		$this->checkToken('request');
 
 		/** @var \Joomla\Component\Installer\Administrator\Model\DiscoverModel $model */
 		$model = $this->getModel('discover');
@@ -72,7 +72,7 @@ class DiscoverController extends BaseController
 	 */
 	public function purge()
 	{
-		$this->checkToken();
+		$this->checkToken('request');
 
 		/** @var \Joomla\Component\Installer\Administrator\Model\DiscoverModel $model */
 		$model = $this->getModel('discover');

--- a/administrator/components/com_installer/src/Controller/DiscoverController.php
+++ b/administrator/components/com_installer/src/Controller/DiscoverController.php
@@ -32,7 +32,7 @@ class DiscoverController extends BaseController
 	 */
 	public function refresh()
 	{
-		$this->checkToken();
+		$this->checkToken('get');
 
 		/** @var \Joomla\Component\Installer\Administrator\Model\DiscoverModel $model */
 		$model = $this->getModel('discover');

--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -243,7 +243,7 @@ class UpdateController extends BaseController
 	public function purge()
 	{
 		// Check for request forgeries
-		$this->checkToken('get');
+		$this->checkToken('request');
 
 		// Purge updates
 		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */

--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -243,7 +243,7 @@ class UpdateController extends BaseController
 	public function purge()
 	{
 		// Check for request forgeries
-		$this->checkToken();
+		$this->checkToken('get');
 
 		// Purge updates
 		/** @var \Joomla\Component\Joomlaupdate\Administrator\Model\UpdateModel $model */


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fix warning with empty state buttons in joomla update and discover.  Changed the controller with checkToken('request'). 
These buttons are originally createButtons and it is a kind of misuse here. But better notto change the layout for users. 

So I am closing this one: https://github.com/joomla/joomla-cms/pull/37526

### Testing Instructions

Use an application where is nothing to discover, Go to system-discover or joomla updtat and activate the button

### Actual result BEFORE applying this Pull Request

![grafik](https://user-images.githubusercontent.com/1035262/162614317-021bb546-52f1-497a-9dbe-e4a6498adc2a.png)


### Expected result AFTER applying this Pull Request

No warning.
