### PR TITLE
[4.1] Fix title by contact save to menu

### DIFF
--- a/administrator/components/com_contact/src/Controller/ContactController.php
+++ b/administrator/components/com_contact/src/Controller/ContactController.php
@@ -134,7 +134,7 @@ class ContactController extends FormController
 
 			$editState['id'] = $id;
 			$editState['link']  = $link;
-			$editState['title'] = $model->getItem($id)->title;
+			$editState['title'] = $model->getItem($id)->name;
 			$editState['type']  = $type;
 			$editState['request']['id'] = $id;
 


### PR DESCRIPTION
### Summary of Changes

contact object has no title property (only name)

### Testing Instructions

Create/Open a contact and click `Save to Menu`

### Actual result BEFORE applying this Pull Request

Menu item title is empty
`PHP Warning: Undefined property: Joomla\CMS\Object\CMSObject::$title in administrator\components\com_contact\src\Controller\ContactController.php on line 137`

### Expected result AFTER applying this Pull Request

Menu item title is name of contact

### Documentation Changes Required

none