### PR TITLE
[4.1] Description for class "Intro Image"

### DIFF
--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -708,7 +708,8 @@
 				type="hidden"
 				label="JFIELD_ALT_LAYOUT_LABEL"
 				useglobal="true"
-				extension="com_content" view="article"
+				extension="com_content"
+				view="article"
 			/>
 		</fieldset>
 	</fields>
@@ -738,6 +739,7 @@
 				name="float_intro"
 				type="text"
 				label="COM_CONTENT_FIELD_IMAGE_CLASS_LABEL"
+				description="COM_CONTENT_FIELD_IMAGE_CLASS_DESC"
 				useglobal="true"
 			/>
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/37560 (part 1).

### Summary of Changes
The description of the parameter for the introductory image is missing (there is a description for the full one).

![Screenshot_1](https://user-images.githubusercontent.com/8440661/163581295-6cdc992a-1183-44ee-8aa2-7fe8da504c49.png)
