### PR TITLE
[4.1] Remove php version to speed up the test

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,15 +8,8 @@ clone_folder: C:\projects\joomla-cms
 environment:
   PHPBuild: "x64"
   matrix:
-  - php_ver_target: 7.2
-  - php_ver_target: 7.3
   - php_ver_target: 7.4
-  - php_ver_target: 8.0
-  - php_ver_target: 8.1
 
-matrix:
-  allow_failures:
-    - php_ver_target: 8.1
 
 init:
   - SET PATH=C:\Tools\php;%PATH%

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,7 +8,7 @@ clone_folder: C:\projects\joomla-cms
 environment:
   PHPBuild: "x64"
   matrix:
-  - php_ver_target: 7.4
+  - php_ver_target: 8.0
 
 
 init:


### PR DESCRIPTION
### Summary of Changes
Remove multiple PHP versions from the appveyor testing. 

We only need to make sure we don't trash something that it realated to Windows and this has not su mch to do with the PHP Version so testing only one PHP Version should do the job.