### PR TITLE
[4.2] Installation: Fatal error: Declaration of Uri::buildQuery(array)

### DIFF
--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -289,7 +289,7 @@ class Uri extends \Joomla\Uri\Uri
 	 * @since   1.7.0
 	 * @note    The parent method is protected, this exposes it as public for B/C
 	 */
-	public static function buildQuery(array $params)
+	public static function buildQuery($params)
 	{
 		return parent::buildQuery($params);
 	}


### PR DESCRIPTION
When trying to install the 4.2-dev branch on PHP7.4, a 500 error occurs:
> Fatal error: Declaration of Joomla\CMS\Uri\Uri::buildQuery(array $params) must be compatible with Joomla\Uri\AbstractUri::buildQuery($params) in /srv/www/joomla/joomla-cms/libraries/src/Uri/Uri.php on line 292

### Testing Instructions
Checkout the 4.2-dev branch (and "composer install", "npm ci") and try to install Joomla


### Actual result BEFORE applying this Pull Request

![screencapture-localhost-joomla-joomla-cms-installation-index-php-2022-04-20-15_45_33](https://user-images.githubusercontent.com/1217850/164246378-c1e06afd-3ebd-4998-a86f-dc8fa1a5bb8c.png)


### Expected result AFTER applying this Pull Request

![screencapture-localhost-joomla-joomla-cms-installation-index-php-2022-04-20-15_47_30](https://user-images.githubusercontent.com/1217850/164246393-d40587bc-f5c9-412a-a594-582937673a2b.png)

