### PR TITLE
[4.x] Article Manager RTL correction

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -276,10 +276,12 @@ $assoc = Associations::isEnabled();
 											$ParentCatUrl = Route::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content');
 											$CurrentCatUrl = Route::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content');
 											$EditCatTxt = Text::_('COM_CONTENT_EDIT_CATEGORY');
+											$catSeparator = Factory::getLanguage()->isRtl() ? ' &#171; ' : ' &#187; ';
+
 											echo Text::_('JCATEGORY') . ': ';
 											if ($item->category_level != '1') :
 												if ($item->parent_category_level != '1') :
-													echo ' &#187; ';
+													echo $catSeparator;
 												endif;
 											endif;
 											if ($item->category_level != '1') :
@@ -290,7 +292,7 @@ $assoc = Associations::isEnabled();
 												if ($canEditParCat || $canEditOwnParCat) :
 													echo '</a>';
 												endif;
-												echo ' &#187; ';
+												echo $catSeparator;
 											endif;
 											if ($canEditCat || $canEditOwnCat) :
 												echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -282,46 +282,23 @@ $assoc = Associations::isEnabled();
 													echo ' &#187; ';
 												endif;
 											endif;
-											if (Factory::getLanguage()->isRtl())
-											{
-												if ($canEditCat || $canEditOwnCat) :
-													echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+											if ($item->category_level != '1') :
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '<a href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
 												endif;
-												echo $this->escape($item->category_title);
-												if ($canEditCat || $canEditOwnCat) :
+												echo $this->escape($item->parent_category_title);
+												if ($canEditParCat || $canEditOwnParCat) :
 													echo '</a>';
 												endif;
-												if ($item->category_level != '1') :
-													echo ' &#171; ';
-													if ($canEditParCat || $canEditOwnParCat) :
-														echo '<a href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
-													endif;
-													echo $this->escape($item->parent_category_title);
-													if ($canEditParCat || $canEditOwnParCat) :
-														echo '</a>';
-													endif;
-												endif;
-											}
-											else
-											{
-												if ($item->category_level != '1') :
-													if ($canEditParCat || $canEditOwnParCat) :
-														echo '<a href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
-													endif;
-													echo $this->escape($item->parent_category_title);
-													if ($canEditParCat || $canEditOwnParCat) :
-														echo '</a>';
-													endif;
-													echo ' &#187; ';
-												endif;
-												if ($canEditCat || $canEditOwnCat) :
-													echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
-												endif;
-												echo $this->escape($item->category_title);
-												if ($canEditCat || $canEditOwnCat) :
-													echo '</a>';
-												endif;
-											}
+												echo ' &#187; ';
+											endif;
+											if ($canEditCat || $canEditOwnCat) :
+												echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+											endif;
+											echo $this->escape($item->category_title);
+											if ($canEditCat || $canEditOwnCat) :
+												echo '</a>';
+											endif;
 											?>
 										</div>
 									</div>

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -280,10 +280,11 @@ $assoc = Associations::isEnabled();
 											$ParentCatUrl = Route::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content');
 											$CurrentCatUrl = Route::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content');
 											$EditCatTxt = Text::_('COM_CONTENT_EDIT_CATEGORY');
+											$catSeparator = Factory::getLanguage()->isRtl() ? ' &#171; ' : ' &#187; ';
 											echo Text::_('JCATEGORY') . ': ';
 											if ($item->category_level != '1') :
 												if ($item->parent_category_level != '1') :
-													echo ' &#187; ';
+													echo $catSeparator;
 												endif;
 											endif;
 											if ($item->category_level != '1') :
@@ -294,7 +295,7 @@ $assoc = Associations::isEnabled();
 												if ($canEditParCat || $canEditOwnParCat) :
 													echo '</a>';
 												endif;
-												echo ' &#187; ';
+												echo $catSeparator;
 											endif;
 											if ($canEditCat || $canEditOwnCat) :
 												echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -286,46 +286,23 @@ $assoc = Associations::isEnabled();
 													echo ' &#187; ';
 												endif;
 											endif;
-											if (Factory::getLanguage()->isRtl())
-											{
-												if ($canEditCat || $canEditOwnCat) :
-													echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+											if ($item->category_level != '1') :
+												if ($canEditParCat || $canEditOwnParCat) :
+													echo '<a href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
 												endif;
-												echo $this->escape($item->category_title);
-												if ($canEditCat || $canEditOwnCat) :
+												echo $this->escape($item->parent_category_title);
+												if ($canEditParCat || $canEditOwnParCat) :
 													echo '</a>';
 												endif;
-												if ($item->category_level != '1') :
-													echo ' &#171; ';
-													if ($canEditParCat || $canEditOwnParCat) :
-														echo '<a href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
-													endif;
-													echo $this->escape($item->parent_category_title);
-													if ($canEditParCat || $canEditOwnParCat) :
-														echo '</a>';
-													endif;
-												endif;
-											}
-											else
-											{
-												if ($item->category_level != '1') :
-													if ($canEditParCat || $canEditOwnParCat) :
-														echo '<a href="' . $ParentCatUrl . '" title="' . $EditCatTxt . '">';
-													endif;
-													echo $this->escape($item->parent_category_title);
-													if ($canEditParCat || $canEditOwnParCat) :
-														echo '</a>';
-													endif;
-													echo ' &#187; ';
-												endif;
-												if ($canEditCat || $canEditOwnCat) :
-													echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
-												endif;
-												echo $this->escape($item->category_title);
-												if ($canEditCat || $canEditOwnCat) :
-													echo '</a>';
-												endif;
-											}
+												echo ' &#187; ';
+											endif;
+											if ($canEditCat || $canEditOwnCat) :
+												echo '<a href="' . $CurrentCatUrl . '" title="' . $EditCatTxt . '">';
+											endif;
+											echo $this->escape($item->category_title);
+											if ($canEditCat || $canEditOwnCat) :
+												echo '</a>';
+											endif;
 											?>
 										</div>
 									</div>


### PR DESCRIPTION
This PR removes a conditional block from the article manager and the featured article manager that was intended to ensure that the display of the category and nested category was correct when the admin is using an rtl language and the category names may be a mix of LTR and RTL.

Not really sure why but
1. this code does not work correctly. the order of the categories is wrong and the « character is wrong
2. there is no need for this alternate block of code for RTL

### Before
![image](https://user-images.githubusercontent.com/1296369/143782928-b374a577-c4fd-45f1-b9db-c36f0d8bdbf0.png)

### After
![image](https://user-images.githubusercontent.com/1296369/143782930-ff8521f2-03a5-496e-b24e-068cf4c38acf.png)
