### PR TITLE
[3.10] Label of privacy confirm request

### DIFF
--- a/language/en-GB/en-GB.com_privacy.ini
+++ b/language/en-GB/en-GB.com_privacy.ini
@@ -9,7 +9,7 @@ COM_PRIVACY_ADMIN_NOTIFICATION_USER_CONFIRMED_REQUEST_SUBJECT="Information Reque
 COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_MESSAGE="A new information request has been submitted by %1$s."
 COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_SUBJECT="Information Request Submitted"
 COM_PRIVACY_CONFIRM_REMIND_SUCCEEDED="Your consent to this web site's Privacy Policy has been extended."
-COM_PRIVACY_CONFIRM_REQUEST_FIELDSET_LABEL="An email has been sent to your email address. The email has a confirmation token, please confirm your email address again and paste the confirmation token in the field below to prove that you are the owner of the information being requested."
+COM_PRIVACY_CONFIRM_REQUEST_FIELDSET_LABEL="An email has been sent to your email address. The email has a confirmation token, please paste the confirmation token in the field below to prove that you are the owner of the information being requested."
 COM_PRIVACY_CONFIRM_REQUEST_SUCCEEDED="Your information request has been confirmed. We will process your request as soon as possible and the export will be sent to your email."
 COM_PRIVACY_CREATE_REQUEST_SUCCEEDED="Your information request has been created. Before it can be processed, you must verify this request. An email has been sent to your address with additional instructions to complete this verification."
 ; You can use the following merge codes for all COM_PRIVACY_EMAIL strings:

--- a/language/en-GB/en-GB.com_privacy.ini
+++ b/language/en-GB/en-GB.com_privacy.ini
@@ -9,7 +9,7 @@ COM_PRIVACY_ADMIN_NOTIFICATION_USER_CONFIRMED_REQUEST_SUBJECT="Information Reque
 COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_MESSAGE="A new information request has been submitted by %1$s."
 COM_PRIVACY_ADMIN_NOTIFICATION_USER_CREATED_REQUEST_SUBJECT="Information Request Submitted"
 COM_PRIVACY_CONFIRM_REMIND_SUCCEEDED="Your consent to this web site's Privacy Policy has been extended."
-COM_PRIVACY_CONFIRM_REQUEST_FIELDSET_LABEL="An email has been sent to your email address. The email has a confirmation token, please paste the confirmation token in the field below to prove that you are the owner of the information being requested."
+COM_PRIVACY_CONFIRM_REQUEST_FIELDSET_LABEL="An email has been sent to your email address. Please paste the confirmation token from the email into the field below to prove that you are the owner of the information being requested."
 COM_PRIVACY_CONFIRM_REQUEST_SUCCEEDED="Your information request has been confirmed. We will process your request as soon as possible and the export will be sent to your email."
 COM_PRIVACY_CREATE_REQUEST_SUCCEEDED="Your information request has been created. Before it can be processed, you must verify this request. An email has been sent to your address with additional instructions to complete this verification."
 ; You can use the following merge codes for all COM_PRIVACY_EMAIL strings:


### PR DESCRIPTION
### Summary of Changes

With PR #35470 the input for confirm the email was removed. This PR should adjust the label for this. Maybe there is also a better version

### Testing Instructions

visit `index.php?option=com_privacy&view=confirm`

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/66922325/164544589-8638869d-2dcf-40e1-8e22-f2b1eb6bfc8c.png)

### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/66922325/164544567-70aedc54-be63-4738-a86c-ff3981b06c11.png)

### Documentation Changes Required

