### PR TITLE
[4.2] Inject the database into the banner HTML service

### DIFF
--- a/administrator/components/com_banners/src/Extension/BannersComponent.php
+++ b/administrator/components/com_banners/src/Extension/BannersComponent.php
@@ -21,6 +21,7 @@ use Joomla\CMS\HTML\HTMLRegistryAwareTrait;
 use Joomla\CMS\Tag\TagServiceInterface;
 use Joomla\CMS\Tag\TagServiceTrait;
 use Joomla\Component\Banners\Administrator\Service\Html\Banner;
+use Joomla\Database\DatabaseInterface;
 use Psr\Container\ContainerInterface;
 
 /**
@@ -53,7 +54,10 @@ class BannersComponent extends MVCComponent implements BootableExtensionInterfac
 	 */
 	public function boot(ContainerInterface $container)
 	{
-		$this->getRegistry()->register('banner', new Banner);
+		$banner = new Banner;
+		$banner->setDatabase($container->get(DatabaseInterface::class));
+
+		$this->getRegistry()->register('banner', $banner);
 	}
 
 	/**

--- a/administrator/components/com_banners/src/Service/Html/Banner.php
+++ b/administrator/components/com_banners/src/Service/Html/Banner.php
@@ -14,6 +14,7 @@ namespace Joomla\Component\Banners\Administrator\Service\Html;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Database\DatabaseAwareTrait;
 
 /**
  * Banner HTML class.
@@ -22,6 +23,8 @@ use Joomla\CMS\Language\Text;
  */
 class Banner
 {
+	use DatabaseAwareTrait;
+
 	/**
 	 * Display a batch widget for the client selector.
 	 *
@@ -56,7 +59,7 @@ class Banner
 	 */
 	public function clientlist()
 	{
-		$db = Factory::getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select(
 				[


### PR DESCRIPTION
### Summary of Changes
Ongoing effort to inject the database into components and get rid of the deprecated `Factory::getDbo();` calls.

### Testing Instructions
- Create a banners client
- Create a banner
- In the banners list, select a banner and then click on the batch action
![image](https://user-images.githubusercontent.com/251072/164709585-a8170a67-2773-42ca-b869-486d3bce2e3d.png)


### Actual result BEFORE applying this Pull Request
The client list in the batch modal shows the new client.

### Expected result AFTER applying this Pull Request
The client list in the batch modal shows the new client.