### PR TITLE
[4.2] Remove not used db reference in users view

### DIFF
--- a/administrator/components/com_users/src/View/Users/HtmlView.php
+++ b/administrator/components/com_users/src/View/Users/HtmlView.php
@@ -19,6 +19,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Database\DatabaseDriver;
 
 /**
  * View class for a list of users.
@@ -77,6 +78,16 @@ class HtmlView extends BaseHtmlView
 	protected $canDo;
 
 	/**
+	 * An instance of DatabaseDriver.
+	 *
+	 * @var    DatabaseDriver
+	 * @since  3.6.3
+	 *
+	 * @deprecated 5.0 Will be removed without replacement
+	 */
+	protected $db;
+
+	/**
 	 * Display the view
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
@@ -91,6 +102,7 @@ class HtmlView extends BaseHtmlView
 		$this->filterForm    = $this->get('FilterForm');
 		$this->activeFilters = $this->get('ActiveFilters');
 		$this->canDo         = ContentHelper::getActions('com_users');
+		$this->db            = Factory::getDbo();
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/administrator/components/com_users/src/View/Users/HtmlView.php
+++ b/administrator/components/com_users/src/View/Users/HtmlView.php
@@ -19,7 +19,6 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\Database\DatabaseDriver;
 
 /**
  * View class for a list of users.
@@ -78,14 +77,6 @@ class HtmlView extends BaseHtmlView
 	protected $canDo;
 
 	/**
-	 * An instance of DatabaseDriver.
-	 *
-	 * @var    DatabaseDriver
-	 * @since  3.6.3
-	 */
-	protected $db;
-
-	/**
 	 * Display the view
 	 *
 	 * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
@@ -100,7 +91,6 @@ class HtmlView extends BaseHtmlView
 		$this->filterForm    = $this->get('FilterForm');
 		$this->activeFilters = $this->get('ActiveFilters');
 		$this->canDo         = ContentHelper::getActions('com_users');
-		$this->db            = Factory::getDbo();
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))


### PR DESCRIPTION
### Summary of Changes
Removes an obsolete reference in the users back end view. It was used for last visit date from #11396. Since dates are `NULL` from #26611, the database reference is not used anymore.

### Testing Instructions
Go to the site /administrator/index.php?option=com_users&view=users.

### Actual result BEFORE applying this Pull Request
All works.

### Expected result AFTER applying this Pull Request
All works.