### PR TITLE
[4.2] Remove obsolete db reference in featured view

### DIFF
--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -68,6 +68,15 @@ class HtmlView extends BaseHtmlView
 	protected $link_items = array();
 
 	/**
+	 * @var    \Joomla\Database\DatabaseDriver
+	 *
+	 * @since  3.6.3
+	 *
+	 * @deprecated 5.0 Will be removed without replacement
+	 */
+	protected $db;
+
+	/**
 	 * The user object
 	 *
 	 * @var \Joomla\CMS\User\User|null
@@ -195,6 +204,7 @@ class HtmlView extends BaseHtmlView
 		$this->items      = &$items;
 		$this->pagination = &$pagination;
 		$this->user       = &$user;
+		$this->db         = Factory::getDbo();
 
 		$this->_prepareDocument();
 

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -68,13 +68,6 @@ class HtmlView extends BaseHtmlView
 	protected $link_items = array();
 
 	/**
-	 * @var    \Joomla\Database\DatabaseDriver
-	 *
-	 * @since  3.6.3
-	 */
-	protected $db;
-
-	/**
 	 * The user object
 	 *
 	 * @var \Joomla\CMS\User\User|null
@@ -202,7 +195,6 @@ class HtmlView extends BaseHtmlView
 		$this->items      = &$items;
 		$this->pagination = &$pagination;
 		$this->user       = &$user;
-		$this->db         = Factory::getDbo();
 
 		$this->_prepareDocument();
 


### PR DESCRIPTION
### Summary of Changes
Removes an obsolete reference in the featured front end view. It was used for last visit date from #11396. During Joomla 4 development the code which was using the database got removed so we can remove the reference in the view too.

### Testing Instructions
- Create an article with featured state
- Open the front end

### Actual result BEFORE applying this Pull Request
All works.

### Expected result AFTER applying this Pull Request
All works.