### PR TITLE
[4.2] Remove obsolete db reference in profile view

### DIFF
--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -58,14 +58,6 @@ class HtmlView extends BaseHtmlView
 	protected $state;
 
 	/**
-	 * An instance of DatabaseDriver.
-	 *
-	 * @var    DatabaseDriver
-	 * @since  3.6.3
-	 */
-	protected $db;
-
-	/**
 	 * Configuration forms for all two-factor authentication methods.
 	 *
 	 * @var    array
@@ -119,7 +111,6 @@ class HtmlView extends BaseHtmlView
 		$this->twofactorform    = $this->get('Twofactorform');
 		$this->twofactormethods = UsersHelper::getTwoFactorMethods();
 		$this->otpConfig        = $this->get('OtpConfig');
-		$this->db               = Factory::getDbo();
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))

--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -58,6 +58,16 @@ class HtmlView extends BaseHtmlView
 	protected $state;
 
 	/**
+	 * An instance of DatabaseDriver.
+	 *
+	 * @var    DatabaseDriver
+	 * @since  3.6.3
+	 *
+	 * @deprecated  5.0 Will be removed without replacement
+	 */
+	protected $db;
+
+	/**
 	 * Configuration forms for all two-factor authentication methods.
 	 *
 	 * @var    array
@@ -111,6 +121,7 @@ class HtmlView extends BaseHtmlView
 		$this->twofactorform    = $this->get('Twofactorform');
 		$this->twofactormethods = UsersHelper::getTwoFactorMethods();
 		$this->otpConfig        = $this->get('OtpConfig');
+		$this->db               = Factory::getDbo();
 
 		// Check for errors.
 		if (count($errors = $this->get('Errors')))


### PR DESCRIPTION
### Summary of Changes
Removes an obsolete reference in the users profile view. It was used for last visit date from #11396. Since dates are `NULL` from #26611, the database reference is not used anymore.

### Testing Instructions
- Log in on the front
- Open the site /index.php?option=com_users&view=profile

### Actual result BEFORE applying this Pull Request
All works.

### Expected result AFTER applying this Pull Request
All works.