### PR TITLE
[4.2] Does a cleanup of the contact icon HTML service

### DIFF
--- a/administrator/components/com_contact/src/Extension/ContactComponent.php
+++ b/administrator/components/com_contact/src/Extension/ContactComponent.php
@@ -11,7 +11,6 @@ namespace Joomla\Component\Contact\Administrator\Extension;
 
 \defined('JPATH_PLATFORM') or die;
 
-use Joomla\CMS\Application\SiteApplication;
 use Joomla\CMS\Association\AssociationServiceInterface;
 use Joomla\CMS\Association\AssociationServiceTrait;
 use Joomla\CMS\Categories\CategoryServiceInterface;
@@ -27,6 +26,7 @@ use Joomla\CMS\HTML\HTMLRegistryAwareTrait;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Tag\TagServiceInterface;
 use Joomla\CMS\Tag\TagServiceTrait;
+use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Component\Contact\Administrator\Service\HTML\AdministratorService;
 use Joomla\Component\Contact\Administrator\Service\HTML\Icon;
 use Psr\Container\ContainerInterface;
@@ -64,7 +64,7 @@ class ContactComponent extends MVCComponent implements
 	public function boot(ContainerInterface $container)
 	{
 		$this->getRegistry()->register('contactadministrator', new AdministratorService);
-		$this->getRegistry()->register('contacticon', new Icon($container->get(SiteApplication::class)));
+		$this->getRegistry()->register('contacticon', new Icon($container->get(UserFactoryInterface::class)));
 	}
 
 	/**

--- a/administrator/components/com_contact/src/Service/HTML/Icon.php
+++ b/administrator/components/com_contact/src/Service/HTML/Icon.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Component\Contact\Site\Helper\RouteHelper;
 use Joomla\Registry\Registry;
 
@@ -29,24 +30,24 @@ use Joomla\Registry\Registry;
 class Icon
 {
 	/**
-	 * The application
+	 * The user factory
 	 *
-	 * @var    CMSApplication
+	 * @var    UserFactoryInterface
 	 *
-	 * @since  4.0.0
+	 * @since  __DEPLOY_VERSION__
 	 */
-	private $application;
+	private $userFactory;
 
 	/**
 	 * Service constructor
 	 *
-	 * @param   CMSApplication  $application  The application
+	 * @param   UserFactoryInterface  $userFactory  The userFactory
 	 *
 	 * @since   4.0.0
 	 */
-	public function __construct(CMSApplication $application)
+	public function __construct(UserFactoryInterface $userFactory)
 	{
-		$this->application = $application;
+		$this->userFactory = $userFactory;
 	}
 
 	/**
@@ -60,7 +61,7 @@ class Icon
 	 *
 	 * @since  4.0.0
 	 */
-	public static function create($category, $params, $attribs = array())
+	public function create($category, $params, $attribs = array())
 	{
 		$uri = Uri::getInstance();
 
@@ -105,7 +106,7 @@ class Icon
 	 *
 	 * @since   4.0.0
 	 */
-	public static function edit($contact, $params, $attribs = array(), $legacy = false)
+	public function edit($contact, $params, $attribs = array(), $legacy = false)
 	{
 		$user = Factory::getUser();
 		$uri  = Uri::getInstance();
@@ -128,7 +129,7 @@ class Icon
 			&& !is_null($contact->checked_out)
 			&& $contact->checked_out !== $user->get('id'))
 		{
-			$checkoutUser = Factory::getUser($contact->checked_out);
+			$checkoutUser = $this->userFactory->loadUserById($contact->checked_out);
 			$date         = HTMLHelper::_('date', $contact->checked_out_time);
 			$tooltip      = Text::sprintf('COM_CONTACT_CHECKED_OUT_BY', $checkoutUser->name)
 				. ' <br> ' . $date;
@@ -157,8 +158,7 @@ class Icon
 		$icon    = $contact->published ? 'edit' : 'eye-slash';
 
 		if (($contact->publish_up !== null && strtotime($contact->publish_up) > $nowDate)
-			|| ($contact->publish_down !== null && strtotime($contact->publish_down) < $nowDate
-			&& $contact->publish_down !== Factory::getDbo()->getNullDate()))
+			|| ($contact->publish_down !== null && strtotime($contact->publish_down) < $nowDate))
 		{
 			$icon = 'eye-slash';
 		}


### PR DESCRIPTION
### Summary of Changes
Since #24311 front en editing of contacts is possible. This pr does a cleanup in the icon class which uses static functions and injects a user factory. Additionally it removes an obsolete null db check as dates are null in Joomla anyway.

### Testing Instructions
- Create a new contact
- Create a contact list menu item
- Log in on the front with an admin user
- Open the contact list
- Click on edit contact
- Close the window without hitting the cancel button
- Log in again with a different admin user
- Open the contact list menu item

### Actual result BEFORE applying this Pull Request
All loads correctly.

### Expected result AFTER applying this Pull Request
All loads correctly.