### PR TITLE
[4.2] The deprecated db functions do have to be the same as the trait

### DIFF
--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -96,6 +96,9 @@ abstract class BaseDatabaseModel extends BaseModel implements DatabaseModelInter
 		{
 			@trigger_error(sprintf('Database is not available in constructor in 5.0.'), E_USER_DEPRECATED);
 			$this->setDatabase($db);
+
+			// Is needed, when models use the deprecated MVC DatabaseAwareTrait, as the trait is overriding the local functions
+			$this->setDbo($db);
 		}
 
 		// Set the default view search path
@@ -364,7 +367,7 @@ abstract class BaseDatabaseModel extends BaseModel implements DatabaseModelInter
 	 *
 	 * @deprecated  5.0 Use getDatabase() instead
 	 */
-	public function getDbo(): DatabaseInterface
+	public function getDbo()
 	{
 		try
 		{
@@ -387,7 +390,7 @@ abstract class BaseDatabaseModel extends BaseModel implements DatabaseModelInter
 	 *
 	 * @deprecated  5.0 Use setDatabase() instead
 	 */
-	public function setDbo(DatabaseInterface $db = null): void
+	public function setDbo(DatabaseInterface $db = null)
 	{
 		if ($db === null)
 		{

--- a/tests/Unit/Libraries/Cms/MVC/Model/DatabaseModelTest.php
+++ b/tests/Unit/Libraries/Cms/MVC/Model/DatabaseModelTest.php
@@ -12,6 +12,7 @@ namespace Joomla\Tests\Unit\Libraries\Cms\MVC\Model;
 use Exception;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use Joomla\CMS\MVC\Model\DatabaseAwareTrait;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\DatabaseQuery;
@@ -211,6 +212,27 @@ class DatabaseModelTest extends UnitTestCase
 		};
 
 		$this->assertEquals(5, $model->_getListCount('query'));
+	}
+
+	/**
+	 * @testdox  Test that the BaseDatabaseModel still can use the old trait
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @deprecated  5.0 Must be removed when trait gets deleted
+	 */
+	public function testUseOldMVCTrait()
+	{
+		$db = $this->createStub(DatabaseInterface::class);
+
+		$model = new class(['dbo' => $db], $this->createStub(MVCFactoryInterface::class)) extends BaseDatabaseModel
+		{
+			use DatabaseAwareTrait;
+		};
+
+		$this->assertEquals($db, $model->getDbo());
 	}
 
 	/**

--- a/tests/Unit/Libraries/Cms/MVC/Model/DatabaseModelTest.php
+++ b/tests/Unit/Libraries/Cms/MVC/Model/DatabaseModelTest.php
@@ -235,7 +235,7 @@ class DatabaseModelTest extends UnitTestCase
 		$this->assertEquals($db, $model->getDbo());
 	}
 
-	/*
+	/**
 	 * @testdox  Test that the BaseDatabaseModel operates normally even when no variable is declared
 	 *
 	 * @return  void


### PR DESCRIPTION
Pull Request for pr #37095.

### Summary of Changes
The function in the deprecated `Joomla\CMS\MVC\Model\DatabaseAwareTrait` must have the same signature as the functions in the `BaseDatabaseModel`. Additionally it ensures, when a model is using that trait and extending the `BaseDatabaseModel` that the database is available as the functions in the trait are overloading the ones from the class. Actually this is not needed as the `BaseDatabaseModel` is using in 4.1 the MVC trait and in 4.2 the DB package trait.

### Testing Instructions
Install the free version of akeeba backup and open the control panel of it in the back end.

### Actual result BEFORE applying this Pull Request
It crashes with the following error:
_Compile Error: Declaration of Joomla\CMS\MVC\Model\DatabaseAwareTrait::getDbo() must be compatible with Joomla\CMS\MVC\Model\BaseDatabaseModel::getDbo(): Joomla\Database\DatabaseInterface_

### Expected result AFTER applying this Pull Request
It works normally.