### PR TITLE
[4.2] Create the field in the base model when it doesn't exist

### DIFF
--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -408,7 +408,7 @@ abstract class BaseDatabaseModel extends BaseModel implements DatabaseModelInter
 	 *
 	 * @deprecated  5.0 Use getDatabase() instead of directly accessing _db
 	 */
-	public function __get($name)
+	public function &__get($name)
 	{
 		if ($name === '_db')
 		{

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -415,6 +415,12 @@ abstract class BaseDatabaseModel extends BaseModel implements DatabaseModelInter
 			return $this->getDatabase();
 		}
 
+		// Default the variable
+		if (!isset($this->$name))
+		{
+			$this->$name = null;
+		}
+
 		return $this->$name;
 	}
 }

--- a/tests/Unit/Libraries/Cms/MVC/Model/DatabaseModelTest.php
+++ b/tests/Unit/Libraries/Cms/MVC/Model/DatabaseModelTest.php
@@ -214,6 +214,30 @@ class DatabaseModelTest extends UnitTestCase
 	}
 
 	/**
+	 * @testdox  Test that the BaseDatabaseModel operates normally even when no variable is declared
+	 *
+	 * @return  void
+	 *
+	 * @since   __DEPLOY_VERSION__
+	 *
+	 * @deprecated  5.0 This has to be removed when we do not support the MVC Trait anymore
+	 */
+	public function testNotDeclaredVariable()
+	{
+		$model = new class(['dbo' => $this->createStub(DatabaseInterface::class)], $this->createStub(MVCFactoryInterface::class)) extends BaseDatabaseModel
+		{
+			public function initVariable($value)
+			{
+				$this->test[$value] = $value;
+
+				return $this->test[$value];
+			}
+		};
+
+		$this->assertEquals(1, $model->initVariable(1));
+	}
+
+	/**
 	 * Returns a database query instance.
 	 *
 	 * @param   DatabaseInterface  $db  The database


### PR DESCRIPTION
### Summary of Changes
The database model has since #37095 a magic method to deliver the _dbo variable. This function needs to create the properties when they do not exist.

### Testing Instructions
Edit a module in the back end.

### Actual result BEFORE applying this Pull Request
The following error happens:
_Attempt to assign property "params" on null _

### Expected result AFTER applying this Pull Request
Module form shows up.