### PR TITLE
[4.1] cli sitedowncommand

### DIFF
--- a/libraries/src/Console/SiteDownCommand.php
+++ b/libraries/src/Console/SiteDownCommand.php
@@ -102,7 +102,7 @@ class SiteDownCommand extends AbstractCommand
 
 		if ($returnCode === 0)
 		{
-			$this->ioStyle->success("Successfully set site to offline");
+			$this->ioStyle->success("Website is now offline");
 
 			return self::SITE_DOWN_SUCCESSFUL;
 		}


### PR DESCRIPTION
We'v already removed the useless word "successfully" from all language strings. 

This PR updates the cli command message to reflect that AND to be consistent with the siteupcommand message

### Testing Instructions
`php cli/joomla.php site:down`


### Actual result BEFORE applying this Pull Request

[OK] Successfully set site to offline

### Expected result AFTER applying this Pull Request

[OK] Website is now offline


### Documentation Changes Required

