### PR TITLE
[4.1] Fix hover button in Templates

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default_modal_rename_footer.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_rename_footer.php
@@ -12,5 +12,5 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 
 ?>
-<button type="button" href="#" class="btn btn-secondary" data-bs-dismiss="modal"><?php echo Text::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></button>
+<button type="button" class="btn btn-secondary" data-bs-dismiss="modal"><?php echo Text::_('COM_TEMPLATES_TEMPLATE_CLOSE'); ?></button>
 <button type="submit" class="btn btn-primary"><?php echo Text::_('COM_TEMPLATES_BUTTON_RENAME'); ?></button>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
**System Dashboard -> Site Templates -> Cassiopeia Details and Files**, in the left column select any file to edit, then click "Rename File" in the toolbar. In a modal window, when hovering over, the CLOSE button will not change the background.

![Screenshot_1](https://user-images.githubusercontent.com/8440661/165390355-917c9639-140a-401c-abbe-00d5f919d3a0.png)

