### PR TITLE
[php 80] Fix error when delete a user that have profile values

### DIFF
--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -495,7 +495,7 @@ class PlgUserProfile extends CMSPlugin
 				->delete($db->quoteName('#__user_profiles'))
 				->where($db->quoteName('user_id') . ' = :userid')
 				->where($db->quoteName('profile_key') . ' LIKE ' . $db->quote('profile.%'))
-				->bind('userid', $userId, ParameterType::INTEGER);
+				->bind(':userid', $userId, ParameterType::INTEGER);
 
 			$db->setQuery($query);
 			$db->execute();


### PR DESCRIPTION
### Summary of Changes
Fix typo


### Testing Instructions
- Install J4.1.2
- Turn on plugin User - Profile
- Open any user, save info with Profile Tab values
- Delete user that has changed
- See Joomla error


### Actual result BEFORE applying this Pull Request

![2022-04-29_134911](https://user-images.githubusercontent.com/20571336/165897548-d2b6850f-fbb8-474c-b1ff-74f274920737.png)

### Expected result AFTER applying this Pull Request

- Delete user without issue

###
Tested on :
- windows 10
- php 8.0.6
- mysql 5.7
- apache 2.4.52

