### PR TITLE
[4.1] subform fields category display

### DIFF
--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -157,8 +157,7 @@ if (count($this->filterForm->getField('context')->options) > 1)
 												<div class="small badge bg-secondary">
 													<?php echo Text::_('COM_FIELDS_FIELD_ONLY_USE_IN_SUBFORM_BADGE'); ?>
 												</div>
-											<?php endif; ?>
-											<?php if ($category && !$item->only_use_in_subform) : ?>
+											<?php elseif ($category) : ?>
 												<div class="small">
 													<?php echo Text::_('JCATEGORY') . ': '; ?>
 													<?php $categories = FieldsHelper::getAssignedCategoriesTitles($item->id); ?>

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -158,7 +158,7 @@ if (count($this->filterForm->getField('context')->options) > 1)
 													<?php echo Text::_('COM_FIELDS_FIELD_ONLY_USE_IN_SUBFORM_BADGE'); ?>
 												</div>
 											<?php endif; ?>
-											<?php if ($category) : ?>
+											<?php if ($category && !$item->only_use_in_subform) : ?>
 												<div class="small">
 													<?php echo Text::_('JCATEGORY') . ': '; ?>
 													<?php $categories = FieldsHelper::getAssignedCategoriesTitles($item->id); ?>


### PR DESCRIPTION
When a field is marked for "subform only" there is no ability to assign a category to the field as its not relevant. However the list display would still display the category.

This PR excludes the display of a category when the field is "subform only"

### Testing Instructions
Create two fields and make one of them subform only


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/165922141-6fbad323-2fd3-4f45-a030-3df437618009.png)



### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/1296369/165922081-3e4dea05-3c5e-48b8-a920-926976a6b10e.png)


### Documentation Changes Required

