### PR TITLE
Selectlist for menuitem parent as fancyselect

### DIFF
--- a/administrator/components/com_menus/forms/item.xml
+++ b/administrator/components/com_menus/forms/item.xml
@@ -95,6 +95,7 @@
 			name="parent_id"
 			type="MenuParent"
 			label="COM_MENUS_ITEM_FIELD_PARENT_LABEL"
+			layout="joomla.form.field.list-fancy-select"
 			default="1"
 			filter="int"
 			clientid="0"


### PR DESCRIPTION
Pull Request for Issue #37659 .

### Summary of Changes
Improve the selection of the parent menu item. 


### Testing Instructions
See #37659. 


### Actual result BEFORE applying this Pull Request
The list for the parent item must be scrolled


### Expected result AFTER applying this Pull Request
It is possible to enter a select 
![grafik](https://user-images.githubusercontent.com/1035262/165939096-b45b5b6e-485c-4b4f-9446-ffe48227478c.png)


### Documentation Changes Required

