### PR TITLE
[4.x] Fix for Modules Filter after duplicate module

### DIFF
--- a/administrator/components/com_modules/src/Controller/ModulesController.php
+++ b/administrator/components/com_modules/src/Controller/ModulesController.php
@@ -55,7 +55,7 @@ class ModulesController extends AdminController
 			$this->app->enqueueMessage($e->getMessage(), 'warning');
 		}
 
-		$this->setRedirect('index.php?option=com_modules&view=modules');
+		$this->setRedirect('index.php?option=com_modules&view=modules'. $this->getRedirectToListAppend());
 	}
 
 	/**

--- a/administrator/components/com_modules/src/Controller/ModulesController.php
+++ b/administrator/components/com_modules/src/Controller/ModulesController.php
@@ -55,7 +55,7 @@ class ModulesController extends AdminController
 			$this->app->enqueueMessage($e->getMessage(), 'warning');
 		}
 
-		$this->setRedirect('index.php?option=com_modules&view=modules'. $this->getRedirectToListAppend());
+		$this->setRedirect('index.php?option=com_modules&view=modules' . $this->getRedirectToListAppend());
 	}
 
 	/**


### PR DESCRIPTION
Pull Request to fix the Admin/Site filter in Modules

### Summary of Changes



### Testing Instructions
- In J4 back-end go to: Content > Administrator Modules
- Notice that the Admin/Site filter is set to "Administrator"
- Select an Admin module from the list
- Choose under "Actions" for "Duplicate"

![modules-filter-instructions](https://user-images.githubusercontent.com/1217850/165951937-faa767eb-0e8c-40a6-b9d5-d867a3c01ef6.png)

### Actual result BEFORE applying this Pull Request
- After the Module got duplicated, the **Admin/Site filter is wrongly set to "Site"**
- The list of Modules displays the Site Modules and not the Administrator Modules

![modules-filter-before-pr](https://user-images.githubusercontent.com/1217850/165952285-ea1b22c6-aeca-43b2-89e5-614a2e73b16b.png)

### Expected result AFTER applying this Pull Request
- After the Module got duplicated, the **Admin/Site filter is set to "Administrator"**
- The list of Modules displays the Administrator Modules like expected

![modules-filter-after](https://user-images.githubusercontent.com/1217850/165952557-73c74eae-b3e5-4c4a-8882-76237a053887.png)

