### PR TITLE
[3.10] remove super user email on pw reset

### DIFF
--- a/components/com_users/models/reset.php
+++ b/components/com_users/models/reset.php
@@ -429,32 +429,6 @@ class UsersModelReset extends JModelForm
 		{
 			$this->setError(JText::_('COM_USERS_REMIND_SUPERADMIN_ERROR'));
 
-			// Put together the email template data.
-			$data = $user->getProperties();
-			$data['fromname'] = $config->get('fromname');
-			$data['mailfrom'] = $config->get('mailfrom');
-			$data['sitename'] = $config->get('sitename');
-
-			$subject = JText::sprintf(
-				'COM_USERS_EMAIL_PASSWORD_RESET_SUBJECT',
-				$data['sitename']
-			);
-
-			$body = JText::sprintf(
-				'COM_USERS_REMIND_SUPERADMIN_BODY',
-				$data['sitename'],
-				'https://docs.joomla.org/Special:MyLanguage/How_do_you_recover_or_reset_your_admin_password%3F'
-			);
-
-			// Send the password reset request email.
-			$return = JFactory::getMailer()->sendMail($data['mailfrom'], $data['fromname'], $user->email, $subject, $body);
-
-			// Check for an error.
-			if ($return !== true)
-			{
-				$this->setError(JText::_('COM_USERS_MAIL_FAILED'));
-			}
-
 			return false;
 		}
 

--- a/language/en-GB/en-GB.com_users.ini
+++ b/language/en-GB/en-GB.com_users.ini
@@ -142,7 +142,6 @@ COM_USERS_REMIND_REQUEST="If the email address you entered is registered on this
 COM_USERS_REMIND_REQUEST_ERROR="Error requesting password reminder."
 COM_USERS_REMIND_REQUEST_FAILED="Reminder failed: %s"
 COM_USERS_REMIND_REQUEST_SUCCESS="Reminder sent. Please check your mail."
-COM_USERS_REMIND_SUPERADMIN_BODY="Hello,\n\nA request has been made to reset your %s account password. But, for security reasons, a Super User can't request a password reminder. Please contact another Super User or use an alternative method as described in the documentation: %s"
 COM_USERS_REMIND_SUPERADMIN_ERROR="A Super User can't request a password reminder. Please contact another Super User or use an <a href='https://docs.joomla.org/Special:MyLanguage/How_do_you_recover_or_reset_your_admin_password%3F' target='_blank' rel='noopener noreferrer'>alternative method</a> as described in the documentation."
 COM_USERS_RESET="Password Reset"
 COM_USERS_RESET_COMPLETE_ERROR="Error completing password reset."


### PR DESCRIPTION
Pull Request for Issue #30787

### Summary of Changes

Remove the super user email on pw reset by partly reverting: https://github.com/joomla/joomla-cms/pull/30787 as discussed with @bembelimen 

### Testing Instructions

On SU PW reset there is no email send

### Actual result BEFORE applying this Pull Request

On SU PW reset there is a email send

### Expected result AFTER applying this Pull Request

On SU PW reset there is an email send

### Documentation Changes Required

n.a.