### PR TITLE
[4.1] Update deleted files list in script.php for upcoming 4.1.3 release and add missing form validation rule from 3.10

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6386,7 +6386,7 @@ class JoomlaInstallerScript
 			// From 4.1.1 to 4.1.2
 			'/administrator/components/com_users/src/Field/PrimaryauthprovidersField.php',
 			// From 4.1.2 to 4.1.3
-			'libraries/vendor/webmozart/assert/.php_cs',
+			'/libraries/vendor/webmozart/assert/.php_cs',
 		);
 
 		$folders = array(

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6383,6 +6383,8 @@ class JoomlaInstallerScript
 			'/libraries/vendor/tobscure/json-api/tests/ParametersTest.php',
 			'/libraries/vendor/tobscure/json-api/tests/ResourceTest.php',
 			'/libraries/vendor/tobscure/json-api/tests/UtilTest.php',
+			// From 4.1.1 to 4.1.2
+			'/administrator/components/com_users/src/Field/PrimaryauthprovidersField.php',
 			// From 4.1.2 to 4.1.3
 			'libraries/vendor/webmozart/assert/.php_cs',
 		);
@@ -7718,8 +7720,6 @@ class JoomlaInstallerScript
 			'/libraries/vendor/tobscure/json-api/.git/hooks',
 			'/libraries/vendor/tobscure/json-api/.git/branches',
 			'/libraries/vendor/tobscure/json-api/.git',
-			// From 4.1.1 to 4.1.2
-			'/administrator/components/com_users/src/Field/PrimaryauthprovidersField.php',
 		);
 
 		$status['files_checked'] = $files;

--- a/libraries/src/Form/Rule/CssIdentifierSubstringRule.php
+++ b/libraries/src/Form/Rule/CssIdentifierSubstringRule.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2020 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Form\Rule;
+
+\defined('JPATH_PLATFORM') or die;
+
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\FormRule;
+use Joomla\Registry\Registry;
+
+/**
+ * Form Rule class for the Joomla Platform.
+ *
+ * @since  3.10.7
+ */
+class CssIdentifierSubstringRule extends FormRule
+{
+	/**
+	 * Method to test if a string is a valid CSS identifer substring
+	 *
+	 * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
+	 * @param   mixed              $value    The form field value to validate.
+	 * @param   string             $group    The field name group control value. This acts as an array container for the field.
+	 *                                       For example if the field has name="foo" and the group value is set to "bar" then the
+	 *                                       full field name would end up being "bar[foo]".
+	 * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
+	 * @param   Form               $form     The form object for which the field is being tested.
+	 *
+	 * @return  boolean  True if the value is valid, false otherwise.
+	 *
+	 * @since   3.10.7
+	 */
+	public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+	{
+		// If the field is empty and not required, the field is valid.
+		$required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');
+
+		if (!$required && empty($value) && $value !== '0')
+		{
+			return true;
+		}
+
+		/**
+		 * The following regex rules are based on the Html::cleanCssIdentifier method from Drupal
+		 * https://github.com/drupal/drupal/blob/8.8.5/core/lib/Drupal/Component/Utility/Html.php#L116-L130
+		 *
+		 * with the addition for Joomla that we allow the colon (U+003A).
+		 */
+
+		/**
+		 * Valid characters in a CSS identifier are:
+		 * - the hyphen (U+002D)
+		 * - a-z (U+0030 - U+0039)
+		 * - A-Z (U+0041 - U+005A)
+		 * - the underscore (U+005F)
+		 * - the colon (U+003A)
+		 * - 0-9 (U+0061 - U+007A)
+		 * - ISO 10646 characters U+00A1 and higher
+		 */
+		// Make sure we allow multiple classes to be added
+		$cssIdentifiers = explode(' ', $value);
+
+		foreach ($cssIdentifiers as $identifier)
+		{
+			if (preg_match('/[^\\x{002D}\\x{0030}-\\x{0039}\\x{0041}-\\x{005A}\\x{005F}\\x{003A}\\x{0061}-\\x{007A}\\x{00A1}-\\x{FFFF}]/u', $identifier))
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the lists of files and folders to be deleted on update by script.php for the upcoming 4.1.3 release - details see below - and adds file "libraries/src/Form/Rule/CssIdentifierSubstringRule.php" from the 3.10-dev branch.

The "CssIdentifierSubstringRule.php" file has been added due to a security patch with commit https://github.com/joomla/joomla-cms/commit/44b7b8977d9bdf2b408b21ed074dfe637501b915 .

In Joomla 4.x this file is not really needed because the same security fix uses the "CssIdentifierRule" from this file https://github.com/joomla/joomla-cms/blob/4.1-dev/libraries/src/Form/Rule/CssIdentifierRule.php , which is more strict.

But it makes sense to keep that file, and so I add it with this PR. It can be used by 3rd party developers to validate form fields for **_parts_** of CSS identifiers like we had them in past (J3) in the core with the "CSS class suffix" fields, while the "CssIdentifierRule" only make sense for validating **_complete_** CSS identifiers.

In detail following changes are made on the lists of files and folders to be deleted on update by script.php:

- Move file "/administrator/components/com_users/src/Field/PrimaryauthprovidersField.php" from the "$folders" to the "$files" array. It was added by mistake to the "$folders" array with PR #37415 . Possibly my mistake with my code suggestion for that PR.
- Add missing leading slash to file "/libraries/vendor/webmozart/assert/.php_cs" - the missing "/" was my mistake from PR #37458 .

There have not been detected any files or folders to be added to the lists in script.php by my tool.

### Testing Instructions

Code review should be enough.

### Actual result BEFORE applying this Pull Request

File "libraries/src/Form/Rule/CssIdentifierSubstringRule.php" doesn't exist.

In file "administrator/components/com_admin/script.php":
- File "/administrator/components/com_users/src/Field/PrimaryauthprovidersField.php" is at the end of the "$folders" array in section "// From 4.1.1 to 4.1.2".
- File "libraries/vendor/webmozart/assert/.php_cs" - mind the missing leading "/" - is at the end of the "$files" array in section "// From 4.1.2 to 4.1.3".

### Expected result AFTER applying this Pull Request

File "libraries/src/Form/Rule/CssIdentifierSubstringRule.php" exists. It is equal to https://github.com/joomla/joomla-cms/blob/3.10-dev/libraries/src/Form/Rule/CssIdentifierSubstringRule.php except of the changed copyright format at the top and the leading backslash of the "defined" statement.

In file "administrator/components/com_admin/script.php":
- File "/administrator/components/com_users/src/Field/PrimaryauthprovidersField.php" is at the end of the "$files" array in section "// From 4.1.1 to 4.1.2".
- The missing leading "/" has been added to file "/libraries/vendor/webmozart/assert/.php_cs" in section "// From 4.1.2 to 4.1.3".

### Documentation Changes Required

None.