### PR TITLE
[4.2] Fix multiselect, Correcting com_installer "update" layout markup

### DIFF
--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -45,9 +45,9 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 							</caption>
 							<thead>
 							<tr>
-								<th class="w-1 text-center">
+								<td class="w-1 text-center">
 									<?php echo HTMLHelper::_('grid.checkall'); ?>
-								</th>
+								</td>
 								<th scope="col">
 									<?php echo HTMLHelper::_('searchtools.sort', 'COM_INSTALLER_HEADING_NAME', 'u.name', $listDirn, $listOrder); ?>
 								</th>


### PR DESCRIPTION
Pull Request for Issue #37600 .

### Summary of Changes

use correct cell tag in com_installer "update" layout.


### Testing Instructions

You need to have some updates available.
Then follow  #37600.


### Actual result BEFORE applying this Pull Request

Select works correctly


### Expected result AFTER applying this Pull Request

Select works incorrectly.


### Documentation Changes Required
none
