### PR TITLE
Warning: Undefined property: Joomla\CMS\Object\CMSObject::$inheritable

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -2218,7 +2218,7 @@ class TemplateModel extends FormModel
 	{
 		$template = $this->getTemplate();
 
-		if (!$template->xmldata->inheritable)
+		if (empty($template->xmldata->inheritable))
 		{
 			return [];
 		}


### PR DESCRIPTION
Pull Request for Issue #37733

### Summary of Changes
A legacy template may not include the inheritable attribute in the XML
This PR checks if it "empty"


### Testing Instructions
Before applying the patch check that you have the warning when viewing the legacy template in the backend


### Actual result BEFORE applying this Pull Request
The following warning is presented
**Warning: Undefined property: Joomla\CMS\Object\CMSObject::$inheritable**


### Expected result AFTER applying this Pull Request
No warning message is displayed,


### Documentation Changes Required

