### PR TITLE
[4.2] Adding missing @since tags

### DIFF
--- a/libraries/src/Console/ExtensionInstallCommand.php
+++ b/libraries/src/Console/ExtensionInstallCommand.php
@@ -49,13 +49,13 @@ class ExtensionInstallCommand extends AbstractCommand
 
 	/**
 	 * Exit Code For installation failure
-	 * @since
+	 * @since 4.0.0
 	 */
 	public const INSTALLATION_FAILED = 1;
 
 	/**
 	 * Exit Code For installation Success
-	 * @since
+	 * @since 4.0.0
 	 */
 	public const INSTALLATION_SUCCESSFUL = 0;
 

--- a/libraries/src/Console/ExtensionRemoveCommand.php
+++ b/libraries/src/Console/ExtensionRemoveCommand.php
@@ -37,55 +37,55 @@ class ExtensionRemoveCommand extends AbstractCommand
 
 	/**
 	 * @var InputInterface
-	 * @since version
+	 * @since 4.0.0
 	 */
 	private $cliInput;
 
 	/**
 	 * @var SymfonyStyle
-	 * @since version
+	 * @since 4.0.0
 	 */
 	private $ioStyle;
 
 	/**
 	 * Exit Code for extensions remove abort
-	 * @since
+	 * @since 4.0.0
 	 */
 	public const REMOVE_ABORT = 3;
 
 	/**
 	 * Exit Code for extensions remove failure
-	 * @since
+	 * @since 4.0.0
 	 */
 	public const REMOVE_FAILED = 1;
 
 	/**
 	 * Exit Code for invalid response
-	 * @since
+	 * @since 4.0.0
 	 */
 	public const REMOVE_INVALID_RESPONSE = 5;
 
 	/**
 	 * Exit Code for invalid type
-	 * @since
+	 * @since 4.0.0
 	 */
 	public const REMOVE_INVALID_TYPE = 6;
 
 	/**
 	 * Exit Code for extensions locked remove failure
-	 * @since
+	 * @since 4.0.0
 	 */
 	public const REMOVE_LOCKED = 4;
 
 	/**
 	 * Exit Code for extensions not found
-	 * @since
+	 * @since 4.0.0
 	 */
 	public const REMOVE_NOT_FOUND = 2;
 
 	/**
 	 * Exit Code for extensions remove success
-	 * @since
+	 * @since 4.0.0
 	 */
 	public const REMOVE_SUCCESSFUL = 0;
 

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -268,7 +268,7 @@ class GetConfigurationCommand extends AbstractCommand
 	 *
 	 * @return string
 	 *
-	 * @since version
+	 * @since 4.0.0
 	 */
 	protected function formatConfigValue($value): string
 	{

--- a/libraries/src/Extension/Service/Provider/HelperFactory.php
+++ b/libraries/src/Extension/Service/Provider/HelperFactory.php
@@ -36,7 +36,7 @@ class HelperFactory implements ServiceProviderInterface
 	 *
 	 * @param   string  $namespace  The namespace
 	 *
-	 * @since   HelperFactory
+	 * @since   4.0.0
 	 */
 	public function __construct(string $namespace)
 	{


### PR DESCRIPTION
While fixing the deployment of the API documentation on api.joomla.org, I ran into a fatal error in phpDocumentor, where empty @since tags resulted in the build process to be aborted. This PR fixes those instances with false @since tags.