### PR TITLE
[4.1] scheduler sort by last run remove todo statement

### DIFF
--- a/administrator/components/com_scheduler/forms/filter_tasks.xml
+++ b/administrator/components/com_scheduler/forms/filter_tasks.xml
@@ -40,7 +40,6 @@
 	</fields>
 
 	<fields name="list">
-		<!-- @todo: Add options for execution date(s) -->
 		<field
 			name="fullordering"
 			type="list"


### PR DESCRIPTION
### Summary of Changes

The option to sort `last_execution` was introduced in #37501, so the todo statement can be removed

See: https://github.com/joomla/joomla-cms/pull/37501#issuecomment-1120371300

### Testing Instructions

Code Review