### PR TITLE
[4.1] Workflows spacer width breaks layout

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_form.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_form.scss
@@ -57,10 +57,6 @@
   hr {
     width: 380px;
   }
-
-  label {
-    width: 440px;
-  }
 }
 
 td .form-control {


### PR DESCRIPTION
#22213 added a width of 440px to the label on a spacer field

This breaks the layout of the article form when workflows is enabled at certain screen resolutions.

Based on the comments on the initial commit this class is no longer required so by removing it here the article form layout is no longer broken.

This is an scss change to will require npm run build:css to test

Workflows must be enabled else the impacted fields will not be displayed.

### Before
![image](https://user-images.githubusercontent.com/1296369/168486477-3807c22d-6013-49e5-aec0-654cc3847f6c.png)

### After
![image](https://user-images.githubusercontent.com/1296369/168486505-507054d4-d202-41ea-a55d-631dfdb0c0b8.png)
