### PR TITLE
[4.1] Fixes spacing for inline tags.

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_tags.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_tags.scss
@@ -11,5 +11,5 @@
 
 .tag {
   display: inline-block;
-  padding: .5rem 0;
+  padding: .5rem .25rem;
 }

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_tags.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_tags.scss
@@ -11,5 +11,5 @@
 
 .tag {
   display: inline-block;
-  padding: .5rem .25rem;
+  padding: .5rem .5rem .5rem 0;
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The spacing for inline tags made things appear smushed.  This fix better delineates between tags


### Testing Instructions
install clean  install of J4
install sample blog data
go to very bottom of page and check that image matches
run npm ci to rebuild template.css and check that image matches.


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/1850089/168491853-b8504a50-8b21-4d6a-ab8d-cf431f77e3b4.png)


### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1850089/168491837-aad8f7f1-d7dd-45fc-9c43-f5ecf59cfd9a.png)



### Documentation Changes Required
none
