### PR TITLE
[4.2] Reduce number of permission columns

### DIFF
--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -22,11 +22,11 @@ $actions = [];
 
 // Split the actions table
 foreach ($this->actions as $action) :
-	$name  = $action[0];
-	if (in_array($name, ['core.login.site', 'core.login.admin', 'core.login.offline', 'core.login.api', 'core.admin'] )) :
-			$loginActions[] = $action;
-		else :
-			$actions[] = $action;
+	$name = $action[0];
+	if (in_array($name, ['core.login.site', 'core.login.admin', 'core.login.offline', 'core.login.api', 'core.admin'])) :
+		$loginActions[] = $action;
+	else :
+		$actions[] = $action;
 	endif;
 endforeach;
 ?>

--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -16,95 +16,137 @@ use Joomla\CMS\Router\Route;
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
+
+$loginActions = [];
+$actions = [];
+
+// Split the actions table
+foreach ($this->actions as $action) :
+	$name  = $action[0];
+	if (in_array($name, ['core.login.site', 'core.login.admin', 'core.login.offline', 'core.login.api', 'core.admin'] )) :
+			$loginActions[] = $action;
+		else :
+			$actions[] = $action;
+	endif;
+endforeach;
 ?>
 <form action="<?php echo Route::_('index.php?option=com_users&view=debuguser&user_id=' . (int) $this->state->get('user_id')); ?>" method="post" name="adminForm" id="adminForm">
 	<div id="j-main-container" class="j-main-container">
 		<?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-		<div class="table-responsive">
-			<table class="table">
-				<caption class="visually-hidden">
-					<?php echo Text::_('COM_USERS_DEBUG_USER_TABLE_CAPTION'); ?>,
-							<span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
-							<span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
-				</caption>
-				<thead>
-					<tr>
-						<th scope="col">
-							<?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_ASSET_TITLE', 'a.title', $listDirn, $listOrder); ?>
-						</th>
-						<th scope="col">
-							<?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_ASSET_NAME', 'a.name', $listDirn, $listOrder); ?>
-						</th>
-						<?php foreach ($this->actions as $key => $action) : ?>
-						<th scope="col" class="w-6 text-center">
-							<?php echo Text::_($key); ?>
-						</th>
-						<?php endforeach; ?>
-						<th scope="col" class="w-6">
-							<?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_LFT', 'a.lft', $listDirn, $listOrder); ?>
-						</th>
-						<th scope="col" class="w-3">
-							<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
-						</th>
-					</tr>
-				</thead>
-				<tbody>
-					<?php foreach ($this->items as $i => $item) : ?>
-						<tr class="row0" scope="row">
-							<td>
-								<?php echo $this->escape(Text::_($item->title)); ?>
-							</td>
-							<td>
-								<?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level + 1)) . $this->escape($item->name); ?>
-							</td>
-							<?php foreach ($this->actions as $action) : ?>
-								<?php
-								$name  = $action[0];
-								$check = $item->checks[$name];
-								if ($check === true) :
-									$class  = 'text-success icon-check';
-									$button = 'btn-success';
-									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
-								elseif ($check === false) :
-									$class  = 'text-danger icon-times';
-									$button = 'btn-danger';
-									$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_DENY');
-								elseif ($check === null) :
-									$class  = 'text-danger icon-minus-circle';
-									$button = 'btn-warning';
-									$text   = Text::_('COM_USERS_DEBUG_IMPLICIT_DENY');
-								else :
-									$class  = '';
-									$button = '';
-									$text   = '';
-								endif;
-								?>
-							<td class="text-center">
-								<span class="<?php echo $class; ?>" aria-hidden="true"></span>
-								<span class="visually-hidden"> <?php echo $text; ?></span>
-							</td>
-							<?php endforeach; ?>
-							<td>
-								<?php echo (int) $item->lft; ?>
-								- <?php echo (int) $item->rgt; ?>
-							</td>
-							<td>
-								<?php echo (int) $item->id; ?>
-							</td>
-						</tr>
-					<?php endforeach; ?>
-				</tbody>
-			</table>
-			<div class="legend">
-				<span class="text-danger icon-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
-				<span class="text-success icon-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-				<span class="text-danger icon-times" aria-hidden="true">&nbsp;</span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+		<div class="d-flex flex-wrap">
+			<?php foreach ($loginActions as $action) :
+				$name  = $action[0];
+				$check = $this->items[0]->checks[$name];
+				if ($check === true) :
+					$class  = 'text-success icon-check';
+					$button = 'btn-success';
+					$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
+				elseif ($check === false) :
+					$class  = 'text-danger icon-times';
+					$button = 'btn-danger';
+					$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_DENY');
+				elseif ($check === null) :
+					$class  = 'text-danger icon-minus-circle';
+					$button = 'btn-warning';
+					$text   = Text::_('COM_USERS_DEBUG_IMPLICIT_DENY');
+				else :
+					$class  = '';
+					$button = '';
+					$text   = '';
+				endif;
+			?>
+			<div class=" d-inline p-2">
+				<?php echo Text::_($action[1]); ?>
+				<span class="<?php echo $class; ?>" aria-hidden="true"></span>
+				<span class="visually-hidden"><?php echo Text::_($text); ?></span>
 			</div>
-
-			<?php // load the pagination. ?>
-			<?php echo $this->pagination->getListFooter(); ?>
-
+			<?php endforeach; ?>
 		</div>
+
+		<table class="table">
+			<caption class="visually-hidden">
+				<?php echo Text::_('COM_USERS_DEBUG_USER_TABLE_CAPTION'); ?>,
+						<span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
+						<span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
+			</caption>
+			<thead>
+				<tr>
+					<th scope="col">
+						<?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_ASSET_TITLE', 'a.title', $listDirn, $listOrder); ?>
+					</th>
+					<th scope="col">
+						<?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_ASSET_NAME', 'a.name', $listDirn, $listOrder); ?>
+					</th>
+					<?php foreach ($actions as $key => $action) : ?>
+					<th scope="col" class="w-6 text-center">
+						<?php echo Text::_($action[1]); ?>
+					</th>
+					<?php endforeach; ?>
+					<th scope="col" class="w-6">
+						<?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_LFT', 'a.lft', $listDirn, $listOrder); ?>
+					</th>
+					<th scope="col" class="w-3">
+						<?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+					</th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php foreach ($this->items as $i => $item) :?>
+					<tr class="row0" scope="row">
+						<td>
+							<?php echo $this->escape(Text::_($item->title)); ?>
+						</td>
+						<td>
+							<?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level + 1)) . $this->escape($item->name); ?>
+						</td>
+						<?php foreach ($actions as $action) : ?>
+							<?php
+							$name  = $action[0];
+							$check = $item->checks[$name];
+							if ($check === true) :
+								$class  = 'text-success icon-check';
+								$button = 'btn-success';
+								$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
+							elseif ($check === false) :
+								$class  = 'text-danger icon-times';
+								$button = 'btn-danger';
+								$text   = Text::_('COM_USERS_DEBUG_EXPLICIT_DENY');
+							elseif ($check === null) :
+								$class  = 'text-danger icon-minus-circle';
+								$button = 'btn-warning';
+								$text   = Text::_('COM_USERS_DEBUG_IMPLICIT_DENY');
+							else :
+								$class  = '';
+								$button = '';
+								$text   = '';
+							endif;
+							?>
+						<td class="text-center">
+							<span class="<?php echo $class; ?>" aria-hidden="true"></span>
+							<span class="visually-hidden"> <?php echo $text; ?></span>
+						</td>
+						<?php endforeach; ?>
+						<td>
+							<?php echo (int) $item->lft; ?>
+							- <?php echo (int) $item->rgt; ?>
+						</td>
+						<td>
+							<?php echo (int) $item->id; ?>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+			</tbody>
+		</table>
+
+		<div class="legend">
+			<span class="text-danger icon-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
+			<span class="text-success icon-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
+			<span class="text-danger icon-times" aria-hidden="true">&nbsp;</span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+		</div>
+
+		<?php // load the pagination. ?>
+		<?php echo $this->pagination->getListFooter(); ?>
+
 		<input type="hidden" name="task" value="">
 		<input type="hidden" name="boxchecked" value="0">
 		<?php echo HTMLHelper::_('form.token'); ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The permissions overview contains 5 columns which contain always the same value because these are global permissions. 
This PR extracts global permissions from the list of possible actions and displays the result in a single line.

It does not resolve the issue https://github.com/joomla/joomla-cms/issues/23628. Horizontal scrolling appears in all screens where the table heading enforces horizontal scrolling, not only here. As soon as the table width cannot be reduced to fit the viewport, a horizontal scrollbar appears. 
We resolve this in other tables by hiding some olumns, but on the permissions this is not possible. 

### Testing Instructions
Have a look on the permissions of a user before and after the patch.



### Actual result BEFORE applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/168559524-418952cd-3709-4ae6-a511-a2f80ccc4174.png)


### Expected result AFTER applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/168559819-2c759d91-4069-4ca4-9a82-6352fdbc0058.png)



### Documentation Changes Required
yes
