### PR TITLE
[3.10.9] Links from numeric tags cause error 404 #37814

### DIFF
--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -178,7 +178,7 @@ class TagsModelTag extends JModelList
 		$this->setState('params', $params);
 
 		// Load state from the request.
-		$ids = (array) $app->input->get('id', array(), 'int');
+		$ids = (array) $app->input->get('id', array(), 'string');
 
 		if (count($ids) == 1)
 		{

--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -178,7 +178,7 @@ class TagsModelTag extends JModelList
 		$this->setState('params', $params);
 
 		// Load state from the request.
-		$ids = (array) $app->input->get('id', array());
+		$ids = (array) $app->input->get('id', array(),'int');
 
 		if (count($ids) == 1)
 		{

--- a/components/com_tags/models/tag.php
+++ b/components/com_tags/models/tag.php
@@ -178,7 +178,7 @@ class TagsModelTag extends JModelList
 		$this->setState('params', $params);
 
 		// Load state from the request.
-		$ids = (array) $app->input->get('id', array(),'int');
+		$ids = (array) $app->input->get('id', array(), 'int');
 
 		if (count($ids) == 1)
 		{


### PR DESCRIPTION
Pull Request for Issue #37814 .

### Summary of Changes



### Testing Instructions

Create a numeric tag, a non-numeric tag starting with a number and a non-numeric tag starting with a non-numeric character in one article

### Actual result BEFORE applying this Pull Request

Non numeric tags articles list displayed when selecting a non-numeric tag
error 404 when clicking on numeric tag or a non-numeric tag starting with a number.

Same results in popular tags module

### Expected result AFTER applying this Pull Request

Non numeric tags articles list displayed when selecting a non-numeric tag
when clicking on numeric tag, articles list is displayed
when clicking on non-numeric tag starting with a number, articles list is displayed

Popular tags module works fine in all cases


