### PR TITLE
[4.1] Fix deprecated warning in chrome html 5

### DIFF
--- a/layouts/chromes/html5.php
+++ b/layouts/chromes/html5.php
@@ -23,7 +23,7 @@ if ((string) $module->content === '')
 
 $moduleTag              = htmlspecialchars($params->get('module_tag', 'div'), ENT_QUOTES, 'UTF-8');
 $moduleAttribs          = [];
-$moduleAttribs['class'] = 'moduletable ' . htmlspecialchars($params->get('moduleclass_sfx'), ENT_QUOTES, 'UTF-8');
+$moduleAttribs['class'] = 'moduletable ' . htmlspecialchars($params->get('moduleclass_sfx', ''), ENT_QUOTES, 'UTF-8');
 $bootstrapSize          = (int) $params->get('bootstrap_size', 0);
 $moduleAttribs['class'] .= $bootstrapSize !== 0 ? ' col-md-' . $bootstrapSize : '';
 $headerTag              = htmlspecialchars($params->get('header_tag', 'h3'), ENT_QUOTES, 'UTF-8');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fix warning Deprecated: htmlspecialchars(): Passing null to parameter #1 ($string) of type string is deprecated in
 layouts\chromes\html5.php on line 26 in php 8.1.5


### Testing Instructions
Set error-reporting to maximum, set Module style to html5 in one of your modules



### Actual result BEFORE applying this Pull Request
The warning above.


### Expected result AFTER applying this Pull Request
Apply the patch, the message is fixed 


### Documentation Changes Required

