### PR TITLE
[4.2] Fix mistakes in lists of deleted files and folders in script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6387,6 +6387,8 @@ class JoomlaInstallerScript
 			'/administrator/components/com_users/src/Field/PrimaryauthprovidersField.php',
 			// From 4.1.2 to 4.1.3
 			'/libraries/vendor/webmozart/assert/.php_cs',
+			// From 4.1 to 4.2.0
+			'/libraries/src/Service/Provider/ApiRouter.php',
 		);
 
 		$folders = array(
@@ -7720,10 +7722,6 @@ class JoomlaInstallerScript
 			'/libraries/vendor/tobscure/json-api/.git/hooks',
 			'/libraries/vendor/tobscure/json-api/.git/branches',
 			'/libraries/vendor/tobscure/json-api/.git',
-			// From 4.1.1 to 4.1.2
-			'/administrator/components/com_users/src/Field/PrimaryauthprovidersField.php',
-			// From 4.1.1 to 4.2.0
-			'/libraries/src/Service/Provider/ApiRouter.php'
 		);
 
 		$status['files_checked'] = $files;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With the last merge from 4.1-dev to 4.2-dev, PR #37714 was not completely merged up.

The files which had been moved from the list of folders to the list of files have been added in the list of files but not removed in the list of folders.

Furthermore, with this commit, another files was added to the list of folders and not the list of files in 4.2-dev: https://github.com/joomla/joomla-cms/commit/61c6f1fe8792fb350034f495a5112d71cfeb96c8

This PR here corrects these mistakes and fixes code style so that the last element in an array is followed by a comma, which is one of our code style rules.

In addition, the version comment "// From 4.1.1 to 4.2.0" is changed to "// From 4.1 to 4.2.0" because that section does not depend on the patch version of 4.1, it applies to any 4.1.

### Testing Instructions

Code review should be enough.

### Actual result BEFORE applying this Pull Request

Files are in the list of folders to be deleted, and '/administrator/components/com_users/src/Field/PrimaryauthprovidersField.php' appears in both lists of files and folders.

### Expected result AFTER applying this Pull Request

Files are in the list of files where they should be.

### Documentation Changes Required

None.