### PR TITLE
[4.1] Frontend: 'Publishing Options: Hide' show 'Publishing' tab fix

### DIFF
--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -100,40 +100,42 @@ if (!$editoroptions)
 			<?php endif; ?>
 
 			<?php echo LayoutHelper::render('joomla.edit.params', $this); ?>
+			
+			<?php if ($params->get('show_publishing_options', 1) == 1) : ?>
+				<?php echo HTMLHelper::_('uitab.addTab', $this->tab_name, 'publishing', Text::_('COM_CONTENT_PUBLISHING')); ?>
 
-			<?php echo HTMLHelper::_('uitab.addTab', $this->tab_name, 'publishing', Text::_('COM_CONTENT_PUBLISHING')); ?>
-
-				<?php echo $this->form->renderField('transition'); ?>
-				<?php echo $this->form->renderField('state'); ?>
-				<?php echo $this->form->renderField('catid'); ?>
-				<?php echo $this->form->renderField('tags'); ?>
-				<?php echo $this->form->renderField('note'); ?>
-				<?php if ($params->get('save_history', 0)) : ?>
-					<?php echo $this->form->renderField('version_note'); ?>
-				<?php endif; ?>
-				<?php if ($params->get('show_publishing_options', 1) == 1) : ?>
-					<?php echo $this->form->renderField('created_by_alias'); ?>
-				<?php endif; ?>
-				<?php if ($this->item->params->get('access-change')) : ?>
-					<?php echo $this->form->renderField('featured'); ?>
-					<?php if ($params->get('show_publishing_options', 1) == 1) : ?>
-						<?php echo $this->form->renderField('featured_up'); ?>
-						<?php echo $this->form->renderField('featured_down'); ?>
-						<?php echo $this->form->renderField('publish_up'); ?>
-						<?php echo $this->form->renderField('publish_down'); ?>
+					<?php echo $this->form->renderField('transition'); ?>
+					<?php echo $this->form->renderField('state'); ?>
+					<?php echo $this->form->renderField('catid'); ?>
+					<?php echo $this->form->renderField('tags'); ?>
+					<?php echo $this->form->renderField('note'); ?>
+					<?php if ($params->get('save_history', 0)) : ?>
+						<?php echo $this->form->renderField('version_note'); ?>
 					<?php endif; ?>
-				<?php endif; ?>
-				<?php echo $this->form->renderField('access'); ?>
-				<?php if (is_null($this->item->id)) : ?>
-					<div class="control-group">
-						<div class="control-label">
+					<?php if ($params->get('show_publishing_options', 1) == 1) : ?>
+						<?php echo $this->form->renderField('created_by_alias'); ?>
+					<?php endif; ?>
+					<?php if ($this->item->params->get('access-change')) : ?>
+						<?php echo $this->form->renderField('featured'); ?>
+						<?php if ($params->get('show_publishing_options', 1) == 1) : ?>
+							<?php echo $this->form->renderField('featured_up'); ?>
+							<?php echo $this->form->renderField('featured_down'); ?>
+							<?php echo $this->form->renderField('publish_up'); ?>
+							<?php echo $this->form->renderField('publish_down'); ?>
+						<?php endif; ?>
+					<?php endif; ?>
+					<?php echo $this->form->renderField('access'); ?>
+					<?php if (is_null($this->item->id)) : ?>
+						<div class="control-group">
+							<div class="control-label">
+							</div>
+							<div class="controls">
+								<?php echo Text::_('COM_CONTENT_ORDERING'); ?>
+							</div>
 						</div>
-						<div class="controls">
-							<?php echo Text::_('COM_CONTENT_ORDERING'); ?>
-						</div>
-					</div>
-				<?php endif; ?>
-			<?php echo HTMLHelper::_('uitab.endTab'); ?>
+					<?php endif; ?>
+				<?php echo HTMLHelper::_('uitab.endTab'); ?>
+			<?php endif; ?>	
 
 			<?php if (Multilanguage::isEnabled()) : ?>
 				<?php echo HTMLHelper::_('uitab.addTab', $this->tab_name, 'language', Text::_('JFIELD_LANGUAGE_LABEL')); ?>


### PR DESCRIPTION
Pull Request for Issue #37816

### Summary of Changes
1. Added condition in frontend article edit file to show publishing tab only when publishing options enabled



### Testing Instructions
Set 'Publishing Options' to hide:
![image](https://user-images.githubusercontent.com/72155000/169457099-2a092b47-0ea7-46b1-aa95-7482ef70dd6b.png)


### Actual result BEFORE applying this Pull Request
Open an article in Frontend, 'Publishing' tab is shown:
![image](https://user-images.githubusercontent.com/72155000/169467757-563dd10e-f6b1-46f4-bbee-c9bd28810ed0.png)




### Expected result AFTER applying this Pull Request
'Publishing' tab is not shown:
![image](https://user-images.githubusercontent.com/72155000/169457495-9aa9c154-1606-4d3c-8628-39114df19a16.png)



