### PR TITLE
[4.1] Initialize the contact text attribute as string

### DIFF
--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -341,7 +341,7 @@ class HtmlView extends BaseHtmlView
 		$offset = $state->get('list.offset');
 
 		// Fix for where some plugins require a text attribute
-		$item->text = null;
+		$item->text = '';
 
 		if (!empty($item->misc))
 		{


### PR DESCRIPTION
### Summary of Changes
When triggering the `onContentPrepare` event in the contact details page, the text attribute is expected to be a string. On PHP 8.1 a couple of deprecated messages are displayed as it is currently null.

### Testing Instructions
- Create a contact
- Create a single contact menu item
- Open the new menu item

### Actual result BEFORE applying this Pull Request
The following deprecated message is displayed:
_Deprecated: strpos(): Passing null to parameter 1 ($haystack) of type string is deprecated in /plugins/content/loadmodule/loadmodule.php on line 49_

### Expected result AFTER applying this Pull Request
No warning.