### PR TITLE
[4.2] Update deleted files and folders for 4.2.0-alpha3

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6387,8 +6387,6 @@ class JoomlaInstallerScript
 			'/administrator/components/com_users/src/Field/PrimaryauthprovidersField.php',
 			// From 4.1.2 to 4.1.3
 			'/libraries/vendor/webmozart/assert/.php_cs',
-			// From 4.1 to 4.2.0
-			'/libraries/src/Service/Provider/ApiRouter.php',
 			// From 4.1.3 to 4.1.4
 			'/libraries/vendor/maximebf/debugbar/.bowerrc',
 			'/libraries/vendor/maximebf/debugbar/bower.json',
@@ -6449,6 +6447,11 @@ class JoomlaInstallerScript
 			'/libraries/vendor/maximebf/debugbar/tests/DebugBar/Tests/TracedStatementTest.php',
 			'/libraries/vendor/maximebf/debugbar/tests/DebugBar/Tests/full_init.html',
 			'/libraries/vendor/maximebf/debugbar/tests/bootstrap.php',
+			// From 4.1 to 4.2.0
+			'/libraries/src/Service/Provider/ApiRouter.php',
+			'/libraries/vendor/nyholm/psr7/doc/final.md',
+			'/modules/mod_articles_news/mod_articles_news.php',
+			'/plugins/system/cache/cache.php',
 		);
 
 		$folders = array(
@@ -7802,6 +7805,8 @@ class JoomlaInstallerScript
 			'/libraries/vendor/maximebf/debugbar/demo/bridge',
 			'/libraries/vendor/maximebf/debugbar/demo',
 			'/libraries/vendor/maximebf/debugbar/build',
+			// From 4.1 to 4.2.0
+			'/libraries/vendor/nyholm/psr7/doc',
 		);
 
 		$status['files_checked'] = $files;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Update the lists of deleted files and folders in script.php to recent changes for the upcoming 4.2.0-alpha3:

- Section "// From 4.1 to 4.2.0" of the `$files` list has been moved to the end of that list.
- File "/modules/mod_articles_news/mod_articles_news.php" has been added to `$files` list. This file has been removed from the sources with PR #37445 .
- File "/plugins/system/cache/cache.php" has been added to `$files` list. This file has been removed from the sources with PR #36042 .
- File "/libraries/vendor/nyholm/psr7/doc/final.md" and folder "/libraries/vendor/nyholm/psr7/doc" have been added to the corresponding lists. This file and the folder are not included anymore in the 3rd party composer dependency "nyholm/psr7" since it has been updated in the 4.2-dev branch with this commit: https://github.com/joomla/joomla-cms/commit/ceb4d8117238ef274525bd3bd6ad483f94f662c6

### Testing Instructions

Code review.

Or if you want to make a real test, update a 4.2.0-alpha2 or a 4.1.3 to the last 4.2 nightly build to get the actual result, and update a 4.2.0-alpha2 or a 4.1.3 to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

Files and folders mentioned in the description above are not deleted when updating from 4.2.0-alpha2 or 4.1.3.

### Expected result AFTER applying this Pull Request

Files and folders mentioned in the description above are deleted when updating from 4.2.0-alpha2 or 4.1.3.

### Documentation Changes Required

None.