### PR TITLE
Modified function name to avoid conflict with PHP keyword.

### DIFF
--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -474,7 +474,7 @@ class Browser
 	 */
 	public function __construct($userAgent = null, $accept = null)
 	{
-		$this->match($userAgent, $accept);
+		$this->_match($userAgent, $accept);
 	}
 
 	/**
@@ -511,7 +511,7 @@ class Browser
 	 *
 	 * @since   1.7.0
 	 */
-	public function match($userAgent = null, $accept = null)
+	public function _match($userAgent = null, $accept = null)
 	{
 		// Set our agent string.
 		if (\is_null($userAgent))

--- a/tests/Unit/Libraries/Cms/Environment/BrowserTest.php
+++ b/tests/Unit/Libraries/Cms/Environment/BrowserTest.php
@@ -175,7 +175,7 @@ class BrowserTest extends UnitTestCase
 	 */
 	public function testBrowserMatching($userAgent, $expectedBrowser, $expectedPlatform, $expectedMajorVersion, $expectedMobile)
 	{
-		$this->browser->match($userAgent);
+		$this->browser->_match($userAgent);
 
 		$this->assertSame($expectedBrowser, $this->browser->getBrowser());
 		$this->assertSame($expectedPlatform, $this->browser->getPlatform());


### PR DESCRIPTION
Pull Request for Issue  #37823 
Link for the issue: 
[https://github.com/joomla/joomla-cms/issues/37823](url)

### Summary of Changes
Changed the function name to avoid conflict with PHP keyword. Previously it was "match", but match is a PHP keyword since PHP 8.0, so changed it to "_match". 


### Open Questions:
I am unware of of the naming standards followed by the Joomla! team, so if you want me to change the name to something more 'understandable', let me know. 
Other function names that I have in mind:
- match_useragent
- match_features


### Actual result BEFORE applying this Pull Request
nil



### Expected result AFTER applying this Pull Request
nil



### Documentation Changes Required
None to my knowledge. 

