### PR TITLE
[4] com_content.article view. Remove redundant  `if $this->item->pagination`

### DIFF
--- a/components/com_content/tmpl/article/default.php
+++ b/components/com_content/tmpl/article/default.php
@@ -91,7 +91,7 @@ $isExpired         = !is_null($this->item->publish_down) && $this->item->publish
 	<?php if ($params->get('access-view')) : ?>
 	<?php echo LayoutHelper::render('joomla.content.full_image', $this->item); ?>
 	<?php
-	if (!empty($this->item->pagination) && $this->item->pagination && !$this->item->paginationposition && !$this->item->paginationrelative) :
+	if (!empty($this->item->pagination) && !$this->item->paginationposition && !$this->item->paginationrelative) :
 		echo $this->item->pagination;
 	endif;
 	?>


### PR DESCRIPTION
### Summary of Changes
- The second part of condition `!empty($this->item->pagination) && $this->item->pagination` is redundant. "If it's not empty then it is" ;-)
- See other similar code lines in the file where this double check has been removed already a long time ago.

### Testing Instructions
- Code review.
