### PR TITLE
[4.2] Waiting for Selenium to be ready

### DIFF
--- a/tests/Codeception/drone-api-run.sh
+++ b/tests/Codeception/drone-api-run.sh
@@ -23,6 +23,7 @@ until $(curl --output /dev/null --silent --head --fail http://localhost:4444/wd/
     printf '.'
     sleep 2
 done
+echo .
 
 echo "[RUNNER] Run Codeception"
 cd /tests/www/$DB_ENGINE

--- a/tests/Codeception/drone-api-run.sh
+++ b/tests/Codeception/drone-api-run.sh
@@ -18,7 +18,7 @@ google-chrome --version
 
 echo "[RUNNER] Start Selenium"
 selenium-standalone start > selenium.api.$DB_ENGINE.log 2>&1 &
-echo "Waiting until Selenium is ready..."
+echo -n "Waiting until Selenium is ready"
 until $(curl --output /dev/null --silent --head --fail http://localhost:4444/wd/hub/status); do
     printf '.'
     sleep 2

--- a/tests/Codeception/drone-api-run.sh
+++ b/tests/Codeception/drone-api-run.sh
@@ -18,8 +18,8 @@ google-chrome --version
 
 echo "[RUNNER] Start Selenium"
 selenium-standalone start > selenium.api.$DB_ENGINE.log 2>&1 &
-echo "Waiting 6 seconds till Selenium is ready..."
-sleep 6
+echo "Waiting 10 seconds till Selenium is ready..."
+sleep 10
 
 echo "[RUNNER] Run Codeception"
 cd /tests/www/$DB_ENGINE

--- a/tests/Codeception/drone-api-run.sh
+++ b/tests/Codeception/drone-api-run.sh
@@ -18,8 +18,11 @@ google-chrome --version
 
 echo "[RUNNER] Start Selenium"
 selenium-standalone start > selenium.api.$DB_ENGINE.log 2>&1 &
-echo "Waiting 10 seconds till Selenium is ready..."
-sleep 10
+echo "Waiting until Selenium is ready..."
+until $(curl --output /dev/null --silent --head --fail http://localhost:4444/wd/hub/status); do
+    printf '.'
+    sleep 2
+done
 
 echo "[RUNNER] Run Codeception"
 cd /tests/www/$DB_ENGINE

--- a/tests/Codeception/drone-system-run.sh
+++ b/tests/Codeception/drone-system-run.sh
@@ -25,8 +25,11 @@ fi
 
 echo "[RUNNER] Start Selenium"
 selenium-standalone start > tests/Codeception/_output/selenium.$DB_ENGINE.log 2>&1 &
-echo "Waiting 10 seconds till Selenium is ready..."
-sleep 10
+echo "Waiting until Selenium is ready..."
+until $(curl --output /dev/null --silent --head --fail http://localhost:4444/wd/hub/status); do
+    printf '.'
+    sleep 2
+done
 
 echo "[RUNNER] Run Codeception"
 cd /tests/www/$DB_ENGINE

--- a/tests/Codeception/drone-system-run.sh
+++ b/tests/Codeception/drone-system-run.sh
@@ -25,8 +25,8 @@ fi
 
 echo "[RUNNER] Start Selenium"
 selenium-standalone start > tests/Codeception/_output/selenium.$DB_ENGINE.log 2>&1 &
-echo "Waiting 6 seconds till Selenium is ready..."
-sleep 6
+echo "Waiting 10 seconds till Selenium is ready..."
+sleep 10
 
 echo "[RUNNER] Run Codeception"
 cd /tests/www/$DB_ENGINE

--- a/tests/Codeception/drone-system-run.sh
+++ b/tests/Codeception/drone-system-run.sh
@@ -30,6 +30,7 @@ until $(curl --output /dev/null --silent --head --fail http://localhost:4444/wd/
     printf '.'
     sleep 2
 done
+echo .
 
 echo "[RUNNER] Run Codeception"
 cd /tests/www/$DB_ENGINE

--- a/tests/Codeception/drone-system-run.sh
+++ b/tests/Codeception/drone-system-run.sh
@@ -25,7 +25,7 @@ fi
 
 echo "[RUNNER] Start Selenium"
 selenium-standalone start > tests/Codeception/_output/selenium.$DB_ENGINE.log 2>&1 &
-echo "Waiting until Selenium is ready..."
+echo -n "Waiting until Selenium is ready"
 until $(curl --output /dev/null --silent --head --fail http://localhost:4444/wd/hub/status); do
     printf '.'
     sleep 2


### PR DESCRIPTION
The selenium tests sometimes fail because selenium isn't ready yet. This changes the call to wait for Selenium to successfully respond instead of waiting a fixed amount of time.