### PR TITLE
[4] Cassipopeia. Banner image and nonces. Move Inline Css to HEAD

### DIFF
--- a/templates/cassiopeia/html/mod_custom/banner.php
+++ b/templates/cassiopeia/html/mod_custom/banner.php
@@ -8,10 +8,23 @@
  */
 
 defined('_JEXEC') or die;
+
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Uri\Uri;
+
+$modId = 'mod-custom' . $module->id;
+
+if ($params->get('backgroundimage'))
+{
+	/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+	$wa = $app->getDocument()->getWebAssetManager();
+	$wa->addInlineStyle('
+#' . $modId . '{background-image: url("' . Uri::root(true) . '/' . HTMLHelper::_('cleanImageURL', $params->get('backgroundimage'))->url . '");}
+', ['name' => $modId]);
+}
 ?>
 
-
-<div class="mod-custom custom banner-overlay" <?php if ($params->get('backgroundimage')) : ?> style="background-image:url(<?php echo $params->get('backgroundimage'); ?>)"<?php endif; ?> >
+<div class="mod-custom custom banner-overlay" id="<?php echo $modId; ?>">
 	<div class="overlay">
 		<?php echo $module->content; ?>
 	</div>


### PR DESCRIPTION
### Summary of Changes
- Adapt module layout code like found in layout `default.php` of `mod_custom`.

### Testing Instructions
- Current Firefox. Should be no difference with other browsers(?).
- After installation of Joomla 4.1.3 you'll see a banner image in frontend. See image 1 below.
  - It's inserted by a site module named "image" of type `mod_custom` that uses layout `Cassiopeia:banner.php`.
- Activate plugin `System - HTTP Headers` and configure it.
  - Activate `Content-Security-Policy (CSP)`
  - Activate `Nonce`. Nothing else.
  - Add a `style-src` Policy Directive: `{nonce} 'self' 'unsafe-inline'`

- Go to frontend. Banner image is gone. See image 2 below.

- Apply patch.
- Image comes back. See image 1 below.

**Image 1**

![grafik](https://user-images.githubusercontent.com/20780646/169899378-8bd54282-9590-4c7b-acbf-b75580aa4716.png)

**Image 2**

![grafik](https://user-images.githubusercontent.com/20780646/169899438-90ea698b-1fa0-4ce3-a9ff-1cb83180fdea.png)
