### PR TITLE
Modify Function name to avoid conflict with PHP keyword. 

### DIFF
--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -474,7 +474,7 @@ class Browser
 	 */
 	public function __construct($userAgent = null, $accept = null)
 	{
-		$this->match($userAgent, $accept);
+		$this->_match($userAgent, $accept);
 	}
 
 	/**
@@ -511,7 +511,7 @@ class Browser
 	 *
 	 * @since   1.7.0
 	 */
-	public function match($userAgent = null, $accept = null)
+	public function _match($userAgent = null, $accept = null)
 	{
 		// Set our agent string.
 		if (\is_null($userAgent))

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -8,6 +8,8 @@
 
 namespace Joomla\CMS\Environment;
 
+use JetBrains\PhpStorm\Deprecated;
+
 \defined('JPATH_PLATFORM') or die;
 
 /**
@@ -474,7 +476,7 @@ class Browser
 	 */
 	public function __construct($userAgent = null, $accept = null)
 	{
-		$this->_match($userAgent, $accept);
+		$this->match($userAgent, $accept);
 	}
 
 	/**
@@ -510,7 +512,14 @@ class Browser
 	 * @return  void
 	 *
 	 * @since   1.7.0
+	 * 
+	 * @deprecated 5.0
 	 */
+	public function match($userAgent = null, $accept = null)
+	{
+		$this->_match($userAgent, $accept);
+		
+	}
 	public function _match($userAgent = null, $accept = null)
 	{
 		// Set our agent string.

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -510,13 +510,11 @@ class Browser
 	 * @return  void
 	 *
 	 * @since   1.7.0
-	 * 
 	 * @deprecated 5.0
 	 */
 	public function match($userAgent = null, $accept = null)
 	{
-		$this->_match($userAgent, $accept);
-		
+		$this->_match($userAgent, $accept);	
 	}
 	public function _match($userAgent = null, $accept = null)
 	{

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -8,8 +8,6 @@
 
 namespace Joomla\CMS\Environment;
 
-use JetBrains\PhpStorm\Deprecated;
-
 \defined('JPATH_PLATFORM') or die;
 
 /**

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -514,7 +514,7 @@ class Browser
 	 */
 	public function match($userAgent = null, $accept = null)
 	{
-		$this->_match($userAgent, $accept);	
+		$this->_match($userAgent, $accept);
 	}
 	public function _match($userAgent = null, $accept = null)
 	{

--- a/tests/Unit/Libraries/Cms/Environment/BrowserTest.php
+++ b/tests/Unit/Libraries/Cms/Environment/BrowserTest.php
@@ -175,7 +175,7 @@ class BrowserTest extends UnitTestCase
 	 */
 	public function testBrowserMatching($userAgent, $expectedBrowser, $expectedPlatform, $expectedMajorVersion, $expectedMobile)
 	{
-		$this->browser->match($userAgent);
+		$this->browser->_match($userAgent);
 
 		$this->assertSame($expectedBrowser, $this->browser->getBrowser());
 		$this->assertSame($expectedPlatform, $this->browser->getPlatform());

--- a/tests/Unit/Libraries/Cms/Environment/BrowserTest.php
+++ b/tests/Unit/Libraries/Cms/Environment/BrowserTest.php
@@ -175,7 +175,7 @@ class BrowserTest extends UnitTestCase
 	 */
 	public function testBrowserMatching($userAgent, $expectedBrowser, $expectedPlatform, $expectedMajorVersion, $expectedMobile)
 	{
-		$this->browser->_match($userAgent);
+		$this->browser->match($userAgent);
 
 		$this->assertSame($expectedBrowser, $this->browser->getBrowser());
 		$this->assertSame($expectedPlatform, $this->browser->getPlatform());


### PR DESCRIPTION
Pull Request for Issue  #37823 

### Summary of Changes
Added a new function '_match' with contents same as the original function. The 'match' function is now just a proxy to the '_match' function, and will be deprecated before version 5.0


### Testing Instructions

-

### Actual result BEFORE applying this Pull Request

-

### Expected result AFTER applying this Pull Request

-


### Documentation Changes Required
Nothing i am aware of. please let me know if any. 
