### PR TITLE
[4.1] Change Nightly URL from Jenkins to Drone

### DIFF
--- a/build/release-checklist.md
+++ b/build/release-checklist.md
@@ -45,7 +45,7 @@ git push upstream --tags
 - [ ] Upload the packages to the GitHub release
 - [ ] Publish GitHub release (remember to mark it as a pre-release!)
 - [ ] `git push upstream 3.10-dev`
-- [ ] Trigger new nightly build: [https://build.joomla.org](https://build.joomla.org:8443/job/cms_packaging/)
+- [ ] Trigger new nightly build: [https://ci.joomla.org/joomla/joomla-cms](https://ci.joomla.org/joomla/joomla-cms)
 - [ ] Wait for `.org Build Notifications` to report back
 - [ ] Merge the [joomla/update.joomla.org PR](https://github.com/joomla/update.joomla.org/pulls)
 - [ ] Wait for `.org Build Notifications` to report back

--- a/build/release-checklist.md
+++ b/build/release-checklist.md
@@ -45,7 +45,7 @@ git push upstream --tags
 - [ ] Upload the packages to the GitHub release
 - [ ] Publish GitHub release (remember to mark it as a pre-release!)
 - [ ] `git push upstream 3.10-dev`
-- [ ] Trigger new nightly build: [https://ci.joomla.org/joomla/joomla-cms](https://ci.joomla.org/joomla/joomla-cms)
+- [ ] Trigger new nightly build: [https://ci.joomla.org/joomla/joomla-cms](https://ci.joomla.org/joomla/joomla-cms) -> New Build -> "<branch-dev>"
 - [ ] Wait for `.org Build Notifications` to report back
 - [ ] Merge the [joomla/update.joomla.org PR](https://github.com/joomla/update.joomla.org/pulls)
 - [ ] Wait for `.org Build Notifications` to report back


### PR DESCRIPTION
This updates the URL to trigger new nightly builds from Jenkins to Drone in the release checklist.