### PR TITLE
[4.2] Reorganizing component tests

### DIFF
--- a/tests/Unit/Component/Actionlogs/Administrator/Model/ActionlogConfigModelTest.php
+++ b/tests/Unit/Component/Actionlogs/Administrator/Model/ActionlogConfigModelTest.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-namespace Joomla\Tests\Unit\Components\Actionlogs;
+namespace Joomla\Tests\Unit\Component\Actionlogs\Administrator\Model;
 
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\Component\Actionlogs\Administrator\Model\ActionlogConfigModel;

--- a/tests/Unit/Component/Finder/Administrator/Indexer/ResultTest.php
+++ b/tests/Unit/Component/Finder/Administrator/Indexer/ResultTest.php
@@ -6,7 +6,7 @@
  * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
-namespace Joomla\Tests\Unit\Administrator\Components\Finder\Indexer;
+namespace Joomla\Tests\Unit\Component\Finder\Administrator\Indexer;
 
 use Joomla\Component\Finder\Administrator\Indexer\Result;
 use Joomla\Tests\Unit\UnitTestCase;
@@ -19,24 +19,6 @@ use ReflectionClass;
  */
 class ResultTest extends UnitTestCase
 {
-	/**
-	 * Include non-autoloaded files as Namespace in the files that don't implement PSR-4
-	 *
-	 * @return void
-	 *
-	 * @since  4.1.3
-	 */
-	protected function setUp(): void
-	{
-		// Can be removed once we have autoloading working in Unit Tests
-		// @see https://github.com/joomla/joomla-cms/pull/36486
-		if (!class_exists(Result::class))
-		{
-			require_once JPATH_ADMINISTRATOR . '/components/com_finder/src/Indexer/Indexer.php';
-			require_once JPATH_ADMINISTRATOR . '/components/com_finder/src/Indexer/Result.php';
-		}
-	}
-
 	/**
 	 * @return void
 	 *


### PR DESCRIPTION
### Summary of Changes
Reorganizing the component tests as they have been in a total different structure. Now they reflect the component classes namespace.

In the finder test is the obsolete class loading removed as automatic class loading is working in unit tests since #37592.

Can be merged by code review when drone run successfully.