### PR TITLE
[4.2] plugin sample data multilang - php 8.1 

### DIFF
--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -1089,6 +1089,7 @@ class PlgSampledataMultilang extends CMSPlugin
 				. 'equidem dolores. Quo no falli viris intellegam, ut fugit veritus placerat'
 				. 'per. Ius id vidit volumus mandamus, vide veritus democritum te nec, ei eos'
 				. 'debet libris consulatu.</p>',
+			'fulltext'         => '',
 			'images'           => json_encode(array()),
 			'urls'             => json_encode(array()),
 			'created'          => $currentDate,


### PR DESCRIPTION
Pull Request for Issue 
 PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /shared/httpd/j4/joomla/libraries/src/Table/Content.php on line 234

### Summary of Changes
 defined the `fulltext`


### Testing Instructions
install a fresh 4.2 with more than 1 language
and use the multilang sample data plugin


### Actual result BEFORE applying this Pull Request
error


### Expected result AFTER applying this Pull Request
multilang sample data created




