### PR TITLE
[4.x] Cassiopeia template Logo and menu alignment

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/vendor/metismenu/_metismenu.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/vendor/metismenu/_metismenu.scss
@@ -38,6 +38,10 @@
           position: relative;
         }
 
+        &:first-of-type {
+          padding-inline-start: 0;
+        }
+
         > ul {
           position: absolute;
           top: 100%;


### PR DESCRIPTION
Pull Request for Issue #37902


### Summary of Changes
Remove left padding on the menu so that it is aligned with the logo


### Testing Instructions
This is a css change so either npm run build:css or use a prebuit package

Installing the sample data is the quickest way to get a logo and the metis menu

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/170661269-219739af-85df-42e9-b5d1-43fcd8123bfb.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/170661157-dcacbb28-ff4d-4bf0-a9b8-9364980c4b80.png)



### Documentation Changes Required

n/a