### PR TITLE
[inlinehelp] enable toggle button for inlinehelp in Article edit

### DIFF
--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form>
+	<config>
+		<inlinehelp button="show"/>
+	</config>
 	<fieldset addfieldprefix="Joomla\Component\Content\Administrator\Field">
 		<field
 			name="id"

--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -239,6 +239,9 @@ class HtmlView extends BaseHtmlView
 		}
 
 		$toolbar->divider();
+
+		ToolbarHelper::inlinehelp();
+
 		$toolbar->help('Articles:_Edit');
 	}
 }


### PR DESCRIPTION
Pull Request to add inlinehelp toggle button (PR https://github.com/joomla/joomla-cms/pull/35610) in edit view.

Since PR #37158 already integrates inlinehelp button in com_content config, if it's ok with this PR, i will be able to integrate toggle button for inlinehelp in each core components.

### Summary of Changes
- Add inlinehelp button in com_content > Article > edit


### Testing Instructions
- Edit an article and play with inlinehelp toggle button.


### Actual result BEFORE applying this Pull Request
- no inlinehelp button
- description shown


### Expected result AFTER applying this Pull Request
- Inlinehelp toggle button in toolbar next to help button.
- Descriptions hidden by default
