### PR TITLE
[4.2] Replace deprecated getDbo() with getDatabase()

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -460,7 +460,7 @@ abstract class AdminModel extends FormModel
 		}
 
 		$newIds = array();
-		$db     = $this->getDbo();
+		$db     = $this->getDatabase();
 
 		// Parent exists so let's proceed
 		while (!empty($pks))
@@ -935,7 +935,7 @@ abstract class AdminModel extends FormModel
 					// Multilanguage: if associated, delete the item in the _associations table
 					if ($this->associationsContext && Associations::isEnabled())
 					{
-						$db = $this->getDbo();
+						$db = $this->getDatabase();
 						$query = $db->getQuery(true)
 							->select(
 								[
@@ -1449,7 +1449,7 @@ abstract class AdminModel extends FormModel
 			}
 
 			// Get associationskey for edited item
-			$db    = $this->getDbo();
+			$db    = $this->getDatabase();
 			$id    = (int) $table->$key;
 			$query = $db->getQuery(true)
 				->select($db->quoteName('key'))

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -290,7 +290,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
 	 */
 	protected function getListQuery()
 	{
-		return $this->getDbo()->getQuery(true);
+		return $this->getDatabase()->getQuery(true);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This small PR replace the deprecated `getDbo()` call by `getDatabase()` method in our model classes in MVC layer.

### Testing Instructions
1. Code review should be enough
2. Or install 4.2, apply patch. Go to articles list, try to edit and save an article, make sure it is still working.