### PR TITLE
com_fields - Fix deprecated warning in group model

### DIFF
--- a/administrator/components/com_fields/src/Model/GroupModel.php
+++ b/administrator/components/com_fields/src/Model/GroupModel.php
@@ -320,7 +320,9 @@ class GroupModel extends AdminModel
 			if (!$data->id)
 			{
 				// Check for which context the Field Group Manager is used and get selected fields
-				$context = substr($app->getUserState('com_fields.groups.filter.context'), 4);
+				$context = $app->getUserState('com_fields.groups.filter.context') ?? '';
+				$context = substr($context, 4);
+
 				$filters = (array) $app->getUserState('com_fields.groups.' . $context . '.filter');
 
 				$data->set(

--- a/administrator/components/com_fields/src/Model/GroupModel.php
+++ b/administrator/components/com_fields/src/Model/GroupModel.php
@@ -320,9 +320,7 @@ class GroupModel extends AdminModel
 			if (!$data->id)
 			{
 				// Check for which context the Field Group Manager is used and get selected fields
-				$context = $app->getUserState('com_fields.groups.filter.context') ?? '';
-				$context = substr($context, 4);
-
+				$context = substr($app->getUserState('com_fields.groups.filter.context', ''), 4);
 				$filters = (array) $app->getUserState('com_fields.groups.' . $context . '.filter');
 
 				$data->set(


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fix warning 
Deprecated: substr(): Passing null to parameter #1 ($string) of type string is deprecated in administrator\components\com_fields\src\Model\GroupModel.php on line 323

### Testing Instructions
Add a new field group in com_contacts (php 8.1.5)

### Actual result BEFORE applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/171040861-5817c3a1-1850-4bba-99dd-3ed4699dc267.png)


### Expected result AFTER applying this Pull Request
No deprecated warning


### Documentation Changes Required

