### PR TITLE
[4.2] Fix uninitialized version variable in installer library

### DIFF
--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -1331,7 +1331,6 @@ class Installer extends Adapter
 		}
 
 		Log::add(Text::_('JLIB_INSTALLER_SQL_BEGIN'), Log::INFO, 'Update');
-		Log::add(Text::sprintf('JLIB_INSTALLER_SQL_BEGIN_SCHEMA', $version), Log::INFO, 'Update');
 
 		$files = str_replace('.sql', '', $files);
 		usort($files, 'version_compare');
@@ -1360,6 +1359,8 @@ class Installer extends Adapter
 		{
 			$version = '0.0.0';
 		}
+
+		Log::add(Text::sprintf('JLIB_INSTALLER_SQL_BEGIN_SCHEMA', $version), Log::INFO, 'Update');
 
 		foreach ($files as $file)
 		{


### PR DESCRIPTION
Pull Request for Issue #37934 .

### Summary of Changes

Move the log of the version number on schema updates to below the code where the version number is set.

### Testing Instructions

See issue #37934 .

But code review should be sufficient.

See also my comment in the issue why it is only a 4.2-dev issue and ok in 4.1-dev: https://github.com/joomla/joomla-cms/issues/37934#issuecomment-1142096060

### Actual result BEFORE applying this Pull Request

No installer error.

### Expected result AFTER applying this Pull Request

PHP warning about uninitialized variable $version being used at line 1334 of file libraries/src/Installer/Installer.php.

### Documentation Changes Required

None.