### PR TITLE
[4.1] added deprecation note for 5.0 signature change

### DIFF
--- a/libraries/src/Encrypt/Aes.php
+++ b/libraries/src/Encrypt/Aes.php
@@ -47,6 +47,8 @@ class Aes
 	 * @param   int             $strength Bit strength (128, 192 or 256) – ALWAYS USE 128 BITS. THIS PARAMETER IS DEPRECATED.
 	 * @param   string          $mode     Encryption mode. Can be ebc or cbc. We recommend using cbc.
 	 * @param   string          $priority Priority which adapter we should try first
+	 *
+	 * @deprecated 5.0 $strength will be removed
 	 */
 	public function __construct($key, $strength = 128, $mode = 'cbc', $priority = 'openssl')
 	{


### PR DESCRIPTION
### Summary of Changes
Added a deprecation note to the doc block of the AES class to emphasize the upcoming signature change in 5.x

### Actual result BEFORE applying this Pull Request
Note is missing


### Expected result AFTER applying this Pull Request
Note is there


### Documentation Changes Required
-
