### PR TITLE
[4.1] PHP 8.1 Fix deprecated parse_str() passing null, in Menu ItemModel

### DIFF
--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -723,7 +723,16 @@ class ItemModel extends AdminModel
 				$table->component_id = 0;
 				$args = array();
 
-				parse_str(parse_url($table->link, PHP_URL_QUERY), $args);
+				if ($table->link)
+				{
+					$q = parse_url($table->link, PHP_URL_QUERY);
+
+					if ($q)
+					{
+						parse_str($q, $args);
+					}
+				}
+
 				break;
 
 			case 'separator':
@@ -743,7 +752,12 @@ class ItemModel extends AdminModel
 
 				if ($table->link)
 				{
-					parse_str(parse_url($table->link, PHP_URL_QUERY), $args);
+					$q = parse_url($table->link, PHP_URL_QUERY);
+
+					if ($q)
+					{
+						parse_str($q, $args);
+					}
 				}
 
 				if (isset($args['option']))


### PR DESCRIPTION
### Summary of Changes
 Fix deprecated parse_str() passing null, in Menu ItemModel


### Testing Instructions

Need PHP 8.1.

Apply patch.
Make sure error_reaporting set to maximum.
Go to menu, and try to create Menu type URL


### Actual result BEFORE applying this Pull Request
PHP message about Deprecated parse_str()  passing null


### Expected result AFTER applying this Pull Request
No message


### Documentation Changes Required
no
