### PR TITLE
Mail Templates cannot be set to not have mailer overrides

### DIFF
--- a/administrator/components/com_mails/forms/template.xml
+++ b/administrator/components/com_mails/forms/template.xml
@@ -65,7 +65,7 @@
 				type="radio"
 				label="COM_MAILS_FIELD_ALTERNATIVE_MAILCONFIG_LABEL"
 				layout="joomla.form.field.radio.switcher"
-				default="1"
+				default="0"
 				filter="boolean"
 				>
 				<option value="0">JNO</option>

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -200,7 +200,7 @@ class MailTemplate
 		$params = $mail->params;
 		$app    = Factory::getApplication();
 
-		if ($config->get('alternative_mailconfig'))
+		if ((int) $config->get('alternative_mailconfig', 0) === 1 && (int) $params->get('alternative_mailconfig', 0) === 1)
 		{
 			if ($this->mailer->Mailer === 'smtp' || $params->get('mailer') === 'smtp')
 			{


### PR DESCRIPTION
Pull Request for Issue #37933.

### Summary of Changes

When System, Mail Templates, Options, “Per Template Mail Settings” is set to Yes the mail templates feature ignores each individual mail template's “Set Mail” option if the latter is set to No. As a result, setting “Per Template Mail Settings” to Yes requires that _all_ email templates duplicate the mailer configuration from the site's Global Configuration.

This PR fixes this problem by making each individual email template's “Set Mail” setting **actually** work.

I also changed the default value of the “Set Mail” to No because it is unlikely that you want to override _every single customised mail template's_ mailer settings. In all likelihood you are customising a lot of mail templates to fit your branding but you only want custom mail settings (typically to implement a different sender or reply to address) for a small subset of them, e.g. the mail templates which are used to send out invoices / receipts on an e-commerce site. Having “Set Mail” enabled by default, in a secondary tab most people will miss, is a great way to make people think Joomla is broken and can't send emails...

### Testing Instructions

* Make sure your PHP **cannot** send emails with mail(). For example, edit your `php.ini` and set
    ```ini
    [mail function]
    sendmail_path=/usr/local/foobar
    ```
* Go to System, Global Configuration, Server and set up your Mail options. I am using [MailHog](https://github.com/mailhog/MailHog) on my local server (SMTP on localhost:1025) for my local testing. You can use whatever works for you.
* **Make sure your site can send emails using the “Send Test Email” button.**
* Click on Save & Close.
* Go to System, Mail Templates, Options.
* Set “Per Template Mail Settings” to Yes.
* Click on Save & Close.
* Go to System, Mail Templates.
* Click on the “Global Configuration: Test Mail” item.
* Go to the Options tab.
* Set Mail Settings to No.
* Click on Save & Close.
* Go to System, Global Configuration, Server tab.
* Click on the “Send Test Email” button.

### Actual result BEFORE applying this Pull Request

Error message, e.g.:
```
SMTP connect() failed. https://github.com/PHPMailer/PHPMailer/wiki/Troubleshooting
```

### Expected result AFTER applying this Pull Request

A test email is sent using the Global Configuration settings.

### Documentation Changes Required

None.

### Additional comments

This has been broken ever since the introduction of the Mail Templates feature in Joomla 4 back in September 2019.

Hat tip to my client, EJ, for reporting this problem and letting me use a backup of his site to verify the conditions which trigger it.