### PR TITLE
[4.x] Cassiopeia - logo/brand and navigation in one line

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -153,8 +153,9 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
 			</div>
 		<?php endif; ?>
 
+		<div class="container-brand-nav">
 		<?php if ($this->params->get('brand', 1)) : ?>
-			<div class="grid-child">
+			<div class="grid-child container-brand">
 				<div class="navbar-brand">
 					<a class="brand-logo" href="<?php echo $this->baseurl; ?>/">
 						<?php echo $logo; ?>
@@ -178,6 +179,7 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
 				<?php endif; ?>
 			</div>
 		<?php endif; ?>
+		</div>
 	</header>
 
 	<div class="site-grid">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

div container and additional class added in index.php

### Testing Instructions

call website in frontend.

### Actual result BEFORE applying this Pull Request

logo/brand and navigation are on top of each other

Static Layout
![Cassiopeia-Default-Static](https://user-images.githubusercontent.com/43771555/171625900-bde341f7-c8c6-4176-a6c0-336006d00da4.png)


Fluid Layout
![Cassiopeia-Default-Fluid](https://user-images.githubusercontent.com/43771555/171625913-b49281fe-04de-4c18-9838-10e9a5806522.png)


### Expected result AFTER applying this Pull Request

using css it becomes possible to get logo/brand and navigation in one line. without css there is no difference in the display.

`.container-brand-nav {
	display: grid;
	margin-left: auto;
	margin-right: auto;
	max-width: 1320px;
	width: 100%;
	/* grid-template-columns: repeat(2, auto); */
	grid-template-columns: 15em auto;
	grid-column-gap: 1em;
	grid-template-areas:
		"brand nav";
}

body.wrapper-fluid .container-brand-nav {
	max-width: none;
}

.container-header .container-brand {
	grid-area: brand;
}

.container-header .container-nav {
	grid-area: nav;
	padding-top: 1.5em;
}

.container-header nav {
	margin: .25em auto 0 0;
}`

Static Layout
![Cassiopeia-Single-Static](https://user-images.githubusercontent.com/43771555/171625946-1094c479-6d71-4198-9dba-7d929922d879.png)

Fluid Layout
![Cassiopeia-Single-Fluid](https://user-images.githubusercontent.com/43771555/171625972-e8d1e2ba-48ac-45e1-bd11-090fc504322f.png)


in the future a template parameter and the css could be added to turn this on and off in the site template backend

### Documentation Changes Required

