### PR TITLE
[4.1] Fix TinyMCE height for multiple editor instances

### DIFF
--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -84,19 +84,34 @@ trait DisplayTrait
 		$editor .= !$this->app->client->mobile ? LayoutHelper::render('joomla.tinymce.togglebutton') : '';
 		$editor .= '</div>';
 
-		// Prepare the instance specific options, actually the ext-buttons
-		if (empty($options['tinyMCE'][$fieldName]['joomlaExtButtons']))
+		// Prepare the instance specific options
+		if (empty($options['tinyMCE'][$fieldName]))
 		{
-			$btns = $this->tinyButtons($id, $buttons);
-
-			// Set editor to readonly mode
-			if (!empty($params['readonly']))
+			// Width and height
+			if ($width)
 			{
-				$options['tinyMCE'][$fieldName]['readonly'] = 1;
+				$options['tinyMCE'][$fieldName]['width'] = $width;
 			}
 
-			$options['tinyMCE'][$fieldName]['joomlaMergeDefaults'] = true;
-			$options['tinyMCE'][$fieldName]['joomlaExtButtons']    = $btns;
+			if ($height)
+			{
+				$options['tinyMCE'][$fieldName]['height'] = $height;
+			}
+
+			// The ext-buttons
+			if (empty($options['tinyMCE'][$fieldName]['joomlaExtButtons']))
+			{
+				$btns = $this->tinyButtons($id, $buttons);
+
+				// Set editor to readonly mode
+				if (!empty($params['readonly']))
+				{
+					$options['tinyMCE'][$fieldName]['readonly'] = 1;
+				}
+
+				$options['tinyMCE'][$fieldName]['joomlaMergeDefaults'] = true;
+				$options['tinyMCE'][$fieldName]['joomlaExtButtons']    = $btns;
+			}
 
 			$doc->addScriptOptions('plg_editor_tinymce', $options, false);
 		}
@@ -471,8 +486,8 @@ trait DisplayTrait
 				'document_base_url'  => Uri::root(true) . '/',
 				'image_caption'      => true,
 				'importcss_append'   => true,
-				'height'             => $height ?: $this->params->get('html_height', '550px'),
-				'width'              => $width ?: $this->params->get('html_width', ''),
+				'height'             => $this->params->get('html_height', '550px'),
+				'width'              => $this->params->get('html_width', ''),
 				'elementpath'        => (bool) $levelParams->get('element_path', true),
 				'resize'             => $resizing,
 				'templates'          => $templates,

--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -98,16 +98,16 @@ trait DisplayTrait
 				$options['tinyMCE'][$fieldName]['height'] = $height;
 			}
 
+			// Set editor to readonly mode
+			if (!empty($params['readonly']))
+			{
+				$options['tinyMCE'][$fieldName]['readonly'] = 1;
+			}
+
 			// The ext-buttons
 			if (empty($options['tinyMCE'][$fieldName]['joomlaExtButtons']))
 			{
 				$btns = $this->tinyButtons($id, $buttons);
-
-				// Set editor to readonly mode
-				if (!empty($params['readonly']))
-				{
-					$options['tinyMCE'][$fieldName]['readonly'] = 1;
-				}
 
 				$options['tinyMCE'][$fieldName]['joomlaMergeDefaults'] = true;
 				$options['tinyMCE'][$fieldName]['joomlaExtButtons']    = $btns;


### PR DESCRIPTION
### Summary of Changes

Fix TinyMCE height for multiple editor instances.
This a little thing that misses after #37603 to make Height work correctly.



### Testing Instructions
Apply patch, create multiple editor instances somwhere, example add in mod_custom:

```xml
<field type="editor" name="editor1" label="Editor 1" height="300"/>
<field type="editor" name="editor2" label="Editor 2" height="800"/>
```
And edit mod_custom content.

### Actual result BEFORE applying this Pull Request
Main editor height: 550 (default, from plugin)
Editor 1 height: 550
Editor 2 height: 550


### Expected result AFTER applying this Pull Request

Main editor height: 550 (default, from plugin)
Editor 1 height: 300
Editor 2 height: 800

### Documentation Changes Required
none
