### PR TITLE
Fix deprecated warning in taskModel

### DIFF
--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -321,8 +321,8 @@ class TaskModel extends AdminModel
 		}
 
 		// Parent call leaves `execution_rules` and `cron_rules` JSON encoded
-		$item->set('execution_rules', json_decode($item->get('execution_rules')));
-		$item->set('cron_rules', json_decode($item->get('cron_rules')));
+		$item->set('execution_rules', json_decode($item->get('execution_rules', '')));
+		$item->set('cron_rules', json_decode($item->get('cron_rules', '')));
 
 		$taskOption = SchedulerHelper::getTaskOptions()->findOption(
 			($item->id ?? 0) ? ($item->type ?? 0) : $this->getState('task.type')


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fix deprecated warning in php 8.1.5
Deprecated: json_decode(): Passing null to parameter #1 ($json) of type string is deprecated in administrator\components\com_scheduler\src\Model\TaskModel.php on line 324 (and 325).


### Testing Instructions
Go to system / task scheduler. Add a new task, select one of the sample tasks and see the form with warning.
![grafik](https://user-images.githubusercontent.com/1035262/171990275-fd3a49b7-3aba-4f56-a0ad-b4aee72357d8.png)



### Actual result BEFORE applying this Pull Request
Deprecated Warning


### Expected result AFTER applying this Pull Request
No Warning. 


### Documentation Changes Required

