### PR TITLE
[4.2] Fix fatal error when update to Joomla 4.2

### DIFF
--- a/administrator/components/com_joomlaupdate/finalisation.php
+++ b/administrator/components/com_joomlaupdate/finalisation.php
@@ -75,6 +75,17 @@ namespace
 			{
 				(new JoomlaInstallerScript)->deleteUnexistingFiles();
 			}
+
+			/**
+			 * Remove autoload_psr4.php so that namespace map is re-generated on the next request. This is needed
+			 * when there are new classes added to extensions on new Joomla! release.
+			 */
+			$namespaceMapFile = JPATH_ROOT . '/administrator/cache/autoload_psr4.php';
+
+			if (\Joomla\CMS\Filesystem\File::exists($namespaceMapFile))
+			{
+				\Joomla\CMS\Filesystem\File::delete($namespaceMapFile);
+			}
 		}
 	}
 }

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -690,9 +690,6 @@ ENDDATA;
 			return false;
 		}
 
-		// Re-create namespace map. It is needed when updating to a Joomla! version has new extension added
-		(new \JNamespacePsr4Map)->create();
-
 		$installer->manifest = $manifest;
 
 		$installer->setUpgrade(true);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
In Joomla 4.2, we convert some plugins to new structure, so the namespace map will need to be re-generated before avoid Joomla calls com_joomlaupdate to finalize upgrade process to avoid fatal error.

### Testing Instructions
1. Install Joomla 4.1.
2. Try to Update that 4.1 website to Joomla 4.2 nightly build. During the update, you would get fatal error saying class `Joomla\Plugin\Actionlog\Joomla\Extension\Joomla` not found (something like that, I don't remember exactly the error message)
3. Install Joomla 4.1 again
4. Try to update to the update package generated for this PR. You can download the package from this link https://ci.joomla.org/artifacts/joomla/joomla-cms/4.2-dev/37990/downloads/54926/Joomla_4.2.0-beta1-dev+pr.37990-Development-Update_Package.zip . Make sure upgrade works properly

### Actual result BEFORE applying this Pull Request
Fatal error while upgrading to Joomla 4.2

### Expected result AFTER applying this Pull Request
Upgrade to Joomla 4.2 works well.