### PR TITLE
[4.x] Newsfeed pagination list

### DIFF
--- a/components/com_newsfeeds/tmpl/category/default_items.php
+++ b/components/com_newsfeeds/tmpl/category/default_items.php
@@ -26,7 +26,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 	<?php else : ?>
 		<form action="<?php echo htmlspecialchars(Uri::getInstance()->toString(), ENT_COMPAT, 'UTF-8'); ?>" method="post" name="adminForm" id="adminForm">
 			<?php if ($this->params->get('filter_field') !== 'hide' || $this->params->get('show_pagination_limit')) : ?>
-				<fieldset class="com-newsfeeds-category__filters filters btn-toolbar">
+				<fieldset class="com-newsfeeds-category__filters filters">
 					<?php if ($this->params->get('filter_field') !== 'hide' && $this->params->get('filter_field') == '1') : ?>
 						<div class="btn-group">
 							<label class="filter-search-lbl visually-hidden" for="filter-search">


### PR DESCRIPTION
Removes class that should not have been present

**partial Pull** Request for Issue #37907 .

### Summary of Changes
Ensure that the item l;ist select is aligned at the end as intended and as is seen in all similar views


### Testing Instructions
Create a newsfeed and then a menu item to display the newsfeed category
make sure that you have **display select** set to show in the list options


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/172307673-20c0129b-2cd7-4b2e-9a27-ffb91fb7966a.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/172307598-124e1031-33f0-4790-85e1-73a55333ea92.png)



### Documentation Changes Required

