### PR TITLE
[4.2] Reintroduce workaround for arguments passed by reference

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -286,7 +286,7 @@ abstract class HTMLHelper
 	 */
 	protected static function call(callable $function, $args)
 	{
-		// PHP 5.3 workaround
+		// Workaround to allow calling helper methods have arguments passed by reference
 		$temp = array();
 
 		foreach ($args as &$arg)

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -287,7 +287,7 @@ abstract class HTMLHelper
 	protected static function call(callable $function, $args)
 	{
 		// Workaround to allow calling helper methods have arguments passed by reference
-		$temp = array();
+		$temp = [];
 
 		foreach ($args as &$arg)
 		{

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -286,7 +286,15 @@ abstract class HTMLHelper
 	 */
 	protected static function call(callable $function, $args)
 	{
-		return \call_user_func_array($function, $args);
+		// PHP 5.3 workaround
+		$temp = array();
+
+		foreach ($args as &$arg)
+		{
+			$temp[] = &$arg;
+		}
+
+		return \call_user_func_array($function, $temp);
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR revert the change introduced in PR https://github.com/joomla/joomla-cms/pull/37178 because it causes some warnings when use HTMLHelper to call a helper method which need parameters passed by reference.


### Testing Instructions
1. Use 4.2 nightly build
2. Open administrator/templates/atum/index.php , add two lines of code below somewhere in that file:

```php
$children = [];
$list      = HTMLHelper::_('menu.treerecurse', 0, '', [], $children, 9999, 0, 0);
```
3. Access to administrator area of the site

### Actual result BEFORE applying this Pull Request
Warnings message is displayed line below:

Warning
Parameter 4 to Joomla\CMS\HTML\Helpers\Menu::treerecurse() expected to be a reference, value given in
D:\www\joomla42\libraries\src\HTML\HTMLHelper.php
on line
289

### Expected result AFTER applying this Pull Request
No warnings anymore.
