### PR TITLE
[inlinehelp] Add inlinehelp toggle button for each component config

### DIFF
--- a/administrator/components/com_banners/config.xml
+++ b/administrator/components/com_banners/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Banners:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="component"
 		label="COM_BANNERS_FIELDSET_CONFIG_CLIENT_OPTIONS_LABEL"

--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Contacts:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="contact"
 		label="COM_CONTACT_FIELD_CONFIG_INDIVIDUAL_CONTACT_DISPLAY"

--- a/administrator/components/com_finder/config.xml
+++ b/administrator/components/com_finder/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Smart_Search:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="search"
 		label="COM_FINDER_FIELDSET_SEARCH_OPTIONS_LABEL"

--- a/administrator/components/com_installer/config.xml
+++ b/administrator/components/com_installer/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Installer:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="preferences"
 		label="COM_INSTALLER_PREFERENCES_LABEL"

--- a/administrator/components/com_joomlaupdate/config.xml
+++ b/administrator/components/com_joomlaupdate/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Joomla_Update:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="sources"
 		label="COM_JOOMLAUPDATE_CONFIG_SOURCES_LABEL"

--- a/administrator/components/com_mails/config.xml
+++ b/administrator/components/com_mails/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Mail_Templates:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="mails_options"
 		label="COM_MAILS_CONFIG_MAIL_OPTIONS" >

--- a/administrator/components/com_media/config.xml
+++ b/administrator/components/com_media/config.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="component"
 		label="COM_MEDIA_FIELDSET_OPTIONS_LABEL">

--- a/administrator/components/com_modules/config.xml
+++ b/administrator/components/com_modules/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Module:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="modules"
 		label="COM_MODULES_GENERAL"

--- a/administrator/components/com_newsfeeds/config.xml
+++ b/administrator/components/com_newsfeeds/config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="News_Feed:_Options"/>
-
+	<inlinehelp button="show"/>
 	<fieldset
 		name="newsfeed"
 		label="COM_NEWSFEEDS_FIELD_CONFIG_NEWSFEED_SETTINGS_LABEL"

--- a/administrator/components/com_privacy/config.xml
+++ b/administrator/components/com_privacy/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Privacy:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="privacy"
 		label="COM_PRIVACY_OPTION_LABEL"

--- a/administrator/components/com_redirect/config.xml
+++ b/administrator/components/com_redirect/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Redirect:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="redirect"
 		label="COM_REDIRECT_ADVANCED_OPTIONS"

--- a/administrator/components/com_scheduler/config.xml
+++ b/administrator/components/com_scheduler/config.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="task_config"
 		label="COM_SCHEDULER_CONFIG_TASKS_FIELDSET_LABEL"

--- a/administrator/components/com_users/config.xml
+++ b/administrator/components/com_users/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Users:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="user_options"
 		label="COM_USERS_CONFIG_USER_OPTIONS" >


### PR DESCRIPTION
Pull Request to add the inlinehelp button in each component configuration where descriptions are present.

### Summary of Changes
Added to the following components:
- **Banners** > com_banners
- **Contacts** > com_contact
- **Installer** > com_installer
- **Joomla! Update** > com_joomlaupdate
- **Mail Templates** > com_mails
- **Media** > com_media
- **Modules** > com_modules
- **News Feeds** > com_newsfeeds
- **Privacy** > com_privacy
- **Redirects** > com_redirect
- **Sheduled Tasks** > com_sheduler
- **Smart Search** > com_finder
- **Users** > com_users

Config (com_config) and Articles (com_content) already merged to 4.1

### Testing Instructions
- Check component config, and test inlinehelp toggle button everywhere this one is display and control it works as expected (descriptions hidden by default).

### Actual result BEFORE applying this Pull Request
Inlinehelp button only on global config and articles configs.

### Expected result AFTER applying this Pull Request
inlinehelp button everywhere in component's config where descriptions are available.
