### PR TITLE
[inlinehelp] Add inlinehelp toggle button for each component config [PART 2]

### DIFF
--- a/administrator/components/com_actionlogs/config.xml
+++ b/administrator/components/com_actionlogs/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config addfieldprefix="Joomla\Component\Actionlogs\Administrator\Field">
 	<help key="User_Actions_Log:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset name="actionlogs" label="COM_ACTIONLOGS_OPTIONS">
 		<field
 			name="ip_logging"

--- a/administrator/components/com_menus/config.xml
+++ b/administrator/components/com_menus/config.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
+	<help key="Menus:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="page-options"
 		label="COM_MENUS_PAGE_OPTIONS_LABEL"
 		>
-
-		<help key="Menus:_Options"/>
 
 		<field
 			name="page_title"

--- a/administrator/components/com_tags/config.xml
+++ b/administrator/components/com_tags/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Tags:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="taglist"
 		label="COM_TAGS_CONFIG_TAG_SETTINGS_LABEL"

--- a/administrator/components/com_templates/config.xml
+++ b/administrator/components/com_templates/config.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
 	<help key="Template:_Options"/>
+	<inlinehelp button="show"/>
 	<fieldset
 		name="templates"
 		label="COM_TEMPLATES_SUBMENU_TEMPLATES"


### PR DESCRIPTION
**PART 2** of the PR #38005 

Pull Request adding support for inlinehelp toggle button in core component having options but none with a description.
It makes it ready to display the toggle button if any description added later.

**This PR requires PR #37915 in order to hide the "Toggle Inline Help" button if no form field with a description.**


### Summary of Changes
Added to the following components:
- **Menus** > com_menus
- **Tags** > com_tags
- **Templates** > com_templates
- **User Actions Log** > com_actionlogs


### Testing Instructions
- Apply PR #37915 (make sure script changes in inlinehelp.js are applied)
- Check that no inlinehelp button is displayed for those config files.
- To test this button to be shown: add a description to one of the form field.


### Actual result BEFORE applying this Pull Request
- No inlinehelp toggle button and no description.


### Expected result AFTER applying this Pull Request
- Nothing changed (just ready for future descriptions that could be added to the form fields)

