### PR TITLE
Add icon to parent category in article details

### DIFF
--- a/layouts/joomla/content/info_block/parent_category.php
+++ b/layouts/joomla/content/info_block/parent_category.php
@@ -10,11 +10,13 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 ?>
 <dd class="parent-category-name">
+	<?php echo LayoutHelper::render('joomla.icon.iconclass', ['icon' => 'icon-folder icon-fw']); ?>
 	<?php $title = $this->escape($displayData['item']->parent_title); ?>
 	<?php if ($displayData['params']->get('link_parent_category') && !empty($displayData['item']->parent_id)) : ?>
 		<?php $url = '<a href="' . Route::_(


### PR DESCRIPTION
Pull Request for Issue #37913 .

### Summary of Changes
An icon is added to parent category


### Testing Instructions
see #37913.
Make article in an category on level 2 and set the param Parent Category to yes.


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/172690774-78912b45-bcef-4e16-b013-fc7d71ae445c.png)



### Documentation Changes Required

