### PR TITLE
[4.2] Remove unnecessary $this->app->getIdentity() check

### DIFF
--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -595,7 +595,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
 			return false;
 		}
 
-		if ($model instanceof CurrentUserInterface && $this->app->getIdentity())
+		if ($model instanceof CurrentUserInterface)
 		{
 			$model->setCurrentUser($this->app->getIdentity());
 		}
@@ -627,7 +627,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
 
 		$view = $this->factory->createView($name, $prefix, $type, $config);
 
-		if ($view instanceof CurrentUserInterface && $this->app->getIdentity())
+		if ($view instanceof CurrentUserInterface)
 		{
 			$view->setCurrentUser($this->app->getIdentity());
 		}


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
As pointed out in my comment https://github.com/joomla/joomla-cms/pull/38011#discussion_r893650429, `$this->app->getIdentity()` will always return a `User` object, so the check here could be removed.


### Testing Instructions
1. Use Joomla 4.2 nightly build
2. Apply patch
3. Access to Articles Management screen from backend, make sure nothing is broken.


### Actual result BEFORE applying this Pull Request
Works but there is unnecessary code.


### Expected result AFTER applying this Pull Request
Works