### PR TITLE
[4.2] Replace deprecated method getDbo() by getDatabase()

### DIFF
--- a/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
@@ -45,7 +45,7 @@ class ActionlogModel extends BaseDatabaseModel
 	public function addLog($messages, $messageLanguageKey, $context, $userId = null)
 	{
 		$user   = Factory::getUser($userId);
-		$db     = $this->getDbo();
+		$db     = $this->getDatabase();
 		$date   = Factory::getDate();
 		$params = ComponentHelper::getComponent('com_actionlogs')->getParams();
 
@@ -116,7 +116,7 @@ class ActionlogModel extends BaseDatabaseModel
 	{
 		$app   = Factory::getApplication();
 		$lang  = $app->getLanguage();
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$query

--- a/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
@@ -87,7 +87,7 @@ class ActionlogsModel extends ListModel
 	 */
 	protected function getListQuery()
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('a.*')
 			->select($db->quoteName('u.name'))
@@ -243,7 +243,7 @@ class ActionlogsModel extends ListModel
 	public function getLogsForItem($extension, $itemId)
 	{
 		$itemId = (int) $itemId;
-		$db     = $this->getDbo();
+		$db     = $this->getDatabase();
 		$query  = $db->getQuery(true)
 			->select('a.*')
 			->select($db->quoteName('u.name'))
@@ -279,7 +279,7 @@ class ActionlogsModel extends ListModel
 	 */
 	public function getLogsData($pks = null)
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $this->getLogDataQuery($pks);
 
 		$db->setQuery($query);
@@ -298,7 +298,7 @@ class ActionlogsModel extends ListModel
 	 */
 	public function getLogDataAsIterator($pks = null)
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $this->getLogDataQuery($pks);
 
 		$db->setQuery($query);
@@ -317,7 +317,7 @@ class ActionlogsModel extends ListModel
 	 */
 	private function getLogDataQuery($pks = null)
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('a.*')
 			->select($db->quoteName('u.name'))
@@ -345,7 +345,7 @@ class ActionlogsModel extends ListModel
 	public function delete(&$pks)
 	{
 		$keys  = ArrayHelper::toInteger($pks);
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->delete($db->quoteName('#__action_logs'))
 			->whereIn($db->quoteName('id'), $keys);
@@ -378,7 +378,7 @@ class ActionlogsModel extends ListModel
 	{
 		try
 		{
-			$this->getDbo()->truncateTable('#__action_logs');
+			$this->getDatabase()->truncateTable('#__action_logs');
 		}
 		catch (Exception $e)
 		{

--- a/administrator/components/com_admin/src/Model/SysinfoModel.php
+++ b/administrator/components/com_admin/src/Model/SysinfoModel.php
@@ -315,7 +315,7 @@ class SysinfoModel extends BaseDatabaseModel
 			return $this->info;
 		}
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$this->info = [
 			'php'                    => php_uname(),

--- a/administrator/components/com_associations/src/Model/AssociationsModel.php
+++ b/administrator/components/com_associations/src/Model/AssociationsModel.php
@@ -180,7 +180,7 @@ class AssociationsModel extends ListModel
 
 		// Create a new query object.
 		$user     = Factory::getUser();
-		$db       = $this->getDbo();
+		$db       = $this->getDatabase();
 		$query    = $db->getQuery(true);
 
 		$details = $type->get('details');
@@ -505,7 +505,7 @@ class AssociationsModel extends ListModel
 	public function purge($context = '', $key = '')
 	{
 		$app   = Factory::getApplication();
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)->delete($db->quoteName('#__associations'));
 
 		// Filter by associations context.
@@ -556,7 +556,7 @@ class AssociationsModel extends ListModel
 	public function clean($context = '', $key = '')
 	{
 		$app   = Factory::getApplication();
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('key') . ', COUNT(*)')
 			->from($db->quoteName('#__associations'))

--- a/administrator/components/com_banners/src/Model/BannerModel.php
+++ b/administrator/components/com_banners/src/Model/BannerModel.php
@@ -332,7 +332,7 @@ class BannerModel extends AdminModel
 			// Set ordering to the last item if not set
 			if (empty($table->ordering))
 			{
-				$db = $this->getDbo();
+				$db = $this->getDatabase();
 				$query = $db->getQuery(true)
 					->select('MAX(' . $db->quoteName('ordering') . ')')
 					->from($db->quoteName('#__banners'));

--- a/administrator/components/com_banners/src/Model/BannersModel.php
+++ b/administrator/components/com_banners/src/Model/BannersModel.php
@@ -73,7 +73,7 @@ class BannersModel extends ListModel
 	{
 		if (!isset($this->cache['categoryorders']))
 		{
-			$db = $this->getDbo();
+			$db = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->select(
 					[
@@ -99,7 +99,7 @@ class BannersModel extends ListModel
 	 */
 	protected function getListQuery()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/administrator/components/com_banners/src/Model/ClientsModel.php
+++ b/administrator/components/com_banners/src/Model/ClientsModel.php
@@ -97,7 +97,7 @@ class ClientsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$defaultPurchase = (int) ComponentHelper::getParams('com_banners')->get('purchase_type', 3);
@@ -232,7 +232,7 @@ class ClientsModel extends ListModel
 		// Faster to do three queries for very large banner trees.
 
 		// Get the clients in the list.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$clientIds = array_column($items, 'id');
 
 		$query = $db->getQuery(true)

--- a/administrator/components/com_banners/src/Model/TracksModel.php
+++ b/administrator/components/com_banners/src/Model/TracksModel.php
@@ -91,7 +91,7 @@ class TracksModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -206,7 +206,7 @@ class TracksModel extends ListModel
 		if ($allow)
 		{
 			// Delete tracks from this banner
-			$db    = $this->getDbo();
+			$db    = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->delete($db->quoteName('#__banner_tracks'));
 
@@ -381,7 +381,7 @@ class TracksModel extends ListModel
 
 		if ($categoryId)
 		{
-			$db    = $this->getDbo();
+			$db    = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('title'))
 				->from($db->quoteName('#__categories'))
@@ -419,7 +419,7 @@ class TracksModel extends ListModel
 
 		if ($clientId)
 		{
-			$db    = $this->getDbo();
+			$db    = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('name'))
 				->from($db->quoteName('#__banner_clients'))

--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -163,7 +163,7 @@ class CategoriesModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$user = Factory::getUser();
 

--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -652,7 +652,7 @@ class CategoryModel extends AdminModel
 			}
 
 			// Get associationskey for edited item
-			$db    = $this->getDbo();
+			$db    = $this->getDatabase();
 			$id    = (int) $table->id;
 			$query = $db->getQuery(true)
 				->select($db->quoteName('key'))
@@ -879,7 +879,7 @@ class CategoryModel extends AdminModel
 	{
 		$successful = array();
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		/**
@@ -937,7 +937,7 @@ class CategoryModel extends AdminModel
 		$parts = explode('.', $value);
 		$parentId = (int) ArrayHelper::getValue($parts, 0, 1);
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$extension = Factory::getApplication()->input->get('extension', '', 'word');
 		$newIds = array();
 
@@ -1164,7 +1164,7 @@ class CategoryModel extends AdminModel
 		$type = new UCMType;
 		$this->type = $type->getTypeByAlias($this->typeAlias);
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$extension = Factory::getApplication()->input->get('extension', '', 'word');
 

--- a/administrator/components/com_checkin/src/Model/CheckinModel.php
+++ b/administrator/components/com_checkin/src/Model/CheckinModel.php
@@ -80,7 +80,7 @@ class CheckinModel extends ListModel
 	 */
 	public function checkin($ids = array())
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		if (!is_array($ids))
 		{
@@ -172,7 +172,7 @@ class CheckinModel extends ListModel
 	{
 		if (!isset($this->items))
 		{
-			$db     = $this->getDbo();
+			$db     = $this->getDatabase();
 			$tables = $db->getTableList();
 			$prefix = Factory::getApplication()->get('dbprefix');
 

--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -392,7 +392,7 @@ class ContactModel extends AdminModel
 			// Set ordering to the last item if not set
 			if (empty($table->ordering))
 			{
-				$db = $this->getDbo();
+				$db = $this->getDatabase();
 				$query = $db->getQuery(true)
 					->select('MAX(ordering)')
 					->from($db->quoteName('#__contact_details'));
@@ -511,7 +511,7 @@ class ContactModel extends AdminModel
 
 		try
 		{
-			$db = $this->getDbo();
+			$db = $this->getDatabase();
 
 			$query = $db->getQuery(true);
 			$query->update($db->quoteName('#__contact_details'));

--- a/administrator/components/com_contact/src/Model/ContactsModel.php
+++ b/administrator/components/com_contact/src/Model/ContactsModel.php
@@ -144,7 +144,7 @@ class ContactsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$user = Factory::getUser();
 

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -135,7 +135,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 		// Check if the article was featured and update the #__content_frontpage table
 		if ($table->featured == 1)
 		{
-			$db = $this->getDbo();
+			$db = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->select(
 					[
@@ -430,7 +430,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 				if ($item->featured)
 				{
 					// Get featured dates.
-					$db = $this->getDbo();
+					$db = $this->getDatabase();
 					$query = $db->getQuery(true)
 						->select(
 							[
@@ -941,7 +941,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 
 		try
 		{
-			$db = $this->getDbo();
+			$db = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__content'))
 				->set($db->quoteName('featured') . ' = :featured')
@@ -1186,7 +1186,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 		if ($return)
 		{
 			// Now check to see if this articles was featured if so delete it from the #__content_frontpage table
-			$db = $this->getDbo();
+			$db = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->delete($db->quoteName('#__content_frontpage'))
 				->whereIn($db->quoteName('content_id'), $pks);

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -229,7 +229,7 @@ class ArticlesModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$user  = Factory::getUser();
 
@@ -600,7 +600,7 @@ class ArticlesModel extends ListModel
 			return $this->cache[$store];
 		}
 
-		$db   = $this->getDbo();
+		$db   = $this->getDatabase();
 		$user = Factory::getUser();
 
 		$items = $this->getItems();

--- a/administrator/components/com_content/src/Model/FeaturedModel.php
+++ b/administrator/components/com_content/src/Model/FeaturedModel.php
@@ -94,7 +94,7 @@ class FeaturedModel extends ArticlesModel
 	{
 		$query = parent::getListQuery();
 
-		$query->select($this->getDbo()->quoteName('fp.ordering'));
+		$query->select($this->getDatabase()->quoteName('fp.ordering'));
 
 		return $query;
 	}

--- a/administrator/components/com_contenthistory/src/Model/CompareModel.php
+++ b/administrator/components/com_contenthistory/src/Model/CompareModel.php
@@ -90,7 +90,7 @@ class CompareModel extends ListModel
 			throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
-		$nullDate = $this->getDbo()->getNullDate();
+		$nullDate = $this->getDatabase()->getNullDate();
 
 		foreach (array($table1, $table2) as $table)
 		{

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -362,7 +362,7 @@ class HistoryModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db     = $this->getDbo();
+		$db     = $this->getDatabase();
 		$query  = $db->getQuery(true);
 		$itemId = $this->getState('item_id');
 

--- a/administrator/components/com_contenthistory/src/Model/PreviewModel.php
+++ b/administrator/components/com_contenthistory/src/Model/PreviewModel.php
@@ -75,7 +75,7 @@ class PreviewModel extends ItemModel
 			'publish_down',
 		);
 
-		$nullDate = $this->getDbo()->getNullDate();
+		$nullDate = $this->getDatabase()->getNullDate();
 
 		foreach ($dateProperties as $dateProperty)
 		{

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -164,7 +164,7 @@ class FieldModel extends AdminModel
 		}
 
 		// Save the assigned categories into #__fields_categories
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$id = (int) $this->getState('field.id');
 
 		/**
@@ -410,7 +410,7 @@ class FieldModel extends AdminModel
 				$result->fieldparams = $registry->toArray();
 			}
 
-			$db = $this->getDbo();
+			$db = $this->getDatabase();
 			$query = $db->getQuery(true);
 			$fieldId = (int) $result->id;
 			$query->select($db->quoteName('category_id'))
@@ -496,20 +496,20 @@ class FieldModel extends AdminModel
 			if (!empty($pks))
 			{
 				// Delete Values
-				$query = $this->getDbo()->getQuery(true);
+				$query = $this->getDatabase()->getQuery(true);
 
 				$query->delete($query->quoteName('#__fields_values'))
 					->whereIn($query->quoteName('field_id'), $pks);
 
-				$this->getDbo()->setQuery($query)->execute();
+				$this->getDatabase()->setQuery($query)->execute();
 
 				// Delete Assigned Categories
-				$query = $this->getDbo()->getQuery(true);
+				$query = $this->getDatabase()->getQuery(true);
 
 				$query->delete($query->quoteName('#__fields_categories'))
 					->whereIn($query->quoteName('field_id'), $pks);
 
-				$this->getDbo()->setQuery($query)->execute();
+				$this->getDatabase()->setQuery($query)->execute();
 			}
 		}
 
@@ -673,7 +673,7 @@ class FieldModel extends AdminModel
 			$fieldId = (int) $fieldId;
 
 			// Deleting the existing record as it is a reset
-			$query = $this->getDbo()->getQuery(true);
+			$query = $this->getDatabase()->getQuery(true);
 
 			$query->delete($query->quoteName('#__fields_values'))
 				->where($query->quoteName('field_id') . ' = :fieldid')
@@ -681,7 +681,7 @@ class FieldModel extends AdminModel
 				->bind(':fieldid', $fieldId, ParameterType::INTEGER)
 				->bind(':itemid', $itemId);
 
-			$this->getDbo()->setQuery($query)->execute();
+			$this->getDatabase()->setQuery($query)->execute();
 		}
 
 		if ($needsInsert)
@@ -695,7 +695,7 @@ class FieldModel extends AdminModel
 			{
 				$newObj->value = $v;
 
-				$this->getDbo()->insertObject('#__fields_values', $newObj);
+				$this->getDatabase()->insertObject('#__fields_values', $newObj);
 			}
 		}
 
@@ -707,7 +707,7 @@ class FieldModel extends AdminModel
 			$updateObj->item_id  = $itemId;
 			$updateObj->value    = reset($value);
 
-			$this->getDbo()->updateObject('#__fields_values', $updateObj, array('field_id', 'item_id'));
+			$this->getDatabase()->updateObject('#__fields_values', $updateObj, array('field_id', 'item_id'));
 		}
 
 		$this->valueCache = array();
@@ -762,7 +762,7 @@ class FieldModel extends AdminModel
 		if (!array_key_exists($key, $this->valueCache))
 		{
 			// Create the query
-			$query = $this->getDbo()->getQuery(true);
+			$query = $this->getDatabase()->getQuery(true);
 
 			$query->select($query->quoteName(['field_id', 'value']))
 				->from($query->quoteName('#__fields_values'))
@@ -771,7 +771,7 @@ class FieldModel extends AdminModel
 				->bind(':itemid', $itemId);
 
 			// Fetch the row from the database
-			$rows = $this->getDbo()->setQuery($query)->loadObjectList();
+			$rows = $this->getDatabase()->setQuery($query)->loadObjectList();
 
 			$data = array();
 
@@ -819,12 +819,12 @@ class FieldModel extends AdminModel
 	public function cleanupValues($context, $itemId)
 	{
 		// Delete with inner join is not possible so we need to do a subquery
-		$fieldsQuery = $this->getDbo()->getQuery(true);
+		$fieldsQuery = $this->getDatabase()->getQuery(true);
 		$fieldsQuery->select($fieldsQuery->quoteName('id'))
 			->from($fieldsQuery->quoteName('#__fields'))
 			->where($fieldsQuery->quoteName('context') . ' = :context');
 
-		$query = $this->getDbo()->getQuery(true);
+		$query = $this->getDatabase()->getQuery(true);
 
 		$query->delete($query->quoteName('#__fields_values'))
 			->where($query->quoteName('field_id') . ' IN (' . $fieldsQuery . ')')
@@ -832,7 +832,7 @@ class FieldModel extends AdminModel
 			->bind(':itemid', $itemId)
 			->bind(':context', $context);
 
-		$this->getDbo()->setQuery($query)->execute();
+		$this->getDatabase()->setQuery($query)->execute();
 	}
 
 	/**

--- a/administrator/components/com_fields/src/Model/FieldsModel.php
+++ b/administrator/components/com_fields/src/Model/FieldsModel.php
@@ -137,7 +137,7 @@ class FieldsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$user  = Factory::getUser();
 		$app   = Factory::getApplication();
@@ -480,7 +480,7 @@ class FieldsModel extends ListModel
 		$viewlevels = ArrayHelper::toInteger($user->getAuthorisedViewLevels());
 		$context    = $this->state->get('filter.context');
 
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$query->select(
 			[

--- a/administrator/components/com_fields/src/Model/GroupsModel.php
+++ b/administrator/components/com_fields/src/Model/GroupsModel.php
@@ -125,7 +125,7 @@ class GroupsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$user = Factory::getUser();
 

--- a/administrator/components/com_finder/src/Model/FilterModel.php
+++ b/administrator/components/com_finder/src/Model/FilterModel.php
@@ -146,7 +146,7 @@ class FilterModel extends AdminModel
 	 */
 	public function getTotal()
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('MAX(link_id)')
 			->from('#__finder_links');

--- a/administrator/components/com_finder/src/Model/FiltersModel.php
+++ b/administrator/components/com_finder/src/Model/FiltersModel.php
@@ -57,7 +57,7 @@ class FiltersModel extends ListModel
 	 */
 	protected function getListQuery()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select all fields from the table.

--- a/administrator/components/com_finder/src/Model/IndexModel.php
+++ b/administrator/components/com_finder/src/Model/IndexModel.php
@@ -190,7 +190,7 @@ class IndexModel extends ListModel
 	 */
 	protected function getListQuery()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('l.*')
 			->select($db->quoteName('t.title', 't_title'))
@@ -276,7 +276,7 @@ class IndexModel extends ListModel
 	 */
 	public function getPluginState()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('name, enabled')
 			->from($db->quoteName('#__extensions'))
@@ -321,7 +321,7 @@ class IndexModel extends ListModel
 	 */
 	public function getTotalIndexed()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('COUNT(link_id)')
 			->from($db->quoteName('#__finder_links'));
@@ -356,7 +356,7 @@ class IndexModel extends ListModel
 	 */
 	public function purge()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Truncate the links table.
 		$db->truncateTable('#__finder_links');

--- a/administrator/components/com_finder/src/Model/MapsModel.php
+++ b/administrator/components/com_finder/src/Model/MapsModel.php
@@ -171,7 +171,7 @@ class MapsModel extends ListModel
 	 */
 	protected function getListQuery()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Select all fields from the table.
 		$query = $db->getQuery(true)
@@ -247,7 +247,7 @@ class MapsModel extends ListModel
 		$query = clone $query;
 		$query->clear('select')->clear('join')->clear('order')->clear('limit')->clear('offset')->select('COUNT(*)');
 
-		return (int) $this->getDbo()->setQuery($query)->loadResult();
+		return (int) $this->getDatabase()->setQuery($query)->loadResult();
 	}
 
 	/**
@@ -385,7 +385,7 @@ class MapsModel extends ListModel
 	 */
 	public function purge()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->delete($db->quoteName('#__finder_taxonomy'))
 			->where($db->quoteName('parent_id') . ' > 1');

--- a/administrator/components/com_finder/src/Model/SearchesModel.php
+++ b/administrator/components/com_finder/src/Model/SearchesModel.php
@@ -101,7 +101,7 @@ class SearchesModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -161,7 +161,7 @@ class SearchesModel extends ListModel
 	 */
 	public function reset()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		try
 		{

--- a/administrator/components/com_finder/src/Model/StatisticsModel.php
+++ b/administrator/components/com_finder/src/Model/StatisticsModel.php
@@ -33,7 +33,7 @@ class StatisticsModel extends BaseDatabaseModel
 	public function getData()
 	{
 		// Initialise
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$data = new CMSObject;
 

--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -145,7 +145,7 @@ class DatabaseModel extends InstallerModel
 				}
 			}
 
-			$db        = $this->getDbo();
+			$db        = $this->getDatabase();
 
 			if ($result->type === 'component')
 			{
@@ -303,7 +303,7 @@ class DatabaseModel extends InstallerModel
 	 */
 	public function fix($cids = array())
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		foreach ($cids as $i => $cid)
 		{
@@ -365,7 +365,7 @@ class DatabaseModel extends InstallerModel
 	 */
 	protected function getListQuery()
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select(
 				$db->quoteName(
@@ -476,7 +476,7 @@ class DatabaseModel extends InstallerModel
 	 */
 	public function getSchemaVersion($extensionId)
 	{
-		$db          = $this->getDbo();
+		$db          = $this->getDatabase();
 		$extensionId = (int) $extensionId;
 		$query       = $db->getQuery(true)
 			->select($db->quoteName('version_id'))
@@ -513,7 +513,7 @@ class DatabaseModel extends InstallerModel
 
 		// Delete old row.
 		$extensionId = (int) $extensionId;
-		$db          = $this->getDbo();
+		$db          = $this->getDatabase();
 		$query       = $db->getQuery(true)
 			->delete($db->quoteName('#__schemas'))
 			->where($db->quoteName('extension_id') . ' = :extensionid')
@@ -634,7 +634,7 @@ class DatabaseModel extends InstallerModel
 	 */
 	public function fixUpdateVersion($extensionId)
 	{
-		$table = new Extension($this->getDbo());
+		$table = new Extension($this->getDatabase());
 		$table->load($extensionId);
 		$cache = new Registry($table->manifest_cache);
 		$updateVersion = $cache->get('version');
@@ -681,7 +681,7 @@ class DatabaseModel extends InstallerModel
 	 */
 	public function getDefaultTextFilters()
 	{
-		$table = new Extension($this->getDbo());
+		$table = new Extension($this->getDatabase());
 		$table->load($table->find(array('name' => 'com_config')));
 
 		return $table->params;
@@ -697,7 +697,7 @@ class DatabaseModel extends InstallerModel
 	 */
 	private function fixDefaultTextFilters()
 	{
-		$table = new Extension($this->getDbo());
+		$table = new Extension($this->getDatabase());
 		$table->load($table->find(array('name' => 'com_config')));
 
 		// Check for empty $config and non-empty content filters.

--- a/administrator/components/com_installer/src/Model/DiscoverModel.php
+++ b/administrator/components/com_installer/src/Model/DiscoverModel.php
@@ -93,7 +93,7 @@ class DiscoverModel extends InstallerModel
 	 */
 	protected function getListQuery()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('*')
 			->from($db->quoteName('#__extensions'))
@@ -158,7 +158,7 @@ class DiscoverModel extends InstallerModel
 		$results = Installer::getInstance()->discover();
 
 		// Get all templates, including discovered ones
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select($db->quoteName(['extension_id', 'element', 'folder', 'client_id', 'type']))
 			->from($db->quoteName('#__extensions'));
@@ -268,7 +268,7 @@ class DiscoverModel extends InstallerModel
 	 */
 	public function purge()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->delete($db->quoteName('#__extensions'))
 			->where($db->quoteName('state') . ' = -1');

--- a/administrator/components/com_installer/src/Model/InstallerModel.php
+++ b/administrator/components/com_installer/src/Model/InstallerModel.php
@@ -70,7 +70,7 @@ class InstallerModel extends ListModel
 		// Replace slashes so preg_match will work
 		$search = $this->getState('filter.search');
 		$search = str_replace('/', ' ', $search);
-		$db     = $this->getDbo();
+		$db     = $this->getDatabase();
 
 		// Define which fields have to be processed in a custom way because of translation.
 		$customOrderFields = array('name', 'client_translated', 'type_translated', 'folder_translated', 'creationDate');

--- a/administrator/components/com_installer/src/Model/LanguagesModel.php
+++ b/administrator/components/com_installer/src/Model/LanguagesModel.php
@@ -63,7 +63,7 @@ class LanguagesModel extends ListModel
 	 */
 	private function getUpdateSite()
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('us.location'))
 			->from($db->quoteName('#__extensions', 'e'))

--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -128,7 +128,7 @@ class ManageModel extends InstallerModel
 		}
 
 		// Get a table object for the extension type
-		$table = new Extension($this->getDbo());
+		$table = new Extension($this->getDatabase());
 
 		// Enable the extension in the table and store it in the database
 		foreach ($eid as $i => $id)
@@ -137,7 +137,7 @@ class ManageModel extends InstallerModel
 
 			if ($table->type == 'template')
 			{
-				$style = new StyleTable($this->getDbo());
+				$style = new StyleTable($this->getDatabase());
 
 				if ($style->load(array('template' => $table->element, 'client_id' => $table->client_id, 'home' => 1)))
 				{
@@ -245,7 +245,7 @@ class ManageModel extends InstallerModel
 
 		// Get an installer object for the extension type
 		$installer = Installer::getInstance();
-		$row       = new \Joomla\CMS\Table\Extension($this->getDbo());
+		$row       = new \Joomla\CMS\Table\Extension($this->getDatabase());
 
 		// Uninstall the chosen extensions
 		$msgs   = array();
@@ -323,7 +323,7 @@ class ManageModel extends InstallerModel
 	 */
 	protected function getListQuery()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('*')
 			->select('2*protected+(1-protected)*enabled AS status')
@@ -424,7 +424,7 @@ class ManageModel extends InstallerModel
 	{
 		// Get the changelog URL
 		$eid = (int) $eid;
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select(
 				$db->quoteName(

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -97,7 +97,7 @@ class UpdateModel extends ListModel
 	 */
 	protected function getListQuery()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Grab updates ignoring new installs
 		$query = $db->getQuery(true)
@@ -226,7 +226,7 @@ class UpdateModel extends ListModel
 	 */
 	protected function _getList($query, $limitstart = 0, $limit = 0)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$listOrder = $this->getState('list.ordering', 'u.name');
 		$listDirn  = $this->getState('list.direction', 'asc');
 
@@ -267,7 +267,7 @@ class UpdateModel extends ListModel
 	 */
 	public function getDisabledUpdateSites()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$query = $db->getQuery(true)
 			->select('COUNT(*)')
@@ -306,7 +306,7 @@ class UpdateModel extends ListModel
 	 */
 	public function purge()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		try
 		{
@@ -353,7 +353,7 @@ class UpdateModel extends ListModel
 		foreach ($uids as $uid)
 		{
 			$update = new Update;
-			$instance = new \Joomla\CMS\Table\Update($this->getDbo());
+			$instance = new \Joomla\CMS\Table\Update($this->getDatabase());
 
 			if (!$instance->load($uid))
 			{
@@ -364,7 +364,7 @@ class UpdateModel extends ListModel
 			$update->loadFromXml($instance->detailsurl, $minimumStability);
 
 			// Find and use extra_query from update_site if available
-			$updateSiteInstance = new \Joomla\CMS\Table\UpdateSite($this->getDbo());
+			$updateSiteInstance = new \Joomla\CMS\Table\UpdateSite($this->getDatabase());
 			$updateSiteInstance->load($instance->update_site_id);
 
 			if ($updateSiteInstance->extra_query)

--- a/administrator/components/com_installer/src/Model/UpdatesiteModel.php
+++ b/administrator/components/com_installer/src/Model/UpdatesiteModel.php
@@ -85,7 +85,7 @@ class UpdatesiteModel extends AdminModel
 	{
 		$item = parent::getItem($pk);
 
-		$db           = $this->getDbo();
+		$db           = $this->getDatabase();
 		$updateSiteId = (int) $item->get('update_site_id');
 		$query        = $db->getQuery(true)
 			->select(
@@ -154,7 +154,7 @@ class UpdatesiteModel extends AdminModel
 		}
 
 		// Delete update records forcing Joomla to fetch them again, applying the new extra_query.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->delete($db->quoteName('#__updates'))
 			->where($db->quoteName('update_site_id') . ' = :updateSiteId');

--- a/administrator/components/com_installer/src/Model/UpdatesitesModel.php
+++ b/administrator/components/com_installer/src/Model/UpdatesitesModel.php
@@ -93,7 +93,7 @@ class UpdatesitesModel extends InstallerModel
 		}
 
 		// Get a table object for the extension type
-		$table = new UpdateSiteTable($this->getDbo());
+		$table = new UpdateSiteTable($this->getDatabase());
 
 		// Enable the update site in the table and store it in the database
 		foreach ($eid as $i => $id)
@@ -135,7 +135,7 @@ class UpdatesitesModel extends InstallerModel
 			$ids = [$ids];
 		}
 
-		$db  = $this->getDbo();
+		$db  = $this->getDatabase();
 		$app = Factory::getApplication();
 
 		$count = 0;
@@ -216,7 +216,7 @@ class UpdatesitesModel extends InstallerModel
 	 */
 	protected function getJoomlaUpdateSitesIds($column = 0)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Fetch the Joomla core update sites ids and their extension ids. We search for all except the core joomla extension with update sites.
 		$query = $db->getQuery(true)
@@ -262,7 +262,7 @@ class UpdatesitesModel extends InstallerModel
 			throw new Exception(Text::_('COM_INSTALLER_MSG_UPDATESITES_REBUILD_NOT_PERMITTED'), 403);
 		}
 
-		$db  = $this->getDbo();
+		$db  = $this->getDatabase();
 		$app = Factory::getApplication();
 
 		// Check if Joomla Extension plugin is enabled.
@@ -545,7 +545,7 @@ class UpdatesitesModel extends InstallerModel
 	 */
 	protected function getListQuery()
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select(
 				$db->quoteName(

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -100,7 +100,7 @@ class UpdateModel extends BaseDatabaseModel
 		}
 
 		$id = ExtensionHelper::getExtensionRecord('joomla', 'file')->extension_id;
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('us') . '.*')
 			->from($db->quoteName('#__update_sites_extensions', 'map'))
@@ -186,7 +186,7 @@ class UpdateModel extends BaseDatabaseModel
 	 */
 	public function getCheckForSelfUpdate()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$query = $db->getQuery(true)
 			->select($db->quoteName('extension_id'))
@@ -264,7 +264,7 @@ class UpdateModel extends BaseDatabaseModel
 
 		// Fetch the update information from the database.
 		$id = ExtensionHelper::getExtensionRecord('joomla', 'file')->extension_id;
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('*')
 			->from($db->quoteName('#__updates'))
@@ -325,7 +325,7 @@ class UpdateModel extends BaseDatabaseModel
 	 */
 	public function purge()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Modify the database record
 		$update_site = new \stdClass;
@@ -695,7 +695,7 @@ ENDDATA;
 		$installer->setUpgrade(true);
 		$installer->setOverwrite(true);
 
-		$installer->extension = new \Joomla\CMS\Table\Extension($this->getDbo());
+		$installer->extension = new \Joomla\CMS\Table\Extension($this->getDatabase());
 		$installer->extension->load(ExtensionHelper::getExtensionRecord('joomla', 'file')->extension_id);
 
 		$installer->setAdapter($installer->extension->type);
@@ -732,7 +732,7 @@ ENDDATA;
 		ob_end_clean();
 
 		// Get a database connector object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		/*
 		 * Check to see if a file extension by the same name is already installed.
@@ -762,7 +762,7 @@ ENDDATA;
 		}
 
 		$id = $db->loadResult();
-		$row = new \Joomla\CMS\Table\Extension($this->getDbo());
+		$row = new \Joomla\CMS\Table\Extension($this->getDatabase());
 
 		if ($id)
 		{
@@ -855,7 +855,7 @@ ENDDATA;
 		ob_end_clean();
 
 		// Clobber any possible pending updates.
-		$update = new \Joomla\CMS\Table\Update($this->getDbo());
+		$update = new \Joomla\CMS\Table\Update($this->getDatabase());
 		$uid = $update->find(
 			array('element' => 'joomla', 'type' => 'file', 'client_id' => '0', 'folder' => '')
 		);
@@ -1432,7 +1432,7 @@ ENDDATA;
 	 */
 	public function getNonCoreExtensions()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$query->select(
@@ -1483,7 +1483,7 @@ ENDDATA;
 	 */
 	public function getNonCorePlugins($folderFilter = ['system','user','authentication','actionlog','multifactorauth'])
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$query->select(
@@ -1591,7 +1591,7 @@ ENDDATA;
 	private function getUpdateSitesInfo($extensionID)
 	{
 		$id = (int) $extensionID;
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$query->select(
@@ -1782,7 +1782,7 @@ ENDDATA;
 	 */
 	public function isTemplateActive($template)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$query->select(

--- a/administrator/components/com_languages/src/Model/LanguagesModel.php
+++ b/administrator/components/com_languages/src/Model/LanguagesModel.php
@@ -109,7 +109,7 @@ class LanguagesModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select all fields from the languages table.

--- a/administrator/components/com_languages/src/Model/OverridesModel.php
+++ b/administrator/components/com_languages/src/Model/OverridesModel.php
@@ -259,7 +259,7 @@ class OverridesModel extends ListModel
 	 */
 	public function purge()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Note: TRUNCATE is a DDL operation
 		// This may or may not mean depending on your database

--- a/administrator/components/com_languages/src/Model/StringsModel.php
+++ b/administrator/components/com_languages/src/Model/StringsModel.php
@@ -36,7 +36,7 @@ class StringsModel extends BaseDatabaseModel
 	public function refresh()
 	{
 		$app = Factory::getApplication();
-		$db  = $this->getDbo();
+		$db  = $this->getDatabase();
 
 		$app->setUserState('com_languages.overrides.cachedtime', null);
 
@@ -141,7 +141,7 @@ class StringsModel extends BaseDatabaseModel
 		$results = array();
 		$input   = Factory::getApplication()->input;
 		$filter  = InputFilter::getInstance();
-		$db      = $this->getDbo();
+		$db      = $this->getDatabase();
 		$searchTerm = $input->getString('searchstring');
 
 		$limitstart = $input->getInt('more');

--- a/administrator/components/com_mails/src/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/src/Model/TemplatesModel.php
@@ -86,7 +86,7 @@ class TemplatesModel extends ListModel
 		$items = parent::getItems();
 		$id    = '';
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('language'))
 			->from($db->quoteName('#__mail_templates'))
@@ -115,7 +115,7 @@ class TemplatesModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -197,7 +197,7 @@ class TemplatesModel extends ListModel
 	 */
 	public function getExtensions()
 	{
-		$db       = $this->getDbo();
+		$db       = $this->getDatabase();
 		$subQuery = $db->getQuery(true)
 			->select($db->quoteName('name'))
 			->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -155,7 +155,7 @@ class ItemModel extends AdminModel
 		$parentId = ArrayHelper::getValue($parts, 1, 0, 'int');
 
 		$table  = $this->getTable();
-		$db     = $this->getDbo();
+		$db     = $this->getDatabase();
 		$query  = $db->getQuery(true);
 		$newIds = array();
 
@@ -367,7 +367,7 @@ class ItemModel extends AdminModel
 		$parentId = ArrayHelper::getValue($parts, 1, 0, 'int');
 
 		$table = $this->getTable();
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 
 		// Check that the parent exists.
 		if ($parentId)
@@ -860,7 +860,7 @@ class ItemModel extends AdminModel
 			return false;
 		}
 
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		/**
@@ -939,7 +939,7 @@ class ItemModel extends AdminModel
 	 */
 	public function getViewLevels()
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Get all the available view levels
@@ -1356,7 +1356,7 @@ class ItemModel extends AdminModel
 	public function rebuild()
 	{
 		// Initialise variables.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$table = $this->getTable();
 
@@ -1449,7 +1449,7 @@ class ItemModel extends AdminModel
 	{
 		$pk      = isset($data['id']) ? $data['id'] : (int) $this->getState('item.id');
 		$isNew   = true;
-		$db      = $this->getDbo();
+		$db      = $this->getDatabase();
 		$query   = $db->getQuery(true);
 		$table   = $this->getTable();
 		$context = $this->option . '.' . $this->name;
@@ -1634,7 +1634,7 @@ class ItemModel extends AdminModel
 			}
 
 			// Get associationskey for edited item
-			$db    = $this->getDbo();
+			$db    = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->select($db->quoteName('key'))
 				->from($db->quoteName('#__associations'))

--- a/administrator/components/com_menus/src/Model/ItemsModel.php
+++ b/administrator/components/com_menus/src/Model/ItemsModel.php
@@ -250,7 +250,7 @@ class ItemsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db       = $this->getDbo();
+		$db       = $this->getDatabase();
 		$query    = $db->getQuery(true);
 		$user     = Factory::getUser();
 		$clientId = (int) $this->getState('filter.client_id');

--- a/administrator/components/com_menus/src/Model/MenuModel.php
+++ b/administrator/components/com_menus/src/Model/MenuModel.php
@@ -353,7 +353,7 @@ class MenuModel extends FormModel
 	 */
 	public function &getModules()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$query = $db->getQuery(true)
 			->select(

--- a/administrator/components/com_menus/src/Model/MenusModel.php
+++ b/administrator/components/com_menus/src/Model/MenusModel.php
@@ -77,7 +77,7 @@ class MenusModel extends ListModel
 		// Faster to do three queries for very large menu trees.
 
 		// Get the menu types of menus in the list.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$menuTypes = array_column((array) $items, 'menutype');
 
 		$query = $db->getQuery(true)
@@ -158,7 +158,7 @@ class MenusModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db       = $this->getDbo();
+		$db       = $this->getDatabase();
 		$query    = $db->getQuery(true);
 		$clientId = (int) $this->getState('client_id');
 
@@ -239,7 +239,7 @@ class MenusModel extends ListModel
 	public function getModMenuId()
 	{
 		$clientId = (int) $this->getState('client_id');
-		$db       = $this->getDbo();
+		$db       = $this->getDatabase();
 		$query    = $db->getQuery(true)
 			->select($db->quoteName('e.extension_id'))
 			->from($db->quoteName('#__extensions', 'e'))

--- a/administrator/components/com_menus/src/Model/MenutypesModel.php
+++ b/administrator/components/com_menus/src/Model/MenutypesModel.php
@@ -83,7 +83,7 @@ class MenutypesModel extends BaseDatabaseModel
 		$list = array();
 
 		// Get the list of components.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select(
 				[

--- a/administrator/components/com_messages/src/Model/ConfigModel.php
+++ b/administrator/components/com_messages/src/Model/ConfigModel.php
@@ -60,7 +60,7 @@ class ConfigModel extends FormModel
 		$item   = new CMSObject;
 		$userid = (int) $this->getState('user.id');
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$query->select(
 			[
@@ -129,7 +129,7 @@ class ConfigModel extends FormModel
 	 */
 	public function save($data)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		if ($userId = (int) $this->getState('user.id'))
 		{

--- a/administrator/components/com_messages/src/Model/MessageModel.php
+++ b/administrator/components/com_messages/src/Model/MessageModel.php
@@ -149,7 +149,7 @@ class MessageModel extends AdminModel
 					if ($replyId = (int) $this->getState('reply.id'))
 					{
 						// If replying to a message, preload some data.
-						$db    = $this->getDbo();
+						$db    = $this->getDatabase();
 						$query = $db->getQuery(true)
 							->select($db->quoteName(['subject', 'user_id_from', 'user_id_to']))
 							->from($db->quoteName('#__messages'))
@@ -192,7 +192,7 @@ class MessageModel extends AdminModel
 				else
 				{
 					// Mark message read
-					$db    = $this->getDbo();
+					$db    = $this->getDatabase();
 					$query = $db->getQuery(true)
 						->update($db->quoteName('#__messages'))
 						->set($db->quoteName('state') . ' = 1')
@@ -467,7 +467,7 @@ class MessageModel extends AdminModel
 	 */
 	public function notifySuperUsers($subject, $message, $fromUser = null)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		try
 		{

--- a/administrator/components/com_messages/src/Model/MessagesModel.php
+++ b/administrator/components/com_messages/src/Model/MessagesModel.php
@@ -104,7 +104,7 @@ class MessagesModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$user = Factory::getUser();
 		$id   = (int) $user->get('id');

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -203,7 +203,7 @@ class ModuleModel extends AdminModel
 				$newIds[$pk] = $newId;
 
 				// Now we need to handle the module assignments
-				$db = $this->getDbo();
+				$db = $this->getDatabase();
 				$query = $db->getQuery(true)
 					->select($db->quoteName('menuid'))
 					->from($db->quoteName('#__modules_menu'))
@@ -377,7 +377,7 @@ class ModuleModel extends AdminModel
 				{
 					// Delete the menu assignments
 					$pk    = (int) $pk;
-					$db    = $this->getDbo();
+					$db    = $this->getDatabase();
 					$query = $db->getQuery(true)
 						->delete($db->quoteName('#__modules_menu'))
 						->where($db->quoteName('moduleid') . ' = :moduleid')
@@ -417,7 +417,7 @@ class ModuleModel extends AdminModel
 	public function duplicate(&$pks)
 	{
 		$user = Factory::getUser();
-		$db   = $this->getDbo();
+		$db   = $this->getDatabase();
 
 		// Access checks.
 		if (!$user->authorise('core.create', 'com_modules'))
@@ -679,7 +679,7 @@ class ModuleModel extends AdminModel
 	public function getItem($pk = null)
 	{
 		$pk = (!empty($pk)) ? (int) $pk : (int) $this->getState('module.id');
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		if (!isset($this->_cache[$pk]))
 		{
@@ -1053,7 +1053,7 @@ class ModuleModel extends AdminModel
 		$table->id = (int) $table->id;
 
 		// Delete old module to menu item associations
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->delete($db->quoteName('#__modules_menu'))
 			->where($db->quoteName('moduleid') . ' = :moduleid')

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -276,7 +276,7 @@ class ModulesModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields.

--- a/administrator/components/com_modules/src/Model/SelectModel.php
+++ b/administrator/components/com_modules/src/Model/SelectModel.php
@@ -85,7 +85,7 @@ class SelectModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
@@ -330,7 +330,7 @@ class NewsfeedModel extends AdminModel
 			// Set ordering to the last item if not set
 			if (empty($table->ordering))
 			{
-				$db = $this->getDbo();
+				$db = $this->getDatabase();
 				$query = $db->getQuery(true)
 					->select('MAX(' . $db->quoteName('ordering') . ')')
 					->from($db->quoteName('#__newsfeeds'));

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedsModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedsModel.php
@@ -147,7 +147,7 @@ class NewsfeedsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$user  = Factory::getUser();
 

--- a/administrator/components/com_plugins/src/Model/PluginModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginModel.php
@@ -261,7 +261,7 @@ class PluginModel extends AdminModel
 		$lang    = Factory::getLanguage();
 
 		// Load the core and/or local language sys file(s) for the ordering field.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('element'))
 			->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_plugins/src/Model/PluginsModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginsModel.php
@@ -207,7 +207,7 @@ class PluginsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -64,7 +64,7 @@ class MessagesModel extends BaseDatabaseModel
 	 */
 	public function getItem($id)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$id = (int) $id;
 
 		$query = $db->getQuery(true);
@@ -106,7 +106,7 @@ class MessagesModel extends BaseDatabaseModel
 	 */
 	public function unpublishMessage($id)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$id = (int) $id;
 
 		$query = $db->getQuery(true);
@@ -136,7 +136,7 @@ class MessagesModel extends BaseDatabaseModel
 		// Build a cache ID for the resulting data object
 		$cacheId = $eid . '.' . $published;
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$query->select(
 			[
@@ -198,7 +198,7 @@ class MessagesModel extends BaseDatabaseModel
 	 */
 	public function getItemsCount()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$query->select(
 			[
@@ -251,7 +251,7 @@ class MessagesModel extends BaseDatabaseModel
 	public function getExtensionName($eid)
 	{
 		// Load the extension's information from the database
-		$db  = $this->getDbo();
+		$db  = $this->getDatabase();
 		$eid = (int) $eid;
 
 		$query = $db->getQuery(true)
@@ -302,7 +302,7 @@ class MessagesModel extends BaseDatabaseModel
 	 */
 	public function resetMessages($eid)
 	{
-		$db  = $this->getDbo();
+		$db  = $this->getDatabase();
 		$eid = (int) $eid;
 
 		$query = $db->getQuery(true)
@@ -329,7 +329,7 @@ class MessagesModel extends BaseDatabaseModel
 	 */
 	public function hideMessages($eid)
 	{
-		$db  = $this->getDbo();
+		$db  = $this->getDatabase();
 		$eid = (int) $eid;
 
 		$query = $db->getQuery(true)
@@ -419,7 +419,7 @@ class MessagesModel extends BaseDatabaseModel
 	 */
 	public function getComponentOptions()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$query = $db->getQuery(true)
 			->select($db->quoteName('extension_id'))
@@ -656,7 +656,7 @@ class MessagesModel extends BaseDatabaseModel
 		$tableName   = $table->getTableName();
 		$extensionId = (int) $options['extension_id'];
 
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('*')
 			->from($db->quoteName($tableName))

--- a/administrator/components/com_privacy/src/Model/ConsentsModel.php
+++ b/administrator/components/com_privacy/src/Model/ConsentsModel.php
@@ -60,7 +60,7 @@ class ConsentsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -197,7 +197,7 @@ class ConsentsModel extends ListModel
 
 		try
 		{
-			$db = $this->getDbo();
+			$db = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__privacy_consents'))
 				->set($db->quoteName('state') . ' = -1')
@@ -227,7 +227,7 @@ class ConsentsModel extends ListModel
 	{
 		try
 		{
-			$db = $this->getDbo();
+			$db = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->update($db->quoteName('#__privacy_consents'))
 				->set($db->quoteName('state') . ' = -1')

--- a/administrator/components/com_privacy/src/Model/ExportModel.php
+++ b/administrator/components/com_privacy/src/Model/ExportModel.php
@@ -79,7 +79,7 @@ class ExportModel extends BaseDatabaseModel
 		}
 
 		// If there is a user account associated with the email address, load it here for use in the plugins
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$userId = (int) $db->setQuery(
 			$db->getQuery(true)
@@ -174,7 +174,7 @@ class ExportModel extends BaseDatabaseModel
 
 		$lang = Factory::getLanguage();
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$userId = (int) $db->setQuery(
 			$db->getQuery(true)

--- a/administrator/components/com_privacy/src/Model/RemoveModel.php
+++ b/administrator/components/com_privacy/src/Model/RemoveModel.php
@@ -74,7 +74,7 @@ class RemoveModel extends BaseDatabaseModel
 		}
 
 		// If there is a user account associated with the email address, load it here for use in the plugins
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$userId = (int) $db->setQuery(
 			$db->getQuery(true)

--- a/administrator/components/com_privacy/src/Model/RequestModel.php
+++ b/administrator/components/com_privacy/src/Model/RequestModel.php
@@ -261,7 +261,7 @@ class RequestModel extends AdminModel
 
 		$lang = Factory::getLanguage();
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$userId = (int) $db->setQuery(
 			$db->getQuery(true)
@@ -421,7 +421,7 @@ class RequestModel extends AdminModel
 		}
 
 		// Check for an active request for this email address
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$query = $db->getQuery(true)
 			->select('COUNT(id)')

--- a/administrator/components/com_privacy/src/Model/RequestsModel.php
+++ b/administrator/components/com_privacy/src/Model/RequestsModel.php
@@ -57,7 +57,7 @@ class RequestsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -189,7 +189,7 @@ class RequestsModel extends ListModel
 		$now    = Factory::getDate()->toSql();
 		$period = '-' . $notify;
 
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('COUNT(*)');
 		$query->from($db->quoteName('#__privacy_requests'));

--- a/administrator/components/com_redirect/src/Model/LinkModel.php
+++ b/administrator/components/com_redirect/src/Model/LinkModel.php
@@ -128,7 +128,7 @@ class LinkModel extends AdminModel
 	public function activate(&$pks, $url, $comment = null)
 	{
 		$user = Factory::getUser();
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Sanitize the ids.
 		$pks = (array) $pks;
@@ -188,7 +188,7 @@ class LinkModel extends AdminModel
 	public function duplicateUrls(&$pks, $url, $comment = null)
 	{
 		$user = Factory::getUser();
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Sanitize the ids.
 		$pks = (array) $pks;

--- a/administrator/components/com_redirect/src/Model/LinksModel.php
+++ b/administrator/components/com_redirect/src/Model/LinksModel.php
@@ -60,7 +60,7 @@ class LinksModel extends ListModel
 	 */
 	public function purge()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$query = $db->getQuery(true);
 
@@ -135,7 +135,7 @@ class LinksModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -211,7 +211,7 @@ class LinksModel extends ListModel
 	 */
 	public function batchProcess($batchUrls)
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$params  = ComponentHelper::getParams('com_redirect');

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -378,7 +378,7 @@ class TaskModel extends AdminModel
 			}
 		}
 
-		$db  = $this->getDbo();
+		$db  = $this->getDatabase();
 		$now = Factory::getDate()->toSql();
 
 		// Get lock on the table to help with concurrency issues

--- a/administrator/components/com_scheduler/src/Model/TasksModel.php
+++ b/administrator/components/com_scheduler/src/Model/TasksModel.php
@@ -109,7 +109,7 @@ class TasksModel extends ListModel
 	protected function getListQuery(): QueryInterface
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		/**
@@ -396,7 +396,7 @@ class TasksModel extends ListModel
 
 		// Set limit parameters and get object list
 		$query->setLimit($limit, $limitstart);
-		$this->getDbo()->setQuery($query);
+		$this->getDatabase()->setQuery($query);
 
 		// Return optionally an extended class.
 		// @todo: Use something other than CMSObject..
@@ -413,12 +413,12 @@ class TasksModel extends ListModel
 
 					return $o;
 				},
-				$this->getDbo()->loadAssocList() ?: []
+				$this->getDatabase()->loadAssocList() ?: []
 			);
 		}
 		else
 		{
-			$responseList = $this->getDbo()->loadObjectList();
+			$responseList = $this->getDatabase()->loadObjectList();
 		}
 
 		// Attach TaskOptions objects and a safe type title

--- a/administrator/components/com_tags/src/Model/TagsModel.php
+++ b/administrator/components/com_tags/src/Model/TagsModel.php
@@ -145,7 +145,7 @@ class TagsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 		$user  = Factory::getUser();
 

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -544,7 +544,7 @@ class StyleModel extends AdminModel
 		if ($user->authorise('core.edit', 'com_menus') && $table->client_id == 0)
 		{
 			$n       = 0;
-			$db      = $this->getDbo();
+			$db      = $this->getDatabase();
 			$user    = Factory::getUser();
 			$tableId = (int) $table->id;
 			$userId  = (int) $user->id;
@@ -617,7 +617,7 @@ class StyleModel extends AdminModel
 	public function setHome($id = 0)
 	{
 		$user = Factory::getUser();
-		$db   = $this->getDbo();
+		$db   = $this->getDatabase();
 
 		// Access checks.
 		if (!$user->authorise('core.edit.state', 'com_templates'))
@@ -680,7 +680,7 @@ class StyleModel extends AdminModel
 	public function unsetHome($id = 0)
 	{
 		$user = Factory::getUser();
-		$db   = $this->getDbo();
+		$db   = $this->getDatabase();
 
 		// Access checks.
 		if (!$user->authorise('core.edit.state', 'com_templates'))

--- a/administrator/components/com_templates/src/Model/StylesModel.php
+++ b/administrator/components/com_templates/src/Model/StylesModel.php
@@ -119,7 +119,7 @@ class StylesModel extends ListModel
 		$clientId = (int) $this->getState('client_id');
 
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -126,7 +126,7 @@ class TemplateModel extends FormModel
 	public function getTemplateList()
 	{
 		// Get a db connection.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Create a new query object.
 		$query = $db->getQuery(true);
@@ -166,7 +166,7 @@ class TemplateModel extends FormModel
 	public function getUpdatedList($state = false, $all = false, $cleanup = false)
 	{
 		// Get a db connection.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Create a new query object.
 		$query = $db->getQuery(true);
@@ -330,7 +330,7 @@ class TemplateModel extends FormModel
 	 */
 	public function publish($ids, $value, $exid)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		foreach ($ids as $id)
 		{
@@ -648,7 +648,7 @@ class TemplateModel extends FormModel
 		if (empty($this->template))
 		{
 			$pk  = (int) $this->getState('extension.id');
-			$db  = $this->getDbo();
+			$db  = $this->getDatabase();
 			$app = Factory::getApplication();
 
 			// Get the template information.
@@ -703,7 +703,7 @@ class TemplateModel extends FormModel
 	 */
 	public function checkNewName()
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$name  = $this->getState('new_name');
 		$query = $db->getQuery(true)
 			->select('COUNT(*)')
@@ -886,7 +886,7 @@ class TemplateModel extends FormModel
 		$app = Factory::getApplication();
 
 		// Codemirror or Editor None should be enabled
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('COUNT(*)')
 			->from('#__extensions as a')
@@ -1747,7 +1747,7 @@ class TemplateModel extends FormModel
 	public function getPreview()
 	{
 		$app = Factory::getApplication();
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$query->select($db->quoteName(['id', 'client_id']));
@@ -2223,7 +2223,7 @@ class TemplateModel extends FormModel
 			return [];
 		}
 
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$query->select($db->quoteName(['id', 'title']))
@@ -2255,7 +2255,7 @@ class TemplateModel extends FormModel
 		$applyStyles = $this->getState('stylesToCopy');
 
 		// Get a db connection.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Create a new query object.
 		$query = $db->getQuery(true);

--- a/administrator/components/com_templates/src/Model/TemplatesModel.php
+++ b/administrator/components/com_templates/src/Model/TemplatesModel.php
@@ -92,7 +92,7 @@ class TemplatesModel extends ListModel
 	 */
 	public function updated($exid)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Select the required fields from the table
 		$query = $db->getQuery(true)
@@ -126,7 +126,7 @@ class TemplatesModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/administrator/components/com_users/src/Model/DebuggroupModel.php
+++ b/administrator/components/com_users/src/Model/DebuggroupModel.php
@@ -181,7 +181,7 @@ class DebuggroupModel extends ListModel
 	{
 		$groupId = (int) $this->getState('group_id');
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select($db->quoteName(['id', 'title']))
 			->from($db->quoteName('#__usergroups'))
@@ -214,7 +214,7 @@ class DebuggroupModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/administrator/components/com_users/src/Model/DebuguserModel.php
+++ b/administrator/components/com_users/src/Model/DebuguserModel.php
@@ -195,7 +195,7 @@ class DebuguserModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/administrator/components/com_users/src/Model/GroupsModel.php
+++ b/administrator/components/com_users/src/Model/GroupsModel.php
@@ -141,7 +141,7 @@ class GroupsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -199,7 +199,7 @@ class GroupsModel extends ListModel
 
 		$groupIds = array_keys($groupsByKey);
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		// Get total enabled users in group.
 		$query = $db->getQuery(true);

--- a/administrator/components/com_users/src/Model/LevelModel.php
+++ b/administrator/components/com_users/src/Model/LevelModel.php
@@ -71,7 +71,7 @@ class LevelModel extends AdminModel
 			// Populate the list once.
 			$this->levelsInUse = array();
 
-			$db    = $this->getDbo();
+			$db    = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->select('DISTINCT access');
 

--- a/administrator/components/com_users/src/Model/LevelsModel.php
+++ b/administrator/components/com_users/src/Model/LevelsModel.php
@@ -99,7 +99,7 @@ class LevelsModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/administrator/components/com_users/src/Model/MailModel.php
+++ b/administrator/components/com_users/src/Model/MailModel.php
@@ -102,7 +102,7 @@ class MailModel extends AdminModel
 		$data     = $app->input->post->get('jform', array(), 'array');
 		$user     = Factory::getUser();
 		$access   = new Access;
-		$db       = $this->getDbo();
+		$db       = $this->getDatabase();
 		$language = Factory::getLanguage();
 
 		$mode         = array_key_exists('mode', $data) ? (int) $data['mode'] : 0;

--- a/administrator/components/com_users/src/Model/MethodsModel.php
+++ b/administrator/components/com_users/src/Model/MethodsModel.php
@@ -105,7 +105,7 @@ class MethodsModel extends BaseDatabaseModel
 			throw new RuntimeException(Text::_('JERROR_ALERTNOAUTHOR'), 403);
 		}
 
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->delete($db->quoteName('#__user_mfa'))
 			->where($db->quoteName('user_id') . ' = :user_id')
@@ -201,7 +201,7 @@ class MethodsModel extends BaseDatabaseModel
 	 */
 	public function setFlag(User $user, bool $flag = true): void
 	{
-		$db         = $this->getDbo();
+		$db         = $this->getDatabase();
 		$profileKey = 'mfa.dontshow';
 		$query      = $db->getQuery(true)
 			->select($db->quoteName('profile_value'))

--- a/administrator/components/com_users/src/Model/NotesModel.php
+++ b/administrator/components/com_users/src/Model/NotesModel.php
@@ -66,7 +66,7 @@ class NotesModel extends ListModel
 	 */
 	protected function getListQuery()
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -708,7 +708,7 @@ class UserModel extends AdminModel
 		}
 
 		// Get the DB object
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$userIds = ArrayHelper::toInteger($userIds);
 
@@ -771,7 +771,7 @@ class UserModel extends AdminModel
 		}
 
 		// Get the DB object
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		switch ($action)
 		{

--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -205,7 +205,7 @@ class UsersModel extends ListModel
 			}
 
 			// Get the counts from the database only for the users in the list.
-			$db    = $this->getDbo();
+			$db    = $this->getDatabase();
 			$query = $db->getQuery(true);
 
 			// Join over the group mapping table.
@@ -311,7 +311,7 @@ class UsersModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.
@@ -645,7 +645,7 @@ class UsersModel extends ListModel
 	 */
 	protected function getUserDisplayedGroups($userId)
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('title'))
 			->from($db->quoteName('#__usergroups', 'ug'))

--- a/administrator/components/com_workflow/src/Model/StagesModel.php
+++ b/administrator/components/com_workflow/src/Model/StagesModel.php
@@ -125,7 +125,7 @@ class StagesModel extends ListModel
 	 */
 	public function getListQuery()
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$query

--- a/administrator/components/com_workflow/src/Model/TransitionModel.php
+++ b/administrator/components/com_workflow/src/Model/TransitionModel.php
@@ -268,8 +268,8 @@ class TransitionModel extends AdminModel
 			);
 		}
 
-		$where = $this->getDbo()->quoteName('workflow_id') . ' = ' . (int) $data['workflow_id'];
-		$where .= ' AND ' . $this->getDbo()->quoteName('published') . ' = 1';
+		$where = $this->getDatabase()->quoteName('workflow_id') . ' = ' . (int) $data['workflow_id'];
+		$where .= ' AND ' . $this->getDatabase()->quoteName('published') . ' = 1';
 
 		$form->setFieldAttribute('from_stage_id', 'sql_where', $where);
 		$form->setFieldAttribute('to_stage_id', 'sql_where', $where);

--- a/administrator/components/com_workflow/src/Model/TransitionsModel.php
+++ b/administrator/components/com_workflow/src/Model/TransitionsModel.php
@@ -126,7 +126,7 @@ class TransitionsModel extends ListModel
 	 */
 	public function getListQuery()
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$query
@@ -223,7 +223,7 @@ class TransitionsModel extends ListModel
 
 		if ($form)
 		{
-			$where = $this->getDbo()->quoteName('workflow_id') . ' = ' . $id . ' AND ' . $this->getDbo()->quoteName('published') . ' = 1';
+			$where = $this->getDatabase()->quoteName('workflow_id') . ' = ' . $id . ' AND ' . $this->getDatabase()->quoteName('published') . ' = 1';
 
 			$form->setFieldAttribute('from_stage', 'sql_where', $where, 'filter');
 			$form->setFieldAttribute('to_stage', 'sql_where', $where, 'filter');

--- a/administrator/components/com_workflow/src/Model/WorkflowsModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowsModel.php
@@ -150,7 +150,7 @@ class WorkflowsModel extends ListModel
 	 */
 	protected function countItems($items)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		$ids = [0];
 
@@ -215,7 +215,7 @@ class WorkflowsModel extends ListModel
 	 */
 	public function getListQuery()
 	{
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$query->select(

--- a/components/com_banners/src/Model/BannerModel.php
+++ b/components/com_banners/src/Model/BannerModel.php
@@ -53,7 +53,7 @@ class BannerModel extends BaseDatabaseModel
 		$id = (int) $this->getState('banner.id');
 
 		// Update click count
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		$query->update($db->quoteName('#__banners'))
@@ -182,7 +182,7 @@ class BannerModel extends BaseDatabaseModel
 			$id = (int) $this->getState('banner.id');
 
 			// For PHP 5.3 compat we can't use $this in the lambda function below, so grab the database driver now to use it
-			$db = $this->getDbo();
+			$db = $this->getDatabase();
 
 			$loader = function ($id) use ($db)
 			{

--- a/components/com_banners/src/Model/BannersModel.php
+++ b/components/com_banners/src/Model/BannersModel.php
@@ -61,7 +61,7 @@ class BannersModel extends ListModel
 	 */
 	protected function getListQuery()
 	{
-		$db         = $this->getDbo();
+		$db         = $this->getDatabase();
 		$query      = $db->getQuery(true);
 		$ordering   = $this->getState('filter.ordering');
 		$tagSearch  = $this->getState('filter.tag_search');
@@ -315,7 +315,7 @@ class BannersModel extends ListModel
 		$trackDate = Factory::getDate()->format('Y-m-d H:00:00');
 		$trackDate = Factory::getDate($trackDate)->toSql();
 		$items     = $this->getItems();
-		$db        = $this->getDbo();
+		$db        = $this->getDatabase();
 		$bid       = [];
 
 		if (!count($items))

--- a/components/com_contact/src/Model/CategoryModel.php
+++ b/components/com_contact/src/Model/CategoryModel.php
@@ -171,7 +171,7 @@ class CategoryModel extends ListModel
 		$groups = $user->getAuthorisedViewLevels();
 
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		/** @var \Joomla\Database\DatabaseQuery $query */
 		$query = $db->getQuery(true);

--- a/components/com_contact/src/Model/ContactModel.php
+++ b/components/com_contact/src/Model/ContactModel.php
@@ -197,7 +197,7 @@ class ContactModel extends FormModel
 		{
 			try
 			{
-				$db    = $this->getDbo();
+				$db    = $this->getDatabase();
 				$query = $db->getQuery(true);
 
 				$query->select($this->getState('item.select', 'a.*'))
@@ -330,7 +330,7 @@ class ContactModel extends FormModel
 	 */
 	protected function buildContactExtendedData($contact)
 	{
-		$db        = $this->getDbo();
+		$db        = $this->getDatabase();
 		$nowDate   = Factory::getDate()->toSql();
 		$user      = Factory::getUser();
 		$groups    = $user->getAuthorisedViewLevels();

--- a/components/com_contact/src/Model/FeaturedModel.php
+++ b/components/com_contact/src/Model/FeaturedModel.php
@@ -87,7 +87,7 @@ class FeaturedModel extends ListModel
 		$groups = $user->getAuthorisedViewLevels();
 
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select required fields from the categories.

--- a/components/com_content/src/Model/ArchiveModel.php
+++ b/components/com_content/src/Model/ArchiveModel.php
@@ -71,7 +71,7 @@ class ArchiveModel extends ArticlesModel
 		$articleOrderDate = $params->get('order_date');
 
 		// No category ordering
-		$secondary = QueryHelper::orderbySecondary($articleOrderby, $articleOrderDate, $this->getDbo());
+		$secondary = QueryHelper::orderbySecondary($articleOrderby, $articleOrderDate, $this->getDatabase());
 
 		$this->setState('list.ordering', $secondary . ', a.created DESC');
 		$this->setState('list.direction', '');
@@ -94,7 +94,7 @@ class ArchiveModel extends ArticlesModel
 		$articleOrderDate = $params->get('order_date');
 
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = parent::getListQuery();
 
 		// Add routing for archive
@@ -107,7 +107,7 @@ class ArchiveModel extends ArticlesModel
 
 		// Filter on month, year
 		// First, get the date field
-		$queryDate = QueryHelper::getQueryDate($articleOrderDate, $this->getDbo());
+		$queryDate = QueryHelper::getQueryDate($articleOrderDate, $this->getDatabase());
 
 		if ($month = (int) $this->getState('filter.month'))
 		{
@@ -166,7 +166,7 @@ class ArchiveModel extends ArticlesModel
 	 */
 	public function getYears()
 	{
-		$db      = $this->getDbo();
+		$db      = $this->getDatabase();
 		$nowDate = Factory::getDate()->toSql();
 		$query   = $db->getQuery(true);
 		$years   = $query->year($db->quoteName('c.created'));
@@ -212,7 +212,7 @@ class ArchiveModel extends ArticlesModel
 	 */
 	private function getSlugColumn($query, $id, $alias)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		return 'CASE WHEN '
 			. $query->charLength($db->quoteName($alias), '!=', '0')

--- a/components/com_content/src/Model/ArticleModel.php
+++ b/components/com_content/src/Model/ArticleModel.php
@@ -95,7 +95,7 @@ class ArticleModel extends ItemModel
 		{
 			try
 			{
-				$db = $this->getDbo();
+				$db = $this->getDatabase();
 				$query = $db->getQuery(true);
 
 				$query->select(
@@ -342,7 +342,7 @@ class ArticleModel extends ItemModel
 			$userIP = IpHelper::getIp();
 
 			// Initialize variables.
-			$db    = $this->getDbo();
+			$db    = $this->getDatabase();
 			$query = $db->getQuery(true);
 
 			// Create the base select statement.

--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -193,7 +193,7 @@ class ArticlesModel extends ListModel
 		$user = Factory::getUser();
 
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		/** @var \Joomla\Database\DatabaseQuery $query */
 		$query = $db->getQuery(true);
@@ -876,7 +876,7 @@ class ArticlesModel extends ListModel
 	public function countItemsByMonth()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Get the list query.

--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -307,7 +307,7 @@ class CategoryModel extends ListModel
 	protected function _buildContentOrderBy()
 	{
 		$app       = Factory::getApplication();
-		$db        = $this->getDbo();
+		$db        = $this->getDatabase();
 		$params    = $this->state->params;
 		$itemid    = $app->input->get('id', 0, 'int') . ':' . $app->input->get('Itemid', 0, 'int');
 		$orderCol  = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.filter_order', 'filter_order', '', 'string');
@@ -332,7 +332,7 @@ class CategoryModel extends ListModel
 		$articleOrderby   = $params->get('orderby_sec', 'rdate');
 		$articleOrderDate = $params->get('order_date');
 		$categoryOrderby  = $params->def('orderby_pri', '');
-		$secondary        = QueryHelper::orderbySecondary($articleOrderby, $articleOrderDate, $this->getDbo()) . ', ';
+		$secondary        = QueryHelper::orderbySecondary($articleOrderby, $articleOrderDate, $this->getDatabase()) . ', ';
 		$primary          = QueryHelper::orderbyPrimary($categoryOrderby);
 
 		$orderby .= $primary . ' ' . $secondary . ' a.created ';

--- a/components/com_content/src/Model/FeaturedModel.php
+++ b/components/com_content/src/Model/FeaturedModel.php
@@ -108,7 +108,7 @@ class FeaturedModel extends ArticlesModel
 		$articleOrderDate = $params->get('order_date');
 		$categoryOrderby  = $params->def('orderby_pri', '');
 
-		$secondary = QueryHelper::orderbySecondary($articleOrderby, $articleOrderDate, $this->getDbo());
+		$secondary = QueryHelper::orderbySecondary($articleOrderby, $articleOrderDate, $this->getDatabase());
 		$primary   = QueryHelper::orderbyPrimary($categoryOrderby);
 
 		$this->setState('list.ordering', $primary . $secondary . ', a.created DESC');

--- a/components/com_content/src/Model/FormModel.php
+++ b/components/com_content/src/Model/FormModel.php
@@ -287,7 +287,7 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
 			{
 				$categoryId = (int) $params->get('catid');
 
-				$db    = $this->getDbo();
+				$db    = $this->getDatabase();
 				$query = $db->getQuery(true)
 					->select($db->quoteName('language'))
 					->from($db->quoteName('#__categories'))

--- a/components/com_finder/src/Model/SearchModel.php
+++ b/components/com_finder/src/Model/SearchModel.php
@@ -132,7 +132,7 @@ class SearchModel extends ListModel
 	protected function getListQuery()
 	{
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select the required fields from the table.

--- a/components/com_finder/src/Model/SuggestionsModel.php
+++ b/components/com_finder/src/Model/SuggestionsModel.php
@@ -70,7 +70,7 @@ class SuggestionsModel extends ListModel
 		$lang   = Helper::getPrimaryLanguage($this->getState('language'));
 
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$termIdQuery = $db->getQuery(true);
 		$termQuery = $db->getQuery(true);
 

--- a/components/com_newsfeeds/src/Model/CategoryModel.php
+++ b/components/com_newsfeeds/src/Model/CategoryModel.php
@@ -160,7 +160,7 @@ class CategoryModel extends ListModel
 		$groups = $user->getAuthorisedViewLevels();
 
 		// Create a new query object.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 
 		/** @var \Joomla\Database\DatabaseQuery $query */
 		$query = $db->getQuery(true);

--- a/components/com_newsfeeds/src/Model/NewsfeedModel.php
+++ b/components/com_newsfeeds/src/Model/NewsfeedModel.php
@@ -87,7 +87,7 @@ class NewsfeedModel extends ItemModel
 		{
 			try
 			{
-				$db = $this->getDbo();
+				$db = $this->getDatabase();
 				$query = $db->getQuery(true)
 					->select(
 						[

--- a/components/com_privacy/src/Model/RemindModel.php
+++ b/components/com_privacy/src/Model/RemindModel.php
@@ -74,7 +74,7 @@ class RemindModel extends AdminModel
 		/** @var ConsentTable $table */
 		$table = $this->getTable();
 
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select($db->quoteName(['r.id', 'r.user_id', 'r.token']));
 		$query->from($db->quoteName('#__privacy_consents', 'r'));

--- a/components/com_privacy/src/Model/RequestModel.php
+++ b/components/com_privacy/src/Model/RequestModel.php
@@ -90,7 +90,7 @@ class RequestModel extends AdminModel
 		$data['email'] = Factory::getUser()->email;
 
 		// Search for an open information request matching the email and type
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('COUNT(id)')
 			->from($db->quoteName('#__privacy_requests'))

--- a/components/com_tags/src/Model/TagsModel.php
+++ b/components/com_tags/src/Model/TagsModel.php
@@ -99,7 +99,7 @@ class TagsModel extends ListModel
 		$language       = $this->getState('tag.language');
 
 		// Create a new query object.
-		$db    = $this->getDbo();
+		$db    = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Select required fields from the tags.

--- a/components/com_users/src/Model/RegistrationModel.php
+++ b/components/com_users/src/Model/RegistrationModel.php
@@ -76,7 +76,7 @@ class RegistrationModel extends FormModel
 	 */
 	public function getUserIdFromToken($token)
 	{
-		$db       = $this->getDbo();
+		$db       = $this->getDatabase();
 
 		// Get the user id based on the token.
 		$query = $db->getQuery(true);
@@ -153,7 +153,7 @@ class RegistrationModel extends FormModel
 			$user->setParam('activate', 1);
 
 			// Get all admin users
-			$db = $this->getDbo();
+			$db = $this->getDatabase();
 			$query = $db->getQuery(true)
 				->select($db->quoteName(array('name', 'email', 'sendEmail', 'id')))
 				->from($db->quoteName('#__users'))
@@ -498,7 +498,7 @@ class RegistrationModel extends FormModel
 		}
 
 		$app = Factory::getApplication();
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true);
 
 		// Compile the notification mail values.
@@ -647,7 +647,7 @@ class RegistrationModel extends FormModel
 			$this->setError(Text::_('COM_USERS_REGISTRATION_SEND_MAIL_FAILED'));
 
 			// Send a system message to administrators receiving system mails
-			$db = $this->getDbo();
+			$db = $this->getDatabase();
 			$query->clear()
 				->select($db->quoteName('id'))
 				->from($db->quoteName('#__users'))

--- a/components/com_users/src/Model/RemindModel.php
+++ b/components/com_users/src/Model/RemindModel.php
@@ -133,7 +133,7 @@ class RemindModel extends FormModel
 		}
 
 		// Find the user id for the given email address.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select('*')
 			->from($db->quoteName('#__users'))

--- a/components/com_users/src/Model/ResetModel.php
+++ b/components/com_users/src/Model/ResetModel.php
@@ -295,7 +295,7 @@ class ResetModel extends FormModel
 		}
 
 		// Find the user id for the given token.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select($db->quoteName(['activation', 'id', 'block']))
 			->from($db->quoteName('#__users'))
@@ -401,7 +401,7 @@ class ResetModel extends FormModel
 		}
 
 		// Find the user id for the given email address.
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$query = $db->getQuery(true)
 			->select($db->quoteName('id'))
 			->from($db->quoteName('#__users'))


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Simple find and replace PR to replace deprecated method `getDbo()` by `getDatabase()` in components models.

### Testing Instructions
1. Code review
2. Or apply patch, access to random pages from frontend and backend, make sure nothing is broken.