### PR TITLE
[4.2] Fix fatal error on users management

### DIFF
--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -14,6 +14,7 @@ namespace Joomla\Component\Users\Administrator\Model;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Form\Form;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -292,12 +293,12 @@ class UsersModel extends ListModel
 	{
 		$form = parent::getFilterForm($data, $loadData);
 
-		if (empty($form) || PluginHelper::isEnabled('multifactorauth'))
+		if ($form && !PluginHelper::isEnabled('multifactorauth'))
 		{
-			return $form;
+			$form->removeField('mfa', 'filter');
 		}
 
-		$form->removeField('mfa', 'filter');
+		return $form;
 	}
 
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR fixes fatal error on Users Management when none Multi-factor Authentication plugins enabled on Joomla 4.2.

### Testing Instructions
1. Use Joomla 4.2 nightly build
2. Go to Users -> Manager

### Actual result BEFORE applying this Pull Request
Get fatal error Call to a member function getGroup() on null

### Expected result AFTER applying this Pull Request
The error is gone