### PR TITLE
Update alternate.xml

### DIFF
--- a/administrator/components/com_menus/presets/alternate.xml
+++ b/administrator/components/com_menus/presets/alternate.xml
@@ -5,10 +5,10 @@
 	xsi:schemaLocation="urn:joomla.org menu.xsd"
 	>
 	<menuitem
-		type="component"
 		title="MOD_MENU_CONTROL_PANEL"
-		link="index.php"
+		type="component"
 		element="com_cpanel"
+		link="index.php?option=com_cpanel&amp;view=cpanel"
 		class="class:home"
 	/>
 	<menuitem


### PR DESCRIPTION
Partial Pull Request for Issue #38032  .

Go to Menu - manage
New menu: enter a name and choose "Alternative Menu Preset"
Save and Close
A new menu is on the menus view

Open the list of menu items

click the first item (home dashboard)
on php 8.1 you will see a deprecated notice
on php < 8.1 you will see the menu item type field is empty

