### PR TITLE
[4.2] Namespace CacheControllerFactoryAwareTraitTest

### DIFF
--- a/tests/Unit/Libraries/Cms/Cache/CacheControllerFactoryAwareTraitTest.php
+++ b/tests/Unit/Libraries/Cms/Cache/CacheControllerFactoryAwareTraitTest.php
@@ -7,7 +7,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-namespace Joomla\Tests\Unit\Libraries\Cms\User;
+namespace Joomla\Tests\Unit\Libraries\Cms\Cache;
 
 use Joomla\CMS\Cache\CacheControllerFactory;
 use Joomla\CMS\Cache\CacheControllerFactoryAwareTrait;

--- a/tests/Unit/Libraries/Cms/Cache/CacheControllerFactoryAwareTraitTest.php
+++ b/tests/Unit/Libraries/Cms/Cache/CacheControllerFactoryAwareTraitTest.php
@@ -14,12 +14,12 @@ use Joomla\CMS\Cache\CacheControllerFactoryAwareTrait;
 use Joomla\Tests\Unit\UnitTestCase;
 
 /**
- * Test class for \Joomla\CMS\MVC\Model\BaseDatabaseModel
+ * Test class for \Joomla\CMS\Cache\CacheControllerFactoryAwareTrait
  *
  * @package     Joomla.UnitTest
- * @subpackage  MVC
+ * @subpackage  Cache
  *
- * @testdoc    The CacheControllerFactoryAwareTrait
+ * @testdoc     The CacheControllerFactoryAwareTrait
  *
  * @since       __DEPLOY_VERSION__
  */

--- a/tests/Unit/Libraries/Cms/Cache/CacheControllerFactoryAwareTraitTest.php
+++ b/tests/Unit/Libraries/Cms/Cache/CacheControllerFactoryAwareTraitTest.php
@@ -11,8 +11,6 @@ namespace Joomla\Tests\Unit\Libraries\Cms\Cache;
 
 use Joomla\CMS\Cache\CacheControllerFactory;
 use Joomla\CMS\Cache\CacheControllerFactoryAwareTrait;
-use Joomla\CMS\User\CurrentUserTrait;
-use Joomla\CMS\User\User;
 use Joomla\Tests\Unit\UnitTestCase;
 
 /**


### PR DESCRIPTION
### Summary of Changes

Adjust Namespace
Remove unsed Import
Fix doc

### Testing Instructions

Run composer install

### Actual result BEFORE applying this Pull Request
It shows the warning:
![image](https://user-images.githubusercontent.com/66922325/174085173-60c63dd5-f857-4215-aacd-552eea527e7d.png)
`Class Joomla\Tests\Unit\Libraries\Cms\User\CacheControllerFactoryAwareTraitTest located in ./tests/Unit/Libraries/Cms/Cache/CacheControllerFactoryAwareTraitTest.php does not comply with psr-4 autoloading standard. Skipping.`

### Expected result AFTER applying this Pull Request

Runs through.
Drone run successfully.
