### PR TITLE
[4.2] Fix missing language strings at installation

### DIFF
--- a/installation/language/en-GB/joomla.ini
+++ b/installation/language/en-GB/joomla.ini
@@ -190,6 +190,9 @@ INSTL_PAGE_TITLE="Joomla Installer"
 INSTL_ERROR_CONNECT_DB="Could not connect to the database. Connector returned number: %d."
 INSTL_STD_OFFLINE_MSG="This site is down for maintenance.<br>Please check back again soon."
 
+; Languages model
+INSTL_ERROR_INVALID_URL="Invalid URL"
+
 ; Others
 INSTL_CONFPROBLEM="Your configuration file or folder is not writable or there was a problem creating the configuration file. You will have to upload the following code by hand. Select in the text area to highlight all of the code and then paste into a new text file. Name this file 'configuration.php' and upload it to your site root folder."
 INSTL_DISPLAY_ERRORS="Display Errors"
@@ -249,6 +252,7 @@ JLIB_INSTALLER_ABORT_CREATE_DIRECTORY="Extension %1$s: Failed to create folder: 
 JLIB_INSTALLER_ABORT_NOINSTALLPATH="Install path does not exist."
 JLIB_INSTALLER_ABORT_PACK_INSTALL_ERROR_EXTENSION="Package %1$s: There was an error installing an extension: %2$s."
 JLIB_INSTALLER_ABORT_PACK_INSTALL_NO_FILES="Package %s: There were no files to install!"
+JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT="Error connecting to the server: %s"
 JLIB_INSTALLER_ERROR_FAIL_COPY_FILE="JInstaller: :Install: Failed to copy file %1$s to %2$s."
 JLIB_INSTALLER_INSTALL="Install"
 JLIB_INSTALLER_NOT_ERROR="If the error is related to the installation of TinyMCE language files it has no effect on the installation of the language(s). Some language packs created prior to Joomla 3.2.0 may try to install separate TinyMCE language files. As these are now included in the core they no longer need to be installed."

--- a/installation/src/Model/LanguagesModel.php
+++ b/installation/src/Model/LanguagesModel.php
@@ -289,7 +289,7 @@ class LanguagesModel extends BaseInstallationModel
 		// Was the package downloaded?
 		if (!$p_file)
 		{
-			$app->enqueueMessage(Text::_('COM_INSTALLER_MSG_INSTALL_INVALID_URL'), 'warning');
+			$app->enqueueMessage(Text::_('INSTL_ERROR_INVALID_URL'), 'warning');
 
 			return false;
 		}


### PR DESCRIPTION
Pull Request for Issue #38077 .

### Summary of Changes

- Add language string `JLIB_INSTALLER_ERROR_DOWNLOAD_SERVER_CONNECT` taken from the "lib_joomla.ini" language file to the installation language file. This is what has been done before with PR #37286 for other languages strings from the library which were not translated in the installation.
- The installer's languages model should not use language string `COM_INSTALLER_MSG_INSTALL_INVALID_URL` from "com_installer.ini". Therefore add a new sting `INSTL_ERROR_INVALID_URL` to the installation language file and use that string instead of the one from the component in the model.

### Testing Instructions

It's very likely that you can't reproduce the errors mentioned in the description of issue #38077 to cause the untranslated string being shown, so we might be limited to code review here.

But if you can reproduce it, then please do a real test and report back how you have tested.

### Actual result BEFORE applying this Pull Request

Untranslated strings mentioned in the issue are shown in certain case of error.

### Expected result AFTER applying this Pull Request

The strings are translated in this particular case of error.

### Documentation Changes Required

None.