### PR TITLE
Fix deprecated warning in Text

### DIFF
--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -94,7 +94,7 @@ class Text
 	private static function passSprintf(&$string, $jsSafe = false, $interpretBackSlashes = true, $script = false)
 	{
 		// Check if string contains a comma
-		if (strpos($string, ',') === false)
+		if (empty($string) || strpos($string, ',') === false)
 		{
 			return false;
 		}


### PR DESCRIPTION
Pull Request for Issue #38032 .

Fix of 
Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in \libraries\src\Language\Text.php on line 97

### Summary of Changes
Exit the method passSprintf() in Text if the String is empty. 


### Testing Instructions
See #38032. 


