### PR TITLE
Fix warnings for in admin sub-menu

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -96,7 +96,7 @@ $itemImage = $currentParams->get('menu_image');
 // Get the menu icon
 $icon      = $this->getIconClass($current);
 $iconClass = ($icon != '' && $current->level == 1) ? '<span class="' . $icon . '" aria-hidden="true"></span>' : '';
-$ajax      = $current->ajaxbadge ? '<span class="menu-badge"><span class="icon-spin icon-spinner mt-1 system-counter" data-url="' . $current->ajaxbadge . '"></span></span>' : '';
+$ajax      = !empty($current->ajaxbadge) ? '<span class="menu-badge"><span class="icon-spin icon-spinner mt-1 system-counter" data-url="' . $current->ajaxbadge . '"></span></span>' : '';
 $iconImage = $current->icon;
 $homeImage = '';
 
@@ -176,7 +176,7 @@ if ($currentParams->get('menu-quicktask') && (int) $this->params->get('shownew',
 	}
 }
 
-if ($current->dashboard)
+if (!empty($current->dashboard))
 {
 	$titleDashboard = Text::sprintf('MOD_MENU_DASHBOARD_LINK', Text::_($current->title));
 	echo '<span class="menu-dashboard"><a href="'


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fix warnings (php 8.1.5)
Warning:  Undefined property: Joomla\CMS\Menu\AdministratorMenuItem::$dashboard in \administrator\modules\mod_menu\tmpl\default_submenu.php on line 179

Warning: Undefined property: Joomla\CMS\Menu\AdministratorMenuItem::$ajaxbadge in modules\mod_menu\tmpl\default_submenu.php on line 99


### Testing Instructions
Code review should do.

Or: Add an own Admin Menu Module to the Backend Menu which has only a few own MenuItems. Activate the revovery mode for this menu. 


### Actual result BEFORE applying this Pull Request

Something like that 

![grafik](https://user-images.githubusercontent.com/1035262/174282024-3a7c1431-6abb-4657-912e-a588b7180bd6.png)


### Expected result AFTER applying this Pull Request

Less warnings.

### Documentation Changes Required

