### PR TITLE
[4.2] mod_article_news dont allow creating new tags

### DIFF
--- a/modules/mod_articles_news/mod_articles_news.xml
+++ b/modules/mod_articles_news/mod_articles_news.xml
@@ -42,6 +42,7 @@
 					multiple="true"
 					filter="intarray"
 					class="multipleTags"
+					custom="deny"
 				/>
 
 				<field


### PR DESCRIPTION
Pull Request for Issue #30525 .

### Summary of Changes
Prevent the ability to create new tags when selecting tags. They're not actually created anyway and it doesnt make sense that you would be able to create a new tag here anyway.

This PR uses a field attribute `custom="deny"` to prevent the fake ability to create a new tag.


### Testing Instructions
Create a few articles with tags
Create a newsflash module and select existing tags AND try to type in a non-existing tag and hit enter

### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/174407230-fd58a519-9ce6-4955-ae64-0f88a5d0cb96.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/174407192-5c7529b1-aafc-486f-9550-84ee751032da.png)



### Documentation Changes Required

