### PR TITLE
[4.2] Banner Tracks Clear

### DIFF
--- a/administrator/components/com_banners/forms/filter_tracks.xml
+++ b/administrator/components/com_banners/forms/filter_tracks.xml
@@ -63,6 +63,7 @@
 			hint="COM_BANNERS_BEGIN_HINT"
 			format="%Y-%m-%d"
 			filter="user_utc"
+			onchange="this.form.submit();"
 		/>
 
 		<field
@@ -72,6 +73,7 @@
 			hint="COM_BANNERS_END_HINT"
 			format="%Y-%m-%d"
 			filter="user_utc"
+			onchange="this.form.submit();"
 		/>
 	</fields>
 	<fields name="list">


### PR DESCRIPTION
Pull Request for Issue #30270 .

### Summary of Changes
Selecting a date filter does not have any effect


### Testing Instructions
Create a banner and make sure you enable tracking for that banner
Publish a banner module and then load the page in the front end a few times
now you have some data in the admin for Banners -> Tracks
Open the filters and select a start date and/or end date


### Actual result BEFORE applying this Pull Request
Nothing happens


### Expected result AFTER applying this Pull Request
page refreshes and the filter is active


### Documentation Changes Required
none
