### PR TITLE
[4.2][cli] cache:clean

### DIFF
--- a/libraries/src/Console/CleanCacheCommand.php
+++ b/libraries/src/Console/CleanCacheCommand.php
@@ -13,6 +13,7 @@ namespace Joomla\CMS\Console;
 use Joomla\CMS\Factory;
 use Joomla\Console\Command\AbstractCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -48,7 +49,30 @@ class CleanCacheCommand extends AbstractCommand
 
 		$symfonyStyle->title('Cleaning System Cache');
 
-		Factory::getCache()->gc();
+		$cache = Factory::getApplication()->bootComponent('com_cache')->getMVCFactory();
+		/** @var Joomla\Component\Cache\Administrator\Model\CacheModel $model */
+		$model = $cache->createModel('Cache', 'Administrator', ['ignore_request' => true]);
+
+		if ($input->getArgument('expired'))
+		{
+			if (!$model->purge())
+			{
+				$symfonyStyle->error('Expired Cache not cleaned');
+
+				return Command::FAILURE;
+			}
+
+			$symfonyStyle->success('Expired Cache cleaned');
+
+			return Command::SUCCESS;
+		}
+
+		if (!$model->clean())
+		{
+			$symfonyStyle->error('Cache not cleaned');
+
+			return Command::FAILURE;
+		}
 
 		$symfonyStyle->success('Cache cleaned');
 

--- a/libraries/src/Console/CleanCacheCommand.php
+++ b/libraries/src/Console/CleanCacheCommand.php
@@ -88,10 +88,11 @@ class CleanCacheCommand extends AbstractCommand
 	 */
 	protected function configure(): void
 	{
-		$help = "<info>%command.name%</info> will clear expired entries from the system cache
+		$help = "<info>%command.name%</info> will clear entries from the system cache
 		\nUsage: <info>php %command.full_name%</info>";
 
-		$this->setDescription('Clean expired cache entries');
+		$this->addArgument('expired', InputArgument::OPTIONAL, 'will clear expired entries from the system cache');
+		$this->setDescription('Clean cache entries');
 		$this->setHelp($help);
 	}
 }

--- a/libraries/src/Console/CleanCacheCommand.php
+++ b/libraries/src/Console/CleanCacheCommand.php
@@ -49,7 +49,7 @@ class CleanCacheCommand extends AbstractCommand
 
 		$symfonyStyle->title('Cleaning System Cache');
 
-		$cache = Factory::getApplication()->bootComponent('com_cache')->getMVCFactory();
+		$cache = $this->getApplication()->bootComponent('com_cache')->getMVCFactory();
 		/** @var Joomla\Component\Cache\Administrator\Model\CacheModel $model */
 		$model = $cache->createModel('Cache', 'Administrator', ['ignore_request' => true]);
 


### PR DESCRIPTION
Pull Request for Issue #37646 .

### Summary of Changes
- added `expired` argument


### Testing Instructions
run `php cli/joomla.php cache:clean`
or
run `php cli/joomla.php cache:clean expired`

check the cache in the admin or cache storage



### Actual result BEFORE applying this Pull Request

cache not cleaned


### Expected result AFTER applying this Pull Request

cache cleaned

### Documentation Changes Required

