### PR TITLE
[4.2] Post-installation messages UX #38064 code optimization

### DIFF
--- a/administrator/components/com_postinstall/src/Controller/MessageController.php
+++ b/administrator/components/com_postinstall/src/Controller/MessageController.php
@@ -35,7 +35,7 @@ class MessageController extends BaseController
 		$this->checkToken('get');
 
 		/** @var MessagesModel $model */
-		$model = $this->getModel('Messages', '', array('ignore_request' => true));
+		$model = $this->getModel('Messages', '', ['ignore_request' => true]);
 		$eid = $this->input->getInt('eid');
 
 		if (empty($eid))
@@ -57,7 +57,7 @@ class MessageController extends BaseController
 	 */
 	public function unpublish()
 	{
-		$model = $this->getModel('Messages', '', array('ignore_request' => true));
+		$model = $this->getModel('Messages', '', ['ignore_request' => true]);
 
 		$id = $this->input->get('id');
 
@@ -83,7 +83,7 @@ class MessageController extends BaseController
 	 */
 	public function republish()
 	{
-		$model = $this->getModel('Messages', '', array('ignore_request' => true));
+		$model = $this->getModel('Messages', '', ['ignore_request' => true]);
 
 		$id = $this->input->get('id');
 
@@ -109,7 +109,7 @@ class MessageController extends BaseController
 	 */
 	public function archive()
 	{
-		$model = $this->getModel('Messages', '', array('ignore_request' => true));
+		$model = $this->getModel('Messages', '', ['ignore_request' => true]);
 
 		$id = $this->input->get('id');
 
@@ -137,7 +137,7 @@ class MessageController extends BaseController
 	{
 		$this->checkToken('get');
 
-		$model = $this->getModel('Messages', '', array('ignore_request' => true));
+		$model = $this->getModel('Messages', '', ['ignore_request' => true]);
 
 		$id = $this->input->get('id');
 
@@ -178,7 +178,7 @@ class MessageController extends BaseController
 		$this->checkToken();
 
 		/** @var MessagesModel $model */
-		$model = $this->getModel('Messages', '', array('ignore_request' => true));
+		$model = $this->getModel('Messages', '', ['ignore_request' => true]);
 		$eid = $this->input->getInt('eid');
 
 		if (empty($eid))

--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -131,7 +131,7 @@ class MessagesModel extends BaseDatabaseModel
 	 */
 	public function archiveMessage($id)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$id = (int) $id;
 
 		$query = $db->getQuery(true);
@@ -156,7 +156,7 @@ class MessagesModel extends BaseDatabaseModel
 	 */
 	public function republishMessage($id)
 	{
-		$db = $this->getDbo();
+		$db = $this->getDatabase();
 		$id = (int) $id;
 
 		$query = $db->getQuery(true);

--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -210,7 +210,7 @@ class MessagesModel extends BaseDatabaseModel
 			->bind(':eid', $eid, ParameterType::INTEGER);
 
 		// Force filter only enabled messages
-		$query->where($db->quoteName('enabled') . ' IN (1,2)');
+		$query->whereIn($db->quoteName('enabled'), [1, 2]);
 		$db->setQuery($query);
 
 		try


### PR DESCRIPTION
Pull Request for PR #38064 .

### Summary of Changes

- Use short array syntax https://github.com/joomla/joomla-cms/pull/38064#discussion_r898053882
- Replace deprecated method getDbo() by getDatabase() #38023
- Replace `where` with `whereIn` in database query

### Testing Instructions

Test the function of buttons at post-installation messages

### Actual result BEFORE applying this Pull Request

use of deprecated function

### Expected result AFTER applying this Pull Request

code optimization