### PR TITLE
[PHP8.1] Contact data deprecated errors

### DIFF
--- a/administrator/components/com_contact/src/Table/ContactTable.php
+++ b/administrator/components/com_contact/src/Table/ContactTable.php
@@ -110,10 +110,16 @@ class ContactTable extends Table implements VersionableTableInterface, TaggableT
 		}
 
 		// Store utf8 email as punycode
-		$this->email_to = PunycodeHelper::emailToPunycode($this->email_to);
+		if ($this->email_to !== null)
+		{
+			$this->email_to = PunycodeHelper::emailToPunycode($this->email_to);
+		}
 
 		// Convert IDN urls to punycode
-		$this->webpage = PunycodeHelper::urlToPunycode($this->webpage);
+		if ($this->webpage !== null)
+		{
+			$this->webpage = PunycodeHelper::urlToPunycode($this->webpage);
+		}
 
 		// Verify that the alias is unique
 		$table = Table::getInstance('ContactTable', __NAMESPACE__ . '\\', array('dbo' => $this->getDbo()));

--- a/administrator/components/com_contact/src/Table/ContactTable.php
+++ b/administrator/components/com_contact/src/Table/ContactTable.php
@@ -151,7 +151,7 @@ class ContactTable extends Table implements VersionableTableInterface, TaggableT
 
 		$this->default_con = (int) $this->default_con;
 
-		if (InputFilter::checkAttribute(array('href', $this->webpage)))
+		if ($this->webpage !== null && InputFilter::checkAttribute(array('href', $this->webpage)))
 		{
 			$this->setError(Text::_('COM_CONTACT_WARNING_PROVIDE_VALID_URL'));
 


### PR DESCRIPTION
Fixes deprecated notices when creating contacts with either empty websites or emails. Cause the test sample data to fail to install at the contact stage on PHP 8.1 currently (note after this PR then the newsfeeds fail to install instead - which requires https://github.com/joomla/joomla-cms/pull/38102)