### PR TITLE
[PHP 8.1] Fix indexing newsfeeds with no summary

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -315,7 +315,7 @@ class Indexer
 		$item->end_date = (int) $item->end_date != 0 ? $item->end_date : null;
 
 		// Prepare the item description.
-		$item->description = Helper::parse($item->summary);
+		$item->description = Helper::parse($item->summary ?? '');
 
 		/*
 		 * Now, we need to enter the item into the links table. If the item


### PR DESCRIPTION
### Summary of Changes
Fixes indexing news feed items when creating sample data. If no summary is present then it needs a string and not null.

### Testing Instructions
Requires parallel application of https://github.com/joomla/joomla-cms/pull/38101

Install sample data from Joomla

### Actual result BEFORE applying this Pull Request
Errors installing sample data

### Expected result AFTER applying this Pull Request
Sample data successfully installs

### Documentation Changes Required
N/A