### PR TITLE
[4.2] cli update extension check

### DIFF
--- a/libraries/src/Console/CheckUpdatesCommand.php
+++ b/libraries/src/Console/CheckUpdatesCommand.php
@@ -52,7 +52,7 @@ class CheckUpdatesCommand extends AbstractCommand
 		// Get the update cache time
 		$component = ComponentHelper::getComponent('com_installer');
 
-		$cache_timeout = 3600 * (int) $component->getParams()->get('cachetimeout', 6);
+		$cache_timeout = (int) $component->getParams()->get('cachetimeout', 6);
 
 		// Find all updates
 		$ret = Updater::getInstance()->findUpdates(0, $cache_timeout);


### PR DESCRIPTION
Pull Request for Issue #37643 .

### Summary of Changes
The cache timeout was incorrectly set at 3600 x 6 HOURS

### Steps to reproduce the issue
Install older versions of a few extensions
Check that the updates are found 

![image](https://user-images.githubusercontent.com/1296369/164998661-c7f8d52f-d8e0-4889-9ddf-6408ad7a2c79.png)

From the cli run

`php cli/joomla.php update:extensions:check`

### Expected result
 ! [NOTE] There are available updates to apply

![image](https://user-images.githubusercontent.com/1296369/174978795-3356c61d-1fd2-47c3-a58a-6b370d1a4ee7.png)


### Actual result
 [OK] There are no available updates                 
![image](https://user-images.githubusercontent.com/1296369/164998698-5b8964f6-4036-419c-b8f6-e5f20184def2.png)


