### PR TITLE
in updates XML always resulted in an error

### DIFF
--- a/administrator/language/en-GB/lib_joomla.ini
+++ b/administrator/language/en-GB/lib_joomla.ini
@@ -758,3 +758,11 @@ JLIB_SIZE_PB="PiB"
 JLIB_SIZE_EB="EiB"
 JLIB_SIZE_ZB="ZiB"
 JLIB_SIZE_YB="YiB"
+
+; Database server technology types in human readable terms. Used in the Updater package.
+JLIB_DB_SERVER_TYPE_MARIADB="MariaDB"
+JLIB_DB_SERVER_TYPE_MSSQL="Microsoft SQL Server"
+JLIB_DB_SERVER_TYPE_MYSQL="MySQL"
+JLIB_DB_SERVER_TYPE_ORACLE="Oracle"
+JLIB_DB_SERVER_TYPE_POSTGRESQL="PostgreSQL"
+JLIB_DB_SERVER_TYPE_SQLITE="SQLite"

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -155,10 +155,13 @@ class ExtensionAdapter extends UpdateAdapter
 							}
 						}
 
+						// $supportedDbs has uppercase keys because they are XML attribute names
+						$dbTypeUcase = strtoupper($dbType);
+
 						// Do we have an entry for the database?
-						if (in_array($dbType, array_map('strtolower', array_keys($supportedDbs))))
+						if (\array_key_exists($dbTypeUcase, $supportedDbs))
 						{
-							$minimumVersion = $supportedDbs[$dbType];
+							$minimumVersion = $supportedDbs[$dbTypeUcase];
 							$dbMatch        = version_compare($dbVersion, $minimumVersion, '>=');
 
 							if (!$dbMatch)
@@ -168,7 +171,7 @@ class ExtensionAdapter extends UpdateAdapter
 									'JLIB_INSTALLER_AVAILABLE_UPDATE_DB_MINIMUM',
 									$this->currentUpdate->name,
 									$this->currentUpdate->version,
-									Text::_($db->name),
+									Text::_('JLIB_DB_SERVER_TYPE_' . $dbTypeUcase),
 									$dbVersion,
 									$minimumVersion
 								);
@@ -183,7 +186,7 @@ class ExtensionAdapter extends UpdateAdapter
 								'JLIB_INSTALLER_AVAILABLE_UPDATE_DB_TYPE',
 								$this->currentUpdate->name,
 								$this->currentUpdate->version,
-								Text::_('JLIB_DB_SERVER_TYPE_' . $dbType)
+								Text::_('JLIB_DB_SERVER_TYPE_' . $dbTypeUcase)
 							);
 
 							Factory::getApplication()->enqueueMessage($dbMsg, 'warning');

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -156,7 +156,7 @@ class ExtensionAdapter extends UpdateAdapter
 						}
 
 						// Do we have an entry for the database?
-						if (\array_key_exists($dbType, $supportedDbs))
+						if (in_array($dbType, array_map('strtolower', array_keys($supportedDbs))))
 						{
 							$minimumVersion = $supportedDbs[$dbType];
 							$dbMatch        = version_compare($dbVersion, $minimumVersion, '>=');
@@ -183,7 +183,7 @@ class ExtensionAdapter extends UpdateAdapter
 								'JLIB_INSTALLER_AVAILABLE_UPDATE_DB_TYPE',
 								$this->currentUpdate->name,
 								$this->currentUpdate->version,
-								Text::_($db->name)
+								Text::_('JLIB_DB_SERVER_TYPE_' . $dbType)
 							);
 
 							Factory::getApplication()->enqueueMessage($dbMsg, 'warning');


### PR DESCRIPTION
Pull Request for Issue #38117 .

### Summary of Changes

Updates `\Joomla\CMS\Updater\Adapter\ExtensionAdapter` to support the `<supported_databases>` tag in XML update files correctly.

Moreover, fixes the message when there is no supported database to display the DB server technology type, not the DB connector type (therefore mysqli and pdomysql / mysql will all be referred to as “MySQL”, whereas the same connectors on a MariaDB server will be referred to as “MariaDB”).

### Testing Instructions

* Install an older version of an extension with <supported_databases> in its XML update file, e.g. https://github.com/lucid-fox/social-magick/releases/download/1.0.1/socialmagick-1.0.1.zip
* Go to System, Update, Extensions
* Click on Check for Updates

### Actual result BEFORE applying this Pull Request

A bunch of misleading warnings:

* For the extension Social Magick version 1.0.2 is available, but your current database MySQL (PDO) is not supported anymore.
* For the extension Social Magick version 1.0.1 is available, but your current database MySQL (PDO) is not supported anymore.
* For the extension Social Magick version 1.0.0 is available, but your current database MySQL (PDO) is not supported anymore.

### Expected result AFTER applying this Pull Request

Update found, no warnings.

### Documentation Changes Required

None

### Translation impact

Added six new translation strings: JLIB_DB_SERVER_TYPE_MARIADB, JLIB_DB_SERVER_TYPE_MYSQL, JLIB_DB_SERVER_TYPE_POSTGRESQL, JLIB_DB_SERVER_TYPE_ORACLE, JLIB_DB_SERVER_TYPE_SQLITE, JLIB_DB_SERVER_TYPE_MSSQL

However, these strings are product names and do not need to be translated; they just need to be copied verbatim into language files by the translation teams.