### PR TITLE
Update ExtensionAdapter.php

### DIFF
--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -139,7 +139,7 @@ class ExtensionAdapter extends UpdateAdapter
 					if (isset($this->currentUpdate->supported_databases))
 					{
 						$db           = Factory::getDbo();
-						$dbType       = strtolower($db->getServerType());
+						$dbType       = strtoupper($db->getServerType());
 						$dbVersion    = $db->getVersion();
 						$supportedDbs = $this->currentUpdate->supported_databases;
 


### PR DESCRIPTION
Line 142 needs to be reverted back to 'strtoupper'. It can't be 'strtolower' as the keys in array $supportedDbs are all upper case. Thus, when checking for the $dbType (value of $dbType was 'mysql' in my testing)  in $supportedDbskey array (
  'MYSQL' => '5.5.3',
  'POSTGRESQL' => '9.1',
  'MSSQL' => '10.50.1600.1',
  'MARIADB' => '10.1',
), it won't be found, because the case is different. The user will see the message: "For the extension SOME_EXTENSION_NAME_VERSION_XXX is available, but your current database MySQLi is not supported anymore."

Pull Request for Issue # .

### Summary of Changes

On line 142, revert "strtolower" to "strtoupper"

### Testing Instructions

Install an extension that has the following line in its update file: "<supported_databases mysql="5.5.3" postgresql="9.1" mssql="10.50.1600.1" mariadb="10.1"/>", and make sure your mysql database version is greater than 5.5.3 (most are 5.7+), then go to System > Extensions Update, then click on "Check for Updates"

### Actual result BEFORE applying this Pull Request

You will get a notice which says "For the extension SOME_EXTENSION_NAME_VERSION_XXX is available, but your current database MySQLi is not supported anymore." You are unable to update the extension via the updater. So the site admin thinks that the extension is not compatible any more, but this is not the case. 

### Expected result AFTER applying this Pull Request

No notice is shown, and you can update the extension via the updater.

### Documentation Changes Required

