### PR TITLE
[4.2] Fix fatal error on webauthn plugin

### DIFF
--- a/plugins/multifactorauth/webauthn/tmpl/default.php
+++ b/plugins/multifactorauth/webauthn/tmpl/default.php
@@ -13,7 +13,6 @@ defined('_JEXEC') || die;
 //phpcs:ignorefile
 
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Uri\Uri;
 
 // This method is only available on HTTPS
@@ -33,7 +32,7 @@ if (Uri::getInstance()->getScheme() !== 'https'): ?>
 	return;
 endif;
 
-$this->app->getDocument()->getWebAssetManager()->useScript('plg_multifactorauth_webauthn.webauthn');
+$this->getApplication()->getDocument()->getWebAssetManager()->useScript('plg_multifactorauth_webauthn.webauthn');
 
 ?>
 <div id="multifactorauth-webauthn-missing" class="my-2">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
PR https://github.com/joomla/joomla-cms/pull/38060/ removed `$app` property from the class, so using `$this->app` in the layout causes fatal error. We need to use `$this->getApplication()` to get application object instead.

I also removed an un-used use statement in the plugin layout code.

### Testing Instructions
I don't have experience with using the plugin, so please ignore if my testing instructions are wrong

1. Use Joomla 4.2 nightly build
2. Make sure **Multi-factor Authentication - Web Authentication** plugin is enabled
3. Login to administrator area of your site, edit an user account, look at **Multi-factor Authentication** tab, click on **Add a new Web Authentication** button.

### Actual result BEFORE applying this Pull Request
Get fatal error: **Call to a member function getDocument() on null**


### Expected result AFTER applying this Pull Request
Error is gone, the page loads OK

