### PR TITLE
Skip Session Manager tests on PHP 8.1 as old version of PHPUnit

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -59,7 +59,6 @@ steps:
   - name: php81-unit
     depends_on: [ phpcs ]
     image: joomlaprojects/docker-images:php8.1
-    failure: ignore
     commands:
       - php -v
       - ./libraries/vendor/bin/phpunit --testsuite Unit
@@ -88,7 +87,6 @@ steps:
   - name: php80-integration
     depends_on: [ npm ]
     image: joomlaprojects/docker-images:php8.0
-    failure: ignore
     commands:
       - php -v
       - ./libraries/vendor/bin/phpunit --testsuite Integration
@@ -131,7 +129,6 @@ steps:
   - name: php80-integration-pgsql
     depends_on: [ npm ]
     image: joomlaprojects/docker-images:php8.0
-    failure: ignore
     commands:
       - php -v
       - ./libraries/vendor/bin/phpunit --testsuite Integration --configuration phpunit-pgsql.xml.dist

--- a/.drone.yml
+++ b/.drone.yml
@@ -475,6 +475,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 234ae9e7e2fbfa114ba754c68056dec518c76a93de2f5b098f569e355b50cc1b
+hmac: d5db8148323f0205a8c0cd165da3934f5a77b25f73862d09ead95d3c42f1df01
 
 ...

--- a/tests/Unit/Libraries/Cms/Session/SessionManagerTest.php
+++ b/tests/Unit/Libraries/Cms/Session/SessionManagerTest.php
@@ -46,6 +46,7 @@ class SessionManagerTest extends UnitTestCase
 	 */
 	protected function setUp(): void
 	{
+		// @todo remove this after upgrading phpunit to 9+ see https://github.com/sebastianbergmann/phpunit/issues/4879
 		if (version_compare(phpversion(), '8.1.0', '>='))
 		{
 			/**

--- a/tests/Unit/Libraries/Cms/Session/SessionManagerTest.php
+++ b/tests/Unit/Libraries/Cms/Session/SessionManagerTest.php
@@ -46,6 +46,15 @@ class SessionManagerTest extends UnitTestCase
 	 */
 	protected function setUp(): void
 	{
+		if (version_compare(phpversion(), '8.1.0', '>='))
+		{
+			/**
+			 * See https://github.com/sebastianbergmann/phpunit/issues/4879 - we'll need a higher phpunit version for 8.1 and
+			 * higher for this to work
+			 */
+			$this->markTestSkipped('PHPUnit 8 cannot mock SessionHandlerInterface in PHP 8.1 and higher');
+		}
+
 		$this->sessionHandler = $this->createMock(\SessionHandlerInterface::class);
 
 		$this->manager = new SessionManager($this->sessionHandler);


### PR DESCRIPTION
Works around https://github.com/sebastianbergmann/phpunit/issues/4879 by skipping these tests for now. At least the remaining tests after this patch run successfully