### PR TITLE
[4.x] Fix TinyMCE ext-buttons options

### DIFF
--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -87,34 +87,37 @@ trait DisplayTrait
 		// Prepare the instance specific options
 		if (empty($options['tinyMCE'][$fieldName]))
 		{
-			// Width and height
-			if ($width)
-			{
-				$options['tinyMCE'][$fieldName]['width'] = $width;
-			}
-
-			if ($height)
-			{
-				$options['tinyMCE'][$fieldName]['height'] = $height;
-			}
-
-			// Set editor to readonly mode
-			if (!empty($params['readonly']))
-			{
-				$options['tinyMCE'][$fieldName]['readonly'] = 1;
-			}
-
-			// The ext-buttons
-			if (empty($options['tinyMCE'][$fieldName]['joomlaExtButtons']))
-			{
-				$btns = $this->tinyButtons($id, $buttons);
-
-				$options['tinyMCE'][$fieldName]['joomlaMergeDefaults'] = true;
-				$options['tinyMCE'][$fieldName]['joomlaExtButtons']    = $btns;
-			}
-
-			$doc->addScriptOptions('plg_editor_tinymce', $options, false);
+			$options['tinyMCE'][$fieldName] = [];
 		}
+
+		// Width and height
+		if ($width && empty($options['tinyMCE'][$fieldName]['width']))
+		{
+			$options['tinyMCE'][$fieldName]['width'] = $width;
+		}
+
+		if ($height && empty($options['tinyMCE'][$fieldName]['height']))
+		{
+			$options['tinyMCE'][$fieldName]['height'] = $height;
+		}
+
+		// Set editor to readonly mode
+		if (!empty($params['readonly']))
+		{
+			$options['tinyMCE'][$fieldName]['readonly'] = 1;
+		}
+
+		// The ext-buttons
+		if (empty($options['tinyMCE'][$fieldName]['joomlaExtButtons']))
+		{
+			$btns = $this->tinyButtons($id, $buttons);
+
+			$options['tinyMCE'][$fieldName]['joomlaMergeDefaults'] = true;
+			$options['tinyMCE'][$fieldName]['joomlaExtButtons']    = $btns;
+		}
+
+		$doc->addScriptOptions('plg_editor_tinymce', $options, false);
+
 
 		// Setup Default (common) options for the Editor script
 

--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -117,8 +117,6 @@ trait DisplayTrait
 		}
 
 		$doc->addScriptOptions('plg_editor_tinymce', $options, false);
-
-
 		// Setup Default (common) options for the Editor script
 
 		// Check whether we already have them


### PR DESCRIPTION
Pull Request for Issue #38127 

### Summary of Changes
Add options with better check


### Testing Instructions
Follow #38127.

Or edit https://github.com/joomla/joomla-cms/blob/bb2e172b059d0fa6de3a180c09179c45945a8143/administrator/components/com_content/src/View/Article/HtmlView.php#L80-L81

Add there:
```php
\JFactory::getDocument()->addScriptOptions('plg_editor_tinymce', [
	'tinyMCE' => [
		'articletext' => [
			'quickbars_selection_toolbar' => 'bold italic | blockquote link',
		],
	],
]);
```
And open article editing.

Addittionaly: please repeat test from #37964

### Actual result BEFORE applying this Pull Request
The editor is broken


### Expected result AFTER applying this Pull Request
All works


### Documentation Changes Required
none
