### PR TITLE
Fix multiselect when not all rows have checkboxes

### DIFF
--- a/build/media_source/system/js/multiselect.es6.js
+++ b/build/media_source/system/js/multiselect.es6.js
@@ -66,12 +66,14 @@
         return;
       }
 
-      const currentRowNum = this.rows.indexOf(target.closest('tr'));
-      const currentCheckBox = this.checkallToggle ? currentRowNum + 1 : currentRowNum;
-      let isChecked = this.boxes[currentCheckBox].checked;
+      const closestRow = target.closest('tr');
+      const currentRowNum = this.rows.indexOf(closestRow);
+      const currentCheckBox = closestRow.querySelector('td input[type=checkbox]');
 
-      if (currentCheckBox >= 0) {
-        if (!(target.id === this.boxes[currentCheckBox].id)) {
+      if (currentCheckBox) {
+        let isChecked = currentCheckBox.checked;
+
+        if (!(target.id === currentCheckBox.id)) {
           // We will prevent selecting text to prevent artifacts
           if (shiftKey) {
             document.body.style['-webkit-user-select'] = 'none';
@@ -80,12 +82,12 @@
             document.body.style['user-select'] = 'none';
           }
 
-          this.boxes[currentCheckBox].checked = !this.boxes[currentCheckBox].checked;
-          isChecked = this.boxes[currentCheckBox].checked;
-          Joomla.isChecked(this.boxes[currentCheckBox].checked, this.tableEl.id);
+          currentCheckBox.checked = !currentCheckBox.checked;
+          isChecked = currentCheckBox.checked;
+          Joomla.isChecked(isChecked, this.tableEl.id);
         }
 
-        this.changeBg(this.rows[currentCheckBox - 1], isChecked);
+        this.changeBg(this.rows[currentRowNum], isChecked);
 
         // Restore normality
         if (shiftKey) {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/38021.

@dgrammatiko would appreciate a review here. Somehow i feel like after this populating `this.boxes` is now overkill but not really sure of a good way to make that optimization after this. Feels like this is 'good enough' though

### Summary of Changes
Fixes the behaviour of multiselect when not all rows have a checkbox (because of ACL restrictions)

### Testing Instructions
See reproduction steps in linked issue

### Actual result BEFORE applying this Pull Request
Multiselect highlights wrong row, when not a super admin in com_users

### Expected result AFTER applying this Pull Request
Multiselect highlights the right row both when super admin with full permissions and as a restricted user.

### Documentation Changes Required
n/a
