### PR TITLE
Change PHP code style to PSR-12 for the build folder

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Script used to build Joomla distribution archive packages
  * Builds packages in tmp/packages folder (for example, 'build/tmp/packages')
@@ -31,174 +32,174 @@ const PHP_TAB = "\t";
 
 function usage(string $command)
 {
-	echo PHP_EOL;
-	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
-	echo PHP_TAB . '[options]:' . PHP_EOL;
-	echo PHP_TAB . PHP_TAB . '--remote=<remote>:' . PHP_TAB . 'The git remote reference to build from (ex: `tags/3.8.6`, `4.0-dev`), defaults to the most recent tag for the repository' . PHP_EOL;
-	echo PHP_TAB . PHP_TAB . '--exclude-zip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .zip packages' . PHP_EOL;
-	echo PHP_TAB . PHP_TAB . '--exclude-gzip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .tar.gz packages' . PHP_EOL;
-	echo PHP_TAB . PHP_TAB . '--exclude-bzip2:' . PHP_TAB . 'Exclude the generation of .tar.bz2 packages' . PHP_EOL;
-	echo PHP_TAB . PHP_TAB . '--include-zstd:' . PHP_TAB . 'Include the generation of .tar.zst packages' . PHP_EOL;
-	echo PHP_TAB . PHP_TAB . '--help:' . PHP_TAB . PHP_TAB . PHP_TAB . 'Show this help output' . PHP_EOL;
-	echo PHP_EOL;
+    echo PHP_EOL;
+    echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
+    echo PHP_TAB . '[options]:' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--remote=<remote>:' . PHP_TAB . 'The git remote reference to build from (ex: `tags/3.8.6`, `4.0-dev`), defaults to the most recent tag for the repository' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--exclude-zip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .zip packages' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--exclude-gzip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .tar.gz packages' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--exclude-bzip2:' . PHP_TAB . 'Exclude the generation of .tar.bz2 packages' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--include-zstd:' . PHP_TAB . 'Include the generation of .tar.zst packages' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--help:' . PHP_TAB . PHP_TAB . PHP_TAB . 'Show this help output' . PHP_EOL;
+    echo PHP_EOL;
 }
 
 function clean_checkout(string $dir)
 {
-	// Save the current working directory to restore when complete
-	$cwd = getcwd();
-	chdir($dir);
+    // Save the current working directory to restore when complete
+    $cwd = getcwd();
+    chdir($dir);
 
-	echo "Cleaning checkout in $dir.\n";
+    echo "Cleaning checkout in $dir.\n";
 
-	// Removes .DS_Store; .git sources; testing, CI, and IDE configuration files; Changelogs; GitHub Meta; and README files
-	system('find . -name .appveyor.yml | xargs rm -rf -');
-	system('find . -name .coveralls.yml | xargs rm -rf -');
-	system('find . -name .DS_Store | xargs rm -rf -');
-	system('find . -name .editorconfig | xargs rm -rf -');
-	system('find . -name .gitattributes | xargs rm -rf -');
-	system('find . -name .github | xargs rm -rf -');
-	system('find . -name .gitignore | xargs rm -rf -');
-	system('find . -name .gitmodules | xargs rm -rf -');
-	system('find . -name .php-cs-fixer.dist.php | xargs rm -rf -');
-	system('find . -name .scrutinizer.yml | xargs rm -rf -');
-	system('find . -name .travis.yml | xargs rm -rf -');
-	system('find . -name appveyor.yml | xargs rm -rf -');
-	system('find . -name CHANGELOG.md | xargs rm -rf -');
-	system('find . -name CONTRIBUTING.md | xargs rm -rf -');
-	system('find . -name psalm.xml | xargs rm -rf -');
-	system('find . -name psalm.xml.dist | xargs rm -rf -');
-	system('find . -name phpcs.xml | xargs rm -rf -');
-	system('find . -name phpcs.xml.dist | xargs rm -rf -');
-	system('find . -name phpunit.xml | xargs rm -rf -');
-	system('find . -name phpunit.*.xml | xargs rm -rf -');
-	system('find . -name phpunit.xml.dist | xargs rm -rf -');
-	system('find . -name README.md | xargs rm -rf -');
-	system('find . -name SECURITY.md | xargs rm -rf -');
+    // Removes .DS_Store; .git sources; testing, CI, and IDE configuration files; Changelogs; GitHub Meta; and README files
+    system('find . -name .appveyor.yml | xargs rm -rf -');
+    system('find . -name .coveralls.yml | xargs rm -rf -');
+    system('find . -name .DS_Store | xargs rm -rf -');
+    system('find . -name .editorconfig | xargs rm -rf -');
+    system('find . -name .gitattributes | xargs rm -rf -');
+    system('find . -name .github | xargs rm -rf -');
+    system('find . -name .gitignore | xargs rm -rf -');
+    system('find . -name .gitmodules | xargs rm -rf -');
+    system('find . -name .php-cs-fixer.dist.php | xargs rm -rf -');
+    system('find . -name .scrutinizer.yml | xargs rm -rf -');
+    system('find . -name .travis.yml | xargs rm -rf -');
+    system('find . -name appveyor.yml | xargs rm -rf -');
+    system('find . -name CHANGELOG.md | xargs rm -rf -');
+    system('find . -name CONTRIBUTING.md | xargs rm -rf -');
+    system('find . -name psalm.xml | xargs rm -rf -');
+    system('find . -name psalm.xml.dist | xargs rm -rf -');
+    system('find . -name phpcs.xml | xargs rm -rf -');
+    system('find . -name phpcs.xml.dist | xargs rm -rf -');
+    system('find . -name phpunit.xml | xargs rm -rf -');
+    system('find . -name phpunit.*.xml | xargs rm -rf -');
+    system('find . -name phpunit.xml.dist | xargs rm -rf -');
+    system('find . -name README.md | xargs rm -rf -');
+    system('find . -name SECURITY.md | xargs rm -rf -');
 
-	echo "Cleaning vendors.\n";
+    echo "Cleaning vendors.\n";
 
-	system('find libraries/vendor -name CODE_OF_CONDUCT.md | xargs rm -rf -');
-	system('find libraries/vendor -name CONDUCT.md | xargs rm -rf -');
-	system('find libraries/vendor -name docker-compose.yml | xargs rm -rf -');
-	system('find libraries/vendor -name phpunit.xml | xargs rm -rf -');
-	system('find libraries/vendor -name README.md | xargs rm -rf -');
-	system('find libraries/vendor -name readme.md | xargs rm -rf -');
-	system('find libraries/vendor -name UPGRADING.md | xargs rm -rf -');
-	system('find libraries/vendor -name SUMMARY.md | xargs rm -rf -');
-	system('find libraries/vendor -name .travis.yml | xargs rm -rf -');
-	system('find libraries/vendor -name .git | xargs rm -rf -');
-	system('find libraries/vendor -name .gitignore | xargs rm -rf -');
-	system('find libraries/vendor -name .gitmodules | xargs rm -rf -');
-	system('find libraries/vendor -name ISSUE_TEMPLATE | xargs rm -rf -');
-	system('find libraries/vendor -name CONTRIBUTING.md | xargs rm -rf -');
-	system('find libraries/vendor -name CHANGES.md | xargs rm -rf -');
-	system('find libraries/vendor -name CHANGELOG.md | xargs rm -rf -');
-	system('find libraries/vendor -name SECURITY.md | xargs rm -rf -');
-	system('find libraries/vendor -name psalm.md | xargs rm -rf -');
-	system('find libraries/vendor -name psalm-baseline.md | xargs rm -rf -');
-	system('find libraries/vendor -name psalm-baseline.xml | xargs rm -rf -');
-	system('find libraries/vendor -name .yamllint | xargs rm -rf -');
-	system('find libraries/vendor -name .remarkrc | xargs rm -rf -');
-	system('find libraries/vendor -name .editorconfig | xargs rm -rf -');
-	system('find libraries/vendor -name appveyor.yml | xargs rm -rf -');
-	system('find libraries/vendor -name phpunit.xml.dist | xargs rm -rf -');
-	system('find libraries/vendor -name .php_cs | xargs rm -rf -');
-	system('find libraries/vendor -name .php_cs.dist | xargs rm -rf -');
-	system('find libraries/vendor -name phpcs.xsd | xargs rm -rf -');
-	system('find libraries/vendor -name phpcs.xml | xargs rm -rf -');
-	system('find libraries/vendor -name build.xml | xargs rm -rf -');
-	system('find libraries/vendor -name infection.json.dist | xargs rm -rf -');
-	system('find libraries/vendor -name phpbench.json | xargs rm -rf -');
-	system('find libraries/vendor -name phpstan.neon.dist | xargs rm -rf -');
-	system('find libraries/vendor -name .doctrine-project.json | xargs rm -rf -');
-	system('find libraries/vendor -name .pullapprove.yml | xargs rm -rf -');
-	system('find libraries/vendor -name phpstan.neon | xargs rm -rf -');
-	system('find libraries/vendor -name _config.yml | xargs rm -rf -');
-	system('find libraries/vendor -name .bowerrc | xargs rm -rf -');
-	system('find libraries/vendor -name bower.json | xargs rm -rf -');
-	system('rm -rf libraries/vendor/bin');
+    system('find libraries/vendor -name CODE_OF_CONDUCT.md | xargs rm -rf -');
+    system('find libraries/vendor -name CONDUCT.md | xargs rm -rf -');
+    system('find libraries/vendor -name docker-compose.yml | xargs rm -rf -');
+    system('find libraries/vendor -name phpunit.xml | xargs rm -rf -');
+    system('find libraries/vendor -name README.md | xargs rm -rf -');
+    system('find libraries/vendor -name readme.md | xargs rm -rf -');
+    system('find libraries/vendor -name UPGRADING.md | xargs rm -rf -');
+    system('find libraries/vendor -name SUMMARY.md | xargs rm -rf -');
+    system('find libraries/vendor -name .travis.yml | xargs rm -rf -');
+    system('find libraries/vendor -name .git | xargs rm -rf -');
+    system('find libraries/vendor -name .gitignore | xargs rm -rf -');
+    system('find libraries/vendor -name .gitmodules | xargs rm -rf -');
+    system('find libraries/vendor -name ISSUE_TEMPLATE | xargs rm -rf -');
+    system('find libraries/vendor -name CONTRIBUTING.md | xargs rm -rf -');
+    system('find libraries/vendor -name CHANGES.md | xargs rm -rf -');
+    system('find libraries/vendor -name CHANGELOG.md | xargs rm -rf -');
+    system('find libraries/vendor -name SECURITY.md | xargs rm -rf -');
+    system('find libraries/vendor -name psalm.md | xargs rm -rf -');
+    system('find libraries/vendor -name psalm-baseline.md | xargs rm -rf -');
+    system('find libraries/vendor -name psalm-baseline.xml | xargs rm -rf -');
+    system('find libraries/vendor -name .yamllint | xargs rm -rf -');
+    system('find libraries/vendor -name .remarkrc | xargs rm -rf -');
+    system('find libraries/vendor -name .editorconfig | xargs rm -rf -');
+    system('find libraries/vendor -name appveyor.yml | xargs rm -rf -');
+    system('find libraries/vendor -name phpunit.xml.dist | xargs rm -rf -');
+    system('find libraries/vendor -name .php_cs | xargs rm -rf -');
+    system('find libraries/vendor -name .php_cs.dist | xargs rm -rf -');
+    system('find libraries/vendor -name phpcs.xsd | xargs rm -rf -');
+    system('find libraries/vendor -name phpcs.xml | xargs rm -rf -');
+    system('find libraries/vendor -name build.xml | xargs rm -rf -');
+    system('find libraries/vendor -name infection.json.dist | xargs rm -rf -');
+    system('find libraries/vendor -name phpbench.json | xargs rm -rf -');
+    system('find libraries/vendor -name phpstan.neon.dist | xargs rm -rf -');
+    system('find libraries/vendor -name .doctrine-project.json | xargs rm -rf -');
+    system('find libraries/vendor -name .pullapprove.yml | xargs rm -rf -');
+    system('find libraries/vendor -name phpstan.neon | xargs rm -rf -');
+    system('find libraries/vendor -name _config.yml | xargs rm -rf -');
+    system('find libraries/vendor -name .bowerrc | xargs rm -rf -');
+    system('find libraries/vendor -name bower.json | xargs rm -rf -');
+    system('rm -rf libraries/vendor/bin');
 
-	// aldo26-matthias/idna-convert
-	system('rm -rf libraries/vendor/algo26-matthias/idna-convert/tests');
+    // aldo26-matthias/idna-convert
+    system('rm -rf libraries/vendor/algo26-matthias/idna-convert/tests');
 
-	// defuse/php-encryption
-	system('rm -rf libraries/vendor/defuse/php-encryption/docs');
+    // defuse/php-encryption
+    system('rm -rf libraries/vendor/defuse/php-encryption/docs');
 
-	// doctrine/inflector
-	system('rm -rf libraries/vendor/doctrine/inflector/docs');
+    // doctrine/inflector
+    system('rm -rf libraries/vendor/doctrine/inflector/docs');
 
-	// fig/link-util
-	system('rm -rf libraries/vendor/fig/link-util/test');
+    // fig/link-util
+    system('rm -rf libraries/vendor/fig/link-util/test');
 
-	// google/recaptcha
-	system('rm -rf libraries/vendor/google/recaptcha/examples');
-	system('rm -rf libraries/vendor/google/recaptcha/tests');
+    // google/recaptcha
+    system('rm -rf libraries/vendor/google/recaptcha/examples');
+    system('rm -rf libraries/vendor/google/recaptcha/tests');
 
-	// jakeasmith/http_build_url
-	system ('rm -rf libraries/vendor/jakeasmith/http_build_url/tests');
+    // jakeasmith/http_build_url
+    system('rm -rf libraries/vendor/jakeasmith/http_build_url/tests');
 
-	// joomla/*
-	system('rm -rf libraries/vendor/joomla/*/docs');
-	system('rm -rf libraries/vendor/joomla/*/tests');
-	system('rm -rf libraries/vendor/joomla/*/Tests');
-	system('rm -rf libraries/vendor/joomla/*/ruleset.xml');
+    // joomla/*
+    system('rm -rf libraries/vendor/joomla/*/docs');
+    system('rm -rf libraries/vendor/joomla/*/tests');
+    system('rm -rf libraries/vendor/joomla/*/Tests');
+    system('rm -rf libraries/vendor/joomla/*/ruleset.xml');
 
-	// testing sampledata
-	system('rm -rf plugins/sampledata/testing');
-	system('rm -rf images/sampledata/parks');
-	system('rm -rf images/sampledata/fruitshop');
+    // testing sampledata
+    system('rm -rf plugins/sampledata/testing');
+    system('rm -rf images/sampledata/parks');
+    system('rm -rf images/sampledata/fruitshop');
 
-	// maximebf/debugbar
-	system('rm -rf libraries/vendor/maximebf/debugbar/build');
-	system('rm -rf libraries/vendor/maximebf/debugbar/demo');
-	system('rm -rf libraries/vendor/maximebf/debugbar/docs');
-	system('rm -rf libraries/vendor/maximebf/debugbar/tests');
+    // maximebf/debugbar
+    system('rm -rf libraries/vendor/maximebf/debugbar/build');
+    system('rm -rf libraries/vendor/maximebf/debugbar/demo');
+    system('rm -rf libraries/vendor/maximebf/debugbar/docs');
+    system('rm -rf libraries/vendor/maximebf/debugbar/tests');
 
-	// paragonie/sodium_compat
-	system('rm -rf libraries/vendor/paragonie/sodium_compat/build-phar.sh');
+    // paragonie/sodium_compat
+    system('rm -rf libraries/vendor/paragonie/sodium_compat/build-phar.sh');
 
-	// phpmailer/phpmailer
-	system('rm -rf libraries/vendor/phpmailer/phpmailer/language');
-	system('rm -rf libraries/vendor/phpmailer/phpmailer/get_oauth_token.php');
+    // phpmailer/phpmailer
+    system('rm -rf libraries/vendor/phpmailer/phpmailer/language');
+    system('rm -rf libraries/vendor/phpmailer/phpmailer/get_oauth_token.php');
 
-	// psr/log
-	system('rm -rf libraries/vendor/psr/log/Psr/Log/Test');
+    // psr/log
+    system('rm -rf libraries/vendor/psr/log/Psr/Log/Test');
 
-	// symfony/*
-	system('rm -rf libraries/vendor/symfony/*/Resources/doc');
-	system('rm -rf libraries/vendor/symfony/*/Tests');
-	system('rm -rf libraries/vendor/symfony/console/Resources');
+    // symfony/*
+    system('rm -rf libraries/vendor/symfony/*/Resources/doc');
+    system('rm -rf libraries/vendor/symfony/*/Tests');
+    system('rm -rf libraries/vendor/symfony/console/Resources');
 
-	// tobscure/json-api
-	system('rm -rf libraries/vendor/tobscure/json-api/tests');
+    // tobscure/json-api
+    system('rm -rf libraries/vendor/tobscure/json-api/tests');
 
-	// wamania/php-stemmer
-	system('rm -rf libraries/vendor/wamania/php-stemmer/test');
+    // wamania/php-stemmer
+    system('rm -rf libraries/vendor/wamania/php-stemmer/test');
 
-	// willdurand/negotiation
-	system('rm -rf libraries/vendor/willdurand/negotiation/tests');
+    // willdurand/negotiation
+    system('rm -rf libraries/vendor/willdurand/negotiation/tests');
 
-	echo "Cleanup complete.\n";
+    echo "Cleanup complete.\n";
 
-	chdir($cwd);
+    chdir($cwd);
 }
 
 function clean_composer(string $dir)
 {
-	// Save the current working directory to restore when complete
-	$cwd = getcwd();
-	chdir($dir);
+    // Save the current working directory to restore when complete
+    $cwd = getcwd();
+    chdir($dir);
 
-	echo "Cleaning Composer manifests in $dir.\n";
+    echo "Cleaning Composer manifests in $dir.\n";
 
-	// Removes Composer manifests
-	system('find . -name composer.json | xargs rm -rf -');
-	system('find . -name composer.lock | xargs rm -rf -');
+    // Removes Composer manifests
+    system('find . -name composer.json | xargs rm -rf -');
+    system('find . -name composer.lock | xargs rm -rf -');
 
-	echo "Cleanup complete.\n";
+    echo "Cleanup complete.\n";
 
-	chdir($cwd);
+    chdir($cwd);
 }
 
 $time = time();
@@ -233,22 +234,20 @@ $showHelp     = isset($options['help']);
 // Disable the generation of extra text files
 $includeExtraTextfiles = false;
 
-if ($showHelp)
-{
-	usage($argv[0]);
-	exit;
+if ($showHelp) {
+    usage($argv[0]);
+    exit;
 }
 
 // If not given a remote, assume we are looking for the latest local tag
-if (!$remote)
-{
-	chdir($repo);
-	$tagVersion = system($systemGit . ' describe --tags `' . $systemGit . ' rev-list --tags --max-count=1`', $tagVersion);
-	$remote = 'tags/' . $tagVersion;
-	chdir($here);
+if (!$remote) {
+    chdir($repo);
+    $tagVersion = system($systemGit . ' describe --tags `' . $systemGit . ' rev-list --tags --max-count=1`', $tagVersion);
+    $remote = 'tags/' . $tagVersion;
+    chdir($here);
 
-	// We are in release mode so we need the extra text files
-	$includeExtraTextfiles = true;
+    // We are in release mode so we need the extra text files
+    $includeExtraTextfiles = true;
 }
 
 echo "Start build for remote $remote.\n";
@@ -265,36 +264,32 @@ system($systemGit . ' archive ' . $remote . ' | tar -x -C ' . $fullpath);
 chdir($fullpath);
 system('composer install --no-dev --no-autoloader --ignore-platform-reqs', $composerReturnCode);
 
-if ($composerReturnCode !== 0)
-{
-	echo "`composer install` did not complete as expected.\n";
-	exit(1);
+if ($composerReturnCode !== 0) {
+    echo "`composer install` did not complete as expected.\n";
+    exit(1);
 }
 
 system('npm install --unsafe-perm', $npmReturnCode);
 
-if ($npmReturnCode !== 0)
-{
-	echo "`npm install` did not complete as expected.\n";
-	exit(1);
+if ($npmReturnCode !== 0) {
+    echo "`npm install` did not complete as expected.\n";
+    exit(1);
 }
 
 // Create gzipped version of the static assets
 system('npm run gzip', $gzipReturnCode);
 
-if ($gzipReturnCode !== 0)
-{
-	echo "`npm run gzip` did not complete as expected.\n";
-	exit(1);
+if ($gzipReturnCode !== 0) {
+    echo "`npm run gzip` did not complete as expected.\n";
+    exit(1);
 }
 
 // Create version entries of the static assets in their respective joomla.asset.json
 system('npm run versioning', $verReturnCode);
 
-if ($verReturnCode !== 0)
-{
-	echo "`npm run versioning` did not complete as expected.\n";
-	exit(1);
+if ($verReturnCode !== 0) {
+    echo "`npm run versioning` did not complete as expected.\n";
+    exit(1);
 }
 
 // Clean the checkout of extra resources
@@ -318,13 +313,12 @@ require_once $fullpath . '/libraries/src/Version.php';
 // Set version information for the build
 $version     = Version::MAJOR_VERSION . '.' . Version::MINOR_VERSION;
 $release     = Version::PATCH_VERSION;
-$fullVersion = (new Version)->getShortVersion();
+$fullVersion = (new Version())->getShortVersion();
 
 $previousRelease = Version::PATCH_VERSION - 1;
 
-if ($previousRelease < 0)
-{
-	$previousRelease = false;
+if ($previousRelease < 0) {
+    $previousRelease = false;
 }
 
 chdir($tmp);
@@ -341,27 +335,27 @@ echo "Create list of changed files from git repository for version $fullVersion.
  * Note: If we add new top-level directories or files, be sure to include them here.
  */
 $filesArray = array(
-	"administrator/index.php\n" => true,
-	"api/index.php\n" => true,
-	"cache/index.html\n" => true,
-	"cli/index.html\n" => true,
-	"components/index.html\n" => true,
-	"images/index.html\n" => true,
-	"includes/index.html\n" => true,
-	"language/index.html\n" => true,
-	"layouts/index.html\n" => true,
-	"libraries/index.html\n" => true,
-	"media/index.html\n" => true,
-	"modules/index.html\n" => true,
-	"plugins/index.html\n" => true,
-	"templates/index.html\n" => true,
-	"tmp/index.html\n" => true,
-	"htaccess.txt\n" => true,
-	"index.php\n" => true,
-	"LICENSE.txt\n" => true,
-	"README.txt\n" => true,
-	"robots.txt.dist\n" => true,
-	"web.config.txt\n" => true
+    "administrator/index.php\n" => true,
+    "api/index.php\n" => true,
+    "cache/index.html\n" => true,
+    "cli/index.html\n" => true,
+    "components/index.html\n" => true,
+    "images/index.html\n" => true,
+    "includes/index.html\n" => true,
+    "language/index.html\n" => true,
+    "layouts/index.html\n" => true,
+    "libraries/index.html\n" => true,
+    "media/index.html\n" => true,
+    "modules/index.html\n" => true,
+    "plugins/index.html\n" => true,
+    "templates/index.html\n" => true,
+    "tmp/index.html\n" => true,
+    "htaccess.txt\n" => true,
+    "index.php\n" => true,
+    "LICENSE.txt\n" => true,
+    "README.txt\n" => true,
+    "robots.txt.dist\n" => true,
+    "web.config.txt\n" => true
 );
 
 /*
@@ -370,34 +364,34 @@ $filesArray = array(
  * Because this is a fresh copy from a git tag, local environment files may be ignored
  */
 $doNotPackage = array(
-	'.appveyor.yml',
-	'.drone.yml',
-	'.editorconfig',
-	'.github',
-	'.gitignore',
-	'.php-cs-fixer.dist.php',
-	'CODE_OF_CONDUCT.md',
-	'README.md',
-	'acceptance.suite.yml',
-	'appveyor-phpunit.xml',
-	'build',
-	'build.xml',
-	'codeception.yml',
-	'composer.json',
-	'composer.lock',
-	'crowdin.yml',
-	'package-lock.json',
-	'package.json',
-	'phpunit-pgsql.xml.dist',
-	'phpunit.xml.dist',
-	'plugins/sampledata/testing/testing.php',
-	'plugins/sampledata/testing/testing.xml',
-	'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.ini',
-	'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.sys.ini',
-	'selenium.log',
-	'tests',
-	// Media Manager Node Assets
-	'administrator/components/com_media/resources',
+    '.appveyor.yml',
+    '.drone.yml',
+    '.editorconfig',
+    '.github',
+    '.gitignore',
+    '.php-cs-fixer.dist.php',
+    'CODE_OF_CONDUCT.md',
+    'README.md',
+    'acceptance.suite.yml',
+    'appveyor-phpunit.xml',
+    'build',
+    'build.xml',
+    'codeception.yml',
+    'composer.json',
+    'composer.lock',
+    'crowdin.yml',
+    'package-lock.json',
+    'package.json',
+    'phpunit-pgsql.xml.dist',
+    'phpunit.xml.dist',
+    'plugins/sampledata/testing/testing.php',
+    'plugins/sampledata/testing/testing.xml',
+    'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.ini',
+    'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.sys.ini',
+    'selenium.log',
+    'tests',
+    // Media Manager Node Assets
+    'administrator/components/com_media/resources',
 );
 
 /*
@@ -405,10 +399,10 @@ $doNotPackage = array(
  * These paths are from the repository root without the leading slash
  */
 $doNotPatch = array(
-	'administrator/cache',
-	'administrator/logs',
-	'installation',
-	'images',
+    'administrator/cache',
+    'administrator/logs',
+    'installation',
+    'images',
 );
 
 /*
@@ -429,149 +423,134 @@ $packageStability = str_replace(' ', '_', Version::DEV_STATUS);
 // Delete the files and folders we exclude from the packages (tests, docs, build, etc.).
 echo "Delete folders not included in packages.\n";
 
-foreach ($doNotPackage as $removeFile)
-{
-	system('rm -rf ' . $time . '/' . $removeFile);
+foreach ($doNotPackage as $removeFile) {
+    system('rm -rf ' . $time . '/' . $removeFile);
 }
 
 // Count down starting with the latest release and add diff files to this array
-for ($num = $release - 1; $num >= 0; $num--)
-{
-	if (!$buildPatchPackages)
-	{
-		echo "Disabled creating patch package for $num per flag.\n";
-		continue;
-	}
+for ($num = $release - 1; $num >= 0; $num--) {
+    if (!$buildPatchPackages) {
+        echo "Disabled creating patch package for $num per flag.\n";
+        continue;
+    }
 
-	echo "Create version $num update packages.\n";
+    echo "Create version $num update packages.\n";
 
-	// Here we get a list of all files that have changed between the two references ($previousTag and $remote) and save in diffdocs
-	$previousTag = $version . '.' . $num;
-	$command     = $systemGit . ' diff tags/' . $previousTag . ' ' . $remote . ' --name-status > diffdocs/' . $version . '.' . $num;
+    // Here we get a list of all files that have changed between the two references ($previousTag and $remote) and save in diffdocs
+    $previousTag = $version . '.' . $num;
+    $command     = $systemGit . ' diff tags/' . $previousTag . ' ' . $remote . ' --name-status > diffdocs/' . $version . '.' . $num;
 
-	system($command);
+    system($command);
 
-	// $filesArray will hold the array of files to include in diff package
-	$deletedFiles = array();
-	$files        = file('diffdocs/' . $version . '.' . $num);
+    // $filesArray will hold the array of files to include in diff package
+    $deletedFiles = array();
+    $files        = file('diffdocs/' . $version . '.' . $num);
 
-	// Loop through and add all files except: tests, installation, build, .git, .travis, travis, phpunit, .md, or images
-	foreach ($files as $file)
-	{
-		if (substr($file, 0, 1) === 'R')
-		{
-			$fileName = substr($file, strrpos($file, "\t") + 1);
-		}
-		else
-		{
-			$fileName = substr($file, 2);
-		}
+    // Loop through and add all files except: tests, installation, build, .git, .travis, travis, phpunit, .md, or images
+    foreach ($files as $file) {
+        if (substr($file, 0, 1) === 'R') {
+            $fileName = substr($file, strrpos($file, "\t") + 1);
+        } else {
+            $fileName = substr($file, 2);
+        }
 
-		$folderPath             = explode('/', $fileName);
-		$baseFolderName         = $folderPath[0];
-		$doNotPackageFile       = in_array(trim($fileName), $doNotPackage);
-		$doNotPatchFile         = in_array(trim($fileName), $doNotPatch);
-		$doNotPackageBaseFolder = in_array($baseFolderName, $doNotPackage);
-		$doNotPatchBaseFolder   = in_array($baseFolderName, $doNotPatch);
-		$dirtyHackForMediaCheck = false;
+        $folderPath             = explode('/', $fileName);
+        $baseFolderName         = $folderPath[0];
+        $doNotPackageFile       = in_array(trim($fileName), $doNotPackage);
+        $doNotPatchFile         = in_array(trim($fileName), $doNotPatch);
+        $doNotPackageBaseFolder = in_array($baseFolderName, $doNotPackage);
+        $doNotPatchBaseFolder   = in_array($baseFolderName, $doNotPatch);
+        $dirtyHackForMediaCheck = false;
 
-		// The raw files for the vue files are not packaged but are not a top level directory so aren't handled by the
-		// above checks. This is dirty but a fairly performant fix for now until we can come up with something better.
-		if (count($folderPath) >= 4)
-		{
-			$fullPath = [$folderPath[0] . '/' . $folderPath[1] . '/' . $folderPath[2] . '/' . $folderPath[3]];
-			$dirtyHackForMediaCheck = in_array('administrator/components/com_media/resources', $fullPath);
-		}
+        // The raw files for the vue files are not packaged but are not a top level directory so aren't handled by the
+        // above checks. This is dirty but a fairly performant fix for now until we can come up with something better.
+        if (count($folderPath) >= 4) {
+            $fullPath = [$folderPath[0] . '/' . $folderPath[1] . '/' . $folderPath[2] . '/' . $folderPath[3]];
+            $dirtyHackForMediaCheck = in_array('administrator/components/com_media/resources', $fullPath);
+        }
 
-		if ($dirtyHackForMediaCheck || $doNotPackageFile || $doNotPatchFile || $doNotPackageBaseFolder || $doNotPatchBaseFolder)
-		{
-			continue;
-		}
+        if ($dirtyHackForMediaCheck || $doNotPackageFile || $doNotPatchFile || $doNotPackageBaseFolder || $doNotPatchBaseFolder) {
+            continue;
+        }
 
-		// Act on the file based on the action
-		switch (substr($file, 0, 1))
-		{
-			// This is a new case with git 2.9 to handle renamed files
-			case 'R':
-				// Explode the file on the tab character; key 0 is the action (rename), key 1 is the old filename, and key 2 is the new filename
-				$renamedFileData = explode("\t", $file);
+        // Act on the file based on the action
+        switch (substr($file, 0, 1)) {
+            // This is a new case with git 2.9 to handle renamed files
+            case 'R':
+                // Explode the file on the tab character; key 0 is the action (rename), key 1 is the old filename, and key 2 is the new filename
+                $renamedFileData = explode("\t", $file);
 
-				// Add the new file for packaging
-				$filesArray[$renamedFileData[2]] = true;
+                // Add the new file for packaging
+                $filesArray[$renamedFileData[2]] = true;
 
-				// And flag the old file as deleted
-				$deletedFiles[] = $renamedFileData[1];
+                // And flag the old file as deleted
+                $deletedFiles[] = $renamedFileData[1];
 
-				break;
+                break;
 
-			// Deleted files
-			case 'D':
-				$deletedFiles[] = $fileName;
+            // Deleted files
+            case 'D':
+                $deletedFiles[] = $fileName;
 
-				break;
+                break;
 
-			// Regular additions and modifications
-			default:
-				$filesArray[$fileName] = true;
+            // Regular additions and modifications
+            default:
+                $filesArray[$fileName] = true;
 
-				break;
-		}
-	}
+                break;
+        }
+    }
 
-	// Write the file list to a text file.
-	$filePut = array_keys($filesArray);
-	sort($filePut);
-	file_put_contents('diffconvert/' . $version . '.' . $num, implode('', $filePut));
-	file_put_contents('diffconvert/' . $version . '.' . $num . '-deleted', $deletedFiles);
+    // Write the file list to a text file.
+    $filePut = array_keys($filesArray);
+    sort($filePut);
+    file_put_contents('diffconvert/' . $version . '.' . $num, implode('', $filePut));
+    file_put_contents('diffconvert/' . $version . '.' . $num . '-deleted', $deletedFiles);
 
-	// Only create archives for 0 and most recent versions. Skip other update versions.
-	if ($num != 0 && ($num != $release - 1))
-	{
-		echo "Skipping patch archive for version $version.$num\n";
+    // Only create archives for 0 and most recent versions. Skip other update versions.
+    if ($num != 0 && ($num != $release - 1)) {
+        echo "Skipping patch archive for version $version.$num\n";
 
-		continue;
-	}
+        continue;
+    }
 
-	$fromName = $num == 0 ? 'x' : $num;
+    $fromName = $num == 0 ? 'x' : $num;
 
-	// Create the diff archive packages using the file name list.
-	if (!$excludeBzip2)
-	{
-		$packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.bz2';
-		echo "Building " . $packageName . "... ";
-		system('tar --create --bzip2 --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
-		echo "done.\n";
-		$checksums[$packageName] = array();
-	}
+    // Create the diff archive packages using the file name list.
+    if (!$excludeBzip2) {
+        $packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.bz2';
+        echo "Building " . $packageName . "... ";
+        system('tar --create --bzip2 --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
+        echo "done.\n";
+        $checksums[$packageName] = array();
+    }
 
-	if (!$excludeGzip)
-	{
-		$packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.gz';
-		echo "Building " . $packageName . "... ";
-		system('tar --create --gzip  --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
-		echo "done.\n";
-		$checksums[$packageName] = array();
-	}
+    if (!$excludeGzip) {
+        $packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.gz';
+        echo "Building " . $packageName . "... ";
+        system('tar --create --gzip  --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
+        echo "done.\n";
+        $checksums[$packageName] = array();
+    }
 
-	if (!$excludeZip)
-	{
-		$packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.zip';
-		echo "Building " . $packageName . "... ";
-		chdir($time);
-		system('zip ../packages/' . $packageName . ' -@ < ../diffconvert/' . $version . '.' . $num . '> /dev/null');
-		chdir('..');
-		echo "done.\n";
-		$checksums[$packageName] = array();
-	}
+    if (!$excludeZip) {
+        $packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.zip';
+        echo "Building " . $packageName . "... ";
+        chdir($time);
+        system('zip ../packages/' . $packageName . ' -@ < ../diffconvert/' . $version . '.' . $num . '> /dev/null');
+        chdir('..');
+        echo "done.\n";
+        $checksums[$packageName] = array();
+    }
 
-	if (!$excludeZstd)
-	{
-		$packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.zst';
-		echo "Building " . $packageName . "... ";
-		system('tar --create --use-compress-program=zstd --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
-		echo "done.\n";
-		$checksums[$packageName] = array();
-	}
+    if (!$excludeZstd) {
+        $packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.zst';
+        echo "Building " . $packageName . "... ";
+        system('tar --create --use-compress-program=zstd --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
+        echo "done.\n";
+        $checksums[$packageName] = array();
+    }
 }
 
 echo "Build full package files.\n";
@@ -584,40 +563,36 @@ system('mv administrator/manifests/packages/pkg_search.xml ../pkg_search.xml');
 system('mv administrator/components/com_joomlaupdate/restore_finalisation.php ../restore_finalisation.php');
 
 // Create full archive packages.
-if (!$excludeBzip2)
-{
-	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.bz2';
-	echo "Building " . $packageName . "... ";
-	system('tar --create --bzip2 --file ../packages/' . $packageName . ' * > /dev/null');
-	echo "done.\n";
-	$checksums[$packageName] = array();
+if (!$excludeBzip2) {
+    $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.bz2';
+    echo "Building " . $packageName . "... ";
+    system('tar --create --bzip2 --file ../packages/' . $packageName . ' * > /dev/null');
+    echo "done.\n";
+    $checksums[$packageName] = array();
 }
 
-if (!$excludeGzip)
-{
-	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.gz';
-	echo "Building " . $packageName . "... ";
-	system('tar --create --gzip --file ../packages/' . $packageName . ' * > /dev/null');
-	echo "done.\n";
-	$checksums[$packageName] = array();
+if (!$excludeGzip) {
+    $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.gz';
+    echo "Building " . $packageName . "... ";
+    system('tar --create --gzip --file ../packages/' . $packageName . ' * > /dev/null');
+    echo "done.\n";
+    $checksums[$packageName] = array();
 }
 
-if (!$excludeZip)
-{
-	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.zip';
-	echo "Building " . $packageName . "... ";
-	system('zip -r ../packages/' . $packageName . ' * > /dev/null');
-	echo "done.\n";
-	$checksums[$packageName] = array();
+if (!$excludeZip) {
+    $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.zip';
+    echo "Building " . $packageName . "... ";
+    system('zip -r ../packages/' . $packageName . ' * > /dev/null');
+    echo "done.\n";
+    $checksums[$packageName] = array();
 }
 
-if (!$excludeZstd)
-{
-	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.zst';
-	echo "Building " . $packageName . "... ";
-	system('tar --create --use-compress-program=zstd --file ../packages/' . $packageName . ' * > /dev/null');
-	echo "done.\n";
-	$checksums[$packageName] = array();
+if (!$excludeZstd) {
+    $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.zst';
+    echo "Building " . $packageName . "... ";
+    system('tar --create --use-compress-program=zstd --file ../packages/' . $packageName . ' * > /dev/null');
+    echo "done.\n";
+    $checksums[$packageName] = array();
 }
 
 // Create full update file without the default logs directory, installation folder, or sample images.
@@ -636,142 +611,117 @@ system('mv ../pkg_search.xml administrator/manifests/packages/pkg_search.xml');
 // Move the restore_finalisation.php back
 system('mv ../restore_finalisation.php administrator/components/com_joomlaupdate/restore_finalisation.php');
 
-if (!$excludeBzip2)
-{
-	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.bz2';
-	echo "Building " . $packageName . "... ";
-	system('tar --create --bzip2 --file ../packages/' . $packageName . ' * > /dev/null');
-	echo "done.\n";
-	$checksums[$packageName] = array();
+if (!$excludeBzip2) {
+    $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.bz2';
+    echo "Building " . $packageName . "... ";
+    system('tar --create --bzip2 --file ../packages/' . $packageName . ' * > /dev/null');
+    echo "done.\n";
+    $checksums[$packageName] = array();
 }
 
-if (!$excludeGzip)
-{
-	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.gz';
-	echo "Building " . $packageName . "... ";
-	system('tar --create --gzip --file ../packages/' . $packageName . ' * > /dev/null');
-	echo "done.\n";
-	$checksums[$packageName] = array();
+if (!$excludeGzip) {
+    $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.gz';
+    echo "Building " . $packageName . "... ";
+    system('tar --create --gzip --file ../packages/' . $packageName . ' * > /dev/null');
+    echo "done.\n";
+    $checksums[$packageName] = array();
 }
 
-if (!$excludeZip)
-{
-	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.zip';
-	echo "Building " . $packageName . "... ";
-	system('zip -r ../packages/' . $packageName . ' * > /dev/null');
-	echo "done.\n";
-	$checksums[$packageName] = array();
+if (!$excludeZip) {
+    $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.zip';
+    echo "Building " . $packageName . "... ";
+    system('zip -r ../packages/' . $packageName . ' * > /dev/null');
+    echo "done.\n";
+    $checksums[$packageName] = array();
 }
 
-if (!$excludeZstd)
-{
-	$packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.zst';
-	echo "Building " . $packageName . "... ";
-	system('tar --create --use-compress-program=zstd --file ../packages/' . $packageName . ' * > /dev/null');
-	echo "done.\n";
-	$checksums[$packageName] = array();
+if (!$excludeZstd) {
+    $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.zst';
+    echo "Building " . $packageName . "... ";
+    system('tar --create --use-compress-program=zstd --file ../packages/' . $packageName . ' * > /dev/null');
+    echo "done.\n";
+    $checksums[$packageName] = array();
 }
 
 chdir('..');
 
 // This is only needed when we release a version
-if ($includeExtraTextfiles)
-{
+if ($includeExtraTextfiles) {
+    foreach (array_keys($checksums) as $packageName) {
+        echo "Generating checksums for $packageName\n";
 
-	foreach (array_keys($checksums) as $packageName)
-	{
-		echo "Generating checksums for $packageName\n";
+        foreach (array('sha256', 'sha384', 'sha512') as $hash) {
+            if (file_exists('packages/' . $packageName)) {
+                $checksums[$packageName][$hash] = hash_file($hash, 'packages/' . $packageName);
+            } else {
+                echo "Package $packageName not found in build directories\n";
+            }
+        }
+    }
 
-		foreach (array('sha256', 'sha384', 'sha512') as $hash)
-		{
-			if (file_exists('packages/' . $packageName))
-			{
-				$checksums[$packageName][$hash] = hash_file($hash, 'packages/' . $packageName);
-			}
-			else
-			{
-				echo "Package $packageName not found in build directories\n";
-			}
-		}
-	}
+    echo "Generating checksums.txt file\n";
 
-	echo "Generating checksums.txt file\n";
+    $checksumsContent = '';
 
-	$checksumsContent = '';
+    foreach ($checksums as $packageName => $packageHashes) {
+        $checksumsContent .= "Filename: $packageName\n";
 
-	foreach ($checksums as $packageName => $packageHashes)
-	{
-		$checksumsContent .= "Filename: $packageName\n";
+        foreach ($packageHashes as $hashType => $hash) {
+            $checksumsContent .= "$hashType: $hash\n";
+        }
 
-		foreach ($packageHashes as $hashType => $hash)
-		{
-			$checksumsContent .= "$hashType: $hash\n";
-		}
+        $checksumsContent .= "\n";
+    }
 
-		$checksumsContent .= "\n";
-	}
+    file_put_contents('checksums.txt', $checksumsContent);
 
-	file_put_contents('checksums.txt', $checksumsContent);
+    echo "Generating github_release.txt file\n";
 
-	echo "Generating github_release.txt file\n";
+    $githubContent = array();
+    $githubText    = '';
+    $releaseText   = array(
+        'FULL'    => 'New Joomla! Installations ',
+        'POINT'   => 'Update from Joomla! ' . $version . '.' . $previousRelease . ' ',
+        'MINOR'   => 'Update from Joomla! ' . $version . '.x ',
+        'UPGRADE' => 'Update from Joomla! 3.10 ',
+    );
 
-	$githubContent = array();
-	$githubText    = '';
-	$releaseText   = array(
-		'FULL'    => 'New Joomla! Installations ',
-		'POINT'   => 'Update from Joomla! ' . $version . '.' . $previousRelease . ' ',
-		'MINOR'   => 'Update from Joomla! ' . $version . '.x ',
-		'UPGRADE' => 'Update from Joomla! 3.10 ',
-	);
+    if (!$buildPatchPackages) {
+        $releaseText['UPGRADE'] = 'Update from a previous version of Joomla! ';
+    }
 
-	if (!$buildPatchPackages)
-	{
-		$releaseText['UPGRADE'] = 'Update from a previous version of Joomla! ';
-	}
+    $githubLink = 'https://github.com/joomla/joomla-cms/releases/download/' . $tagVersion . '/';
 
-	$githubLink = 'https://github.com/joomla/joomla-cms/releases/download/' . $tagVersion . '/';
+    foreach ($checksums as $packageName => $packageHashes) {
+        $type = '';
 
-	foreach ($checksums as $packageName => $packageHashes)
-	{
-		$type = '';
+        if (strpos($packageName, 'Full_Package') !== false) {
+            $type = 'FULL';
+        } elseif (strpos($packageName, 'Patch_Package') !== false) {
+            if (strpos($packageName, '.x_to') !== false) {
+                $type = 'MINOR';
+            } else {
+                $type = 'POINT';
+            }
+        } elseif (strpos($packageName, 'Update_Package') !== false) {
+            $type = 'UPGRADE';
+        }
 
-		if (strpos($packageName, 'Full_Package') !== false)
-		{
-			$type = 'FULL';
-		}
-		elseif (strpos($packageName, 'Patch_Package') !== false)
-		{
-			if (strpos($packageName, '.x_to') !== false)
-			{
-				$type = 'MINOR';
-			}
-			else
-			{
-				$type = 'POINT';
-			}
-		}
-		elseif (strpos($packageName, 'Update_Package') !== false)
-		{
-			$type = 'UPGRADE';
-		}
+        $githubContent[$type][] = '[' . substr($packageName, strpos($packageName, 'Package') + 7) . '](' . $githubLink . $packageName . ')';
+    }
 
-		$githubContent[$type][] = '[' . substr($packageName, strpos($packageName, 'Package') + 7) . '](' . $githubLink . $packageName . ')';
-	}
+    foreach ($releaseText as $type => $text) {
+        if (empty($githubContent[$type])) {
+            continue;
+        }
 
-	foreach ($releaseText as $type => $text)
-	{
-		if (empty($githubContent[$type]))
-		{
-			continue;
-		}
+        $githubText .= $text;
+        $githubText .= implode(" | ", $githubContent[$type]);
 
-		$githubText .= $text;
-		$githubText .= implode(" | ", $githubContent[$type]);
+        $githubText .= "\n";
+    }
 
-		$githubText .= "\n";
-	}
-
-	file_put_contents('github_release.txt', $githubText);
+    file_put_contents('github_release.txt', $githubText);
 }
 
 echo "Build of version $fullVersion complete!\n";

--- a/build/bump.php
+++ b/build/bump.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Script used to make a version bump
  * Updates all versions xmls and version.php
@@ -24,12 +25,12 @@
 // Functions.
 function usage($command)
 {
-	echo PHP_EOL;
-	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
-	echo PHP_TAB . '[options]:'.PHP_EOL;
-	echo PHP_TAB . PHP_TAB . '-v <version>:' . PHP_TAB . 'Version (ex: 3.6.0-dev, 3.6.0-beta1, 3.6.0-beta1-dev, 3.6.0-rc1, 3.6.0)' . PHP_EOL;
-	echo PHP_TAB . PHP_TAB . '-c <codename>:' . PHP_TAB . 'Codename [optional] (ex: Unicorn)' . PHP_EOL;
-	echo PHP_EOL;
+    echo PHP_EOL;
+    echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
+    echo PHP_TAB . '[options]:' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '-v <version>:' . PHP_TAB . 'Version (ex: 3.6.0-dev, 3.6.0-beta1, 3.6.0-beta1-dev, 3.6.0-rc1, 3.6.0)' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '-c <codename>:' . PHP_TAB . 'Codename [optional] (ex: Unicorn)' . PHP_EOL;
+    echo PHP_EOL;
 }
 
 // Constants.
@@ -39,17 +40,17 @@ const PHP_TAB = "\t";
 $versionFile = '/libraries/src/Version.php';
 
 $coreXmlFiles = array(
-	'/administrator/manifests/files/joomla.xml',
+    '/administrator/manifests/files/joomla.xml',
 );
 
 $languageXmlFiles = array(
-	'/language/en-GB/langmetadata.xml',
-	'/language/en-GB/install.xml',
-	'/administrator/language/en-GB/langmetadata.xml',
-	'/administrator/language/en-GB/install.xml',
-	'/installation/language/en-GB/langmetadata.xml',
-	'/api/language/en-GB/langmetadata.xml',
-	'/api/language/en-GB/install.xml',
+    '/language/en-GB/langmetadata.xml',
+    '/language/en-GB/install.xml',
+    '/administrator/language/en-GB/langmetadata.xml',
+    '/administrator/language/en-GB/install.xml',
+    '/installation/language/en-GB/langmetadata.xml',
+    '/api/language/en-GB/langmetadata.xml',
+    '/api/language/en-GB/install.xml',
 );
 
 $languagePackXmlFile = '/administrator/manifests/packages/pkg_en-GB.xml';
@@ -57,8 +58,8 @@ $languagePackXmlFile = '/administrator/manifests/packages/pkg_en-GB.xml';
 $antJobFile = '/build.xml';
 
 $readMeFiles = array(
-	'/README.md',
-	'/README.txt',
+    '/README.md',
+    '/README.txt',
 );
 
 /*
@@ -68,13 +69,13 @@ $readMeFiles = array(
  * as well as external libraries.
  */
 $directoryLoopExcludeDirectories = array(
-	'/.git',
-	'/build/api/',
-	'/build/coverage/',
-	'/build/tmp/',
-	'/libraries/vendor/',
-	'/libraries/php-encryption/',
-	'/libraries/phpass/',
+    '/.git',
+    '/build/api/',
+    '/build/coverage/',
+    '/build/tmp/',
+    '/libraries/vendor/',
+    '/libraries/php-encryption/',
+    '/libraries/phpass/',
 );
 
 $directoryLoopExcludeFiles = array();
@@ -82,31 +83,27 @@ $directoryLoopExcludeFiles = array();
 // Check arguments (exit if incorrect cli arguments).
 $opts = getopt("v:c:");
 
-if (empty($opts['v']))
-{
-	usage($argv[0]);
-	die();
+if (empty($opts['v'])) {
+    usage($argv[0]);
+    die();
 }
 
 // Check version string (exit if not correct).
 $versionParts = explode('-', $opts['v']);
 
-if (!preg_match('#^[0-9]+\.[0-9]+\.[0-9]+$#', $versionParts[0]))
-{
-	usage($argv[0]);
-	die();
+if (!preg_match('#^[0-9]+\.[0-9]+\.[0-9]+$#', $versionParts[0])) {
+    usage($argv[0]);
+    die();
 }
 
-if (isset($versionParts[1]) && !preg_match('#(dev|alpha|beta|rc)[0-9]*#', $versionParts[1]))
-{
-	usage($argv[0]);
-	die();
+if (isset($versionParts[1]) && !preg_match('#(dev|alpha|beta|rc)[0-9]*#', $versionParts[1])) {
+    usage($argv[0]);
+    die();
 }
 
-if (isset($versionParts[2]) && $versionParts[2] !== 'dev')
-{
-	usage($argv[0]);
-	die();
+if (isset($versionParts[2]) && $versionParts[2] !== 'dev') {
+    usage($argv[0]);
+    die();
 }
 
 // Make sure we use the correct language and timezone.
@@ -119,62 +116,48 @@ umask(022);
 // Get version dev status.
 $dev_status = 'Stable';
 
-if (!isset($versionParts[1]))
-{
-	$versionParts[1] = '';
-}
-else
-{
-	if (preg_match('#^dev#', $versionParts[1]))
-	{
-		$dev_status = 'Development';
-	}
-	elseif (preg_match('#^alpha#', $versionParts[1]))
-	{
-		$dev_status = 'Alpha';
-	}
-	elseif (preg_match('#^beta#', $versionParts[1]))
-	{
-		$dev_status = 'Beta';
-	}
-	elseif (preg_match('#^rc#', $versionParts[1]))
-	{
-		$dev_status = 'Release Candidate';
-	}
+if (!isset($versionParts[1])) {
+    $versionParts[1] = '';
+} else {
+    if (preg_match('#^dev#', $versionParts[1])) {
+        $dev_status = 'Development';
+    } elseif (preg_match('#^alpha#', $versionParts[1])) {
+        $dev_status = 'Alpha';
+    } elseif (preg_match('#^beta#', $versionParts[1])) {
+        $dev_status = 'Beta';
+    } elseif (preg_match('#^rc#', $versionParts[1])) {
+        $dev_status = 'Release Candidate';
+    }
 }
 
-if (!isset($versionParts[2]))
-{
-	$versionParts[2] = '';
-}
-else
-{
-	$dev_status = 'Development';
+if (!isset($versionParts[2])) {
+    $versionParts[2] = '';
+} else {
+    $dev_status = 'Development';
 }
 
 // Set version properties.
 $versionSubParts = explode('.', $versionParts[0]);
 
 $version = array(
-	'main'       => $versionSubParts[0] . '.' . $versionSubParts[1],
-	'major'      => $versionSubParts[0],
-	'minor'      => $versionSubParts[1],
-	'patch'      => $versionSubParts[2],
-	'extra'      => (!empty($versionParts[1]) ? $versionParts[1] : '') . (!empty($versionParts[2]) ? (!empty($versionParts[1]) ? '-' : '') . $versionParts[2] : ''),
-	'release'    => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
-	'dev_devel'  => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : '') . (!empty($versionParts[2]) ? '-' . $versionParts[2] : ''),
-	'dev_status' => $dev_status,
-	'build'      => '',
-	'reldate'    => date('j-F-Y'),
-	'reltime'    => date('H:i'),
-	'reltz'      => 'GMT',
-	'credate'    => date('Y-m'),
+    'main'       => $versionSubParts[0] . '.' . $versionSubParts[1],
+    'major'      => $versionSubParts[0],
+    'minor'      => $versionSubParts[1],
+    'patch'      => $versionSubParts[2],
+    'extra'      => (!empty($versionParts[1]) ? $versionParts[1] : '') . (!empty($versionParts[2]) ? (!empty($versionParts[1]) ? '-' : '') . $versionParts[2] : ''),
+    'release'    => $versionSubParts[0] . '.' . $versionSubParts[1] . '.' . $versionSubParts[2],
+    'dev_devel'  => $versionSubParts[2] . (!empty($versionParts[1]) ? '-' . $versionParts[1] : '') . (!empty($versionParts[2]) ? '-' . $versionParts[2] : ''),
+    'dev_status' => $dev_status,
+    'build'      => '',
+    'reldate'    => date('j-F-Y'),
+    'reltime'    => date('H:i'),
+    'reltz'      => 'GMT',
+    'credate'    => date('Y-m'),
 );
 
 // Version Codename.
-if (!empty($opts['c']))
-{
-	$version['codename'] = trim($opts['c']);
+if (!empty($opts['c'])) {
+    $version['codename'] = trim($opts['c']);
 }
 
 // Prints version information.
@@ -191,9 +174,8 @@ echo '- Release time:' . PHP_TAB . PHP_TAB . $version['reltime'] . PHP_EOL;
 echo '- Release timezone:' . PHP_TAB . $version['reltz'] . PHP_EOL;
 echo '- Creation date:' . PHP_TAB . $version['credate'] . PHP_EOL;
 
-if (!empty($version['codename']))
-{
-	echo '- Codename:' . PHP_TAB . PHP_TAB . $version['codename'] . PHP_EOL;
+if (!empty($version['codename'])) {
+    echo '- Codename:' . PHP_TAB . PHP_TAB . $version['codename'] . PHP_EOL;
 }
 
 echo PHP_EOL;
@@ -201,80 +183,70 @@ echo PHP_EOL;
 $rootPath = dirname(__DIR__);
 
 // Updates the version in version class.
-if (file_exists($rootPath . $versionFile))
-{
-	$fileContents = file_get_contents($rootPath . $versionFile);
-	$fileContents = preg_replace("#MAJOR_VERSION\s*=\s*[^;]*#", "MAJOR_VERSION = " . $version['major'], $fileContents);
-	$fileContents = preg_replace("#MINOR_VERSION\s*=\s*[^;]*#", "MINOR_VERSION = " . $version['minor'], $fileContents);
-	$fileContents = preg_replace("#PATCH_VERSION\s*=\s*[^;]*#", "PATCH_VERSION = " . $version['patch'], $fileContents);
-	$fileContents = preg_replace("#EXTRA_VERSION\s*=\s*'[^\']*'#", "EXTRA_VERSION = '" . $version['extra'] . "'", $fileContents);
-	$fileContents = preg_replace("#RELEASE\s*=\s*'[^\']*'#", "RELEASE = '" . $version['main'] . "'", $fileContents);
-	$fileContents = preg_replace("#DEV_LEVEL\s*=\s*'[^\']*'#", "DEV_LEVEL = '" . $version['dev_devel'] . "'", $fileContents);
-	$fileContents = preg_replace("#DEV_STATUS\s*=\s*'[^\']*'#", "DEV_STATUS = '" . $version['dev_status'] . "'", $fileContents);
-	$fileContents = preg_replace("#BUILD\s*=\s*'[^\']*'#", "BUILD = '" . $version['build'] . "'", $fileContents);
-	$fileContents = preg_replace("#RELDATE\s*=\s*'[^\']*'#", "RELDATE = '" . $version['reldate'] . "'", $fileContents);
-	$fileContents = preg_replace("#RELTIME\s*=\s*'[^\']*'#", "RELTIME = '" . $version['reltime'] . "'", $fileContents);
-	$fileContents = preg_replace("#RELTZ\s*=\s*'[^\']*'#", "RELTZ = '" . $version['reltz'] . "'", $fileContents);
+if (file_exists($rootPath . $versionFile)) {
+    $fileContents = file_get_contents($rootPath . $versionFile);
+    $fileContents = preg_replace("#MAJOR_VERSION\s*=\s*[^;]*#", "MAJOR_VERSION = " . $version['major'], $fileContents);
+    $fileContents = preg_replace("#MINOR_VERSION\s*=\s*[^;]*#", "MINOR_VERSION = " . $version['minor'], $fileContents);
+    $fileContents = preg_replace("#PATCH_VERSION\s*=\s*[^;]*#", "PATCH_VERSION = " . $version['patch'], $fileContents);
+    $fileContents = preg_replace("#EXTRA_VERSION\s*=\s*'[^\']*'#", "EXTRA_VERSION = '" . $version['extra'] . "'", $fileContents);
+    $fileContents = preg_replace("#RELEASE\s*=\s*'[^\']*'#", "RELEASE = '" . $version['main'] . "'", $fileContents);
+    $fileContents = preg_replace("#DEV_LEVEL\s*=\s*'[^\']*'#", "DEV_LEVEL = '" . $version['dev_devel'] . "'", $fileContents);
+    $fileContents = preg_replace("#DEV_STATUS\s*=\s*'[^\']*'#", "DEV_STATUS = '" . $version['dev_status'] . "'", $fileContents);
+    $fileContents = preg_replace("#BUILD\s*=\s*'[^\']*'#", "BUILD = '" . $version['build'] . "'", $fileContents);
+    $fileContents = preg_replace("#RELDATE\s*=\s*'[^\']*'#", "RELDATE = '" . $version['reldate'] . "'", $fileContents);
+    $fileContents = preg_replace("#RELTIME\s*=\s*'[^\']*'#", "RELTIME = '" . $version['reltime'] . "'", $fileContents);
+    $fileContents = preg_replace("#RELTZ\s*=\s*'[^\']*'#", "RELTZ = '" . $version['reltz'] . "'", $fileContents);
 
-	if (!empty($version['codename']))
-	{
-		$fileContents = preg_replace("#CODENAME\s*=\s*'[^\']*'#", "CODENAME = '" . $version['codename'] . "'", $fileContents);
-	}
+    if (!empty($version['codename'])) {
+        $fileContents = preg_replace("#CODENAME\s*=\s*'[^\']*'#", "CODENAME = '" . $version['codename'] . "'", $fileContents);
+    }
 
-	file_put_contents($rootPath . $versionFile, $fileContents);
+    file_put_contents($rootPath . $versionFile, $fileContents);
 }
 
 // Updates the version and creation date in core xml files.
-foreach ($coreXmlFiles as $coreXmlFile)
-{
-	if (file_exists($rootPath . $coreXmlFile))
-	{
-		$fileContents = file_get_contents($rootPath . $coreXmlFile);
-		$fileContents = preg_replace('#<version>[^<]*</version>#', '<version>' . $version['main'] . '.' . $version['dev_devel'] . '</version>', $fileContents);
-		$fileContents = preg_replace('#<creationDate>[^<]*</creationDate>#', '<creationDate>' . $version['credate'] . '</creationDate>', $fileContents);
-		file_put_contents($rootPath . $coreXmlFile, $fileContents);
-	}
+foreach ($coreXmlFiles as $coreXmlFile) {
+    if (file_exists($rootPath . $coreXmlFile)) {
+        $fileContents = file_get_contents($rootPath . $coreXmlFile);
+        $fileContents = preg_replace('#<version>[^<]*</version>#', '<version>' . $version['main'] . '.' . $version['dev_devel'] . '</version>', $fileContents);
+        $fileContents = preg_replace('#<creationDate>[^<]*</creationDate>#', '<creationDate>' . $version['credate'] . '</creationDate>', $fileContents);
+        file_put_contents($rootPath . $coreXmlFile, $fileContents);
+    }
 }
 
 // Updates the version and creation date in language xml files.
-foreach ($languageXmlFiles as $languageXmlFile)
-{
-	if (file_exists($rootPath . $languageXmlFile))
-	{
-		$fileContents = file_get_contents($rootPath . $languageXmlFile);
-		$fileContents = preg_replace('#<version>[^<]*</version>#', '<version>' . $version['release'] . '</version>', $fileContents);
-		$fileContents = preg_replace('#<creationDate>[^<]*</creationDate>#', '<creationDate>' . $version['credate'] . '</creationDate>', $fileContents);
-		file_put_contents($rootPath . $languageXmlFile, $fileContents);
-	}
+foreach ($languageXmlFiles as $languageXmlFile) {
+    if (file_exists($rootPath . $languageXmlFile)) {
+        $fileContents = file_get_contents($rootPath . $languageXmlFile);
+        $fileContents = preg_replace('#<version>[^<]*</version>#', '<version>' . $version['release'] . '</version>', $fileContents);
+        $fileContents = preg_replace('#<creationDate>[^<]*</creationDate>#', '<creationDate>' . $version['credate'] . '</creationDate>', $fileContents);
+        file_put_contents($rootPath . $languageXmlFile, $fileContents);
+    }
 }
 
 // Updates the version and creation date in language package xml file.
-if (file_exists($rootPath . $languagePackXmlFile))
-{
-	$fileContents = file_get_contents($rootPath . $languagePackXmlFile);
-	$fileContents = preg_replace('#<version>[^<]*</version>#', '<version>' . $version['release'] . '.1</version>', $fileContents);
-	$fileContents = preg_replace('#<creationDate>[^<]*</creationDate>#', '<creationDate>' . $version['credate'] . '</creationDate>', $fileContents);
-	file_put_contents($rootPath . $languagePackXmlFile, $fileContents);
+if (file_exists($rootPath . $languagePackXmlFile)) {
+    $fileContents = file_get_contents($rootPath . $languagePackXmlFile);
+    $fileContents = preg_replace('#<version>[^<]*</version>#', '<version>' . $version['release'] . '.1</version>', $fileContents);
+    $fileContents = preg_replace('#<creationDate>[^<]*</creationDate>#', '<creationDate>' . $version['credate'] . '</creationDate>', $fileContents);
+    file_put_contents($rootPath . $languagePackXmlFile, $fileContents);
 }
 
 // Updates the version for the `phpdoc` task in the Ant job file.
-if (file_exists($rootPath . $antJobFile))
-{
-	$fileContents = file_get_contents($rootPath . $antJobFile);
-	$fileContents = preg_replace('#<arg value="Joomla! CMS [^ ]* API" />#', '<arg value="Joomla! CMS ' . $version['main'] . ' API" />', $fileContents);
-	file_put_contents($rootPath . $antJobFile, $fileContents);
+if (file_exists($rootPath . $antJobFile)) {
+    $fileContents = file_get_contents($rootPath . $antJobFile);
+    $fileContents = preg_replace('#<arg value="Joomla! CMS [^ ]* API" />#', '<arg value="Joomla! CMS ' . $version['main'] . ' API" />', $fileContents);
+    file_put_contents($rootPath . $antJobFile, $fileContents);
 }
 
 // Updates the version in readme files.
-foreach ($readMeFiles as $readMeFile)
-{
-	if (file_exists($rootPath . $readMeFile))
-	{
-		$fileContents = file_get_contents($rootPath . $readMeFile);
-		$fileContents = preg_replace('#Joomla! [0-9]+\.[0-9]+ (|\[)version#', 'Joomla! ' . $version['main'] . ' $1version', $fileContents);
-		$fileContents = preg_replace('#Joomla_[0-9]+\.[0-9]+_version#', 'Joomla_' . $version['main'] . '_version', $fileContents);
-		file_put_contents($rootPath . $readMeFile, $fileContents);
-	}
+foreach ($readMeFiles as $readMeFile) {
+    if (file_exists($rootPath . $readMeFile)) {
+        $fileContents = file_get_contents($rootPath . $readMeFile);
+        $fileContents = preg_replace('#Joomla! [0-9]+\.[0-9]+ (|\[)version#', 'Joomla! ' . $version['main'] . ' $1version', $fileContents);
+        $fileContents = preg_replace('#Joomla_[0-9]+\.[0-9]+_version#', 'Joomla_' . $version['main'] . '_version', $fileContents);
+        file_put_contents($rootPath . $readMeFile, $fileContents);
+    }
 }
 
 $changedFilesSinceVersion  = 0;
@@ -282,65 +254,55 @@ $year                      = date('Y');
 $directory                 = new RecursiveDirectoryIterator($rootPath);
 $iterator                  = new RecursiveIteratorIterator($directory, RecursiveIteratorIterator::SELF_FIRST);
 
-foreach ($iterator as $file)
-{
-	if ($file->isFile())
-	{
-		$filePath     = $file->getPathname();
-		$relativePath = str_replace($rootPath, '', $filePath);
+foreach ($iterator as $file) {
+    if ($file->isFile()) {
+        $filePath     = $file->getPathname();
+        $relativePath = str_replace($rootPath, '', $filePath);
 
-		// Exclude certain extensions.
-		if (preg_match('#\.(png|jpeg|jpg|gif|bmp|ico|webp|svg|woff|woff2|ttf|eot)$#', $filePath))
-		{
-			continue;
-		}
+        // Exclude certain extensions.
+        if (preg_match('#\.(png|jpeg|jpg|gif|bmp|ico|webp|svg|woff|woff2|ttf|eot)$#', $filePath)) {
+            continue;
+        }
 
-		// Exclude certain files.
-		if (in_array($relativePath, $directoryLoopExcludeFiles))
-		{
-			continue;
-		}
+        // Exclude certain files.
+        if (in_array($relativePath, $directoryLoopExcludeFiles)) {
+            continue;
+        }
 
-		// Exclude certain directories.
-		$continue = true;
+        // Exclude certain directories.
+        $continue = true;
 
-		foreach ($directoryLoopExcludeDirectories as $excludeDirectory)
-		{
-			if (preg_match('#^' . preg_quote($excludeDirectory) . '#', $relativePath))
-			{
-				$continue = false;
-				break;
-			}
-		}
+        foreach ($directoryLoopExcludeDirectories as $excludeDirectory) {
+            if (preg_match('#^' . preg_quote($excludeDirectory) . '#', $relativePath)) {
+                $continue = false;
+                break;
+            }
+        }
 
-		if ($continue)
-		{
-			$changeSinceVersion  = false;
+        if ($continue) {
+            $changeSinceVersion  = false;
 
-			// Load the file.
-			$fileContents = file_get_contents($filePath);
+            // Load the file.
+            $fileContents = file_get_contents($filePath);
 
-			// Check if need to change the since version.
-			if ($relativePath !== '/build/bump.php' && preg_match('#__DEPLOY_VERSION__#', $fileContents))
-			{
-				$changeSinceVersion = true;
-				$fileContents = preg_replace('#__DEPLOY_VERSION__#', $version['release'], $fileContents);
-				$changedFilesSinceVersion++;
-			}
+            // Check if need to change the since version.
+            if ($relativePath !== '/build/bump.php' && preg_match('#__DEPLOY_VERSION__#', $fileContents)) {
+                $changeSinceVersion = true;
+                $fileContents = preg_replace('#__DEPLOY_VERSION__#', $version['release'], $fileContents);
+                $changedFilesSinceVersion++;
+            }
 
-			// Save the file.
-			if ($changeSinceVersion)
-			{
-				file_put_contents($filePath, $fileContents);
-			}
-		}
-	}
+            // Save the file.
+            if ($changeSinceVersion) {
+                file_put_contents($filePath, $fileContents);
+            }
+        }
+    }
 }
 
-if ($changedFilesSinceVersion > 0)
-{
-	echo '- Since Version changed in ' . $changedFilesSinceVersion . ' files.' . PHP_EOL;
-	echo PHP_EOL;
+if ($changedFilesSinceVersion > 0) {
+    echo '- Since Version changed in ' . $changedFilesSinceVersion . ' files.' . PHP_EOL;
+    echo PHP_EOL;
 }
 
 echo 'Version bump complete!' . PHP_EOL;

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * This file is used to build the list of deleted files between two reference points.
  *
@@ -25,11 +26,11 @@ const PHP_TAB = "\t";
 
 function usage($command)
 {
-	echo PHP_EOL;
-	echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
-	echo PHP_TAB . '--from <ref>:' . PHP_TAB . 'Starting commit reference (branch/tag)' . PHP_EOL;
-	echo PHP_TAB . '--to <ref>:' . PHP_TAB . 'Ending commit reference (branch/tag) [optional]' . PHP_EOL;
-	echo PHP_EOL;
+    echo PHP_EOL;
+    echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
+    echo PHP_TAB . '--from <ref>:' . PHP_TAB . 'Starting commit reference (branch/tag)' . PHP_EOL;
+    echo PHP_TAB . '--to <ref>:' . PHP_TAB . 'Ending commit reference (branch/tag) [optional]' . PHP_EOL;
+    echo PHP_EOL;
 }
 
 /*
@@ -39,39 +40,37 @@ function usage($command)
 $options = getopt('', array('from:', 'to::'));
 
 // We need the from reference, otherwise we're doomed to fail
-if (empty($options['from']))
-{
-	echo PHP_EOL;
-	echo 'Missing starting directory' . PHP_EOL;
+if (empty($options['from'])) {
+    echo PHP_EOL;
+    echo 'Missing starting directory' . PHP_EOL;
 
-	usage($argv[0]);
+    usage($argv[0]);
 
-	exit(1);
+    exit(1);
 }
 
 // Missing the to reference?  No problem, grab the current HEAD
-if (empty($options['to']))
-{
-	echo PHP_EOL;
-	echo 'Missing ending directory' . PHP_EOL;
+if (empty($options['to'])) {
+    echo PHP_EOL;
+    echo 'Missing ending directory' . PHP_EOL;
 
-	usage($argv[0]);
+    usage($argv[0]);
 
-	exit(1);
+    exit(1);
 }
 
 // Directories to skip for the check (needs to include anything from J3 we want to keep)
 $previousReleaseExclude = [
-	$options['from'] . '/administrator/components/com_search',
-	$options['from'] . '/components/com_search',
-	$options['from'] . '/images/sampledata',
-	$options['from'] . '/installation',
-	$options['from'] . '/media/plg_quickicon_eos310',
-	$options['from'] . '/media/system/images',
-	$options['from'] . '/modules/mod_search',
-	$options['from'] . '/plugins/fields/repeatable',
-	$options['from'] . '/plugins/quickicon/eos310',
-	$options['from'] . '/plugins/search',
+    $options['from'] . '/administrator/components/com_search',
+    $options['from'] . '/components/com_search',
+    $options['from'] . '/images/sampledata',
+    $options['from'] . '/installation',
+    $options['from'] . '/media/plg_quickicon_eos310',
+    $options['from'] . '/media/system/images',
+    $options['from'] . '/modules/mod_search',
+    $options['from'] . '/plugins/fields/repeatable',
+    $options['from'] . '/plugins/quickicon/eos310',
+    $options['from'] . '/plugins/search',
 ];
 
 /**
@@ -82,17 +81,16 @@ $previousReleaseExclude = [
  * @return bool True if you need to recurse or if the item is acceptable
  */
 $previousReleaseFilter = function ($file, $key, $iterator) use ($previousReleaseExclude) {
-	if ($iterator->hasChildren() && !in_array($file->getPathname(), $previousReleaseExclude))
-	{
-		return true;
-	}
+    if ($iterator->hasChildren() && !in_array($file->getPathname(), $previousReleaseExclude)) {
+        return true;
+    }
 
-	return $file->isFile();
+    return $file->isFile();
 };
 
 // Directories to skip for the check
 $newReleaseExclude = [
-	$options['to'] . '/installation'
+    $options['to'] . '/installation'
 ];
 
 /**
@@ -103,50 +101,45 @@ $newReleaseExclude = [
  * @return bool True if you need to recurse or if the item is acceptable
  */
 $newReleaseFilter = function ($file, $key, $iterator) use ($newReleaseExclude) {
-	if ($iterator->hasChildren() && !in_array($file->getPathname(), $newReleaseExclude))
-	{
-		return true;
-	}
+    if ($iterator->hasChildren() && !in_array($file->getPathname(), $newReleaseExclude)) {
+        return true;
+    }
 
-	return $file->isFile();
+    return $file->isFile();
 };
 
 $previousReleaseDirIterator = new RecursiveDirectoryIterator($options['from'], RecursiveDirectoryIterator::SKIP_DOTS);
 $previousReleaseIterator = new RecursiveIteratorIterator(
-	new RecursiveCallbackFilterIterator($previousReleaseDirIterator, $previousReleaseFilter),
-	RecursiveIteratorIterator::SELF_FIRST
+    new RecursiveCallbackFilterIterator($previousReleaseDirIterator, $previousReleaseFilter),
+    RecursiveIteratorIterator::SELF_FIRST
 );
 $previousReleaseFiles = [];
 $previousReleaseFolders = [];
 
-foreach ($previousReleaseIterator as $info)
-{
-	if ($info->isDir())
-	{
-		$previousReleaseFolders[] = "'" . str_replace($options['from'], '', $info->getPathname()) . "',";
-		continue;
-	}
+foreach ($previousReleaseIterator as $info) {
+    if ($info->isDir()) {
+        $previousReleaseFolders[] = "'" . str_replace($options['from'], '', $info->getPathname()) . "',";
+        continue;
+    }
 
-	$previousReleaseFiles[] = "'" . str_replace($options['from'], '', $info->getPathname()) . "',";
+    $previousReleaseFiles[] = "'" . str_replace($options['from'], '', $info->getPathname()) . "',";
 }
 
 $newReleaseDirIterator = new RecursiveDirectoryIterator($options['to'], RecursiveDirectoryIterator::SKIP_DOTS);
 $newReleaseIterator = new RecursiveIteratorIterator(
-	new RecursiveCallbackFilterIterator($newReleaseDirIterator, $newReleaseFilter),
-	RecursiveIteratorIterator::SELF_FIRST
+    new RecursiveCallbackFilterIterator($newReleaseDirIterator, $newReleaseFilter),
+    RecursiveIteratorIterator::SELF_FIRST
 );
 $newReleaseFiles = [];
 $newReleaseFolders = [];
 
-foreach ($newReleaseIterator as $info)
-{
-	if ($info->isDir())
-	{
-		$newReleaseFolders[] = "'" . str_replace($options['to'], '', $info->getPathname()) . "',";
-		continue;
-	}
+foreach ($newReleaseIterator as $info) {
+    if ($info->isDir()) {
+        $newReleaseFolders[] = "'" . str_replace($options['to'], '', $info->getPathname()) . "',";
+        continue;
+    }
 
-	$newReleaseFiles[] = "'" . str_replace($options['to'], '', $info->getPathname()) . "',";
+    $newReleaseFiles[] = "'" . str_replace($options['to'], '', $info->getPathname()) . "',";
 }
 
 $filesDifference = array_diff($previousReleaseFiles, $newReleaseFiles);
@@ -155,45 +148,44 @@ $foldersDifference = array_diff($previousReleaseFolders, $newReleaseFolders);
 
 // Specific files (e.g. language files) that we want to keep on upgrade
 $filesToKeep = [
-	"'/administrator/components/com_joomlaupdate/restore_finalisation.php',",
-	"'/administrator/language/en-GB/en-GB.com_search.ini',",
-	"'/administrator/language/en-GB/en-GB.com_search.sys.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.sys.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_fields_repeatable.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_fields_repeatable.sys.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_quickicon_eos310.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_quickicon_eos310.sys.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_categories.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_categories.sys.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_contacts.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_contacts.sys.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_content.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_content.sys.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_newsfeeds.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_newsfeeds.sys.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_tags.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_tags.sys.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_weblinks.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_search_weblinks.sys.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_system_weblinks.ini',",
-	"'/administrator/language/en-GB/en-GB.plg_system_weblinks.sys.ini',",
-	"'/language/en-GB/en-GB.com_search.ini',",
-	"'/language/en-GB/en-GB.mod_search.ini',",
-	"'/language/en-GB/en-GB.mod_search.sys.ini',",
+    "'/administrator/components/com_joomlaupdate/restore_finalisation.php',",
+    "'/administrator/language/en-GB/en-GB.com_search.ini',",
+    "'/administrator/language/en-GB/en-GB.com_search.sys.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_editors-xtd_weblink.sys.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_fields_repeatable.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_fields_repeatable.sys.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_quickicon_eos310.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_quickicon_eos310.sys.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_categories.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_categories.sys.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_contacts.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_contacts.sys.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_content.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_content.sys.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_newsfeeds.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_newsfeeds.sys.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_tags.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_tags.sys.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_weblinks.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_search_weblinks.sys.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_system_weblinks.ini',",
+    "'/administrator/language/en-GB/en-GB.plg_system_weblinks.sys.ini',",
+    "'/language/en-GB/en-GB.com_search.ini',",
+    "'/language/en-GB/en-GB.mod_search.ini',",
+    "'/language/en-GB/en-GB.mod_search.sys.ini',",
 ];
 
 // Specific folders that we want to keep on upgrade
 $foldersToKeep = [
-	"'/bin',",
+    "'/bin',",
 ];
 
 // Remove folders from the results which we want to keep on upgrade
-foreach ($foldersToKeep as $folder)
-{
-	if (($key = array_search($folder, $foldersDifference)) !== false) {
-		unset($foldersDifference[$key]);
-	}
+foreach ($foldersToKeep as $folder) {
+    if (($key = array_search($folder, $foldersDifference)) !== false) {
+        unset($foldersDifference[$key]);
+    }
 }
 
 asort($filesDifference);
@@ -202,34 +194,29 @@ rsort($foldersDifference);
 $deletedFiles = [];
 $renamedFiles = [];
 
-foreach ($filesDifference as $file)
-{
-	// Don't remove any specific files (e.g. language files) that we want to keep on upgrade
-	if (array_search($file, $filesToKeep) !== false)
-	{
-		continue;
-	}
+foreach ($filesDifference as $file) {
+    // Don't remove any specific files (e.g. language files) that we want to keep on upgrade
+    if (array_search($file, $filesToKeep) !== false) {
+        continue;
+    }
 
-	// Check for files which might have been renamed only
-	$matches = preg_grep('/^' . preg_quote($file, '/') . '$/i', $newReleaseFiles);
+    // Check for files which might have been renamed only
+    $matches = preg_grep('/^' . preg_quote($file, '/') . '$/i', $newReleaseFiles);
 
-	if ($matches !== false)
-	{
-		foreach ($matches as $match)
-		{
-			if (dirname($match) === dirname($file) && strtolower(basename($match)) === strtolower(basename($file)))
-			{
-				// File has been renamed only: Add to renamed files list
-				$renamedFiles[] = substr($file, 0, -1) . ' => ' . $match;
+    if ($matches !== false) {
+        foreach ($matches as $match) {
+            if (dirname($match) === dirname($file) && strtolower(basename($match)) === strtolower(basename($file))) {
+                // File has been renamed only: Add to renamed files list
+                $renamedFiles[] = substr($file, 0, -1) . ' => ' . $match;
 
-				// Go on with the next file in $filesDifference
-				continue 2;
-			}
-		}
-	}
+                // Go on with the next file in $filesDifference
+                continue 2;
+            }
+        }
+    }
 
-	// File has been really deleted and not just renamed
-	$deletedFiles[] = $file;
+    // File has been really deleted and not just renamed
+    $deletedFiles[] = $file;
 }
 
 // Write the lists to files for later reference

--- a/build/helpTOC.php
+++ b/build/helpTOC.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * @package    Joomla.Build
  *
@@ -28,10 +29,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  */
 const JOOMLA_MINIMUM_PHP = '7.2.5';
 
-if (!defined('_JDEFINES'))
-{
-	define('JPATH_BASE', dirname(__DIR__));
-	require_once JPATH_BASE . '/includes/defines.php';
+if (!defined('_JDEFINES')) {
+    define('JPATH_BASE', dirname(__DIR__));
+    require_once JPATH_BASE . '/includes/defines.php';
 }
 
 // Get the framework.
@@ -39,182 +39,163 @@ require_once JPATH_BASE . '/includes/framework.php';
 
 $command = new class extends AbstractCommand
 {
-	/**
-	 * The default command name
-	 *
-	 * @var  string
-	 */
-	protected static $defaultName = 'build-help-toc';
+    /**
+     * The default command name
+     *
+     * @var  string
+     */
+    protected static $defaultName = 'build-help-toc';
 
-	/**
-	 * Initialise the command.
-	 *
-	 * @return  void
-	 */
-	protected function configure(): void
-	{
-		$this->setDescription('Generates the help system table of contents file');
-	}
+    /**
+     * Initialise the command.
+     *
+     * @return  void
+     */
+    protected function configure(): void
+    {
+        $this->setDescription('Generates the help system table of contents file');
+    }
 
-	/**
-	 * Internal function to execute the command.
-	 *
-	 * @param   InputInterface   $input   The input to inject into the command.
-	 * @param   OutputInterface  $output  The output to inject into the command.
-	 *
-	 * @return  integer  The command exit code
-	 */
-	protected function doExecute(InputInterface $input, OutputInterface $output): int
-	{
-		$io = new SymfonyStyle($input, $output);
+    /**
+     * Internal function to execute the command.
+     *
+     * @param   InputInterface   $input   The input to inject into the command.
+     * @param   OutputInterface  $output  The output to inject into the command.
+     *
+     * @return  integer  The command exit code
+     */
+    protected function doExecute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
 
-		if (!class_exists(Http::class))
-		{
-			$io->error(
-				'The `joomla/mediawiki` package is not installed. To use this script, you must run `composer install` to install development'
-				. ' dependencies not tracked in this repo.'
-			);
+        if (!class_exists(Http::class)) {
+            $io->error(
+                'The `joomla/mediawiki` package is not installed. To use this script, you must run `composer install` to install development'
+                . ' dependencies not tracked in this repo.'
+            );
 
-			return 1;
-		}
+            return 1;
+        }
 
-		// Set up HTTP driver for MediaWiki
-		$http = new Http([], HttpFactory::getAvailableDriver());
+        // Set up HTTP driver for MediaWiki
+        $http = new Http([], HttpFactory::getAvailableDriver());
 
-		// Set up options for the Mediawiki class
-		$options = new Registry;
-		$options->set('api.url', 'https://docs.joomla.org');
+        // Set up options for the Mediawiki class
+        $options = new Registry();
+        $options->set('api.url', 'https://docs.joomla.org');
 
-		$mediawiki = new Mediawiki($options, $http);
+        $mediawiki = new Mediawiki($options, $http);
 
-		$io->comment('Fetching data from docs wiki');
+        $io->comment('Fetching data from docs wiki');
 
-		// Get the category members (local hack)
-		$categoryMembers = $mediawiki->categories->getCategoryMembers(
-			sprintf('Category:Help_screen_%s.%s', Version::MAJOR_VERSION, Version::MINOR_VERSION),
-			null,
-			'max'
-		);
+        // Get the category members (local hack)
+        $categoryMembers = $mediawiki->categories->getCategoryMembers(
+            sprintf('Category:Help_screen_%s.%s', Version::MAJOR_VERSION, Version::MINOR_VERSION),
+            null,
+            'max'
+        );
 
-		$members = [];
+        $members = [];
 
-		// Loop through the result objects to get every document
-		foreach ($categoryMembers->query->categorymembers as $catmembers)
-		{
-			foreach ($catmembers as $member)
-			{
-				$members[] = (string) $member['title'];
-			}
-		}
+        // Loop through the result objects to get every document
+        foreach ($categoryMembers->query->categorymembers as $catmembers) {
+            foreach ($catmembers as $member) {
+                $members[] = (string) $member['title'];
+            }
+        }
 
-		// Get the language object
-		$language = Factory::getLanguage();
+        // Get the language object
+        $language = Factory::getLanguage();
 
-		/*
-		 * Now we start fancy processing so we can get the language key for the titles
-		 */
+        /*
+         * Now we start fancy processing so we can get the language key for the titles
+         */
 
-		$cleanMembers = [];
+        $cleanMembers = [];
 
-		// Strip the namespace prefix off the titles and replace spaces with underscores
-		$namespace = sprintf('Help%d.x:', Version::MAJOR_VERSION);
+        // Strip the namespace prefix off the titles and replace spaces with underscores
+        $namespace = sprintf('Help%d.x:', Version::MAJOR_VERSION);
 
-		foreach ($members as $member)
-		{
-			$cleanMembers[] = str_replace([$namespace, ' '], ['', '_'], $member);
-		}
+        foreach ($members as $member) {
+            $cleanMembers[] = str_replace([$namespace, ' '], ['', '_'], $member);
+        }
 
-		// Make sure we only have an array of unique values before continuing
+        // Make sure we only have an array of unique values before continuing
 
-		$cleanMembers = array_unique($cleanMembers);
+        $cleanMembers = array_unique($cleanMembers);
 
-		// Load the admin com_admin language file
-		$language->load('com_admin', JPATH_ADMINISTRATOR);
+        // Load the admin com_admin language file
+        $language->load('com_admin', JPATH_ADMINISTRATOR);
 
-		$toc = [];
+        $toc = [];
 
-		foreach ($cleanMembers as $key => $value)
-		{
-			$string = strtoupper($value);
+        foreach ($cleanMembers as $key => $value) {
+            $string = strtoupper($value);
 
-			// Validate the key exists
-			$io->comment(sprintf('Validating key COM_ADMIN_HELP_%s', $string));
+            // Validate the key exists
+            $io->comment(sprintf('Validating key COM_ADMIN_HELP_%s', $string));
 
-			if ($language->hasKey('COM_ADMIN_HELP_' . $string))
-			{
-				$io->comment(sprintf('Adding %s', $string));
+            if ($language->hasKey('COM_ADMIN_HELP_' . $string)) {
+                $io->comment(sprintf('Adding %s', $string));
 
-				$toc[$value] = $string;
-			}
-			// We check the string for words in singular/plural form and check again
-			else
-			{
-				$io->comment(sprintf('Inflecting %s', $string));
+                $toc[$value] = $string;
+            } else {
+                // We check the string for words in singular/plural form and check again
+                $io->comment(sprintf('Inflecting %s', $string));
 
-				if (strpos($string, '_CATEGORIES') !== false)
-				{
-					$inflected = str_replace('_CATEGORIES', '_CATEGORY', $string);
-				}
-				elseif (strpos($string, '_USERS') !== false)
-				{
-					$inflected = str_replace('_USERS', '_USER', $string);
-				}
-				elseif (strpos($string, '_CATEGORY') !== false)
-				{
-					$inflected = str_replace('_CATEGORY', '_CATEGORIES', $string);
-				}
-				elseif (strpos($string, '_USER') !== false)
-				{
-					$inflected = str_replace('_USER', '_USERS', $string);
-				}
-				else
-				{
-					$inflected = '';
-				}
+                if (strpos($string, '_CATEGORIES') !== false) {
+                    $inflected = str_replace('_CATEGORIES', '_CATEGORY', $string);
+                } elseif (strpos($string, '_USERS') !== false) {
+                    $inflected = str_replace('_USERS', '_USER', $string);
+                } elseif (strpos($string, '_CATEGORY') !== false) {
+                    $inflected = str_replace('_CATEGORY', '_CATEGORIES', $string);
+                } elseif (strpos($string, '_USER') !== false) {
+                    $inflected = str_replace('_USER', '_USERS', $string);
+                } else {
+                    $inflected = '';
+                }
 
-				// Now try to validate the key
-				if ($inflected !== '')
-				{
-					$io->comment(sprintf('Validating key COM_ADMIN_HELP_%s', $inflected));
+                // Now try to validate the key
+                if ($inflected !== '') {
+                    $io->comment(sprintf('Validating key COM_ADMIN_HELP_%s', $inflected));
 
-					if ($language->hasKey('COM_ADMIN_HELP_' . $inflected))
-					{
-						$io->comment(sprintf('Adding %s', $inflected));
+                    if ($language->hasKey('COM_ADMIN_HELP_' . $inflected)) {
+                        $io->comment(sprintf('Adding %s', $inflected));
 
-						$toc[$value] = $inflected;
-					}
-				}
-			}
-		}
+                        $toc[$value] = $inflected;
+                    }
+                }
+            }
+        }
 
-		$io->comment(sprintf('Number of strings: %d', count($toc)));
+        $io->comment(sprintf('Number of strings: %d', count($toc)));
 
-		// JSON encode the file and write it to JPATH_ADMINISTRATOR/help/en-GB/toc.json
-		file_put_contents(JPATH_ADMINISTRATOR . '/help/en-GB/toc.json', json_encode($toc));
+        // JSON encode the file and write it to JPATH_ADMINISTRATOR/help/en-GB/toc.json
+        file_put_contents(JPATH_ADMINISTRATOR . '/help/en-GB/toc.json', json_encode($toc));
 
-		$io->success('Help Screen TOC written');
+        $io->success('Help Screen TOC written');
 
-		return 0;
-	}
+        return 0;
+    }
 };
 
 $input = new ArrayInput(
-	[
-		'command' => $command::getDefaultName(),
-	]
+    [
+        'command' => $command::getDefaultName(),
+    ]
 );
 
-$app = new class($input) extends Application
+$app = new class ($input) extends Application
 {
-	/**
-	 * Retrieve the application configuration object.
-	 *
-	 * @return  Registry
-	 */
-	public function getConfig()
-	{
-		return $this->config;
-	}
+    /**
+     * Retrieve the application configuration object.
+     *
+     * @return  Registry
+     */
+    public function getConfig()
+    {
+        return $this->config;
+    }
 };
 $app->addCommand($command);
 

--- a/build/psr12/phpcs.joomla.report.php
+++ b/build/psr12/phpcs.joomla.report.php
@@ -25,7 +25,6 @@ use function str_replace;
 use const JSON_OBJECT_AS_ARRAY;
 use const JSON_PRETTY_PRINT;
 
-
 class Joomla implements \PHP_CodeSniffer\Reports\Report
 {
     private $tmpDir = __DIR__ . '/../tmp/psr12';
@@ -85,7 +84,7 @@ class Joomla implements \PHP_CodeSniffer\Reports\Report
                                   <pre>{$error['message']}</pre>
                                 </div>
                                 HTML;
-                    $this->prepareProcessing($report['filename'],$phpcsFile, $line, $column, $error);
+                    $this->prepareProcessing($report['filename'], $phpcsFile, $line, $column, $error);
                 }
             }
         }
@@ -99,7 +98,8 @@ class Joomla implements \PHP_CodeSniffer\Reports\Report
         return true;
     }
 
-    private function prepareProcessing($file, $phpcsFile, $line, $column, $error) {
+    private function prepareProcessing($file, $phpcsFile, $line, $column, $error)
+    {
 
         switch ($error['source']) {
             case 'PSR1.Files.SideEffects.FoundWithSymbols':
@@ -109,7 +109,7 @@ class Joomla implements \PHP_CodeSniffer\Reports\Report
                     strpos($fileContent, "defined('_JEXEC')") !== false
                     || strpos($fileContent, "defined('JPATH_PLATFORM')") !== false
                     || strpos($fileContent, "defined('JPATH_BASE')") !== false
-            ) {
+                ) {
                     $this->preProcessing[] = [
                         'file' => $file,
                         'line' => $line,
@@ -183,7 +183,6 @@ class Joomla implements \PHP_CodeSniffer\Reports\Report
             case 'PSR2.Methods.MethodDeclaration.Underscore':
             case 'PSR1.Classes.ClassDeclaration.MultipleClasses':
             case 'PSR1.Methods.CamelCapsMethodName.NotCamelCaps':
-
                 $targetFile = $this->tmpDir . '/' . $error['source'] . '.txt';
                 $fileContent = '';
                 if (file_exists($targetFile)) {
@@ -235,12 +234,12 @@ class Joomla implements \PHP_CodeSniffer\Reports\Report
     ) {
 
         $preprocessing = [];
-        if (file_exists($this->tmpDir .'/cleanup.json')) {
-            $preprocessing = json_decode(file_get_contents($this->tmpDir .'/cleanup.json'), JSON_OBJECT_AS_ARRAY);
+        if (file_exists($this->tmpDir . '/cleanup.json')) {
+            $preprocessing = json_decode(file_get_contents($this->tmpDir . '/cleanup.json'), JSON_OBJECT_AS_ARRAY);
         }
 
         $preprocessing = array_merge($this->preProcessing, $preprocessing);
-        file_put_contents($this->tmpDir .'/cleanup.json', json_encode($preprocessing, JSON_PRETTY_PRINT));
+        file_put_contents($this->tmpDir . '/cleanup.json', json_encode($preprocessing, JSON_PRETTY_PRINT));
     }
 
     private function getTemplate($section)

--- a/build/psr12/psr12_converter.php
+++ b/build/psr12/psr12_converter.php
@@ -113,7 +113,7 @@ if ($tasks['BRANCH']) {
         die('Unable to find changes for this branch');
     }
 
-    foreach($output as $k => $line) {
+    foreach ($output as $k => $line) {
         if (substr($line, -4) !== '.php') {
             unset($output[$k]);
         }
@@ -237,7 +237,7 @@ foreach ($items as $item) {
 
 if ($tasks['CMS']) {
     passthru($git . ' add ' . $root);
-    passthru($git . ' commit -m "Phase 1 convert ' . ($tasks['BRANCH'] ? 'BRANCH' : 'CMS') .' to PSR-12"');
+    passthru($git . ' commit -m "Phase 1 convert ' . ($tasks['BRANCH'] ? 'BRANCH' : 'CMS') . ' to PSR-12"');
 }
 
 if ($tasks['CLEAN'] && file_exists($tmpDir . '/cleanup.json')) {
@@ -289,4 +289,3 @@ if (!empty($tasks['CMS']) && empty($tasks['BRANCH'])) {
 
         Text;
 }
-

--- a/build/stubGenerator.php
+++ b/build/stubGenerator.php
@@ -1,9 +1,12 @@
 <?php
+
 /**
  * @package    Joomla.Build
  *
  * @copyright  (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
 // Set flag that this is a parent file.
@@ -14,15 +17,13 @@ use Joomla\CMS\Application\CliApplication;
 use Joomla\CMS\Factory;
 
 // Load system defines
-if (file_exists(dirname(__DIR__) . '/defines.php'))
-{
-	require_once dirname(__DIR__) . '/defines.php';
+if (file_exists(dirname(__DIR__) . '/defines.php')) {
+    require_once dirname(__DIR__) . '/defines.php';
 }
 
-if (!defined('_JDEFINES'))
-{
-	define('JPATH_BASE', dirname(__DIR__));
-	require_once JPATH_BASE . '/includes/defines.php';
+if (!defined('_JDEFINES')) {
+    define('JPATH_BASE', dirname(__DIR__));
+    require_once JPATH_BASE . '/includes/defines.php';
 }
 
 // Get the Platform with legacy libraries.
@@ -49,115 +50,110 @@ ini_set('display_errors', 1);
  */
 class StubGenerator extends CliApplication
 {
-	use \Joomla\CMS\Application\ExtensionNamespaceMapper;
+    use \Joomla\CMS\Application\ExtensionNamespaceMapper;
 
-	/**
-	 * Entry point for CLI script
-	 *
-	 * @return  void
-	 *
-	 * @since   3.0
-	 */
-	public function doExecute()
-	{
-		$this->createExtensionNamespaceMap();
-		$contentsByNamespace = [];
+    /**
+     * Entry point for CLI script
+     *
+     * @return  void
+     *
+     * @since   3.0
+     */
+    public function doExecute()
+    {
+        $this->createExtensionNamespaceMap();
+        $contentsByNamespace = [];
 
-		$file = "<?php\n";
+        $file = "<?php\n";
 
-		// Loop the aliases to generate the stubs data
-		foreach (JLoader::getDeprecatedAliases() as $alias)
-		{
-			$oldName           = $alias['old'];
-			$newName           = $alias['new'];
-			$deprecatedVersion = $alias['version'];
+        // Loop the aliases to generate the stubs data
+        foreach (JLoader::getDeprecatedAliases() as $alias) {
+            $oldName           = $alias['old'];
+            $newName           = $alias['new'];
+            $deprecatedVersion = $alias['version'];
 
-			// Figure out if the alias is for a class or interface
-			$reflection = new ReflectionClass($newName);
-			$type       = $reflection->isInterface() ? 'interface' : 'class';
-			$modifier   = (!$reflection->isInterface() && $reflection->isFinal()) ? 'final ' : '';
-			$modifier   = ($reflection->isAbstract() && !$reflection->isInterface()) ? $modifier . 'abstract ' : $modifier;
+            // Figure out if the alias is for a class or interface
+            $reflection = new ReflectionClass($newName);
+            $type       = $reflection->isInterface() ? 'interface' : 'class';
+            $modifier   = (!$reflection->isInterface() && $reflection->isFinal()) ? 'final ' : '';
+            $modifier   = ($reflection->isAbstract() && !$reflection->isInterface()) ? $modifier . 'abstract ' : $modifier;
 
-			$namespaceSegments = explode('\\', $oldName);
-			$className         = array_pop($namespaceSegments);
-			$targetNamespace   = ltrim(implode('\\', $namespaceSegments), '\\');
+            $namespaceSegments = explode('\\', $oldName);
+            $className         = array_pop($namespaceSegments);
+            $targetNamespace   = ltrim(implode('\\', $namespaceSegments), '\\');
 
-			// If a deprecated version is available, write a stub class doc block with a deprecated tag
-			if ($deprecatedVersion !== false)
-			{
-				$fileContents = <<<PHP
+            // If a deprecated version is available, write a stub class doc block with a deprecated tag
+            if ($deprecatedVersion !== false) {
+                $fileContents = <<<PHP
 	/**
 	 * @deprecated $deprecatedVersion Use $newName instead.
 	 */
 
 PHP;
-			}
+            }
 
-			$fileContents .= "\t$modifier$type $className extends \\$newName {}\n\n";
+            $fileContents .= "\t$modifier$type $className extends \\$newName {}\n\n";
 
-			if (!array_key_exists($targetNamespace, $contentsByNamespace))
-			{
-				$contentsByNamespace[$targetNamespace] = '';
-			}
+            if (!array_key_exists($targetNamespace, $contentsByNamespace)) {
+                $contentsByNamespace[$targetNamespace] = '';
+            }
 
-			$contentsByNamespace[$targetNamespace] .= $fileContents;
-		}
+            $contentsByNamespace[$targetNamespace] .= $fileContents;
+        }
 
-		foreach ($contentsByNamespace as $namespace => $contents)
-		{
-			$file .= "namespace $namespace {\n";
-			$file .= $contents;
-			$file .= "}\n\n";
-		}
+        foreach ($contentsByNamespace as $namespace => $contents) {
+            $file .= "namespace $namespace {\n";
+            $file .= $contents;
+            $file .= "}\n\n";
+        }
 
-		// And save the file locally
-		file_put_contents(JPATH_ROOT . '/stubs.php', $file);
+        // And save the file locally
+        file_put_contents(JPATH_ROOT . '/stubs.php', $file);
 
-		$this->out('Stubs file written', true);
-	}
+        $this->out('Stubs file written', true);
+    }
 
-	/**
-	 * Gets the name of the current running application.
-	 *
-	 * @return  string  The name of the application.
-	 *
-	 * @since   4.0.0
-	 */
-	public function getName()
-	{
-		return 'cli-stubgen';
-	}
+    /**
+     * Gets the name of the current running application.
+     *
+     * @return  string  The name of the application.
+     *
+     * @since   4.0.0
+     */
+    public function getName()
+    {
+        return 'cli-stubgen';
+    }
 
-	/**
-	 * Get the menu object.
-	 *
-	 * @param string $name    The application name for the menu
-	 * @param array  $options An array of options to initialise the menu with
-	 *
-	 * @throws   \BadMethodCallException  Exception thrown as CLI Application has no menu.
-	 *
-	 * @since   4.0.0
-	 */
-	public function getMenu($name = null, $options = array())
-	{
-		throw new \BadMethodCallException('CLI Application has no menu');
-	}
+    /**
+     * Get the menu object.
+     *
+     * @param string $name    The application name for the menu
+     * @param array  $options An array of options to initialise the menu with
+     *
+     * @throws   \BadMethodCallException  Exception thrown as CLI Application has no menu.
+     *
+     * @since   4.0.0
+     */
+    public function getMenu($name = null, $options = array())
+    {
+        throw new \BadMethodCallException('CLI Application has no menu');
+    }
 }
 
 Factory::getContainer()->share(
-	'StubGenerator',
-	function (\Joomla\DI\Container $container)
-	{
-		return new \StubGenerator(
-			null,
-			null,
-			null,
-			null,
-			$container->get(\Joomla\Event\DispatcherInterface::class),
-			$container
-		);
-	},
-	true
+    'StubGenerator',
+    function (\Joomla\DI\Container $container) {
+        return new \StubGenerator(
+            null,
+            null,
+            null,
+            null,
+            $container->get(\Joomla\Event\DispatcherInterface::class),
+            $container
+        );
+    },
+    true
 );
 
 $app = Factory::getContainer()->get('StubGenerator');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Converts the PHP files in the build folder to PSR-12 and but does **_not_** include them into the cs check yet.

The files in subfolder "psr12" are already PSR-12, but this PR fixes a few smaller code style errors in these files, too.

This PR here makes sure that people who use the right .editorconfig for PSR-12 can edit the files in the build folder without getting mad.

### Testing Instructions

On a clean, current 4.2-dev run `composer install` if not done before.

Then run `./libraries/vendor/bin/phpcs --extensions=php -p --standard=ruleset.xml ./build`

### Actual result BEFORE applying this Pull Request

Lots of code style errors and warnings.

### Expected result AFTER applying this Pull Request

Only the following warning is remaining for some files:

```
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------------------------------------
 1 | WARNING | A file should declare new symbols (classes, functions, constants, etc.) and cause no other side effects, or it should execute logic
   |         | with side effects, but should not do both. The first symbol is defined on line 25 and the first side effect is on line 26.
------------------------------------------------------------------------------------------------------------------------------------------------------
```

### Documentation Changes Required

None.