### PR TITLE
Workaround for removed _db, fix backward compatibility without __get

### DIFF
--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -401,6 +401,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
 
     /**
      * Set the database.
+     * @todo: This is a workaround for backward compatibility, when $this->_db still in use. Should be removed in 5.0
      *
      * @param   DatabaseInterface  $db  The database.
      *

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -48,7 +48,9 @@ abstract class BaseDatabaseModel extends BaseModel implements
     CurrentUserInterface,
     CacheControllerFactoryAwareInterface
 {
-    use DatabaseAwareTrait;
+    use DatabaseAwareTrait {
+        setDatabase as private setDatabaseTrait;
+    }
     use MVCFactoryAwareTrait;
     use DispatcherAwareTrait;
     use CurrentUserTrait;
@@ -69,6 +71,16 @@ abstract class BaseDatabaseModel extends BaseModel implements
      * @since  3.0
      */
     protected $event_clean_cache = null;
+
+    /**
+     * The database driver.
+     *
+     * @var    DatabaseInterface
+     * @since  __DEPLOY_VERSION__
+     *
+     * @deprecated  5.0 Use getDatabase() instead of directly accessing _db
+     */
+    protected $_db;
 
     /**
      * Constructor
@@ -353,6 +365,8 @@ abstract class BaseDatabaseModel extends BaseModel implements
      */
     public function getDbo()
     {
+        @trigger_error('Method getDbo() is deprecated, use getDatabase() instead.', E_USER_DEPRECATED);
+
         try {
             return $this->getDatabase();
         } catch (DatabaseNotFoundException $e) {
@@ -373,6 +387,8 @@ abstract class BaseDatabaseModel extends BaseModel implements
      */
     public function setDbo(DatabaseInterface $db = null)
     {
+        @trigger_error('Method setDbo() is deprecated, use setDatabase() instead.', E_USER_DEPRECATED);
+
         if ($db === null) {
             return;
         }
@@ -381,27 +397,18 @@ abstract class BaseDatabaseModel extends BaseModel implements
     }
 
     /**
-     * Proxy for _db variable.
+     * Set the database.
      *
-     * @param   string  $name  The name of the element
+     * @param   DatabaseInterface  $db  The database.
      *
-     * @return  mixed  The value of the element if set, null otherwise
+     * @return  void
      *
-     * @since   4.2.0
-     *
-     * @deprecated  5.0 Use getDatabase() instead of directly accessing _db
+     * @since   __DEPLOY_VERSION__
      */
-    public function __get($name)
+    public function setDatabase(DatabaseInterface $db): void
     {
-        if ($name === '_db') {
-            return $this->getDatabase();
-        }
-
-        // Default the variable
-        if (!isset($this->$name)) {
-            $this->$name = null;
-        }
-
-        return $this->$name;
+        // Workaround for backward compatibility
+        $this->_db = $db;
+        $this->setDatabaseTrait($db);
     }
 }

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -7,6 +7,9 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+// Disable Underscore, because we need $_db for backward compatibility
+// phpcs:disable PSR2.Classes.PropertyDeclaration.Underscore
+
 namespace Joomla\CMS\MVC\Model;
 
 use Joomla\CMS\Cache\CacheControllerFactoryAwareInterface;


### PR DESCRIPTION
### Summary of Changes

This is redo #37636
Create a `_db` without use of magic `__get`.

The magic `get` changes behavior of the object A LOT, example if any model have created a property "on fly" it crashes.
Like:
```php
class FooBar{
  public function __get($name){ return null; }
}

$c = new FooBar;
$c->_cache[1] = 'foobar';

var_dump($c->_cache[1] ); // Will be NULL instead of "foobar"
```

That what happen in https://github.com/joomla/joomla-cms/blob/dd91072a956a19a43798515239892edd2b49ac7b/administrator/components/com_modules/src/Model/ModuleModel.php#L676-L679


### Testing Instructions

Because it is an alternative fix, it still should work as before.
Addittionaly, please test any 3d component, wich use `_db` in its model.

### Documentation Changes Required

As part of #37095
