### PR TITLE
Remove subform in subform limitation for custom fields

### DIFF
--- a/administrator/components/com_fields/src/Field/SubfieldsField.php
+++ b/administrator/components/com_fields/src/Field/SubfieldsField.php
@@ -71,11 +71,6 @@ class SubfieldsField extends ListField
 
         // Iterate over the custom fields for this context
         foreach (static::$customFieldsCache[$this->context] as $customField) {
-            // Skip our own subform type. We won't have subform in subform.
-            if ($customField->type == 'subform') {
-                continue;
-            }
-
             $options[] = HTMLHelper::_(
                 'select.option',
                 $customField->id,


### PR DESCRIPTION
### Summary of Changes
Remove the limitation to select a subform as a subform field in custom fields.

There is no reason we have this limit, subforms can already be used as field of another subform.


### Testing Instructions
* Create a number of custom fields
* Create a subform !1
* Add the fields to the subform
* Create a subform !2
* Add subform !1 to subform !2
* check if everything works

### Actual result BEFORE applying this Pull Request
It's not possible to select subform !1 in subform !2


### Expected result AFTER applying this Pull Request
You can select subform !1 in subform !2 and you also can edit it


