### PR TITLE
Use tabs for non php files in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,12 +5,16 @@ root = true
 
 # Unix-style end of lines and a blank line at the end of the file
 [*]
-indent_style = space
-indent_size = 4
+indent_style = tab
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
+[*.php]
+indent_style = space
+indent_size = 4
+
 [*.{js,json,scss,css,vue}]
+indent_style = space
 indent_size = 2


### PR DESCRIPTION
On PSR-12 conversion the editor config change was to generic which affects other files then *.php. All files used spaces which was not the expected behavior. For example xml files still use tabs.