### PR TITLE
Installer must implement the DB aware interface as well

### DIFF
--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Extension;
 use Joomla\CMS\Table\Table;
+use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Database\DatabaseInterface;
@@ -33,7 +34,7 @@ use Joomla\DI\ContainerAwareInterface;
  *
  * @since  3.1
  */
-class Installer extends Adapter
+class Installer extends Adapter implements DatabaseAwareInterface
 {
     use DatabaseAwareTrait;
 


### PR DESCRIPTION
Pull Request for Issue #38173.

### Summary of Changes
The `Installer` must also implement the `DatabaseAwareInterface` so the database is automatically populated in the Adapter class.

### Testing Instructions
Install OSMap through the web installer.

### Actual result BEFORE applying this Pull Request
A warning is displayed with the message that the database is not set.

### Expected result AFTER applying this Pull Request
No error and the extension installs fine.