### PR TITLE
Workaround for possible missed $app property in override for plugin tmpl

### DIFF
--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -395,11 +395,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
     public function setApplication(CMSApplicationInterface $application): void
     {
         // @todo: Workaround for possible missed $app property in override #38153, #38060. Remove in 5.0.
-        if (empty($this->app))
-        {
-            $this->app = $application;
-        }
-
+        $this->app = $application;
         $this->application = $application;
     }
 }

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -394,6 +394,12 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
      */
     public function setApplication(CMSApplicationInterface $application): void
     {
+        // @todo: Workaround for possible missed $app property in override #38153, #38060. Remove in 5.0.
+        if (empty($this->app))
+        {
+            $this->app = $application;
+        }
+
         $this->application = $application;
     }
 }


### PR DESCRIPTION
Pull Request for Issue #38153 .

### Summary of Changes

Make sure that the property $app exists, for plugins that strated migration to Service.
More info in comment https://github.com/joomla/joomla-cms/pull/38153#issuecomment-1169939718

### Testing Instructions

To mimic possible bug, edit https://github.com/joomla/joomla-cms/blob/dd91072a956a19a43798515239892edd2b49ac7b/plugins/quickicon/joomlaupdate/src/Extension/Joomlaupdate.php#L89

Add there `dump($this->app->getName());`
And open Dashboard.

### Actual result BEFORE applying this Pull Request
You will get error `Call to a member function getName() on null`


### Expected result AFTER applying this Pull Request
You will get `"administrator"`.


### Documentation Changes Required
As part of #38060

ping @laoneo @nikosdion 