### PR TITLE
[4.2] The translate function in the CMS plugin class is too generic

### DIFF
--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -185,7 +185,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
      *
      * @see     sprintf
      */
-    protected function translate(string $key): string
+    protected function translateKey(string $key): string
     {
         $language = $this->getApplication()->getLanguage();
 

--- a/plugins/api-authentication/basic/src/Extension/Basic.php
+++ b/plugins/api-authentication/basic/src/Extension/Basic.php
@@ -70,7 +70,7 @@ final class Basic extends CMSPlugin
 
         if ($password === '') {
             $response->status        = Authentication::STATUS_FAILURE;
-            $response->error_message = $this->translate('JGLOBAL_AUTH_EMPTY_PASS_NOT_ALLOWED');
+            $response->error_message = $this->translateKey('JGLOBAL_AUTH_EMPTY_PASS_NOT_ALLOWED');
 
             return;
         }
@@ -106,7 +106,7 @@ final class Basic extends CMSPlugin
             } else {
                 // Invalid password
                 $response->status        = Authentication::STATUS_FAILURE;
-                $response->error_message = $this->translate('JGLOBAL_AUTH_INVALID_PASS');
+                $response->error_message = $this->translateKey('JGLOBAL_AUTH_INVALID_PASS');
             }
         } else {
             // Let's hash the entered password even if we don't have a matching user for some extra response time
@@ -115,7 +115,7 @@ final class Basic extends CMSPlugin
 
             // Invalid user
             $response->status        = Authentication::STATUS_FAILURE;
-            $response->error_message = $this->translate('JGLOBAL_AUTH_NO_USER');
+            $response->error_message = $this->translateKey('JGLOBAL_AUTH_NO_USER');
         }
     }
 }

--- a/plugins/api-authentication/token/src/Extension/Token.php
+++ b/plugins/api-authentication/token/src/Extension/Token.php
@@ -95,7 +95,7 @@ final class Token extends CMSPlugin
         // Default response is authentication failure.
         $response->type          = 'Token';
         $response->status        = Authentication::STATUS_FAILURE;
-        $response->error_message = $this->translate('JGLOBAL_AUTH_FAIL');
+        $response->error_message = $this->translateKey('JGLOBAL_AUTH_FAIL');
 
         /**
          * First look for an HTTP Authorization header with the following format:

--- a/plugins/task/requests/src/Extension/Requests.php
+++ b/plugins/task/requests/src/Extension/Requests.php
@@ -128,7 +128,7 @@ final class Requests extends CMSPlugin implements SubscriberInterface
         try {
             $response = $this->httpFactory->getHttp([])->get($url, $headers, $timeout);
         } catch (Exception $e) {
-            $this->logTask($this->translate('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_TIMEOUT'));
+            $this->logTask($this->translateKey('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_TIMEOUT'));
 
             return TaskStatus::TIMEOUT;
         }
@@ -144,7 +144,7 @@ final class Requests extends CMSPlugin implements SubscriberInterface
             $this->snapshot['output_file'] = $responseFilename;
             $responseStatus = 'SAVED';
         } catch (Exception $e) {
-            $this->logTask($this->translate('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_UNWRITEABLE_OUTPUT'), 'error');
+            $this->logTask($this->translateKey('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_UNWRITEABLE_OUTPUT'), 'error');
             $responseStatus = 'NOT_SAVED';
         }
 
@@ -155,7 +155,7 @@ final class Requests extends CMSPlugin implements SubscriberInterface
 > Response: $responseStatus
 EOF;
 
-        $this->logTask($this->translate('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_RESPONSE', $responseCode));
+        $this->logTask($this->translateKey('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_RESPONSE', $responseCode));
 
         if ($response->code !== 200) {
             return TaskStatus::KNOCKOUT;

--- a/plugins/task/sitestatus/src/Extension/SiteStatus.php
+++ b/plugins/task/sitestatus/src/Extension/SiteStatus.php
@@ -139,7 +139,7 @@ final class SiteStatus extends CMSPlugin implements SubscriberInterface
 
         $newStatus = $config['offline'] ? 'offline' : 'online';
         $exit      = $this->writeConfigFile(new Registry($config));
-        $this->logTask($this->translate('PLG_TASK_SITE_STATUS_TASK_LOG_SITE_STATUS', $oldStatus, $newStatus));
+        $this->logTask($this->translateKey('PLG_TASK_SITE_STATUS_TASK_LOG_SITE_STATUS', $oldStatus, $newStatus));
 
         $this->endRoutine($event, $exit);
     }
@@ -161,7 +161,7 @@ final class SiteStatus extends CMSPlugin implements SubscriberInterface
 
         // Attempt to make the file writeable.
         if (file_exists($file) && Path::isOwner($file) && !Path::setPermissions($file)) {
-            $this->logTask($this->translate('PLG_TASK_SITE_STATUS_ERROR_CONFIGURATION_PHP_NOTWRITABLE'), 'notice');
+            $this->logTask($this->translateKey('PLG_TASK_SITE_STATUS_ERROR_CONFIGURATION_PHP_NOTWRITABLE'), 'notice');
         }
 
         try {
@@ -169,7 +169,7 @@ final class SiteStatus extends CMSPlugin implements SubscriberInterface
             $configuration = $config->toString('PHP', array('class' => 'JConfig', 'closingtag' => false));
             File::write($file, $configuration);
         } catch (Exception $e) {
-            $this->logTask($this->translate('PLG_TASK_SITE_STATUS_ERROR_WRITE_FAILED'), 'error');
+            $this->logTask($this->translateKey('PLG_TASK_SITE_STATUS_ERROR_WRITE_FAILED'), 'error');
 
             return Status::KNOCKOUT;
         }
@@ -181,7 +181,7 @@ final class SiteStatus extends CMSPlugin implements SubscriberInterface
 
         // Attempt to make the file un-writeable.
         if (Path::isOwner($file) && !Path::setPermissions($file, '0444')) {
-            $this->logTask($this->translate('PLG_TASK_SITE_STATUS_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'), 'notice');
+            $this->logTask($this->translateKey('PLG_TASK_SITE_STATUS_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'), 'notice');
         }
 
         return Status::OK;

--- a/tests/Unit/Libraries/Cms/Plugin/CMSPluginTest.php
+++ b/tests/Unit/Libraries/Cms/Plugin/CMSPluginTest.php
@@ -264,7 +264,7 @@ class CMSPluginTest extends UnitTestCase
         {
             public function test(): string
             {
-                return parent::translate('unit');
+                return parent::translateKey('unit');
             }
         };
         $plugin->setApplication($app);
@@ -292,7 +292,7 @@ class CMSPluginTest extends UnitTestCase
         {
             public function test(): string
             {
-                return parent::translate('unit', 1, 'two');
+                return parent::translateKey('unit', 1, 'two');
             }
         };
         $plugin->setApplication($app);


### PR DESCRIPTION
### Summary of Changes
Renames the translate function to something less generic to avoid potential conflicts with existing plugins. If there are better names feel free to comment, because for me is translate the right name.

Ping @roland-d 

### Testing Instructions
Create a GET request task and run it manually in the back end from the web interface.

### Actual result BEFORE applying this Pull Request
All works.

### Expected result AFTER applying this Pull Request
All works.