### PR TITLE
[4.2] Use the app language translate function in plugins

### DIFF
--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -173,34 +173,6 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface
     }
 
     /**
-     * Translates the given key with the local applications language. If arguments are available, then
-     * injects them into the translated string.
-     *
-     * @param   string   $key        The key to translate
-     * @param   mixed[]  $arguments  The arguments
-     *
-     * @return  string  The translated string
-     *
-     * @since   4.2.0
-     *
-     * @see     sprintf
-     */
-    protected function translate(string $key): string
-    {
-        $language = $this->getApplication()->getLanguage();
-
-        $arguments = \func_get_args();
-
-        if (count($arguments) > 1) {
-            $arguments[0] = $language->_($key);
-
-            return \call_user_func_array('sprintf', $arguments);
-        }
-
-        return $language->_($key);
-    }
-
-    /**
      * Registers legacy Listeners to the Dispatcher, emulating how plugins worked under Joomla! 3.x and below.
      *
      * By default, this method will look for all public methods whose name starts with "on". It will register

--- a/plugins/api-authentication/basic/src/Extension/Basic.php
+++ b/plugins/api-authentication/basic/src/Extension/Basic.php
@@ -70,7 +70,7 @@ final class Basic extends CMSPlugin
 
         if ($password === '') {
             $response->status        = Authentication::STATUS_FAILURE;
-            $response->error_message = $this->translate('JGLOBAL_AUTH_EMPTY_PASS_NOT_ALLOWED');
+            $response->error_message = $this->getApplication()->getLanguage()->_('JGLOBAL_AUTH_EMPTY_PASS_NOT_ALLOWED');
 
             return;
         }
@@ -106,7 +106,7 @@ final class Basic extends CMSPlugin
             } else {
                 // Invalid password
                 $response->status        = Authentication::STATUS_FAILURE;
-                $response->error_message = $this->translate('JGLOBAL_AUTH_INVALID_PASS');
+                $response->error_message = $this->getApplication()->getLanguage()->_('JGLOBAL_AUTH_INVALID_PASS');
             }
         } else {
             // Let's hash the entered password even if we don't have a matching user for some extra response time
@@ -115,7 +115,7 @@ final class Basic extends CMSPlugin
 
             // Invalid user
             $response->status        = Authentication::STATUS_FAILURE;
-            $response->error_message = $this->translate('JGLOBAL_AUTH_NO_USER');
+            $response->error_message = $this->getApplication()->getLanguage()->_('JGLOBAL_AUTH_NO_USER');
         }
     }
 }

--- a/plugins/api-authentication/token/src/Extension/Token.php
+++ b/plugins/api-authentication/token/src/Extension/Token.php
@@ -95,7 +95,7 @@ final class Token extends CMSPlugin
         // Default response is authentication failure.
         $response->type          = 'Token';
         $response->status        = Authentication::STATUS_FAILURE;
-        $response->error_message = $this->translate('JGLOBAL_AUTH_FAIL');
+        $response->error_message = $this->getApplication()->getLanguage()->_('JGLOBAL_AUTH_FAIL');
 
         /**
          * First look for an HTTP Authorization header with the following format:

--- a/plugins/task/requests/src/Extension/Requests.php
+++ b/plugins/task/requests/src/Extension/Requests.php
@@ -128,7 +128,7 @@ final class Requests extends CMSPlugin implements SubscriberInterface
         try {
             $response = $this->httpFactory->getHttp([])->get($url, $headers, $timeout);
         } catch (Exception $e) {
-            $this->logTask($this->translate('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_TIMEOUT'));
+            $this->logTask($this->getApplication()->getLanguage()->_('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_TIMEOUT'));
 
             return TaskStatus::TIMEOUT;
         }
@@ -144,7 +144,7 @@ final class Requests extends CMSPlugin implements SubscriberInterface
             $this->snapshot['output_file'] = $responseFilename;
             $responseStatus = 'SAVED';
         } catch (Exception $e) {
-            $this->logTask($this->translate('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_UNWRITEABLE_OUTPUT'), 'error');
+            $this->logTask($this->getApplication()->getLanguage()->_('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_UNWRITEABLE_OUTPUT'), 'error');
             $responseStatus = 'NOT_SAVED';
         }
 
@@ -155,7 +155,7 @@ final class Requests extends CMSPlugin implements SubscriberInterface
 > Response: $responseStatus
 EOF;
 
-        $this->logTask($this->translate('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_RESPONSE', $responseCode));
+        $this->logTask(sprintf($this->getApplication()->getLanguage()->_('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_RESPONSE'), $responseCode));
 
         if ($response->code !== 200) {
             return TaskStatus::KNOCKOUT;

--- a/plugins/task/sitestatus/src/Extension/SiteStatus.php
+++ b/plugins/task/sitestatus/src/Extension/SiteStatus.php
@@ -139,7 +139,7 @@ final class SiteStatus extends CMSPlugin implements SubscriberInterface
 
         $newStatus = $config['offline'] ? 'offline' : 'online';
         $exit      = $this->writeConfigFile(new Registry($config));
-        $this->logTask($this->translate('PLG_TASK_SITE_STATUS_TASK_LOG_SITE_STATUS', $oldStatus, $newStatus));
+        $this->logTask(sprintf($this->getApplication()->getLanguage()->_('PLG_TASK_SITE_STATUS_TASK_LOG_SITE_STATUS'), $oldStatus, $newStatus));
 
         $this->endRoutine($event, $exit);
     }
@@ -161,7 +161,7 @@ final class SiteStatus extends CMSPlugin implements SubscriberInterface
 
         // Attempt to make the file writeable.
         if (file_exists($file) && Path::isOwner($file) && !Path::setPermissions($file)) {
-            $this->logTask($this->translate('PLG_TASK_SITE_STATUS_ERROR_CONFIGURATION_PHP_NOTWRITABLE'), 'notice');
+            $this->logTask($this->getApplication()->getLanguage()->_('PLG_TASK_SITE_STATUS_ERROR_CONFIGURATION_PHP_NOTWRITABLE'), 'notice');
         }
 
         try {
@@ -169,7 +169,7 @@ final class SiteStatus extends CMSPlugin implements SubscriberInterface
             $configuration = $config->toString('PHP', array('class' => 'JConfig', 'closingtag' => false));
             File::write($file, $configuration);
         } catch (Exception $e) {
-            $this->logTask($this->translate('PLG_TASK_SITE_STATUS_ERROR_WRITE_FAILED'), 'error');
+            $this->logTask($this->getApplication()->getLanguage()->_('PLG_TASK_SITE_STATUS_ERROR_WRITE_FAILED'), 'error');
 
             return Status::KNOCKOUT;
         }
@@ -181,7 +181,7 @@ final class SiteStatus extends CMSPlugin implements SubscriberInterface
 
         // Attempt to make the file un-writeable.
         if (Path::isOwner($file) && !Path::setPermissions($file, '0444')) {
-            $this->logTask($this->translate('PLG_TASK_SITE_STATUS_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'), 'notice');
+            $this->logTask($this->getApplication()->getLanguage()->_('PLG_TASK_SITE_STATUS_ERROR_CONFIGURATION_PHP_NOTUNWRITABLE'), 'notice');
         }
 
         return Status::OK;

--- a/tests/Unit/Libraries/Cms/Plugin/CMSPluginTest.php
+++ b/tests/Unit/Libraries/Cms/Plugin/CMSPluginTest.php
@@ -245,62 +245,6 @@ class CMSPluginTest extends UnitTestCase
     }
 
     /**
-     * @testdox  can translate a string without arguments
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testTranslateWithoutArguments()
-    {
-        $dispatcher = new Dispatcher();
-        $language = $this->createMock(Language::class);
-        $language->method('_')->willReturn('test');
-
-        $app = $this->createStub(CMSApplicationInterface::class);
-        $app->method('getLanguage')->willReturn($language);
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin
-        {
-            public function test(): string
-            {
-                return parent::translate('unit');
-            }
-        };
-        $plugin->setApplication($app);
-
-        $this->assertEquals('test', $plugin->test());
-    }
-
-    /**
-     * @testdox  can translate a string with arguments
-     *
-     * @return  void
-     *
-     * @since   4.2.0
-     */
-    public function testTranslateWithArguments()
-    {
-        $dispatcher = new Dispatcher();
-        $language = $this->createMock(Language::class);
-        $language->method('_')->willReturn('test %s in %s');
-
-        $app = $this->createStub(CMSApplicationInterface::class);
-        $app->method('getLanguage')->willReturn($language);
-
-        $plugin = new class ($dispatcher, []) extends CMSPlugin
-        {
-            public function test(): string
-            {
-                return parent::translate('unit', 1, 'two');
-            }
-        };
-        $plugin->setApplication($app);
-
-        $this->assertEquals('test 1 in two', $plugin->test());
-    }
-
-    /**
      * @testdox  can register the listeners when is SubscriberInterface
      *
      * @return  void


### PR DESCRIPTION
### Summary of Changes
Reverts the translate function in the `CMSPlugin` class and uses the translate function from the application language object.

### Testing Instructions
Create a GET request task and run it manually in the back end from the web interface.

### Actual result BEFORE applying this Pull Request
An output is displayed with the string "Response Code: 200".

### Expected result AFTER applying this Pull Request
An output is displayed with the string "Response Code: 200".