### PR TITLE
[4.2] CLI user scripts cleanup

### DIFF
--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -125,7 +125,7 @@ class AddUserCommand extends AbstractCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->configureIO($input, $output);
-        $this->ioStyle->title('Add user');
+        $this->ioStyle->title('Add User');
         $this->user = $this->getStringFromOption('username', 'Please enter a username');
         $this->name = $this->getStringFromOption('name', 'Please enter a name (full name of user)');
         $this->email = $this->getStringFromOption('email', 'Please enter an email address');

--- a/libraries/src/Console/AddUserToGroupCommand.php
+++ b/libraries/src/Console/AddUserToGroupCommand.php
@@ -99,8 +99,8 @@ class AddUserToGroupCommand extends AbstractCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->configureIO($input, $output);
+        $this->ioStyle->title('Add User To Group');
         $this->username = $this->getStringFromOption('username', 'Please enter a username');
-        $this->ioStyle->title('Add user to group');
 
         $userId = $this->getUserId($this->username);
 

--- a/libraries/src/Console/ChangeUserPasswordCommand.php
+++ b/libraries/src/Console/ChangeUserPasswordCommand.php
@@ -78,8 +78,8 @@ class ChangeUserPasswordCommand extends AbstractCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->configureIO($input, $output);
+        $this->ioStyle->title('Change Password');
         $this->username = $this->getStringFromOption('username', 'Please enter a username');
-        $this->ioStyle->title('Change password');
 
         $userId = UserHelper::getUserId($this->username);
 

--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -90,7 +90,7 @@ class DeleteUserCommand extends AbstractCommand
     {
         $this->configureIO($input, $output);
 
-        $this->ioStyle->title('Delete users');
+        $this->ioStyle->title('Delete User');
 
         $this->username = $this->getStringFromOption('username', 'Please enter a username');
 

--- a/libraries/src/Console/ListUserCommand.php
+++ b/libraries/src/Console/ListUserCommand.php
@@ -71,7 +71,7 @@ class ListUserCommand extends AbstractCommand
         $db = $this->getDatabase();
 
         $this->configureIO($input, $output);
-        $this->ioStyle->title('List users');
+        $this->ioStyle->title('List Users');
 
         $groupsQuery = $db->getQuery(true)
             ->select($db->quoteName(['title', 'id']))
@@ -101,7 +101,7 @@ class ListUserCommand extends AbstractCommand
             $users[] = $user;
         }
 
-        $this->ioStyle->table(['id', 'username', 'name', 'email', 'blocked', 'groups'], $users);
+        $this->ioStyle->table(['ID', 'Username', 'Name', 'Email', 'Blocked', 'Groups'], $users);
 
         return Command::SUCCESS;
     }

--- a/libraries/src/Console/RemoveUserFromGroupCommand.php
+++ b/libraries/src/Console/RemoveUserFromGroupCommand.php
@@ -99,8 +99,8 @@ class RemoveUserFromGroupCommand extends AbstractCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->configureIO($input, $output);
+        $this->ioStyle->title('Remove User From Group');
         $this->username = $this->getStringFromOption('username', 'Please enter a username');
-        $this->ioStyle->title('Remove user from group');
 
         $userId = UserHelper::getUserId($this->username);
 


### PR DESCRIPTION
This is part of a series of pr (broken down to smaller ones to make testing easier) that fixes several issues in the cli commands.

1. Make sure the title is displayed
2. Make sure the case of the title matches the styleguide
3. Make sure table column headings match the styleguide

## Before and after
### Delete User
![EeAtdW7eP6](https://user-images.githubusercontent.com/1296369/177031123-6aaab3dc-815a-4401-91e1-53e30c910734.png)

### Add User
![ETNKnNtukE](https://user-images.githubusercontent.com/1296369/177031130-fb6f752a-7e03-4cee-a69a-428b83fc5e73.png)

### Add user to group
![JmrYkA44pS](https://user-images.githubusercontent.com/1296369/177031138-8a9f9a88-e5ed-486c-96f6-5629f30ca79c.png)

### Remove user from group
![VSLxzhiV95](https://user-images.githubusercontent.com/1296369/177031156-a4dff23d-1344-4568-a5d6-2187ca7781db.png)

