### PR TITLE
[4.1] CLI extension scripts cleanup

### DIFF
--- a/libraries/src/Console/ExtensionDiscoverCommand.php
+++ b/libraries/src/Console/ExtensionDiscoverCommand.php
@@ -138,7 +138,7 @@ class ExtensionDiscoverCommand extends AbstractCommand
         $this->configureIO($input, $output);
 
         $count = $this->processDiscover();
-
+        $this->ioStyle->title('Discover Extensions');
         $this->ioStyle->note($this->getNote($count));
 
         return Command::SUCCESS;

--- a/libraries/src/Console/ExtensionDiscoverListCommand.php
+++ b/libraries/src/Console/ExtensionDiscoverListCommand.php
@@ -96,7 +96,7 @@ class ExtensionDiscoverListCommand extends ExtensionsListCommand
 
         $discovered_extensions = $this->getExtensionsNameAndId($discovered_extensions);
 
-        $this->ioStyle->title('Discovered extensions.');
+        $this->ioStyle->title('Discovered Extensions');
         $this->ioStyle->table(['Name', 'Extension ID', 'Version', 'Type', 'Active'], $discovered_extensions);
 
         return Command::SUCCESS;

--- a/libraries/src/Console/ExtensionInstallCommand.php
+++ b/libraries/src/Console/ExtensionInstallCommand.php
@@ -179,6 +179,7 @@ class ExtensionInstallCommand extends AbstractCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->configureIO($input, $output);
+        $this->ioStyle->title('Install Extension');
 
         if ($path = $this->cliInput->getOption('path')) {
             $result = $this->processPathInstallation($path);

--- a/libraries/src/Console/ExtensionRemoveCommand.php
+++ b/libraries/src/Console/ExtensionRemoveCommand.php
@@ -165,6 +165,8 @@ class ExtensionRemoveCommand extends AbstractCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->configureIO($input, $output);
+        $this->ioStyle->title('Remove Extension');
+
         $extensionId = $this->cliInput->getArgument('extensionId');
 
         $response = $this->ioStyle->ask('Are you sure you want to remove this extension?', 'yes/no');

--- a/libraries/src/Console/ExtensionsListCommand.php
+++ b/libraries/src/Console/ExtensionsListCommand.php
@@ -238,7 +238,7 @@ class ExtensionsListCommand extends AbstractCommand
 
         $extensions = $this->getExtensionsNameAndId($extensions);
 
-        $this->ioStyle->title('Installed extensions.');
+        $this->ioStyle->title('Installed Extensions');
         $this->ioStyle->table(['Name', 'Extension ID', 'Version', 'Type', 'Active'], $extensions);
 
         return Command::SUCCESS;


### PR DESCRIPTION
This is part of a series of pr (broken down to smaller ones to make testing easier) that fixes several issues in the cli commands.

Make sure the title is displayed
Make sure the case of the title matches the styleguide
Make sure table column headings match the styleguide

Also see other changes #38205

## Before and After
### Discover Extensions
![AOU4D8GUKf](https://user-images.githubusercontent.com/1296369/177032136-b1f2babc-5bc7-4f76-a038-b0530133e273.png)

### Install Extensions
![fB6yHwRoIF](https://user-images.githubusercontent.com/1296369/177032145-0d019522-0b3e-44c0-a1d8-8bc8301e7434.png)

### Remove Extension
![rVygy8onOE](https://user-images.githubusercontent.com/1296369/177032153-43abb5ca-e982-4086-b292-912625e233e3.png)

### Discover Extensions
![UpSX6jgNfX](https://user-images.githubusercontent.com/1296369/177032163-7c618020-c54b-4251-8b27-ac1b52d1893f.png)

### Installed Extensions
![xN4vIwwQBt](https://user-images.githubusercontent.com/1296369/177032172-30f5a39b-0c7b-4a17-9549-2d53f6438013.png)

