### PR TITLE
[4.2] CLI site scripts cleanup

### DIFF
--- a/libraries/src/Console/SiteDownCommand.php
+++ b/libraries/src/Console/SiteDownCommand.php
@@ -94,6 +94,7 @@ class SiteDownCommand extends AbstractCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->configureIO($input, $output);
+        $this->ioStyle->title('Site Offline');
 
         $returnCode = $this->getApplication()->getCommand(SetConfigurationCommand::getDefaultName())->execute(
             new ArrayInput(['options' => ['offline=true']]),

--- a/libraries/src/Console/SiteUpCommand.php
+++ b/libraries/src/Console/SiteUpCommand.php
@@ -94,6 +94,7 @@ class SiteUpCommand extends AbstractCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->configureIO($input, $output);
+        $this->ioStyle->title('Site Online');
 
         $returnCode = $this->getApplication()->getCommand(SetConfigurationCommand::getDefaultName())->execute(
             new ArrayInput(['options' => ['offline=false']]),


### PR DESCRIPTION
This is part of a series of pr (broken down to smaller ones to make testing easier) that fixes several issues in the cli commands.

Make sure the title is displayed
Make sure the case of the title matches the styleguide
Make sure table column headings match the styleguide

## Before and After

### Site Up
![image](https://user-images.githubusercontent.com/1296369/177032795-6870d31c-afbc-4c56-a3eb-75875c358f23.png)

### site Down
![image](https://user-images.githubusercontent.com/1296369/177032810-52a0eff5-512d-45d3-ac29-a57085af96f3.png)
