### PR TITLE
[4.2] CLI core scripts cleanup

### DIFF
--- a/libraries/src/Console/UpdateCoreCommand.php
+++ b/libraries/src/Console/UpdateCoreCommand.php
@@ -142,6 +142,7 @@ class UpdateCoreCommand extends AbstractCommand
     public function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->configureIO($input, $output);
+        $this->ioStyle->title('Updating Joomla');
 
         $this->progressBar->setMessage("Starting up ...");
         $this->progressBar->start();


### PR DESCRIPTION
This is part of a series of pr (broken down to smaller ones to make testing easier) that fixes several issues in the cli commands.

Make sure the title is displayed
Make sure the case of the title matches the styleguide
Make sure table column headings match the styleguide

## Before and After

### core update
![image](https://user-images.githubusercontent.com/1296369/177032970-27cd8004-7e87-42d4-a92b-5419ca64b968.png)
