### PR TITLE
[4.2] CLI tasks scripts cleanup

### DIFF
--- a/libraries/src/Console/TasksListCommand.php
+++ b/libraries/src/Console/TasksListCommand.php
@@ -82,7 +82,7 @@ class TasksListCommand extends AbstractCommand
             $this->getTasks()
         );
 
-        $this->ioStyle->table(['id', 'title', 'type', 'state', 'next run'], $tasks);
+        $this->ioStyle->table(['ID', 'Title', 'Type', 'State', 'Next Run'], $tasks);
 
         return 0;
     }

--- a/libraries/src/Console/TasksRunCommand.php
+++ b/libraries/src/Console/TasksRunCommand.php
@@ -64,7 +64,7 @@ class TasksRunCommand extends AbstractCommand
         ];
 
         $this->configureIo($input, $output);
-        $this->ioStyle->title('Run tasks');
+        $this->ioStyle->title('Run Tasks');
 
         $scheduler = new Scheduler();
 

--- a/libraries/src/Console/TasksStateCommand.php
+++ b/libraries/src/Console/TasksStateCommand.php
@@ -69,6 +69,7 @@ class TasksStateCommand extends AbstractCommand
         Factory::getApplication()->getLanguage()->load('joomla', JPATH_ADMINISTRATOR);
 
         $this->configureIO($input, $output);
+        $this->ioStyle->title('Change Task State');
 
         $id = (string) $input->getOption('id');
         $state = (string) $input->getOption('state');


### PR DESCRIPTION
This is part of a series of pr (broken down to smaller ones to make testing easier) that fixes several issues in the cli commands.

Make sure the title is displayed
Make sure the case of the title matches the styleguide
Make sure table column headings match the styleguide

## Before and After

### List tasks
![XzLnECGezK](https://user-images.githubusercontent.com/1296369/177033413-9d0080e1-bdd6-44de-947d-57b6014e7db9.png)

### Run Tasks
![TFsilMD9T5](https://user-images.githubusercontent.com/1296369/177033421-243de900-a291-4ef9-a595-eb037cdb850b.png)

### Change state
![N3JC1fMOai](https://user-images.githubusercontent.com/1296369/177033428-2de96a1e-b193-4ca2-9dbb-f809009026a4.png)

