### PR TITLE
[4][cli] finder:index

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -463,4 +463,29 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
 
         return Router::getInstance($name, $options);
     }
+
+    /**
+     * Gets the name of the current template.
+     *
+     * @param   boolean  $params  True to return the template parameters
+     *
+     * @return  string|\stdClass
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getTemplate($params = false)
+    {
+        // The CLI application should not need to use a template
+        if ($params) {
+            $template              = new \stdClass();
+            $template->template    = 'system';
+            $template->params      = new Registry();
+            $template->inheritable = 0;
+            $template->parent      = '';
+
+            return $template;
+        }
+
+        return 'system';
+    }
 }


### PR DESCRIPTION
Pull Request for Issue #38214 .

### Summary of Changes
get the Template in the Console Application (even if not needed) but like API application 


### Testing Instructions
from cli run
`php cli/joomla.php finder:index`


### Actual result BEFORE applying this Pull Request

`In PluginHelper.php line 46:
  Call to undefined method Joomla\CMS\Application\ConsoleApplication::getTemplate()`

### Expected result AFTER applying this Pull Request

finder indexer works 

