### PR TITLE
[4.2] further CLI discover scripts cleanup

### DIFF
--- a/libraries/src/Console/ExtensionDiscoverInstallCommand.php
+++ b/libraries/src/Console/ExtensionDiscoverInstallCommand.php
@@ -194,6 +194,7 @@ class ExtensionDiscoverInstallCommand extends AbstractCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->configureIO($input, $output);
+        $this->ioStyle->title('Install Discovered Extensions');
 
         if ($eid = $this->cliInput->getOption('eid')) {
             $result = $this->processDiscover($eid);

--- a/libraries/src/Console/ExtensionDiscoverListCommand.php
+++ b/libraries/src/Console/ExtensionDiscoverListCommand.php
@@ -82,6 +82,7 @@ class ExtensionDiscoverListCommand extends ExtensionsListCommand
     protected function doExecute(InputInterface $input, OutputInterface $output): int
     {
         $this->configureIO($input, $output);
+        $this->ioStyle->title('Discovered Extensions');
 
         $extensions = $this->getExtensions();
         $state = -1;
@@ -96,7 +97,6 @@ class ExtensionDiscoverListCommand extends ExtensionsListCommand
 
         $discovered_extensions = $this->getExtensionsNameAndId($discovered_extensions);
 
-        $this->ioStyle->title('Discovered Extensions');
         $this->ioStyle->table(['Name', 'Extension ID', 'Version', 'Type', 'Enabled'], $discovered_extensions);
 
         return Command::SUCCESS;


### PR DESCRIPTION
### Summary of Changes
Adds a title for install discovered extensions
Moves the title for list discovered extensions so that it will appear when there are no extensions

