### PR TITLE
ci: add GitHub token permissions for workflow

### DIFF
--- a/.github/workflows/cacert-update.yml
+++ b/.github/workflows/cacert-update.yml
@@ -7,8 +7,14 @@ on:
     # Runs on the first day of every month at 03:00
     - cron:  '0 3 1 * *'
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for peter-evans/create-pull-request to create branch
+      pull-requests: write  # for peter-evans/create-pull-request to create a PR
     if: (github.event_name == 'schedule' && github.repository == 'joomla/joomla-cms') || (github.event_name != 'schedule')
 
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Summary of Changes

This PR adds minimum token permissions for the GITHUB_TOKEN using https://github.com/step-security/secure-workflows.

GitHub recommends defining minimum GITHUB_TOKEN permissions for securing GitHub Actions workflows 
- https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/  
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) treats not setting token permissions as a high-risk issue 

This project is part of the top 100 critical projects as per OpenSSF (https://github.com/ossf/wg-securing-critical-projects), so fixing the token permissions to improve security.

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>

### Testing Instructions

N/A

### Actual result BEFORE applying this Pull Request
`GITHUB_TOKEN` has all permissions
https://github.com/joomla/joomla-cms/runs/7143497554?check_suite_focus=true#step:1:16

### Expected result AFTER applying this Pull Request
`GITHUB_TOKEN` will have minimum permissions needed


### Documentation Changes Required

N/A