### PR TITLE
[4] com_content. blog. Remove unused $leadingcount, $introcount, $counter

### DIFF
--- a/components/com_content/tmpl/category/blog.php
+++ b/components/com_content/tmpl/category/blog.php
@@ -81,7 +81,6 @@ $htag    = $this->params->get('show_page_heading') ? 'h2' : 'h1';
         <?php endif; ?>
     <?php endif; ?>
 
-    <?php $leadingcount = 0; ?>
     <?php if (!empty($this->lead_items)) : ?>
         <div class="com-content-category-blog__items blog-items items-leading <?php echo $this->params->get('blog_class_leading'); ?>">
             <?php foreach ($this->lead_items as &$item) : ?>
@@ -91,15 +90,9 @@ $htag    = $this->params->get('show_page_heading') ? 'h2' : 'h1';
                     echo $this->loadTemplate('item');
                     ?>
                 </div>
-                <?php $leadingcount++; ?>
             <?php endforeach; ?>
         </div>
     <?php endif; ?>
-
-    <?php
-    $introcount = count($this->intro_items);
-    $counter = 0;
-    ?>
 
     <?php if (!empty($this->intro_items)) : ?>
         <?php $blogClass = $this->params->get('blog_class', ''); ?>


### PR DESCRIPTION
### Summary of Changes
- Remove variables `$leadingcount`, `$introcount`, `$counter` that are never used in this file.

### Testing Instructions
- Code review should be sufficient. Check if somewhere else in this file the variables are used. https://github.com/joomla/joomla-cms/blob/29a7cde454984b087feed175656dbfc9e50a8eed/components/com_content/tmpl/category/blog.php

### Actual result BEFORE applying this Pull Request
All OK in frontend blog views.

### Expected result AFTER applying this Pull Request
Nothing changes in frontend blog views.
