### PR TITLE
DatabaseInterface missing namespace causing JCategories call to fail

### DIFF
--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\Database\DatabaseAwareInterface;
 use Joomla\Database\DatabaseAwareTrait;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Exception\DatabaseNotFoundException;
 use Joomla\Database\ParameterType;
 


### PR DESCRIPTION
Pull Request for Issue #38265 .

### Summary of Changes



### Testing Instructions
See #38265


### Actual result BEFORE applying this Pull Request
     0 Resource 'Joomla\CMS\Categories\DatabaseInterface' has not been registered with the container. 


### Expected result AFTER applying this Pull Request
Works


### Documentation Changes Required

