### PR TITLE
[4][com_templates] deprecated php 8.1

### DIFF
--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -155,7 +155,7 @@ class HtmlView extends BaseHtmlView
     public function display($tpl = null)
     {
         $app               = Factory::getApplication();
-        $this->file        = $app->input->get('file');
+        $this->file        = $app->input->get('file', '');
         $this->fileName    = InputFilter::getInstance()->clean(base64_decode($this->file), 'string');
         $explodeArray      = explode('.', $this->fileName);
         $ext               = end($explodeArray);


### PR DESCRIPTION
### Summary of Changes

set default as string


### Testing Instructions

![j4deprecated](https://user-images.githubusercontent.com/181681/179488906-7e0efe0e-3c92-4789-b903-1672a0808d71.gif)


### Actual result BEFORE applying this Pull Request

Deprecated: base64_decode(): Passing null to parameter #1 ($string) of type string is deprecated 

### Expected result AFTER applying this Pull Request

no more deprecated



