### PR TITLE
[4.2] Fix Deprecated warnings on login

### DIFF
--- a/components/com_users/tmpl/login/default_login.php
+++ b/components/com_users/tmpl/login/default_login.php
@@ -33,7 +33,7 @@ $usersConfig = ComponentHelper::getParams('com_users');
     </div>
     <?php endif; ?>
 
-    <?php if (($this->params->get('logindescription_show') == 1 && str_replace(' ', '', $this->params->get('login_description')) != '') || $this->params->get('login_image') != '') : ?>
+    <?php if (($this->params->get('logindescription_show') == 1 && str_replace(' ', '', $this->params->get('login_description', '')) != '') || $this->params->get('login_image') != '') : ?>
     <div class="com-users-login__description login-description">
     <?php endif; ?>
 
@@ -45,7 +45,7 @@ $usersConfig = ComponentHelper::getParams('com_users');
             <?php echo HTMLHelper::_('image', $this->params->get('login_image'), empty($this->params->get('login_image_alt')) && empty($this->params->get('login_image_alt_empty')) ? false : $this->params->get('login_image_alt'), ['class' => 'com-users-login__image login-image']); ?>
         <?php endif; ?>
 
-    <?php if (($this->params->get('logindescription_show') == 1 && str_replace(' ', '', $this->params->get('login_description')) != '') || $this->params->get('login_image') != '') : ?>
+    <?php if (($this->params->get('logindescription_show') == 1 && str_replace(' ', '', $this->params->get('login_description', '')) != '') || $this->params->get('login_image') != '') : ?>
     </div>
     <?php endif; ?>
 


### PR DESCRIPTION
Pull Request for Issue #38296.

### Summary of Changes
This PR provides default value for $params->get method calls to fixed deprecated warnings as described at https://github.com/joomla/joomla-cms/issues/38296

### Testing Instructions
1. Install latest 4.2.0
2. Confirm the issue as described at https://github.com/joomla/joomla-cms/issues/38296
3. Apply patch, confirm that the issue fixed.


### Actual result BEFORE applying this Pull Request
Deprecated warnings on login page on PHP 8.1

### Expected result AFTER applying this Pull Request
The deprecated warnings are gone.

### Documentation Changes Required
None.
