### PR TITLE
Remove filename from mod_quickicon manifest

### DIFF
--- a/administrator/modules/mod_quickicon/mod_quickicon.xml
+++ b/administrator/modules/mod_quickicon/mod_quickicon.xml
@@ -11,8 +11,7 @@
 	<description>MOD_QUICKICON_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Module\Quickicon</namespace>
 	<files>
-		<filename module="mod_quickicon">mod_quickicon.php</filename>
-		<folder>services</folder>
+		<folder module="mod_quickicon">services</folder>
 		<folder>src</folder>
 		<folder>tmpl</folder>
 	</files>


### PR DESCRIPTION
Pull Request for Issue #38307 .

### Summary of Changes

Removes the obsolete `<filename module="mod_quickicon">mod_quickicon.php</filename>` from file "administrator/modules/mod_quickicon/mod_quickicon.xml" and use the `module` attribute on the "services" folder like it is correct here for another module: https://github.com/joomdonation/joomla-cms/blob/4.2-dev/modules/mod_articles_latest/mod_articles_latest.xml#L14

I haven't deeply checked if there is already a PR which solves that. On a quick search I haven't found one. If there is one, I will of course close mine in favour of that one.

### Testing Instructions

Code review and check that quickicon modules are still working in backend.

### Actual result BEFORE applying this Pull Request

Quickicon modules are working but the manifest contains the obsolete `<filename>` element for a not existing file.

### Expected result AFTER applying this Pull Request

Quickicon modules are still working and the manifest XML is correct.

### Documentation Changes Required

None.