### PR TITLE
Fix wrong extra version from last version reset

### DIFF
--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,7 +6,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>4.2.0-dev</version>
+	<version>4.2.0-rc2-dev</version>
 	<creationDate>2022-07</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -62,7 +62,7 @@ final class Version
      * @var    string
      * @since  3.8.0
      */
-    public const EXTRA_VERSION = 'dev';
+    public const EXTRA_VERSION = 'rc2-dev';
 
     /**
      * Development status.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With the last version reset (commit https://github.com/joomla/joomla-cms/commit/156fe71b43f919c2353cbc3695173826e21b0180 ), the extra version has not been set in the right way, so the package names and therefore the download URL differs from that the update site for the nightly builds expects, see https://github.com/joomla/update.joomla.org/pull/258/files .

So the manual download links for the packages are working on https://developer.joomla.org/nightly-builds.html , but the update site's details XML https://update.joomla.org/core/nightlies/next_minor_extension.xml will not work.

This PR fixes that so the package names are like they should be and like they are expected by the update site's details XML.

Even if we do not plan an RC 2 but a stable as next, we should use "rc2-dev" in package names like we have done it in past in the same situation.

### Testing Instructions

Code review, or run `php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2` on a local git clone of the branch of this PR on Linux or on Windows with WSL and check that the name of the zip packages fits to the URLs in file https://update.joomla.org/core/nightlies/next_minor_extension.xml .

### Actual result BEFORE applying this Pull Request

Updates to the 4.2-dev nightlies is not possible with Live Update.

### Expected result AFTER applying this Pull Request

Updates to the 4.2-dev nightlies is possible with Live Update.

### Documentation Changes Required

None.