### PR TITLE
[3.10] Workaround the a bit off monthsUntilEOS calculation

### DIFF
--- a/plugins/quickicon/eos310/eos310.php
+++ b/plugins/quickicon/eos310/eos310.php
@@ -210,8 +210,8 @@ class PlgQuickiconEos310 extends CMSPlugin
 			);
 		}
 
-		// The security support is ending in 6 months
-		if ($monthsUntilEOS <= 6)
+		// The security support is ending in 6 months; The calculation is a month off so we use 5 here.
+		if ($monthsUntilEOS <= 5)
 		{
 			return array(
 				'id'            => 4,
@@ -225,8 +225,8 @@ class PlgQuickiconEos310 extends CMSPlugin
 			);
 		}
 
-		// We are in security only mode now, 12 month to go from now on
-		if ($monthsUntilEOS <= 12)
+		// We are in security only mode now, 12 month to go from now on; The calculation is a month off so we use 11 here.
+		if ($monthsUntilEOS <= 11)
 		{
 			return array(
 				'id'            => 3,
@@ -240,8 +240,8 @@ class PlgQuickiconEos310 extends CMSPlugin
 			);
 		}
 
-		// We still have 16 month to go, lets remind our users about the pre upgrade checker
-		if ($monthsUntilEOS <= 16)
+		// We still have 16 month to go, lets remind our users about the pre upgrade checker; The calculation is a month off so we use 15 here.
+		if ($monthsUntilEOS <= 15)
 		{
 			return array(
 				'id'            => 2,
@@ -255,8 +255,8 @@ class PlgQuickiconEos310 extends CMSPlugin
 			);
 		}
 
-		// Lets start our messages 2 month after the initial release, still 22 month to go
-		if ($monthsUntilEOS <= 22)
+		// Lets start our messages 2 month after the initial release, still 22 month to go; The calculation is a month off so we use 21 here.
+		if ($monthsUntilEOS <= 21)
 		{
 			return array(
 				'id'            => 1,

--- a/plugins/quickicon/eos310/eos310.php
+++ b/plugins/quickicon/eos310/eos310.php
@@ -210,8 +210,8 @@ class PlgQuickiconEos310 extends CMSPlugin
 			);
 		}
 
-		// The security support is ending in 6 months; The calculation is a month off so we use 5 here.
-		if ($monthsUntilEOS <= 5)
+		// The security support is ending in 6 months
+		if ($monthsUntilEOS < 6)
 		{
 			return array(
 				'id'            => 4,
@@ -225,8 +225,8 @@ class PlgQuickiconEos310 extends CMSPlugin
 			);
 		}
 
-		// We are in security only mode now, 12 month to go from now on; The calculation is a month off so we use 11 here.
-		if ($monthsUntilEOS <= 11)
+		// We are in security only mode now, 12 month to go from now on
+		if ($monthsUntilEOS < 12)
 		{
 			return array(
 				'id'            => 3,
@@ -240,8 +240,8 @@ class PlgQuickiconEos310 extends CMSPlugin
 			);
 		}
 
-		// We still have 16 month to go, lets remind our users about the pre upgrade checker; The calculation is a month off so we use 15 here.
-		if ($monthsUntilEOS <= 15)
+		// We still have 16 month to go, lets remind our users about the pre upgrade checker
+		if ($monthsUntilEOS < 16)
 		{
 			return array(
 				'id'            => 2,
@@ -255,8 +255,8 @@ class PlgQuickiconEos310 extends CMSPlugin
 			);
 		}
 
-		// Lets start our messages 2 month after the initial release, still 22 month to go; The calculation is a month off so we use 21 here.
-		if ($monthsUntilEOS <= 21)
+		// Lets start our messages 2 month after the initial release, still 22 month to go
+		if ($monthsUntilEOS < 22)
 		{
 			return array(
 				'id'            => 1,


### PR DESCRIPTION
### Summary of Changes

The message checks for the EOS plugin depend on the monthsUntilEOS but that calculation is a bit off.

### Testing Instructions

- Install 3.10
- Notice the "securrity only mode" message
- Apply this patch
- you get the Info 2 message
- modify the eos setting to: const EOS_DATE = '2023-07-17'; (would mean we would be actually in sec only mode already)#
- notice the "securrity only mode" message came up again

### Actual result BEFORE applying this Pull Request

The messages where one month to early

### Expected result AFTER applying this Pull Request

The messages come on the expected months

### Documentation Changes Required

n.a.

cc @tecpromotion 