### PR TITLE
[4.2] Webauth Authenticator Table

### DIFF
--- a/layouts/plugins/system/webauthn/manage.php
+++ b/layouts/plugins/system/webauthn/manage.php
@@ -126,7 +126,7 @@ HTMLHelper::_('bootstrap.tooltip', '.plg_system_webauth-has-tooltip');
         <?php
         if (empty($credentials)) : ?>
             <tr>
-                <td colspan="2">
+                <td colspan="<?php echo $attestationSupport ? '3' : '2'; ?>">
                     <?php echo Text::_('PLG_SYSTEM_WEBAUTHN_MANAGE_HEADER_NOMETHODS_LABEL') ?>
                 </td>
             </tr>


### PR DESCRIPTION
### Summary of Changes

Fix colspan if attestation support is enabled

### Testing Instructions

- no webauthn authenticator is registered
- check table if attestation support is enabled
- check table if attestation support is not enabled

### Actual result BEFORE applying this Pull Request

colspan is wrong (if attestation support is enabled)
![image](https://user-images.githubusercontent.com/66922325/180312458-addd1c82-aafc-4a29-9a54-49ffad0ace91.png)

### Expected result AFTER applying this Pull Request

colspan is correct
![image](https://user-images.githubusercontent.com/66922325/180312311-e5afac9e-ee13-465f-9975-37dac51b7671.png)

### Documentation Changes Required

No