### PR TITLE
[4.3] Enabling packaging for 4.3-dev in drone

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -411,7 +411,7 @@ steps:
         path: /reference
     when:
       branch:
-        - 4.2-dev
+        - 4.3-dev
 
 ---
 kind: pipeline
@@ -475,6 +475,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 783273e5140ae315f2403b13eb12f4773b77995a3d44a38551b55c89b9d40350
+hmac: e1fe0d199dce2362ee1b27adeeafc64fa2a955fcd66db2d90a266612fb96b0c1
 
 ...


### PR DESCRIPTION
This enables pre-build packages for the 4.3-dev branch.