### PR TITLE
full width spacer hr line

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_form.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_form.scss
@@ -49,14 +49,15 @@
   }
 }
 
-.stack .control-label {
-  width: 100%;
+.field-spacer {
+  .control-label {
+    padding: 0;
+    width: 100%;
+  }
 }
 
-.spacer {
-  hr {
-    width: 380px;
-  }
+.stack .control-label {
+  width: 100%;
 }
 
 td .form-control {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_form.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_form.scss
@@ -51,8 +51,8 @@
 
 .field-spacer {
   .control-label {
-    padding: 0;
     width: 100%;
+    padding: 0;
   }
 }
 

--- a/libraries/src/Form/Field/SpacerField.php
+++ b/libraries/src/Form/Field/SpacerField.php
@@ -31,6 +31,14 @@ class SpacerField extends FormField
     protected $type = 'Spacer';
 
     /**
+     * Hide the description when rendering the form field.
+     *
+     * @var    boolean
+     * @since  4.0.0
+     */
+    protected $hiddenDescription = true;
+
+    /**
      * Method to get the field input markup for a spacer.
      * The spacer does not have accept input.
      *


### PR DESCRIPTION
Pull Request for Issue # . No issue created for it.

My first Joomla! PR ...

### Summary of Changes
In the current Joomla 4 backend the space hr form field only creates a line partially.
![Bildschirmfoto vom 2022-07-28 19-50-15](https://user-images.githubusercontent.com/806395/181651108-3fc13f72-93f5-4ece-a3d1-b302438d5dfb.png)
With this changes the hr line is again on the full width and looks much better as spacer.
The changes are only made for the hr=true case, because if nothing is shown it doesn't matter. 
If text is used it only gets displayed as label and hr=false need to be set.
For bigger text the note form field should be used.
![Bildschirmfoto vom 2022-07-29 00-31-17](https://user-images.githubusercontent.com/806395/181651110-588b8b1d-12a8-490c-b1e2-46c1d0b4bab5.png)



### Testing Instructions




### Actual result BEFORE applying this Pull Request
Open Modules: Articles - Category Filtering-Options and you see a small line space left aligned.


### Expected result AFTER applying this Pull Request
After the patch you should see a full width line


### Documentation Changes Required

