### PR TITLE
Fix PHP notices in CLI coming from the WebAuthn plugin

### DIFF
--- a/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
@@ -40,6 +40,7 @@ trait UserProfileFields
      * @since  4.2.0
      */
     protected $app;
+
     /**
      * User object derived from the displayed user profile data.
      *

--- a/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
@@ -36,6 +36,11 @@ use Joomla\Registry\Registry;
 trait UserProfileFields
 {
     /**
+     * @var  CMSApplication
+     * @since  4.2.0
+     */
+    protected $app;
+    /**
      * User object derived from the displayed user profile data.
      *
      * This is required to display the number and names of authenticators already registered when

--- a/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
@@ -98,11 +98,6 @@ trait UserProfileFields
          */
         [$form, $data] = $event->getArguments();
 
-        // This feature only applies to HTTPS sites.
-        if (!Uri::getInstance()->isSsl()) {
-            return;
-        }
-
         $name = $form->getName();
 
         $allowedForms = [
@@ -110,6 +105,16 @@ trait UserProfileFields
         ];
 
         if (!\in_array($name, $allowedForms)) {
+            return;
+        }
+
+        // This feature only applies in the site and administrator applications
+        if (!$this->app->isClient('site') && !$this->app->isClient('administrator')) {
+            return;
+        }
+
+        // This feature only applies to HTTPS sites.
+        if (!Uri::getInstance()->isSsl()) {
             return;
         }
 

--- a/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
@@ -36,12 +36,6 @@ use Joomla\Registry\Registry;
 trait UserProfileFields
 {
     /**
-     * @var  CMSApplication
-     * @since  4.2.0
-     */
-    protected $app;
-
-    /**
      * User object derived from the displayed user profile data.
      *
      * This is required to display the number and names of authenticators already registered when
@@ -115,7 +109,10 @@ trait UserProfileFields
         }
 
         // This feature only applies in the site and administrator applications
-        if (!$this->app->isClient('site') && !$this->app->isClient('administrator')) {
+        if (
+            !$this->getApplication()->isClient('site')
+            && !$this->getApplication()->isClient('administrator')
+        ) {
             return;
         }
 


### PR DESCRIPTION
### Summary of Changes
This PR aims to fix some PHP notices when running under CLI. In that case, if a form is loaded (for example to gather the default data), the `onContentPrepareForm` event is fired. The WebAuthn plugin kicks in, tries to read the current URL and a notice is raised.  
This PR will double check that we are in a web environment before continuing the execution

### Testing Instructions
The best way to test it is to have a small script that tries to load an XML form. Sadly at the moment I don't have any, I came across this bug by developing CLI commands for the next version of Admin Tools.

### Actual result BEFORE applying this Pull Request
PHP notice:
```
Notice: Undefined index: HTTP_HOST in /var/www/html/temp/libraries/src/Uri/Uri.php on line 103
```


### Expected result AFTER applying this Pull Request
No PHP notice


### Documentation Changes Required
None
