### PR TITLE
Do not show the webauthn form on the registration page

### DIFF
--- a/administrator/language/en-GB/plg_system_webauthn.ini
+++ b/administrator/language/en-GB/plg_system_webauthn.ini
@@ -19,6 +19,7 @@ PLG_SYSTEM_WEBAUTHN_ERR_EMPTY_USERNAME="You need to enter your username (but NOT
 PLG_SYSTEM_WEBAUTHN_ERR_INVALID_USERNAME="The specified username does not correspond to a user account that has enabled passwordless login on this site."
 PLG_SYSTEM_WEBAUTHN_ERR_LABEL_NOT_SAVED="Could not save the new label"
 PLG_SYSTEM_WEBAUTHN_ERR_NOT_DELETED="Could not remove the authenticator"
+PLG_SYSTEM_WEBAUTHN_ERR_NOUSER="No user account has been found"
 PLG_SYSTEM_WEBAUTHN_ERR_NO_BROWSER_SUPPORT="Sorry, your browser does not support the W3C Web Authentication standard for passwordless logins or your site is not being served over HTTPS with a valid certificate, signed by a Certificate Authority your browser trusts. You will need to log into this site using your username and password."
 PLG_SYSTEM_WEBAUTHN_ERR_NO_STORED_CREDENTIAL="Cannot find the stored credentials for your login authenticator."
 PLG_SYSTEM_WEBAUTHN_ERR_USER_REMOVED="The user for this authenticator seems to no longer exist on this site."

--- a/plugins/system/webauthn/services/provider.php
+++ b/plugins/system/webauthn/services/provider.php
@@ -12,7 +12,6 @@ defined('_JEXEC') || die;
 
 use Joomla\Application\ApplicationInterface;
 use Joomla\Application\SessionAwareWebApplicationInterface;
-use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;

--- a/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
@@ -127,10 +127,12 @@ trait UserProfileFields
         }
 
         // Add the fields to the form.
-        Log::add('Injecting WebAuthn Passwordless Login fields in user profile edit page', Log::DEBUG, 'webauthn.system');
+	    if ($name !== 'com_users.registration') {
+	        Log::add('Injecting WebAuthn Passwordless Login fields in user profile edit page', Log::DEBUG, 'webauthn.system');
 
-        Form::addFormPath(JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name . '/forms');
-        $form->loadFile('webauthn', false);
+	        Form::addFormPath(JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name . '/forms');
+	        $form->loadFile('webauthn', false);
+	    }
     }
 
     /**

--- a/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserProfileFields.php
@@ -127,12 +127,12 @@ trait UserProfileFields
         }
 
         // Add the fields to the form.
-	    if ($name !== 'com_users.registration') {
-	        Log::add('Injecting WebAuthn Passwordless Login fields in user profile edit page', Log::DEBUG, 'webauthn.system');
+        if ($name !== 'com_users.registration') {
+            Log::add('Injecting WebAuthn Passwordless Login fields in user profile edit page', Log::DEBUG, 'webauthn.system');
 
-	        Form::addFormPath(JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name . '/forms');
-	        $form->loadFile('webauthn', false);
-	    }
+            Form::addFormPath(JPATH_PLUGINS . '/' . $this->_type . '/' . $this->_name . '/forms');
+            $form->loadFile('webauthn', false);
+        }
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #38260 .

### Summary of Changes
This change adds:
- the missing language string in case a user account cannot be found
- does not show the webauthn form on the user registration page
- Removed an unused use statement

### Testing Instructions
See issue #38260 for the excellent test instructions, picture by picture. 
1. Take the steps as outlined in #38260 
2. Confirm you see the Web Authentication on the registration page and the missing language string
3. Apply the patch
4. Refresh the registration page and the Web Authentication should be gone
5. Login as a user
6. Go to edit your profile
7. Verify you see the Web Authentication form


### Actual result BEFORE applying this Pull Request
The Web Authentication form is shown on the user registration page


### Expected result AFTER applying this Pull Request
The Web Authentication form is **not** shown on the user registration page

### Documentation Changes Required
None
