### PR TITLE
com_finder unused css

### DIFF
--- a/build/media_source/com_finder/css/dates.css
+++ b/build/media_source/com_finder/css/dates.css
@@ -13,7 +13,6 @@ ul#finder-filter-select-dates {
 
 ul#finder-filter-select-dates li.filter-date {
   background: none;
-  float: left;
   list-style: none;
   margin: 0;
   padding: 5px 0;


### PR DESCRIPTION
Removes the property float:left as it is not used due to the additional class float-start applied to the same element. (makes it easier to convert to use logical properties if we don't have unused css)

![image](https://user-images.githubusercontent.com/1296369/182018015-fcb7968e-d319-488d-8dfb-bfcb1458beac.png)
