### PR TITLE
centered search box - rtl

### DIFF
--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -31,7 +31,7 @@ endif;
 
 <div class="d-none" id="comModulesSelectSearchContainer">
     <div class="d-flex mt-2">
-        <div class="ms-auto me-auto">
+        <div class="m-auto">
             <label class="visually-hidden" for="comModulesSelectSearch">
                 <?php echo Text::_('COM_MODULES_TYPE_CHOOSE'); ?>
             </label>

--- a/administrator/components/com_scheduler/tmpl/select/default.php
+++ b/administrator/components/com_scheduler/tmpl/select/default.php
@@ -31,7 +31,7 @@ $wa->useScript('com_scheduler.admin-view-select-task-search');
 <!-- Tasks search box on below the toolbar begins -->
 <div class="d-none" id="comSchedulerSelectSearchContainer">
     <div class="d-flex mt-2">
-        <div class="ms-auto me-auto">
+        <div class="m-auto">
             <label class="visually-hidden" for="comSchedulerSelectSearch">
                 <?php echo Text::_('COM_SCHEDULER_TYPE_CHOOSE'); ?>
             </label>


### PR DESCRIPTION
due to the daft RTL overrides we have in place the search boxes on the new module and new scheduled tasks pages are not centered in RTL.

without changing the daft RTL overrides (which really should be done) this PR fixes the problem by using the correct css for centering a block

## New Module LTR

![image](https://user-images.githubusercontent.com/1296369/182115062-3d3bc2da-b484-4e86-8605-a00596fe263e.png)


## New Module RTL - BEFORE

![image](https://user-images.githubusercontent.com/1296369/182114912-28974391-a40d-497a-8f02-bb93a73a58b0.png)

## New Module RTL - AFTER

![image](https://user-images.githubusercontent.com/1296369/182114784-1ecd7fc0-0f29-4047-9512-0abf5fb4f57f.png)
