### PR TITLE
Content Plugins are not triggered upon batch copy

### DIFF
--- a/administrator/components/com_content/models/article.php
+++ b/administrator/components/com_content/models/article.php
@@ -87,7 +87,8 @@ class ContentModelArticle extends JModelAdmin
 				$fieldsData['com_fields'][$field->name] = $field->rawvalue;
 			}
 		}
-
+		
+		JPluginHelper::importPlugin('content');
 		JEventDispatcher::getInstance()->trigger('onContentAfterSave', array('com_content.article', &$this->table, true, $fieldsData));
 	}
 


### PR DESCRIPTION
Content plugins are not being triggered when an article is batch copied, despite the model `cleanupPostBatchCopy` function triggering the content plugins.

Content plugins are not triggered without importing the content plugins, so now import the content plugins before triggering the event.

### Summary of Changes

Import content plugins before triggering them.

### Testing Instructions

Batch copy an article, onContentAfterSave ought to be triggered upon saving the new article.

### Actual result BEFORE applying this Pull Request

onContentBeforeSave is not triggered.

### Expected result AFTER applying this Pull Request

onContentBeforeSave is triggered.

### Documentation Changes Required

