### PR TITLE
Add new trigger for custom fields to manage the form before display in the backend

### DIFF
--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -240,7 +240,6 @@ class FieldModel extends AdminModel
         return true;
     }
 
-
     /**
      * Checks if the default value is valid for the given data. If a string is returned then
      * it can be assumed that the default value is invalid.
@@ -979,6 +978,9 @@ class FieldModel extends AdminModel
             if ($dataObject->type == 'list') {
                 $form->removeField('hint', 'params');
             }
+
+            PluginHelper::importPlugin('fields', $dataObject->type);
+            Factory::getApplication()->triggerEvent('onCustomFieldsPreprocessForm', [$form]);
         }
 
         // Get the categories for this component (and optionally this section, if available)

--- a/plugins/fields/menuitem/menuitem.php
+++ b/plugins/fields/menuitem/menuitem.php
@@ -10,6 +10,8 @@
  * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
+use Joomla\CMS\Form\Form;
+
 /**
  * Fields Menuitem Plugin
  *
@@ -17,4 +19,18 @@
  */
 class PlgFieldsMenuitem extends \Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin
 {
+
+    /**
+     * Prepare the form for display.
+     *
+     * @param   Form  $form The form being prepared for display
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function onCustomFieldsPreprocessForm(Form $form): void
+    {
+        $form->removeField('default_value');
+    }
 }


### PR DESCRIPTION
Pull Request for Issue #38244 

### Summary of Changes
The new `menuitem` field cannot use nor has any use for the `Default value` field. Since there is no switch we can use to set this field a new plugin trigger has been added with the name `onCustomFieldsPreprocessForm` which can be picked up by the custom fields plugins.

Using this new trigger we can remove the `Default value` from the form and the mentioned error will not happen.


### Testing Instructions
1. Create a new custom field for Articles of the type `List of Menu Items`
2. Set a default value as `abc`
3. Save the custom field
4. Edit or create a new article
5. The page won't load the article edit form but will show an error on the page.
6. Apply this pull request
7. Reload the page or restart from step 4
8. The page loads as expected and you can edit/create the article


### Actual result BEFORE applying this Pull Request
Page crashed with a fatal error


### Expected result AFTER applying this Pull Request
The content editing page loads as expected an article can be edited/created.


### Documentation Changes Required
Yes, plugin trigger `onCustomFieldsPreprocessForm` needs to be documented.
