### PR TITLE
Use the right mime type in the the media field

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -33,7 +33,6 @@ class JoomlaFieldMedia extends HTMLElement {
     this.validateValue = this.validateValue.bind(this);
     this.markValid = this.markValid.bind(this);
     this.markInvalid = this.markInvalid.bind(this);
-
     this.mimeType = '';
   }
 
@@ -136,7 +135,6 @@ class JoomlaFieldMedia extends HTMLElement {
 
     this.inputElement.removeAttribute('readonly');
     this.inputElement.addEventListener('change', this.validateValue);
-
 
     // Force input revalidation
     (async () => {

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -101,7 +101,7 @@ class JoomlaFieldMedia extends HTMLElement {
 
   // attributeChangedCallback(attr, oldValue, newValue) {}
 
-  async connectedCallback() {
+  connectedCallback() {
     this.button = this.querySelector(this.buttonSelect);
     this.inputElement = this.querySelector(this.input);
     this.buttonClearEl = this.querySelector(this.buttonClear);
@@ -139,9 +139,10 @@ class JoomlaFieldMedia extends HTMLElement {
 
 
     // Force input revalidation
-    await this.validateValue({ target: this.inputElement })
-
-    this.updatePreview();
+    (async () => {
+      await this.validateValue({ target: this.inputElement });
+      this.updatePreview();
+    })();
   }
 
   disconnectedCallback() {

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -33,6 +33,8 @@ class JoomlaFieldMedia extends HTMLElement {
     this.validateValue = this.validateValue.bind(this);
     this.markValid = this.markValid.bind(this);
     this.markInvalid = this.markInvalid.bind(this);
+
+    this.mimeType = '';
   }
 
   static get observedAttributes() {
@@ -99,7 +101,7 @@ class JoomlaFieldMedia extends HTMLElement {
 
   // attributeChangedCallback(attr, oldValue, newValue) {}
 
-  connectedCallback() {
+  async connectedCallback() {
     this.button = this.querySelector(this.buttonSelect);
     this.inputElement = this.querySelector(this.input);
     this.buttonClearEl = this.querySelector(this.buttonClear);
@@ -132,9 +134,14 @@ class JoomlaFieldMedia extends HTMLElement {
       throw new Error('Joomla API is not properly initiated');
     }
 
-    this.updatePreview();
     this.inputElement.removeAttribute('readonly');
     this.inputElement.addEventListener('change', this.validateValue);
+
+
+    // Force input revalidation
+    await this.validateValue({ target: this.inputElement })
+
+    this.updatePreview();
   }
 
   disconnectedCallback() {
@@ -181,6 +188,7 @@ class JoomlaFieldMedia extends HTMLElement {
   setValue(value) {
     this.inputElement.value = value;
     this.validatedUrl = value;
+    this.mimeType = Joomla.selectedMediaFile.fileType;
     this.updatePreview();
 
     // trigger change event both on the input and on the custom element
@@ -191,7 +199,7 @@ class JoomlaFieldMedia extends HTMLElement {
     }));
   }
 
-  validateValue(event) {
+  async validateValue(event) {
     let { value } = event.target;
     if (this.validatedUrl === value || value === '') return;
 
@@ -231,14 +239,17 @@ class JoomlaFieldMedia extends HTMLElement {
               this.markValid();
             };
           } else if (blob.type.includes('audio')) {
+            this.mimeType = blob.type;
             this.inputElement.value = value;
             this.validatedUrl = value;
             this.markValid();
           } else if (blob.type.includes('video')) {
+            this.mimeType = blob.type;
             this.inputElement.value = value;
             this.validatedUrl = value;
             this.markValid();
           } else if (blob.type.includes('application/pdf')) {
+            this.mimeType = blob.type;
             this.inputElement.value = value;
             this.validatedUrl = value;
             this.markValid();
@@ -325,7 +336,7 @@ class JoomlaFieldMedia extends HTMLElement {
               previewElement = document.createElement('video');
               const previewElementSource = document.createElement('source');
               previewElementSource.src = /http/.test(value) ? value : Joomla.getOptions('system.paths').rootFull + value;
-              previewElementSource.type = `video/${ext}`;
+              previewElementSource.type = this.mimeType;
               previewElement.setAttribute('controls', '');
               previewElement.setAttribute('width', this.previewWidth);
               previewElement.setAttribute('height', this.previewHeight);
@@ -336,7 +347,7 @@ class JoomlaFieldMedia extends HTMLElement {
             if (supportedExtensions.documents.includes(ext)) {
               previewElement = document.createElement('object');
               previewElement.data = /http/.test(value) ? value : Joomla.getOptions('system.paths').rootFull + value;
-              previewElement.type = `application/${ext}`;
+              previewElement.type = this.mimeType;
               previewElement.setAttribute('width', this.previewWidth);
               previewElement.setAttribute('height', this.previewHeight);
             }


### PR DESCRIPTION
Pull Request for Issue #38333 .

### Summary of Changes

The preview might get the wrong mime type in some cases.

### Testing Instructions

- Edit the file `administrator/components/com_content/forms/article.xml` and add `types="images,audios,videos,documents"` after https://github.com/joomla/joomla-cms/blob/7cf5e1228db337881d7678ad1c71915d5c885150/administrator/components/com_content/forms/article.xml#L752
- Try to upload and select different type of media, especially video, audio and document (eg, mp3, mp4, mov, pdf, doc, docx, etc)


### Actual result BEFORE applying this Pull Request

No preview in some cases

### Expected result AFTER applying this Pull Request

Preview is ok

### Documentation Changes Required

No