### PR TITLE
[4.2] Fix empty default_value check in fields plugin

### DIFF
--- a/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
+++ b/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
@@ -186,7 +186,7 @@ abstract class FieldsPlugin extends CMSPlugin
             $node->setAttribute('layout', $layout);
         }
 
-        if ($field->default_value !== '') {
+        if ($field->default_value !== null && $field->default_value !== '') {
             $defaultNode = $node->appendChild(new \DOMElement('default'));
             $defaultNode->appendChild(new \DOMCdataSection($field->default_value));
         }

--- a/plugins/fields/menuitem/params/menuitem.xml
+++ b/plugins/fields/menuitem/params/menuitem.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<form>
+	<fieldset>
+		<!-- Disable default_value, it's not supported by GroupedlistField -->
+		<field type="hidden" name="default_value" readonly="true" filter="unset" />
+	</fieldset>
+</form>


### PR DESCRIPTION
Pull Request for Issue introduced in #18032 .

### Summary of Changes
* Don't add a default_value attribute if value is NULL. This crashes GroupedlistField and maybe other fields.
* Hide default value field custom fields for the menuitem


### Testing Instructions
Test custom fields, especially menuitem


### Actual result BEFORE applying this Pull Request
see https://github.com/joomla/joomla-cms/pull/38244#issuecomment-1208287580


### Expected result AFTER applying this Pull Request
works


