### PR TITLE
[4.3] Deprecate Joomla\CMS\Schema\ChangeItem\SqlsrvChangeItem for 5.0

### DIFF
--- a/libraries/src/Schema/ChangeItem/SqlsrvChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/SqlsrvChangeItem.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Schema\ChangeItem;
  * Checks the database schema against one SQL Server DDL query to see if it has been run.
  *
  * @since  2.5
+ * @deprecated  5.0   Will be removed without replacement
  */
 class SqlsrvChangeItem extends ChangeItem
 {


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/38405#pullrequestreview-1066493530 .

### Summary of Changes

Deprecate the SqlsrvChangeItem class which was used by the database checker in Joomla 3 for checking the schema on MS SQL Server databases and which will be removed in Joomla 5 with PR #38405 .

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

The SqlsrvChangeItem class which is already useless in J4 is not marked as deprecated.

### Expected result AFTER applying this Pull Request

The SqlsrvChangeItem class which is already useless in J4 is marked as deprecated.

### Documentation Changes Required

None. It is already documented that Joomla 4 does not support running with a MS SQL Server database.