### PR TITLE
OpenSearch fix for: passing null is deprecated

### DIFF
--- a/components/com_finder/src/View/Search/OpensearchView.php
+++ b/components/com_finder/src/View/Search/OpensearchView.php
@@ -38,8 +38,8 @@ class OpensearchView extends AbstractView
         $app = Factory::getApplication();
 
         $params = ComponentHelper::getParams('com_finder');
-        $this->document->setShortName($params->get('opensearch_name', $app->get('sitename')));
-        $this->document->setDescription($params->get('opensearch_description', $app->get('MetaDesc')));
+        $this->document->setShortName($params->get('opensearch_name', $app->get('sitename', '')));
+        $this->document->setDescription($params->get('opensearch_description', $app->get('MetaDesc', '')));
 
         // Prevent any output when OpenSearch Support is disabled
         if (!$params->get('opensearch', 1)) {


### PR DESCRIPTION
Pull Request for Issue #38427 .

### Summary of Changes
Fix PHP 8 deprecation warning: Passing null to parameter ($string) of type string is deprecated


### Testing Instructions
Use php 8+, error_reporting maximum
Apply patch.
Open smart search page. Add `?format=opensearch` to URL, and open.
Inspect the result.


### Actual result BEFORE applying this Pull Request
deprecation warning


### Expected result AFTER applying this Pull Request
no deprecation warning


### Documentation Changes Required
no
