### PR TITLE
Change bulk unarchive action for redirect links to unpublish

### DIFF
--- a/administrator/components/com_redirect/src/View/Links/HtmlView.php
+++ b/administrator/components/com_redirect/src/View/Links/HtmlView.php
@@ -179,7 +179,7 @@ class HtmlView extends BaseHtmlView
                 if ($state->get('filter.state') != 2) {
                     $childBar->archive('links.archive')->listCheck(true);
                 } elseif ($state->get('filter.state') == 2) {
-                    $childBar->unarchive('links.unarchive')->listCheck(true);
+                    $childBar->unarchive('links.unpublish')->listCheck(true);
                 }
             }
 


### PR DESCRIPTION
Pull Request for Issue #38434.

### Summary of Changes

![unarchive](https://user-images.githubusercontent.com/42969457/183969080-b2b27419-b962-41d2-9540-afbb44b9889d.png)

Attempting to unarchive multiple redirect links using the 'Unarchive' option in the Actions dropdown currently has no effect. When unarchiving individual redirect links, the unpublish action is used to set them to the 'Disabled' state. This update applies the same unpublish action to the bulk unarchive option.

### Testing Instructions

1. Create several redirect links.
2. Archive the redirect links.
3. Attempt to unarchive all archived redirect links simultaneously.

### Actual result BEFORE applying this Pull Request

A form submission occurs, the page reloads, but the selected redirect links remain archived.

### Expected result AFTER applying this Pull Request

The selected redirect links will be set to the unpublished/'Disabled' state.

### Documentation Changes Required

None.