### PR TITLE
Missing help buttons

### DIFF
--- a/administrator/components/com_media/config.xml
+++ b/administrator/components/com_media/config.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
+	<help key="Media:_Options"/>
 	<inlinehelp button="show"/>
 	<fieldset
 		name="component"

--- a/administrator/components/com_scheduler/config.xml
+++ b/administrator/components/com_scheduler/config.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <config>
+	<help key="Scheduled_Tasks:_Options"/>
 	<inlinehelp button="show"/>
 	<fieldset
 		name="task_config"


### PR DESCRIPTION
The help button was missing for the options screen of both Scheduled Tasks and Media

Testing is easy. Apply the pr
go to the component and c;lick on options
before this PR thwere is no help button - now there is

Pull Request for Issue #38430
