### PR TITLE
Allow the statistics plugin to run on the captive page

### DIFF
--- a/libraries/src/Application/MultiFactorAuthenticationHandler.php
+++ b/libraries/src/Application/MultiFactorAuthenticationHandler.php
@@ -293,6 +293,16 @@ trait MultiFactorAuthenticationHandler
             return false;
         }
 
+        // Allow the statistics plugin to run
+        if ($isAdmin && $option === 'com_ajax' && $task === '') {
+            $group  = strtolower($this->input->getCmd('group', ''));
+            $plugin = strtolower($this->input->getCmd('plugin', ''));
+
+            if ($group === 'system' && $plugin === 'sendstats') {
+                return false;
+            }
+        }
+
         return true;
     }
 


### PR DESCRIPTION
### Summary of Changes
When a user is using multi-factor authentication to login it may show some HTML in the message box. This is the result of a failed check on the multi-factor authentication because the Statistics plugin is trying to send data to the Joomla server On the captive page a user is already logged-in but it has not yet completed the multi-factor authentication. Duh, we are trying to complete that page when the "message" shows up. This is part of what a user will see:
![image](https://user-images.githubusercontent.com/359377/183975200-f96d8781-6f07-4a03-92ec-6ce41f2fbd31.png)

The page can still be used but it does not look pretty.


### Testing Instructions
This assumes you have setup one or more multi-factor authtentications

1. Enable the Statistics plugin
2. Open the file `plugins/system/stats/stats.php`
3. Uncomment line 24 so it says `define('PLG_SYSTEM_STATS_DEBUG', 1);`
4. Log out of the website
5. Login by entering a username and password
6. You now get to the captive page and soon after the image shown in the summary will popup
7. You can click on `Select a different method` in the toolbar and you go to the page to select which multi-factor authentication you want to use but again the message popup will show
8. Apply the patch
9. Refresh or repeat steps 5 - 7. You should no longer see the popups


### Actual result BEFORE applying this Pull Request
You get some HTML output in the message box


### Expected result AFTER applying this Pull Request
No message box is shown

### Documentation Changes Required
None
