### PR TITLE
Set a default for events to email in User Action Log Options

### DIFF
--- a/plugins/system/actionlogs/forms/actionlogs.xml
+++ b/plugins/system/actionlogs/forms/actionlogs.xml
@@ -22,6 +22,7 @@
 				validate="options"
 				layout="joomla.form.field.list-fancy-select"
 				showon="actionlogsNotify:1"
+				default="com_content"
 			/>
 		</fields>
 	</fieldset>


### PR DESCRIPTION
### Summary of Changes
When you create a new super user and this super user logs in and tries to save their profile without changing the options on the `User Action Log Options` the save will fail with this error:
![image](https://user-images.githubusercontent.com/359377/184222361-8968ae96-3c07-4135-b87c-7c26bb57a23d.png)

One way around this is to set `Email Notifications` to `Yes` and select 1 or more extensions and save the profile. After that set the `Email Notifications` to `No` and save it again. The error will be gone but this is not user friendly.

The solution is to set a default value for the action logs extensions because then a value will be saved but that does not matter because the `Email Notifications` defaults to `No` so nothing will be set. If a user decides to set this to `Yes`, they need to select which extensions they want anyway.


### Testing Instructions
1. Create a new super user account
2. Login with the new super user account
3. Click on User Menu -> Edit Account
4. Click on Save
5. The error as shown above appears
6. Apply patch
7. Click on Save
8. The account is saved successfully


### Actual result BEFORE applying this Pull Request
User account cannot be saved


### Expected result AFTER applying this Pull Request
User account can be saved


### Documentation Changes Required
None
