### PR TITLE
[4.3] Convert recaptcha plugin to services and add captcha plugin interface

### DIFF
--- a/libraries/src/Captcha/CaptchaPluginInterface.php
+++ b/libraries/src/Captcha/CaptchaPluginInterface.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Captcha;
+
+use Joomla\CMS\Form\Field\CaptchaField;
+use SimpleXMLElement;
+
+/**
+ * Interface defining a captcha plugin.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface CaptchaPluginInterface
+{
+    /**
+     * Gets the challenge HTML
+     *
+     * @param   string  $id     The id of the field
+     * @param   string  $class  The class of the field
+     *
+     * @return  string  The HTML to be embedded in the form
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function display(string $id = '', string $class = ''): string;
+
+    /**
+     * Calls an HTTP POST function to verify if the user's guess was correct.
+     *
+     * @param   string  $code  Answer provided by user
+     *
+     * @return  bool    If the answer is correct, false otherwise
+     *
+     * @since   __DEPLOY_VERSION__
+     *
+     * @throws  \RuntimeException
+     */
+    public function checkAnswer(string $code = null): bool;
+
+    /**
+     * Method to react on the setup of a captcha field. Gives the possibility
+     * to change the field and/or the XML element for the field.
+     *
+     * @param   CaptchaField      $field    Captcha field instance
+     * @param   SimpleXMLElement  $element  XML form definition
+     *
+     * @return void
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function setupField(CaptchaField $field, SimpleXMLElement $element): void;
+}

--- a/plugins/captcha/recaptcha/recaptcha.xml
+++ b/plugins/captcha/recaptcha/recaptcha.xml
@@ -9,8 +9,10 @@
 	<copyright>(C) 2011 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<description>PLG_CAPTCHA_RECAPTCHA_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\Captcha\Recaptcha</namespace>
 	<files>
-		<filename plugin="recaptcha">recaptcha.php</filename>
+		<folder plugin="recaptcha">services</folder>
+		<folder>src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_captcha_recaptcha.ini</language>

--- a/plugins/captcha/recaptcha/services/provider.php
+++ b/plugins/captcha/recaptcha/services/provider.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Captcha.recaptcha
+ *
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Captcha\Google\HttpBridgePostRequestMethod;
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\Captcha\Recaptcha\Extension\Recaptcha;
+
+return new class implements ServiceProviderInterface
+{
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   4.2.0
+     */
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $plugin = new Recaptcha(
+                    $container->get(DispatcherInterface::class),
+                    (array) PluginHelper::getPlugin('captcha', 'recaptcha'),
+                    new HttpBridgePostRequestMethod()
+                );
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plugins/captcha/recaptcha/src/Extension/Recaptcha.php
+++ b/plugins/captcha/recaptcha/src/Extension/Recaptcha.php
@@ -138,7 +138,7 @@ final class Recaptcha extends CMSPlugin implements CaptchaPluginInterface
      */
     public function checkAnswer(string $code = null): bool
     {
-        $input      = $this->getApplication()->input;
+        $input      = $this->getApplication()->getInput();
         $privatekey = $this->params->get('private_key', '');
         $version    = $this->params->get('version', '2.0');
         $remoteip   = IpHelper::getIp();

--- a/plugins/captcha/recaptcha/src/Extension/Recaptcha.php
+++ b/plugins/captcha/recaptcha/src/Extension/Recaptcha.php
@@ -40,7 +40,7 @@ final class Recaptcha extends CMSPlugin implements CaptchaPluginInterface
      * The requestMethod for the captcha API
      *
      * @var    RequestMethod
-	 *
+     *
      * @since  __DEPLOY_VERSION__
      */
     private $requestMethod;
@@ -176,7 +176,9 @@ final class Recaptcha extends CMSPlugin implements CaptchaPluginInterface
      *
      * @since  __DEPLOY_VERSION__
      */
-    public function setupField(CaptchaField $field, SimpleXMLElement $element): void {}
+    public function setupField(CaptchaField $field, SimpleXMLElement $element): void
+    {
+    }
 
     /**
      * Get the reCaptcha response.

--- a/tests/Unit/Plugin/Captcha/Extension/RecaptchaPluginTest.php
+++ b/tests/Unit/Plugin/Captcha/Extension/RecaptchaPluginTest.php
@@ -22,7 +22,6 @@ use Joomla\Tests\Unit\UnitTestCase;
 use Joomla\Utilities\IpHelper;
 use ReCaptcha\RequestMethod;
 use ReCaptcha\RequestParameters;
-use ReCaptcha\Response;
 use RuntimeException;
 use SimpleXMLElement;
 
@@ -68,7 +67,7 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-     * @testdox  can initialize empty public key
+     * @testdox  cannot display when the public key is empty
      *
      * @return  void
      *
@@ -87,7 +86,7 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-     * @testdox  can initialize empty public key
+     * @testdox  cannot display when the app is not a CMSApplication
      *
      * @return  void
      *
@@ -114,9 +113,8 @@ class RecaptchaPluginTest extends UnitTestCase
      */
     public function testCheckSuccessfulAnswer()
     {
-        $app = $this->createStub(CMSApplicationInterface::class);
+        $app = $this->createStub(CMSApplication::class);
         $app->method('getLanguage')->willReturn($this->createStub(Language::class));
-        $app->input = new Input();
 
         IpHelper::setIp('test');
 
@@ -136,9 +134,8 @@ class RecaptchaPluginTest extends UnitTestCase
      */
     public function testCheckErrorAnswer()
     {
-        $app = $this->createStub(CMSApplicationInterface::class);
+        $app = $this->createStub(CMSApplication::class);
         $app->method('getLanguage')->willReturn($this->createStub(Language::class));
-        $app->input = new Input();
 
         IpHelper::setIp('test');
 
@@ -160,9 +157,8 @@ class RecaptchaPluginTest extends UnitTestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $app = $this->createStub(CMSApplicationInterface::class);
+        $app = $this->createStub(CMSApplication::class);
         $app->method('getLanguage')->willReturn($this->createStub(Language::class));
-        $app->input = new Input();
 
         IpHelper::setIp('test');
 
@@ -182,9 +178,8 @@ class RecaptchaPluginTest extends UnitTestCase
     {
         $this->expectException(RuntimeException::class);
 
-        $app = $this->createStub(CMSApplicationInterface::class);
+        $app = $this->createStub(CMSApplication::class);
         $app->method('getLanguage')->willReturn($this->createStub(Language::class));
-        $app->input = new Input();
 
         IpHelper::setIp(false);
 
@@ -194,19 +189,19 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-     * @testdox  can check error answer with no IP available
+     * @testdox  can check error answer with empty response
      *
      * @return  void
      *
      * @since   __DEPLOY_VERSION__
      */
-    public function testCheckAnswerWithErrorResponse()
+    public function testCheckAnswerWithEmptyResponse()
     {
         $this->expectException(RuntimeException::class);
 
-        $app = $this->createStub(CMSApplicationInterface::class);
+        $app = $this->createStub(CMSApplication::class);
         $app->method('getLanguage')->willReturn($this->createStub(Language::class));
-        $app->input = new Input(['g-recaptcha-response' => '']);
+        $app->method('getInput')->willReturn(new Input(['g-recaptcha-response' => '']));
 
         IpHelper::setIp('test');
 
@@ -216,7 +211,7 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-     * @testdox  can check error answer with no IP available
+     * @testdox  can deliver admin capabilities
      *
      * @return  void
      *
@@ -224,7 +219,7 @@ class RecaptchaPluginTest extends UnitTestCase
      */
     public function testAdminCapabilities()
     {
-        $app = $this->createStub(CMSApplicationInterface::class);
+        $app = $this->createStub(CMSApplication::class);
         $app->method('getLanguage')->willReturn($this->createStub(Language::class));
 
         $plugin = new Recaptcha(new Dispatcher(), ['params' => []], $this->getRequestMethod());
@@ -235,7 +230,7 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-     * @testdox  can check error answer with no IP available
+     * @testdox  can setup the field
      *
      * @return  void
      *
@@ -244,13 +239,22 @@ class RecaptchaPluginTest extends UnitTestCase
     public function testSetupField()
     {
         $plugin = new Recaptcha(new Dispatcher(), ['params' => []], $this->getRequestMethod());
-        $plugin->setApplication($this->createStub(CMSApplicationInterface::class));
+        $plugin->setApplication($this->createStub(CMSApplication::class));
         $result = $plugin->setupField(new CaptchaField(), new SimpleXMLElement('<test/>'));
 
         $this->assertEmpty($result);
     }
 
-    private function getRequestMethod($data = ['success' => true]) {
+     /**
+     * Returns a request method for the given data.
+     *
+     * @param   array  $data  The data
+     *
+     * @return  RequestMethod
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    private function getRequestMethod(array $data = ['success' => true]): RequestMethod {
         return new class($data) implements RequestMethod {
 
             private $data = [];

--- a/tests/Unit/Plugin/Captcha/Extension/RecaptchaPluginTest.php
+++ b/tests/Unit/Plugin/Captcha/Extension/RecaptchaPluginTest.php
@@ -254,9 +254,10 @@ class RecaptchaPluginTest extends UnitTestCase
      *
      * @since   __DEPLOY_VERSION__
      */
-    private function getRequestMethod(array $data = ['success' => true]): RequestMethod {
-        return new class($data) implements RequestMethod {
-
+    private function getRequestMethod(array $data = ['success' => true]): RequestMethod
+    {
+        return new class ($data) implements RequestMethod
+        {
             private $data = [];
 
             public function __construct(array $data)
@@ -264,7 +265,8 @@ class RecaptchaPluginTest extends UnitTestCase
                 $this->data = $data;
             }
 
-            public function submit(RequestParameters $params) {
+            public function submit(RequestParameters $params)
+            {
                 return json_encode($this->data);
             }
         };

--- a/tests/Unit/Plugin/Captcha/Extension/RecaptchaPluginTest.php
+++ b/tests/Unit/Plugin/Captcha/Extension/RecaptchaPluginTest.php
@@ -1,0 +1,268 @@
+<?php
+
+/**
+ * @package     Joomla.UnitTest
+ * @subpackage  Extension
+ *
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Tests\Unit\Plugin\Captcha\Recaptcha\Extension;
+
+use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Document\HtmlDocument;
+use Joomla\CMS\Form\Field\CaptchaField;
+use Joomla\CMS\Language\Language;
+use Joomla\Event\Dispatcher;
+use Joomla\Input\Input;
+use Joomla\Plugin\Captcha\Recaptcha\Extension\Recaptcha;
+use Joomla\Tests\Unit\UnitTestCase;
+use Joomla\Utilities\IpHelper;
+use ReCaptcha\RequestMethod;
+use ReCaptcha\RequestParameters;
+use ReCaptcha\Response;
+use RuntimeException;
+use SimpleXMLElement;
+
+/**
+ * Test class for Recaptcha plugin
+ *
+ * @package     Joomla.UnitTest
+ * @subpackage  Recaptcha
+ *
+ * @testdox     The Recaptcha plugin
+ *
+ * @since       __DEPLOY_VERSION__
+ */
+class RecaptchaPluginTest extends UnitTestCase
+{
+    /**
+     * @testdox  can display a field
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testDisplayCaptcha()
+    {
+        $document = new HtmlDocument();
+        $language = $this->createStub(Language::class);
+        $language->method('getTag')->willReturn('en');
+
+        $app = $this->createStub(CMSApplication::class);
+        $app->method('getLanguage')->willReturn($language);
+        $app->method('getDocument')->willReturn($document);
+
+        $plugin = new Recaptcha(new Dispatcher(), ['params' => ['public_key' => 'test']], $this->getRequestMethod());
+        $plugin->setApplication($app);
+        $xml = $plugin->display('unit', 'test');
+
+        $this->assertStringContainsString('unit', $xml);
+        $this->assertStringContainsString('test', $xml);
+        $this->assertStringContainsString(
+            'google.com/recaptcha/api.js',
+            $document->getWebAssetManager()->getAsset('script', 'plg_captcha_recaptcha.api')->getUri()
+        );
+    }
+
+    /**
+     * @testdox  can initialize empty public key
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testDisplayWithEmptyPublicKey()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $app = $this->createStub(CMSApplication::class);
+        $app->method('getLanguage')->willReturn($this->createStub(Language::class));
+
+        $plugin = new Recaptcha(new Dispatcher(), ['params' => []], $this->getRequestMethod());
+        $plugin->setApplication($app);
+        $plugin->display('unit', 'test');
+    }
+
+    /**
+     * @testdox  can initialize empty public key
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testDisplayWithWrongApplication()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $app = $this->createStub(CMSApplicationInterface::class);
+        $app->method('getLanguage')->willReturn($this->createStub(Language::class));
+
+        $plugin = new Recaptcha(new Dispatcher(), ['params' => ['public_key' => 'test']], $this->getRequestMethod());
+        $plugin->setApplication($app);
+        $plugin->display('unit', 'test');
+    }
+
+    /**
+     * @testdox  can check successful answer
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testCheckSuccessfulAnswer()
+    {
+        $app = $this->createStub(CMSApplicationInterface::class);
+        $app->method('getLanguage')->willReturn($this->createStub(Language::class));
+        $app->input = new Input();
+
+        IpHelper::setIp('test');
+
+        $plugin = new Recaptcha(new Dispatcher(), ['params' => ['private_key' => 'test']], $this->getRequestMethod());
+        $plugin->setApplication($app);
+        $success = $plugin->checkAnswer('unit test');
+
+        $this->assertTrue($success);
+    }
+
+    /**
+     * @testdox  can check error answer
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testCheckErrorAnswer()
+    {
+        $app = $this->createStub(CMSApplicationInterface::class);
+        $app->method('getLanguage')->willReturn($this->createStub(Language::class));
+        $app->input = new Input();
+
+        IpHelper::setIp('test');
+
+        $plugin = new Recaptcha(new Dispatcher(), ['params' => ['private_key' => 'test']], $this->getRequestMethod(['error-codes' => []]));
+        $plugin->setApplication($app);
+        $success = $plugin->checkAnswer('unit test');
+
+        $this->assertFalse($success);
+    }
+
+    /**
+     * @testdox  can check error answer with error codes
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testCheckErrorAnswerWithErrorCodes()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $app = $this->createStub(CMSApplicationInterface::class);
+        $app->method('getLanguage')->willReturn($this->createStub(Language::class));
+        $app->input = new Input();
+
+        IpHelper::setIp('test');
+
+        $plugin = new Recaptcha(new Dispatcher(), ['params' => ['private_key' => 'test']], $this->getRequestMethod(['error-codes' => ['test']]));
+        $plugin->setApplication($app);
+        $plugin->checkAnswer('unit test');
+    }
+
+    /**
+     * @testdox  can check error answer with no IP available
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testCheckAnswerWithNoIPAvailable()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $app = $this->createStub(CMSApplicationInterface::class);
+        $app->method('getLanguage')->willReturn($this->createStub(Language::class));
+        $app->input = new Input();
+
+        IpHelper::setIp(false);
+
+        $plugin = new Recaptcha(new Dispatcher(), ['params' => []], $this->getRequestMethod());
+        $plugin->setApplication($app);
+        $plugin->checkAnswer('unit test');
+    }
+
+    /**
+     * @testdox  can check error answer with no IP available
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testCheckAnswerWithErrorResponse()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $app = $this->createStub(CMSApplicationInterface::class);
+        $app->method('getLanguage')->willReturn($this->createStub(Language::class));
+        $app->input = new Input(['g-recaptcha-response' => '']);
+
+        IpHelper::setIp('test');
+
+        $plugin = new Recaptcha(new Dispatcher(), ['params' => []], $this->getRequestMethod());
+        $plugin->setApplication($app);
+        $plugin->checkAnswer();
+    }
+
+    /**
+     * @testdox  can check error answer with no IP available
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testAdminCapabilities()
+    {
+        $app = $this->createStub(CMSApplicationInterface::class);
+        $app->method('getLanguage')->willReturn($this->createStub(Language::class));
+
+        $plugin = new Recaptcha(new Dispatcher(), ['params' => []], $this->getRequestMethod());
+        $plugin->setApplication($app);
+        $strings = $plugin->onPrivacyCollectAdminCapabilities();
+
+        $this->assertNotEmpty($strings);
+    }
+
+    /**
+     * @testdox  can check error answer with no IP available
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function testSetupField()
+    {
+        $plugin = new Recaptcha(new Dispatcher(), ['params' => []], $this->getRequestMethod());
+        $plugin->setApplication($this->createStub(CMSApplicationInterface::class));
+        $result = $plugin->setupField(new CaptchaField(), new SimpleXMLElement('<test/>'));
+
+        $this->assertEmpty($result);
+    }
+
+    private function getRequestMethod($data = ['success' => true]) {
+        return new class($data) implements RequestMethod {
+
+            private $data = [];
+
+            public function __construct(array $data)
+            {
+                $this->data = $data;
+            }
+
+            public function submit(RequestParameters $params) {
+                return json_encode($this->data);
+            }
+        };
+    }
+}


### PR DESCRIPTION
### Summary of Changes
The pr introduces a new interface for captcha based plugins so operations on them is more clear. Additionally it deprecates the `Captcha` class as it basically duplicates the code of the `bootPlugin` operation and does some method checks for plugins which do not implement the interface.

### Testing Instructions
- Setup the recaptcha and invisible captcha plugin in the plugin manager with the proper keys
- Select recaptcha in the contact options in the form tab
- Create a single contact menu item
- Open that contact menu item and send a mail as not logged in user
- Select invisible captcha in the contact options in the form tab
- Open that contact menu item and send a mail as not logged in user

### Actual result BEFORE applying this Pull Request
Both times is a captcha challenge executed and two mails are sent out.

### Expected result AFTER applying this Pull Request
Both times is a captcha challenge executed and two mails are sent out.

### Documentation Changes Required
When deprecated messages are already documented, then this one needs to be added.