### PR TITLE
Fixed custom field menuitem warning

### DIFF
--- a/plugins/fields/menuitem/menuitem.php
+++ b/plugins/fields/menuitem/menuitem.php
@@ -10,11 +10,13 @@
  * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
+use Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin;
+
 /**
  * Fields Menuitem Plugin
  *
  * @since  4.2.0
  */
-class PlgFieldsMenuitem extends \Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin
+class PlgFieldsMenuitem extends FieldsPlugin
 {
 }

--- a/plugins/fields/menuitem/tmpl/menuitem.php
+++ b/plugins/fields/menuitem/tmpl/menuitem.php
@@ -14,13 +14,14 @@ use Joomla\CMS\Router\Route;
 
 defined('_JEXEC') or die;
 
-$value = (int) $field->value;
+$value = (int)$field->value;
+$menu  = Factory::getApplication()->getMenu()->getItem($value);
 
-if ($value == '') {
+if ($value === 0 || !$menu) {
     return;
 }
 
 $url   = Route::_('index.php?Itemid=' . $value);
-$title = Factory::getApplication()->getMenu()->getItem($value)->title;
+$title = $menu->title;
 
 echo HTMLHelper::_('link', $url, $title);

--- a/plugins/fields/menuitem/tmpl/menuitem.php
+++ b/plugins/fields/menuitem/tmpl/menuitem.php
@@ -10,6 +10,7 @@
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Menu\MenuItem;
 use Joomla\CMS\Router\Route;
 
 defined('_JEXEC') or die;
@@ -17,7 +18,7 @@ defined('_JEXEC') or die;
 $value = (int)$field->value;
 $menu  = Factory::getApplication()->getMenu()->getItem($value);
 
-if ($value === 0 || !$menu) {
+if (!$menu instanceof MenuItem) {
     return;
 }
 

--- a/plugins/fields/menuitem/tmpl/menuitem.php
+++ b/plugins/fields/menuitem/tmpl/menuitem.php
@@ -8,15 +8,19 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
+use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\CMS\Router\Route;
+
 defined('_JEXEC') or die;
 
-$value = $field->value;
+$value = (int) $field->value;
 
 if ($value == '') {
     return;
 }
 
-$url   = \Joomla\CMS\Router\Route::_("index.php?Itemid={$value}");
-$title = \Joomla\CMS\Factory::getApplication()->getMenu()->getItem($value)->title;
+$url   = Route::_('index.php?Itemid=' . $value);
+$title = Factory::getApplication()->getMenu()->getItem($value)->title;
 
-echo "<a href=\"{$url}\">{$title}</a>";
+echo HTMLHelper::_('link', $url, $title);


### PR DESCRIPTION
Pull Request for Issue #38244

### Summary of Changes
This PR fixes a few issues with the menu item field:
- Cast value to integer as menu item IDs are always numbers
- Check if the menu item exists in case the number is wrong or unpublished
- Use single quotes around strings
- Use HTMLHelper for rendering link


### Testing Instructions
1. Create a custom field of the type `List Of Menu Items (menuitem)`
2. Save the custom field
3. Create an article and select a menu item on the Fields tab
4. Create a menu item of the type `Single Article` and select the new created article
5. Visit the article on the front-end
6. You should see the menu item listed
7. Unpublish the menu item that was selected in the article
8. Refresh the page
9. You see a warning `Attempted to read property title on null`
10. Apply patch
11. Refresh the page
12. The link and warning should be gone


### Actual result BEFORE applying this Pull Request
A warning `Attempted to read property title on null` when menu item is not available


### Expected result AFTER applying this Pull Request
No warning is displayed and no link is displayed


### Documentation Changes Required
None
