### PR TITLE
Make sure the itemID is of type int

### DIFF
--- a/components/com_users/src/Controller/UserController.php
+++ b/components/com_users/src/Controller/UserController.php
@@ -48,10 +48,11 @@ class UserController extends BaseController
 
         // Check for a simple menu item id
         if (is_numeric($data['return'])) {
-            $data['return'] = 'index.php?Itemid=' . $data['return'];
+            $itemId = (int) $data['return'];
+            $data['return'] = 'index.php?Itemid=' . $itemId;
 
             if (Multilanguage::isEnabled()) {
-                $language = $this->getModel('Login', 'Site')->getMenuLanguage($data['return']);
+                $language = $this->getModel('Login', 'Site')->getMenuLanguage($itemId);
 
                 if ($language !== '*') {
                     $data['return'] .= '&lang=' . $language;


### PR DESCRIPTION
Pull Request for Issue #38489.

### Summary of Changes
When you have a login menu item and use that on a multi-lingual site, logging in will end in failure `Argument must be of the type int`


### Testing Instructions
1. Use a mutli-language site
2. Create a menu item of the type Login
3. Set the redirect to another menu item
4. Try to login on the frontend
5. You see the fatal error
6. Apply patch
7. Try to login again
8. You are now redirected to the page set in the menu item


### Actual result BEFORE applying this Pull Request
Fatal error on login on multi-language site


### Expected result AFTER applying this Pull Request
User is logged in


### Documentation Changes Required
None