### PR TITLE
[4.2] Fix issue "updateCheck is null"

### DIFF
--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -10,13 +10,14 @@ Joomla = window.Joomla || {};
 
   Joomla.submitbuttonUpload = () => {
     const form = document.getElementById('uploadForm');
+    const confirmBackup = document.getElementById('joomlaupdate-confirm-backup');
 
     // do field validation
     if (form.install_package.value === '') {
       alert(Joomla.Text._('COM_INSTALLER_MSG_INSTALL_PLEASE_SELECT_A_PACKAGE'), true);
     } else if (form.install_package.files[0].size > form.max_upload_size.value) {
       alert(Joomla.Text._('COM_INSTALLER_MSG_WARNINGS_UPLOADFILETOOBIG'), true);
-    } else if (document.getElementById('joomlaupdate-confirm-backup').checked) {
+    } else if (confirmBackup && confirmBackup.checked) {
       form.submit();
     }
   };
@@ -53,13 +54,15 @@ Joomla = window.Joomla || {};
     const form = installButton ? installButton.closest('form') : null;
     const task = form ? form.querySelector('[name=task]', form) : null;
     if (uploadButton) {
-      uploadButton.disabled = !updateCheck.checked;
       uploadButton.addEventListener('click', Joomla.submitbuttonUpload);
-      updateCheck.addEventListener('change', () => {
-        uploadButton.disabled = !updateCheck.checked;
-      });
+      uploadButton.disabled = updateCheck && !updateCheck.checked;
+      if (updateCheck) {
+        updateCheck.addEventListener('change', () => {
+          uploadButton.disabled = !updateCheck.checked;
+        });
+      }
     }
-    if (confirmButton && !updateCheck.checked) {
+    if (confirmButton && updateCheck && !updateCheck.checked) {
       confirmButton.classList.add('disabled');
     }
     if (confirmButton && updateCheck) {
@@ -73,22 +76,24 @@ Joomla = window.Joomla || {};
     }
     if (uploadField) {
       uploadField.addEventListener('change', Joomla.installpackageChange);
-      uploadField.addEventListener('change', () => {
-        const fileSize = uploadForm.install_package.files[0].size;
-        const allowedSize = uploadForm.max_upload_size.value;
-        if (fileSize <= allowedSize && updateCheck.disabled) {
-          updateCheck.disabled = !updateCheck.disabled;
-        } else if (fileSize <= allowedSize && !updateCheck.disabled && !updateCheck.checked) {
-          updateCheck.disabled = false;
-        } else if (fileSize <= allowedSize && updateCheck.checked) {
-          updateCheck.checked = updateCheck.classList.contains('d-none');
-          uploadButton.disabled = true;
-        } else if (fileSize > allowedSize && !updateCheck.disabled) {
-          updateCheck.disabled = !updateCheck.disabled;
-          updateCheck.checked = updateCheck.classList.contains('d-none');
-          uploadButton.disabled = true;
-        }
-      });
+      if (updateCheck) {
+        uploadField.addEventListener('change', () => {
+          const fileSize = uploadForm.install_package.files[0].size;
+          const allowedSize = uploadForm.max_upload_size.value;
+          if (fileSize <= allowedSize && updateCheck.disabled) {
+            updateCheck.disabled = !updateCheck.disabled;
+          } else if (fileSize <= allowedSize && !updateCheck.disabled && !updateCheck.checked) {
+            updateCheck.disabled = false;
+          } else if (fileSize <= allowedSize && updateCheck.checked) {
+            updateCheck.checked = updateCheck.classList.contains('d-none');
+            uploadButton.disabled = true;
+          } else if (fileSize > allowedSize && !updateCheck.disabled) {
+            updateCheck.disabled = !updateCheck.disabled;
+            updateCheck.checked = updateCheck.classList.contains('d-none');
+            uploadButton.disabled = true;
+          }
+        });
+      }
     }
     // Trigger (re-) install (including checkbox confirm if we update)
     if (installButton && installButton.getAttribute('href') === '#' && task) {


### PR DESCRIPTION
Pull Request for Issue #38513.

### Summary of Changes
Going to the joomla updater can lead to a js error because an optional element can not be found. This PR checks the element before it is used.

### Testing Instructions
Short: Follow the instructions in the linked issue.
Long: 
Open the developer tools of your browser to see the console. 
Go to System -> Global Configuration -> Joomla! Update. 
Try out different channels. 
Everytime you click "Save & Close" you are redirected to the update page.
There you can click buttons like "Reinstall Joomla! core files"

### Actual result BEFORE applying this Pull Request
An js error saying "TypeError: updateCheck is null" appears in the browser console. Depending on your debug settings it could say "a is null" or something like this. Buttons are not working.

### Expected result AFTER applying this Pull Request
There is no js error and buttons should work as always.

### Documentation Changes Required
Nope.
