### PR TITLE
[4.2] Remove hotkeys.js by script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6438,7 +6438,7 @@ class JoomlaInstallerScript
             // From 4.2.0 to 4.2.1
             '/media/vendor/hotkeys.js/js/hotkeys.js',
             '/media/vendor/hotkeys.js/js/hotkeys.min.js',
-            '/media/vendor/hotkeys.js/js/hotkeys.min.js.gz'
+            '/media/vendor/hotkeys.js/js/hotkeys.min.js.gz',
             '/media/vendor/hotkeys.js/LICENSE',
         );
 
@@ -7808,9 +7808,9 @@ class JoomlaInstallerScript
             '/plugins/system/webauthn/src/Helper',
             '/plugins/system/webauthn/src/Exception',
             // From 4.2.0 to 4.2.1
-            '/libraries/vendor/symfony/string/Resources/bin',
             '/media/vendor/hotkeys.js/js',
             '/media/vendor/hotkeys.js',
+            '/libraries/vendor/symfony/string/Resources/bin',
         );
 
         $status['files_checked'] = $files;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6435,6 +6435,10 @@ class JoomlaInstallerScript
             '/plugins/system/webauthn/webauthn.php',
             '/plugins/task/checkfiles/checkfiles.php',
             '/plugins/task/demotasks/demotasks.php',
+            // From 4.2.0 to 4.2.1
+            '/media/vendor/hotkeys.js/js/hotkeys.js',
+            '/media/vendor/hotkeys.js/js/hotkeys.min.js',
+            '/media/vendor/hotkeys.js/LICENSE',
         );
 
         $folders = array(
@@ -7804,6 +7808,8 @@ class JoomlaInstallerScript
             '/plugins/system/webauthn/src/Exception',
             // From 4.2.0 to 4.2.1
             '/libraries/vendor/symfony/string/Resources/bin',
+            '/media/vendor/hotkeys.js/js',
+            '/media/vendor/hotkeys.js',
         );
 
         $status['files_checked'] = $files;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6438,6 +6438,7 @@ class JoomlaInstallerScript
             // From 4.2.0 to 4.2.1
             '/media/vendor/hotkeys.js/js/hotkeys.js',
             '/media/vendor/hotkeys.js/js/hotkeys.min.js',
+            '/media/vendor/hotkeys.js/js/hotkeys.min.js.gz'
             '/media/vendor/hotkeys.js/LICENSE',
         );
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
While the development of 4.2 hotkeys.js was renamed to hotkeysjs to avoid issues. Currently both ~~are in the build~~ may be on sites, but the one with the dot should be removed with all its files and folders.

@richard67 please have a look

