### PR TITLE
CLI application crashed instantiating MVCFactory

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -527,7 +527,7 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
          */
         $_SERVER['HTTP_HOST']   = $uri->toString(['host', 'port']);
         $_SERVER['REQUEST_URI'] = $uri->getPath();
-        $_SERVER['HTTPS'] = $uri->getScheme() === 'https' ? 'on' : 'off';
+        $_SERVER['HTTPS']       = $uri->getScheme() === 'https' ? 'on' : 'off';
     }
 
     /**

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -482,9 +482,9 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
     /**
      * Populates the HTTP_HOST and REQUEST_URI from the URL provided in the --live-site parameter.
      *
-     * If the URL provided is empty or invalid we will use the URL http://www.example.com just so
-     * that the CLI application doesn't crash when a WebApplication descendant is instantiated in
-     * it.
+     * If the URL provided is empty or invalid we will use the URL
+     * https://joomla.invalid/set/by/console/application just so that the CLI application doesn't
+     * crash when a WebApplication descendant is instantiated in it.
      *
      * This is a practical workaround for using any service depending on a WebApplication
      * descendant under CLI.
@@ -508,13 +508,16 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
         }
 
         // Fallback to the $live_site global configuration option in configuration.php
-        $liveSite = $liveSite ?: $this->get('live_site', 'http://www.example.com');
+        $liveSite = $liveSite ?: $this->get('live_site', 'https://joomla.invalid/set/by/console/application');
 
-        // Try to use the live site URL we were given. If all else fails, fall back to example.com.
+        /**
+         * Try to use the live site URL we were given. If all else fails, fall back to
+         * https://joomla.invalid/set/by/console/application.
+         */
         try {
             $uri = Uri::getInstance($liveSite);
         } catch (\RuntimeException $e) {
-            $uri = Uri::getInstance('http://www.example.com');
+            $uri = Uri::getInstance('https://joomla.invalid/set/by/console/application');
         }
 
         /**
@@ -524,6 +527,7 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
          */
         $_SERVER['HTTP_HOST']   = $uri->toString(['host', 'port']);
         $_SERVER['REQUEST_URI'] = $uri->getPath();
+        $_SERVER['HTTPS'] = $uri->getScheme() === 'https' ? 'on' : 'off';
     }
 
     /**

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -499,12 +499,11 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
     protected function populateHttpHost()
     {
         // First check for the --live-site command line option.
-        $input = $this->getConsoleInput();
+        $input    = $this->getConsoleInput();
+        $liveSite = '';
 
         if ($input->hasParameterOption(['--live-site', false])) {
             $liveSite = $input->getParameterOption(['--live-site'], '');
-        } else {
-            $liveSite = '';
         }
 
         // Fallback to the $live_site global configuration option in configuration.php

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -500,11 +500,9 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
     {
         // First check for the --live-site command line option.
         $input    = $this->getConsoleInput();
-        $liveSite = '';
-
-        if ($input->hasParameterOption(['--live-site', false])) {
-            $liveSite = $input->getParameterOption(['--live-site'], '');
-        }
+        $liveSite = $input->hasParameterOption(['--live-site', false])
+            ? $input->getParameterOption(['--live-site'], '')
+            : '';
 
         // Fallback to the $live_site global configuration option in configuration.php
         $liveSite = $liveSite ?: $this->get('live_site', 'https://joomla.invalid/set/by/console/application');

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -28,7 +28,10 @@ use Joomla\Event\DispatcherInterface;
 use Joomla\Input\Input;
 use Joomla\Registry\Registry;
 use Joomla\Session\SessionInterface;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputDefinition;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -522,4 +525,49 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
         $_SERVER['HTTP_HOST']   = $uri->toString(['host', 'port']);
         $_SERVER['REQUEST_URI'] = $uri->getPath();
     }
+
+    /**
+     * Builds the default input definition.
+     *
+     * @return  InputDefinition
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function getDefaultInputDefinition(): InputDefinition
+    {
+        return new InputDefinition(
+            [
+                new InputArgument('command', InputArgument::REQUIRED, 'The command to execute'),
+                new InputOption(
+                    '--live-site',
+                    null,
+                    InputOption::VALUE_OPTIONAL,
+                    'The URL to your site, e.g. http://www.example.com'
+                ),
+                new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display the help information'),
+                new InputOption(
+                    '--quiet',
+                    '-q',
+                    InputOption::VALUE_NONE,
+                    'Flag indicating that all output should be silenced'
+                ),
+                new InputOption(
+                    '--verbose',
+                    '-v|vv|vvv',
+                    InputOption::VALUE_NONE,
+                    'Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug'
+                ),
+                new InputOption('--version', '-V', InputOption::VALUE_NONE, 'Displays the application version'),
+                new InputOption('--ansi', '', InputOption::VALUE_NONE, 'Force ANSI output'),
+                new InputOption('--no-ansi', '', InputOption::VALUE_NONE, 'Disable ANSI output'),
+                new InputOption(
+                    '--no-interaction',
+                    '-n',
+                    InputOption::VALUE_NONE,
+                    'Flag to disable interacting with the user'
+                ),
+            ]
+        );
+    }
+
 }

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -569,5 +569,4 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
             ]
         );
     }
-
 }

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -500,9 +500,11 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
     {
         // First check for the --live-site command line option.
         $input    = $this->getConsoleInput();
-        $liveSite = $input->hasParameterOption(['--live-site', false])
-            ? $input->getParameterOption(['--live-site'], '')
-            : '';
+        $liveSite = '';
+
+        if ($input->hasParameterOption(['--live-site', false])) {
+            $liveSite = $input->getParameterOption(['--live-site'], '');
+        }
 
         // Fallback to the $live_site global configuration option in configuration.php
         $liveSite = $liveSite ?: $this->get('live_site', 'https://joomla.invalid/set/by/console/application');

--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -546,7 +546,7 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
                     '--live-site',
                     null,
                     InputOption::VALUE_OPTIONAL,
-                    'The URL to your site, e.g. http://www.example.com'
+                    'The URL to your site, e.g. https://www.example.com'
                 ),
                 new InputOption('--help', '-h', InputOption::VALUE_NONE, 'Display the help information'),
                 new InputOption(


### PR DESCRIPTION
Pull Request for Issue #38518 .

### Summary of Changes

The CLI application (`cli/joomla.php`) now accepts a `--live-site=URL` option to set up the URL of your site.

If you do not define this option it falls back to the `$live_site` in configuration.php. If that is empty it uses the fake URL ~`http://www.example.com`~ `https://joomla.invalid/set/by/console/application` just so that the CLI application does not crash.

### Testing Instructions

* Install a Joomla 4.2.0 site
* Install the minimum reproduction plugin: [plg_console_derp.zip](https://github.com/joomla/joomla-cms/files/9375325/plg_console_derp.zip)
* Go to System, Manage, Plugins and enable the Console - Derp plugin we just installed.
* Open your command line terminal and go to your site's cli directory e.g. `cd /var/www/test/cli`
* TEST 1: Run the CLI application as `php joomla.php`
* TEST 2: Run the CLI application with THE FULL path to the `joomla.php` file, e.g. `php /var/www/test/cli/joomla.php`

### Actual result BEFORE applying this Pull Request

Test 1 works: you get a list of the available CLI commands.

Test 2 returns an error: Could not parse the requested URI http:///var/www/test/cli/joomla.php

### Expected result AFTER applying this Pull Request

Test 1 works: you get a list of the available CLI commands.

Test 2 works: you get a list of the available CLI commands.

### Documentation Changes Required

Add the following to the documentation of the CLI application:

* `--live-site=URL` Tells the CLI application what is the URL to your site. This is mainly used for creating URLs in articles, emails etc. If you do not specify this parameter Joomla will read the `$live_site` parameter in your `configuration.php` file. If that is empty, or if the URL you specified is invalid, the URL `http://www.example.com` will be used instead.