### PR TITLE
Remove the autoload_psr4 before running finalisation.php

### DIFF
--- a/administrator/components/com_joomlaupdate/extract.php
+++ b/administrator/components/com_joomlaupdate/extract.php
@@ -1930,6 +1930,16 @@ if ($enabled) {
         case 'finalizeUpdate':
             $root = $configuration['setup.destdir'] ?? '';
 
+            // Remove the administrator/cache/autoload_psr4.php file
+            $filename = $root . (empty($root) ? '' : '/') . 'administrator/cache/autoload_psr4.php';
+
+            if (file_exists($filename)) {
+                clearFileInOPCache($filename);
+                clearstatcache(true, $filename);
+
+                @unlink($filename);
+            }
+
             // Remove update.php
             clearFileInOPCache($basePath . 'update.php');
             @unlink($basePath . 'update.php');

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -95,7 +95,7 @@ class UpdateModel extends BaseDatabaseModel
         }
 
         $id = ExtensionHelper::getExtensionRecord('joomla', 'file')->extension_id;
-        $db = $this->getDatabase();
+        $db = version_compare(JVERSION, '4.2.0', 'lt') ? $this->getDbo() : $this->getDatabase();
         $query = $db->getQuery(true)
             ->select($db->quoteName('us') . '.*')
             ->from($db->quoteName('#__update_sites_extensions', 'map'))
@@ -173,7 +173,7 @@ class UpdateModel extends BaseDatabaseModel
      */
     public function getCheckForSelfUpdate()
     {
-        $db = $this->getDatabase();
+        $db = version_compare(JVERSION, '4.2.0', 'lt') ? $this->getDbo() : $this->getDatabase();
 
         $query = $db->getQuery(true)
             ->select($db->quoteName('extension_id'))
@@ -244,7 +244,7 @@ class UpdateModel extends BaseDatabaseModel
 
         // Fetch the update information from the database.
         $id = ExtensionHelper::getExtensionRecord('joomla', 'file')->extension_id;
-        $db = $this->getDatabase();
+        $db = version_compare(JVERSION, '4.2.0', 'lt') ? $this->getDbo() : $this->getDatabase();
         $query = $db->getQuery(true)
             ->select('*')
             ->from($db->quoteName('#__updates'))
@@ -300,7 +300,7 @@ class UpdateModel extends BaseDatabaseModel
      */
     public function purge()
     {
-        $db = $this->getDatabase();
+        $db = version_compare(JVERSION, '4.2.0', 'lt') ? $this->getDbo() : $this->getDatabase();
 
         // Modify the database record
         $update_site = new \stdClass();
@@ -632,7 +632,8 @@ ENDDATA;
         $installer->setUpgrade(true);
         $installer->setOverwrite(true);
 
-        $installer->extension = new \Joomla\CMS\Table\Extension($this->getDatabase());
+        $db = version_compare(JVERSION, '4.2.0', 'lt') ? $this->getDbo() : $this->getDatabase();
+        $installer->extension = new \Joomla\CMS\Table\Extension($db);
         $installer->extension->load(ExtensionHelper::getExtensionRecord('joomla', 'file')->extension_id);
 
         $installer->setAdapter($installer->extension->type);
@@ -667,7 +668,7 @@ ENDDATA;
         ob_end_clean();
 
         // Get a database connector object.
-        $db = $this->getDatabase();
+        $db = version_compare(JVERSION, '4.2.0', 'lt') ? $this->getDbo() : $this->getDatabase();
 
         /*
          * Check to see if a file extension by the same name is already installed.
@@ -694,7 +695,7 @@ ENDDATA;
         }
 
         $id = $db->loadResult();
-        $row = new \Joomla\CMS\Table\Extension($this->getDatabase());
+        $row = new \Joomla\CMS\Table\Extension($db);
 
         if ($id) {
             // Load the entry and update the manifest_cache.
@@ -779,7 +780,7 @@ ENDDATA;
         ob_end_clean();
 
         // Clobber any possible pending updates.
-        $update = new \Joomla\CMS\Table\Update($this->getDatabase());
+        $update = new \Joomla\CMS\Table\Update($db);
         $uid = $update->find(
             array('element' => 'joomla', 'type' => 'file', 'client_id' => '0', 'folder' => '')
         );
@@ -1325,7 +1326,7 @@ ENDDATA;
      */
     public function getNonCoreExtensions()
     {
-        $db = $this->getDatabase();
+        $db = version_compare(JVERSION, '4.2.0', 'lt') ? $this->getDbo() : $this->getDatabase();
         $query = $db->getQuery(true);
 
         $query->select(
@@ -1375,7 +1376,7 @@ ENDDATA;
      */
     public function getNonCorePlugins($folderFilter = ['system','user','authentication','actionlog','multifactorauth'])
     {
-        $db    = $this->getDatabase();
+        $db = version_compare(JVERSION, '4.2.0', 'lt') ? $this->getDbo() : $this->getDatabase();
         $query = $db->getQuery(true);
 
         $query->select(
@@ -1476,7 +1477,7 @@ ENDDATA;
     private function getUpdateSitesInfo($extensionID)
     {
         $id = (int) $extensionID;
-        $db = $this->getDatabase();
+        $db = version_compare(JVERSION, '4.2.0', 'lt') ? $this->getDbo() : $this->getDatabase();
         $query = $db->getQuery(true);
 
         $query->select(
@@ -1659,7 +1660,7 @@ ENDDATA;
      */
     public function isTemplateActive($template)
     {
-        $db = $this->getDatabase();
+        $db = version_compare(JVERSION, '4.2.0', 'lt') ? $this->getDbo() : $this->getDatabase();
         $query = $db->getQuery(true);
 
         $query->select(

--- a/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
@@ -275,7 +275,11 @@ class HtmlView extends BaseHtmlView
         }
 
         // Add toolbar buttons.
-        if ($this->getCurrentUser()->authorise('core.admin')) {
+        $currentUser = version_compare(JVERSION, '4.2.0', 'ge')
+            ? $this->getCurrentUser()
+            : Factory::getApplication()->getIdentity();
+
+        if ($currentUser->authorise('core.admin')) {
             ToolbarHelper::preferences('com_joomlaupdate');
         }
 


### PR DESCRIPTION
Replaces #38491

Pull Request for Issue https://github.com/joomla/joomla-cms/issues/38486 .

### Summary of Changes

Add code in extract.php to remove the administrator/cache/autoload_psr4.php file _before_ loading the finalisation.php as the latter might try to use core code which depends on the former.

### Testing Instructions

#### From Joomla 4.0.0

* Install a Joomla 4.0.0 site
* Replace administrator/components/com_joomlaupdate, components/com_joomlaupdate, media/com_joomlaupdate, and administrator/language/en-GB/com_joomlaupdate.* with the files from this PR.
* Log into the backend
* Do an md5sum of the administrator/cache/autoload_psr4.php file
* Upgrade the site to Joomla 4.2 using the package built from this PR
* Try to access your site's frontend
* Do an md5sum of the administrator/cache/autoload_psr4.php file

#### From Joomla 4.1.5

* Install a Joomla 4.1.5 site
* Log into the backend
* Do an md5sum of the administrator/cache/autoload_psr4.php file
* Upgrade the site to Joomla 4.2 using the package built from this PR
* Try to access your site's frontend
* Do an md5sum of the administrator/cache/autoload_psr4.php file

### Actual result BEFORE applying this Pull Request

The MD5 sums are identical (the autoload_psr4.php file was not removed on update). 

### Expected result AFTER applying this Pull Request

The MD5 sums are different (the autoload_psr4.php file was removed on update and replaced when accessing your site again).

### Documentation Changes Required

None.