### PR TITLE
Freeze loading of plugins on update finalisation

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -875,7 +875,7 @@ ENDDATA;
         try {
             $app->triggerEvent('onJoomlaAfterUpdate', [$oldVersion]);
         } catch (\Exception $e) {
-            // Swallow any PHp errors
+            // Swallow any PHP errors
         }
 
         $app->setUserState('com_joomlaupdate.oldversion', null);

--- a/libraries/src/Application/PluginFreezingApplicationInterface.php
+++ b/libraries/src/Application/PluginFreezingApplicationInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Application;
+
+/**
+ * An interface for applications which can temporarily freeze loading any plugins.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface PluginFreezingApplicationInterface
+{
+    /**
+     * Is loading plugins temporarily frozen?
+     *
+     * @return  bool
+     * @since   __DEPLOY_VERSION__
+     */
+    public function isPluginLoadingFrozen(): bool;
+}


### PR DESCRIPTION
Replaces gh-38491 (part 2 of splitting that PR)

Pull Request for Issue #38486 .

### Summary of Changes

Disable loading all non-core and most core plugins during the task=update.finalise, task=update.cleanup and related helper tasks of com_joomlaupdate to prevent third party plugins which are not compatible with the new version being installed from getting in the way of the update (they would prevent schema update and any post-update and cleanup tasks we need to perform). They are NOT disabled in the database, just not loaded during those tasks.

You will need the System - Sabotage plugin: 
[plg_system_sabotage.zip](https://github.com/joomla/joomla-cms/files/9373831/plg_system_sabotage.zip)

#### From Joomla 4.0.0

* Install a Joomla 4.0.0 site
* Replace administrator/components/com_joomlaupdate, components/com_joomlaupdate, media/com_joomlaupdate, and administrator/language/en-GB/com_joomlaupdate.* with the files from this PR.
* Log into the backend
* Install the plg_system_sabotage plugin
* Go to Extensions, Manage, Plugins. Enable the System - Sabotage plugin and click on its title.
* Set the sabotage type to Both and the minimum Joomla version to 4.1.9999
* Upgrade the site to Joomla 4.2 using the package built from this PR
* Try to access your site's frontend
* Make sure the `#__user_mfa` table exists

#### From Joomla 4.1.5

* Install a Joomla 4.1.5 site
* Log into the backend
* Install the plg_system_sabotage plugin
* Go to Extensions, Manage, Plugins. Enable the System - Sabotage plugin and click on its title.
* Set the sabotage type to Both and the minimum Joomla version to 4.1.9999
* Upgrade the site to Joomla 4.2 using the package built from this PR
* Try to access your site's frontend
* Make sure the `#__user_mfa` table exists

### Actual result BEFORE applying this Pull Request

The table is missing

You WILL receive errors once the update is done. That is exactly what the System - Sabotage plugin as configured in the test instructions is meant to do: throw an error with a stanza from Beastie Boys' “Sabotage” on the target Joomla version and any later version. This error got in the way of running the update finalisation which is why the schema update and cleanup did not run. It's a sabotage!

### Expected result AFTER applying this Pull Request

The table exists.

You WILL receive errors once the update is done. That is exactly what the System - Sabotage plugin as configured in the test instructions is meant to do: throw an error with a stanza from Beastie Boys' “Sabotage” on the target Joomla version and any later version. HOWEVER, this time around the sabotage plugin did not run during the update finalisation and cleanup. Therefore both the schema update and cleanup ran just fine. It's a mirage!

### Documentation Changes Required

None.