### PR TITLE
[4.2] Removing obsolete PHP setting

### DIFF
--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -15,7 +15,6 @@
 define('_JEXEC', 1);
 
 // Maximise error reporting.
-ini_set('zend.ze1_compatibility_mode', '0');
 error_reporting(E_ALL);
 ini_set('display_errors', 1);
 


### PR DESCRIPTION
The PHP setting zend.ze1_compatibility_mode has been removed in PHP 5.3. Time to remove it here as well...
https://php-legacy-docs.zend.com/manual/php4/en/ini.core