### PR TITLE
[4.2] Return messages from the media helper upload on failure

### DIFF
--- a/plugins/filesystem/local/src/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/src/Adapter/LocalAdapter.php
@@ -765,18 +765,17 @@ class LocalAdapter implements AdapterInterface
         File::delete($tmpFile);
 
         if (!$can) {
-            
             $exception = Text::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT');
 
-        	$messages = Factory::getApplication()->getMessageQueue();
-        	if (\is_array($messages) && \count($messages)) {
-        		foreach ($messages as $message) {
-        			if (isset($message['type']) && isset($message['message'])) {
-        				$exception = $message['message'];
-        			}
-        		}
-        	}
-            
+            $messages = Factory::getApplication()->getMessageQueue();
+            if (\is_array($messages) && \count($messages)) {
+                foreach ($messages as $message) {
+                    if (isset($message['type']) && isset($message['message'])) {
+                        $exception = $message['message'];
+                    }
+                }
+            }
+
             throw new \Exception($exception, 403);
         }
     }

--- a/plugins/filesystem/local/src/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/src/Adapter/LocalAdapter.php
@@ -765,7 +765,19 @@ class LocalAdapter implements AdapterInterface
         File::delete($tmpFile);
 
         if (!$can) {
-            throw new \Exception(Text::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT'), 403);
+            
+            $exception = Text::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT');
+
+        	$messages = Factory::getApplication()->getMessageQueue();
+        	if (\is_array($messages) && \count($messages)) {
+        		foreach ($messages as $message) {
+        			if (isset($message['type']) && isset($message['message'])) {
+        				$exception = $message['message'];
+        			}
+        		}
+        	}
+            
+            throw new \Exception($exception, 403);
         }
     }
 


### PR DESCRIPTION
When coming back from the Media Helper 'canUpload' function, error messages are lost. 

Pull Request for Issue #38068.

### Summary of Changes

When a file is denied upload, the message 'Unable to upload file.' is returned.
In the case of SVGs, for instance, a file can be denied for security reasons but no feedback is returned to the user, although all messages are present in the Media Helper.

This PR uses the last entry returned by the Media Helper rather than the default message.

### Testing Instructions

Upload a file that is not part of the allowed file types, a file that is too large or an SVG file that is complex and contains suspicious tags (like DOCTYPE). Or remove SVG from the allowed extensions... Anything that can fail the upload of an image or SVG file. 

### Actual result BEFORE applying this Pull Request

The error message is 'Unable to upload file.'

### Expected result AFTER applying this Pull Request

In the case of a SVG file, the message returned should be 'Possible IE XSS Attack found.'

### Documentation Changes Required

None