### PR TITLE
Stats collection must not be shown in captive MFA pages

### DIFF
--- a/libraries/src/Application/MultiFactorAuthenticationHandler.php
+++ b/libraries/src/Application/MultiFactorAuthenticationHandler.php
@@ -293,26 +293,18 @@ trait MultiFactorAuthenticationHandler
             return false;
         }
 
-        // Allow the statistics plugin to run
-        if ($isAdmin && $option === 'com_ajax' && $task === '') {
-            $group  = strtolower($this->input->getCmd('group', ''));
-            $plugin = strtolower($this->input->getCmd('plugin', ''));
-
-            if ($group === 'system' && $plugin === 'sendstats') {
-                return false;
-            }
-        }
-
         return true;
     }
 
     /**
      * Is this a page concerning the Multi-factor Authentication feature?
      *
-     * @return boolean
-     * @since  4.2.0
+     * @param   bool  $onlyCaptive  Should I only check for the MFA captive page?
+     *
+     * @return  boolean
+     * @since   4.2.0
      */
-    private function isMultiFactorAuthenticationPage(): bool
+    public function isMultiFactorAuthenticationPage(bool $onlyCaptive = false): bool
     {
         $option = $this->input->get('option');
         $task   = $this->input->get('task');
@@ -325,9 +317,18 @@ trait MultiFactorAuthenticationHandler
         $allowedViews = ['captive', 'method', 'methods', 'callback'];
         $allowedTasks = [
             'captive.display', 'captive.captive', 'captive.validate',
-            'method.display', 'method.add', 'method.edit', 'method.regenerateBackupCodes', 'method.delete', 'method.save',
-            'methods.display', 'methods.disable', 'methods.doNotShowThisAgain',
+            'methods.display',
         ];
+
+        if (!$onlyCaptive) {
+            $allowedTasks = array_merge(
+                $allowedTasks,
+                [
+                    'method.display', 'method.add', 'method.edit', 'method.regenerateBackupCodes',
+                    'method.delete', 'method.save', 'methods.disable', 'methods.doNotShowThisAgain',
+                ]
+            );
+        }
 
         return in_array($view, $allowedViews) || in_array($task, $allowedTasks);
     }

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -94,6 +94,10 @@ class PlgSystemStats extends CMSPlugin
             return;
         }
 
+        if ($this->isCaptiveMFA()) {
+            return;
+        }
+
         if (!$this->isDebugEnabled() && !$this->isUpdateRequired()) {
             return;
         }
@@ -116,6 +120,10 @@ class PlgSystemStats extends CMSPlugin
     public function onAfterDispatch()
     {
         if (!$this->app->isClient('administrator') || !$this->isAllowedUser()) {
+            return;
+        }
+
+        if ($this->isCaptiveMFA()) {
             return;
         }
 
@@ -606,5 +614,17 @@ class PlgSystemStats extends CMSPlugin
         }
 
         return $result;
+    }
+
+    /**
+     * Are we in a Multi-factor Authentication page?
+     *
+     * @return  bool
+     * @since   __DEPLOY_VERSION__
+     */
+    private function isCaptiveMFA(): bool
+    {
+        return method_exists($this->app, 'isMultiFactorAuthenticationPage')
+            && $this->app->isMultiFactorAuthenticationPage(true);
     }
 }


### PR DESCRIPTION
Pull Request for Issue #38476 .

### Summary of Changes

The `Joomla\CMS\Application\MultiFactorAuthenticationHandler::isMultiFactorAuthenticationPage` method is now public and has an optional argument to only consider captive pages.

The `plg_system_stats` plugin uses this method to check whether it is running a captive MFA page and refuse to continue.

A previously hard-coded exception for the stats plugin has been removed from the `MultiFactorAuthenticationHandler ` Trait.

### Testing Instructions

* Install Joomla 4.2.0
* DO NOT make a choice about the stats collection just yet
* Set up MFA for your user account
* Log out
* Log back in

### Actual result BEFORE applying this Pull Request

You see the stats collection interface in the captive MFA page. Trying to use its buttons leads to a broken display experience as per the issue #38476.

### Expected result AFTER applying this Pull Request

You do NOT see the stats collection interface in the captive MFA page or any of the captive pages you are allowed access to (basically, selecting an MFA method). It does appear after completing the MFA validation.

### Documentation Changes Required

Plugins which render user interfaces in the backend of the site must check whether they are running under the Multi-factor Authentication feature's captive pages using the following code:

```php
method_exists($this->app, 'isMultiFactorAuthenticationPage')
            && $this->app->isMultiFactorAuthenticationPage(true);
```

If this returns true the plugin **MUST NOT** render its user interface.