### PR TITLE
[4.2] Fix Error that feed is not working

### DIFF
--- a/libraries/src/Feed/Parser/RssParser.php
+++ b/libraries/src/Feed/Parser/RssParser.php
@@ -347,9 +347,6 @@ class RssParser extends FeedParser
      */
     protected function initialise()
     {
-        // We want to move forward to the first XML Element after the xml doc type declaration
-        $this->moveToNextElement();
-
         // Read the version attribute.
         $this->version = $this->stream->getAttribute('version');
 


### PR DESCRIPTION
Pull Request for Issue #38531 .

### Summary of Changes

The change in #38095 results in an empty xml string.


### Testing Instructions
* Install joomla 4.2.0
* Create a new feed item. You can add this: https://www.joomla.org/announcements.feed?type=rss
* Create a menu item for the feed
* Go to the frontend and click on the menu item
* Apply patch
* Go to the frontend and click on the menu item


### Actual result BEFORE applying this Pull Request
You will see an Error: String could not be parsed as XML


### Expected result AFTER applying this Pull Request
You should see the feed


### Documentation Changes Required
none
