### PR TITLE
Child templates languages

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -774,8 +774,9 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
 
         // 1.5 or core then 1.6
         $lang->load('tpl_' . $template, JPATH_BASE)
-            || ($inherits !== '' && $lang->load('tpl_' . $inherits, $directory . '/' . $inherits))
-            || $lang->load('tpl_' . $template, $directory . '/' . $template);
+            || ($inherits !== '' && $lang->load('tpl_' . $inherits, JPATH_BASE))
+            || $lang->load('tpl_' . $template, $directory . '/' . $template)
+            || ($inherits !== '' && $lang->load('tpl_' . $inherits, $directory . '/' . $inherits));
 
         // Assign the variables
         $this->baseurl = Uri::base(true);


### PR DESCRIPTION
Pull Request for Issue #38568.

### Summary of Changes
- respect the language cascade (eg the core templates don't use the default language folder in the root of the template directory)


### Testing Instructions
- Create a child of cassiopeia
- Assign all the menu items to that template
- copy the index.php to the child root folder
- add `<?= Text::_('TPL_CASSIOPEIA_XML_DESCRIPTION'); ?>` after the `<body>` opening tag
- check that the translated string is in the output
- Repeat for the Atum

![Screenshot 2022-08-24 at 10 51 34](https://user-images.githubusercontent.com/3889375/186374888-b470c2ff-dfcc-4077-b4df-f32aea29fbf6.png)


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Documentation Changes Required

