### PR TITLE
Fix DataFormatter::formatCallerInfo to handle Closure

### DIFF
--- a/plugins/system/debug/src/DataFormatter.php
+++ b/plugins/system/debug/src/DataFormatter.php
@@ -69,7 +69,16 @@ class DataFormatter extends DebugBarDataFormatter
 
             $string = rtrim($string, ', ') . ')';
         } elseif (isset($call['args'][0])) {
-            $string .= htmlspecialchars($call['function']) . ' ' . $call['args'][0];
+            $string .= htmlspecialchars($call['function']) . '(';
+
+            if (is_scalar($call['args'][0])) {
+                $string .= $call['args'][0];
+            } elseif (\is_object($call['args'][0])) {
+                $string .=  \get_class($call['args'][0]);
+            } else {
+                $string .=  gettype($call['args'][0]);
+            }
+            $string .= ')';
         } else {
             // It's a function.
             $string .= htmlspecialchars($call['function']) . '()';

--- a/plugins/system/debug/src/DataFormatter.php
+++ b/plugins/system/debug/src/DataFormatter.php
@@ -74,9 +74,9 @@ class DataFormatter extends DebugBarDataFormatter
             if (is_scalar($call['args'][0])) {
                 $string .= $call['args'][0];
             } elseif (\is_object($call['args'][0])) {
-                $string .=  \get_class($call['args'][0]);
+                $string .= \get_class($call['args'][0]);
             } else {
-                $string .=  gettype($call['args'][0]);
+                $string .= gettype($call['args'][0]);
             }
             $string .= ')';
         } else {


### PR DESCRIPTION
Pull Request for Issue #38556 .

### Summary of Changes
Correct DataFormatter::formatCallerInfo to handle Closure variable


### Testing Instructions
Please follow #38556


### Actual result BEFORE applying this Pull Request
An error


### Expected result AFTER applying this Pull Request
No error


### Documentation Changes Required
nope
