### PR TITLE
Fix CaptchaRule to use correct plugin

### DIFF
--- a/libraries/src/Form/Rule/CaptchaRule.php
+++ b/libraries/src/Form/Rule/CaptchaRule.php
@@ -39,12 +39,14 @@ class CaptchaRule extends FormRule
      */
     public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
     {
-        $app    = Factory::getApplication();
-        $plugin = $app->get('captcha');
+        $app     = Factory::getApplication();
+        $default = $app->get('captcha');
 
         if ($app->isClient('site')) {
-            $plugin = $app->getParams()->get('captcha', $plugin);
+            $default = $app->getParams()->get('captcha', $default);
         }
+
+        $plugin = $element['plugin'] ? (string) $element['plugin'] : $default;
 
         $namespace = $element['namespace'] ?: $form->getName();
 


### PR DESCRIPTION
### Summary of Changes

CaptchaRule ignores the plugin attribute of the field.
This PR fixing it.


### Testing Instructions
Enable Captcha (enter invalid site and private keys) and Captcha Invisible (enter correct keys) on your site.
Set Captcha as default in global config.
Edit https://github.com/joomla/joomla-cms/blob/b6bb1dbb313019e6ffd065899071ed0662853907/components/com_users/forms/reset_request.xml#L14-L19
Add `plugin="recaptcha_invisible"`

Then go to Password reset page and try reset.


### Actual result BEFORE applying this Pull Request
An error `invalid-input-secret` or similar


### Expected result AFTER applying this Pull Request
No error


### Documentation Changes Required
nope
