### PR TITLE
Add an MVCFactoryWrapper for MVCFactory customisation

### DIFF
--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -1088,5 +1088,4 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
     {
         $this->factory = $mvcFactory;
     }
-
 }

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -1057,4 +1057,36 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
 
         return $this;
     }
+
+    /**
+     * Returns the MVC factory.
+     *
+     * @return  MVCFactoryInterface
+     *
+     * @since   __DEPLOY_VERSION__
+     * @throws  \UnexpectedValueException
+     */
+    protected function getMVCFactory(): MVCFactoryInterface
+    {
+        if ($this->factory) {
+            return $this->factory;
+        }
+
+        throw new \UnexpectedValueException('MVC Factory not set in ' . __CLASS__);
+    }
+
+    /**
+     * Set the MVC factory.
+     *
+     * @param   MVCFactoryInterface  $mvcFactory  The MVC factory
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function setMVCFactory(MVCFactoryInterface $mvcFactory)
+    {
+        $this->factory = $mvcFactory;
+    }
+
 }

--- a/libraries/src/MVC/Factory/MVCFactoryWrapper.php
+++ b/libraries/src/MVC/Factory/MVCFactoryWrapper.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Joomla\CMS\MVC\Factory;
+
+use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\MVC\Model\ModelInterface;
+use Joomla\Input\Input;
+
+class MVCFactoryWrapper implements MVCFactoryInterface
+{
+    use MVCFactoryAwareTrait;
+
+    /**
+     * Public constructor. Wraps an existing MVCFactory so it can be extended.
+     *
+     * @param   MVCFactoryInterface  $factory
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct(MVCFactoryInterface $factory)
+    {
+        $this->setMVCFactory($factory);
+    }
+
+    /**
+     * Method to load and return a controller object.
+     *
+     * @param   string                   $name    The name of the controller
+     * @param   string                   $prefix  The controller prefix
+     * @param   array                    $config  The configuration array for the controller
+     * @param   CMSApplicationInterface  $app     The app
+     * @param   Input                    $input   The input
+     *
+     * @return  \Joomla\CMS\MVC\Controller\ControllerInterface
+     *
+     * @since   1.0.0
+     * @throws  \Exception
+     */
+    public function createController($name, $prefix, array $config, CMSApplicationInterface $app, Input $input)
+    {
+        $controller = $this->getMVCFactory()->createController($name, $prefix, $config, $app, $input);
+
+        $controller->setMVCFactory($this);
+
+        return $controller;
+    }
+
+    /**
+     * Method to load and return a model object.
+     *
+     * @param   string  $name    The name of the model.
+     * @param   string  $prefix  Optional model prefix.
+     * @param   array   $config  Optional configuration array for the model.
+     *
+     * @return  ModelInterface  The model object
+     *
+     * @since   1.0.0
+     * @throws  \Exception
+     */
+    public function createModel($name, $prefix = '', array $config = [])
+    {
+        $model = $this->getMVCFactory()->createModel($name, $prefix, $config);
+
+        if (method_exists($model, 'setMVCFactory')) {
+            $model->setMVCFactory($this);
+        }
+
+        return $model;
+    }
+
+    /**
+     * Method to load and return a view object.
+     *
+     * @param   string  $name    The name of the view.
+     * @param   string  $prefix  Optional view prefix.
+     * @param   string  $type    Optional type of view.
+     * @param   array   $config  Optional configuration array for the view.
+     *
+     * @return  \Joomla\CMS\MVC\View\ViewInterface  The view object
+     *
+     * @since   1.0.0
+     * @throws  \Exception
+     */
+    public function createView($name, $prefix = '', $type = '', array $config = [])
+    {
+        return $this->getMVCFactory()->createView($name, $prefix, $type, $config);
+    }
+
+    /**
+     * Method to load and return a table object.
+     *
+     * @param   string  $name    The name of the table.
+     * @param   string  $prefix  Optional table prefix.
+     * @param   array   $config  Optional configuration array for the table.
+     *
+     * @return  \Joomla\CMS\Table\Table  The table object
+     *
+     * @since   1.0.0
+     * @throws  \Exception
+     */
+    public function createTable($name, $prefix = '', array $config = [])
+    {
+        return $this->getMVCFactory()->createTable($name, $prefix, $config);
+    }
+}

--- a/libraries/src/MVC/Factory/MVCFactoryWrapper.php
+++ b/libraries/src/MVC/Factory/MVCFactoryWrapper.php
@@ -33,7 +33,7 @@ class MVCFactoryWrapper implements MVCFactoryInterface
      *
      * @return  \Joomla\CMS\MVC\Controller\ControllerInterface
      *
-     * @since   1.0.0
+     * @since   __DEPLOY_VERSION__
      * @throws  \Exception
      */
     public function createController($name, $prefix, array $config, CMSApplicationInterface $app, Input $input)
@@ -54,7 +54,7 @@ class MVCFactoryWrapper implements MVCFactoryInterface
      *
      * @return  ModelInterface  The model object
      *
-     * @since   1.0.0
+     * @since   __DEPLOY_VERSION__
      * @throws  \Exception
      */
     public function createModel($name, $prefix = '', array $config = [])
@@ -78,7 +78,7 @@ class MVCFactoryWrapper implements MVCFactoryInterface
      *
      * @return  \Joomla\CMS\MVC\View\ViewInterface  The view object
      *
-     * @since   1.0.0
+     * @since   __DEPLOY_VERSION__
      * @throws  \Exception
      */
     public function createView($name, $prefix = '', $type = '', array $config = [])
@@ -95,7 +95,7 @@ class MVCFactoryWrapper implements MVCFactoryInterface
      *
      * @return  \Joomla\CMS\Table\Table  The table object
      *
-     * @since   1.0.0
+     * @since   __DEPLOY_VERSION__
      * @throws  \Exception
      */
     public function createTable($name, $prefix = '', array $config = [])


### PR DESCRIPTION
Pull Request for Issue #38555 .

### Summary of Changes

* Adds `setMVCFactory` and `getMVCFactory` public methods to the BaseController
* Adds a new `\Joomla\CMS\MVC\Factory\MVCFactoryWrapper` class for wrapping the MVCFactory service to extend it.

### Testing Instructions

1. Without the patch: Install the component https://github.com/nikosdion/com_example/commit/06f43fde850b79673500697e41c4945602fa34152. 

2. With the patch: Install the component https://github.com/nikosdion/com_example/commit/4413a9a399e0634cc7d37967188210a8185cc35d

### Actual result BEFORE applying this Pull Request

You get an error.

That's because the custom MVCFactoryWrapper of the component cannot force itself as the MVCFactory service of the Controller. As a result, when the Controller calls its `getModel` or `getView` methods it uses the undecorated MVCFactory object which, of course, is blissfully unaware of our custom service. Therefore the Model which wants to use this service breaks.

### Expected result AFTER applying this Pull Request

It works!

Our custom MVCFactoryWrapper extends from `\Joomla\CMS\MVC\Factory\MVCFactoryWrapper` which means that the created Controller and Model objects use our decorated wrapper as their MVCFactory instead of the undecorated service. Our decorated wrapper is aware of our custom service, therefore it can push it to the created models, even if they are created through the Controller's `createModel` method.

### Documentation Changes Required

I will be documenting that in the developer's docs as there is currently nothing of the sort.