### PR TITLE
Contact form captcha

### DIFF
--- a/components/com_contact/tmpl/contact/default_form.php
+++ b/components/com_contact/tmpl/contact/default_form.php
@@ -21,7 +21,7 @@ HTMLHelper::_('behavior.formvalidator');
 <div class="com-contact__form contact-form">
     <form id="contact-form" action="<?php echo Route::_('index.php'); ?>" method="post" class="form-validate form-horizontal well">
         <?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
-            <?php if ($fieldset->name === 'captcha' && !$this->captchaEnabled) : ?>
+            <?php if ($fieldset->name === 'captcha') : ?>
                 <?php continue; ?>
             <?php endif; ?>
             <?php $fields = $this->form->getFieldset($fieldset->name); ?>
@@ -34,6 +34,11 @@ HTMLHelper::_('behavior.formvalidator');
                         <?php echo $field->renderField(); ?>
                     <?php endforeach; ?>
                 </fieldset>
+            <?php endif; ?>
+        <?php endforeach; ?>
+        <?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
+            <?php if ($fieldset->name === 'captcha' && $this->captchaEnabled) : ?>
+                <?php echo $this->form->renderFieldset('captcha'); ?>
             <?php endif; ?>
         <?php endforeach; ?>
         <div class="control-group">

--- a/components/com_contact/tmpl/contact/default_form.php
+++ b/components/com_contact/tmpl/contact/default_form.php
@@ -17,11 +17,13 @@ use Joomla\CMS\Router\Route;
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');
 
+$hasCaptcha = false;
 ?>
 <div class="com-contact__form contact-form">
     <form id="contact-form" action="<?php echo Route::_('index.php'); ?>" method="post" class="form-validate form-horizontal well">
         <?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
-            <?php if ($fieldset->name === 'captcha') : ?>
+            <?php if ($fieldset->name === 'captcha' && $this->captchaEnabled) : ?>
+                <?php $hasCaptcha = true; ?>
                 <?php continue; ?>
             <?php endif; ?>
             <?php $fields = $this->form->getFieldset($fieldset->name); ?>
@@ -36,11 +38,9 @@ HTMLHelper::_('behavior.formvalidator');
                 </fieldset>
             <?php endif; ?>
         <?php endforeach; ?>
-        <?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
-            <?php if ($fieldset->name === 'captcha' && $this->captchaEnabled) : ?>
-                <?php echo $this->form->renderFieldset('captcha'); ?>
-            <?php endif; ?>
-        <?php endforeach; ?>
+        <?php if ($hasCaptcha) : ?>
+            <?php echo $this->form->renderFieldset('captcha'); ?>
+        <?php endif; ?>
         <div class="control-group">
             <div class="controls">
                 <button class="btn btn-primary validate" type="submit"><?php echo Text::_('COM_CONTACT_CONTACT_SEND'); ?></button>

--- a/components/com_contact/tmpl/contact/default_form.php
+++ b/components/com_contact/tmpl/contact/default_form.php
@@ -17,13 +17,11 @@ use Joomla\CMS\Router\Route;
 HTMLHelper::_('behavior.keepalive');
 HTMLHelper::_('behavior.formvalidator');
 
-$hasCaptcha = false;
 ?>
 <div class="com-contact__form contact-form">
     <form id="contact-form" action="<?php echo Route::_('index.php'); ?>" method="post" class="form-validate form-horizontal well">
         <?php foreach ($this->form->getFieldsets() as $fieldset) : ?>
             <?php if ($fieldset->name === 'captcha' && $this->captchaEnabled) : ?>
-                <?php $hasCaptcha = true; ?>
                 <?php continue; ?>
             <?php endif; ?>
             <?php $fields = $this->form->getFieldset($fieldset->name); ?>
@@ -38,7 +36,7 @@ $hasCaptcha = false;
                 </fieldset>
             <?php endif; ?>
         <?php endforeach; ?>
-        <?php if ($hasCaptcha) : ?>
+        <?php if ($this->captchaEnabled) : ?>
             <?php echo $this->form->renderFieldset('captcha'); ?>
         <?php endif; ?>
         <div class="control-group">


### PR DESCRIPTION
Pull Request for Issue #27407.

### Summary of Changes
Moves the captcha to the end of the form. 


### Testing Instructions
1. Enable recaptcha
2. set the captcha in global config
3. create a contact
4. create custom contact fields for mails
5. check the contact form on the front end - captcha displayed
6. disable captcha in global config
7. check the contact form on the front end - no captcha displayed
8. enable captcha in the contact component
9.  check the contact form on the front end - captcha displayed

### Actual result BEFORE applying this Pull Request
the captcha is rendered after the default fields but before any custom fields


### Expected result AFTER applying this Pull Request
the captcha is rendered at the end of the form

