### PR TITLE
Fix position name in component dashboard

### DIFF
--- a/administrator/components/com_cpanel/src/Controller/DisplayController.php
+++ b/administrator/components/com_cpanel/src/Controller/DisplayController.php
@@ -78,7 +78,7 @@ class DisplayController extends BaseController
         $clientId = (\Joomla\CMS\Application\ApplicationHelper::getClientInfo('administrator', true))->id;
 
         $this->app->setUserState('com_modules.modules.' . $clientId . '.filter.position', $position);
-        $this->app->setUserState('com_modules.modules.client_id', (int) $clientId);
+        $this->app->setUserState('com_modules.modules.client_id', (string) $clientId);
 
         $this->setRedirect(Route::_('index.php?option=com_modules&view=select&tmpl=component&layout=modal' . $appendLink, false));
     }

--- a/administrator/components/com_cpanel/src/Controller/DisplayController.php
+++ b/administrator/components/com_cpanel/src/Controller/DisplayController.php
@@ -77,7 +77,7 @@ class DisplayController extends BaseController
         // Administrator
         $clientId = (\Joomla\CMS\Application\ApplicationHelper::getClientInfo('administrator', true))->id;
 
-        $this->app->setUserState('com_modules.modules.' . (int) $clientId . '.filter.position', $position);
+        $this->app->setUserState('com_modules.modules.' . $clientId . '.filter.position', $position);
         $this->app->setUserState('com_modules.modules.client_id', (int) $clientId);
 
         $this->setRedirect(Route::_('index.php?option=com_modules&view=select&tmpl=component&layout=modal' . $appendLink, false));

--- a/administrator/components/com_cpanel/src/Controller/DisplayController.php
+++ b/administrator/components/com_cpanel/src/Controller/DisplayController.php
@@ -74,8 +74,11 @@ class DisplayController extends BaseController
             $position = 'cpanel';
         }
 
-        $this->app->setUserState('com_modules.modules.1.filter.position', $position);
-        $this->app->setUserState('com_modules.modules.client_id', '1');
+        // Administrator
+        $clientId = 1;
+
+        $this->app->setUserState('com_modules.modules.' . $clientId . '.filter.position', $position);
+        $this->app->setUserState('com_modules.modules.client_id', (int) $clientId);
 
         $this->setRedirect(Route::_('index.php?option=com_modules&view=select&tmpl=component&layout=modal' . $appendLink, false));
     }

--- a/administrator/components/com_cpanel/src/Controller/DisplayController.php
+++ b/administrator/components/com_cpanel/src/Controller/DisplayController.php
@@ -74,7 +74,7 @@ class DisplayController extends BaseController
             $position = 'cpanel';
         }
 
-        $this->app->setUserState('com_modules.modules.filter.position', $position);
+        $this->app->setUserState('com_modules.modules.1.filter.position', $position);
         $this->app->setUserState('com_modules.modules.client_id', '1');
 
         $this->setRedirect(Route::_('index.php?option=com_modules&view=select&tmpl=component&layout=modal' . $appendLink, false));

--- a/administrator/components/com_cpanel/src/Controller/DisplayController.php
+++ b/administrator/components/com_cpanel/src/Controller/DisplayController.php
@@ -75,7 +75,7 @@ class DisplayController extends BaseController
         }
 
         // Administrator
-        $clientId = 1;
+        $clientId = (\Joomla\CMS\Application\ApplicationHelper::getClientInfo('administrator', true))->id;
 
         $this->app->setUserState('com_modules.modules.' . (int) $clientId . '.filter.position', $position);
         $this->app->setUserState('com_modules.modules.client_id', (int) $clientId);

--- a/administrator/components/com_cpanel/src/Controller/DisplayController.php
+++ b/administrator/components/com_cpanel/src/Controller/DisplayController.php
@@ -77,7 +77,7 @@ class DisplayController extends BaseController
         // Administrator
         $clientId = 1;
 
-        $this->app->setUserState('com_modules.modules.' . $clientId . '.filter.position', $position);
+        $this->app->setUserState('com_modules.modules.' . (int) $clientId . '.filter.position', $position);
         $this->app->setUserState('com_modules.modules.client_id', (int) $clientId);
 
         $this->setRedirect(Route::_('index.php?option=com_modules&view=select&tmpl=component&layout=modal' . $appendLink, false));


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
It is possible to add new modules to a dashboard. The dashboard name should be preselected in the position field, as it is a special position for every component (also for own components).
The PR adds the clientID to the position filter. 

It was possible in former 4 versions but forgotten here https://github.com/joomla/joomla-cms/pull/33763


### Testing Instructions
Open any dashboard for example users. 
Click the "add new module" button and select a module, the module is opened. 


### Actual result BEFORE applying this Pull Request
The position field shows "none"
![grafik](https://user-images.githubusercontent.com/1035262/186995692-68f59955-ee37-484d-892f-aa68cbecac92.png)

You have to search for the right position in the list of possible positions 

### Expected result AFTER applying this Pull Request
In the position field the name of the active dashboard is preselected

![grafik](https://user-images.githubusercontent.com/1035262/186995933-63db9791-30fc-4990-9ad3-485066a52162.png)




### Documentation Changes Required

