### PR TITLE
Pagination Only child

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_global.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_global.scss
@@ -235,11 +235,11 @@ meter {
     padding: 0;
     margin: $cassiopeia-grid-gutter 0;
 
-    li.next:only-child {
+    .next:only-child {
       margin-left: auto;
     }
 
-    [dir="rtl"] &>li.next:only-child {
+    [dir="rtl"] &>.next:only-child {
       margin-right: auto;
       margin-left: $cassiopeia-grid-gutter;
     }

--- a/plugins/content/pagenavigation/tmpl/default.php
+++ b/plugins/content/pagenavigation/tmpl/default.php
@@ -29,7 +29,7 @@ $lang = Factory::getLanguage(); ?>
     <?php endif; ?>
     <?php if ($row->next) :
         $direction = $lang->isRtl() ? 'left' : 'right'; ?>
-            <a class="btn btn-sm btn-secondary" href="<?php echo Route::_($row->next); ?>" rel="next">
+            <a class="btn btn-sm btn-secondary next" href="<?php echo Route::_($row->next); ?>" rel="next">
             <span class="visually-hidden">
                 <?php echo Text::sprintf('JNEXT_TITLE', htmlspecialchars($rows[$location + 1]->title)); ?>
             </span>


### PR DESCRIPTION
Pull request for #38512

When there is only a next button it is no longer on the right as intended. this was due to a change in the markup.

As this a change in the scss you will need to either `npm run build:css` or use one of the prebuilt packages

### Before
![image](https://user-images.githubusercontent.com/1296369/186997637-6d8ad05c-7621-4bf3-8c95-fd7e7a66bea6.png)

### After
![image](https://user-images.githubusercontent.com/1296369/186997562-c9204da2-ab40-46c6-ad8d-49a517b37dfd.png)
