### PR TITLE
Language override both

### DIFF
--- a/administrator/components/com_languages/tmpl/override/edit.php
+++ b/administrator/components/com_languages/tmpl/override/edit.php
@@ -35,11 +35,7 @@ $wa->useScript('keepalive')
                 <?php echo $this->form->renderField('client'); ?>
                 <?php echo $this->form->renderField('key'); ?>
                 <?php echo $this->form->renderField('override'); ?>
-
-                <?php if ($this->state->get('filter.client') == 'administrator') : ?>
-                    <?php echo $this->form->renderField('both'); ?>
-                <?php endif; ?>
-
+                <?php echo $this->form->renderField('both'); ?>
                 <?php echo $this->form->renderField('file'); ?>
                 </div>
             </fieldset>


### PR DESCRIPTION
When you create a language override there is an option to create the override in both the admin and site language. However this is only available if you have selected as admin language.

I can see no logical reason for this restriction today. Its very frustrating to have to create an override twice just because you selected site as the client first.

This PR removes the restriction

To test create a new override by selecting the language and site
Create an override and check the box for both locations
In the list of overrides you should now see it listed in both locations

![image](https://user-images.githubusercontent.com/1296369/187170257-79f98074-57ab-4fb6-b013-8721f16e3b46.png)
