### PR TITLE
Unused Factory

### DIFF
--- a/administrator/components/com_admin/src/View/Sysinfo/HtmlView.php
+++ b/administrator/components/com_admin/src/View/Sysinfo/HtmlView.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Admin\Administrator\View\Sysinfo;
 
 use Exception;
 use Joomla\CMS\Access\Exception\NotAllowed;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;


### PR DESCRIPTION
Joomla\cms\factory is not used in this file and can be safely removed.