### PR TITLE
Lazy load the web auth MDS cache in system WebAuthn plugin

### DIFF
--- a/plugins/system/webauthn/src/MetadataRepository.php
+++ b/plugins/system/webauthn/src/MetadataRepository.php
@@ -52,16 +52,6 @@ final class MetadataRepository implements MetadataStatementRepository
     private $mdsMap = [];
 
     /**
-     * Public constructor.
-     *
-     * @since 4.2.0
-     */
-    public function __construct()
-    {
-        $this->load();
-    }
-
-    /**
      * Find an authenticator metadata statement given an AAGUID
      *
      * @param   string  $aaguid  The AAGUID to find
@@ -71,6 +61,8 @@ final class MetadataRepository implements MetadataStatementRepository
      */
     public function findOneByAAGUID(string $aaguid): ?MetadataStatement
     {
+        $this->load();
+
         $idx = $this->mdsMap[$aaguid] ?? null;
 
         return $idx ? $this->mdsCache[$idx] : null;
@@ -84,6 +76,8 @@ final class MetadataRepository implements MetadataStatementRepository
      */
     public function getKnownAuthenticators(): array
     {
+        $this->load();
+
         $mapKeys = function (MetadataStatement $meta) {
             return $meta->getAaguid();
         };
@@ -114,6 +108,10 @@ final class MetadataRepository implements MetadataStatementRepository
      */
     private function load(bool $force = false): void
     {
+        if ($this->mdsCache) {
+            return;
+        }
+
         $this->mdsCache = [];
         $this->mdsMap   = [];
         $jwtFilename    = JPATH_CACHE . '/fido.jwt';

--- a/plugins/system/webauthn/src/MetadataRepository.php
+++ b/plugins/system/webauthn/src/MetadataRepository.php
@@ -52,6 +52,14 @@ final class MetadataRepository implements MetadataStatementRepository
     private $mdsMap = [];
 
     /**
+     * Flag if the MSD data is loaded
+     *
+     * @var   bool
+     * @since __DEPLOY_VERSION__
+     */
+    private $msdDataLoaded = false;
+
+    /**
      * Find an authenticator metadata statement given an AAGUID
      *
      * @param   string  $aaguid  The AAGUID to find
@@ -108,13 +116,14 @@ final class MetadataRepository implements MetadataStatementRepository
      */
     private function load(bool $force = false): void
     {
-        if ($this->mdsCache) {
+        if ($this->msdDataLoaded && !$force) {
             return;
         }
 
-        $this->mdsCache = [];
-        $this->mdsMap   = [];
-        $jwtFilename    = JPATH_CACHE . '/fido.jwt';
+        $this->msdDataLoaded = true;
+        $this->mdsCache      = [];
+        $this->mdsMap        = [];
+        $jwtFilename         = JPATH_CACHE . '/fido.jwt';
 
         // If the file exists and it's over one month old do retry loading it.
         if (file_exists($jwtFilename) && filemtime($jwtFilename) < (time() - 2592000)) {


### PR DESCRIPTION
Pull Request for Issue #38654.

### Summary of Changes
Loads the MDS cache when is needed and not on object instantiation.

### Testing Instructions
You need to have a host where you see a performance loss when the webauth system plugin is activated.

### Actual result BEFORE applying this Pull Request
Slow page load.

### Expected result AFTER applying this Pull Request
Fast page load.