### PR TITLE
[4.3] NPM build tools cleanup/Perf fixes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -517,6 +517,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 62722201dc57c6d193bed2a67860fe4cced46d38ebfdfe12a45a79a15a59e07e
+hmac: 05c1f15cfad7564a9479535f7b0727b63056f9b38f66453cbefab877d7db52b9
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -54,7 +54,7 @@ steps:
       - echo $(date)
 
   - name: npm
-    image: node:18-bullseye-slim
+    image: node:16-bullseye-slim
     depends_on: [ phpcs ]
     volumes:
       - name: npm-cache

--- a/.drone.yml
+++ b/.drone.yml
@@ -54,7 +54,7 @@ steps:
       - echo $(date)
 
   - name: npm
-    image: node:16-alpine
+    image: node:18-bullseye-slim
     depends_on: [ phpcs ]
     volumes:
       - name: npm-cache

--- a/build/build-modules-js/init/minify-vendor.es6.js
+++ b/build/build-modules-js/init/minify-vendor.es6.js
@@ -26,8 +26,6 @@ const noMinified = [
 const alreadyMinified = [
   'media/vendor/webcomponentsjs/js/webcomponents-bundle.js',
   'media/vendor/debugbar/vendor/highlightjs/highlight.pack.js',
-
-
 ];
 
 /**

--- a/build/build-modules-js/init/minify-vendor.es6.js
+++ b/build/build-modules-js/init/minify-vendor.es6.js
@@ -25,6 +25,9 @@ const noMinified = [
 
 const alreadyMinified = [
   'media/vendor/webcomponentsjs/js/webcomponents-bundle.js',
+  'media/vendor/debugbar/vendor/highlightjs/highlight.pack.js',
+
+
 ];
 
 /**
@@ -86,7 +89,6 @@ const minifyJS = async (file) => {
  * @returns {Promise}
  */
 module.exports.minifyVendor = async () => {
-  // return;
   const folderPromises = [];
   const filesPromises = [];
 

--- a/build/build-modules-js/javascript/build-com_media-js.es6.js
+++ b/build/build-modules-js/javascript/build-com_media-js.es6.js
@@ -1,11 +1,12 @@
 const { resolve } = require('path');
+const { writeFile } = require('fs').promises;
 const rollup = require('rollup');
 const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const replace = require('@rollup/plugin-replace');
 const { babel } = require('@rollup/plugin-babel');
 const VuePlugin = require('rollup-plugin-vue');
 const commonjs = require('@rollup/plugin-commonjs');
-const { minifyJs } = require('./minify.es6.js');
+const { minifyJsCode } = require('./minify.es6.js');
 
 const inputJS = 'administrator/components/com_media/resources/scripts/mediamanager.es6.js';
 
@@ -48,15 +49,20 @@ const buildLegacy = async (file) => {
     sourcemap: false,
     name: 'JoomlaMediaManager',
     file: 'media/com_media/js/media-manager-es5.js',
-  });
+  })
+    .then((value) => minifyJsCode(value.output[0].code))
+    .then((content) => {
+      // eslint-disable-next-line no-console
+      console.log('✅ Legacy Media Manager ready');
+      return writeFile(resolve('media/com_media/js/media-manager-es5.min.js'), content.code, { encoding: 'utf8', mode: 0o644 });
+    })
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    });
 
   // closes the bundle
   await bundle.close();
-
-  // eslint-disable-next-line no-console
-  console.log('Legacy Media Manager ready ✅');
-
-  minifyJs('media/com_media/js/media-manager-es5.js');
 };
 
 module.exports.mediaManager = async () => {
@@ -104,19 +110,26 @@ module.exports.mediaManager = async () => {
     ],
   });
 
-  await bundle.write({
+  bundle.write({
     format: 'es',
     sourcemap: false,
     file: 'media/com_media/js/media-manager.js',
-  });
+  })
+    .then((value) => minifyJsCode(value.output[0].code))
+    .then((content) => {
+      // eslint-disable-next-line no-console
+      console.log('✅ ES2017 Media Manager ready');
+
+      return writeFile(resolve('media/com_media/js/media-manager.min.js'), content.code, { encoding: 'utf8', mode: 0o644 });
+    })
+    .then(() => buildLegacy(resolve('media/com_media/js/media-manager.js')))
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    });
 
   // closes the bundle
   await bundle.close();
-
-  // eslint-disable-next-line no-console
-  console.log('✅ ES2017 Media Manager ready');
-  minifyJs('media/com_media/js/media-manager.js');
-  return buildLegacy(resolve('media/com_media/js/media-manager.js'));
 };
 
 module.exports.watchMediaManager = async () => {
@@ -181,8 +194,8 @@ module.exports.watchMediaManager = async () => {
   watcher.on('event', (event) => {
     if (event.code === 'BUNDLE_END') {
       // eslint-disable-next-line no-console
-      console.log(`File ${event.output[0]} updated ✅
-File ${event.output[1]} updated ✅
+      console.log(`✅ File ${event.output[0]} updated
+✅ File ${event.output[1]} updated
 =========`);
     }
   });

--- a/build/build-modules-js/javascript/compile-to-es2017.es6.js
+++ b/build/build-modules-js/javascript/compile-to-es2017.es6.js
@@ -1,4 +1,4 @@
-const { access } = require('fs').promises;
+const { access, writeFile } = require('fs').promises;
 const { constants } = require('fs');
 const Autoprefixer = require('autoprefixer');
 const CssNano = require('cssnano');
@@ -8,8 +8,8 @@ const { nodeResolve } = require('@rollup/plugin-node-resolve');
 const replace = require('@rollup/plugin-replace');
 const { babel } = require('@rollup/plugin-babel');
 const Postcss = require('postcss');
-const { renderSync } = require('sass');
-const { minifyJs } = require('./minify.es6.js');
+const { renderSync } = require('sass-embedded');
+const { minifyJsCode } = require('./minify.es6.js');
 const { handleESMToLegacy } = require('./compile-to-es5.es6.js');
 
 const getWcMinifiedCss = async (file) => {
@@ -49,8 +49,6 @@ const getWcMinifiedCss = async (file) => {
  * @param file the full path to the file + filename + extension
  */
 module.exports.handleESMFile = async (file) => {
-  // eslint-disable-next-line no-console
-  console.log(`Transpiling ES2017 file: ${basename(file).replace('.es6.js', '.js')}...`);
   const newPath = file.replace(/\.w-c\.es6\.js$/, '').replace(/\.es6\.js$/, '').replace(`${sep}build${sep}media_source${sep}`, `${sep}media${sep}`);
   const minifiedCss = await getWcMinifiedCss(file);
   const bundle = await rollup.rollup({
@@ -89,15 +87,24 @@ module.exports.handleESMFile = async (file) => {
     external: [],
   });
 
-  await bundle.write({
+  bundle.write({
     format: 'es',
     sourcemap: false,
     file: resolve(`${newPath}.js`),
-  });
+  })
+    .then((value) => minifyJsCode(value.output[0].code))
+    .then((content) => {
+      // eslint-disable-next-line no-console
+      console.log(`✅ ES2017 file: ${basename(file).replace('.es6.js', '.js')}: transpiled`);
 
-  // eslint-disable-next-line no-console
-  console.log(`ES2017 file: ${basename(file).replace('.es6.js', '.js')}: ✅ transpiled`);
+      return writeFile(resolve(`${newPath}.min.js`), content.code, { encoding: 'utf8', mode: 0o644 });
+    })
+    .then(() => handleESMToLegacy(resolve(`${newPath}.js`)))
+    .catch((error) => {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    });
 
-  await handleESMToLegacy(resolve(`${newPath}.js`));
-  await minifyJs(resolve(`${newPath}.js`));
+  // closes the bundle
+  await bundle.close();
 };

--- a/build/build-modules-js/javascript/compile-to-es5.es6.js
+++ b/build/build-modules-js/javascript/compile-to-es5.es6.js
@@ -11,8 +11,6 @@ const { minifyJs } = require('./minify.es6.js');
  * @param file the full path to the file + filename + extension
  */
 module.exports.handleESMToLegacy = async (file) => {
-  // eslint-disable-next-line no-console
-  console.log(`Transpiling ES5 file: ${basename(file).replace('.js', '-es5.js')}...`);
   const bundleLegacy = await rollup.rollup({
     input: resolve(file),
     plugins: [
@@ -46,10 +44,11 @@ module.exports.handleESMToLegacy = async (file) => {
     format: 'iife',
     sourcemap: false,
     file: resolve(`${file.replace(/\.js$/, '')}-es5.js`),
+  })
+  .then(() => {
+    // eslint-disable-next-line no-console
+    console.log(`✅ ES5 file: ${basename(file).replace('.js', '-es5.js')}: transpiled`);
+
+    minifyJs(resolve(`${file.replace(/\.js$/, '')}-es5.js`));
   });
-
-  // eslint-disable-next-line no-console
-  console.log(`ES5 file: ${basename(file).replace('.js', '-es5.js')}: ✅ transpiled`);
-
-  minifyJs(resolve(`${file.replace(/\.js$/, '')}-es5.js`));
 };

--- a/build/build-modules-js/javascript/compile-to-es5.es6.js
+++ b/build/build-modules-js/javascript/compile-to-es5.es6.js
@@ -44,8 +44,7 @@ module.exports.handleESMToLegacy = async (file) => {
     format: 'iife',
     sourcemap: false,
     file: resolve(`${file.replace(/\.js$/, '')}-es5.js`),
-  })
-  .then(() => {
+  }).then(() => {
     // eslint-disable-next-line no-console
     console.log(`✅ ES5 file: ${basename(file).replace('.js', '-es5.js')}: transpiled`);
 

--- a/build/build-modules-js/javascript/handle-es5.es6.js
+++ b/build/build-modules-js/javascript/handle-es5.es6.js
@@ -4,14 +4,12 @@ const { minifyJs } = require('./minify.es6.js');
 
 module.exports.handleES5File = async (file) => {
   if (file.match(/\.es5\.js$/)) {
-    // eslint-disable-next-line no-console
-    console.log(`Processing Legacy js file: ${basename(file)}...`);
     // ES5 file, we will copy the file and then minify it in place
     // Ensure that the directories exist or create them
     await FsExtra.ensureDir(dirname(file).replace(`${sep}build${sep}media_source${sep}`, `${sep}media${sep}`));
     await FsExtra.copy(file, file.replace(`${sep}build${sep}media_source${sep}`, `${sep}media${sep}`).replace('.es5.js', '.js'), { preserveTimestamps: true });
     // eslint-disable-next-line no-console
-    console.log(`Legacy js file: ${basename(file)}: ✅ copied`);
+    console.log(`✅ Legacy js file: ${basename(file)}: copied`);
 
     minifyJs(file.replace(`${sep}build${sep}media_source${sep}`, `${sep}media${sep}`).replace('.es5.js', '.js'));
   }

--- a/build/build-modules-js/javascript/minify.es6.js
+++ b/build/build-modules-js/javascript/minify.es6.js
@@ -12,7 +12,16 @@ const minifyFile = async (file) => {
   const content = await minify(fileContent, { sourceMap: false, format: { comments: false } });
   await writeFile(file.replace('.js', '.min.js'), content.code, { encoding: 'utf8', mode: 0o644 });
   // eslint-disable-next-line no-console
-  console.log(`Legacy js file: ${basename(file)}: ✅ minified`);
+  console.log(`✅ Legacy js file: ${basename(file)}: minified`);
 };
 
+/**
+ * Minify a chunk of js using Terser
+ *
+ * @param code
+ * @returns {Promise<void>}
+ */
+const minifyCode = async (code) => minify(code, { sourceMap: false, format: { comments: false } });
+
 module.exports.minifyJs = minifyFile;
+module.exports.minifyJsCode = minifyCode;

--- a/build/build-modules-js/stylesheets/handle-scss.es6.js
+++ b/build/build-modules-js/stylesheets/handle-scss.es6.js
@@ -5,7 +5,7 @@ const { writeFile } = require('fs').promises;
 const { ensureDir } = require('fs-extra');
 const { dirname, sep } = require('path');
 const Postcss = require('postcss');
-const Sass = require('sass');
+const Sass = require('sass-embedded');
 
 module.exports.handleScssFile = async (file) => {
   const cssFile = file.replace(`${sep}scss${sep}`, `${sep}css${sep}`)

--- a/build/build-modules-js/stylesheets/scss-transform.es6.js
+++ b/build/build-modules-js/stylesheets/scss-transform.es6.js
@@ -4,7 +4,7 @@ const Fs = require('fs').promises;
 const FsExtra = require('fs-extra');
 const { dirname, sep } = require('path');
 const Postcss = require('postcss');
-const Sass = require('sass');
+const Sass = require('sass-embedded');
 
 module.exports.compile = async (file) => {
   const cssFile = file.replace(`${sep}scss${sep}`, `${sep}css${sep}`)
@@ -18,9 +18,6 @@ module.exports.compile = async (file) => {
     console.error(error.formatted);
     process.exit(1);
   }
-
-  // forked.on('message', async (msg) => {
-  // console.log('Message from child', msg);
 
   // Auto prefixing
   const cleaner = Postcss([Autoprefixer()]);
@@ -46,7 +43,4 @@ module.exports.compile = async (file) => {
 
   // eslint-disable-next-line no-console
   console.log(`✅ SCSS File compiled: ${cssFile}`);
-  // });
-
-  // forked.send({ file });
 };

--- a/build/media_source/plg_system_jooa11y/scss/jooa11y.scss
+++ b/build/media_source/plg_system_jooa11y/scss/jooa11y.scss
@@ -1,1 +1,1 @@
-@import "node_modules/@joomla/joomla-a11y-checker/dist/css/joomla-a11y-checker";
+@import "../../../../node_modules/@joomla/joomla-a11y-checker/dist/css/joomla-a11y-checker";

--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "rimraf": "^3.0.2",
         "rollup": "^2.61.1",
         "rollup-plugin-vue": "^6.0.0",
-        "sass": "^1.49.9",
+        "sass-embedded": "^1.54.4",
         "selenium-standalone": "^8.0.8",
         "stylelint": "^14.1.0",
         "stylelint-config-standard": "^24.0.0",
@@ -3023,6 +3023,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "node_modules/buffer-builder": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
+      "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
+      "dev": true
+    },
     "node_modules/buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -5480,6 +5486,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true
+    },
+    "node_modules/google-protobuf": {
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
       "dev": true
     },
     "node_modules/got": {
@@ -8857,21 +8869,182 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "node_modules/sass": {
+    "node_modules/sass-embedded": {
       "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
-      "integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.55.0.tgz",
+      "integrity": "sha512-6AkKEyRjxz37iNwOdTOW94I33j5mxcih9Z604q1w0M1dOTKaZgtyNI67O0zb4akwZ9dVZ2VSJBXqY8/1TZRBIw==",
       "dev": true,
       "dependencies": {
-        "chokidar": ">=3.0.0 <4.0.0",
+        "buffer-builder": "^0.2.0",
+        "google-protobuf": "^3.11.4",
         "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
-      },
-      "bin": {
-        "sass": "sass.js"
+        "rxjs": "^7.4.0",
+        "supports-color": "^8.1.1"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "sass-embedded-darwin-arm64": "1.55.0",
+        "sass-embedded-darwin-x64": "1.55.0",
+        "sass-embedded-linux-arm": "1.55.0",
+        "sass-embedded-linux-arm64": "1.55.0",
+        "sass-embedded-linux-ia32": "1.55.0",
+        "sass-embedded-linux-x64": "1.55.0",
+        "sass-embedded-win32-ia32": "1.55.0",
+        "sass-embedded-win32-x64": "1.55.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-arm64": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.55.0.tgz",
+      "integrity": "sha512-cQ43gYDFo4xWSqG01ZmOhTyTgk/RYK7s1a4R+7VSQPhYTsd4VofAmTNw0MkLR3RzR53ziGgawA6uT/WHTm+yjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-darwin-x64": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.55.0.tgz",
+      "integrity": "sha512-ra8z++EBey01pkiwCwjWyMbf6G5xm2Uj0dUJzzsS1MI6Fw6XaesrWmYico5pnawm3rOYtKlMxkd2Y6b1Jwxy8A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.55.0.tgz",
+      "integrity": "sha512-UIW7CaRLjHMWm64jH23n5eji/RAv8XIJ2qpFh0Ds8EJeDZmRA+qyIFHcQ805fZ22u6o0mkxq0kE4+j1XmmbBeg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-arm64": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.55.0.tgz",
+      "integrity": "sha512-P4zL4PnujdiSkek/g0RJjyNZcYEqSm6WFr0sSIrxe3byhGg56mWr4WJdxUNwFZ6sxyy2s0PFSjSKGmBtgEfIpw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-ia32": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.55.0.tgz",
+      "integrity": "sha512-9XJyAl4w5KBjR4LAXckfQKqPv9UYPmOv2HFRBwhHD1k4Dc8gZbfTCzK5wl49z5Z4z1GPvqV9ucIZceXzgJ5e6Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-linux-x64": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.55.0.tgz",
+      "integrity": "sha512-vd4/4/L7gZcVyxq03/MY/+rcpGgOI0ihOUpwRJLj+9CmUxvhxCSTF51/QO5CW7Z5oJSYEABA/RYlj8NPm4ZejA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-ia32": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.55.0.tgz",
+      "integrity": "sha512-4HxK0byJ3iIn5OECIeNVz9GcGBuQcQT6kTvI+3QSHzuKsqgQrlXOPJ3772zKD6PVwZJNFZJFf3o9w8V2VSHbTQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded-win32-x64": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.55.0.tgz",
+      "integrity": "sha512-LWUp5YpJy0/Q+5AOVcw919jktw+OnPiM4f4j5K6MJAiaodJwrSTqRGwMa2wOWyAUpjIdka8Ygm6j+2h5HNgSNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/sass-embedded/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sass-embedded/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/selenium-standalone": {
@@ -12618,6 +12791,12 @@
         "ieee754": "^1.1.13"
       }
     },
+    "buffer-builder": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-builder/-/buffer-builder-0.2.0.tgz",
+      "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
+      "dev": true
+    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
@@ -14486,6 +14665,12 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true
+    },
+    "google-protobuf": {
+      "version": "3.21.2",
+      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
+      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA==",
       "dev": true
     },
     "got": {
@@ -16923,16 +17108,99 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
-    "sass": {
+    "sass-embedded": {
       "version": "1.55.0",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
-      "integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
+      "resolved": "https://registry.npmjs.org/sass-embedded/-/sass-embedded-1.55.0.tgz",
+      "integrity": "sha512-6AkKEyRjxz37iNwOdTOW94I33j5mxcih9Z604q1w0M1dOTKaZgtyNI67O0zb4akwZ9dVZ2VSJBXqY8/1TZRBIw==",
       "dev": true,
       "requires": {
-        "chokidar": ">=3.0.0 <4.0.0",
+        "buffer-builder": "^0.2.0",
+        "google-protobuf": "^3.11.4",
         "immutable": "^4.0.0",
-        "source-map-js": ">=0.6.2 <2.0.0"
+        "rxjs": "^7.4.0",
+        "sass-embedded-darwin-arm64": "1.55.0",
+        "sass-embedded-darwin-x64": "1.55.0",
+        "sass-embedded-linux-arm": "1.55.0",
+        "sass-embedded-linux-arm64": "1.55.0",
+        "sass-embedded-linux-ia32": "1.55.0",
+        "sass-embedded-linux-x64": "1.55.0",
+        "sass-embedded-win32-ia32": "1.55.0",
+        "sass-embedded-win32-x64": "1.55.0",
+        "supports-color": "^8.1.1"
+      },
+      "dependencies": {
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
       }
+    },
+    "sass-embedded-darwin-arm64": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-arm64/-/sass-embedded-darwin-arm64-1.55.0.tgz",
+      "integrity": "sha512-cQ43gYDFo4xWSqG01ZmOhTyTgk/RYK7s1a4R+7VSQPhYTsd4VofAmTNw0MkLR3RzR53ziGgawA6uT/WHTm+yjg==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-darwin-x64": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-darwin-x64/-/sass-embedded-darwin-x64-1.55.0.tgz",
+      "integrity": "sha512-ra8z++EBey01pkiwCwjWyMbf6G5xm2Uj0dUJzzsS1MI6Fw6XaesrWmYico5pnawm3rOYtKlMxkd2Y6b1Jwxy8A==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-arm": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm/-/sass-embedded-linux-arm-1.55.0.tgz",
+      "integrity": "sha512-UIW7CaRLjHMWm64jH23n5eji/RAv8XIJ2qpFh0Ds8EJeDZmRA+qyIFHcQ805fZ22u6o0mkxq0kE4+j1XmmbBeg==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-arm64": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-arm64/-/sass-embedded-linux-arm64-1.55.0.tgz",
+      "integrity": "sha512-P4zL4PnujdiSkek/g0RJjyNZcYEqSm6WFr0sSIrxe3byhGg56mWr4WJdxUNwFZ6sxyy2s0PFSjSKGmBtgEfIpw==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-ia32": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-ia32/-/sass-embedded-linux-ia32-1.55.0.tgz",
+      "integrity": "sha512-9XJyAl4w5KBjR4LAXckfQKqPv9UYPmOv2HFRBwhHD1k4Dc8gZbfTCzK5wl49z5Z4z1GPvqV9ucIZceXzgJ5e6Q==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-linux-x64": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.55.0.tgz",
+      "integrity": "sha512-vd4/4/L7gZcVyxq03/MY/+rcpGgOI0ihOUpwRJLj+9CmUxvhxCSTF51/QO5CW7Z5oJSYEABA/RYlj8NPm4ZejA==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-win32-ia32": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-ia32/-/sass-embedded-win32-ia32-1.55.0.tgz",
+      "integrity": "sha512-4HxK0byJ3iIn5OECIeNVz9GcGBuQcQT6kTvI+3QSHzuKsqgQrlXOPJ3772zKD6PVwZJNFZJFf3o9w8V2VSHbTQ==",
+      "dev": true,
+      "optional": true
+    },
+    "sass-embedded-win32-x64": {
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass-embedded-win32-x64/-/sass-embedded-win32-x64-1.55.0.tgz",
+      "integrity": "sha512-LWUp5YpJy0/Q+5AOVcw919jktw+OnPiM4f4j5K6MJAiaodJwrSTqRGwMa2wOWyAUpjIdka8Ygm6j+2h5HNgSNQ==",
+      "dev": true,
+      "optional": true
     },
     "selenium-standalone": {
       "version": "8.2.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.61.1",
     "rollup-plugin-vue": "^6.0.0",
-    "sass-embedded": "1.54.4",
+    "sass-embedded": "^1.54.4",
     "selenium-standalone": "^8.0.8",
     "stylelint": "^14.1.0",
     "stylelint-config-standard": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.61.1",
     "rollup-plugin-vue": "^6.0.0",
-    "sass": "^1.49.9",
+    "sass-embedded": "1.54.4",
     "selenium-standalone": "^8.0.8",
     "stylelint": "^14.1.0",
     "stylelint-config-standard": "^24.0.0",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- remove some I/O operations on both the JS and SCSS minification (eg use the code output directly)
- Switch for Sass to Sass-embedded

About SASS-EMBEDDED: This package is an alternative to the [sass](https://www.npmjs.com/package/sass) package. It supports the same JS API as sass and is maintained by the same team, but where the sass package is pure JavaScript, sass-embedded is instead a JavaScript wrapper around a native Dart executable. This means sass-embedded will generally be much faster especially for large Sass compilations, but it can only be installed on the platforms that Dart supports: Windows, Mac OS, and Linux. [npmjs](https://www.npmjs.com/package/sass-embedded)

### Testing Instructions
On a fresh installation of Joomla (ie `git clone`) do the composer install and then the npm install. Copy the media folder somewhere in your hardisk. (check the time needed)
Now clone this PR and do both the composer and npm installations. Once done do a folder compare of the current media folder against the folder that you saved in the previous step. You should have the same files. Check the template.css for both the core templates to ensure that the file contents are the same.

Compare the times and do a brief check that both front end and back still work as expected


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request
It should a bit faster due to less I/O operations and the sass-embedded is the recommended compiler for speed


### Documentation Changes Required

NO

This PR replaces #38225 and https://github.com/joomla/joomla-cms/pull/36919

Note to anyone that will merge this: you probably need at least a successful test both from windows and macOS env (assuming that the linux env from the automated tests can be accepted as one for the Linuxes)


@HLeithner have this merged before trying out more exotic solutions