### PR TITLE
Duplicated code

### DIFF
--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -114,29 +114,6 @@ if ($clientId === 1) {
                         'parent_id',
                         'menuordering',
                         'published',
-                        'publish_up',
-                        'publish_down',
-                        'home',
-                        'access',
-                        'language',
-                        'note',
-                    );
-
-                    if ($this->item->type != 'component') {
-                        $this->fields = array_diff($this->fields, array('home'));
-                        $this->form->setFieldAttribute('publish_up', 'showon', '');
-                        $this->form->setFieldAttribute('publish_down', 'showon', '');
-                    }
-                    ?>
-                <?php
-                    // Set main fields.
-                    $this->fields = array(
-                        'id',
-                        'client_id',
-                        'menutype',
-                        'parent_id',
-                        'menuordering',
-                        'published',
                         'home',
                         'publish_up',
                         'publish_down',


### PR DESCRIPTION
This PR removes a block of duplicated code. They two blocks are slightly different as the home is in a different place. But as the first block is overridden by the second block I have deleted the first block.

There is no visible changes as a result of this PR. Either test by code review or by checking that you can still create and edit menu items exactly the same as before this PR

_(any comments about codestyle will be ignored as out of scope for this pr)_