### PR TITLE
Use 4.2-dev in core translation workflow

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,6 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
-[*.{js,json,scss,css,vue}]
+[*.{js,json,scss,css,yml,vue}]
 indent_style = space
 indent_size = 2

--- a/.github/workflows/create-translation-pull-request-v4.yml
+++ b/.github/workflows/create-translation-pull-request-v4.yml
@@ -36,8 +36,8 @@ jobs:
           git config user.email release+translation-bot@joomla.org
           git remote add upstream https://github.com/joomla/joomla-cms.git
           git fetch upstream
-          git checkout --progress --force -B translation refs/remotes/origin/translation          
-          git merge upstream/4.1-dev
+          git checkout --progress --force -B translation refs/remotes/origin/translation
+          git merge upstream/4.2-dev
 
       - name: Fetch and extract translations
         run: |
@@ -50,15 +50,15 @@ jobs:
         run: |
           cd ..
           SYNC_VERSION="v4"
-          
+
           SYNC_PATH="installation/language/"
           echo ${SYNC_PATH}
-          rsync -i -rptgo --checksum --ignore-times --delete --exclude="*en-GB*" core-translations-main/joomla_${SYNC_VERSION}/translations/core/${SYNC_PATH} joomla-cms/${SYNC_PATH} 
-          
+          rsync -i -rptgo --checksum --ignore-times --delete --exclude="*en-GB*" core-translations-main/joomla_${SYNC_VERSION}/translations/core/${SYNC_PATH} joomla-cms/${SYNC_PATH}
+
       - name: Update static error pages
         run: |
           npm ci --ignore-scripts && node build/build.js --build-pages
-          
+
       - name: Create commit
         run: |
           git config user.name Translation Bot
@@ -66,10 +66,10 @@ jobs:
           git add .
           git commit -m "Language update"
           git push --force
-          
+
       - name: Create pull request
         env:
-          GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}      
+          GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
         run: |
           gh pr list -R joomla/joomla-cms --state open --author joomla-translation-bot -S "Translation Update" | grep -v "No pull" || \
-            gh pr create --title "Translation Update" --body "Automatically created pull request based on core-translation repository changes" -R joomla/joomla-cms --base 4.1-dev
+            gh pr create --title "Translation Update" --body "Automatically created pull request based on core-translation repository changes" -R joomla/joomla-cms --base 4.2-dev


### PR DESCRIPTION
Use 4.2-dev branch in `Create translation pull request` workflow in addition updated `.editotorconfig` file to use spaces as a indentation for `*.yml`.
fix https://github.com/joomla/joomla-cms/discussions/38684