### PR TITLE
Fix for cp cannot create regular file: File exists

### DIFF
--- a/tests/Codeception/drone-system-run.sh
+++ b/tests/Codeception/drone-system-run.sh
@@ -20,7 +20,7 @@ google-chrome --version
 echo "[RUNNER] Prepare Selenium"
 mkdir -p tests/Codeception/_output
 if [[ -f "/usr/lib/node_modules/selenium-standalone/lib/default-config.js" ]]; then
-	cp /usr/lib/node_modules/selenium-standalone/lib/default-config.js tests/Codeception/_output/selenium.config.js
+	flock tests/Codeception/_output/selenium.config.js cp /usr/lib/node_modules/selenium-standalone/lib/default-config.js tests/Codeception/_output/selenium.config.js
 fi
 
 echo "[RUNNER] Start Selenium"


### PR DESCRIPTION
phpmax-system-mysql test failed on drone with message:
```
cp: cannot create regular file 'tests/Codeception/_output/selenium.config.js': File exists
```
See https://ci.joomla.org/joomla/joomla-cms/57663/1/33
Probably caused by running the tests in parallel

### Summary of Changes
Fix based on explanation in https://unix.stackexchange.com/a/116281


### Testing Instructions
Run the drone tests


### Actual result BEFORE applying this Pull Request
test fails as explained before


### Expected result AFTER applying this Pull Request
all tests always succeed (except when they are broken or encounter a timeout)


### Documentation Changes Required
none
