### PR TITLE
Fix package doc block tag in site module PHP files

### DIFF
--- a/modules/mod_articles_latest/services/provider.php
+++ b/modules/mod_articles_latest/services/provider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @package     Joomla.Administrator
+ * @package     Joomla.Site
  * @subpackage  mod_articles_latest
  *
  * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>

--- a/modules/mod_articles_news/services/provider.php
+++ b/modules/mod_articles_news/services/provider.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * @package     Joomla.Administrator
+ * @package     Joomla.Site
  * @subpackage  mod_articles_news
  *
  * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

The only two modules "mod_articles_latest" and "mod_articles_news" which have been refactored to the new services structure have a doc block tag `@package  Joomla.Administrator` in their "provider.php" files.

This is possibly a remainder from copying from previously refactored administrator modules.

It should be `@package  Joomla.Site` like for all other PHP files of site modules.

This pull request (PR) fixes that.

### Testing Instructions

Check the `@package` doc block tag of all PHP files below the "modules" folder, i.e. of all site modules.

On Windows you can use following commands in a Windows Command Shell (CMD):
```
cd modules
findstr /s /i /c:"@package" *.php
```
On Linux and similar you can use following commands in a command shell (e.g. bash):
```
find ./modules -type f -name "*\.php" -exec grep -iH "@package" {} \;
```
### Actual result BEFORE applying this Pull Request

All PHP files of site modules have `@package  Joomla.Site` except of the two files modified by this PR, those have `@package  Joomla.Administrator`

### Expected result AFTER applying this Pull Request

All PHP files of site modules have `@package  Joomla.Site`.

### Documentation Changes Required

None.