### PR TITLE
Fix "bind and search" on php8

### DIFF
--- a/libraries/vendor/joomla/ldap/src/LdapClient.php
+++ b/libraries/vendor/joomla/ldap/src/LdapClient.php
@@ -690,7 +690,7 @@ class LdapClient
 	 */
 	public function isConnected()
 	{
-		return $this->resource && \is_resource($this->resource);
+		return \is_resource($this->resource) || ( \is_object($this->resource) && $this->resource instanceof \LDAP\Connection );
 	}
 
 	/**


### PR DESCRIPTION
Pull Request for Issue #38672 and  #37060 .

I am aware this probably won't be accepted in Joomla 3 anymore, but I wanted to check this problem anyway and give those people a solution.

Remark for people needing this: please test your website using LDAP authentication on Joomla 4. It has some issues currently and the solutions need some testing. This ensures it will work once you need to upgrade to Joomla 4. Thanks!
If you need the fixes, here they are:
* #37959
* #37962
* #38388

### Summary of Changes
As php8 returns an instance of LDAP\Connection instead of a resource, check for it.

### Testing Instructions
Log in using LDAP "search and bind" method using php8


### Actual result BEFORE applying this Pull Request
It fails: "Username and password do not match or you do not have an account yet."


### Expected result AFTER applying this Pull Request
It succeeds


### Documentation Changes Required
none
