### PR TITLE
mod_submenu throws a fatal error if you use quicktask-permission in presets

### DIFF
--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+$user = \Joomla\CMS\Factory::getApplication()->getIdentity();
+
 /** @var  \Joomla\CMS\Menu\MenuItem  $root */
 ?>
 <?php foreach ($root->getChildren() as $child) : ?>


### PR DESCRIPTION
### Summary of Changes

Added missing `$user` variable declaration in `administrator/modules/mod_submenu/tmpl/default.php`

### Testing Instructions

1. Edit `administrator/components/com_content/presets/content.xml`
2. Change the COM_CONTENT_MENUS_ARTICLE_MANAGER entry adding a `quicktask-permission` attribute, i.e. change it to read:
```xml
<menuitem
	title="COM_CONTENT_MENUS_ARTICLE_MANAGER"
	type="component"
	element="com_content"
	link="index.php?option=com_content&amp;view=articles"
	quicktask="index.php?option=com_content&amp;task=article.add"
	quicktask-title="COM_CONTENT_MENUS_NEW_ARTICLE"
	quicktask-permission="core.create;com_content"
/>
```
3. Go to the content dashboard (`/administrator/index.php?option=com_cpanel&view=cpanel&dashboard=content`)

### Actual result BEFORE applying this Pull Request

The page breaks with an error: “Call to a member function authorise() on null”

### Expected result AFTER applying this Pull Request

The page works.

### Documentation Changes Required

None

### Side note

This issue was discovered while trying to set up a dashboard with a custom preset for my own component. That is to say, it affects all core and third party extensions since it's a very obvious omission when the view template was copied from mod_menu to mod_submenu and subsequently refactored.

Also note that the static code analysis in PhpStorm also caught the problem when I opened the affected file.