### PR TITLE
[4.2] Do not checkout a record when the user is not logged in

### DIFF
--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -129,6 +129,13 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
      */
     public function checkout($pk = null)
     {
+        $user = $this->getCurrentUser();
+
+        // When the user is a guest, don't do a checkout
+        if (!$user->id) {
+            return true;
+        }
+
         // Only attempt to check the row in if it exists.
         if ($pk) {
             // Get an instance of the row to checkout.
@@ -150,7 +157,6 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
                 return true;
             }
 
-            $user            = $this->getCurrentUser();
             $checkedOutField = $table->getColumnAlias('checked_out');
 
             // Check if this is the user having previously checked out the row.

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -154,7 +154,7 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
 
             // When the user is a guest, don't do a checkout
             if (!$user->id) {
-                return true;
+                return false;
             }
 
             $checkedOutField = $table->getColumnAlias('checked_out');

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -129,13 +129,6 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
      */
     public function checkout($pk = null)
     {
-        $user = $this->getCurrentUser();
-
-        // When the user is a guest, don't do a checkout
-        if (!$user->id) {
-            return true;
-        }
-
         // Only attempt to check the row in if it exists.
         if ($pk) {
             // Get an instance of the row to checkout.
@@ -154,6 +147,13 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
 
             // If there is no checked_out or checked_out_time field, just return true.
             if (!$table->hasField('checked_out') || !$table->hasField('checked_out_time')) {
+                return true;
+            }
+
+            $user = $this->getCurrentUser();
+
+            // When the user is a guest, don't do a checkout
+            if (!$user->id) {
                 return true;
             }
 

--- a/tests/Unit/Libraries/Cms/MVC/Model/FormModelTest.php
+++ b/tests/Unit/Libraries/Cms/MVC/Model/FormModelTest.php
@@ -244,7 +244,7 @@ class FormModelTest extends UnitTestCase
      *
      * @since   4.2.0
      */
-    public function testSucessfullCheckout()
+    public function testSuccessfulCheckout()
     {
         $table              = $this->createStub(Table::class);
         $table->checked_out = 0;
@@ -263,7 +263,11 @@ class FormModelTest extends UnitTestCase
                 return null;
             }
         };
-        $model->setCurrentUser(new User());
+
+        // Must be a valid user
+        $user     = new User();
+        $user->id = 1;
+        $model->setCurrentUser($user);
 
         $this->assertTrue($model->checkout(1));
     }
@@ -275,7 +279,7 @@ class FormModelTest extends UnitTestCase
      *
      * @since   4.2.0
      */
-    public function testSucessfullCheckoutWithEmptyRecord()
+    public function testSuccessfulCheckoutWithEmptyRecord()
     {
         $model = new class (['dbo' => $this->createStub(DatabaseInterface::class)], $this->createStub(MVCFactoryInterface::class)) extends FormModel
         {
@@ -296,6 +300,41 @@ class FormModelTest extends UnitTestCase
      * @since   4.2.0
      */
     public function testFailedCheckout()
+    {
+        $table              = $this->createStub(Table::class);
+        $table->checked_out = 0;
+        $table->method('load')->willReturn(true);
+        $table->method('hasField')->willReturn(true);
+        $table->method('checkIn')->willReturn(false);
+        $table->method('getColumnAlias')->willReturn('checked_out');
+
+        $mvcFactory = $this->createStub(MVCFactoryInterface::class);
+        $mvcFactory->method('createTable')->willReturn($table);
+
+        $model = new class (['dbo' => $this->createStub(DatabaseInterface::class)], $mvcFactory) extends FormModel
+        {
+            public function getForm($data = array(), $loadData = true)
+            {
+                return null;
+            }
+        };
+
+        // Must be a valid user
+        $user     = new User();
+        $user->id = 1;
+        $model->setCurrentUser($user);
+
+        $this->assertFalse($model->checkout(1));
+    }
+
+    /**
+     * @testdox  can't checkout a record when the current user is a guest
+     *
+     * @return  void
+     *
+     * @since   4.2.0
+     */
+    public function testFailedCheckoutAsGuest()
     {
         $table              = $this->createStub(Table::class);
         $table->checked_out = 0;
@@ -353,7 +392,7 @@ class FormModelTest extends UnitTestCase
      *
      * @since   4.2.0
      */
-    public function testSuccessfullCheckoutFieldNotAvailableCheck()
+    public function testSuccessfulCheckoutFieldNotAvailableCheck()
     {
         $table              = $this->createStub(Table::class);
         $table->checked_out = 0;
@@ -381,7 +420,7 @@ class FormModelTest extends UnitTestCase
      *
      * @since   4.2.0
      */
-    public function testSuccessfullCheckoutWhenCurrentUserIsDifferent()
+    public function testSuccessfulCheckoutWhenCurrentUserIsDifferent()
     {
         $table              = $this->createStub(Table::class);
         $table->checked_out = 1;


### PR DESCRIPTION
### Summary of Changes
When not logged in users can create articles, an exception is thrown that the article can not be checked out when saving it.

### Testing Instructions
- Set the create permission for the public user group to allowed.
- Create a "Create Article" menu item
- Open the front end as not logged in user
- Go to the "Create Article" menu item
- Set a title in the form
- Click on the "Save" button (NOT "Save and Close")

### Actual result BEFORE applying this Pull Request
"Argument 'userId' of event onTableBeforeCheckout must be an integer " error is displayed.

### Expected result AFTER applying this Pull Request
FrontPage is loaded with text "Article submitted.".