### PR TITLE
[4.2] npm: fix bootstrap to version 5.1.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@webcomponents/webcomponentsjs": "^2.6.0",
     "accessibility": "^3.0.14",
     "awesomplete": "^1.1.5",
-    "bootstrap": "5.1.3",
+    "bootstrap": "~5.1.3",
     "choices.js": "^9.0.1",
     "chosen-js": "^1.8.7",
     "codemirror": "^5.65.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@webcomponents/webcomponentsjs": "^2.6.0",
     "accessibility": "^3.0.14",
     "awesomplete": "^1.1.5",
-    "bootstrap": "^5.1.3",
+    "bootstrap": "5.1.3",
     "choices.js": "^9.0.1",
     "chosen-js": "^1.8.7",
     "codemirror": "^5.65.0",


### PR DESCRIPTION
### Summary of Changes
Right now, when we simply run npm update, npm tries to update bootstrap to version 5.2, which doesn't work. Right now we can't update to more than 5.1.3. This pins the package to that version.