### PR TITLE
[4.2] Override Check quick Icon

### DIFF
--- a/build/media_source/plg_quickicon_overridecheck/js/overridecheck.es6.js
+++ b/build/media_source/plg_quickicon_overridecheck/js/overridecheck.es6.js
@@ -50,17 +50,17 @@
               // Scroll to page top
               window.scrollTo(0, 0);
 
-              update('danger', Joomla.Text._('PLG_QUICKICON_OVERRIDECHECK_OVERRIDEFOUND').replace('%s', `<span class="badge text-dark bg-light">${updateInfoList.length}</span>`), '');
+              update('warning', Joomla.Text._('PLG_QUICKICON_OVERRIDECHECK_OVERRIDEFOUND').replace('%s', `<span class="badge text-dark bg-light">${updateInfoList.length}</span>`), '');
             }
           } else {
             throw new Error('Override check: unexpected value type');
           }
         } else {
-          update('danger', Joomla.Text._('PLG_QUICKICON_OVERRIDECHECK_ERROR_ENABLE'), `index.php?option=com_plugins&task=plugin.edit&extension_id=${options.pluginId}`);
+          update('warning', Joomla.Text._('PLG_QUICKICON_OVERRIDECHECK_ERROR_ENABLE'), `index.php?option=com_plugins&task=plugin.edit&extension_id=${options.pluginId}`);
         }
       }).catch(() => {
         // An error occurred
-        update('danger', Joomla.Text._('PLG_QUICKICON_OVERRIDECHECK_ERROR'), '');
+        update('warning', Joomla.Text._('PLG_QUICKICON_OVERRIDECHECK_ERROR'), '');
       });
     }
   };

--- a/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
@@ -80,12 +80,18 @@
         }
       }
 
-      &.warning,
       &.danger {
         --text-color: var(--danger);
         --bg-color: #f4f0f0;
         --icon-color: #ce8484;
         --bg-color-hvr: var(--danger);
+      }
+
+      &.warning{
+        --text-color: var(--warning);
+        --bg-color: #f4f0f0;
+        --icon-color: #ffb520;
+        --bg-color-hvr: var(--warning);
       }
 
       &.success {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
@@ -87,7 +87,7 @@
         --bg-color-hvr: var(--danger);
       }
 
-      &.warning{
+      &.warning {
         --text-color: var(--warning);
         --bg-color: #f4f0f0;
         --icon-color: #ffb520;

--- a/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
@@ -90,7 +90,7 @@
       &.warning {
         --text-color: var(--warning);
         --bg-color: #f4f0f0;
-        --icon-color: #ffb520;
+        --icon-color: #ffd176;
         --bg-color-hvr: var(--warning);
       }
 


### PR DESCRIPTION
Several users have expressed the view that the red error styling on th quickicon when there are overrides to check is too "scary".

This pr introduces a separate warning class for "warning" and updates the js to use this warning instead of the error

To test either run npm ci or use a prebuilt build