### PR TITLE
[4.2] Renovatebot: Changing asset updates to npm run update

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
     "npm": "> 8.0"
   },
   "postUpgradeTasks": {
-    "commands": ["node build/build.js --copy-assets"],
+    "commands": ["npm run update"],
     "fileFilters": ["**/*.*"],
     "executionMode": "branch"
   }


### PR DESCRIPTION
### Summary of Changes
This is basically a test to fix the command for asset updates in renovatebot. The previous command failed.