### PR TITLE
[4,2] remove JDEFAULT override for com_menus

### DIFF
--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -158,7 +158,7 @@ if (!empty($editor)) {
                         <?php if ($multilang) : ?>
                             <td class="small d-none d-md-table-cell">
                                 <?php if ($item->language == '') : ?>
-                                    <?php echo Text::_('JDEFAULT'); ?>
+                                    <?php echo Text::_('COM_MENUS_HOME'); ?>
                                 <?php elseif ($item->language == '*') : ?>
                                     <?php echo Text::alt('JALL', 'language'); ?>
                                 <?php else : ?>

--- a/administrator/language/en-GB/com_menus.ini
+++ b/administrator/language/en-GB/com_menus.ini
@@ -64,6 +64,7 @@ COM_MENUS_HEADING_POSITION="Position"
 COM_MENUS_HEADING_PUBLISHED_ITEMS="Published"
 COM_MENUS_HEADING_TRASHED_ITEMS="Trashed"
 COM_MENUS_HEADING_UNPUBLISHED_ITEMS="Unpublished"
+COM_MENUS_HOME="Home"
 COM_MENUS_INTEGRATION_FIELDSET_LABEL="Integration"
 COM_MENUS_ITEM_DETAILS="Details"
 COM_MENUS_ITEM_FIELD_ALIAS_MENU_LABEL="Menu Item"
@@ -205,6 +206,5 @@ COM_MENUS_XML_DESCRIPTION="Component for creating menus."
 
 JLIB_RULES_SETTING_NOTES_COM_MENUS="Changes apply to this component only.<br><em><strong>Inherited</strong></em> - a Global Configuration setting or higher level setting is applied.<br><em><strong>Denied</strong></em> always wins - whatever is set at the Global or higher level and applies to all child elements.<br><em><strong>Allowed</strong></em> will enable the action for this component unless overruled by a Global Configuration setting." ; Alternate language strings for the rules form field
 
-JDEFAULT="Home" ; Alternate language strings for the default menu item
 JLIB_HTML_SETDEFAULT_ITEM="Set as Home" ; Alternate language strings for the default menu item
 JTOOLBAR_DEFAULT="Home" ; Alternate language strings for the default menu item


### PR DESCRIPTION
see #38815

Stops overriding the string JDEFAULT in com_menus and uses a dedicated string instead.

Took longer to write this issue than it took to write a pull request.
