### PR TITLE
[4.2] Renovate: Adding npm ci

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,7 +16,7 @@
     "npm": "> 8.0"
   },
   "postUpgradeTasks": {
-    "commands": ["npm run update"],
+    "commands": ["npm ci", "node build/build.js --copy-assets"],
     "fileFilters": ["**/*.*"],
     "executionMode": "branch"
   }


### PR DESCRIPTION
The commands executed by renovate failed because we didn't have the dependencies installed. This adds npm ci to the commands, preparing the environments properly.