### PR TITLE
Adding "pattern" attribute to "tel" form field

### DIFF
--- a/layouts/joomla/form/field/tel.php
+++ b/layouts/joomla/form/field/tel.php
@@ -60,6 +60,7 @@ $attributes = array(
     $onchange ? 'onchange="' . $onchange . '"' : '',
     !empty($maxLength) ? $maxLength : '',
     $required ? 'required' : '',
+    !empty($pattern) ? 'pattern="' . $pattern . '"' : '',
     $dataAttribute,
 );
 ?>


### PR DESCRIPTION
According to this documentation: https://docs.joomla.org/Tel_form_field_type is "tel" form field an alias for "text", but it does not contain "pattern" attribute. This means, XML form field types "tel" will not include pattern attribute when rendering.

BEFORE PR
- XML form field type="tel" does not render "pattern" attribute

AFTER PR
- XML form field type="tel" will render the "pattern" attribute the same way like XML form field type="text"

Example:

`<field name="phone_1" type="tel" label="COM_XXX_PHONE_1_LABEL" description="COM_XXX_PHONE_1_DESC" pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}"  validate="tel" class=" validate-tel" />`

will produce

BEFORE PR:

`<input type="tel" inputmode="tel" name="jform[phone_1]" class="form-control validate-tel" id="jform_phone_1" value="" aria-describedby="jform_phone_1-desc">`

AFTER PR:

`<input type="tel" inputmode="tel" name="jform[phone_1]" class="form-control validate-tel" id="jform_phone_1" value="" aria-describedby="jform_phone_1-desc" pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}">`



### Summary of Changes
Adding option to add "pattern" attribute into the "tel" form field like it is included in "text" form field


### Testing Instructions
Edit the file, create form field with tel type and pattern. Such field will include pattern attribute when rendering.


### Actual result BEFORE applying this Pull Request
Pattern attribute is not rendered in "tel" form fields

### Expected result AFTER applying this Pull Request
Pattern attribute is rendered in "tel" form fields

