### PR TITLE
Fix Dashboards for third party components

### DIFF
--- a/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
+++ b/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomla\Component\Cpanel\Administrator\View\Cpanel;
 
-use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\Helper\ModuleHelper;

--- a/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
+++ b/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
@@ -61,7 +61,7 @@ class HtmlView extends BaseHtmlView
         $app = Factory::getApplication();
         $dashboard = $app->input->getCmd('dashboard', '');
 
-        $position = OutputFilter::stringUrlUnicodeSlug($dashboard);
+        $position = OutputFilter::stringURLSafe($dashboard);
 
         // Generate a title for the view cpanel
         if (!empty($dashboard)) {

--- a/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
+++ b/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Cpanel\Administrator\View\Cpanel;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
+use Joomla\CMS\Filter\OutputFilter;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
@@ -61,7 +62,7 @@ class HtmlView extends BaseHtmlView
         $app = Factory::getApplication();
         $dashboard = $app->input->getCmd('dashboard', '');
 
-        $position = ApplicationHelper::stringURLSafe($dashboard);
+        $position = OutputFilter::stringUrlUnicodeSlug($dashboard);
 
         // Generate a title for the view cpanel
         if (!empty($dashboard)) {


### PR DESCRIPTION
Pull Request for Issue #38849 .

### Summary of Changes

Updated `\Joomla\Component\Cpanel\Administrator\View\Cpanel\HtmlView::display` to make the control panel position on third party components' dashboards independent of the Unicode Slugs setting in Global Configuration.

### Testing Instructions

* Install a new site.
* Install an extension with a custom Dashboard, e.g. https://www.akeeba.com/download/arsdev/7-1-0-dev202209271443-revc1215dcb.html

**TEST 1**

* Go to System, Global Configuration, Site.
* Set Unicode Aliases to No (that's the default).
* Click on Save & Close.
* TEST 1.A: Go to extension's dashboard (e.g. Components, and click the dashboard icon next to Akeeba Release System)
* TEST 1.B: Go to the Joomla administrator control panel.

**TEST 2**

* Go to System, Global Configuration, Site.
* Set Unicode Aliases to Yes.
* Click on Save & Close.
* TEST 2.A: Go to extension's dashboard (e.g. Components, and click the dashboard icon next to Akeeba Release System)
* TEST 2.B: Go to the Joomla administrator control panel.


### Actual result BEFORE applying this Pull Request

**Test 1.A**: The component dashboard is **NOT** shown
**Test 1.B**: The system dashboard is shown
**Test 2.A**: The component dashboard is shown
**Test 2.B**: The system dashboard is shown

### Expected result AFTER applying this Pull Request

**Test 1.A**: The component dashboard is shown
**Test 1.B**: The system dashboard is shown
**Test 2.A**: The component dashboard is shown
**Test 2.B**: The system dashboard is shown

### Documentation Changes Required

Technically, none.

Please note that there's currently zero documentation on custom dashboards. I am writing it which is how I bumped into this issue to begin with.