### PR TITLE
[4.3] Cypress: Improving Joomla installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -65,7 +65,7 @@
         "fs-extra": "^10.0.0",
         "ini": "^2.0.0",
         "jasmine-core": "^3.10.1",
-        "joomla-cypress": "^0.0.12",
+        "joomla-cypress": "^0.0.15",
         "karma": "^6.3.14",
         "karma-coverage": "^2.1.0",
         "karma-firefox-launcher": "^2.1.2",
@@ -5964,9 +5964,9 @@
       "dev": true
     },
     "node_modules/joomla-cypress": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/joomla-cypress/-/joomla-cypress-0.0.12.tgz",
-      "integrity": "sha512-HF9qartxUB/ot0EJmJS7pNkQuL1LVR24chdRJNbGHLJCVWufyfPGDjywd8f75TRmBz9TOKnvahwDcktC6pWacw==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/joomla-cypress/-/joomla-cypress-0.0.15.tgz",
+      "integrity": "sha512-yrIiYsf9ivI0hyA1ZvElpbQDlwpdxasVcKo6krEhnRSYFrol0/lItIXxiVHUfrQlcecsV83Ns//iVJ/R7DQe+A==",
       "dev": true
     },
     "node_modules/joomla-ui-custom-elements": {
@@ -14178,9 +14178,9 @@
       "dev": true
     },
     "joomla-cypress": {
-      "version": "0.0.12",
-      "resolved": "https://registry.npmjs.org/joomla-cypress/-/joomla-cypress-0.0.12.tgz",
-      "integrity": "sha512-HF9qartxUB/ot0EJmJS7pNkQuL1LVR24chdRJNbGHLJCVWufyfPGDjywd8f75TRmBz9TOKnvahwDcktC6pWacw==",
+      "version": "0.0.15",
+      "resolved": "https://registry.npmjs.org/joomla-cypress/-/joomla-cypress-0.0.15.tgz",
+      "integrity": "sha512-yrIiYsf9ivI0hyA1ZvElpbQDlwpdxasVcKo6krEhnRSYFrol0/lItIXxiVHUfrQlcecsV83Ns//iVJ/R7DQe+A==",
       "dev": true
     },
     "joomla-ui-custom-elements": {

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "fs-extra": "^10.0.0",
     "ini": "^2.0.0",
     "jasmine-core": "^3.10.1",
-    "joomla-cypress": "^0.0.12",
+    "joomla-cypress": "^0.0.15",
     "karma": "^6.3.14",
     "karma-coverage": "^2.1.0",
     "karma-firefox-launcher": "^2.1.2",

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -116,10 +116,7 @@ Cypress.Commands.add('trashArticle', (title) => {
 
 Cypress.Commands.add('deleteArticle', (title) => {
   cy.visit('administrator/index.php?option=com_content&view=articles')
-  cy.get('.js-stools-btn-filter').click()
-  cy.intercept('index.php?option=com_content&view=articles*').as('articles_trashed')
-  cy.get('#filter_published').select('Trashed')
-  cy.wait('@articles_trashed')
+  cy.setFilter('published', 'Trashed')
   cy.searchForItem(title)
   cy.checkAllResults()
   cy.on("window:confirm", (s) => {


### PR DESCRIPTION
This improves our cypress tests slightly by hopefully making the installation of Joomla in cypress more stable and introducing the setFilter() command to set a filter in a list view.