### PR TITLE
[4.2] remove limit to nested tag form field

### DIFF
--- a/libraries/src/Form/Field/TagField.php
+++ b/libraries/src/Form/Field/TagField.php
@@ -128,9 +128,11 @@ class TagField extends ListField
         $language  = null;
         $options   = [];
 
+        if (!$this->isNested()) {
         // This limit is only used with isRemoteSearch
-        $prefillLimit   = 30;
-        $isRemoteSearch = $this->isRemoteSearch();
+            $prefillLimit   = 30;
+            $isRemoteSearch = $this->isRemoteSearch();
+        }
 
         $db    = $this->getDatabase();
         $query = $db->getQuery(true)


### PR DESCRIPTION
No limit if tag form field mode is set to nested.

### Summary of Changes
Whatever mode tag form field value, a limit to 30 elements is set in libraries/src/Form/Field/TagField.php (line 133) and isRemoteSearch is set to true : general parameter tag_field_ajax_mode is set to 1 as default value.

### Testing Instructions
Create more than 30 tags
Create a Tags - Popular module
Set up its parameters

### Actual result BEFORE applying this Pull Request

In tags - popular module, Parent Tag parameter only shows 30 tags.

### Expected result AFTER applying this Pull Request

In tags - popular module, Parent Tag parameter list shows all available tags
