### PR TITLE
[4] admin - show association button  when supported

### DIFF
--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -20,6 +20,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Associations\Administrator\Helper\AssociationsHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -233,7 +234,10 @@ class HtmlView extends BaseHtmlView
                 ToolbarHelper::versions($typeAlias, $this->item->id);
             }
 
-            if (Associations::isEnabled() && ComponentHelper::isEnabled('com_associations')) {
+            if (Associations::isEnabled() &&
+                ComponentHelper::isEnabled('com_associations') &&
+                AssociationsHelper::hasSupport($component)
+                ) {
                 ToolbarHelper::custom('category.editAssociations', 'contract', '', 'JTOOLBAR_ASSOCIATIONS', false, false);
             }
         }

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -238,7 +238,7 @@ class HtmlView extends BaseHtmlView
                 Associations::isEnabled() &&
                 ComponentHelper::isEnabled('com_associations') &&
                 AssociationsHelper::hasSupport($component)
-             ) {
+            ) {
                 ToolbarHelper::custom('category.editAssociations', 'contract', '', 'JTOOLBAR_ASSOCIATIONS', false, false);
             }
         }

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -234,10 +234,11 @@ class HtmlView extends BaseHtmlView
                 ToolbarHelper::versions($typeAlias, $this->item->id);
             }
 
-            if (Associations::isEnabled() &&
+            if (
+                Associations::isEnabled() &&
                 ComponentHelper::isEnabled('com_associations') &&
                 AssociationsHelper::hasSupport($component)
-                ) {
+             ) {
                 ToolbarHelper::custom('category.editAssociations', 'contract', '', 'JTOOLBAR_ASSOCIATIONS', false, false);
             }
         }


### PR DESCRIPTION
Pull Request for Issue #38837 .

### Summary of Changes
show association button only  when supported


### Testing Instructions
see #38837


### Actual result BEFORE applying this Pull Request
Extensions not supporting multilingual associations  like banner categorie etc , show button 'Associations'.


### Expected result AFTER applying this Pull Request
Extensions not supporting multilingual associations don't show button 'Associations'.


### Link to documentations
Please select:
- [X] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
