### PR TITLE
JS error in com_scheduler with empty task list

### DIFF
--- a/build/media_source/com_scheduler/js/admin-view-run-test-task.es6.js
+++ b/build/media_source/com_scheduler/js/admin-view-run-test-task.es6.js
@@ -85,8 +85,10 @@ const initRunner = () => {
     window.location.href = `${paths ? `${paths.base}/index.php` : window.location.pathname}?option=com_scheduler&view=tasks`;
   };
 
-  modal.addEventListener('show.bs.modal', triggerTaskAndShowOutput);
-  modal.addEventListener('hidden.bs.modal', reloadOnClose);
+  if (modal) {
+    modal.addEventListener('show.bs.modal', triggerTaskAndShowOutput);
+    modal.addEventListener('hidden.bs.modal', reloadOnClose);
+  }
   document.removeEventListener('DOMContentLoaded', initRunner);
 };
 


### PR DESCRIPTION
### Summary of Changes

JS error on missing tasks.

### Testing Instructions

Open backend Scheduled Tasks /administrator/index.php?option=com_scheduler&view=tasks
Type any blabla in search field, see no tasks filtered.
See JS error in console:
```
Uncaught TypeError: Cannot read properties of null (reading 'addEventListener')
    at HTMLDocument.initRunner
```
The reason is that admin script always uses modal element while it's missed when empty layout is loaded.

### Actual result BEFORE applying this Pull Request

JS error.

### Expected result AFTER applying this Pull Request

No JS erros.
