### PR TITLE
Ignore PHP warnings raised by simplexml_load_file()

### DIFF
--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -228,7 +228,7 @@ class JNamespacePsr4Map
                 }
 
                 // Load the manifest file
-                $xml = @simplexml_load_file($file, 'SimpleXMLElement', LIBXML_NOWARNING);
+                $xml = simplexml_load_file($file, 'SimpleXMLElement', LIBXML_NOERROR);
 
                 // When invalid, ignore
                 if (!$xml) {

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -228,7 +228,7 @@ class JNamespacePsr4Map
                 }
 
                 // Load the manifest file
-                $xml = simplexml_load_file($file);
+                $xml = @simplexml_load_file($file);
 
                 // When invalid, ignore
                 if (!$xml) {

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -228,7 +228,7 @@ class JNamespacePsr4Map
                 }
 
                 // Load the manifest file
-                $xml = @simplexml_load_file($file);
+                $xml = @simplexml_load_file($file, 'SimpleXMLElement', LIBXML_NOWARNING);
 
                 // When invalid, ignore
                 if (!$xml) {


### PR DESCRIPTION
Such warnings cause com_installer to raise a JSON error because it messes up the Ajax response.

Pull Request for Issue # .

### Summary of Changes

Supress such warnings by adding @ to simplexml_load_file($file)

### Testing Instructions

Install an extension with duplicate client attributes
`<extension type="module" client="administrator" method="upgrade" version="3.1" client="administrator" position="cpanel">`
Installs OK.

Try to install any other extension and get JSON error.
For some reason the installer runs through all the existing manifest files and hits the problem when it meets the previously installed extension.


### Actual result BEFORE applying this Pull Request

Get JSON parse error

### Expected result AFTER applying this Pull Request

Not a problem with extension being installed so would not expect an error.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
