### PR TITLE
Initial thoughts on v5 View structure

### DIFF
--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -20,6 +20,7 @@ use Joomla\CMS\MVC\Factory\LegacyFactory;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\MVC\Model\BaseModel;
+use Joomla\CMS\MVC\View\HtmlView;
 use Joomla\CMS\MVC\View\ViewInterface;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
@@ -597,9 +598,14 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
         $document = $this->app->getDocument();
         $viewType = $document->getType();
         $viewName = $this->input->get('view', $this->default_view);
-        $viewLayout = $this->input->get('layout', 'default', 'string');
 
-        $view = $this->getView($viewName, $viewType, '', array('base_path' => $this->basePath, 'layout' => $viewLayout));
+        $view = $this->getView($viewName, $viewType, '', []);
+
+		if ($view instanceof HtmlView) {
+			$viewLayout = $this->input->get('layout', 'default', 'string');
+
+			$view->setLayout($viewLayout);
+		}
 
         // Get/Create the model
         if ($model = $this->getModel($viewName, '', array('base_path' => $this->basePath))) {

--- a/libraries/src/MVC/Factory/MVCFactory.php
+++ b/libraries/src/MVC/Factory/MVCFactory.php
@@ -191,7 +191,7 @@ class MVCFactory implements MVCFactoryInterface, FormFactoryAwareInterface, Site
             return null;
         }
 
-        $view = new $className($config);
+        $view = new $className(Factory::getApplication()->getDocument());
         $this->setFormFactoryOnObject($view);
         $this->setDispatcherOnObject($view);
         $this->setRouterOnObject($view);

--- a/libraries/src/MVC/View/CategoriesView.php
+++ b/libraries/src/MVC/View/CategoriesView.php
@@ -9,8 +9,10 @@
 
 namespace Joomla\CMS\MVC\View;
 
+use Joomla\CMS\Categories\CategoryNode;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('JPATH_PLATFORM') or die;
@@ -47,7 +49,23 @@ class CategoriesView extends HtmlView
      */
     protected $pageHeading;
 
-    /**
+	/**
+	 * The category parameters
+	 *
+	 * @var   Registry
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $params;
+
+	/**
+	 * The parent category
+	 *
+	 * @var   CategoryNode
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $parent;
+
+	/**
      * Execute and display a template script.
      *
      * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.

--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -26,7 +26,7 @@ use Joomla\CMS\UCM\UCMType;
  *
  * @since  3.2
  */
-class CategoryFeedView extends HtmlView
+class CategoryFeedView extends AbstractView
 {
 	/**
 	 * The active document object. Redeclared for type hinting
@@ -94,8 +94,8 @@ class CategoryFeedView extends HtmlView
 
             // Strip html from feed item title
             if ($titleField) {
-                $title = $this->escape($item->$titleField);
-                $title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
+	            $title = htmlspecialchars($item->$titleField, ENT_QUOTES, 'UTF-8');
+                $title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
             } else {
                 $title = '';
             }

--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -9,6 +9,7 @@
 
 namespace Joomla\CMS\MVC\View;
 
+use Joomla\CMS\Document\FeedDocument;
 use Joomla\CMS\Document\Feed\FeedItem;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\RouteHelper;
@@ -27,7 +28,16 @@ use Joomla\CMS\UCM\UCMType;
  */
 class CategoryFeedView extends HtmlView
 {
-    /**
+	/**
+	 * The active document object. Redeclared for type hinting
+	 *
+	 * @var    FeedDocument
+	 * @since  3.0
+	 * @note   In Version 5.0 this will change to being a protected property
+	 */
+	public $document;
+
+	/**
      * Execute and display a template script.
      *
      * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
@@ -40,7 +50,6 @@ class CategoryFeedView extends HtmlView
     public function display($tpl = null)
     {
         $app      = Factory::getApplication();
-        $document = Factory::getDocument();
 
         $extension      = $app->input->getString('option');
         $contentType = $extension . '.' . $this->viewName;
@@ -59,16 +68,16 @@ class CategoryFeedView extends HtmlView
             $titleField = $ucmMapCommon[0]->core_title;
         }
 
-        $document->link = Route::_(RouteHelper::getCategoryRoute($app->input->getInt('id'), $language = 0, $extension));
+	    $this->document->link = Route::_(RouteHelper::getCategoryRoute($app->input->getInt('id'), $language = 0, $extension));
 
         $app->input->set('limit', $app->get('feed_limit'));
         $siteEmail        = $app->get('mailfrom');
         $fromName         = $app->get('fromname');
         $feedEmail        = $app->get('feed_email', 'none');
-        $document->editor = $fromName;
+	    $this->document->editor = $fromName;
 
         if ($feedEmail !== 'none') {
-            $document->editorEmail = $siteEmail;
+	        $this->document->editorEmail = $siteEmail;
         }
 
         // Get some data from the model
@@ -123,7 +132,7 @@ class CategoryFeedView extends HtmlView
             }
 
             // Loads item information into RSS array
-            $document->addItem($feeditem);
+            $this->document->addItem($feeditem);
         }
     }
 

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -124,7 +124,7 @@ class CategoryView extends HtmlView
 	 * @var   integer
 	 * @since __DEPLOY_VERSION__
 	 */
-	protected $maxLevel;
+	public $maxLevel;
 
 	/**
 	 * The category parameters
@@ -132,7 +132,7 @@ class CategoryView extends HtmlView
 	 * @var   Registry
 	 * @since __DEPLOY_VERSION__
 	 */
-	protected $params;
+	public $params;
 
 	/**
 	 * The active user

--- a/libraries/src/MVC/View/CategoryView.php
+++ b/libraries/src/MVC/View/CategoryView.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\User\User;
+use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('JPATH_PLATFORM') or die;
@@ -116,7 +118,39 @@ class CategoryView extends HtmlView
      */
     protected $menuItemMatchCategory = false;
 
-    /**
+	/**
+	 * The max level  of nesting to display sub-categories
+	 *
+	 * @var   integer
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $maxLevel;
+
+	/**
+	 * The category parameters
+	 *
+	 * @var   Registry
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $params;
+
+	/**
+	 * The active user
+	 *
+	 * @var   User
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $user;
+
+	/**
+	 * The parent category
+	 *
+	 * @var   CategoryNode
+	 * @since __DEPLOY_VERSION__
+	 */
+	protected $parent;
+
+	/**
      * Method with common display elements used in category list displays
      *
      * @return  void

--- a/libraries/src/MVC/View/FormView.php
+++ b/libraries/src/MVC/View/FormView.php
@@ -10,6 +10,7 @@
 namespace Joomla\CMS\MVC\View;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Document\HtmlDocument;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
@@ -68,7 +69,7 @@ class FormView extends HtmlView
      *
      * @var string
      */
-    protected $toolbarIcon;
+    protected $toolbarIcon = '';
 
     /**
      * The preview link
@@ -86,20 +87,12 @@ class FormView extends HtmlView
 
     /**
      * Constructor
-     *
-     * @param   array  $config  An optional associative array of configuration settings.
      */
-    public function __construct(array $config)
+    public function __construct(HtmlDocument $document)
     {
-        parent::__construct($config);
+        parent::__construct($document);
 
-        if (isset($config['help_link'])) {
-            $this->helpLink = $config['help_link'];
-        }
-
-        if (isset($config['toolbar_icon'])) {
-            $this->toolbarIcon = $config['toolbar_icon'];
-        } else {
+        if ($this->toolbarIcon === '') {
             $this->toolbarIcon = 'pencil-2 ' . $this->getName() . '-add';
         }
 

--- a/libraries/src/MVC/View/JsonApiView.php
+++ b/libraries/src/MVC/View/JsonApiView.php
@@ -83,22 +83,17 @@ abstract class JsonApiView extends JsonView
     /**
      * Constructor.
      *
-     * @param   array  $config  A named configuration array for object construction.
-     *                          contentType: the name (optional) of the content type to use for the serialization
+     * @param   JsonapiDocument  $document  The active document object
      *
      * @since   4.0.0
      */
-    public function __construct($config = [])
+    public function __construct(JsonapiDocument $document)
     {
-        if (\array_key_exists('contentType', $config)) {
-            $this->type = $config['contentType'];
-        }
-
         if ($this->serializer === null) {
             $this->serializer = new JoomlaSerializer($this->type);
         }
 
-        parent::__construct($config);
+        parent::__construct($document);
     }
 
     /**

--- a/libraries/src/MVC/View/JsonView.php
+++ b/libraries/src/MVC/View/JsonView.php
@@ -10,6 +10,8 @@
 namespace Joomla\CMS\MVC\View;
 
 // phpcs:disable PSR1.Files.SideEffects
+use Joomla\CMS\Document\JsonDocument;
+
 \defined('JPATH_PLATFORM') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
@@ -31,14 +33,6 @@ class JsonView extends AbstractView
     protected $_basePath = null;
 
     /**
-     * Charset to use in escaping mechanisms; defaults to urf8 (UTF-8)
-     *
-     * @var    string
-     * @since  4.0.0
-     */
-    protected $_charset = 'UTF-8';
-
-    /**
      * The output of the view.
      *
      * @var    array
@@ -49,34 +43,14 @@ class JsonView extends AbstractView
     /**
      * Constructor
      *
-     * @param   array  $config  A named configuration array for object construction.
-     *                          name: the name (optional) of the view (defaults to the view class name suffix).
-     *                          charset: the character set to use for display
-     *                          escape: the name (optional) of the function to use for escaping strings
-     *                          base_path: the parent path (optional) of the views directory (defaults to the component folder)
-     *                          template_plath: the path (optional) of the layout directory (defaults to base_path + /views/ + view name
-     *                          helper_path: the path (optional) of the helper files (defaults to base_path + /helpers/)
-     *                          layout: the layout (optional) to use to display the view
-     *
      * @since   4.0.0
      */
-    public function __construct($config = array())
+    public function __construct(JsonDocument $document)
     {
-        parent::__construct($config);
-
-        // Set the charset (used by the variable escaping functions)
-        if (\array_key_exists('charset', $config)) {
-            @trigger_error(
-                'Setting a custom charset for escaping is deprecated. Override \JViewLegacy::escape() instead.',
-                E_USER_DEPRECATED
-            );
-            $this->_charset = $config['charset'];
-        }
+		parent::__construct($document);
 
         // Set a base path for use by the view
-        if (\array_key_exists('base_path', $config)) {
-            $this->_basePath = $config['base_path'];
-        } else {
+        if ($this->_basePath === null) {
             $this->_basePath = JPATH_COMPONENT;
         }
     }

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -9,6 +9,7 @@
 
 namespace Joomla\CMS\MVC\View;
 
+use Joomla\CMS\Document\HtmlDocument;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
@@ -83,14 +84,14 @@ class ListView extends HtmlView
      *
      * @var string
      */
-    protected $toolbarTitle;
+    protected $toolbarTitle = '';
 
     /**
      * The toolbar icon
      *
      * @var string
      */
-    protected $toolbarIcon;
+    protected $toolbarIcon = '';
 
     /**
      * The flag which determine whether we want to show batch button
@@ -108,32 +109,18 @@ class ListView extends HtmlView
 
     /**
      * Constructor
-     *
-     * @param   array  $config  An optional associative array of configuration settings.
      */
-    public function __construct(array $config)
+    public function __construct(HtmlDocument $document)
     {
-        parent::__construct($config);
+        parent::__construct($document);
 
         // Set class properties from config data passed in constructor
-        if (isset($config['toolbar_title'])) {
-            $this->toolbarTitle = $config['toolbar_title'];
-        } else {
+        if ($this->toolbarTitle === '') {
             $this->toolbarTitle = strtoupper($this->option . '_MANAGER_' . $this->getName());
         }
 
-        if (isset($config['toolbar_icon'])) {
-            $this->toolbarIcon = $config['toolbar_icon'];
-        } else {
+        if ($this->toolbarIcon === '') {
             $this->toolbarIcon = strtolower($this->getName());
-        }
-
-        if (isset($config['supports_batch'])) {
-            $this->supportsBatch = $config['supports_batch'];
-        }
-
-        if (isset($config['help_link'])) {
-            $this->helpLink = $config['help_link'];
         }
 
         // Set default value for $canDo to avoid fatal error if child class doesn't set value for this property

--- a/tests/Unit/Libraries/Cms/MVC/View/AbstractViewTest.php
+++ b/tests/Unit/Libraries/Cms/MVC/View/AbstractViewTest.php
@@ -251,7 +251,7 @@ class AbstractViewTest extends UnitTestCase
         {
             public function dispatchEvent(EventInterface $event)
             {
-                parent::dispatchEvent($event);
+                return parent::dispatchEvent($event);
             }
 
             public function display($tpl = null)


### PR DESCRIPTION
OK So I had a bit of time on a train this morning and the stuff in https://github.com/joomla/joomla-cms/pull/38926 prompted me to have a think about what would actually be involved in removing the View package's CMSObject dependencies and also moving it towards a better semblance of DI whilst we were at it for a v5.0 package by removing the config object in favour of child classes directly setting things in their own constructors - none of these properties are actually things that the controller really cares about. Finally I've removed the concept of helper classes as I can't see any use of these in core for like 10 years or more.

This is purely PoC for discussion. I'm know the branch tests will fail because I've not made the relevant changes to the MVCFactory to build the view with the new constructor. This is purely about opening a conversation with the aim of requirements gathering for what we do and don't need in the other PR to get us to this as a proposed end state. Some of this stuff will end up being backported into the 4.x series to give us b/c, docs will be needed in the manual. Again this is a PoC for discussion not something intended to be merged today or tomorrow.

I've been reasonably aggressive with my constructor refactoring here. I'm sure I'm going to get shouted down a bit by @nikosdion to be more practical and that's fine. I completely accept there will need to be revisions based on this (please don't kill me too much :D )