### PR TITLE
Fix order of items not always saved

### DIFF
--- a/build/media_source/system/js/draggable.es6.js
+++ b/build/media_source/system/js/draggable.es6.js
@@ -54,19 +54,17 @@ if (container) {
 
     // Element is moved down
     if (dragIndex < dropIndex) {
-      rows[dropIndex].setAttribute('value', rows[dropIndex - 1].value);
+      rows[dropIndex].value = rows[dropIndex - 1].value;
 
       for (i = dragIndex; i < dropIndex; i += 1) {
         if (direction === 'asc') {
-          rows[i].setAttribute('value', parseInt(rows[i].value, 10) - 1);
+          rows[i].value = parseInt(rows[i].value, 10) - 1;
         } else {
-          rows[i].setAttribute('value', parseInt(rows[i].value, 10) + 1);
+          rows[i].value = parseInt(rows[i].value, 10) + 1;
         }
       }
     } else {
       // Element is moved up
-
-      rows[dropIndex].setAttribute('value', rows[dropIndex + 1].value);
       rows[dropIndex].value = rows[dropIndex + 1].value;
 
       for (i = dropIndex + 1; i <= dragIndex; i += 1) {


### PR DESCRIPTION
Pull Request for Issue #38910 .

### Summary of Changes
Use `input.value = x`, instead of `input.setAttribute('value', x)`


### Testing Instructions
Apply patch, run `npm install`. 

And follow #38910 , or:

Open sample data menus list for Top menu.
Drag "Fruit Shop" to:
3-d position, check frontend - position should change,
then drag to 5-th position, check fronted - position stays 3-rd
**Important**: do not reload the menu list page.


### Actual result BEFORE applying this Pull Request
Order randomly saved wrongly


### Expected result AFTER applying this Pull Request
Order always saved


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
