### PR TITLE
[4.4] PHP8.2 Add missing class properties to views

### DIFF
--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -85,6 +85,14 @@ class HtmlView extends BaseHtmlView
     private $isEmptyState = false;
 
     /**
+     * The ordering list for the categories
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $ordering = [];
+
+    /**
      * Display the view
      *
      * @param   string|null  $tpl  The name of the template file to parse; automatically searches through the template paths.

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -85,6 +85,22 @@ class HtmlView extends BaseHtmlView
     private $isEmptyState = false;
 
     /**
+     * Is the vote plugin enabled on the site
+     *
+     * @var   boolean
+     * @since __DEPLOY_VERSION__
+     */
+    protected $vote = false;
+
+    /**
+     * Are hits being recorded on the site?
+     *
+     * @var   boolean
+     * @since __DEPLOY_VERSION__
+     */
+    protected $hits = false;
+
+    /**
      * Display the view
      *
      * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.
@@ -99,7 +115,7 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $this->get('FilterForm');
         $this->activeFilters = $this->get('ActiveFilters');
         $this->vote          = PluginHelper::isEnabled('content', 'vote');
-        $this->hits          = ComponentHelper::getParams('com_content')->get('record_hits', 1);
+        $this->hits          = (ComponentHelper::getParams('com_content')->get('record_hits', 1) == 1);
 
         if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
             $this->setLayout('emptystate');

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -115,7 +115,7 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $this->get('FilterForm');
         $this->activeFilters = $this->get('ActiveFilters');
         $this->vote          = PluginHelper::isEnabled('content', 'vote');
-        $this->hits          = (ComponentHelper::getParams('com_content')->get('record_hits', 1) == 1);
+        $this->hits          = ComponentHelper::getParams('com_content')->get('record_hits', 1) == 1;
 
         if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
             $this->setLayout('emptystate');

--- a/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
@@ -69,6 +69,20 @@ class HtmlView extends BaseHtmlView
     private $isEmptyState = false;
 
     /**
+     * Form object for search filters
+     *
+     * @var  \Joomla\CMS\Form\Form
+     */
+    public $filterForm;
+
+    /**
+     * The active search filters
+     *
+     * @var  array
+     */
+    public $activeFilters;
+
+    /**
      * Execute and display a template script.
      *
      * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.

--- a/administrator/components/com_tags/src/View/Tags/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tags/HtmlView.php
@@ -81,6 +81,14 @@ class HtmlView extends BaseHtmlView
     private $isEmptyState = false;
 
     /**
+     * The ordering list for the tags
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $ordering = [];
+
+    /**
      * Execute and display a template script.
      *
      * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.


### PR DESCRIPTION
### Summary of Changes
In several view classes we are missing defining properties of the class that we then use later on in the view causing us to have magic properties. This ensures that they are correctly set in the code base as explicit properties

### Testing Instructions
Check tag list, categories, articles list and newsfeed list views and check that they continue to work as before with no changes

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
