### PR TITLE
Fix Automatic conversion of false to array

### DIFF
--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -542,7 +542,7 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
                     ]
                 )
             );
-            $cbuffer = $cache->get('cbuffer_' . $type);
+            $cbuffer = $cache->get('cbuffer_' . $type) ?: [];
 
             if (isset($cbuffer[$hash])) {
                 return Cache::getWorkarounds($cbuffer[$hash], array('mergehead' => 1));


### PR DESCRIPTION
Pull Request for Issue #38927 .

### Summary of Changes
Make sure variable is initialised as array


### Testing Instructions
Please follow #38927


### Actual result BEFORE applying this Pull Request
PHP warning


### Expected result AFTER applying this Pull Request
No PHP warning


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
