### PR TITLE
[4.2] Serialization Error when using mod_articles_categories with cache 

### DIFF
--- a/libraries/src/Cache/Controller/CallbackController.php
+++ b/libraries/src/Cache/Controller/CallbackController.php
@@ -153,7 +153,7 @@ class CallbackController extends CacheController
 		}
 
 		// Store the cache data
-		$this->cache->store(serialize($data), $id);
+		$this->cache->store(serialize($data['output']), $id);
 
 		if ($locktest->locked === true)
 		{


### PR DESCRIPTION
Pull Request for Issue #38782 .

### Summary of Changes
fix serialization error


### Testing Instructions
- Turn on caching in Global Configuration.
- Publish mod_articles_categories module and set it to display all categories.
- Reload the frontend


### Actual result BEFORE applying this Pull Request
   you will get following error: Serialization of 'Closure' is not allowed


### Expected result AFTER applying this Pull Request

no error module dislayed

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
