### PR TITLE
Fix empty table in users permissions

### DIFF
--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -20,136 +20,140 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 
 $loginActions = [];
 $actions = [];
-
-// Split the actions table
-foreach ($this->actions as $action) :
-    $name = $action[0];
-    if (in_array($name, ['core.login.site', 'core.login.admin', 'core.login.offline', 'core.login.api', 'core.admin'])) :
-        $loginActions[] = $action;
-    else :
-        $actions[] = $action;
-    endif;
-endforeach;
 ?>
 <form action="<?php echo Route::_('index.php?option=com_users&view=debuguser&user_id=' . (int) $this->state->get('user_id')); ?>" method="post" name="adminForm" id="adminForm">
     <div id="j-main-container" class="j-main-container">
         <?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
-        <div class="d-flex flex-wrap">
-            <?php foreach ($loginActions as $action) :
-                $name  = $action[0];
-                $check = $this->items[0]->checks[$name];
-                if ($check === true) :
-                    $class  = 'text-success icon-check';
-                    $button = 'btn-success';
-                    $text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
-                elseif ($check === false) :
-                    $class  = 'text-danger icon-times';
-                    $button = 'btn-danger';
-                    $text   = Text::_('COM_USERS_DEBUG_EXPLICIT_DENY');
-                elseif ($check === null) :
-                    $class  = 'text-danger icon-minus-circle';
-                    $button = 'btn-warning';
-                    $text   = Text::_('COM_USERS_DEBUG_IMPLICIT_DENY');
-                else :
-                    $class  = '';
-                    $button = '';
-                    $text   = '';
-                endif;
-                ?>
-            <div class="d-inline p-2">
-                <?php echo Text::_($action[1]); ?>
-                <span class="<?php echo $class; ?>" aria-hidden="true"></span>
-                <span class="visually-hidden"><?php echo Text::_($text); ?></span>
+        <?php if (empty($this->items)) : ?>
+            <div class="alert alert-info">
+                <span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
+                <?php echo Text::_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
             </div>
-            <?php endforeach; ?>
-        </div>
-
-        <table class="table">
-            <caption class="visually-hidden">
-                <?php echo Text::_('COM_USERS_DEBUG_USER_TABLE_CAPTION'); ?>,
-                        <span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
-                        <span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
-            </caption>
-            <thead>
-                <tr>
-                    <th scope="col">
-                        <?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_ASSET_TITLE', 'a.title', $listDirn, $listOrder); ?>
-                    </th>
-                    <th scope="col">
-                        <?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_ASSET_NAME', 'a.name', $listDirn, $listOrder); ?>
-                    </th>
-                    <?php foreach ($actions as $key => $action) : ?>
-                    <th scope="col" class="w-6 text-center">
-                        <?php echo Text::_($action[1]); ?>
-                    </th>
-                    <?php endforeach; ?>
-                    <th scope="col" class="w-6">
-                        <?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_LFT', 'a.lft', $listDirn, $listOrder); ?>
-                    </th>
-                    <th scope="col" class="w-3">
-                        <?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
-                    </th>
-                </tr>
-            </thead>
-            <tbody>
-                <?php foreach ($this->items as $i => $item) :?>
-                    <tr class="row0" scope="row">
-                        <td>
-                            <?php echo $this->escape(Text::_($item->title)); ?>
-                        </td>
-                        <td>
-                            <?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level + 1)) . $this->escape($item->name); ?>
-                        </td>
-                        <?php foreach ($actions as $action) : ?>
-                            <?php
-                            $name  = $action[0];
-                            $check = $item->checks[$name];
-                            if ($check === true) :
-                                $class  = 'text-success icon-check';
-                                $button = 'btn-success';
-                                $text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
-                            elseif ($check === false) :
-                                $class  = 'text-danger icon-times';
-                                $button = 'btn-danger';
-                                $text   = Text::_('COM_USERS_DEBUG_EXPLICIT_DENY');
-                            elseif ($check === null) :
-                                $class  = 'text-danger icon-minus-circle';
-                                $button = 'btn-warning';
-                                $text   = Text::_('COM_USERS_DEBUG_IMPLICIT_DENY');
-                            else :
-                                $class  = '';
-                                $button = '';
-                                $text   = '';
-                            endif;
-                            ?>
-                        <td class="text-center">
-                            <span class="<?php echo $class; ?>" aria-hidden="true"></span>
-                            <span class="visually-hidden"> <?php echo $text; ?></span>
-                        </td>
-                        <?php endforeach; ?>
-                        <td>
-                            <?php echo (int) $item->lft; ?>
-                            - <?php echo (int) $item->rgt; ?>
-                        </td>
-                        <td>
-                            <?php echo (int) $item->id; ?>
-                        </td>
-                    </tr>
+        <?php else : ?>
+            <?php
+            // Split the actions table
+            foreach ($this->actions as $action) :
+                $name = $action[0];
+                if (in_array($name, ['core.login.site', 'core.login.admin', 'core.login.offline', 'core.login.api', 'core.admin'])) :
+                    $loginActions[] = $action;
+                else :
+                    $actions[] = $action;
+                endif;
+            endforeach;
+            ?>
+            <div class="d-flex flex-wrap">
+                <?php foreach ($loginActions as $action) :
+                    $name  = $action[0];
+                    $check = $this->items[0]->checks[$name];
+                    if ($check === true) :
+                        $class  = 'text-success icon-check';
+                        $button = 'btn-success';
+                        $text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
+                    elseif ($check === false) :
+                        $class  = 'text-danger icon-times';
+                        $button = 'btn-danger';
+                        $text   = Text::_('COM_USERS_DEBUG_EXPLICIT_DENY');
+                    elseif ($check === null) :
+                        $class  = 'text-danger icon-minus-circle';
+                        $button = 'btn-warning';
+                        $text   = Text::_('COM_USERS_DEBUG_IMPLICIT_DENY');
+                    endif;
+                    ?>
+                <div class="d-inline p-2">
+                    <?php echo Text::_($action[1]); ?>
+                    <span class="<?php echo $class; ?>" aria-hidden="true"></span>
+                    <span class="visually-hidden"><?php echo Text::_($text); ?></span>
+                </div>
                 <?php endforeach; ?>
-            </tbody>
-        </table>
+            </div>
 
-        <div class="legend">
-            <span class="text-danger icon-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
-            <span class="text-success icon-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
-            <span class="text-danger icon-times" aria-hidden="true">&nbsp;</span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
-        </div>
+            <table class="table">
+                <caption class="visually-hidden">
+                    <?php echo Text::_('COM_USERS_DEBUG_USER_TABLE_CAPTION'); ?>,
+                            <span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,
+                            <span id="filteredBy"><?php echo Text::_('JGLOBAL_FILTERED_BY'); ?></span>
+                </caption>
+                <thead>
+                    <tr>
+                        <th scope="col">
+                            <?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_ASSET_TITLE', 'a.title', $listDirn, $listOrder); ?>
+                        </th>
+                        <th scope="col">
+                            <?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_ASSET_NAME', 'a.name', $listDirn, $listOrder); ?>
+                        </th>
+                        <?php foreach ($actions as $key => $action) : ?>
+                        <th scope="col" class="w-6 text-center">
+                            <?php echo Text::_($action[1]); ?>
+                        </th>
+                        <?php endforeach; ?>
+                        <th scope="col" class="w-6">
+                            <?php echo HTMLHelper::_('searchtools.sort', 'COM_USERS_HEADING_LFT', 'a.lft', $listDirn, $listOrder); ?>
+                        </th>
+                        <th scope="col" class="w-3">
+                            <?php echo HTMLHelper::_('searchtools.sort', 'JGRID_HEADING_ID', 'a.id', $listDirn, $listOrder); ?>
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php foreach ($this->items as $i => $item) :?>
+                        <tr class="row0" scope="row">
+                            <td>
+                                <?php echo $this->escape(Text::_($item->title)); ?>
+                            </td>
+                            <td>
+                                <?php echo LayoutHelper::render('joomla.html.treeprefix', array('level' => $item->level + 1)) . $this->escape($item->name); ?>
+                            </td>
+                            <?php foreach ($actions as $action) : ?>
+                                <?php
+                                $name  = $action[0];
+                                $check = $item->checks[$name];
+                                if ($check === true) :
+                                    $class  = 'text-success icon-check';
+                                    $button = 'btn-success';
+                                    $text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
+                                elseif ($check === false) :
+                                    $class  = 'text-danger icon-times';
+                                    $button = 'btn-danger';
+                                    $text   = Text::_('COM_USERS_DEBUG_EXPLICIT_DENY');
+                                elseif ($check === null) :
+                                    $class  = 'text-danger icon-minus-circle';
+                                    $button = 'btn-warning';
+                                    $text   = Text::_('COM_USERS_DEBUG_IMPLICIT_DENY');
+                                else :
+                                    $class  = '';
+                                    $button = '';
+                                    $text   = '';
+                                endif;
+                                ?>
+                            <td class="text-center">
+                                <span class="<?php echo $class; ?>" aria-hidden="true"></span>
+                                <span class="visually-hidden"> <?php echo $text; ?></span>
+                            </td>
+                            <?php endforeach; ?>
+                            <td>
+                                <?php echo (int) $item->lft; ?>
+                                - <?php echo (int) $item->rgt; ?>
+                            </td>
+                            <td>
+                                <?php echo (int) $item->id; ?>
+                            </td>
+                        </tr>
+                    <?php endforeach; ?>
+                </tbody>
+            </table>
 
-        <?php // load the pagination. ?>
-        <?php echo $this->pagination->getListFooter(); ?>
+            <div class="legend">
+                <span class="text-danger icon-minus-circle" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_IMPLICIT_DENY'); ?>&nbsp;
+                <span class="text-success icon-check" aria-hidden="true"></span>&nbsp;<?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW'); ?>&nbsp;
+                <span class="text-danger icon-times" aria-hidden="true">&nbsp;</span><?php echo Text::_('COM_USERS_DEBUG_EXPLICIT_DENY'); ?>
+            </div>
 
-        <input type="hidden" name="task" value="">
-        <input type="hidden" name="boxchecked" value="0">
-        <?php echo HTMLHelper::_('form.token'); ?>
+            <?php // load the pagination. ?>
+            <?php echo $this->pagination->getListFooter(); ?>
+
+            <input type="hidden" name="task" value="">
+            <input type="hidden" name="boxchecked" value="0">
+            <?php echo HTMLHelper::_('form.token'); ?>
+        <?php endif; ?>
     </div>
 </form>


### PR DESCRIPTION
Pull Request for Issue #38830 .

### Summary of Changes
Add a check for empty result array to user permissions table, like all other tables. 


### Testing Instructions
Open user permissions, filter for a permission level which has no results (in general >= 4


### Actual result BEFORE applying this Pull Request
see #38830


### Expected result AFTER applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/195872112-de18b7d8-ae8f-4228-8bf0-7115f58be47b.png)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
