### PR TITLE
Added class `previous` to the 'Previous' button.

### DIFF
--- a/plugins/content/pagenavigation/tmpl/default.php
+++ b/plugins/content/pagenavigation/tmpl/default.php
@@ -20,7 +20,7 @@ $lang = Factory::getLanguage(); ?>
     <span class="pagination ms-0">
     <?php if ($row->prev) :
         $direction = $lang->isRtl() ? 'right' : 'left'; ?>
-            <a class="btn btn-sm btn-secondary" href="<?php echo Route::_($row->prev); ?>" rel="prev">
+            <a class="btn btn-sm btn-secondary previous" href="<?php echo Route::_($row->prev); ?>" rel="prev">
             <span class="visually-hidden">
                 <?php echo Text::sprintf('JPREVIOUS_TITLE', htmlspecialchars($rows[$location - 1]->title)); ?>
             </span>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Added class `previous` to the 'Previous' button. Right now there is no additional class available for the 'Previous' button. 



### Testing Instructions
There will be a new class in the 'Previous' button. 



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request
One new class was added to the button. Functionally and visually there will be no changes. By using this new class, it will be be easier to write button specific styles easily.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
