### PR TITLE
Correct var type for $fieldCache

### DIFF
--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Fields\Administrator\Model\FieldsModel;
+use Joomla\Component\Fields\Administrator\Model\FieldModel;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -38,7 +39,7 @@ class FieldsHelper
     private static $fieldsCache = null;
 
     /**
-     * @var    FieldsModel
+     * @var    FieldModel
      */
     private static $fieldCache = null;
 


### PR DESCRIPTION
$fieldCache had invalid type of FieldsModel, should be FieldModel

### Summary of Changes
Added use and corrected var type


### Testing Instructions
Open FieldsHelper in yor favourite IDE (PHPStorm in my case)


### Actual result BEFORE applying this Pull Request
self::$fieldCache->getFieldValues (line 171) will show warning "Cannot find declaration of getFieldValues"


### Expected result AFTER applying this Pull Request
Declaration is found, you can click to go to it.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
