### PR TITLE
Bugfix for issue 38814

### DIFF
--- a/administrator/components/com_content/src/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/src/Field/Modal/ArticleField.php
@@ -124,10 +124,6 @@ class ArticleField extends FormField
                 Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
             }
             if (empty($title)) {
-                $allowClear = true;
-                $allowEdit = true;
-                $allowSelect = true;
-                $allowNew = true;
                 $value = '';
             }
         }

--- a/administrator/components/com_content/src/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/src/Field/Modal/ArticleField.php
@@ -123,6 +123,13 @@ class ArticleField extends FormField
             } catch (\RuntimeException $e) {
                 Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
             }
+            if (empty($title)) {
+                $allowClear = true;
+                $allowEdit = true;
+                $allowSelect = true;
+                $allowNew = true;
+                $value = '';
+            }
         }
 
         $title = empty($title) ? Text::_('COM_CONTENT_SELECT_AN_ARTICLE') : htmlspecialchars($title, ENT_QUOTES, 'UTF-8');


### PR DESCRIPTION
Pull Request for Issue # 38814
If an article is deleted completely and it is used in a Single Article Menu item then while editing this menu item it is wrongly considered that the article still exits which lead to a wrong modal window when clicking on Edit. The Edit button should no be there

Buttons in the modal window without function #38814 

### Summary of Changes
in getInput check if article exists with title, change allowed actions to the ones if there was no article

### Testing Instructions (taken from #38814)

    I create a menu item (single article) and select an existing article.
    Then I delete the article (also from the recycle bin)
    In the menu management I would now like to select a new article, but at the end it says "Edit" instead of "Select":


### Actual result BEFORE applying this Pull Request

'Edit' Button is there

### Expected result AFTER applying this Pull Request

The 'Select' and the 'Create' Button are there instead

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x ] No documentation changes for manual.joomla.org needed
