### PR TITLE
Child Templates html directory

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1935,7 +1935,7 @@ class TemplateModel extends FormModel
 
         $files = $xml->addChild('files');
         $files->addChild('filename', 'templateDetails.xml');
-        $files->addChild('folder','html');
+        $files->addChild('folder', 'html');
 
         // Media folder
         $media = $xml->addChild('media');

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1875,6 +1875,9 @@ class TemplateModel extends FormModel
             }
         }
 
+        // Create the html folder
+        Folder::create($toPath . '/html');
+
         // Copy the template definition from the parent template
         if (!File::copy($fromPath, $toPath . '/templateDetails.xml')) {
             return false;
@@ -1932,6 +1935,7 @@ class TemplateModel extends FormModel
 
         $files = $xml->addChild('files');
         $files->addChild('filename', 'templateDetails.xml');
+        $files->addChild('folder','html');
 
         // Media folder
         $media = $xml->addChild('media');
@@ -1940,7 +1944,6 @@ class TemplateModel extends FormModel
         $media->addChild('folder', 'css');
         $media->addChild('folder', 'js');
         $media->addChild('folder', 'images');
-        $media->addChild('folder', 'html');
         $media->addChild('folder', 'scss');
 
         $xml->name = $template->element . '_' . $newName;
@@ -1966,7 +1969,6 @@ class TemplateModel extends FormModel
             || !Folder::create($toPath . '/media/css')
             || !Folder::create($toPath . '/media/js')
             || !Folder::create($toPath . '/media/images')
-            || !Folder::create($toPath . '/media/html/tinymce')
             || !Folder::create($toPath . '/media/scss')
         ) {
             return false;


### PR DESCRIPTION
### Summary of Changes
when creating a child template it is incorrectly creating the html directory as a subdirectory of media - it should be /templates/childname/html - you can verify that by creating a template override and observing where the files are created.

the templateDetails.xml is also incorrect for the same reason


### Testing Instructions
Create a child template.


### Actual result BEFORE applying this Pull Request
You will see the child template has no template subdirectories and has a media/html subdirectoy
Check the templateDetails.xml and you will see

```
		<filename>templateDetails.xml</filename>
		<folder>html</folder>
	</files>
	<media destination="templates/site/cassiopeia" folder="media">
		<folder>js</folder>
		<folder>css</folder>
		<folder>scss</folder>
		<folder>images</folder>
	</media>
```

![image](https://user-images.githubusercontent.com/1296369/196300591-c56bd92c-8053-403d-bed4-f7211f95694f.png)



### Expected result AFTER applying this Pull Request
You will see the child template has a template/html subdirectory and no media/html subdirectoy
Check the templateDetails.xml and you will see
```

  <files>
    <filename>templateDetails.xml</filename>
    <folder>html</folder>
  </files>
  <media folder="media" destination="templates/site/cassiopeia_after_pr">
    <folder>css</folder>
    <folder>js</folder>
    <folder>images</folder>
    <folder>scss</folder>
  </media>

![image](https://user-images.githubusercontent.com/1296369/196300773-4496ca7f-f5bc-4520-ab88-310941a2b310.png)

```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
