### PR TITLE
Update OutputFilter.php

### DIFF
--- a/libraries/vendor/joomla/filter/src/OutputFilter.php
+++ b/libraries/vendor/joomla/filter/src/OutputFilter.php
@@ -8,7 +8,7 @@
 
 namespace Joomla\Filter;
 
-use Joomla\Language\Language;
+use Joomla\CMS\Language\Language;
 use Joomla\String\StringHelper;
 
 /**


### PR DESCRIPTION
I couldn't force to work OutputFilter::stringUrlSafe. But after this correction of namespace I get correct alias from cyrillic title. It was 500 error in string 102 for Language::getInstance();
I found this path in Joomla Docu 

Pull Request for Issue # .

### Summary of Changes
Corrected namespace for Language


### Testing Instructions
Try to transliterate some cyrillic string by Output filter. For example:
```
use Joomla\Filter\OutputFilter;

$text = OutputFilter::stringUrlSafe('Тест',  'ru-RU');
```


### Actual result BEFORE applying this Pull Request
Error 500


### Expected result AFTER applying this Pull Request

```$text='test';```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ *] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [* ] No documentation changes for manual.joomla.org needed
