### PR TITLE
onContentPrepare for com_xxx.categories custom fields load

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -444,6 +444,11 @@ class PlgSystemFields extends CMSPlugin
             return;
         }
 
+        // If we have a category, set the catid field to fetch only the fields which belong to it
+        if ($parts[1] === 'categories' && !isset($item->catid)) {
+            $item->catid = $item->id;
+        }
+
         $context = $parts[0] . '.' . $parts[1];
 
         // Convert tags


### PR DESCRIPTION
### Summary of Changes

Auto-add `catid` property for `com_xxx.categories` context on `onContentPrepare` event.

It's already done in `PlgSystemFields::onContentAfterTitle()`, `PlgSystemFields::onContentBeforeDisplay()` and , `PlgSystemFields::onContentAfterDisplay()` which all use `PlgSystemFields::display()` method with:

```
        // If we have a category, set the catid field to fetch only the fields which belong to it
        if ($parts[1] === 'categories' && !isset($item->catid)) {
            $item->catid = $item->id;
        }
```

Otherwise, `FieldsHelper::getFields()` doesn't apply `filter.assigned_cat_ids` state on fields model, it results on extra database query and actually all fields applied in this event.

### Testing Instructions

Assign custom field to only specific category, insert field value into category description.

Also test database queries for blog articles layout when category description is displayed and there are category custom fields.

See 4 events triggered on the category in `components/com_content/tmpl/category/blog.php`, they should all use the single fields load while actually we have too because the `onContentPrepare` event is not loading fields with `filter.assigned_cat_ids` model state:

```
$this->category->text = $this->category->description;
$app->triggerEvent('onContentPrepare', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
$this->category->description = $this->category->text;

$results = $app->triggerEvent('onContentAfterTitle', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
$afterDisplayTitle = trim(implode("\n", $results));

$results = $app->triggerEvent('onContentBeforeDisplay', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
$beforeDisplayContent = trim(implode("\n", $results));

$results = $app->triggerEvent('onContentAfterDisplay', array($this->category->extension . '.categories', &$this->category, &$this->params, 0));
$afterDisplayContent = trim(implode("\n", $results));
```

### Actual result BEFORE applying this Pull Request

See field value in all categories, extra database query for fields load without `filter.assigned_cat_ids` model state.

### Expected result AFTER applying this Pull Request

Field value only in field-specific category, all events for the category text are using the single load of fields for this category.

