### PR TITLE
Renovatebot: Only do security updates on 4.2-dev

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,6 +11,16 @@
   "composerIgnorePlatformReqs": ["ext-*", "lib-*"],
   "rangeStrategy": "update-lockfile",
   "baseBranches": ["4.2-dev", "4.3-dev", "5.0-dev"],
+  "packageRules": [
+    {
+      "enabled": false,
+      "matchBaseBranches": "4.2-dev",
+      "matchPackagePatterns": ["*"]
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "enabled": true
+  },
   "constraints": {
     "composer": "> 2.3",
     "npm": "> 8.0"


### PR DESCRIPTION
According to https://github.com/renovatebot/renovate/discussions/15490#discussioncomment-2702421 this should force Renovatebot to only do security updates for the 4.2-dev branch and still do normal dependency updates for everything else.