### PR TITLE
[4.3] Change application input access to getInput

### DIFF
--- a/administrator/components/com_admin/src/Model/HelpModel.php
+++ b/administrator/components/com_admin/src/Model/HelpModel.php
@@ -78,7 +78,7 @@ class HelpModel extends BaseDatabaseModel
     public function &getHelpSearch()
     {
         if (\is_null($this->help_search)) {
-            $this->help_search = Factory::getApplication()->input->getString('helpsearch');
+            $this->help_search = Factory::getApplication()->getInput()->getString('helpsearch');
         }
 
         return $this->help_search;
@@ -94,7 +94,7 @@ class HelpModel extends BaseDatabaseModel
     public function &getPage()
     {
         if (\is_null($this->page)) {
-            $this->page = Help::createUrl(Factory::getApplication()->input->get('page', 'Start_Here'));
+            $this->page = Help::createUrl(Factory::getApplication()->getInput()->get('page', 'Start_Here'));
         }
 
         return $this->page;

--- a/administrator/components/com_associations/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_associations/layouts/joomla/searchtools/default.php
@@ -83,7 +83,7 @@ HTMLHelper::_('searchtools.form', $data['options']['formSelector'], $data['optio
 <div class="js-stools" role="search">
     <?php // Add the itemtype and language selectors before the form filters. Do not display in modal. ?>
     <?php $app = Factory::getApplication(); ?>
-    <?php if ($app->input->get('forcedItemType', '', 'string') == '') : ?>
+    <?php if ($app->getInput()->get('forcedItemType', '', 'string') == '') : ?>
         <?php $itemTypeField = $data['view']->filterForm->getField('itemtype'); ?>
         <div class="js-stools-container-selector">
             <div class="js-stools-field-selector js-stools-itemtype">
@@ -92,7 +92,7 @@ HTMLHelper::_('searchtools.form', $data['options']['formSelector'], $data['optio
             </div>
         </div>
     <?php endif; ?>
-    <?php if ($app->input->get('forcedLanguage', '', 'cmd') == '') : ?>
+    <?php if ($app->getInput()->get('forcedLanguage', '', 'cmd') == '') : ?>
         <?php $languageField = $data['view']->filterForm->getField('language'); ?>
         <div class="js-stools-container-selector">
             <div class="js-stools-field-selector js-stools-language">

--- a/administrator/components/com_associations/src/Field/ItemlanguageField.php
+++ b/administrator/components/com_associations/src/Field/ItemlanguageField.php
@@ -44,7 +44,7 @@ class ItemlanguageField extends ListField
      */
     protected function getOptions()
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         list($extensionName, $typeName) = explode('.', $input->get('itemtype', '', 'string'), 2);
 

--- a/administrator/components/com_associations/src/Field/Modal/AssociationField.php
+++ b/administrator/components/com_associations/src/Field/Modal/AssociationField.php
@@ -58,7 +58,7 @@ class AssociationField extends FormField
         $html = array();
 
         $linkAssociations = 'index.php?option=com_associations&amp;view=associations&amp;layout=modal&amp;tmpl=component'
-            . '&amp;forcedItemType=' . Factory::getApplication()->input->get('itemtype', '', 'string') . '&amp;function=jSelectAssociation_' . $this->id;
+            . '&amp;forcedItemType=' . Factory::getApplication()->getInput()->get('itemtype', '', 'string') . '&amp;function=jSelectAssociation_' . $this->id;
 
         $linkAssociations .= "&amp;forcedLanguage=' + document.getElementById('target-association').getAttribute('data-language') + '";
 

--- a/administrator/components/com_associations/src/Model/AssociationsModel.php
+++ b/administrator/components/com_associations/src/Model/AssociationsModel.php
@@ -79,11 +79,11 @@ class AssociationsModel extends ListModel
     {
         $app = Factory::getApplication();
 
-        $forcedLanguage = $app->input->get('forcedLanguage', '', 'cmd');
-        $forcedItemType = $app->input->get('forcedItemType', '', 'string');
+        $forcedLanguage = $app->getInput()->get('forcedLanguage', '', 'cmd');
+        $forcedItemType = $app->getInput()->get('forcedItemType', '', 'string');
 
         // Adjust the context to support modal layouts.
-        if ($layout = $app->input->get('layout')) {
+        if ($layout = $app->getInput()->get('layout')) {
             $this->context .= '.' . $layout;
         }
 

--- a/administrator/components/com_associations/src/View/Association/HtmlView.php
+++ b/administrator/components/com_associations/src/View/Association/HtmlView.php
@@ -234,7 +234,7 @@ class HtmlView extends BaseHtmlView
         $this->app  = Factory::getApplication();
         $this->form = $model->getForm();
         /** @var Input $input */
-        $input             = $this->app->input;
+        $input             = $this->app->getInput();
         $this->referenceId = $input->get('id', 0, 'int');
 
         [$extensionName, $typeName] = explode('.', $input->get('itemtype', '', 'string'), 2);
@@ -339,7 +339,7 @@ class HtmlView extends BaseHtmlView
     protected function addToolbar(): void
     {
         // Hide main menu.
-        $this->app->input->set('hidemainmenu', 1);
+        $this->app->getInput()->set('hidemainmenu', 1);
 
         $helper = AssociationsHelper::getExtensionHelper($this->extensionName);
         $title  = $helper->getTypeTitle($this->typeName);

--- a/administrator/components/com_associations/src/View/Associations/HtmlView.php
+++ b/administrator/components/com_associations/src/View/Associations/HtmlView.php
@@ -155,7 +155,7 @@ class HtmlView extends BaseHtmlView
 
                     if ($this->getLayout() == 'modal') {
                         // We need to change the category filter to only show categories tagged to All or to the forced language.
-                        if ($forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'CMD')) {
+                        if ($forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD')) {
                             $this->filterForm->setFieldAttribute('category_id', 'language', '*,' . $forcedLanguage, 'filter');
                         }
                     }

--- a/administrator/components/com_associations/tmpl/association/edit.php
+++ b/administrator/components/com_associations/tmpl/association/edit.php
@@ -25,7 +25,7 @@ $wa->useScript('keepalive')
     ->useScript('webcomponent.core-loader');
 
 $options = [
-    'layout'   => $this->app->input->get('layout', '', 'string'),
+    'layout'   => $this->app->getInput()->get('layout', '', 'string'),
     'itemtype' => $this->itemType,
     'id'       => $this->referenceId,
 ];

--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -29,7 +29,7 @@ $wa = $this->document->getWebAssetManager();
 $wa->useScript('multiselect')
     ->useScript('com_associations.admin-associations-modal');
 
-$function         = $app->input->getCmd('function', 'jSelectAssociation');
+$function         = $app->getInput()->getCmd('function', 'jSelectAssociation');
 $listOrder        = $this->escape($this->state->get('list.ordering'));
 $listDirn         = $this->escape($this->state->get('list.direction'));
 $canManageCheckin = Factory::getUser()->authorise('core.manage', 'com_checkin');
@@ -163,8 +163,8 @@ $this->document->addScriptOptions('associations-modal', ['func' => $function]);
         <?php endif; ?>
 
         <input type="hidden" name="task" value="">
-        <input type="hidden" name="forcedItemType" value="<?php echo $app->input->get('forcedItemType', '', 'string'); ?>">
-        <input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'cmd'); ?>">
+        <input type="hidden" name="forcedItemType" value="<?php echo $app->getInput()->get('forcedItemType', '', 'string'); ?>">
+        <input type="hidden" name="forcedLanguage" value="<?php echo $app->getInput()->get('forcedLanguage', '', 'cmd'); ?>">
         <?php echo HTMLHelper::_('form.token'); ?>
     </form>
 </div>

--- a/administrator/components/com_banners/src/Model/BannerModel.php
+++ b/administrator/components/com_banners/src/Model/BannerModel.php
@@ -234,7 +234,7 @@ class BannerModel extends AdminModel
                 $filters     = (array) $app->getUserState('com_banners.banners.filter');
                 $filterCatId = $filters['category_id'] ?? null;
 
-                $data->set('catid', $app->input->getInt('catid', $filterCatId));
+                $data->set('catid', $app->getInput()->getInt('catid', $filterCatId));
             }
         }
 
@@ -374,7 +374,7 @@ class BannerModel extends AdminModel
      */
     public function save($data)
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         // Create new category, if needed.
         $createCategory = true;

--- a/administrator/components/com_banners/src/Model/DownloadModel.php
+++ b/administrator/components/com_banners/src/Model/DownloadModel.php
@@ -43,7 +43,7 @@ class DownloadModel extends FormModel
      */
     protected function populateState()
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         $this->setState('basename', $input->cookie->getString(ApplicationHelper::getHash($this->_context . '.basename'), '__SITE__'));
         $this->setState('compressed', $input->cookie->getInt(ApplicationHelper::getHash($this->_context . '.compressed'), 1));

--- a/administrator/components/com_banners/src/View/Banner/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Banner/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();
         $userId     = $user->id;

--- a/administrator/components/com_banners/src/View/Client/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Client/HtmlView.php
@@ -106,7 +106,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar(): void
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();
         $isNew      = ($this->item->id == 0);

--- a/administrator/components/com_categories/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_categories/src/Dispatcher/Dispatcher.php
@@ -31,7 +31,7 @@ class Dispatcher extends ComponentDispatcher
      */
     protected function checkAccess()
     {
-        $extension = $this->getApplication()->input->getCmd('extension');
+        $extension = $this->getApplication()->getInput()->getCmd('extension');
 
         $parts = explode('.', $extension);
 

--- a/administrator/components/com_categories/src/Field/CategoryeditField.php
+++ b/administrator/components/com_categories/src/Field/CategoryeditField.php
@@ -150,7 +150,7 @@ class CategoryeditField extends ListField
         $name = (string) $this->element['name'];
 
         // Let's get the id for the current item, either category or content item.
-        $jinput = Factory::getApplication()->input;
+        $jinput = Factory::getApplication()->getInput();
 
         // Load the category options for a given extension.
 

--- a/administrator/components/com_categories/src/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/src/Field/Modal/CategoryField.php
@@ -49,7 +49,7 @@ class CategoryField extends FormField
         if ($this->element['extension']) {
             $extension = (string) $this->element['extension'];
         } else {
-            $extension = (string) Factory::getApplication()->input->get('extension', 'com_content');
+            $extension = (string) Factory::getApplication()->getInput()->get('extension', 'com_content');
         }
 
         $allowNew       = ((string) $this->element['new'] == 'true');

--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -92,10 +92,10 @@ class CategoriesModel extends ListModel
     {
         $app = Factory::getApplication();
 
-        $forcedLanguage = $app->input->get('forcedLanguage', '', 'cmd');
+        $forcedLanguage = $app->getInput()->get('forcedLanguage', '', 'cmd');
 
         // Adjust the context to support modal layouts.
-        if ($layout = $app->input->get('layout')) {
+        if ($layout = $app->getInput()->get('layout')) {
             $this->context .= '.' . $layout;
         }
 

--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -89,7 +89,7 @@ class CategoryModel extends AdminModel
      */
     public function __construct($config = array(), MVCFactoryInterface $factory = null)
     {
-        $extension = Factory::getApplication()->input->get('extension', 'com_content');
+        $extension = Factory::getApplication()->getInput()->get('extension', 'com_content');
         $this->typeAlias = $extension . '.category';
 
         // Add a new batch command
@@ -172,14 +172,14 @@ class CategoryModel extends AdminModel
     {
         $app = Factory::getApplication();
 
-        $parentId = $app->input->getInt('parent_id');
+        $parentId = $app->getInput()->getInt('parent_id');
         $this->setState('category.parent_id', $parentId);
 
         // Load the User state.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
         $this->setState($this->getName() . '.id', $pk);
 
-        $extension = $app->input->get('extension', 'com_content');
+        $extension = $app->getInput()->get('extension', 'com_content');
         $this->setState('category.extension', $extension);
         $parts = explode('.', $extension);
 
@@ -248,7 +248,7 @@ class CategoryModel extends AdminModel
     public function getForm($data = array(), $loadData = true)
     {
         $extension = $this->getState('category.extension');
-        $jinput = Factory::getApplication()->input;
+        $jinput = Factory::getApplication()->getInput();
 
         // A workaround to get the extension into the model for save requests.
         if (empty($extension) && isset($data['extension'])) {
@@ -338,15 +338,15 @@ class CategoryModel extends AdminModel
 
                 $data->set(
                     'published',
-                    $app->input->getInt(
+                    $app->getInput()->getInt(
                         'published',
                         ((isset($filters['published']) && $filters['published'] !== '') ? $filters['published'] : null)
                     )
                 );
-                $data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+                $data->set('language', $app->getInput()->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
                 $data->set(
                     'access',
-                    $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
+                    $app->getInput()->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
                 );
             }
         }
@@ -400,7 +400,7 @@ class CategoryModel extends AdminModel
         $lang = Factory::getLanguage();
         $component = $this->getState('category.component');
         $section = $this->getState('category.section');
-        $extension = Factory::getApplication()->input->get('extension', null);
+        $extension = Factory::getApplication()->getInput()->get('extension', null);
 
         // Get the component form if it exists
         $name = 'category' . ($section ? ('.' . $section) : '');
@@ -508,7 +508,7 @@ class CategoryModel extends AdminModel
     public function save($data)
     {
         $table      = $this->getTable();
-        $input      = Factory::getApplication()->input;
+        $input      = Factory::getApplication()->getInput();
         $pk         = (!empty($data['id'])) ? $data['id'] : (int) $this->getState($this->getName() . '.id');
         $isNew      = true;
         $context    = $this->option . '.' . $this->name;
@@ -714,7 +714,7 @@ class CategoryModel extends AdminModel
 
         $this->setState($this->getName() . '.id', $table->id);
 
-        if (Factory::getApplication()->input->get('task') == 'editAssociations') {
+        if (Factory::getApplication()->getInput()->get('task') == 'editAssociations') {
             return $this->redirectToAssociations($data);
         }
 
@@ -737,7 +737,7 @@ class CategoryModel extends AdminModel
     public function publish(&$pks, $value = 1)
     {
         if (parent::publish($pks, $value)) {
-            $extension = Factory::getApplication()->input->get('extension');
+            $extension = Factory::getApplication()->getInput()->get('extension');
 
             // Include the content plugins for the change of category state event.
             PluginHelper::importPlugin('content');
@@ -874,7 +874,7 @@ class CategoryModel extends AdminModel
         $parentId = (int) ArrayHelper::getValue($parts, 0, 1);
 
         $db = $this->getDatabase();
-        $extension = Factory::getApplication()->input->get('extension', '', 'word');
+        $extension = Factory::getApplication()->getInput()->get('extension', '', 'word');
         $newIds = array();
 
         // Check that the parent exists
@@ -1077,7 +1077,7 @@ class CategoryModel extends AdminModel
 
         $db = $this->getDatabase();
         $query = $db->getQuery(true);
-        $extension = Factory::getApplication()->input->get('extension', '', 'word');
+        $extension = Factory::getApplication()->getInput()->get('extension', '', 'word');
 
         // Check that the parent exists.
         if ($parentId) {
@@ -1202,7 +1202,7 @@ class CategoryModel extends AdminModel
      */
     protected function cleanCache($group = null, $clientId = 0)
     {
-        $extension = Factory::getApplication()->input->get('extension');
+        $extension = Factory::getApplication()->getInput()->get('extension');
 
         switch ($extension) {
             case 'com_content':

--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -127,7 +127,7 @@ class HtmlView extends BaseHtmlView
             }
         } else {
             // In article associations modal we need to remove language filter if forcing a language.
-            if ($forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'CMD')) {
+            if ($forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD')) {
                 // If the language is forced we can't allow to select the language, so transform the language selector filter into a hidden field.
                 $languageXml = new \SimpleXMLElement('<field name="language" type="hidden" default="' . $forcedLanguage . '" />');
                 $this->filterForm->setField($languageXml, 'filter', true);

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -102,10 +102,10 @@ class HtmlView extends BaseHtmlView
             $this->checkTags = true;
         }
 
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         // If we are forcing a language in modal (used for associations).
-        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'cmd')) {
+        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'cmd')) {
             // Set the language field to the forcedLanguage and disable changing it.
             $this->form->setValue('language', null, $forcedLanguage);
             $this->form->setFieldAttribute('language', 'readonly', 'true');
@@ -131,7 +131,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        $extension = Factory::getApplication()->input->get('extension');
+        $extension = Factory::getApplication()->getInput()->get('extension');
         $user = $this->getCurrentUser();
         $userId = $user->id;
 

--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -28,7 +28,7 @@ if ($app->isClient('site')) {
 HTMLHelper::_('behavior.core');
 
 $extension = $this->escape($this->state->get('filter.extension'));
-$function  = $app->input->getCmd('function', 'jSelectCategory');
+$function  = $app->getInput()->getCmd('function', 'jSelectCategory');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 ?>
@@ -132,7 +132,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
         <input type="hidden" name="extension" value="<?php echo $extension; ?>">
         <input type="hidden" name="task" value="">
         <input type="hidden" name="boxchecked" value="0">
-        <input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>">
+        <input type="hidden" name="forcedLanguage" value="<?php echo $app->getInput()->get('forcedLanguage', '', 'CMD'); ?>">
         <?php echo HTMLHelper::_('form.token'); ?>
 
     </form>

--- a/administrator/components/com_categories/tmpl/category/edit.php
+++ b/administrator/components/com_categories/tmpl/category/edit.php
@@ -24,7 +24,7 @@ $wa->useScript('keepalive')
     ->useScript('form.validate');
 
 $app = Factory::getApplication();
-$input = $app->input;
+$input = $app->getInput();
 
 $assoc = Associations::isEnabled();
 // Are associations implemented for this extension?

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -846,16 +846,17 @@ class ApplicationModel extends FormModel
     public function storePermissions($permission = null)
     {
         $app  = Factory::getApplication();
+        $input = $app->getInput();
         $user = $this->getCurrentUser();
 
         if (is_null($permission)) {
             // Get data from input.
             $permission = array(
-                'component' => $app->getInput()->Json->get('comp'),
-                'action'    => $app->getInput()->Json->get('action'),
-                'rule'      => $app->getInput()->Json->get('rule'),
-                'value'     => $app->getInput()->Json->get('value'),
-                'title'     => $app->getInput()->Json->get('title', '', 'RAW')
+                'component' => $input->Json->get('comp'),
+                'action'    => $input->Json->get('action'),
+                'rule'      => $input->Json->get('rule'),
+                'value'     => $input->Json->get('value'),
+                'title'     => $input->Json->get('title', '', 'RAW')
             );
         }
 

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -851,11 +851,11 @@ class ApplicationModel extends FormModel
         if (is_null($permission)) {
             // Get data from input.
             $permission = array(
-                'component' => $app->input->Json->get('comp'),
-                'action'    => $app->input->Json->get('action'),
-                'rule'      => $app->input->Json->get('rule'),
-                'value'     => $app->input->Json->get('value'),
-                'title'     => $app->input->Json->get('title', '', 'RAW')
+                'component' => $app->getInput()->Json->get('comp'),
+                'action'    => $app->getInput()->Json->get('action'),
+                'rule'      => $app->getInput()->Json->get('rule'),
+                'value'     => $app->getInput()->Json->get('value'),
+                'title'     => $app->getInput()->Json->get('title', '', 'RAW')
             );
         }
 
@@ -1174,7 +1174,7 @@ class ApplicationModel extends FormModel
         // Set the new values to test with the current settings
         $app = Factory::getApplication();
         $user = $this->getCurrentUser();
-        $input = $app->input->json;
+        $input = $app->getInput()->json;
         $smtppass = $input->get('smtppass', null, 'RAW');
 
         $app->set('smtpauth', $input->get('smtpauth'));

--- a/administrator/components/com_config/src/Model/ComponentModel.php
+++ b/administrator/components/com_config/src/Model/ComponentModel.php
@@ -43,7 +43,7 @@ class ComponentModel extends FormModel
      */
     protected function populateState()
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         // Set the component (option) we are dealing with.
         $component = $input->get('component');

--- a/administrator/components/com_config/src/View/Component/HtmlView.php
+++ b/administrator/components/com_config/src/View/Component/HtmlView.php
@@ -92,8 +92,8 @@ class HtmlView extends BaseHtmlView
         $this->components = ConfigHelper::getComponentsWithConfig();
 
         $this->userIsSuperAdmin = $user->authorise('core.admin');
-        $this->currentComponent = Factory::getApplication()->input->get('component');
-        $this->return = Factory::getApplication()->input->get('return', '', 'base64');
+        $this->currentComponent = Factory::getApplication()->getInput()->get('component');
+        $this->return = Factory::getApplication()->getInput()->get('return', '', 'base64');
 
         $this->addToolbar();
 

--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -258,7 +258,7 @@ class ContactModel extends AdminModel
 
             // Prime some default values.
             if ($this->getState('contact.id') == 0) {
-                $data->set('catid', $app->input->get('catid', $app->getUserState('com_contact.contacts.filter.category_id'), 'int'));
+                $data->set('catid', $app->getInput()->get('catid', $app->getUserState('com_contact.contacts.filter.category_id'), 'int'));
             }
         }
 
@@ -278,7 +278,7 @@ class ContactModel extends AdminModel
      */
     public function save($data)
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         // Create new category, if needed.
         $createCategory = true;

--- a/administrator/components/com_contact/src/Model/ContactsModel.php
+++ b/administrator/components/com_contact/src/Model/ContactsModel.php
@@ -84,10 +84,10 @@ class ContactsModel extends ListModel
     {
         $app = Factory::getApplication();
 
-        $forcedLanguage = $app->input->get('forcedLanguage', '', 'cmd');
+        $forcedLanguage = $app->getInput()->get('forcedLanguage', '', 'cmd');
 
         // Adjust the context to support modal layouts.
-        if ($layout = $app->input->get('layout')) {
+        if ($layout = $app->getInput()->get('layout')) {
             $this->context .= '.' . $layout;
         }
 

--- a/administrator/components/com_contact/src/View/Contact/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contact/HtmlView.php
@@ -72,7 +72,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // If we are forcing a language in modal (used for associations).
-        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'cmd')) {
+        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'cmd')) {
             // Set the language field to the forcedLanguage and disable changing it.
             $this->form->setValue('language', null, $forcedLanguage);
             $this->form->setFieldAttribute('language', 'readonly', 'true');
@@ -98,7 +98,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();
         $userId     = $user->id;

--- a/administrator/components/com_contact/src/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contacts/HtmlView.php
@@ -117,7 +117,7 @@ class HtmlView extends BaseHtmlView
         } else {
             // In article associations modal we need to remove language filter if forcing a language.
             // We also need to change the category filter to show show categories with All or the forced language.
-            if ($forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'CMD')) {
+            if ($forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD')) {
                 // If the language is forced we can't allow to select the language, so transform the language selector filter into a hidden field.
                 $languageXml = new \SimpleXMLElement('<field name="language" type="hidden" default="' . $forcedLanguage . '" />');
                 $this->filterForm->setField($languageXml, 'filter', true);

--- a/administrator/components/com_contact/tmpl/contact/edit.php
+++ b/administrator/components/com_contact/tmpl/contact/edit.php
@@ -23,7 +23,7 @@ $wa->useScript('keepalive')
     ->useScript('form.validate');
 
 $app = Factory::getApplication();
-$input = $app->input;
+$input = $app->getInput();
 
 $assoc = Associations::isEnabled();
 

--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -29,8 +29,8 @@ if ($app->isClient('site')) {
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_contact.admin-contacts-modal');
 
-$function  = $app->input->getCmd('function', 'jSelectContact');
-$editor    = $app->input->getCmd('editor', '');
+$function  = $app->getInput()->getCmd('function', 'jSelectContact');
+$editor    = $app->getInput()->getCmd('editor', '');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $onclick   = $this->escape($function);
@@ -148,7 +148,7 @@ if (!empty($editor)) {
         <?php endif; ?>
 
         <input type="hidden" name="task" value="">
-        <input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>">
+        <input type="hidden" name="forcedLanguage" value="<?php echo $app->getInput()->get('forcedLanguage', '', 'CMD'); ?>">
         <?php echo HTMLHelper::_('form.token'); ?>
 
     </form>

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -474,8 +474,8 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 
         // Get ID of the article from input, for frontend, we use a_id while backend uses id
         $articleIdFromInput = $app->isClient('site')
-            ? $app->input->getInt('a_id', 0)
-            : $app->input->getInt('id', 0);
+            ? $app->getInput()->getInt('a_id', 0)
+            : $app->getInput()->getInt('id', 0);
 
         // On edit article, we get ID of article from article.id state, but on save, we use data from input
         $id = (int) $this->getState('article.id', $articleIdFromInput);
@@ -581,20 +581,20 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
                 $filters = (array) $app->getUserState('com_content.articles.filter');
                 $data->set(
                     'state',
-                    $app->input->getInt(
+                    $app->getInput()->getInt(
                         'state',
                         ((isset($filters['published']) && $filters['published'] !== '') ? $filters['published'] : null)
                     )
                 );
-                $data->set('catid', $app->input->getInt('catid', (!empty($filters['category_id']) ? $filters['category_id'] : null)));
+                $data->set('catid', $app->getInput()->getInt('catid', (!empty($filters['category_id']) ? $filters['category_id'] : null)));
 
                 if ($app->isClient('administrator')) {
-                    $data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+                    $data->set('language', $app->getInput()->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
                 }
 
                 $data->set(
                     'access',
-                    $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
+                    $app->getInput()->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
                 );
             }
         }
@@ -645,7 +645,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
     public function save($data)
     {
         $app    = Factory::getApplication();
-        $input  = $app->input;
+        $input  = $app->getInput();
         $filter = InputFilter::getInstance();
 
         if (isset($data['metadata']) && isset($data['metadata']['author'])) {

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -127,10 +127,10 @@ class ArticlesModel extends ListModel
     {
         $app = Factory::getApplication();
 
-        $forcedLanguage = $app->input->get('forcedLanguage', '', 'cmd');
+        $forcedLanguage = $app->getInput()->get('forcedLanguage', '', 'cmd');
 
         // Adjust the context to support modal layouts.
-        if ($layout = $app->input->get('layout')) {
+        if ($layout = $app->getInput()->get('layout')) {
             $this->context .= '.' . $layout;
         }
 
@@ -154,7 +154,7 @@ class ArticlesModel extends ListModel
         $language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '');
         $this->setState('filter.language', $language);
 
-        $formSubmitted = $app->input->post->get('form_submitted');
+        $formSubmitted = $app->getInput()->post->get('form_submitted');
 
         // Gets the value of a user state variable and sets it in the session
         $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access');
@@ -163,16 +163,16 @@ class ArticlesModel extends ListModel
         $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '');
 
         if ($formSubmitted) {
-            $access = $app->input->post->get('access');
+            $access = $app->getInput()->post->get('access');
             $this->setState('filter.access', $access);
 
-            $authorId = $app->input->post->get('author_id');
+            $authorId = $app->getInput()->post->get('author_id');
             $this->setState('filter.author_id', $authorId);
 
-            $categoryId = $app->input->post->get('category_id');
+            $categoryId = $app->getInput()->post->get('category_id');
             $this->setState('filter.category_id', $categoryId);
 
-            $tag = $app->input->post->get('tag');
+            $tag = $app->getInput()->post->get('tag');
             $this->setState('filter.tag', $tag);
         }
 

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -125,12 +125,13 @@ class ArticlesModel extends ListModel
      */
     protected function populateState($ordering = 'a.id', $direction = 'desc')
     {
-        $app = Factory::getApplication();
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
 
-        $forcedLanguage = $app->getInput()->get('forcedLanguage', '', 'cmd');
+        $forcedLanguage = $input->get('forcedLanguage', '', 'cmd');
 
         // Adjust the context to support modal layouts.
-        if ($layout = $app->getInput()->get('layout')) {
+        if ($layout = $input->get('layout')) {
             $this->context .= '.' . $layout;
         }
 
@@ -154,7 +155,7 @@ class ArticlesModel extends ListModel
         $language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '');
         $this->setState('filter.language', $language);
 
-        $formSubmitted = $app->getInput()->post->get('form_submitted');
+        $formSubmitted = $input->post->get('form_submitted');
 
         // Gets the value of a user state variable and sets it in the session
         $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access');
@@ -163,16 +164,16 @@ class ArticlesModel extends ListModel
         $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '');
 
         if ($formSubmitted) {
-            $access = $app->getInput()->post->get('access');
+            $access = $input->post->get('access');
             $this->setState('filter.access', $access);
 
-            $authorId = $app->getInput()->post->get('author_id');
+            $authorId = $input->post->get('author_id');
             $this->setState('filter.author_id', $authorId);
 
-            $categoryId = $app->getInput()->post->get('category_id');
+            $categoryId = $input->post->get('category_id');
             $this->setState('filter.category_id', $categoryId);
 
-            $tag = $app->getInput()->post->get('tag');
+            $tag = $input->post->get('tag');
             $this->setState('filter.tag', $tag);
         }
 

--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -99,7 +99,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // If we are forcing a language in modal (used for associations).
-        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'cmd')) {
+        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'cmd')) {
             // Set the language field to the forcedLanguage and disable changing it.
             $this->form->setValue('language', null, $forcedLanguage);
             $this->form->setFieldAttribute('language', 'readonly', 'true');
@@ -127,7 +127,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
         $user       = $this->getCurrentUser();
         $userId     = $user->id;
         $isNew      = ($this->item->id == 0);

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -127,7 +127,7 @@ class HtmlView extends BaseHtmlView
         } else {
             // In article associations modal we need to remove language filter if forcing a language.
             // We also need to change the category filter to show show categories with All or the forced language.
-            if ($forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'CMD')) {
+            if ($forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD')) {
                 // If the language is forced we can't allow to select the language, so transform the language selector filter into a hidden field.
                 $languageXml = new \SimpleXMLElement('<field name="language" type="hidden" default="' . $forcedLanguage . '" />');
                 $this->filterForm->setField($languageXml, 'filter', true);

--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -38,7 +38,7 @@ $this->useCoreUI = true;
 $params = clone $this->state->get('params');
 $params->merge(new Registry($this->item->attribs));
 
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 
 $assoc              = Associations::isEnabled();
 $showArticleOptions = $params->get('show_article_options', 1);

--- a/administrator/components/com_content/tmpl/article/pagebreak.php
+++ b/administrator/components/com_content/tmpl/article/pagebreak.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Language\Text;
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_content.admin-article-pagebreak');
 
-$this->eName = Factory::getApplication()->input->getCmd('e_name', '');
+$this->eName = Factory::getApplication()->getInput()->getCmd('e_name', '');
 $this->eName = preg_replace('#[^A-Z0-9\-\_\[\]]#i', '', $this->eName);
 $this->document->setTitle(Text::_('COM_CONTENT_PAGEBREAK_DOC_TITLE'));
 

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -31,8 +31,8 @@ $wa->useScript('core')
     ->useScript('multiselect')
     ->useScript('com_content.admin-articles-modal');
 
-$function  = $app->input->getCmd('function', 'jSelectArticle');
-$editor    = $app->input->getCmd('editor', '');
+$function  = $app->getInput()->getCmd('function', 'jSelectArticle');
+$editor    = $app->getInput()->getCmd('editor', '');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $onclick   = $this->escape($function);
@@ -162,7 +162,7 @@ if (!empty($editor)) {
 
         <input type="hidden" name="task" value="">
         <input type="hidden" name="boxchecked" value="0">
-        <input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>">
+        <input type="hidden" name="forcedLanguage" value="<?php echo $app->getInput()->get('forcedLanguage', '', 'CMD'); ?>">
         <?php echo HTMLHelper::_('form.token'); ?>
 
     </form>

--- a/administrator/components/com_contenthistory/src/Model/CompareModel.php
+++ b/administrator/components/com_contenthistory/src/Model/CompareModel.php
@@ -42,7 +42,7 @@ class CompareModel extends ListModel
      */
     public function getItems()
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         /** @var ContentHistory $table1 */
         $table1 = $this->getTable('ContentHistory');

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -300,7 +300,7 @@ class HistoryModel extends ListModel
      */
     protected function populateState($ordering = 'h.save_date', $direction = 'DESC')
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $itemId = $input->get('item_id', '', 'string');
 
         $this->setState('item_id', $itemId);
@@ -375,7 +375,7 @@ class HistoryModel extends ListModel
     protected function getSha1Hash()
     {
         $result    = false;
-        $item_id   = Factory::getApplication()->input->getCmd('item_id', '');
+        $item_id   = Factory::getApplication()->getInput()->getCmd('item_id', '');
         $typeAlias = explode('.', $item_id);
         Table::addIncludePath(JPATH_ADMINISTRATOR . '/components/' . $typeAlias[0] . '/tables');
         $typeTable = $this->getTable('ContentType');

--- a/administrator/components/com_contenthistory/src/Model/PreviewModel.php
+++ b/administrator/components/com_contenthistory/src/Model/PreviewModel.php
@@ -46,7 +46,7 @@ class PreviewModel extends ItemModel
     {
         /** @var ContentHistory $table */
         $table = $this->getTable('ContentHistory');
-        $versionId = Factory::getApplication()->input->getInt('version_id');
+        $versionId = Factory::getApplication()->getInput()->getInt('version_id');
 
         if (!$versionId || \is_array($versionId) || !$table->load($versionId)) {
             return false;

--- a/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
+++ b/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
@@ -59,7 +59,7 @@ class HtmlView extends BaseHtmlView
     public function display($tpl = null)
     {
         $app = Factory::getApplication();
-        $dashboard = $app->input->getCmd('dashboard', '');
+        $dashboard = $app->getInput()->getCmd('dashboard', '');
 
         $position = OutputFilter::stringURLSafe($dashboard);
 

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -454,11 +454,11 @@ class FieldsHelper
             ->getMVCFactory()->createModel('Field', 'Administrator', ['ignore_request' => true]);
 
         if (
-            (!isset($data->id) || !$data->id) && Factory::getApplication()->input->getCmd('controller') == 'modules'
+            (!isset($data->id) || !$data->id) && Factory::getApplication()->getInput()->getCmd('controller') == 'modules'
             && Factory::getApplication()->isClient('site')
         ) {
             // Modules on front end editing don't have data and an id set
-            $data->id = Factory::getApplication()->input->getInt('id');
+            $data->id = Factory::getApplication()->getInput()->getInt('id');
         }
 
         // Looping through the fields again to set the value

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -879,8 +879,9 @@ class FieldModel extends AdminModel
     protected function loadFormData()
     {
         // Check the session for previously entered form data.
-        $app  = Factory::getApplication();
-        $data = $app->getUserState('com_fields.edit.field.data', array());
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
+        $data  = $app->getUserState('com_fields.edit.field.data', array());
 
         if (empty($data)) {
             $data = $this->getItem();
@@ -892,16 +893,16 @@ class FieldModel extends AdminModel
                 // get selected fields
                 $filters = (array) $app->getUserState('com_fields.fields.filter');
 
-                $data->set('state', $app->getInput()->getInt('state', ((isset($filters['state']) && $filters['state'] !== '') ? $filters['state'] : null)));
-                $data->set('language', $app->getInput()->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
-                $data->set('group_id', $app->getInput()->getString('group_id', (!empty($filters['group_id']) ? $filters['group_id'] : null)));
+                $data->set('state', $input->getInt('state', ((isset($filters['state']) && $filters['state'] !== '') ? $filters['state'] : null)));
+                $data->set('language', $input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+                $data->set('group_id', $input->getString('group_id', (!empty($filters['group_id']) ? $filters['group_id'] : null)));
                 $data->set(
                     'access',
-                    $app->getInput()->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
+                    $input->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
                 );
 
                 // Set the type if available from the request
-                $data->set('type', $app->getInput()->getWord('type', $this->state->get('field.type', $data->get('type'))));
+                $data->set('type', $input->getWord('type', $this->state->get('field.type', $data->get('type'))));
             }
 
             if ($data->label && !isset($data->params['label'])) {

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -95,7 +95,7 @@ class FieldModel extends AdminModel
     {
         parent::__construct($config, $factory);
 
-        $this->typeAlias = Factory::getApplication()->input->getCmd('context', 'com_content.article') . '.field';
+        $this->typeAlias = Factory::getApplication()->getInput()->getCmd('context', 'com_content.article') . '.field';
     }
 
     /**
@@ -122,7 +122,7 @@ class FieldModel extends AdminModel
         }
 
         // Alter the title for save as copy
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         if ($input->get('task') == 'save2copy') {
             $origTable = clone $this->getTable();
@@ -365,7 +365,7 @@ class FieldModel extends AdminModel
         if ($result) {
             // Prime required properties.
             if (empty($result->id)) {
-                $result->context = Factory::getApplication()->input->getCmd('context', $this->getState('field.context'));
+                $result->context = Factory::getApplication()->getInput()->getCmd('context', $this->getState('field.context'));
             }
 
             if (property_exists($result, 'fieldparams') && $result->fieldparams !== null) {
@@ -496,7 +496,7 @@ class FieldModel extends AdminModel
     public function getForm($data = array(), $loadData = true)
     {
         $context = $this->getState('field.context');
-        $jinput  = Factory::getApplication()->input;
+        $jinput  = Factory::getApplication()->getInput();
 
         // A workaround to get the context into the model for save requests.
         if (empty($context) && isset($data['context'])) {
@@ -833,10 +833,10 @@ class FieldModel extends AdminModel
         $app = Factory::getApplication();
 
         // Load the User state.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
         $this->setState($this->getName() . '.id', $pk);
 
-        $context = $app->input->get('context', 'com_content.article');
+        $context = $app->getInput()->get('context', 'com_content.article');
         $this->setState('field.context', $context);
         $parts = FieldsHelper::extract($context);
 
@@ -892,16 +892,16 @@ class FieldModel extends AdminModel
                 // get selected fields
                 $filters = (array) $app->getUserState('com_fields.fields.filter');
 
-                $data->set('state', $app->input->getInt('state', ((isset($filters['state']) && $filters['state'] !== '') ? $filters['state'] : null)));
-                $data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
-                $data->set('group_id', $app->input->getString('group_id', (!empty($filters['group_id']) ? $filters['group_id'] : null)));
+                $data->set('state', $app->getInput()->getInt('state', ((isset($filters['state']) && $filters['state'] !== '') ? $filters['state'] : null)));
+                $data->set('language', $app->getInput()->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+                $data->set('group_id', $app->getInput()->getString('group_id', (!empty($filters['group_id']) ? $filters['group_id'] : null)));
                 $data->set(
                     'access',
-                    $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
+                    $app->getInput()->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
                 );
 
                 // Set the type if available from the request
-                $data->set('type', $app->input->getWord('type', $this->state->get('field.type', $data->get('type'))));
+                $data->set('type', $app->getInput()->getWord('type', $this->state->get('field.type', $data->get('type'))));
             }
 
             if ($data->label && !isset($data->params['label'])) {
@@ -1067,7 +1067,7 @@ class FieldModel extends AdminModel
      */
     protected function cleanCache($group = null, $clientId = 0)
     {
-        $context = Factory::getApplication()->input->get('context');
+        $context = Factory::getApplication()->getInput()->get('context');
 
         switch ($context) {
             case 'com_content':

--- a/administrator/components/com_fields/src/Model/FieldsModel.php
+++ b/administrator/components/com_fields/src/Model/FieldsModel.php
@@ -281,8 +281,8 @@ class FieldsModel extends ListModel
 
         // Include group state only when not on on back end list
         $includeGroupState = !$app->isClient('administrator') ||
-            $app->input->get('option') != 'com_fields' ||
-            $app->input->get('view') != 'fields';
+            $app->getInput()->get('option') != 'com_fields' ||
+            $app->getInput()->get('view') != 'fields';
 
         if (is_numeric($state)) {
             $state = (int) $state;

--- a/administrator/components/com_fields/src/Model/GroupModel.php
+++ b/administrator/components/com_fields/src/Model/GroupModel.php
@@ -59,7 +59,7 @@ class GroupModel extends AdminModel
     public function save($data)
     {
         // Alter the title for save as copy
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         // Save new group as unpublished
         if ($input->get('task') == 'save2copy') {
@@ -99,7 +99,7 @@ class GroupModel extends AdminModel
     public function getForm($data = array(), $loadData = true)
     {
         $context = $this->getState('filter.context');
-        $jinput = Factory::getApplication()->input;
+        $jinput = Factory::getApplication()->getInput();
 
         if (empty($context) && isset($data['context'])) {
             $context = $data['context'];
@@ -315,15 +315,15 @@ class GroupModel extends AdminModel
 
                 $data->set(
                     'state',
-                    $app->input->getInt('state', (!empty($filters['state']) ? $filters['state'] : null))
+                    $app->getInput()->getInt('state', (!empty($filters['state']) ? $filters['state'] : null))
                 );
                 $data->set(
                     'language',
-                    $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null))
+                    $app->getInput()->getString('language', (!empty($filters['language']) ? $filters['language'] : null))
                 );
                 $data->set(
                     'access',
-                    $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
+                    $app->getInput()->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
                 );
             }
         }
@@ -370,7 +370,7 @@ class GroupModel extends AdminModel
      */
     protected function cleanCache($group = null, $clientId = 0)
     {
-        $context = Factory::getApplication()->input->get('context');
+        $context = Factory::getApplication()->getInput()->get('context');
 
         parent::cleanCache($context);
     }

--- a/administrator/components/com_fields/src/Model/GroupModel.php
+++ b/administrator/components/com_fields/src/Model/GroupModel.php
@@ -301,8 +301,9 @@ class GroupModel extends AdminModel
     protected function loadFormData()
     {
         // Check the session for previously entered form data.
-        $app = Factory::getApplication();
-        $data = $app->getUserState('com_fields.edit.group.data', array());
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
+        $data  = $app->getUserState('com_fields.edit.group.data', array());
 
         if (empty($data)) {
             $data = $this->getItem();
@@ -315,15 +316,15 @@ class GroupModel extends AdminModel
 
                 $data->set(
                     'state',
-                    $app->getInput()->getInt('state', (!empty($filters['state']) ? $filters['state'] : null))
+                    $input->getInt('state', (!empty($filters['state']) ? $filters['state'] : null))
                 );
                 $data->set(
                     'language',
-                    $app->getInput()->getString('language', (!empty($filters['language']) ? $filters['language'] : null))
+                    $input->getString('language', (!empty($filters['language']) ? $filters['language'] : null))
                 );
                 $data->set(
                     'access',
-                    $app->getInput()->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
+                    $input->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access')))
                 );
             }
         }

--- a/administrator/components/com_fields/src/View/Field/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Field/HtmlView.php
@@ -75,7 +75,7 @@ class HtmlView extends BaseHtmlView
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $this->addToolbar();
 

--- a/administrator/components/com_fields/src/View/Group/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Group/HtmlView.php
@@ -93,7 +93,7 @@ class HtmlView extends BaseHtmlView
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $this->addToolbar();
 

--- a/administrator/components/com_fields/tmpl/field/edit.php
+++ b/administrator/components/com_fields/tmpl/field/edit.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 $app = Factory::getApplication();
-$input = $app->input;
+$input = $app->getInput();
 
 $this->useCoreUI = true;
 

--- a/administrator/components/com_fields/tmpl/fields/modal.php
+++ b/administrator/components/com_fields/tmpl/fields/modal.php
@@ -27,7 +27,7 @@ $wa->useScript('com_fields.admin-fields-modal');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
+$editor    = Factory::getApplication()->getInput()->get('editor', '', 'cmd');
 ?>
 <div class="container-popup">
 

--- a/administrator/components/com_fields/tmpl/group/edit.php
+++ b/administrator/components/com_fields/tmpl/group/edit.php
@@ -22,7 +22,7 @@ $wa->useScript('keepalive')
     ->useScript('form.validate');
 
 $app = Factory::getApplication();
-$input = $app->input;
+$input = $app->getInput();
 
 $this->useCoreUI = true;
 

--- a/administrator/components/com_finder/src/Indexer/Query.php
+++ b/administrator/components/com_finder/src/Indexer/Query.php
@@ -312,7 +312,7 @@ class Query
         }
 
         // Get the filters in the request.
-        $t = Factory::getApplication()->input->request->get('t', array(), 'array');
+        $t = Factory::getApplication()->getInput()->request->get('t', array(), 'array');
 
         // Add the dynamic taxonomy filters if present.
         if ((bool) $this->filters) {

--- a/administrator/components/com_finder/src/Service/HTML/Filter.php
+++ b/administrator/components/com_finder/src/Service/HTML/Filter.php
@@ -363,7 +363,7 @@ class Filter
             // Check if the branch is in the filter.
             if (array_key_exists($bv->title, $idxQuery->filters)) {
                 // Get the request filters.
-                $temp   = Factory::getApplication()->input->request->get('t', array(), 'array');
+                $temp   = Factory::getApplication()->getInput()->request->get('t', array(), 'array');
 
                 // Search for active nodes in the branch and get the active node.
                 $active = array_intersect($temp, $idxQuery->filters[$bv->title]);

--- a/administrator/components/com_finder/src/Service/HTML/Query.php
+++ b/administrator/components/com_finder/src/Service/HTML/Query.php
@@ -77,7 +77,7 @@ class Query
         // Process the taxonomy filters.
         if (!empty($query->filters)) {
             // Get the filters in the request.
-            $t = Factory::getApplication()->input->request->get('t', array(), 'array');
+            $t = Factory::getApplication()->getInput()->request->get('t', array(), 'array');
 
             // Process the taxonomy branches.
             foreach ($query->filters as $branch => $nodes) {

--- a/administrator/components/com_finder/src/View/Filter/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Filter/HtmlView.php
@@ -112,7 +112,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $isNew = ($this->item->filter_id == 0);
         $checkedOut = !(is_null($this->item->checked_out) || $this->item->checked_out == $this->getCurrentUser()->id);

--- a/administrator/components/com_finder/tmpl/filter/edit.php
+++ b/administrator/components/com_finder/tmpl/filter/edit.php
@@ -86,7 +86,7 @@ $wa->useScript('keepalive')
         <?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 
         <input type="hidden" name="task" value="">
-        <input type="hidden" name="return" value="<?php echo Factory::getApplication()->input->get('return', '', 'BASE64'); ?>">
+        <input type="hidden" name="return" value="<?php echo Factory::getApplication()->getInput()->get('return', '', 'BASE64'); ?>">
         <?php echo HTMLHelper::_('form.token'); ?>
     </div>
 </form>

--- a/administrator/components/com_installer/src/Model/DiscoverModel.php
+++ b/administrator/components/com_installer/src/Model/DiscoverModel.php
@@ -212,7 +212,7 @@ class DiscoverModel extends InstallerModel
     public function discover_install()
     {
         $app   = Factory::getApplication();
-        $input = $app->input;
+        $input = $app->getInput();
         $eid   = $input->get('cid', 0, 'array');
 
         if (is_array($eid) || $eid) {

--- a/administrator/components/com_installer/src/Model/InstallModel.php
+++ b/administrator/components/com_installer/src/Model/InstallModel.php
@@ -101,8 +101,8 @@ class InstallModel extends BaseDatabaseModel
             return false;
         }
 
-        $installType = $app->input->getWord('installtype');
-        $installLang = $app->input->getWord('package');
+        $installType = $app->getInput()->getWord('installtype');
+        $installLang = $app->getInput()->getWord('package');
 
         if ($package === null) {
             switch ($installType) {
@@ -239,7 +239,7 @@ class InstallModel extends BaseDatabaseModel
     protected function _getPackageFromUpload()
     {
         // Get the uploaded file information.
-        $input    = Factory::getApplication()->input;
+        $input    = Factory::getApplication()->getInput();
 
         // Do not change the filter type 'raw'. We need this to let files containing PHP code to upload. See \JInputFiles::get.
         $userfile = $input->files->get('install_package', null, 'raw');
@@ -315,7 +315,7 @@ class InstallModel extends BaseDatabaseModel
      */
     protected function _getPackageFromFolder()
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         // Get the path to the package to install.
         $p_dir = $input->getString('install_directory');
@@ -353,7 +353,7 @@ class InstallModel extends BaseDatabaseModel
      */
     protected function _getPackageFromUrl()
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         // Get the URL of the package to install.
         $url = $input->getString('install_url');

--- a/administrator/components/com_installer/src/View/Updatesite/HtmlView.php
+++ b/administrator/components/com_installer/src/View/Updatesite/HtmlView.php
@@ -95,7 +95,7 @@ class HtmlView extends InstallerViewDefault
     protected function addToolbar(): void
     {
         $app = Factory::getApplication();
-        $app->input->set('hidemainmenu', true);
+        $app->getInput()->set('hidemainmenu', true);
 
         $user       = $app->getIdentity();
         $userId     = $user->id;

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -883,7 +883,7 @@ ENDDATA;
     public function upload()
     {
         // Get the uploaded file information.
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         // Do not change the filter type 'raw'. We need this to let files containing PHP code to upload. See \JInputFiles::get.
         $userfile = $input->files->get('install_package', null, 'raw');

--- a/administrator/components/com_joomlaupdate/src/View/Update/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Update/HtmlView.php
@@ -35,7 +35,7 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         // Set the toolbar information.
         ToolbarHelper::title(Text::_('COM_JOOMLAUPDATE_OVERVIEW'), 'sync install');

--- a/administrator/components/com_languages/src/Model/LanguageModel.php
+++ b/administrator/components/com_languages/src/Model/LanguageModel.php
@@ -88,7 +88,7 @@ class LanguageModel extends AdminModel
         $params = ComponentHelper::getParams('com_languages');
 
         // Load the User state.
-        $langId = $app->input->getInt('lang_id');
+        $langId = $app->getInput()->getInt('lang_id');
         $this->setState('language.id', $langId);
 
         // Load the parameters.

--- a/administrator/components/com_languages/src/Model/OverrideModel.php
+++ b/administrator/components/com_languages/src/Model/OverrideModel.php
@@ -96,7 +96,7 @@ class OverrideModel extends AdminModel
      */
     public function getItem($pk = null)
     {
-        $input    = Factory::getApplication()->input;
+        $input    = Factory::getApplication()->getInput();
         $pk       = !empty($pk) ? $pk : $input->get('id');
         $fileName = constant('JPATH_' . strtoupper($this->getState('filter.client')))
             . '/language/overrides/' . $this->getState('filter.language', 'en-GB') . '.override.ini';

--- a/administrator/components/com_languages/src/Model/StringsModel.php
+++ b/administrator/components/com_languages/src/Model/StringsModel.php
@@ -131,7 +131,7 @@ class StringsModel extends BaseDatabaseModel
     public function search()
     {
         $results = array();
-        $input   = Factory::getApplication()->input;
+        $input   = Factory::getApplication()->getInput();
         $filter  = InputFilter::getInstance();
         $db      = $this->getDatabase();
         $searchTerm = $input->getString('searchstring');

--- a/administrator/components/com_languages/src/View/Language/HtmlView.php
+++ b/administrator/components/com_languages/src/View/Language/HtmlView.php
@@ -91,7 +91,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', 1);
+        Factory::getApplication()->getInput()->set('hidemainmenu', 1);
         $isNew = empty($this->item->lang_id);
         $canDo = $this->canDo;
 

--- a/administrator/components/com_languages/src/View/Override/HtmlView.php
+++ b/administrator/components/com_languages/src/View/Override/HtmlView.php
@@ -109,7 +109,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $canDo = ContentHelper::getActions('com_languages');
 

--- a/administrator/components/com_login/src/Model/LoginModel.php
+++ b/administrator/components/com_login/src/Model/LoginModel.php
@@ -39,7 +39,7 @@ class LoginModel extends BaseDatabaseModel
      */
     protected function populateState()
     {
-        $input = Factory::getApplication()->input->getInputForRequestMethod();
+        $input = Factory::getApplication()->getInput()->getInputForRequestMethod();
 
         $credentials = array(
             'username'  => $input->get('username', '', 'USERNAME'),

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -398,10 +398,10 @@ class TemplateModel extends AdminModel
     {
         parent::populateState();
 
-        $template_id = Factory::getApplication()->input->getCmd('template_id');
+        $template_id = Factory::getApplication()->getInput()->getCmd('template_id');
         $this->setState($this->getName() . '.template_id', $template_id);
 
-        $language = Factory::getApplication()->input->getCmd('language');
+        $language = Factory::getApplication()->getInput()->getCmd('language');
         $this->setState($this->getName() . '.language', $language);
     }
 }

--- a/administrator/components/com_mails/src/View/Template/HtmlView.php
+++ b/administrator/components/com_mails/src/View/Template/HtmlView.php
@@ -130,7 +130,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
         $toolbar = Toolbar::getInstance();
 
         ToolbarHelper::title(

--- a/administrator/components/com_mails/tmpl/template/edit.php
+++ b/administrator/components/com_mails/tmpl/template/edit.php
@@ -28,7 +28,7 @@ $wa->useScript('keepalive')
 
 $this->useCoreUI = true;
 
-$input = $app->input;
+$input = $app->getInput();
 list($component, $sub_id) = explode('.', $this->master->template_id, 2);
 $sub_id = str_replace('.', '_', $sub_id);
 

--- a/administrator/components/com_media/src/Model/ApiModel.php
+++ b/administrator/components/com_media/src/Model/ApiModel.php
@@ -451,7 +451,7 @@ class ApiModel extends BaseDatabaseModel
         // Initialize the allowed extensions
         if ($this->allowedExtensions === null) {
             // Get options from the input or fallback to images only
-            $mediaTypes = explode(',', Factory::getApplication()->input->getString('mediatypes', '0'));
+            $mediaTypes = explode(',', Factory::getApplication()->getInput()->getString('mediatypes', '0'));
             $types      = [];
             $extensions = [];
 

--- a/administrator/components/com_media/src/View/File/HtmlView.php
+++ b/administrator/components/com_media/src/View/File/HtmlView.php
@@ -38,7 +38,7 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         $this->form = $this->get('Form');
 

--- a/administrator/components/com_media/src/View/Media/HtmlView.php
+++ b/administrator/components/com_media/src/View/Media/HtmlView.php
@@ -70,7 +70,7 @@ class HtmlView extends BaseHtmlView
 			Factory::getApplication()->enqueueMessage(Text::sprintf('COM_MEDIA_ERROR_NO_PROVIDERS', $link), CMSApplication::MSG_WARNING);
 		}
 
-		$this->currentPath = Factory::getApplication()->input->getString('path');
+		$this->currentPath = Factory::getApplication()->getInput()->getString('path');
 
 		parent::display($tpl);
 	}
@@ -84,7 +84,7 @@ class HtmlView extends BaseHtmlView
 	 */
 	protected function prepareToolbar()
 	{
-		$tmpl = Factory::getApplication()->input->getCmd('tmpl');
+		$tmpl = Factory::getApplication()->getInput()->getCmd('tmpl');
 
 		// Get the toolbar object instance
 		$bar  = Toolbar::getInstance('toolbar');

--- a/administrator/components/com_media/tmpl/file/default.php
+++ b/administrator/components/com_media/tmpl/file/default.php
@@ -27,7 +27,7 @@ $wa->useScript('keepalive')
 $script = $wa->getAsset('script', 'com_media.edit-images')->getUri(true);
 
 $params = ComponentHelper::getParams('com_media');
-$input  = Factory::getApplication()->input;
+$input  = Factory::getApplication()->getInput();
 
 /** @var \Joomla\CMS\Form\Form $form */
 $form = $this->form;

--- a/administrator/components/com_media/tmpl/media/default.php
+++ b/administrator/components/com_media/tmpl/media/default.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Uri\Uri;
 
 $app    = Factory::getApplication();
 $params = ComponentHelper::getParams('com_media');
-$input  = $app->input;
+$input  = $app->getInput();
 $user   = $app->getIdentity();
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */

--- a/administrator/components/com_menus/layouts/joomla/menu/edit_modules.php
+++ b/administrator/components/com_menus/layouts/joomla/menu/edit_modules.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Factory;
 
 $app       = Factory::getApplication();
 $form      = $displayData->getForm();
-$input     = $app->input;
+$input     = $app->getInput();
 $component = $input->getCmd('option', 'com_content');
 
 if ($component == 'com_categories') {

--- a/administrator/components/com_menus/src/Field/MenuItemByTypeField.php
+++ b/administrator/components/com_menus/src/Field/MenuItemByTypeField.php
@@ -155,7 +155,7 @@ class MenuItemByTypeField extends GroupedlistField
             if (!$menuType) {
                 $app = Factory::getApplication();
                 $currentMenuType = $app->getUserState('com_menus.items.menutype', '');
-                $menuType        = $app->input->getString('menutype', $currentMenuType);
+                $menuType        = $app->getInput()->getString('menutype', $currentMenuType);
             }
 
             $this->menuType  = $menuType;

--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -930,7 +930,7 @@ class ItemModel extends AdminModel
         $app = Factory::getApplication();
 
         // Load the User state.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
         $this->setState('item.id', $pk);
 
         if (!$app->isClient('api')) {
@@ -938,11 +938,11 @@ class ItemModel extends AdminModel
             $menuType = $app->getUserStateFromRequest('com_menus.items.menutype', 'menutype', '', 'string');
         } else {
             $parentId = null;
-            $menuType = $app->input->get('com_menus.items.menutype');
+            $menuType = $app->getInput()->get('com_menus.items.menutype');
         }
 
         if (!$parentId) {
-            $parentId = $app->input->getInt('parent_id');
+            $parentId = $app->getInput()->getInt('parent_id');
         }
 
         $this->setState('item.parent_id', $parentId);
@@ -957,12 +957,12 @@ class ItemModel extends AdminModel
             $clientId   = (int) $menuTypeObj->client_id;
         } else {
             $menuTypeId = 0;
-            $clientId   = $app->isClient('api') ? $app->input->get('client_id') :
+            $clientId   = $app->isClient('api') ? $app->getInput()->get('client_id') :
                 $app->getUserState('com_menus.items.client_id', 0);
         }
 
         // Forced client id will override/clear menuType if conflicted
-        $forcedClientId = $app->input->get('client_id', null, 'string');
+        $forcedClientId = $app->getInput()->get('client_id', null, 'string');
 
         if (!$app->isClient('api')) {
             // Set the menu type and client id on the list view state, so we return to this menu after saving.
@@ -988,7 +988,7 @@ class ItemModel extends AdminModel
         $this->setState('item.menutypeid', $menuTypeId);
 
         if (!($type = $app->getUserState('com_menus.edit.item.type'))) {
-            $type = $app->input->get('type');
+            $type = $app->getInput()->get('type');
 
             /**
              * Note: a new menu item will have no field type.
@@ -998,7 +998,7 @@ class ItemModel extends AdminModel
 
         $this->setState('item.type', $type);
 
-        $link = $app->isClient('api') ? $app->input->get('link') :
+        $link = $app->isClient('api') ? $app->getInput()->get('link') :
             $app->getUserState('com_menus.edit.item.link');
 
         if ($link) {
@@ -1379,7 +1379,7 @@ class ItemModel extends AdminModel
         }
 
         // Alter the title & alias for save2copy when required. Also, unset the home record.
-        if (Factory::getApplication()->input->get('task') === 'save2copy' && $data['id'] === 0) {
+        if (Factory::getApplication()->getInput()->get('task') === 'save2copy' && $data['id'] === 0) {
             $origTable = $this->getTable();
             $origTable->load($this->getState('item.id'));
 
@@ -1569,7 +1569,7 @@ class ItemModel extends AdminModel
             parent::cleanCache($option);
         }
 
-        if (Factory::getApplication()->input->get('task') === 'editAssociations') {
+        if (Factory::getApplication()->getInput()->get('task') === 'editAssociations') {
             return $this->redirectToAssociations($data);
         }
 

--- a/administrator/components/com_menus/src/Model/ItemsModel.php
+++ b/administrator/components/com_menus/src/Model/ItemsModel.php
@@ -89,10 +89,10 @@ class ItemsModel extends ListModel
     {
         $app = Factory::getApplication();
 
-        $forcedLanguage = $app->input->get('forcedLanguage', '', 'cmd');
+        $forcedLanguage = $app->getInput()->get('forcedLanguage', '', 'cmd');
 
         // Adjust the context to support modal layouts.
-        if ($layout = $app->input->get('layout')) {
+        if ($layout = $app->getInput()->get('layout')) {
             $this->context .= '.' . $layout;
         }
 
@@ -118,7 +118,7 @@ class ItemsModel extends ListModel
 
         // Watch changes in client_id and menutype and keep sync whenever needed.
         $currentClientId = $app->getUserState($this->context . '.client_id', 0);
-        $clientId        = $app->input->getInt('client_id', $currentClientId);
+        $clientId        = $app->getInput()->getInt('client_id', $currentClientId);
 
         // Load mod_menu.ini file when client is administrator
         if ($clientId == 1) {
@@ -126,19 +126,19 @@ class ItemsModel extends ListModel
         }
 
         $currentMenuType = $app->getUserState($this->context . '.menutype', '');
-        $menuType        = $app->input->getString('menutype', $currentMenuType);
+        $menuType        = $app->getInput()->getString('menutype', $currentMenuType);
 
         // If client_id changed clear menutype and reset pagination
         if ($clientId != $currentClientId) {
             $menuType = '';
 
-            $app->input->set('limitstart', 0);
-            $app->input->set('menutype', '');
+            $app->getInput()->set('limitstart', 0);
+            $app->getInput()->set('menutype', '');
         }
 
         // If menutype changed reset pagination.
         if ($menuType != $currentMenuType) {
-            $app->input->set('limitstart', 0);
+            $app->getInput()->set('limitstart', 0);
         }
 
         if (!$menuType) {
@@ -148,7 +148,7 @@ class ItemsModel extends ListModel
         } elseif ($menuType == 'main') {
             // Special menu types, if selected explicitly, will be allowed as a filter
             // Adjust client_id to match the menutype. This is safe as client_id was not changed in this request.
-            $app->input->set('client_id', 1);
+            $app->getInput()->set('client_id', 1);
 
             $app->setUserState($this->context . '.menutype', $menuType);
             $this->setState('menutypetitle', ucfirst($menuType));
@@ -156,7 +156,7 @@ class ItemsModel extends ListModel
         } elseif ($cMenu = $this->getMenu($menuType, true)) {
             // Get the menutype object with appropriate checks.
             // Adjust client_id to match the menutype. This is safe as client_id was not changed in this request.
-            $app->input->set('client_id', $cMenu->client_id);
+            $app->getInput()->set('client_id', $cMenu->client_id);
 
             $app->setUserState($this->context . '.menutype', $menuType);
             $this->setState('menutypetitle', $cMenu->title);
@@ -165,8 +165,8 @@ class ItemsModel extends ListModel
             // This menutype does not exist, leave client id unchanged but reset menutype and pagination
             $menuType = '';
 
-            $app->input->set('limitstart', 0);
-            $app->input->set('menutype', $menuType);
+            $app->getInput()->set('limitstart', 0);
+            $app->getInput()->set('menutype', $menuType);
 
             $app->setUserState($this->context . '.menutype', $menuType);
             $this->setState('menutypetitle', '');

--- a/administrator/components/com_menus/src/Model/MenuModel.php
+++ b/administrator/components/com_menus/src/Model/MenuModel.php
@@ -104,7 +104,7 @@ class MenuModel extends FormModel
         $app = Factory::getApplication();
 
         // Load the User state.
-        $id = $app->input->getInt('id');
+        $id = $app->getInput()->getInt('id');
         $this->setState('menu.id', $id);
 
         // Load the parameters.

--- a/administrator/components/com_menus/src/Model/MenutypesModel.php
+++ b/administrator/components/com_menus/src/Model/MenutypesModel.php
@@ -51,7 +51,7 @@ class MenutypesModel extends BaseDatabaseModel
     {
         parent::populateState();
 
-        $clientId = Factory::getApplication()->input->get('client_id', 0);
+        $clientId = Factory::getApplication()->getInput()->get('client_id', 0);
 
         $this->state->set('client_id', $clientId);
     }

--- a/administrator/components/com_menus/src/View/Item/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Item/HtmlView.php
@@ -103,7 +103,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // If we are forcing a language in modal (used for associations).
-        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'cmd')) {
+        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'cmd')) {
             // Set the language field to the forcedLanguage and disable changing it.
             $this->form->setValue('language', null, $forcedLanguage);
             $this->form->setFieldAttribute('language', 'readonly', 'true');
@@ -125,7 +125,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $input->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();

--- a/administrator/components/com_menus/src/View/Items/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Items/HtmlView.php
@@ -265,7 +265,7 @@ class HtmlView extends BaseHtmlView
             }
         } else {
             // In menu associations modal we need to remove language filter if forcing a language.
-            if ($forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'CMD')) {
+            if ($forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD')) {
                 // If the language is forced we can't allow to select the language, so transform the language selector filter into a hidden field.
                 $languageXml = new \SimpleXMLElement('<field name="language" type="hidden" default="' . $forcedLanguage . '" />');
                 $this->filterForm->setField($languageXml, 'filter', true);

--- a/administrator/components/com_menus/src/View/Menu/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menu/HtmlView.php
@@ -92,7 +92,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $input->set('hidemainmenu', true);
 
         $isNew = ($this->item->id == 0);

--- a/administrator/components/com_menus/src/View/Menu/XmlView.php
+++ b/administrator/components/com_menus/src/View/Menu/XmlView.php
@@ -54,7 +54,7 @@ class XmlView extends BaseHtmlView
     public function display($tpl = null)
     {
         $app      = Factory::getApplication();
-        $menutype = $app->input->getCmd('menutype');
+        $menutype = $app->getInput()->getCmd('menutype');
 
         if ($menutype) {
             $root = MenusHelper::getMenuItems($menutype, true);

--- a/administrator/components/com_menus/src/View/Menutypes/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menutypes/HtmlView.php
@@ -57,7 +57,7 @@ class HtmlView extends BaseHtmlView
     public function display($tpl = null)
     {
         $app            = Factory::getApplication();
-        $this->recordId = $app->input->getInt('recordId');
+        $this->recordId = $app->getInput()->getInt('recordId');
 
         $types = $this->get('TypeOptions');
 

--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -31,7 +31,7 @@ $wa->useScript('keepalive')
     ->useScript('com_menus.admin-item-edit');
 
 $assoc = Associations::isEnabled();
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 
 // In case of modal
 $isModal  = $input->get('layout') === 'modal';

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -28,8 +28,8 @@ if ($app->isClient('site')) {
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_menus.admin-items-modal');
 
-$function  = $app->input->get('function', 'jSelectMenuItem', 'cmd');
-$editor    = $app->input->getCmd('editor', '');
+$function  = $app->getInput()->get('function', 'jSelectMenuItem', 'cmd');
+$editor    = $app->getInput()->getCmd('editor', '');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $link      = 'index.php?option=com_menus&view=items&layout=modal&tmpl=component&' . Session::getFormToken() . '=1';
@@ -177,7 +177,7 @@ if (!empty($editor)) {
         <input type="hidden" name="task" value="">
         <input type="hidden" name="boxchecked" value="0">
         <input type="hidden" name="function" value="<?php echo $function; ?>">
-        <input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'cmd'); ?>">
+        <input type="hidden" name="forcedLanguage" value="<?php echo $app->getInput()->get('forcedLanguage', '', 'cmd'); ?>">
         <?php echo HTMLHelper::_('form.token'); ?>
 
     </form>

--- a/administrator/components/com_menus/tmpl/menutypes/default.php
+++ b/administrator/components/com_menus/tmpl/menutypes/default.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 
 // Checking if loaded via index.php or component.php
 $tmpl = ($input->getCmd('tmpl') != '') ? '1' : '';

--- a/administrator/components/com_messages/src/Model/MessageModel.php
+++ b/administrator/components/com_messages/src/Model/MessageModel.php
@@ -62,7 +62,7 @@ class MessageModel extends AdminModel
     {
         parent::populateState();
 
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         $user  = $this->getCurrentUser();
         $this->setState('user.id', $user->get('id'));

--- a/administrator/components/com_messages/src/View/Config/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Config/HtmlView.php
@@ -85,7 +85,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         ToolbarHelper::title(Text::_('COM_MESSAGES_TOOLBAR_MY_SETTINGS'), 'envelope');
 

--- a/administrator/components/com_messages/src/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Message/HtmlView.php
@@ -87,7 +87,7 @@ class HtmlView extends BaseHtmlView
         $app = Factory::getApplication();
 
         if ($this->getLayout() == 'edit') {
-            $app->input->set('hidemainmenu', true);
+            $app->getInput()->set('hidemainmenu', true);
             ToolbarHelper::title(Text::_('COM_MESSAGES_WRITE_PRIVATE_MESSAGE'), 'envelope-open-text new-privatemessage');
             ToolbarHelper::custom('message.save', 'envelope', '', 'COM_MESSAGES_TOOLBAR_SEND', false);
             ToolbarHelper::cancel('message.cancel');

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -122,7 +122,7 @@ class ModuleModel extends AdminModel
         $app = Factory::getApplication();
 
         // Load the User state.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
 
         if (!$pk) {
             if ($extensionId = (int) $app->getUserState('com_modules.add.module.extension_id')) {
@@ -590,12 +590,12 @@ class ModuleModel extends AdminModel
 
             // Pre-select some filters (Status, Module Position, Language, Access Level) in edit form if those have been selected in Module Manager
             if (!$data->id) {
-                $clientId = $app->input->getInt('client_id', 0);
+                $clientId = $app->getInput()->getInt('client_id', 0);
                 $filters  = (array) $app->getUserState('com_modules.modules.' . $clientId . '.filter');
-                $data->set('published', $app->input->getInt('published', ((isset($filters['state']) && $filters['state'] !== '') ? $filters['state'] : null)));
-                $data->set('position', $app->input->getInt('position', (!empty($filters['position']) ? $filters['position'] : null)));
-                $data->set('language', $app->input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
-                $data->set('access', $app->input->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access'))));
+                $data->set('published', $app->getInput()->getInt('published', ((isset($filters['state']) && $filters['state'] !== '') ? $filters['state'] : null)));
+                $data->set('position', $app->getInput()->getInt('position', (!empty($filters['position']) ? $filters['position'] : null)));
+                $data->set('language', $app->getInput()->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+                $data->set('access', $app->getInput()->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access'))));
             }
 
             // Avoid to delete params of a second module opened in a new browser tab while new one is not saved yet.
@@ -893,7 +893,7 @@ class ModuleModel extends AdminModel
      */
     public function save($data)
     {
-        $input      = Factory::getApplication()->input;
+        $input      = Factory::getApplication()->getInput();
         $table      = $this->getTable();
         $pk         = (!empty($data['id'])) ? $data['id'] : (int) $this->getState('module.id');
         $isNew      = true;

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -580,7 +580,8 @@ class ModuleModel extends AdminModel
      */
     protected function loadFormData()
     {
-        $app = Factory::getApplication();
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
 
         // Check the session for previously entered form data.
         $data = $app->getUserState('com_modules.edit.module.data', array());
@@ -590,12 +591,12 @@ class ModuleModel extends AdminModel
 
             // Pre-select some filters (Status, Module Position, Language, Access Level) in edit form if those have been selected in Module Manager
             if (!$data->id) {
-                $clientId = $app->getInput()->getInt('client_id', 0);
+                $clientId = $input->getInt('client_id', 0);
                 $filters  = (array) $app->getUserState('com_modules.modules.' . $clientId . '.filter');
-                $data->set('published', $app->getInput()->getInt('published', ((isset($filters['state']) && $filters['state'] !== '') ? $filters['state'] : null)));
-                $data->set('position', $app->getInput()->getInt('position', (!empty($filters['position']) ? $filters['position'] : null)));
-                $data->set('language', $app->getInput()->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
-                $data->set('access', $app->getInput()->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access'))));
+                $data->set('published', $input->getInt('published', ((isset($filters['state']) && $filters['state'] !== '') ? $filters['state'] : null)));
+                $data->set('position', $input->getInt('position', (!empty($filters['position']) ? $filters['position'] : null)));
+                $data->set('language', $input->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));
+                $data->set('access', $input->getInt('access', (!empty($filters['access']) ? $filters['access'] : $app->get('access'))));
             }
 
             // Avoid to delete params of a second module opened in a new browser tab while new one is not saved yet.

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -82,7 +82,7 @@ class ModulesModel extends ListModel
     {
         $app = Factory::getApplication();
 
-        $layout = $app->input->get('layout', '', 'cmd');
+        $layout = $app->getInput()->get('layout', '', 'cmd');
 
         // Adjust the context to support modal layouts.
         if ($layout) {
@@ -90,7 +90,7 @@ class ModulesModel extends ListModel
         }
 
         // Make context client aware
-        $this->context .= '.' . $app->input->get->getInt('client_id', 0);
+        $this->context .= '.' . $app->getInput()->get->getInt('client_id', 0);
 
         // Load the filter state.
         $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));

--- a/administrator/components/com_modules/src/View/Module/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Module/HtmlView.php
@@ -90,7 +90,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();
         $isNew      = ($this->item->id == 0);

--- a/administrator/components/com_modules/tmpl/module/edit.php
+++ b/administrator/components/com_modules/tmpl/module/edit.php
@@ -43,7 +43,7 @@ $wa->useScript('keepalive')
     ->useScript('form.validate')
     ->useScript('com_modules.admin-module-edit');
 
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 
 // In case of modal
 $isModal = $input->get('layout') === 'modal';

--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -27,7 +27,7 @@ $wa->useScript('com_modules.admin-modules-modal');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
-$editor    = Factory::getApplication()->input->get('editor', '', 'cmd');
+$editor    = Factory::getApplication()->getInput()->get('editor', '', 'cmd');
 $link      = 'index.php?option=com_modules&view=modules&layout=modal&tmpl=component&' . Session::getFormToken() . '=1';
 
 if (!empty($editor)) {

--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Router\Route;
 
 $app = Factory::getApplication();
 
-$function  = $app->input->getCmd('function');
+$function  = $app->getInput()->getCmd('function');
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
@@ -157,7 +157,7 @@ class NewsfeedModel extends AdminModel
             // Prime some default values.
             if ($this->getState('newsfeed.id') == 0) {
                 $app = Factory::getApplication();
-                $data->set('catid', $app->input->get('catid', $app->getUserState('com_newsfeeds.newsfeeds.filter.category_id'), 'int'));
+                $data->set('catid', $app->getInput()->get('catid', $app->getUserState('com_newsfeeds.newsfeeds.filter.category_id'), 'int'));
             }
         }
 
@@ -177,7 +177,7 @@ class NewsfeedModel extends AdminModel
      */
     public function save($data)
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         // Create new category, if needed.
         $createCategory = true;

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedsModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedsModel.php
@@ -87,10 +87,10 @@ class NewsfeedsModel extends ListModel
     {
         $app = Factory::getApplication();
 
-        $forcedLanguage = $app->input->get('forcedLanguage', '', 'cmd');
+        $forcedLanguage = $app->getInput()->get('forcedLanguage', '', 'cmd');
 
         // Adjust the context to support modal layouts.
-        if ($layout = $app->input->get('layout')) {
+        if ($layout = $app->getInput()->get('layout')) {
             $this->context .= '.' . $layout;
         }
 

--- a/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -78,7 +78,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // If we are forcing a language in modal (used for associations).
-        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'cmd')) {
+        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'cmd')) {
             // Set the language field to the forcedLanguage and disable changing it.
             $this->form->setValue('language', null, $forcedLanguage);
             $this->form->setFieldAttribute('language', 'readonly', 'true');
@@ -103,7 +103,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();
         $isNew      = ($this->item->id == 0);

--- a/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
@@ -105,7 +105,7 @@ class HtmlView extends BaseHtmlView
         } else {
             // In article associations modal we need to remove language filter if forcing a language.
             // We also need to change the category filter to show show categories with All or the forced language.
-            if ($forcedLanguage = Factory::getApplication()->input->get('forcedLanguage', '', 'CMD')) {
+            if ($forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD')) {
                 // If the language is forced we can't allow to select the language, so transform the language selector filter into a hidden field.
                 $languageXml = new \SimpleXMLElement('<field name="language" type="hidden" default="' . $forcedLanguage . '" />');
                 $this->filterForm->setField($languageXml, 'filter', true);

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
@@ -23,7 +23,7 @@ $wa->useScript('keepalive')
     ->useScript('form.validate');
 
 $app   = Factory::getApplication();
-$input = $app->input;
+$input = $app->getInput();
 
 $assoc = Associations::isEnabled();
 

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -22,7 +22,7 @@ HTMLHelper::_('behavior.core');
 
 $app = Factory::getApplication();
 
-$function  = $app->input->getCmd('function', 'jSelectNewsfeed');
+$function  = $app->getInput()->getCmd('function', 'jSelectNewsfeed');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $multilang = Multilanguage::isEnabled();
@@ -125,7 +125,7 @@ $multilang = Multilanguage::isEnabled();
 
         <input type="hidden" name="task" value="">
         <input type="hidden" name="boxchecked" value="0">
-        <input type="hidden" name="forcedLanguage" value="<?php echo $app->input->get('forcedLanguage', '', 'CMD'); ?>">
+        <input type="hidden" name="forcedLanguage" value="<?php echo $app->getInput()->get('forcedLanguage', '', 'CMD'); ?>">
         <?php echo HTMLHelper::_('form.token'); ?>
 
     </form>

--- a/administrator/components/com_plugins/src/Model/PluginModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginModel.php
@@ -229,7 +229,7 @@ class PluginModel extends AdminModel
         $app = Factory::getApplication();
 
         // Load the User state.
-        $pk = $app->input->getInt('extension_id');
+        $pk = $app->getInput()->getInt('extension_id');
         $this->setState('plugin.id', $pk);
     }
 

--- a/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
@@ -81,7 +81,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $canDo = ContentHelper::getActions('com_plugins');
 

--- a/administrator/components/com_plugins/tmpl/plugin/edit.php
+++ b/administrator/components/com_plugins/tmpl/plugin/edit.php
@@ -24,7 +24,7 @@ $wa->useScript('keepalive')
 $this->fieldsets = $this->form->getFieldsets('params');
 $this->useCoreUI = true;
 
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 
 // In case of modal
 $isModal  = $input->get('layout') === 'modal';

--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -48,7 +48,7 @@ class MessagesModel extends BaseDatabaseModel
     {
         parent::populateState();
 
-        $eid = (int) Factory::getApplication()->input->getInt('eid');
+        $eid = (int) Factory::getApplication()->getInput()->getInt('eid');
 
         if ($eid) {
             $this->setState('eid', $eid);

--- a/administrator/components/com_privacy/src/Model/ExportModel.php
+++ b/administrator/components/com_privacy/src/Model/ExportModel.php
@@ -305,7 +305,7 @@ class ExportModel extends BaseDatabaseModel
     protected function populateState()
     {
         // Get the pk of the record from the request.
-        $this->setState($this->getName() . '.request_id', Factory::getApplication()->input->getUint('id'));
+        $this->setState($this->getName() . '.request_id', Factory::getApplication()->getInput()->getUint('id'));
 
         // Load the parameters.
         $this->setState('params', ComponentHelper::getParams('com_privacy'));

--- a/administrator/components/com_privacy/src/Model/RemoveModel.php
+++ b/administrator/components/com_privacy/src/Model/RemoveModel.php
@@ -194,7 +194,7 @@ class RemoveModel extends BaseDatabaseModel
     protected function populateState()
     {
         // Get the pk of the record from the request.
-        $this->setState($this->getName() . '.request_id', Factory::getApplication()->input->getUint('id'));
+        $this->setState($this->getName() . '.request_id', Factory::getApplication()->getInput()->getUint('id'));
 
         // Load the parameters.
         $this->setState('params', ComponentHelper::getParams('com_privacy'));

--- a/administrator/components/com_privacy/src/View/Request/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Request/HtmlView.php
@@ -120,7 +120,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         // Set the title and toolbar based on the layout
         if ($this->getLayout() === 'edit') {

--- a/administrator/components/com_redirect/src/View/Link/HtmlView.php
+++ b/administrator/components/com_redirect/src/View/Link/HtmlView.php
@@ -82,7 +82,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $isNew = ($this->item->id == 0);
         $canDo = ContentHelper::getActions('com_redirect');

--- a/administrator/components/com_tags/src/Model/TagModel.php
+++ b/administrator/components/com_tags/src/Model/TagModel.php
@@ -86,11 +86,11 @@ class TagModel extends AdminModel
     {
         $app = Factory::getApplication();
 
-        $parentId = $app->input->getInt('parent_id');
+        $parentId = $app->getInput()->getInt('parent_id');
         $this->setState('tag.parent_id', $parentId);
 
         // Load the User state.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
         $this->setState($this->getName() . '.id', $pk);
 
         // Load the parameters.
@@ -154,7 +154,7 @@ class TagModel extends AdminModel
      */
     public function getForm($data = array(), $loadData = true)
     {
-        $jinput = Factory::getApplication()->input;
+        $jinput = Factory::getApplication()->getInput();
 
         // Get the form.
         $form = $this->loadForm('com_tags.tag', 'tag', array('control' => 'jform', 'load_data' => $loadData));
@@ -213,7 +213,7 @@ class TagModel extends AdminModel
     {
         /** @var \Joomla\Component\Tags\Administrator\Table\TagTable $table */
         $table      = $this->getTable();
-        $input      = Factory::getApplication()->input;
+        $input      = Factory::getApplication()->getInput();
         $pk         = (!empty($data['id'])) ? $data['id'] : (int) $this->getState($this->getName() . '.id');
         $isNew      = true;
         $context    = $this->option . '.' . $this->name;

--- a/administrator/components/com_tags/src/View/Tag/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tag/HtmlView.php
@@ -99,7 +99,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();
         $userId     = $user->get('id');

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -102,7 +102,7 @@ class StyleModel extends AdminModel
         $app = Factory::getApplication();
 
         // Load the User state.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
         $this->setState('style.id', $pk);
 
         // Load the parameters.
@@ -474,7 +474,7 @@ class StyleModel extends AdminModel
             $isNew = false;
         }
 
-        if ($app->input->get('task') == 'save2copy') {
+        if ($app->getInput()->get('task') == 'save2copy') {
             $data['title']    = $this->generateNewTitle(null, null, $data['title']);
             $data['home']     = 0;
             $data['assigned'] = '';

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -577,7 +577,7 @@ class TemplateModel extends FormModel
         $app = Factory::getApplication();
 
         // Load the User state.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
         $this->setState('extension.id', $pk);
 
         // Load the parameters.
@@ -874,7 +874,7 @@ class TemplateModel extends FormModel
         }
 
         if ($this->template) {
-            $input    = Factory::getApplication()->input;
+            $input    = Factory::getApplication()->getInput();
             $fileName = base64_decode($input->get('file'));
             $fileName = str_replace('//', '/', $fileName);
             $isMedia  = $input->getInt('isMedia', 0);
@@ -929,8 +929,8 @@ class TemplateModel extends FormModel
         }
 
         $app      = Factory::getApplication();
-        $fileName = base64_decode($app->input->get('file'));
-        $isMedia  = $app->input->getInt('isMedia', 0);
+        $fileName = base64_decode($app->getInput()->get('file'));
+        $isMedia  = $app->getInput()->getInt('isMedia', 0);
         $fileName = $isMedia ? JPATH_ROOT . '/media/templates/' . ($this->template->client_id === 0 ? 'site' : 'administrator') . '/' . $this->template->element . $fileName  :
             JPATH_ROOT . '/' . ($this->template->client_id === 0 ? '' : 'administrator/') . 'templates/' . $this->template->element . $fileName;
 
@@ -1452,7 +1452,7 @@ class TemplateModel extends FormModel
     {
         if ($this->getTemplate()) {
             $app      = Factory::getApplication();
-            $fileName = base64_decode($app->input->get('file'));
+            $fileName = base64_decode($app->getInput()->get('file'));
             $path     = $this->getBasePath();
 
             $uri = Uri::root(false) . ltrim(str_replace(JPATH_ROOT, '', $this->getBasePath()), '/');
@@ -1610,10 +1610,10 @@ class TemplateModel extends FormModel
         if ($template = $this->getTemplate()) {
             $app          = Factory::getApplication();
             $client       = ApplicationHelper::getClientInfo($template->client_id);
-            $relPath      = base64_decode($app->input->get('file'));
+            $relPath      = base64_decode($app->getInput()->get('file'));
             $explodeArray = explode('/', $relPath);
             $fileName     = end($explodeArray);
-            $path         = $this->getBasePath() . base64_decode($app->input->get('file'));
+            $path         = $this->getBasePath() . base64_decode($app->getInput()->get('file'));
 
             if (stristr($client->path, 'administrator') == false) {
                 $folder = '/templates/';
@@ -1687,7 +1687,7 @@ class TemplateModel extends FormModel
     {
         if ($this->getTemplate()) {
             $app  = Factory::getApplication();
-            $path = $this->getBasePath() . base64_decode($app->input->get('file'));
+            $path = $this->getBasePath() . base64_decode($app->getInput()->get('file'));
 
             if (file_exists(Path::clean($path))) {
                 $files = array();
@@ -1831,7 +1831,7 @@ class TemplateModel extends FormModel
     private function getBasePath()
     {
         $app      = Factory::getApplication();
-        $isMedia  = $app->input->getInt('isMedia', 0);
+        $isMedia  = $app->getInput()->getInt('isMedia', 0);
 
         return $isMedia ? JPATH_ROOT . '/media/templates/' . ($this->template->client_id === 0 ? 'site' : 'administrator') . '/' . $this->template->element :
             JPATH_ROOT . '/' . ($this->template->client_id === 0 ? '' : 'administrator/') . 'templates/' . $this->template->element;

--- a/administrator/components/com_templates/src/View/Style/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Style/HtmlView.php
@@ -94,7 +94,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $isNew = ($this->item->id == 0);
         $canDo = $this->canDo;

--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -160,7 +160,7 @@ class HtmlView extends BaseHtmlView
     public function display($tpl = null)
     {
         $app               = Factory::getApplication();
-        $this->file        = $app->input->get('file', '');
+        $this->file        = $app->getInput()->get('file', '');
         $this->fileName    = InputFilter::getInstance()->clean(base64_decode($this->file), 'string');
         $explodeArray      = explode('.', $this->fileName);
         $ext               = end($explodeArray);
@@ -233,7 +233,7 @@ class HtmlView extends BaseHtmlView
     {
         $app   = Factory::getApplication();
         $user  = $this->getCurrentUser();
-        $app->input->set('hidemainmenu', true);
+        $app->getInput()->set('hidemainmenu', true);
 
         // User is global SuperUser
         $isSuperUser = $user->authorise('core.admin');

--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -24,7 +24,7 @@ HTMLHelper::_('bootstrap.modal');
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa    = $this->document->getWebAssetManager();
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 
 // Enable assets
 $wa->useScript('form.validate')

--- a/administrator/components/com_templates/tmpl/template/default_modal_delete_footer.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_delete_footer.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 ?>
 <form method="post" action="">
     <input type="hidden" name="option" value="com_templates">

--- a/administrator/components/com_templates/tmpl/template/default_modal_file_body.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_file_body.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Utility\Utility;
 
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 ?>
 <div id="#template-manager-file" class="container-fluid">
     <div class="mt-2 p-2">

--- a/administrator/components/com_templates/tmpl/template/default_modal_folder_body.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_folder_body.php
@@ -15,7 +15,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 ?>
 <div id="#template-manager-folder" class="container-fluid">
     <div class="mt-2 p-2">

--- a/administrator/components/com_templates/tmpl/template/default_modal_folder_footer.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_folder_footer.php
@@ -15,7 +15,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 ?>
 <form id="deleteFolder" method="post" action="<?php echo Route::_('index.php?option=com_templates&task=template.deleteFolder&id=' . $input->getInt('id') . '&file=' . $this->file); ?>">
     <fieldset>

--- a/administrator/components/com_templates/tmpl/template/default_updated_files.php
+++ b/administrator/components/com_templates/tmpl/template/default_updated_files.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Router\Route;
 
 HTMLHelper::_('bootstrap.dropdown', '.dropdown-toggle');
 
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 ?>
 
 <?php if (count($this->updatedList) === 0) : ?>

--- a/administrator/components/com_templates/tmpl/template/readonly.php
+++ b/administrator/components/com_templates/tmpl/template/readonly.php
@@ -15,7 +15,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 ?>
 <form action="<?php echo Route::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm">
     <?php echo HTMLHelper::_('uitab.startTabSet', 'myTab', ['active' => 'description', 'recall' => true, 'breakpoint' => 768]); ?>

--- a/administrator/components/com_users/src/Controller/MethodController.php
+++ b/administrator/components/com_users/src/Controller/MethodController.php
@@ -309,7 +309,7 @@ class MethodController extends BaseControllerAlias
 
         // Ask the plugin to validate the input by calling onUserMultifactorSaveSetup
         $result = [];
-        $input  = $this->app->input;
+        $input  = $this->app->getInput();
 
         $event = new NotifyActionLog('onComUsersControllerMethodBeforeSave', [$id, $user]);
         $this->app->getDispatcher()->dispatch($event->getName(), $event);

--- a/administrator/components/com_users/src/Field/GroupparentField.php
+++ b/administrator/components/com_users/src/Field/GroupparentField.php
@@ -67,7 +67,7 @@ class GroupparentField extends ListField
     protected function getOptions()
     {
         $options        = UserGroupsHelper::getInstance()->getAll();
-        $currentGroupId = (int) Factory::getApplication()->input->get('id', 0, 'int');
+        $currentGroupId = (int) Factory::getApplication()->getInput()->get('id', 0, 'int');
 
         // Prevent to set yourself as parent
         if ($currentGroupId) {

--- a/administrator/components/com_users/src/Helper/Mfa.php
+++ b/administrator/components/com_users/src/Helper/Mfa.php
@@ -78,7 +78,7 @@ abstract class Mfa
         /** @var CMSApplication $app */
         $app = Factory::getApplication();
 
-        if (!$app->input->getCmd('option', '') === 'com_users') {
+        if (!$app->getInput()->getCmd('option', '') === 'com_users') {
             $app->getLanguage()->load('com_users');
             $app->getDocument()
                 ->getWebAssetManager()

--- a/administrator/components/com_users/src/Model/DebuggroupModel.php
+++ b/administrator/components/com_users/src/Model/DebuggroupModel.php
@@ -113,7 +113,7 @@ class DebuggroupModel extends ListModel
         $app = Factory::getApplication();
 
         // Adjust the context to support modal layouts.
-        $layout = $app->input->get('layout', 'default');
+        $layout = $app->getInput()->get('layout', 'default');
 
         if ($layout) {
             $this->context .= '.' . $layout;

--- a/administrator/components/com_users/src/Model/DebuguserModel.php
+++ b/administrator/components/com_users/src/Model/DebuguserModel.php
@@ -114,7 +114,7 @@ class DebuguserModel extends ListModel
         $app = Factory::getApplication();
 
         // Adjust the context to support modal layouts.
-        $layout = $app->input->get('layout', 'default');
+        $layout = $app->getInput()->get('layout', 'default');
 
         if ($layout) {
             $this->context .= '.' . $layout;

--- a/administrator/components/com_users/src/Model/GroupModel.php
+++ b/administrator/components/com_users/src/Model/GroupModel.php
@@ -218,7 +218,7 @@ class GroupModel extends AdminModel
             }
         }
 
-        if (Factory::getApplication()->input->get('task') == 'save2copy') {
+        if (Factory::getApplication()->getInput()->get('task') == 'save2copy') {
             $data['title'] = $this->generateGroupTitle($data['parent_id'], $data['title']);
         }
 

--- a/administrator/components/com_users/src/Model/MailModel.php
+++ b/administrator/components/com_users/src/Model/MailModel.php
@@ -101,7 +101,7 @@ class MailModel extends AdminModel
     public function send()
     {
         $app      = Factory::getApplication();
-        $data     = $app->input->post->get('jform', array(), 'array');
+        $data     = $app->getInput()->post->get('jform', array(), 'array');
         $user     = $this->getCurrentUser();
         $access   = new Access();
         $db       = $this->getDatabase();

--- a/administrator/components/com_users/src/Model/NoteModel.php
+++ b/administrator/components/com_users/src/Model/NoteModel.php
@@ -105,10 +105,10 @@ class NoteModel extends AdminModel
 
             // Prime some default values.
             if ($this->getState('note.id') == 0) {
-                $data->set('catid', $app->input->get('catid', $app->getUserState('com_users.notes.filter.category_id'), 'int'));
+                $data->set('catid', $app->getInput()->get('catid', $app->getUserState('com_users.notes.filter.category_id'), 'int'));
             }
 
-            $userId = $app->input->get('u_id', 0, 'int');
+            $userId = $app->getInput()->get('u_id', 0, 'int');
 
             if ($userId != 0) {
                 $data->user_id = $userId;
@@ -134,7 +134,7 @@ class NoteModel extends AdminModel
     {
         parent::populateState();
 
-        $userId = Factory::getApplication()->input->get('u_id', 0, 'int');
+        $userId = Factory::getApplication()->getInput()->get('u_id', 0, 'int');
         $this->setState('note.user_id', $userId);
     }
 }

--- a/administrator/components/com_users/src/Model/NotesModel.php
+++ b/administrator/components/com_users/src/Model/NotesModel.php
@@ -222,7 +222,7 @@ class NotesModel extends ListModel
     protected function populateState($ordering = 'a.review_time', $direction = 'desc')
     {
         // Adjust the context to support modal layouts.
-        if ($layout = Factory::getApplication()->input->get('layout')) {
+        if ($layout = Factory::getApplication()->getInput()->get('layout')) {
             $this->context .= '.' . $layout;
         }
 

--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -89,14 +89,15 @@ class UsersModel extends ListModel
      */
     protected function populateState($ordering = 'a.name', $direction = 'asc')
     {
-        $app = Factory::getApplication();
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
 
         // Adjust the context to support modal layouts.
-        if ($layout = $app->getInput()->get('layout', 'default', 'cmd')) {
+        if ($layout = $input->get('layout', 'default', 'cmd')) {
             $this->context .= '.' . $layout;
         }
 
-        $groups = json_decode(base64_decode($app->getInput()->get('groups', '', 'BASE64')));
+        $groups = json_decode(base64_decode($input->get('groups', '', 'BASE64')));
 
         if (isset($groups)) {
             $groups = ArrayHelper::toInteger($groups);
@@ -104,7 +105,7 @@ class UsersModel extends ListModel
 
         $this->setState('filter.groups', $groups);
 
-        $excluded = json_decode(base64_decode($app->getInput()->get('excluded', '', 'BASE64')));
+        $excluded = json_decode(base64_decode($input->get('excluded', '', 'BASE64')));
 
         if (isset($excluded)) {
             $excluded = ArrayHelper::toInteger($excluded);

--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -92,11 +92,11 @@ class UsersModel extends ListModel
         $app = Factory::getApplication();
 
         // Adjust the context to support modal layouts.
-        if ($layout = $app->input->get('layout', 'default', 'cmd')) {
+        if ($layout = $app->getInput()->get('layout', 'default', 'cmd')) {
             $this->context .= '.' . $layout;
         }
 
-        $groups = json_decode(base64_decode($app->input->get('groups', '', 'BASE64')));
+        $groups = json_decode(base64_decode($app->getInput()->get('groups', '', 'BASE64')));
 
         if (isset($groups)) {
             $groups = ArrayHelper::toInteger($groups);
@@ -104,7 +104,7 @@ class UsersModel extends ListModel
 
         $this->setState('filter.groups', $groups);
 
-        $excluded = json_decode(base64_decode($app->input->get('excluded', '', 'BASE64')));
+        $excluded = json_decode(base64_decode($app->getInput()->get('excluded', '', 'BASE64')));
 
         if (isset($excluded)) {
             $excluded = ArrayHelper::toInteger($excluded);

--- a/administrator/components/com_users/src/View/Group/HtmlView.php
+++ b/administrator/components/com_users/src/View/Group/HtmlView.php
@@ -84,7 +84,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $isNew = ($this->item->id == 0);
         $canDo = ContentHelper::getActions('com_users');

--- a/administrator/components/com_users/src/View/Level/HtmlView.php
+++ b/administrator/components/com_users/src/View/Level/HtmlView.php
@@ -84,7 +84,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $isNew = ($this->item->id == 0);
         $canDo = ContentHelper::getActions('com_users');

--- a/administrator/components/com_users/src/View/Mail/HtmlView.php
+++ b/administrator/components/com_users/src/View/Mail/HtmlView.php
@@ -67,7 +67,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         ToolbarHelper::title(Text::_('COM_USERS_MASS_MAIL'), 'users massmail');
         ToolbarHelper::custom('mail.send', 'envelope', '', 'COM_USERS_TOOLBAR_MAIL_SEND_MAIL', false);

--- a/administrator/components/com_users/src/View/Note/HtmlView.php
+++ b/administrator/components/com_users/src/View/Note/HtmlView.php
@@ -91,7 +91,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $input->set('hidemainmenu', 1);
 
         $user       = $this->getCurrentUser();

--- a/administrator/components/com_users/src/View/SiteTemplateTrait.php
+++ b/administrator/components/com_users/src/View/SiteTemplateTrait.php
@@ -43,13 +43,13 @@ trait SiteTemplateTrait
             return;
         }
 
-        $itemId = $app->input->get('Itemid');
+        $itemId = $app->getInput()->get('Itemid');
 
         if (!empty($itemId)) {
             return;
         }
 
-        $app->input->set('templateStyle', $templateStyle);
+        $app->getInput()->set('templateStyle', $templateStyle);
 
         try {
             $refApp      = new ReflectionObject($app);

--- a/administrator/components/com_users/src/View/User/HtmlView.php
+++ b/administrator/components/com_users/src/View/User/HtmlView.php
@@ -144,7 +144,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user      = Factory::getApplication()->getIdentity();
         $canDo     = ContentHelper::getActions('com_users');

--- a/administrator/components/com_users/tmpl/user/edit.php
+++ b/administrator/components/com_users/tmpl/user/edit.php
@@ -23,7 +23,7 @@ $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')
     ->useScript('form.validate');
 
-$input = Factory::getApplication()->input;
+$input = Factory::getApplication()->getInput();
 
 // Get the form fieldsets.
 $fieldsets = $this->form->getFieldsets();

--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Router\Route;
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('multiselect');
 
-$input           = Factory::getApplication()->input;
+$input           = Factory::getApplication()->getInput();
 $field           = $input->getCmd('field');
 $listOrder       = $this->escape($this->state->get('list.ordering'));
 $listDirn        = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_workflow/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_workflow/src/Dispatcher/Dispatcher.php
@@ -31,7 +31,7 @@ class Dispatcher extends ComponentDispatcher
      */
     protected function checkAccess()
     {
-        $extension = $this->getApplication()->input->getCmd('extension');
+        $extension = $this->getApplication()->getInput()->getCmd('extension');
 
         $parts = explode('.', $extension);
 

--- a/administrator/components/com_workflow/src/Model/StageModel.php
+++ b/administrator/components/com_workflow/src/Model/StageModel.php
@@ -87,7 +87,7 @@ class StageModel extends AdminModel
         $context    = $this->option . '.' . $this->name;
         $app        = Factory::getApplication();
         $user       = $app->getIdentity();
-        $input      = $app->input;
+        $input      = $app->getInput();
         $workflowID = $app->getUserStateFromRequest($context . '.filter.workflow_id', 'workflow_id', 0, 'int');
 
         if (empty($data['workflow_id'])) {
@@ -359,7 +359,7 @@ class StageModel extends AdminModel
      */
     protected function preprocessForm(Form $form, $data, $group = 'content')
     {
-        $extension = Factory::getApplication()->input->get('extension');
+        $extension = Factory::getApplication()->getInput()->get('extension');
 
         $parts = explode('.', $extension);
 

--- a/administrator/components/com_workflow/src/Model/TransitionModel.php
+++ b/administrator/components/com_workflow/src/Model/TransitionModel.php
@@ -136,7 +136,7 @@ class TransitionModel extends AdminModel
         $context    = $this->option . '.' . $this->name;
         $app        = Factory::getApplication();
         $user       = $app->getIdentity();
-        $input      = $app->input;
+        $input      = $app->getInput();
 
         $workflowID = $app->getUserStateFromRequest($context . '.filter.workflow_id', 'workflow_id', 0, 'int');
 
@@ -319,7 +319,7 @@ class TransitionModel extends AdminModel
      */
     protected function preprocessForm(Form $form, $data, $group = 'content')
     {
-        $extension = Factory::getApplication()->input->get('extension');
+        $extension = Factory::getApplication()->getInput()->get('extension');
 
         $parts = explode('.', $extension);
 

--- a/administrator/components/com_workflow/src/Model/WorkflowModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowModel.php
@@ -86,7 +86,7 @@ class WorkflowModel extends AdminModel
         $table             = $this->getTable();
         $app               = Factory::getApplication();
         $user              = $app->getIdentity();
-        $input             = $app->input;
+        $input             = $app->getInput();
         $context           = $this->option . '.' . $this->name;
         $extension         = $app->getUserStateFromRequest($context . '.filter.extension', 'extension', null, 'cmd');
         $data['extension'] = !empty($data['extension']) ? $data['extension'] : $extension;
@@ -226,7 +226,7 @@ class WorkflowModel extends AdminModel
      */
     protected function preprocessForm(Form $form, $data, $group = 'content')
     {
-        $extension = Factory::getApplication()->input->get('extension');
+        $extension = Factory::getApplication()->getInput()->get('extension');
 
         $parts = explode('.', $extension);
 

--- a/administrator/components/com_workflow/src/View/Stage/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Stage/HtmlView.php
@@ -116,7 +116,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();
         $userId     = $user->id;

--- a/administrator/components/com_workflow/src/View/Stages/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Stages/HtmlView.php
@@ -147,7 +147,7 @@ class HtmlView extends BaseHtmlView
         }
 
         if (!empty($this->stages)) {
-            $extension = Factory::getApplication()->input->getCmd('extension');
+            $extension = Factory::getApplication()->getInput()->getCmd('extension');
             $workflow  = new Workflow($extension);
         }
 

--- a/administrator/components/com_workflow/src/View/Transition/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Transition/HtmlView.php
@@ -105,7 +105,7 @@ class HtmlView extends BaseHtmlView
     public function display($tpl = null)
     {
         $this->app = Factory::getApplication();
-        $this->input = $this->app->input;
+        $this->input = $this->app->getInput();
 
         // Get the Data
         $this->state      = $this->get('State');
@@ -146,7 +146,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();
         $userId     = $user->id;

--- a/administrator/components/com_workflow/src/View/Workflow/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Workflow/HtmlView.php
@@ -121,7 +121,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user       = $this->getCurrentUser();
         $userId     = $user->id;

--- a/administrator/components/com_workflow/tmpl/stage/edit.php
+++ b/administrator/components/com_workflow/tmpl/stage/edit.php
@@ -23,7 +23,7 @@ $wa->useScript('keepalive')
 
 $app   = Factory::getApplication();
 $user  = $app->getIdentity();
-$input = $app->input;
+$input = $app->getInput();
 
 // In case of modal
 $isModal  = $input->get('layout') === 'modal';

--- a/administrator/components/com_workflow/tmpl/workflow/edit.php
+++ b/administrator/components/com_workflow/tmpl/workflow/edit.php
@@ -23,7 +23,7 @@ $wa->useScript('keepalive')
 
 $app = Factory::getApplication();
 $user = $app->getIdentity();
-$input = $app->input;
+$input = $app->getInput();
 
 // In case of modal
 $isModal  = $input->get('layout') === 'modal';

--- a/administrator/modules/mod_menu/mod_menu.php
+++ b/administrator/modules/mod_menu/mod_menu.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\Module\Menu\Administrator\Menu\CssMenu;
 
-$enabled = !$app->input->getBool('hidemainmenu');
+$enabled = !$app->getInput()->getBool('hidemainmenu');
 
 $menu = new CssMenu($app);
 $root = $menu->load($params, $enabled);

--- a/administrator/modules/mod_messages/tmpl/default.php
+++ b/administrator/modules/mod_messages/tmpl/default.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-$hideLinks = $app->input->getBool('hidemainmenu');
+$hideLinks = $app->getInput()->getBool('hidemainmenu');
 
 if ($hideLinks || $countUnread < 1) {
     return;

--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -14,7 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-$hideLinks = $app->input->getBool('hidemainmenu');
+$hideLinks = $app->getInput()->getBool('hidemainmenu');
 
 if (!$multilanguageEnabled || $hideLinks) {
     return;

--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
-$hideLinks = $app->input->getBool('hidemainmenu');
+$hideLinks = $app->getInput()->getBool('hidemainmenu');
 
 if ($hideLinks || $messagesCount < 1) {
     return;

--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 
-$hideLinks = $app->input->getBool('hidemainmenu');
+$hideLinks = $app->getInput()->getBool('hidemainmenu');
 
 if ($hideLinks) {
     return;

--- a/administrator/templates/atum/error_full.php
+++ b/administrator/templates/atum/error_full.php
@@ -19,7 +19,7 @@ use Joomla\CMS\Uri\Uri;
 /** @var \Joomla\CMS\Document\ErrorDocument $this */
 
 $app   = Factory::getApplication();
-$input = $app->input;
+$input = $app->getInput();
 $wa    = $this->getWebAssetManager();
 
 // Detecting Active Variables
@@ -28,7 +28,7 @@ $view       = $input->get('view', '');
 $layout     = $input->get('layout', 'default');
 $task       = $input->get('task', 'display');
 $cpanel     = $option === 'com_cpanel';
-$hiddenMenu = $app->input->get('hidemainmenu');
+$hiddenMenu = $app->getInput()->get('hidemainmenu');
 
 // Browsers support SVG favicons
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon.svg', '', [], true, 1), 'icon', 'rel', ['type' => 'image/svg+xml']);

--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -19,7 +19,7 @@ use Joomla\CMS\Uri\Uri;
 /** @var \Joomla\CMS\Document\ErrorDocument $this */
 
 $app   = Factory::getApplication();
-$input = $app->input;
+$input = $app->getInput();
 $wa    = $this->getWebAssetManager();
 
 // Detecting Active Variables

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Uri\Uri;
 /** @var \Joomla\CMS\Document\HtmlDocument $this */
 
 $app   = Factory::getApplication();
-$input = $app->input;
+$input = $app->getInput();
 $wa    = $this->getWebAssetManager();
 
 // Detecting Active Variables
@@ -29,7 +29,7 @@ $view         = $input->get('view', '');
 $layout       = $input->get('layout', 'default');
 $task         = $input->get('task', 'display');
 $cpanel       = $option === 'com_cpanel' || ($option === 'com_admin' && $view === 'help');
-$hiddenMenu   = $app->input->get('hidemainmenu');
+$hiddenMenu   = $app->getInput()->get('hidemainmenu');
 $sidebarState = $input->cookie->get('atumSidebarState', '');
 
 // Getting user accessibility settings

--- a/administrator/templates/atum/login.php
+++ b/administrator/templates/atum/login.php
@@ -19,7 +19,7 @@ use Joomla\CMS\Uri\Uri;
 /** @var \Joomla\CMS\Document\HtmlDocument $this */
 
 $app   = Factory::getApplication();
-$input = $app->input;
+$input = $app->getInput();
 $wa    = $this->getWebAssetManager();
 
 // Detecting Active Variables

--- a/api/components/com_languages/src/Controller/StringsController.php
+++ b/api/components/com_languages/src/Controller/StringsController.php
@@ -63,9 +63,9 @@ class StringsController extends ApiController
         }
 
         $app = Factory::getApplication();
-        $app->input->set('searchstring', $data['searchstring']);
-        $app->input->set('searchtype', $data['searchtype']);
-        $app->input->set('more', 0);
+        $app->getInput()->set('searchstring', $data['searchstring']);
+        $app->getInput()->set('searchtype', $data['searchtype']);
+        $app->getInput()->set('more', 0);
 
         $viewType   = $this->app->getDocument()->getType();
         $viewName   = $this->input->get('view', $this->default_view);

--- a/api/components/com_languages/src/Controller/StringsController.php
+++ b/api/components/com_languages/src/Controller/StringsController.php
@@ -62,10 +62,9 @@ class StringsController extends ApiController
             throw new InvalidParameterException("Invalid param 'searchtype'");
         }
 
-        $app = Factory::getApplication();
-        $app->getInput()->set('searchstring', $data['searchstring']);
-        $app->getInput()->set('searchtype', $data['searchtype']);
-        $app->getInput()->set('more', 0);
+        $this->input->set('searchstring', $data['searchstring']);
+        $this->input->set('searchtype', $data['searchtype']);
+        $this->input->set('more', 0);
 
         $viewType   = $this->app->getDocument()->getType();
         $viewName   = $this->input->get('view', $this->default_view);

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -34,7 +34,7 @@ $app->allowCache(false);
 $app->setHeader('X-Robots-Tag', 'noindex, nofollow');
 
 // JInput object
-$input = $app->input;
+$input = $app->getInput();
 
 // Requested format passed via URL
 $format = strtolower($input->getWord('format', ''));

--- a/components/com_config/src/Controller/ConfigController.php
+++ b/components/com_config/src/Controller/ConfigController.php
@@ -83,7 +83,7 @@ class ConfigController extends BaseController
         $model = $this->getModel();
 
         $form  = $model->getForm();
-        $data  = $this->app->input->post->get('jform', array(), 'array');
+        $data  = $this->app->getInput()->post->get('jform', array(), 'array');
 
         // Validate the posted data.
         $return = $model->validate($form, $data);

--- a/components/com_config/src/Controller/TemplatesController.php
+++ b/components/com_config/src/Controller/TemplatesController.php
@@ -86,7 +86,7 @@ class TemplatesController extends BaseController
 
         // Access backend com_templates
         $controllerClass = $app->bootComponent('com_templates')
-            ->getMVCFactory()->createController('Style', 'Administrator', [], $app, $app->input);
+            ->getMVCFactory()->createController('Style', 'Administrator', [], $app, $app->getInput());
 
         // Get a document object
         $document = $app->getDocument();

--- a/components/com_config/src/Model/ModulesModel.php
+++ b/components/com_config/src/Model/ModulesModel.php
@@ -41,7 +41,7 @@ class ModulesModel extends FormModel
         $app = Factory::getApplication();
 
         // Load the User state.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
 
         $this->setState('module.id', $pk);
     }

--- a/components/com_config/src/View/Modules/HtmlView.php
+++ b/components/com_config/src/View/Modules/HtmlView.php
@@ -60,7 +60,7 @@ class HtmlView extends BaseHtmlView
         $lang->load('com_modules', JPATH_ADMINISTRATOR, $lang->getTag());
 
         // @todo Move and clean up
-        $module = (new \Joomla\Component\Modules\Administrator\Model\ModuleModel())->getItem(Factory::getApplication()->input->getInt('id'));
+        $module = (new \Joomla\Component\Modules\Administrator\Model\ModuleModel())->getItem(Factory::getApplication()->getInput()->getInt('id'));
 
         $moduleData = $module->getProperties();
         unset($moduleData['xml']);

--- a/components/com_config/src/View/Templates/HtmlView.php
+++ b/components/com_config/src/View/Templates/HtmlView.php
@@ -86,7 +86,7 @@ class HtmlView extends BaseHtmlView
 
         $app   = Factory::getApplication();
 
-        $app->input->set('id', $app->getTemplate(true)->id);
+        $app->getInput()->set('id', $app->getTemplate(true)->id);
 
         /** @var MVCFactory $factory */
         $factory = $app->bootComponent('com_templates')->getMVCFactory();

--- a/components/com_config/tmpl/modules/default.php
+++ b/components/com_config/tmpl/modules/default.php
@@ -165,7 +165,7 @@ if (Multilanguage::isEnabled()) {
                 </div>
 
                 <input type="hidden" name="id" value="<?php echo $this->item['id']; ?>">
-                <input type="hidden" name="return" value="<?php echo Factory::getApplication()->input->get('return', null, 'base64'); ?>">
+                <input type="hidden" name="return" value="<?php echo Factory::getApplication()->getInput()->get('return', null, 'base64'); ?>">
                 <input type="hidden" name="task" value="">
                 <?php echo HTMLHelper::_('form.token'); ?>
             </div>

--- a/components/com_contact/src/Controller/DisplayController.php
+++ b/components/com_contact/src/Controller/DisplayController.php
@@ -39,7 +39,7 @@ class DisplayController extends BaseController
     public function __construct($config = array(), MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         // Contact frontpage Editor contacts proxying.
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         if ($input->get('view') === 'contacts' && $input->get('layout') === 'modal') {
             $config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;

--- a/components/com_contact/src/Helper/AssociationHelper.php
+++ b/components/com_contact/src/Helper/AssociationHelper.php
@@ -37,7 +37,7 @@ abstract class AssociationHelper extends CategoryAssociationHelper
      */
     public static function getAssociations($id = 0, $view = null)
     {
-        $jinput = Factory::getApplication()->input;
+        $jinput = Factory::getApplication()->getInput();
         $view   = $view ?? $jinput->get('view');
         $id     = empty($id) ? $jinput->getInt('id') : $id;
 

--- a/components/com_contact/src/Model/CategoriesModel.php
+++ b/components/com_contact/src/Model/CategoriesModel.php
@@ -73,7 +73,7 @@ class CategoriesModel extends ListModel
         $this->setState('filter.extension', $this->_extension);
 
         // Get the parent id if defined.
-        $parentId = $app->input->getInt('id');
+        $parentId = $app->getInput()->getInt('id');
         $this->setState('filter.parentId', $parentId);
 
         $params = $app->getParams();

--- a/components/com_contact/src/Model/CategoryModel.php
+++ b/components/com_contact/src/Model/CategoryModel.php
@@ -267,7 +267,7 @@ class CategoryModel extends ListModel
         $this->setState('params', $params);
 
         // List state information
-        $format = $app->input->getWord('format');
+        $format = $app->getInput()->getWord('format');
 
         if ($format === 'feed') {
             $limit = $app->get('feed_limit');
@@ -282,15 +282,15 @@ class CategoryModel extends ListModel
 
         $this->setState('list.limit', $limit);
 
-        $limitstart = $app->input->get('limitstart', 0, 'uint');
+        $limitstart = $app->getInput()->get('limitstart', 0, 'uint');
         $this->setState('list.start', $limitstart);
 
         // Optional filter text
-        $itemid = $app->input->get('Itemid', 0, 'int');
+        $itemid = $app->getInput()->get('Itemid', 0, 'int');
         $search = $app->getUserStateFromRequest('com_contact.category.list.' . $itemid . '.filter-search', 'filter-search', '', 'string');
         $this->setState('list.filter', $search);
 
-        $orderCol = $app->input->get('filter_order', $params->get('initial_sort', 'ordering'));
+        $orderCol = $app->getInput()->get('filter_order', $params->get('initial_sort', 'ordering'));
 
         if (!in_array($orderCol, $this->filter_fields)) {
             $orderCol = 'ordering';
@@ -298,7 +298,7 @@ class CategoryModel extends ListModel
 
         $this->setState('list.ordering', $orderCol);
 
-        $listOrder = $app->input->get('filter_order_Dir', 'ASC');
+        $listOrder = $app->getInput()->get('filter_order_Dir', 'ASC');
 
         if (!in_array(strtoupper($listOrder), array('ASC', 'DESC', ''))) {
             $listOrder = 'ASC';
@@ -306,7 +306,7 @@ class CategoryModel extends ListModel
 
         $this->setState('list.direction', $listOrder);
 
-        $id = $app->input->get('id', 0, 'int');
+        $id = $app->getInput()->get('id', 0, 'int');
         $this->setState('category.id', $id);
 
         $user = $this->getCurrentUser();
@@ -454,7 +454,7 @@ class CategoryModel extends ListModel
      */
     public function hit($pk = 0)
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $hitcount = $input->getInt('hitcount', 1);
 
         if ($hitcount) {

--- a/components/com_contact/src/Model/CategoryModel.php
+++ b/components/com_contact/src/Model/CategoryModel.php
@@ -261,13 +261,14 @@ class CategoryModel extends ListModel
      */
     protected function populateState($ordering = null, $direction = null)
     {
-        $app = Factory::getApplication();
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
 
         $params = $app->getParams();
         $this->setState('params', $params);
 
         // List state information
-        $format = $app->getInput()->getWord('format');
+        $format = $input->getWord('format');
 
         if ($format === 'feed') {
             $limit = $app->get('feed_limit');
@@ -282,15 +283,15 @@ class CategoryModel extends ListModel
 
         $this->setState('list.limit', $limit);
 
-        $limitstart = $app->getInput()->get('limitstart', 0, 'uint');
+        $limitstart = $input->get('limitstart', 0, 'uint');
         $this->setState('list.start', $limitstart);
 
         // Optional filter text
-        $itemid = $app->getInput()->get('Itemid', 0, 'int');
+        $itemid = $input->get('Itemid', 0, 'int');
         $search = $app->getUserStateFromRequest('com_contact.category.list.' . $itemid . '.filter-search', 'filter-search', '', 'string');
         $this->setState('list.filter', $search);
 
-        $orderCol = $app->getInput()->get('filter_order', $params->get('initial_sort', 'ordering'));
+        $orderCol = $input->get('filter_order', $params->get('initial_sort', 'ordering'));
 
         if (!in_array($orderCol, $this->filter_fields)) {
             $orderCol = 'ordering';
@@ -298,7 +299,7 @@ class CategoryModel extends ListModel
 
         $this->setState('list.ordering', $orderCol);
 
-        $listOrder = $app->getInput()->get('filter_order_Dir', 'ASC');
+        $listOrder = $input->get('filter_order_Dir', 'ASC');
 
         if (!in_array(strtoupper($listOrder), array('ASC', 'DESC', ''))) {
             $listOrder = 'ASC';
@@ -306,7 +307,7 @@ class CategoryModel extends ListModel
 
         $this->setState('list.direction', $listOrder);
 
-        $id = $app->getInput()->get('id', 0, 'int');
+        $id = $input->get('id', 0, 'int');
         $this->setState('category.id', $id);
 
         $user = $this->getCurrentUser();

--- a/components/com_contact/src/Model/ContactModel.php
+++ b/components/com_contact/src/Model/ContactModel.php
@@ -76,9 +76,9 @@ class ContactModel extends FormModel
         if (Factory::getApplication()->isClient('api')) {
             // @todo: remove this
             $app->loadLanguage();
-            $this->setState('contact.id', Factory::getApplication()->input->post->getInt('id'));
+            $this->setState('contact.id', Factory::getApplication()->getInput()->post->getInt('id'));
         } else {
-            $this->setState('contact.id', $app->input->getInt('id'));
+            $this->setState('contact.id', $app->getInput()->getInt('id'));
         }
 
         $this->setState('params', $app->getParams());
@@ -423,7 +423,7 @@ class ContactModel extends FormModel
      */
     public function hit($pk = 0)
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $hitcount = $input->getInt('hitcount', 1);
 
         if ($hitcount) {

--- a/components/com_contact/src/Model/FeaturedModel.php
+++ b/components/com_contact/src/Model/FeaturedModel.php
@@ -167,13 +167,13 @@ class FeaturedModel extends ListModel
         $limit = $app->getUserStateFromRequest('global.list.limit', 'limit', $app->get('list_limit'), 'uint');
         $this->setState('list.limit', $limit);
 
-        $limitstart = $app->input->get('limitstart', 0, 'uint');
+        $limitstart = $app->getInput()->get('limitstart', 0, 'uint');
         $this->setState('list.start', $limitstart);
 
         // Optional filter text
-        $this->setState('list.filter', $app->input->getString('filter-search'));
+        $this->setState('list.filter', $app->getInput()->getString('filter-search'));
 
-        $orderCol = $app->input->get('filter_order', 'ordering');
+        $orderCol = $app->getInput()->get('filter_order', 'ordering');
 
         if (!in_array($orderCol, $this->filter_fields)) {
             $orderCol = 'ordering';
@@ -181,7 +181,7 @@ class FeaturedModel extends ListModel
 
         $this->setState('list.ordering', $orderCol);
 
-        $listOrder = $app->input->get('filter_order_Dir', 'ASC');
+        $listOrder = $app->getInput()->get('filter_order_Dir', 'ASC');
 
         if (!in_array(strtoupper($listOrder), array('ASC', 'DESC', ''))) {
             $listOrder = 'ASC';

--- a/components/com_contact/src/Model/FeaturedModel.php
+++ b/components/com_contact/src/Model/FeaturedModel.php
@@ -160,20 +160,21 @@ class FeaturedModel extends ListModel
      */
     protected function populateState($ordering = null, $direction = null)
     {
-        $app = Factory::getApplication();
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
         $params = ComponentHelper::getParams('com_contact');
 
         // List state information
         $limit = $app->getUserStateFromRequest('global.list.limit', 'limit', $app->get('list_limit'), 'uint');
         $this->setState('list.limit', $limit);
 
-        $limitstart = $app->getInput()->get('limitstart', 0, 'uint');
+        $limitstart = $input->get('limitstart', 0, 'uint');
         $this->setState('list.start', $limitstart);
 
         // Optional filter text
-        $this->setState('list.filter', $app->getInput()->getString('filter-search'));
+        $this->setState('list.filter', $input->getString('filter-search'));
 
-        $orderCol = $app->getInput()->get('filter_order', 'ordering');
+        $orderCol = $input->get('filter_order', 'ordering');
 
         if (!in_array($orderCol, $this->filter_fields)) {
             $orderCol = 'ordering';
@@ -181,7 +182,7 @@ class FeaturedModel extends ListModel
 
         $this->setState('list.ordering', $orderCol);
 
-        $listOrder = $app->getInput()->get('filter_order_Dir', 'ASC');
+        $listOrder = $input->get('filter_order_Dir', 'ASC');
 
         if (!in_array(strtoupper($listOrder), array('ASC', 'DESC', ''))) {
             $listOrder = 'ASC';

--- a/components/com_contact/src/Model/FormModel.php
+++ b/components/com_contact/src/Model/FormModel.php
@@ -181,19 +181,19 @@ class FormModel extends \Joomla\Component\Contact\Administrator\Model\ContactMod
         $app = Factory::getApplication();
 
         // Load state from the request.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
         $this->setState('contact.id', $pk);
 
-        $this->setState('contact.catid', $app->input->getInt('catid'));
+        $this->setState('contact.catid', $app->getInput()->getInt('catid'));
 
-        $return = $app->input->get('return', '', 'base64');
+        $return = $app->getInput()->get('return', '', 'base64');
         $this->setState('return_page', base64_decode($return));
 
         // Load the parameters.
         $params = $app->getParams();
         $this->setState('params', $params);
 
-        $this->setState('layout', $app->input->getString('layout'));
+        $this->setState('layout', $app->getInput()->getString('layout'));
     }
 
     /**

--- a/components/com_contact/src/Model/FormModel.php
+++ b/components/com_contact/src/Model/FormModel.php
@@ -178,22 +178,23 @@ class FormModel extends \Joomla\Component\Contact\Administrator\Model\ContactMod
      */
     protected function populateState()
     {
-        $app = Factory::getApplication();
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
 
         // Load state from the request.
-        $pk = $app->getInput()->getInt('id');
+        $pk = $input->getInt('id');
         $this->setState('contact.id', $pk);
 
-        $this->setState('contact.catid', $app->getInput()->getInt('catid'));
+        $this->setState('contact.catid', $input->getInt('catid'));
 
-        $return = $app->getInput()->get('return', '', 'base64');
+        $return = $input->get('return', '', 'base64');
         $this->setState('return_page', base64_decode($return));
 
         // Load the parameters.
         $params = $app->getParams();
         $this->setState('params', $params);
 
-        $this->setState('layout', $app->getInput()->getString('layout'));
+        $this->setState('layout', $input->getString('layout'));
     }
 
     /**

--- a/components/com_content/src/Controller/ArticleController.php
+++ b/components/com_content/src/Controller/ArticleController.php
@@ -347,7 +347,7 @@ class ArticleController extends FormController
         }
 
         $app       = $this->app;
-        $articleId = $app->input->getInt('a_id');
+        $articleId = $app->getInput()->getInt('a_id');
 
         // Load the parameters.
         $params   = $app->getParams();

--- a/components/com_content/src/Controller/DisplayController.php
+++ b/components/com_content/src/Controller/DisplayController.php
@@ -39,7 +39,7 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
      */
     public function __construct($config = array(), MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
-        $this->input = Factory::getApplication()->input;
+        $this->input = Factory::getApplication()->getInput();
 
         // Article frontpage Editor pagebreak proxying:
         if ($this->input->get('view') === 'article' && $this->input->get('layout') === 'pagebreak') {

--- a/components/com_content/src/Helper/AssociationHelper.php
+++ b/components/com_content/src/Helper/AssociationHelper.php
@@ -40,7 +40,7 @@ abstract class AssociationHelper extends CategoryAssociationHelper
      */
     public static function getAssociations($id = 0, $view = null, $layout = null)
     {
-        $jinput    = Factory::getApplication()->input;
+        $jinput    = Factory::getApplication()->getInput();
         $view      = $view ?? $jinput->get('view');
         $component = $jinput->getCmd('option');
         $id        = empty($id) ? $jinput->getInt('id') : $id;

--- a/components/com_content/src/Model/ArchiveModel.php
+++ b/components/com_content/src/Model/ArchiveModel.php
@@ -58,14 +58,14 @@ class ArchiveModel extends ArticlesModel
         $this->setState('filter.published', ContentComponent::CONDITION_ARCHIVED);
 
         // Filter on month, year
-        $this->setState('filter.month', $app->input->getInt('month'));
-        $this->setState('filter.year', $app->input->getInt('year'));
+        $this->setState('filter.month', $app->getInput()->getInt('month'));
+        $this->setState('filter.year', $app->getInput()->getInt('year'));
 
         // Optional filter text
-        $this->setState('list.filter', $app->input->getString('filter-search'));
+        $this->setState('list.filter', $app->getInput()->getString('filter-search'));
 
         // Get list limit
-        $itemid = $app->input->get('Itemid', 0, 'int');
+        $itemid = $app->getInput()->get('Itemid', 0, 'int');
         $limit = $app->getUserStateFromRequest('com_content.archive.list' . $itemid . '.limit', 'limit', $params->get('display_num', 20), 'uint');
         $this->setState('list.limit', $limit);
 
@@ -91,7 +91,7 @@ class ArchiveModel extends ArticlesModel
     {
         $params           = $this->state->params;
         $app              = Factory::getApplication();
-        $catids           = $app->input->get('catid', array(), 'array');
+        $catids           = $app->getInput()->get('catid', array(), 'array');
         $catids           = array_values(array_diff($catids, array('')));
 
         $articleOrderDate = $params->get('order_date');
@@ -145,8 +145,8 @@ class ArchiveModel extends ArticlesModel
             $params = $app->getParams();
 
             // Get the pagination request variables
-            $limit      = $app->input->get('limit', $params->get('display_num', 20), 'uint');
-            $limitstart = $app->input->get('limitstart', 0, 'uint');
+            $limit      = $app->getInput()->get('limit', $params->get('display_num', 20), 'uint');
+            $limitstart = $app->getInput()->get('limitstart', 0, 'uint');
 
             $query = $this->_buildQuery();
 

--- a/components/com_content/src/Model/ArchiveModel.php
+++ b/components/com_content/src/Model/ArchiveModel.php
@@ -49,7 +49,8 @@ class ArchiveModel extends ArticlesModel
     {
         parent::populateState();
 
-        $app = Factory::getApplication();
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
 
         // Add archive properties
         $params = $this->state->get('params');
@@ -58,14 +59,14 @@ class ArchiveModel extends ArticlesModel
         $this->setState('filter.published', ContentComponent::CONDITION_ARCHIVED);
 
         // Filter on month, year
-        $this->setState('filter.month', $app->getInput()->getInt('month'));
-        $this->setState('filter.year', $app->getInput()->getInt('year'));
+        $this->setState('filter.month', $input->getInt('month'));
+        $this->setState('filter.year', $input->getInt('year'));
 
         // Optional filter text
-        $this->setState('list.filter', $app->getInput()->getString('filter-search'));
+        $this->setState('list.filter', $input->getString('filter-search'));
 
         // Get list limit
-        $itemid = $app->getInput()->get('Itemid', 0, 'int');
+        $itemid = $input->get('Itemid', 0, 'int');
         $limit = $app->getUserStateFromRequest('com_content.archive.list' . $itemid . '.limit', 'limit', $params->get('display_num', 20), 'uint');
         $this->setState('list.limit', $limit);
 

--- a/components/com_content/src/Model/ArticleModel.php
+++ b/components/com_content/src/Model/ArticleModel.php
@@ -52,10 +52,10 @@ class ArticleModel extends ItemModel
         $app = Factory::getApplication();
 
         // Load state from the request.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
         $this->setState('article.id', $pk);
 
-        $offset = $app->input->getUint('limitstart');
+        $offset = $app->getInput()->getUint('limitstart');
         $this->setState('list.offset', $offset);
 
         // Load the parameters.
@@ -288,7 +288,7 @@ class ArticleModel extends ItemModel
      */
     public function hit($pk = 0)
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $hitcount = $input->getInt('hitcount', 1);
 
         if ($hitcount) {

--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -93,16 +93,16 @@ class ArticlesModel extends ListModel
         $app = Factory::getApplication();
 
         // List state information
-        $value = $app->input->get('limit', $app->get('list_limit', 0), 'uint');
+        $value = $app->getInput()->get('limit', $app->get('list_limit', 0), 'uint');
         $this->setState('list.limit', $value);
 
-        $value = $app->input->get('limitstart', 0, 'uint');
+        $value = $app->getInput()->get('limitstart', 0, 'uint');
         $this->setState('list.start', $value);
 
-        $value = $app->input->get('filter_tag', 0, 'uint');
+        $value = $app->getInput()->get('filter_tag', 0, 'uint');
         $this->setState('filter.tag', $value);
 
-        $orderCol = $app->input->get('filter_order', 'a.ordering');
+        $orderCol = $app->getInput()->get('filter_order', 'a.ordering');
 
         if (!in_array($orderCol, $this->filter_fields)) {
             $orderCol = 'a.ordering';
@@ -110,7 +110,7 @@ class ArticlesModel extends ListModel
 
         $this->setState('list.ordering', $orderCol);
 
-        $listOrder = $app->input->get('filter_order_Dir', 'ASC');
+        $listOrder = $app->getInput()->get('filter_order_Dir', 'ASC');
 
         if (!in_array(strtoupper($listOrder), array('ASC', 'DESC', ''))) {
             $listOrder = 'ASC';
@@ -137,7 +137,7 @@ class ArticlesModel extends ListModel
             $this->setState('filter.access', false);
         }
 
-        $this->setState('layout', $app->input->getString('layout'));
+        $this->setState('layout', $app->getInput()->getString('layout'));
     }
 
     /**
@@ -643,7 +643,7 @@ class ArticlesModel extends ListModel
         $userId = $user->get('id');
         $guest = $user->get('guest');
         $groups = $user->getAuthorisedViewLevels();
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         // Get the global params
         $globalParams = ComponentHelper::getParams('com_content', true);

--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -90,19 +90,20 @@ class ArticlesModel extends ListModel
      */
     protected function populateState($ordering = 'ordering', $direction = 'ASC')
     {
-        $app = Factory::getApplication();
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
 
         // List state information
-        $value = $app->getInput()->get('limit', $app->get('list_limit', 0), 'uint');
+        $value = $input->get('limit', $app->get('list_limit', 0), 'uint');
         $this->setState('list.limit', $value);
 
-        $value = $app->getInput()->get('limitstart', 0, 'uint');
+        $value = $input->get('limitstart', 0, 'uint');
         $this->setState('list.start', $value);
 
-        $value = $app->getInput()->get('filter_tag', 0, 'uint');
+        $value = $input->get('filter_tag', 0, 'uint');
         $this->setState('filter.tag', $value);
 
-        $orderCol = $app->getInput()->get('filter_order', 'a.ordering');
+        $orderCol = $input->get('filter_order', 'a.ordering');
 
         if (!in_array($orderCol, $this->filter_fields)) {
             $orderCol = 'a.ordering';
@@ -110,7 +111,7 @@ class ArticlesModel extends ListModel
 
         $this->setState('list.ordering', $orderCol);
 
-        $listOrder = $app->getInput()->get('filter_order_Dir', 'ASC');
+        $listOrder = $input->get('filter_order_Dir', 'ASC');
 
         if (!in_array(strtoupper($listOrder), array('ASC', 'DESC', ''))) {
             $listOrder = 'ASC';
@@ -137,7 +138,7 @@ class ArticlesModel extends ListModel
             $this->setState('filter.access', false);
         }
 
-        $this->setState('layout', $app->getInput()->getString('layout'));
+        $this->setState('layout', $input->getString('layout'));
     }
 
     /**

--- a/components/com_content/src/Model/CategoriesModel.php
+++ b/components/com_content/src/Model/CategoriesModel.php
@@ -66,7 +66,7 @@ class CategoriesModel extends ListModel
         $this->setState('filter.extension', $this->_extension);
 
         // Get the parent id if defined.
-        $parentId = $app->input->getInt('id');
+        $parentId = $app->getInput()->getInt('id');
         $this->setState('filter.parentId', $parentId);
 
         $params = $app->getParams();

--- a/components/com_content/src/Model/CategoryModel.php
+++ b/components/com_content/src/Model/CategoryModel.php
@@ -138,7 +138,7 @@ class CategoryModel extends ListModel
     {
         $app = Factory::getApplication();
 
-        $pk  = $app->input->getInt('id');
+        $pk  = $app->getInput()->getInt('id');
         $this->setState('category.id', $pk);
 
         // Load the parameters. Merge Global and Menu Item params into new object
@@ -167,7 +167,7 @@ class CategoryModel extends ListModel
             $this->setState('filter.access', false);
         }
 
-        $itemid = $app->input->get('id', 0, 'int') . ':' . $app->input->get('Itemid', 0, 'int');
+        $itemid = $app->getInput()->get('id', 0, 'int') . ':' . $app->getInput()->get('Itemid', 0, 'int');
 
         $value = $this->getUserStateFromRequest('com_content.category.filter.' . $itemid . '.tag', 'filter_tag', 0, 'int', false);
         $this->setState('filter.tag', $value);
@@ -193,10 +193,10 @@ class CategoryModel extends ListModel
 
         $this->setState('list.direction', $listOrder);
 
-        $this->setState('list.start', $app->input->get('limitstart', 0, 'uint'));
+        $this->setState('list.start', $app->getInput()->get('limitstart', 0, 'uint'));
 
         // Set limit for query. If list, use parameter. If blog, add blog parameters for limit.
-        if (($app->input->get('layout') === 'blog') || $params->get('layout_type') === 'blog') {
+        if (($app->getInput()->get('layout') === 'blog') || $params->get('layout_type') === 'blog') {
             $limit = $params->get('num_leading_articles') + $params->get('num_intro_articles') + $params->get('num_links');
             $this->setState('list.links', $params->get('num_links'));
         } else {
@@ -215,7 +215,7 @@ class CategoryModel extends ListModel
 
         $this->setState('filter.language', Multilanguage::isEnabled());
 
-        $this->setState('layout', $app->input->getString('layout'));
+        $this->setState('layout', $app->getInput()->getString('layout'));
 
         // Set the featured articles state
         $this->setState('filter.featured', $params->get('show_featured'));
@@ -281,7 +281,7 @@ class CategoryModel extends ListModel
         $app       = Factory::getApplication();
         $db        = $this->getDatabase();
         $params    = $this->state->params;
-        $itemid    = $app->input->get('id', 0, 'int') . ':' . $app->input->get('Itemid', 0, 'int');
+        $itemid    = $app->getInput()->get('id', 0, 'int') . ':' . $app->getInput()->get('Itemid', 0, 'int');
         $orderCol  = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.filter_order', 'filter_order', '', 'string');
         $orderDirn = $app->getUserStateFromRequest('com_content.category.list.' . $itemid . '.filter_order_Dir', 'filter_order_Dir', '', 'cmd');
         $orderby   = ' ';
@@ -460,7 +460,7 @@ class CategoryModel extends ListModel
      */
     public function hit($pk = 0)
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $hitcount = $input->getInt('hitcount', 1);
 
         if ($hitcount) {

--- a/components/com_content/src/Model/FeaturedModel.php
+++ b/components/com_content/src/Model/FeaturedModel.php
@@ -51,7 +51,7 @@ class FeaturedModel extends ArticlesModel
         parent::populateState($ordering, $direction);
 
         $app   = Factory::getApplication();
-        $input = $app->input;
+        $input = $app->getInput();
         $user  = $app->getIdentity();
 
         // List state information

--- a/components/com_content/src/Model/FormModel.php
+++ b/components/com_content/src/Model/FormModel.php
@@ -63,15 +63,15 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
         }
 
         // Load state from the request.
-        $pk = $app->input->getInt('a_id');
+        $pk = $app->getInput()->getInt('a_id');
         $this->setState('article.id', $pk);
 
-        $this->setState('article.catid', $app->input->getInt('catid', $catId));
+        $this->setState('article.catid', $app->getInput()->getInt('catid', $catId));
 
-        $return = $app->input->get('return', '', 'base64');
+        $return = $app->getInput()->get('return', '', 'base64');
         $this->setState('return_page', base64_decode($return));
 
-        $this->setState('layout', $app->input->getString('layout'));
+        $this->setState('layout', $app->getInput()->getString('layout'));
     }
 
     /**
@@ -219,7 +219,7 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
         $user = $app->getIdentity();
 
         // On edit article, we get ID of article from article.id state, but on save, we use data from input
-        $id = (int) $this->getState('article.id', $app->input->getInt('a_id'));
+        $id = (int) $this->getState('article.id', $app->getInput()->getInt('a_id'));
 
         // Existing record. We can't edit the category in frontend if not edit.state.
         if ($id > 0 && !$user->authorise('core.edit.state', 'com_content.article.' . $id)) {

--- a/components/com_content/src/Model/FormModel.php
+++ b/components/com_content/src/Model/FormModel.php
@@ -50,7 +50,8 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
      */
     protected function populateState()
     {
-        $app = Factory::getApplication();
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
 
         // Load the parameters.
         $params = $app->getParams();
@@ -63,15 +64,15 @@ class FormModel extends \Joomla\Component\Content\Administrator\Model\ArticleMod
         }
 
         // Load state from the request.
-        $pk = $app->getInput()->getInt('a_id');
+        $pk = $input->getInt('a_id');
         $this->setState('article.id', $pk);
 
-        $this->setState('article.catid', $app->getInput()->getInt('catid', $catId));
+        $this->setState('article.catid', $input->getInt('catid', $catId));
 
-        $return = $app->getInput()->get('return', '', 'base64');
+        $return = $input->get('return', '', 'base64');
         $this->setState('return_page', base64_decode($return));
 
-        $this->setState('layout', $app->getInput()->getString('layout'));
+        $this->setState('layout', $input->getString('layout'));
     }
 
     /**

--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
         $user = $this->getCurrentUser();
 
         $this->item  = $this->get('Item');
-        $this->print = $app->input->getBool('print', false);
+        $this->print = $app->getInput()->getBool('print', false);
         $this->state = $this->get('State');
         $this->user  = $user;
 

--- a/components/com_content/src/View/Featured/FeedView.php
+++ b/components/com_content/src/View/Featured/FeedView.php
@@ -48,7 +48,7 @@ class FeedView extends AbstractView
         $this->document->link = Route::_('index.php?option=com_content&view=featured');
 
         // Get some data from the model
-        $app->input->set('limit', $app->get('feed_limit'));
+        $app->getInput()->set('limit', $app->get('feed_limit'));
         $categories = Categories::getInstance('Content');
         $rows       = $this->get('Items');
 

--- a/components/com_finder/src/Controller/DisplayController.php
+++ b/components/com_finder/src/Controller/DisplayController.php
@@ -37,7 +37,7 @@ class DisplayController extends BaseController
      */
     public function display($cachable = false, $urlparams = array())
     {
-        $input = $this->app->input;
+        $input = $this->app->getInput();
         $cachable = true;
 
         // Load plugin language files.

--- a/components/com_finder/src/Controller/SuggestionsController.php
+++ b/components/com_finder/src/Controller/SuggestionsController.php
@@ -59,7 +59,7 @@ class SuggestionsController extends BaseController
         $app = $this->app;
         $app->mimeType = 'application/json';
         $result = array();
-        $result[] = $app->input->request->get('q', '', 'string');
+        $result[] = $app->getInput()->request->get('q', '', 'string');
 
         $result[] = $this->getSuggestions();
 

--- a/components/com_finder/src/Model/SearchModel.php
+++ b/components/com_finder/src/Model/SearchModel.php
@@ -350,7 +350,7 @@ class SearchModel extends ListModel
     {
         // Get the configuration options.
         $app      = Factory::getApplication();
-        $input    = $app->input;
+        $input    = $app->getInput();
         $params   = $app->getParams();
         $user     = $this->getCurrentUser();
         $language = Factory::getLanguage();

--- a/components/com_finder/src/Model/SuggestionsModel.php
+++ b/components/com_finder/src/Model/SuggestionsModel.php
@@ -152,7 +152,7 @@ class SuggestionsModel extends ListModel
     {
         // Get the configuration options.
         $app = Factory::getApplication();
-        $input = $app->input;
+        $input = $app->getInput();
         $params = ComponentHelper::getParams('com_finder');
         $user = $this->getCurrentUser();
 

--- a/components/com_finder/src/View/Search/FeedView.php
+++ b/components/com_finder/src/View/Search/FeedView.php
@@ -42,7 +42,7 @@ class FeedView extends BaseHtmlView
         $app = Factory::getApplication();
 
         // Adjust the list limit to the feed limit.
-        $app->input->set('limit', $app->get('feed_limit'));
+        $app->getInput()->set('limit', $app->get('feed_limit'));
 
         // Get view data.
         $state = $this->get('State');

--- a/components/com_modules/src/Controller/DisplayController.php
+++ b/components/com_modules/src/Controller/DisplayController.php
@@ -39,7 +39,7 @@ class DisplayController extends BaseController
      */
     public function __construct($config = array(), MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
-        $this->input = Factory::getApplication()->input;
+        $this->input = Factory::getApplication()->getInput();
 
         // Modules frontpage Editor Module proxying.
         if ($this->input->get('view') === 'modules' && $this->input->get('layout') === 'modal') {

--- a/components/com_newsfeeds/src/Helper/AssociationHelper.php
+++ b/components/com_newsfeeds/src/Helper/AssociationHelper.php
@@ -37,7 +37,7 @@ abstract class AssociationHelper extends CategoryAssociationHelper
      */
     public static function getAssociations($id = 0, $view = null)
     {
-        $jinput = Factory::getApplication()->input;
+        $jinput = Factory::getApplication()->getInput();
         $view   = $view ?? $jinput->get('view');
         $id     = empty($id) ? $jinput->getInt('id') : $id;
 

--- a/components/com_newsfeeds/src/Model/CategoriesModel.php
+++ b/components/com_newsfeeds/src/Model/CategoriesModel.php
@@ -75,7 +75,7 @@ class CategoriesModel extends ListModel
         $this->setState('filter.extension', $this->_extension);
 
         // Get the parent id if defined.
-        $parentId = $app->input->getInt('id');
+        $parentId = $app->getInput()->getInt('id');
         $this->setState('filter.parentId', $parentId);
 
         $params = $app->getParams();

--- a/components/com_newsfeeds/src/Model/CategoryModel.php
+++ b/components/com_newsfeeds/src/Model/CategoryModel.php
@@ -251,13 +251,13 @@ class CategoryModel extends ListModel
         $limit = $app->getUserStateFromRequest('global.list.limit', 'limit', $app->get('list_limit'), 'uint');
         $this->setState('list.limit', $limit);
 
-        $limitstart = $app->input->get('limitstart', 0, 'uint');
+        $limitstart = $app->getInput()->get('limitstart', 0, 'uint');
         $this->setState('list.start', $limitstart);
 
         // Optional filter text
-        $this->setState('list.filter', $app->input->getString('filter-search'));
+        $this->setState('list.filter', $app->getInput()->getString('filter-search'));
 
-        $orderCol = $app->input->get('filter_order', 'ordering');
+        $orderCol = $app->getInput()->get('filter_order', 'ordering');
 
         if (!in_array($orderCol, $this->filter_fields)) {
             $orderCol = 'ordering';
@@ -265,7 +265,7 @@ class CategoryModel extends ListModel
 
         $this->setState('list.ordering', $orderCol);
 
-        $listOrder = $app->input->get('filter_order_Dir', 'ASC');
+        $listOrder = $app->getInput()->get('filter_order_Dir', 'ASC');
 
         if (!in_array(strtoupper($listOrder), array('ASC', 'DESC', ''))) {
             $listOrder = 'ASC';
@@ -273,7 +273,7 @@ class CategoryModel extends ListModel
 
         $this->setState('list.direction', $listOrder);
 
-        $id = $app->input->get('id', 0, 'int');
+        $id = $app->getInput()->get('id', 0, 'int');
         $this->setState('category.id', $id);
 
         $user = $this->getCurrentUser();
@@ -398,7 +398,7 @@ class CategoryModel extends ListModel
      */
     public function hit($pk = 0)
     {
-        $input    = Factory::getApplication()->input;
+        $input    = Factory::getApplication()->getInput();
         $hitcount = $input->getInt('hitcount', 1);
 
         if ($hitcount) {

--- a/components/com_newsfeeds/src/Model/CategoryModel.php
+++ b/components/com_newsfeeds/src/Model/CategoryModel.php
@@ -242,7 +242,8 @@ class CategoryModel extends ListModel
      */
     protected function populateState($ordering = null, $direction = null)
     {
-        $app = Factory::getApplication();
+        $app   = Factory::getApplication();
+        $input = $app->getInput();
 
         $params = $app->getParams();
         $this->setState('params', $params);
@@ -251,13 +252,13 @@ class CategoryModel extends ListModel
         $limit = $app->getUserStateFromRequest('global.list.limit', 'limit', $app->get('list_limit'), 'uint');
         $this->setState('list.limit', $limit);
 
-        $limitstart = $app->getInput()->get('limitstart', 0, 'uint');
+        $limitstart = $input->get('limitstart', 0, 'uint');
         $this->setState('list.start', $limitstart);
 
         // Optional filter text
-        $this->setState('list.filter', $app->getInput()->getString('filter-search'));
+        $this->setState('list.filter', $input->getString('filter-search'));
 
-        $orderCol = $app->getInput()->get('filter_order', 'ordering');
+        $orderCol = $input->get('filter_order', 'ordering');
 
         if (!in_array($orderCol, $this->filter_fields)) {
             $orderCol = 'ordering';
@@ -265,7 +266,7 @@ class CategoryModel extends ListModel
 
         $this->setState('list.ordering', $orderCol);
 
-        $listOrder = $app->getInput()->get('filter_order_Dir', 'ASC');
+        $listOrder = $input->get('filter_order_Dir', 'ASC');
 
         if (!in_array(strtoupper($listOrder), array('ASC', 'DESC', ''))) {
             $listOrder = 'ASC';
@@ -273,7 +274,7 @@ class CategoryModel extends ListModel
 
         $this->setState('list.direction', $listOrder);
 
-        $id = $app->getInput()->get('id', 0, 'int');
+        $id = $input->get('id', 0, 'int');
         $this->setState('category.id', $id);
 
         $user = $this->getCurrentUser();

--- a/components/com_newsfeeds/src/Model/NewsfeedModel.php
+++ b/components/com_newsfeeds/src/Model/NewsfeedModel.php
@@ -49,10 +49,10 @@ class NewsfeedModel extends ItemModel
         $app = Factory::getApplication();
 
         // Load state from the request.
-        $pk = $app->input->getInt('id');
+        $pk = $app->getInput()->getInt('id');
         $this->setState('newsfeed.id', $pk);
 
-        $offset = $app->input->get('limitstart', 0, 'uint');
+        $offset = $app->getInput()->get('limitstart', 0, 'uint');
         $this->setState('list.offset', $offset);
 
         // Load the parameters.
@@ -210,7 +210,7 @@ class NewsfeedModel extends ItemModel
      */
     public function hit($pk = 0)
     {
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $hitcount = $input->getInt('hitcount', 1);
 
         if ($hitcount) {

--- a/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -99,7 +99,7 @@ class HtmlView extends BaseHtmlView
         $user = $this->getCurrentUser();
 
         // Get view related request variables.
-        $print = $app->input->getBool('print');
+        $print = $app->getInput()->getBool('print');
 
         // Get model data.
         $state = $this->get('State');

--- a/components/com_privacy/src/Model/ConfirmModel.php
+++ b/components/com_privacy/src/Model/ConfirmModel.php
@@ -175,7 +175,7 @@ class ConfirmModel extends AdminModel
             return false;
         }
 
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         if ($input->getMethod() === 'GET') {
             $form->setValue('confirm_token', '', $input->get->getAlnum('confirm_token'));

--- a/components/com_privacy/src/Model/RemindModel.php
+++ b/components/com_privacy/src/Model/RemindModel.php
@@ -145,7 +145,7 @@ class RemindModel extends AdminModel
             return false;
         }
 
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         if ($input->getMethod() === 'GET') {
             $form->setValue('remind_token', '', $input->get->getAlnum('remind_token'));

--- a/components/com_tags/src/Model/TagModel.php
+++ b/components/com_tags/src/Model/TagModel.php
@@ -184,7 +184,7 @@ class TagModel extends ListModel
         $this->setState('params', $params);
 
         // Load state from the request.
-        $ids = (array) $app->input->get('id', array(), 'string');
+        $ids = (array) $app->getInput()->get('id', array(), 'string');
 
         if (count($ids) == 1) {
             $ids = explode(',', $ids[0]);
@@ -200,7 +200,7 @@ class TagModel extends ListModel
         $this->setState('tag.id', $pkString);
 
         // Get the selected list of types from the request. If none are specified all are used.
-        $typesr = $app->input->get('types', array(), 'array');
+        $typesr = $app->getInput()->get('types', array(), 'array');
 
         if ($typesr) {
             // Implode is needed because the array can contain a string with a coma separated list of ids
@@ -213,11 +213,11 @@ class TagModel extends ListModel
             $this->setState('tag.typesr', $typesr);
         }
 
-        $language = $app->input->getString('tag_list_language_filter');
+        $language = $app->getInput()->getString('tag_list_language_filter');
         $this->setState('tag.language', $language);
 
         // List state information
-        $format = $app->input->getWord('format');
+        $format = $app->getInput()->getWord('format');
 
         if ($format === 'feed') {
             $limit = $app->get('feed_limit');
@@ -228,10 +228,10 @@ class TagModel extends ListModel
 
         $this->setState('list.limit', $limit);
 
-        $offset = $app->input->get('limitstart', 0, 'uint');
+        $offset = $app->getInput()->get('limitstart', 0, 'uint');
         $this->setState('list.start', $offset);
 
-        $itemid = $pkString . ':' . $app->input->get('Itemid', 0, 'int');
+        $itemid = $pkString . ':' . $app->getInput()->get('Itemid', 0, 'int');
         $orderCol = $app->getUserStateFromRequest('com_tags.tag.list.' . $itemid . '.filter_order', 'filter_order', '', 'string');
         $orderCol = !$orderCol ? $this->state->params->get('tag_list_orderby', 'c.core_title') : $orderCol;
 
@@ -326,7 +326,7 @@ class TagModel extends ListModel
      */
     public function hit($pk = 0)
     {
-        $input    = Factory::getApplication()->input;
+        $input    = Factory::getApplication()->getInput();
         $hitcount = $input->getInt('hitcount', 1);
 
         if ($hitcount) {

--- a/components/com_tags/src/Model/TagsModel.php
+++ b/components/com_tags/src/Model/TagsModel.php
@@ -52,13 +52,13 @@ class TagsModel extends ListModel
         $app = Factory::getApplication();
 
         // Load state from the request.
-        $pid = $app->input->getInt('parent_id');
+        $pid = $app->getInput()->getInt('parent_id');
         $this->setState('tag.parent_id', $pid);
 
-        $language = $app->input->getString('tag_list_language_filter');
+        $language = $app->getInput()->getString('tag_list_language_filter');
         $this->setState('tag.language', $language);
 
-        $offset = $app->input->get('limitstart', 0, 'uint');
+        $offset = $app->getInput()->get('limitstart', 0, 'uint');
         $this->setState('list.offset', $offset);
         $app = Factory::getApplication();
 
@@ -77,7 +77,7 @@ class TagsModel extends ListModel
         }
 
         // Optional filter text
-        $itemid = $pid . ':' . $app->input->getInt('Itemid', 0);
+        $itemid = $pid . ':' . $app->getInput()->getInt('Itemid', 0);
         $filterSearch = $app->getUserStateFromRequest('com_tags.tags.list.' . $itemid . '.filter_search', 'filter-search', '', 'string');
         $this->setState('list.filter', $filterSearch);
     }
@@ -132,7 +132,7 @@ class TagsModel extends ListModel
         }
 
         // List state information
-        $format = $app->input->getWord('format');
+        $format = $app->getInput()->getWord('format');
 
         if ($format === 'feed') {
             $limit = $app->get('feed_limit');
@@ -146,7 +146,7 @@ class TagsModel extends ListModel
 
         $this->setState('list.limit', $limit);
 
-        $offset = $app->input->get('limitstart', 0, 'uint');
+        $offset = $app->getInput()->get('limitstart', 0, 'uint');
         $this->setState('list.start', $offset);
 
         // Optionally filter on entered value

--- a/components/com_tags/src/View/Tag/FeedView.php
+++ b/components/com_tags/src/View/Tag/FeedView.php
@@ -37,7 +37,7 @@ class FeedView extends BaseHtmlView
     public function display($tpl = null)
     {
         $app    = Factory::getApplication();
-        $ids    = (array) $app->input->get('id', array(), 'int');
+        $ids    = (array) $app->getInput()->get('id', array(), 'int');
         $i      = 0;
         $tagIds = '';
 
@@ -56,7 +56,7 @@ class FeedView extends BaseHtmlView
 
         $this->document->link = Route::_('index.php?option=com_tags&view=tag&' . $tagIds);
 
-        $app->input->set('limit', $app->get('feed_limit'));
+        $app->getInput()->set('limit', $app->get('feed_limit'));
         $siteEmail = $app->get('mailfrom');
         $fromName  = $app->get('fromname');
         $feedEmail = $app->get('feed_email', 'none');

--- a/components/com_tags/src/View/Tags/FeedView.php
+++ b/components/com_tags/src/View/Tags/FeedView.php
@@ -38,7 +38,7 @@ class FeedView extends BaseHtmlView
         $app                  = Factory::getApplication();
         $this->document->link = Route::_('index.php?option=com_tags&view=tags');
 
-        $app->input->set('limit', $app->get('feed_limit'));
+        $app->getInput()->set('limit', $app->get('feed_limit'));
         $siteEmail = $app->get('mailfrom');
         $fromName  = $app->get('fromname');
         $feedEmail = $app->get('feed_email', 'none');

--- a/components/com_users/src/Controller/ProfileController.php
+++ b/components/com_users/src/Controller/ProfileController.php
@@ -91,7 +91,7 @@ class ProfileController extends BaseController
         $userId = (int) $user->get('id');
 
         // Get the user data.
-        $requestData = $app->input->post->get('jform', array(), 'array');
+        $requestData = $app->getInput()->post->get('jform', array(), 'array');
 
         // Force the ID to this user.
         $requestData['id'] = $userId;

--- a/components/com_users/src/Controller/UserController.php
+++ b/components/com_users/src/Controller/UserController.php
@@ -127,7 +127,7 @@ class UserController extends BaseController
 
         // Perform the log out.
         $error = $app->logout(null, $options);
-        $input = $app->input->getInputForRequestMethod();
+        $input = $app->getInput()->getInputForRequestMethod();
 
         // Check if the log out succeeded.
         if ($error instanceof \Exception) {
@@ -185,7 +185,7 @@ class UserController extends BaseController
                 $url = 'index.php?Itemid=' . $itemid . ($language !== '*' ? '&lang=' . $language : '');
             } else {
                 // Logout is set to default. Get the home page ItemID
-                $lang_code = $app->input->cookie->getString(ApplicationHelper::getHash('language'));
+                $lang_code = $app->getInput()->cookie->getString(ApplicationHelper::getHash('language'));
                 $item      = $app->getMenu()->getDefault($lang_code);
                 $itemid    = $item->id;
 

--- a/components/com_users/src/Model/LoginModel.php
+++ b/components/com_users/src/Model/LoginModel.php
@@ -67,7 +67,7 @@ class LoginModel extends FormModel
         $app  = Factory::getApplication();
         $data = $app->getUserState('users.login.form.data', array());
 
-        $input = $app->input->getInputForRequestMethod();
+        $input = $app->getInput()->getInputForRequestMethod();
 
         // Check for return URL from the request first
         if ($return = $input->get('return', '', 'BASE64')) {

--- a/components/com_users/src/Model/ResetModel.php
+++ b/components/com_users/src/Model/ResetModel.php
@@ -99,7 +99,7 @@ class ResetModel extends FormModel
         if (empty($form)) {
             return false;
         } else {
-            $form->setValue('token', '', Factory::getApplication()->input->get('token'));
+            $form->setValue('token', '', Factory::getApplication()->getInput()->get('token'));
         }
 
         return $form;

--- a/installation/src/Model/ChecksModel.php
+++ b/installation/src/Model/ChecksModel.php
@@ -250,7 +250,7 @@ class ChecksModel extends BaseInstallationModel
     public function getForm($view = null)
     {
         if (!$view) {
-            $view = Factory::getApplication()->input->getWord('view', 'setup');
+            $view = Factory::getApplication()->getInput()->getWord('view', 'setup');
         }
 
         // Get the form.

--- a/installation/src/Model/LanguagesModel.php
+++ b/installation/src/Model/LanguagesModel.php
@@ -514,7 +514,7 @@ class LanguagesModel extends BaseInstallationModel implements DatabaseAwareInter
     public function getForm($view = null)
     {
         if (!$view) {
-            $view = Factory::getApplication()->input->getWord('view', 'defaultlanguage');
+            $view = Factory::getApplication()->getInput()->getWord('view', 'defaultlanguage');
         }
 
         // Get the form.

--- a/installation/src/Model/SetupModel.php
+++ b/installation/src/Model/SetupModel.php
@@ -95,7 +95,7 @@ class SetupModel extends BaseInstallationModel
     public function getForm($view = null)
     {
         if (!$view) {
-            $view = Factory::getApplication()->input->getWord('view', 'setup');
+            $view = Factory::getApplication()->getInput()->getWord('view', 'setup');
         }
 
         // Get the form.
@@ -132,7 +132,7 @@ class SetupModel extends BaseInstallationModel
     public function checkForm($page = 'setup')
     {
         // Get the posted values from the request and validate them.
-        $data   = Factory::getApplication()->input->post->get('jform', array(), 'array');
+        $data   = Factory::getApplication()->getInput()->post->get('jform', array(), 'array');
         $return = $this->validate($data, $page);
 
         // Attempt to save the data before validation.

--- a/layouts/joomla/content/emptystate.php
+++ b/layouts/joomla/content/emptystate.php
@@ -18,7 +18,7 @@ use Joomla\CMS\Router\Route;
 $textPrefix = $displayData['textPrefix'] ?? '';
 
 if (!$textPrefix) {
-    $textPrefix = strtoupper(Factory::getApplication()->input->get('option'));
+    $textPrefix = strtoupper(Factory::getApplication()->getInput()->get('option'));
 }
 
 $formURL    = $displayData['formURL'] ?? '';
@@ -41,7 +41,7 @@ $btnadd     = $displayData['btnadd'] ?? Text::_($textPrefix . '_EMPTYSTATE_BUTTO
                 <?php echo $content; ?>
             </p>
             <div class="d-grid gap-2 d-sm-flex justify-content-sm-center">
-                <?php if ($createURL && Factory::getApplication()->input->get('tmpl') !== 'component') : ?>
+                <?php if ($createURL && Factory::getApplication()->getInput()->get('tmpl') !== 'component') : ?>
                     <a href="<?php echo Route::_($createURL); ?>"
                      id="confirmButton" class="btn btn-primary btn-lg px-4 me-sm-3 emptystate-btnadd"><?php echo $btnadd; ?></a>
                 <?php endif; ?>

--- a/layouts/joomla/edit/admin_modules.php
+++ b/layouts/joomla/edit/admin_modules.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Helper\ModuleHelper;
 
 $app    = Factory::getApplication();
 $form   = $displayData->getForm();
-$input  = $app->input;
+$input  = $app->getInput();
 
 $fields = $displayData->get('fields') ?: array(
     array('parent', 'parent_id'),

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -24,7 +24,7 @@ $menusEditing = $displayData['menusediting'];
 $parameters   = ComponentHelper::getParams('com_modules');
 $redirectUri  = '&return=' . urlencode(base64_encode(Uri::getInstance()->toString()));
 $target       = '_blank';
-$itemid       = Factory::getApplication()->input->get('Itemid', '0', 'int');
+$itemid       = Factory::getApplication()->getInput()->get('Itemid', '0', 'int');
 $editUrl      = Uri::base() . 'administrator/index.php?option=com_modules&task=module.edit&id=' . (int) $mod->id;
 
 // If Module editing site

--- a/layouts/joomla/edit/global.php
+++ b/layouts/joomla/edit/global.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Language\Text;
 
 $app       = Factory::getApplication();
 $form      = $displayData->getForm();
-$input     = $app->input;
+$input     = $app->getInput();
 $component = $input->getCmd('option', 'com_content');
 
 if ($component === 'com_categories') {

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -94,7 +94,7 @@ foreach ($fieldSets as $name => $fieldSet) {
     } else {
         $label = strtoupper('JGLOBAL_FIELDSET_' . $name);
         if (Text::_($label) === $label) {
-            $label = strtoupper($app->input->get('option') . '_' . $name . '_FIELDSET_LABEL');
+            $label = strtoupper($app->getInput()->get('option') . '_' . $name . '_FIELDSET_LABEL');
         }
         $label = Text::_($label);
     }

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -457,7 +457,7 @@ class AdministratorApplication extends CMSApplication
     {
         /** @var self $app */
         $app    = Factory::getApplication();
-        $option = strtolower($app->input->get('option', ''));
+        $option = strtolower($app->getInput()->get('option', ''));
         $user   = $app->getIdentity();
 
         /**
@@ -484,7 +484,7 @@ class AdministratorApplication extends CMSApplication
          * Force the option to the input object. This is necessary because we might have force-changed the component in
          * the two if-blocks above.
          */
-        $app->input->set('option', $option);
+        $app->getInput()->set('option', $option);
 
         return $option;
     }

--- a/libraries/src/Application/ApplicationHelper.php
+++ b/libraries/src/Application/ApplicationHelper.php
@@ -49,7 +49,7 @@ class ApplicationHelper
             return $option;
         }
 
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $option = strtolower($input->get('option', ''));
 
         if (empty($option)) {

--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -761,7 +761,7 @@ class Cache
 
 		foreach ($registeredurlparams as $key => $value)
 		{
-			$safeuriaddon->$key = $app->input->get($key, null, $value);
+			$safeuriaddon->$key = $app->getInput()->get($key, null, $value);
 		}
 
 		return md5(serialize($safeuriaddon));

--- a/libraries/src/Client/ClientHelper.php
+++ b/libraries/src/Client/ClientHelper.php
@@ -196,7 +196,7 @@ class ClientHelper
     public static function setCredentialsFromRequest($client)
     {
         // Determine whether FTP credentials have been passed along with the current request
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $user = $input->post->getString('username', null);
         $pass = $input->post->getString('password', null);
 

--- a/libraries/src/Component/Router/Rules/NomenuRules.php
+++ b/libraries/src/Component/Router/Rules/NomenuRules.php
@@ -79,9 +79,10 @@ class NomenuRules implements RulesInterface
 
                 if (isset($view->key) && isset($segments[0])) {
                     if (\is_callable(array($this->router, 'get' . ucfirst($view->name) . 'Id'))) {
-                        if ($view->parent_key && $this->router->app->getInput()->get($view->parent_key)) {
-                            $vars[$view->parent->key] = $this->router->app->getInput()->get($view->parent_key);
-                            $vars[$view->parent_key] = $this->router->app->getInput()->get($view->parent_key);
+                        $input = $this->app->getInput;
+                        if ($view->parent_key && $input->get($view->parent_key)) {
+                            $vars[$view->parent->key] = $input->get($view->parent_key);
+                            $vars[$view->parent_key] = $input->get($view->parent_key);
                         }
 
                         if ($view->nestable) {

--- a/libraries/src/Component/Router/Rules/NomenuRules.php
+++ b/libraries/src/Component/Router/Rules/NomenuRules.php
@@ -79,7 +79,7 @@ class NomenuRules implements RulesInterface
 
                 if (isset($view->key) && isset($segments[0])) {
                     if (\is_callable(array($this->router, 'get' . ucfirst($view->name) . 'Id'))) {
-                        $input = $this->app->getInput;
+                        $input = $this->app->getInput();
                         if ($view->parent_key && $input->get($view->parent_key)) {
                             $vars[$view->parent->key] = $input->get($view->parent_key);
                             $vars[$view->parent_key] = $input->get($view->parent_key);

--- a/libraries/src/Component/Router/Rules/NomenuRules.php
+++ b/libraries/src/Component/Router/Rules/NomenuRules.php
@@ -79,9 +79,9 @@ class NomenuRules implements RulesInterface
 
                 if (isset($view->key) && isset($segments[0])) {
                     if (\is_callable(array($this->router, 'get' . ucfirst($view->name) . 'Id'))) {
-                        if ($view->parent_key && $this->router->app->input->get($view->parent_key)) {
-                            $vars[$view->parent->key] = $this->router->app->input->get($view->parent_key);
-                            $vars[$view->parent_key] = $this->router->app->input->get($view->parent_key);
+                        if ($view->parent_key && $this->router->app->getInput()->get($view->parent_key)) {
+                            $vars[$view->parent->key] = $this->router->app->getInput()->get($view->parent_key);
+                            $vars[$view->parent_key] = $this->router->app->getInput()->get($view->parent_key);
                         }
 
                         if ($view->nestable) {

--- a/libraries/src/Document/FeedDocument.php
+++ b/libraries/src/Document/FeedDocument.php
@@ -203,7 +203,7 @@ class FeedDocument extends Document
     public function render($cache = false, $params = array())
     {
         // Get the feed type
-        $type = CmsFactory::getApplication()->input->get('type', 'rss');
+        $type = CmsFactory::getApplication()->getInput()->get('type', 'rss');
 
         // Instantiate feed renderer and set the mime encoding
         $renderer = $this->loadRenderer($type ?: 'rss');

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -530,7 +530,7 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
             /** @var  \Joomla\CMS\Document\Renderer\Html\ModulesRenderer  $renderer */
             /** @var  \Joomla\CMS\Cache\Controller\OutputController  $cache */
             $cache  = $this->getCacheControllerFactory()->createCacheController('output', ['defaultgroup' => 'com_modules']);
-            $itemId = (int) CmsFactory::getApplication()->input->get('Itemid', 0, 'int');
+            $itemId = (int) CmsFactory::getApplication()->getInput()->get('Itemid', 0, 'int');
 
             $hash = md5(
                 serialize(

--- a/libraries/src/Document/ImageDocument.php
+++ b/libraries/src/Document/ImageDocument.php
@@ -53,7 +53,7 @@ class ImageDocument extends Document
     public function render($cache = false, $params = array())
     {
         // Get the image type
-        $type = Factory::getApplication()->input->get('type', 'png');
+        $type = Factory::getApplication()->getInput()->get('type', 'png');
 
         switch ($type) {
             case 'jpg':

--- a/libraries/src/Exception/ExceptionHandler.php
+++ b/libraries/src/Exception/ExceptionHandler.php
@@ -104,7 +104,7 @@ class ExceptionHandler
             if (Factory::$document) {
                 $format = Factory::$document->getType();
             } else {
-                $format = $app->input->getString('format', 'html');
+                $format = $app->getInput()->getString('format', 'html');
             }
 
             try {

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -148,7 +148,7 @@ class ListField extends FormField
             $tmp        = new \stdClass();
             $tmp->value = '';
             $tmp->text  = Text::_('JGLOBAL_USE_GLOBAL');
-            $component  = Factory::getApplication()->input->getCmd('option');
+            $component  = Factory::getApplication()->getInput()->getCmd('option');
 
             // Get correct component for menu items
             if ($component === 'com_menus') {
@@ -166,7 +166,7 @@ class ListField extends FormField
             }
 
             // Try with menu configuration
-            if (\is_null($value) && Factory::getApplication()->input->getCmd('option') === 'com_menus') {
+            if (\is_null($value) && Factory::getApplication()->getInput()->getCmd('option') === 'com_menus') {
                 $value = ComponentHelper::getParams('com_menus')->get($this->fieldname);
             }
 

--- a/libraries/src/Form/Field/MediaField.php
+++ b/libraries/src/Form/Field/MediaField.php
@@ -259,7 +259,7 @@ class MediaField extends FormField
         $asset = $this->asset;
 
         if ($asset === '') {
-            $asset = Factory::getApplication()->input->get('option');
+            $asset = Factory::getApplication()->getInput()->get('option');
         }
 
         // Value in new format such as images/headers/blue-flower.jpg#joomlaImage://local-images/headers/blue-flower.jpg?width=700&height=180

--- a/libraries/src/Form/Field/NumberField.php
+++ b/libraries/src/Form/Field/NumberField.php
@@ -159,7 +159,7 @@ class NumberField extends FormField
     protected function getInput()
     {
         if ($this->element['useglobal']) {
-            $component = Factory::getApplication()->input->getCmd('option');
+            $component = Factory::getApplication()->getInput()->getCmd('option');
 
             // Get correct component for menu items
             if ($component === 'com_menus') {
@@ -177,7 +177,7 @@ class NumberField extends FormField
             }
 
             // Try with menu configuration
-            if (\is_null($value) && Factory::getApplication()->input->getCmd('option') === 'com_menus') {
+            if (\is_null($value) && Factory::getApplication()->getInput()->getCmd('option') === 'com_menus') {
                 $value = ComponentHelper::getParams('com_menus')->get($this->fieldname);
             }
 

--- a/libraries/src/Form/Field/TextField.php
+++ b/libraries/src/Form/Field/TextField.php
@@ -220,7 +220,7 @@ class TextField extends FormField
     protected function getInput()
     {
         if ($this->element['useglobal']) {
-            $component = Factory::getApplication()->input->getCmd('option');
+            $component = Factory::getApplication()->getInput()->getCmd('option');
 
             // Get correct component for menu items
             if ($component === 'com_menus') {
@@ -238,7 +238,7 @@ class TextField extends FormField
             }
 
             // Try with menu configuration
-            if (\is_null($value) && Factory::getApplication()->input->getCmd('option') === 'com_menus') {
+            if (\is_null($value) && Factory::getApplication()->getInput()->getCmd('option') === 'com_menus') {
                 $value = ComponentHelper::getParams('com_menus')->get($this->fieldname);
             }
 

--- a/libraries/src/Form/Field/TransitionField.php
+++ b/libraries/src/Form/Field/TransitionField.php
@@ -66,7 +66,7 @@ class TransitionField extends ListField
         $result = parent::setup($element, $value, $group);
 
         if ($result) {
-            $input = Factory::getApplication()->input;
+            $input = Factory::getApplication()->getInput();
 
             if (\strlen($element['extension'])) {
                 $this->extension = (string) $element['extension'];
@@ -94,7 +94,7 @@ class TransitionField extends ListField
     protected function getOptions()
     {
         // Let's get the id for the current item, either category or content item.
-        $jinput = Factory::getApplication()->input;
+        $jinput = Factory::getApplication()->getInput();
 
         // Initialise variable.
         $db = $this->getDatabase();

--- a/libraries/src/Form/Field/WorkflowconditionField.php
+++ b/libraries/src/Form/Field/WorkflowconditionField.php
@@ -69,7 +69,7 @@ class WorkflowconditionField extends ListField
             if (\strlen($element['extension'])) {
                 $this->extension = (string) $element['extension'];
             } else {
-                $this->extension = Factory::getApplication()->input->getCmd('extension');
+                $this->extension = Factory::getApplication()->getInput()->getCmd('extension');
             }
 
             if (\strlen($element['hide_all'])) {

--- a/libraries/src/Form/Field/WorkflowstageField.php
+++ b/libraries/src/Form/Field/WorkflowstageField.php
@@ -69,7 +69,7 @@ class WorkflowstageField extends GroupedlistField
             if (\strlen($element['extension'])) {
                 $this->extension = (string) $element['extension'];
             } else {
-                $this->extension = Factory::getApplication()->input->getCmd('extension');
+                $this->extension = Factory::getApplication()->getInput()->getCmd('extension');
             }
 
             if ((string) $element['activeonly'] === '1' || (string) $element['activeonly'] === 'true') {

--- a/libraries/src/HTML/Helpers/Dropdown.php
+++ b/libraries/src/HTML/Helpers/Dropdown.php
@@ -137,7 +137,7 @@ abstract class Dropdown
         static::start();
 
         if (!$customLink) {
-            $option = Factory::getApplication()->input->getCmd('option');
+            $option = Factory::getApplication()->getInput()->getCmd('option');
             $link = 'index.php?option=' . $option;
         } else {
             $link = $customLink;

--- a/libraries/src/HTML/Helpers/Sidebar.php
+++ b/libraries/src/HTML/Helpers/Sidebar.php
@@ -63,7 +63,7 @@ abstract class Sidebar
         $data->action         = static::getAction();
         $data->displayMenu    = count($data->list);
         $data->displayFilters = count($data->filters);
-        $data->hide           = Factory::getApplication()->input->getBool('hidemainmenu');
+        $data->hide           = Factory::getApplication()->getInput()->getBool('hidemainmenu');
 
         // Create a layout object and ask it to render the sidebar
         $layout      = new FileLayout('joomla.sidebars.submenu');

--- a/libraries/src/Helper/CMSHelper.php
+++ b/libraries/src/Helper/CMSHelper.php
@@ -49,7 +49,7 @@ class CMSHelper
             $pluginParams = new Registry($plugin->params);
 
             if ((int) $pluginParams->get('lang_cookie', 1) === 1) {
-                $langCode = $app->input->cookie->getString(ApplicationHelper::getHash('language'));
+                $langCode = $app->getInput()->cookie->getString(ApplicationHelper::getHash('language'));
             } else {
                 $langCode = $app->getSession()->get('plg_system_languagefilter.language');
             }

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -212,7 +212,7 @@ class ContentHelper
             $pluginParams = new Registry($plugin->params);
 
             if ((int) $pluginParams->get('lang_cookie', 1) === 1) {
-                $langCode = $app->input->cookie->getString(ApplicationHelper::getHash('language'));
+                $langCode = $app->getInput()->cookie->getString(ApplicationHelper::getHash('language'));
             } else {
                 $langCode = $app->getSession()->get('plg_system_languagefilter.language');
             }

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -84,7 +84,7 @@ abstract class ModuleHelper
     {
         $position = strtolower($position);
         $result   = array();
-        $input    = Factory::getApplication()->input;
+        $input    = Factory::getApplication()->getInput();
         $modules  = &static::load();
         $total    = \count($modules);
 
@@ -199,7 +199,7 @@ abstract class ModuleHelper
         }
 
         // Dynamically add outline style
-        if ($app->input->getBool('tp') && ComponentHelper::getParams('com_templates')->get('template_positions_display')) {
+        if ($app->getInput()->getBool('tp') && ComponentHelper::getParams('com_templates')->get('template_positions_display')) {
             $attribs['style'] .= ' outline';
         }
 
@@ -390,7 +390,7 @@ abstract class ModuleHelper
     public static function getModuleList()
     {
         $app      = Factory::getApplication();
-        $itemId   = $app->input->getInt('Itemid', 0);
+        $itemId   = $app->getInput()->getInt('Itemid', 0);
         $groups   = $app->getIdentity()->getAuthorisedViewLevels();
         $clientId = (int) $app->getClientId();
 
@@ -492,7 +492,7 @@ abstract class ModuleHelper
     public static function cleanModuleList($modules)
     {
         // Apply negative selections and eliminate duplicates
-        $Itemid = Factory::getApplication()->input->getInt('Itemid');
+        $Itemid = Factory::getApplication()->getInput()->getInt('Itemid');
         $negId = $Itemid ? -(int) $Itemid : false;
         $clean = array();
         $dupes = array();
@@ -602,7 +602,7 @@ abstract class ModuleHelper
                 $secureid = null;
 
                 if (\is_array($cacheparams->modeparams)) {
-                    $input   = $app->input;
+                    $input   = $app->getInput();
                     $uri     = $input->getArray();
                     $safeuri = new \stdClass();
                     $noHtmlFilter = InputFilter::getInstance();
@@ -640,7 +640,7 @@ abstract class ModuleHelper
                 $ret = $cache->get(
                     array($cacheparams->class, $cacheparams->method),
                     $cacheparams->methodparams,
-                    $module->id . $view_levels . $app->input->getInt('Itemid', null) . $cacheparams->cachesuffix,
+                    $module->id . $view_levels . $app->getInput()->getInt('Itemid', null) . $cacheparams->cachesuffix,
                     $wrkarounds,
                     $wrkaroundoptions
                 );

--- a/libraries/src/Helper/RouteHelper.php
+++ b/libraries/src/Helper/RouteHelper.php
@@ -74,8 +74,8 @@ class RouteHelper
             $this->view = $typeExploded[1];
             $this->extension = $typeExploded[0];
         } else {
-            $this->view = Factory::getApplication()->input->getString('view');
-            $this->extension = Factory::getApplication()->input->getCmd('option');
+            $this->view = Factory::getApplication()->getInput()->getString('view');
+            $this->extension = Factory::getApplication()->getInput()->getCmd('option');
         }
 
         $name = ucfirst(substr_replace($this->extension, '', 0, 4));
@@ -135,7 +135,7 @@ class RouteHelper
 
         // $this->extension may not be set if coming from a static method, check it
         if ($this->extension === null) {
-            $this->extension = $app->input->getCmd('option');
+            $this->extension = $app->getInput()->getCmd('option');
         }
 
         // Prepare the reverse lookup array.

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -266,7 +266,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
         );
 
         $app   = Factory::getApplication();
-        $input = $app->input;
+        $input = $app->getInput();
 
         // Get the environment configuration.
         $basePath = \array_key_exists('base_path', $config) ? $config['base_path'] : JPATH_COMPONENT;
@@ -358,7 +358,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
         $this->taskMap = array();
 
         $this->app   = $app ?: Factory::getApplication();
-        $this->input = $input ?: $this->app->input;
+        $this->input = $input ?: $this->app->getInput();
 
         if (\defined('JDEBUG') && JDEBUG) {
             Log::addLogger(array('text_file' => 'jcontroller.log.php'), Log::ALL, array('controller'));

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -874,7 +874,7 @@ class FormController extends BaseController implements FormFactoryAwareInterface
     {
         // Initialise variables.
         $app   = $this->app;
-        $input = $app->input;
+        $input = $app->getInput();
         $model = $this->getModel();
 
         $data = $input->get('jform', array(), 'array');

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1025,7 +1025,7 @@ abstract class AdminModel extends FormModel
         $key = $table->getKeyName();
 
         // Get the pk of the record from the request.
-        $pk = Factory::getApplication()->input->getInt($key);
+        $pk = Factory::getApplication()->getInput()->getInt($key);
         $this->setState($this->getName() . '.id', $pk);
 
         // Load the parameters.
@@ -1379,7 +1379,7 @@ abstract class AdminModel extends FormModel
             }
         }
 
-        if ($app->input->get('task') == 'editAssociations') {
+        if ($app->getInput()->get('task') == 'editAssociations') {
             return $this->redirectToAssociations($data);
         }
 
@@ -1500,7 +1500,7 @@ abstract class AdminModel extends FormModel
         }
 
         // Check that the user has create permission for the component
-        $extension = Factory::getApplication()->input->get('option', '');
+        $extension = Factory::getApplication()->getInput()->get('option', '');
         $user = Factory::getUser();
 
         if (!$user->authorise('core.create', $extension . '.category.' . $categoryId)) {
@@ -1596,7 +1596,7 @@ abstract class AdminModel extends FormModel
 
         // Deal with categories associations
         if ($this->text_prefix === 'COM_CATEGORIES') {
-            $extension       = $app->input->get('extension', 'com_content');
+            $extension       = $app->getInput()->get('extension', 'com_content');
             $this->typeAlias = $extension . '.category';
             $component       = strtolower($this->text_prefix);
             $view            = 'category';

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -297,7 +297,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
         $app = Factory::getApplication();
 
         $options = [
-            'defaultgroup' => $group ?: ($this->option ?? $app->input->get('option')),
+            'defaultgroup' => $group ?: ($this->option ?? $app->getInput()->get('option')),
             'cachebase'    => $app->get('cache_path', JPATH_CACHE),
             'result'       => true,
         ];

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -592,14 +592,14 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
             }
 
             // Support old ordering field
-            $oldOrdering = $app->input->get('filter_order');
+            $oldOrdering = $app->getInput()->get('filter_order');
 
             if (!empty($oldOrdering) && \in_array($oldOrdering, $this->filter_fields)) {
                 $this->setState('list.ordering', $oldOrdering);
             }
 
             // Support old direction field
-            $oldDirection = $app->input->get('filter_order_Dir');
+            $oldDirection = $app->getInput()->get('filter_order_Dir');
 
             if (!empty($oldDirection) && \in_array(strtoupper($oldDirection), array('ASC', 'DESC', ''))) {
                 $this->setState('list.direction', $oldDirection);
@@ -633,7 +633,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
     public function getUserStateFromRequest($key, $request, $default = null, $type = 'none', $resetPage = true)
     {
         $app       = Factory::getApplication();
-        $input     = $app->input;
+        $input     = $app->getInput();
         $old_state = $app->getUserState($key);
         $cur_state = $old_state ?? $default;
         $new_state = $input->get($request, null, $type);
@@ -641,7 +641,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
         // BC for Search Tools which uses different naming
         if ($new_state === null && strpos($request, 'filter_') === 0) {
             $name    = substr($request, 7);
-            $filters = $app->input->get('filter', array(), 'array');
+            $filters = $app->getInput()->get('filter', array(), 'array');
 
             if (isset($filters[$name])) {
                 $new_state = $filters[$name];

--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -42,7 +42,7 @@ class CategoryFeedView extends HtmlView
         $app      = Factory::getApplication();
         $document = Factory::getDocument();
 
-        $extension      = $app->input->getString('option');
+        $extension      = $app->getInput()->getString('option');
         $contentType = $extension . '.' . $this->viewName;
 
         $ucmType = new UCMType();
@@ -59,9 +59,9 @@ class CategoryFeedView extends HtmlView
             $titleField = $ucmMapCommon[0]->core_title;
         }
 
-        $document->link = Route::_(RouteHelper::getCategoryRoute($app->input->getInt('id'), $language = 0, $extension));
+        $document->link = Route::_(RouteHelper::getCategoryRoute($app->getInput()->getInt('id'), $language = 0, $extension));
 
-        $app->input->set('limit', $app->get('feed_limit'));
+        $app->getInput()->set('limit', $app->get('feed_limit'));
         $siteEmail        = $app->get('mailfrom');
         $fromName         = $app->get('fromname');
         $feedEmail        = $app->get('feed_email', 'none');

--- a/libraries/src/MVC/View/FormView.php
+++ b/libraries/src/MVC/View/FormView.php
@@ -160,7 +160,7 @@ class FormView extends HtmlView
      */
     protected function addToolbar()
     {
-        Factory::getApplication()->input->set('hidemainmenu', true);
+        Factory::getApplication()->getInput()->set('hidemainmenu', true);
 
         $user       = Factory::getUser();
         $userId     = $user->id;

--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -87,7 +87,7 @@ class Session implements ServiceProviderInterface
                 }
 
                 return $this->buildSession(
-                    new JoomlaStorage($app->input, $handler, $options),
+                    new JoomlaStorage($app->getInput(), $handler, $options),
                     $app,
                     $container->get(DispatcherInterface::class),
                     $options
@@ -132,7 +132,7 @@ class Session implements ServiceProviderInterface
                 }
 
                 return $this->buildSession(
-                    new JoomlaStorage($app->input, $handler),
+                    new JoomlaStorage($app->getInput(), $handler),
                     $app,
                     $container->get(DispatcherInterface::class),
                     $options
@@ -171,7 +171,7 @@ class Session implements ServiceProviderInterface
                 }
 
                 return $this->buildSession(
-                    new JoomlaStorage($app->input, $handler, $options),
+                    new JoomlaStorage($app->getInput(), $handler, $options),
                     $app,
                     $container->get(DispatcherInterface::class),
                     $options
@@ -304,7 +304,7 @@ class Session implements ServiceProviderInterface
         DispatcherInterface $dispatcher,
         array $options
     ): SessionInterface {
-        $input = $app->input;
+        $input = $app->getInput();
 
         if (method_exists($app, 'afterSessionStart')) {
             $dispatcher->addListener(SessionEvents::START, [$app, 'afterSessionStart'], Priority::HIGH);

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -67,12 +67,12 @@ class Session extends BaseSession
         $token = static::getFormToken();
 
         // Check from header first
-        if ($token === $app->input->server->get('HTTP_X_CSRF_TOKEN', '', 'alnum')) {
+        if ($token === $app->getInput()->server->get('HTTP_X_CSRF_TOKEN', '', 'alnum')) {
             return true;
         }
 
         // Then fallback to HTTP query
-        if (!$app->input->$method->get($token, '', 'alnum')) {
+        if (!$app->getInput()->$method->get($token, '', 'alnum')) {
             if ($app->getSession()->isNew()) {
                 // Redirect to login screen.
                 $app->enqueueMessage(Text::_('JLIB_ENVIRONMENT_SESSION_EXPIRED'), 'warning');

--- a/libraries/src/UCM/UCMBase.php
+++ b/libraries/src/UCM/UCMBase.php
@@ -52,7 +52,7 @@ class UCMBase implements UCM
     public function __construct($alias = null, UCMType $type = null)
     {
         // Setup dependencies.
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
         $this->alias = $alias ?: $input->get('option') . '.' . $input->get('view');
 
         $this->type = $type ?: $this->getType();

--- a/libraries/src/UCM/UCMType.php
+++ b/libraries/src/UCM/UCMType.php
@@ -97,7 +97,7 @@ class UCMType implements UCM
         $app      = $application ?: Factory::getApplication();
 
         // Make the best guess we can in the absence of information.
-        $this->alias = $alias ?: $app->input->get('option') . '.' . $app->input->get('view');
+        $this->alias = $alias ?: $app->getInput()->get('option') . '.' . $app->getInput()->get('view');
         $this->type  = $this->getTypeByAlias($this->alias);
     }
 

--- a/libraries/src/Workflow/WorkflowPluginTrait.php
+++ b/libraries/src/Workflow/WorkflowPluginTrait.php
@@ -65,7 +65,7 @@ trait WorkflowPluginTrait
      */
     protected function getWorkflow(int $workflowId = null)
     {
-        $workflowId = !empty($workflowId) ? $workflowId : $this->app->input->getInt('workflow_id');
+        $workflowId = !empty($workflowId) ? $workflowId : $this->app->getInput()->getInt('workflow_id');
 
         if (is_array($workflowId)) {
             return false;

--- a/modules/mod_articles_categories/tmpl/default_items.php
+++ b/modules/mod_articles_categories/tmpl/default_items.php
@@ -15,7 +15,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
-$input  = $app->input;
+$input  = $app->getInput();
 $option = $input->getCmd('option');
 $view   = $input->getCmd('view');
 $id     = $input->getInt('id');

--- a/modules/mod_articles_category/mod_articles_category.php
+++ b/modules/mod_articles_category/mod_articles_category.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\Module\ArticlesCategory\Site\Helper\ArticlesCategoryHelper;
 
-$input = $app->input;
+$input = $app->getInput();
 
 // Prep for Normal or Dynamic Modes
 $mode   = $params->get('mode', 'normal');

--- a/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
@@ -50,7 +50,7 @@ abstract class ArticlesCategoryHelper
         $articles = $factory->createModel('Articles', 'Site', ['ignore_request' => true]);
 
         // Set application parameters in model
-        $input     = $app->input;
+        $input     = $app->getInput();
         $appParams = $app->getParams();
         $articles->setState('params', $appParams);
 

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -92,11 +92,11 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
         // Filter by id in case it should be excluded
         if (
             $params->get('exclude_current', true)
-            && $app->input->get('option') === 'com_content'
-            && $app->input->get('view') === 'article'
+            && $app->getInput()->get('option') === 'com_content'
+            && $app->getInput()->get('view') === 'article'
         ) {
             // Exclude the current article from displaying in this module
-            $model->setState('filter.article_id', $app->input->get('id', 0, 'UINT'));
+            $model->setState('filter.article_id', $app->getInput()->get('id', 0, 'UINT'));
             $model->setState('filter.article_id.include', false);
         }
 

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -89,14 +89,16 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
             $model->setState('filter.featured', 'hide');
         }
 
+        $input = $app->getInput();
+
         // Filter by id in case it should be excluded
         if (
             $params->get('exclude_current', true)
-            && $app->getInput()->get('option') === 'com_content'
-            && $app->getInput()->get('view') === 'article'
+            && $input->get('option') === 'com_content'
+            && $input->get('view') === 'article'
         ) {
             // Exclude the current article from displaying in this module
-            $model->setState('filter.article_id', $app->getInput()->get('id', 0, 'UINT'));
+            $model->setState('filter.article_id', $input->get('id', 0, 'UINT'));
             $model->setState('filter.article_id.include', false);
         }
 

--- a/modules/mod_finder/src/Helper/FinderHelper.php
+++ b/modules/mod_finder/src/Helper/FinderHelper.php
@@ -65,7 +65,7 @@ class FinderHelper
      */
     public static function getQuery($params)
     {
-        $request = Factory::getApplication()->input->request;
+        $request = Factory::getApplication()->getInput()->request;
         $filter  = InputFilter::getInstance();
 
         // Get the static taxonomy filters.

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -19,7 +19,7 @@ use Joomla\Module\Finder\Site\Helper\FinderHelper;
 $lang = $app->getLanguage();
 $lang->load('com_finder', JPATH_SITE);
 
-$input = '<input type="text" name="q" id="mod-finder-searchword' . $module->id . '" class="js-finder-search-query form-control" value="' . htmlspecialchars($app->input->get('q', '', 'string'), ENT_COMPAT, 'UTF-8') . '"'
+$input = '<input type="text" name="q" id="mod-finder-searchword' . $module->id . '" class="js-finder-search-query form-control" value="' . htmlspecialchars($app->getInput()->get('q', '', 'string'), ENT_COMPAT, 'UTF-8') . '"'
     . ' placeholder="' . Text::_('MOD_FINDER_SEARCH_VALUE') . '">';
 
 $showLabel  = $params->get('show_label', 1);

--- a/modules/mod_languages/src/Helper/LanguagesHelper.php
+++ b/modules/mod_languages/src/Helper/LanguagesHelper.php
@@ -66,7 +66,7 @@ abstract class LanguagesHelper
                 $associations = MenusHelper::getAssociations($active->id);
             }
 
-            $option = $app->input->get('option');
+            $option = $app->getInput()->get('option');
             $component = $app->bootComponent($option);
 
             if ($component instanceof AssociationServiceInterface) {

--- a/modules/mod_related_items/src/Helper/RelatedItemsHelper.php
+++ b/modules/mod_related_items/src/Helper/RelatedItemsHelper.php
@@ -40,7 +40,7 @@ abstract class RelatedItemsHelper
     {
         $db        = Factory::getDbo();
         $app       = Factory::getApplication();
-        $input     = $app->input;
+        $input     = $app->getInput();
         $groups    = Factory::getUser()->getAuthorisedViewLevels();
         $maximum   = (int) $params->get('maximum', 5);
         $factory   = $app->bootComponent('com_content')->getMVCFactory();

--- a/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
+++ b/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
@@ -40,8 +40,8 @@ abstract class TagsSimilarHelper
     public static function getList(&$params)
     {
         $app    = Factory::getApplication();
-        $option = $app->input->get('option');
-        $view   = $app->input->get('view');
+        $option = $app->getInput()->get('option');
+        $view   = $app->getInput()->get('view');
 
         // For now assume com_tags and com_users do not have tags.
         // This module does not apply to list views in general at this point.
@@ -56,7 +56,7 @@ abstract class TagsSimilarHelper
         $ordering   = $params->get('ordering', 'count');
         $tagsHelper = new TagsHelper();
         $prefix     = $option . '.' . $view;
-        $id         = $app->input->getInt('id');
+        $id         = $app->getInput()->getInt('id');
         $now        = Factory::getDate()->toSql();
         $nullDate   = $db->getNullDate();
 

--- a/modules/mod_wrapper/src/Helper/WrapperHelper.php
+++ b/modules/mod_wrapper/src/Helper/WrapperHelper.php
@@ -48,7 +48,7 @@ class WrapperHelper
             // Adds 'http://' if none is set
             if (strpos($url, '/') === 0) {
                 // Relative URL in component. use server http_host.
-                $url = 'http://' . Factory::getApplication()->input->server->get('HTTP_HOST') . $url;
+                $url = 'http://' . Factory::getApplication()->getInput()->server->get('HTTP_HOST') . $url;
             } elseif (strpos($url, 'http') === false && strpos($url, 'https') === false) {
                 $url = 'http://' . $url;
             }

--- a/plugins/actionlog/joomla/src/Extension/Joomla.php
+++ b/plugins/actionlog/joomla/src/Extension/Joomla.php
@@ -163,7 +163,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onContentAfterDelete($context, $article): void
     {
-        $option = $this->getApplication()->input->get('option');
+        $option = $this->getApplication()->getInput()->get('option');
 
         if (!$this->checkLoggable($option)) {
             return;
@@ -210,7 +210,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onContentChangeState($context, $pks, $value)
     {
-        $option = $this->getApplication()->input->getCmd('option');
+        $option = $this->getApplication()->getInput()->getCmd('option');
 
         if (!$this->checkLoggable($option)) {
             return;
@@ -300,7 +300,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onApplicationAfterSave($config): void
     {
-        $option = $this->getApplication()->input->getCmd('option');
+        $option = $this->getApplication()->getInput()->getCmd('option');
 
         if (!$this->checkLoggable($option)) {
             return;
@@ -333,7 +333,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onExtensionAfterInstall($installer, $eid)
     {
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
 
         if (!$this->checkLoggable($context)) {
             return;
@@ -380,7 +380,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onExtensionAfterUninstall($installer, $eid, $result)
     {
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
 
         if (!$this->checkLoggable($context)) {
             return;
@@ -431,7 +431,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onExtensionAfterUpdate($installer, $eid)
     {
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
 
         if (!$this->checkLoggable($context)) {
             return;
@@ -477,7 +477,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onExtensionAfterSave($context, $table, $isNew): void
     {
-        $option = $this->getApplication()->input->getCmd('option');
+        $option = $this->getApplication()->getInput()->getCmd('option');
 
         if ($table->get('module') != null) {
             $option = 'com_modules';
@@ -534,7 +534,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onExtensionAfterDelete($context, $table): void
     {
-        if (!$this->checkLoggable($this->getApplication()->input->get('option'))) {
+        if (!$this->checkLoggable($this->getApplication()->getInput()->get('option'))) {
             return;
         }
 
@@ -573,8 +573,8 @@ final class Joomla extends ActionLogPlugin
      */
     public function onUserAfterSave($user, $isnew, $success, $msg): void
     {
-        $context = $this->getApplication()->input->get('option');
-        $task    = $this->getApplication()->input->post->get('task');
+        $context = $this->getApplication()->getInput()->get('option');
+        $task    = $this->getApplication()->getInput()->post->get('task');
 
         if (!$this->checkLoggable($context)) {
             return;
@@ -643,7 +643,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onUserAfterDelete($user, $success, $msg): void
     {
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
 
         if (!$this->checkLoggable($context)) {
             return;
@@ -677,7 +677,7 @@ final class Joomla extends ActionLogPlugin
     public function onUserAfterSaveGroup($context, $table, $isNew): void
     {
         // Override context (com_users.group) with the component context (com_users) to pass the checkLoggable
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
 
         if (!$this->checkLoggable($context)) {
             return;
@@ -717,7 +717,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onUserAfterDeleteGroup($group, $success, $msg): void
     {
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
 
         if (!$this->checkLoggable($context)) {
             return;
@@ -886,7 +886,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onUserAfterRemind($user)
     {
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
 
         if (!$this->checkLoggable($context)) {
             return;
@@ -954,7 +954,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onAfterLogPurge($group = '')
     {
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
         $user    = Factory::getUser();
         $message = array(
             'action'      => 'actionlogs',
@@ -982,7 +982,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onAfterLogExport($group = '')
     {
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
         $user    = Factory::getUser();
         $message = array(
             'action'      => 'actionlogs',
@@ -1010,7 +1010,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onAfterPurge($group = 'all')
     {
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
         $user    = Factory::getUser();
 
         if (!$this->checkLoggable($context)) {
@@ -1050,13 +1050,13 @@ final class Joomla extends ActionLogPlugin
             return;
         }
 
-        $verb = $this->getApplication()->input->getMethod();
+        $verb = $this->getApplication()->getInput()->getMethod();
 
         if (!in_array($verb, $this->loggableVerbs)) {
             return;
         }
 
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
 
         if (!$this->checkLoggable($context)) {
             return;
@@ -1086,7 +1086,7 @@ final class Joomla extends ActionLogPlugin
      */
     public function onJoomlaAfterUpdate($oldVersion = null)
     {
-        $context = $this->getApplication()->input->get('option');
+        $context = $this->getApplication()->getInput()->get('option');
         $user    = Factory::getUser();
 
         if (empty($oldVersion)) {

--- a/plugins/api-authentication/basic/src/Extension/Basic.php
+++ b/plugins/api-authentication/basic/src/Extension/Basic.php
@@ -69,8 +69,8 @@ final class Basic extends CMSPlugin
     {
         $response->type = 'Basic';
 
-        $username = $this->getApplication()->input->server->get('PHP_AUTH_USER', '', 'USERNAME');
-        $password = $this->getApplication()->input->server->get('PHP_AUTH_PW', '', 'RAW');
+        $username = $this->getApplication()->getInput()->server->get('PHP_AUTH_USER', '', 'USERNAME');
+        $password = $this->getApplication()->getInput()->server->get('PHP_AUTH_PW', '', 'RAW');
 
         if ($password === '') {
             $response->status        = Authentication::STATUS_FAILURE;

--- a/plugins/api-authentication/token/src/Extension/Token.php
+++ b/plugins/api-authentication/token/src/Extension/Token.php
@@ -107,7 +107,7 @@ final class Token extends CMSPlugin
          * Do keep in mind that Bearer is **case-sensitive**. Whitespace between Bearer and the
          * token, as well as any whitespace following the token is discarded.
          */
-        $authHeader  = $this->getApplication()->input->server->get('HTTP_AUTHORIZATION', '', 'string');
+        $authHeader  = $this->getApplication()->getInput()->server->get('HTTP_AUTHORIZATION', '', 'string');
         $tokenString = '';
 
         // Apache specific fixes. See https://github.com/symfony/symfony/issues/19693
@@ -129,7 +129,7 @@ final class Token extends CMSPlugin
         }
 
         if (empty($tokenString)) {
-            $tokenString = $this->getApplication()->input->server->get('HTTP_X_JOOMLA_TOKEN', '', 'string');
+            $tokenString = $this->getApplication()->getInput()->server->get('HTTP_X_JOOMLA_TOKEN', '', 'string');
         }
 
         // No token: authentication failure

--- a/plugins/authentication/cookie/cookie.php
+++ b/plugins/authentication/cookie/cookie.php
@@ -85,12 +85,12 @@ class PlgAuthenticationCookie extends CMSPlugin
 
         // Get cookie
         $cookieName  = 'joomla_remember_me_' . UserHelper::getShortHashedUserAgent();
-        $cookieValue = $this->app->input->cookie->get($cookieName);
+        $cookieValue = $this->app->getInput()->cookie->get($cookieName);
 
         // Try with old cookieName (pre 3.6.0) if not found
         if (!$cookieValue) {
             $cookieName  = UserHelper::getShortHashedUserAgent();
-            $cookieValue = $this->app->input->cookie->get($cookieName);
+            $cookieValue = $this->app->getInput()->cookie->get($cookieName);
         }
 
         if (!$cookieValue) {
@@ -102,7 +102,7 @@ class PlgAuthenticationCookie extends CMSPlugin
         // Check for valid cookie value
         if (count($cookieArray) !== 2) {
             // Destroy the cookie in the browser.
-            $this->app->input->cookie->set($cookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
+            $this->app->getInput()->cookie->set($cookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
             Log::add('Invalid cookie detected.', Log::WARNING, 'error');
 
             return false;
@@ -147,7 +147,7 @@ class PlgAuthenticationCookie extends CMSPlugin
 
         if (count($results) !== 1) {
             // Destroy the cookie in the browser.
-            $this->app->input->cookie->set($cookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
+            $this->app->getInput()->cookie->set($cookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
             $response->status = Authentication::STATUS_FAILURE;
 
             return false;
@@ -177,7 +177,7 @@ class PlgAuthenticationCookie extends CMSPlugin
             }
 
             // Destroy the cookie in the browser.
-            $this->app->input->cookie->set($cookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
+            $this->app->getInput()->cookie->set($cookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
 
             // Issue warning by email to user and/or admin?
             Log::add(Text::sprintf('PLG_AUTHENTICATION_COOKIE_ERROR_LOG_LOGIN_FAILED', $results[0]->user_id), Log::WARNING, 'security');
@@ -245,15 +245,15 @@ class PlgAuthenticationCookie extends CMSPlugin
             $cookieName = 'joomla_remember_me_' . UserHelper::getShortHashedUserAgent();
 
             // We need the old data to get the existing series
-            $cookieValue = $this->app->input->cookie->get($cookieName);
+            $cookieValue = $this->app->getInput()->cookie->get($cookieName);
 
             // Try with old cookieName (pre 3.6.0) if not found
             if (!$cookieValue) {
                 $oldCookieName = UserHelper::getShortHashedUserAgent();
-                $cookieValue   = $this->app->input->cookie->get($oldCookieName);
+                $cookieValue   = $this->app->getInput()->cookie->get($oldCookieName);
 
                 // Destroy the old cookie in the browser
-                $this->app->input->cookie->set($oldCookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
+                $this->app->getInput()->cookie->set($oldCookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
             }
 
             $cookieArray = explode('.', $cookieValue);
@@ -305,7 +305,7 @@ class PlgAuthenticationCookie extends CMSPlugin
         $cookieValue = $token . '.' . $series;
 
         // Overwrite existing cookie with new value
-        $this->app->input->cookie->set(
+        $this->app->getInput()->cookie->set(
             $cookieName,
             $cookieValue,
             time() + $lifetime,
@@ -374,7 +374,7 @@ class PlgAuthenticationCookie extends CMSPlugin
         }
 
         $cookieName  = 'joomla_remember_me_' . UserHelper::getShortHashedUserAgent();
-        $cookieValue = $this->app->input->cookie->get($cookieName);
+        $cookieValue = $this->app->getInput()->cookie->get($cookieName);
 
         // There are no cookies to delete.
         if (!$cookieValue) {
@@ -400,7 +400,7 @@ class PlgAuthenticationCookie extends CMSPlugin
         }
 
         // Destroy the cookie
-        $this->app->input->cookie->set($cookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
+        $this->app->getInput()->cookie->set($cookieName, '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
 
         return true;
     }

--- a/plugins/behaviour/versionable/src/Extension/Versionable.php
+++ b/plugins/behaviour/versionable/src/Extension/Versionable.php
@@ -117,7 +117,7 @@ final class Versionable extends CMSPlugin implements SubscriberInterface
 
         $id     = $table->getId();
         $data   = $this->helper->getDataObject($table);
-        $input  = $this->getApplication()->input;
+        $input  = $this->getApplication()->getInput();
         $jform  = $input->get('jform', array(), 'array');
         $versionNote = '';
 

--- a/plugins/captcha/recaptcha/recaptcha.php
+++ b/plugins/captcha/recaptcha/recaptcha.php
@@ -135,7 +135,7 @@ class PlgCaptchaRecaptcha extends CMSPlugin
      */
     public function onCheckAnswer($code = null)
     {
-        $input      = Factory::getApplication()->input;
+        $input      = Factory::getApplication()->getInput();
         $privatekey = $this->params->get('private_key');
         $version    = $this->params->get('version', '2.0');
         $remoteip   = IpHelper::getIp();

--- a/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
+++ b/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php
@@ -134,7 +134,7 @@ class PlgCaptchaRecaptcha_Invisible extends CMSPlugin
      */
     public function onCheckAnswer($code = null)
     {
-        $input      = Factory::getApplication()->input;
+        $input      = Factory::getApplication()->getInput();
         $privatekey = $this->params->get('private_key');
         $remoteip   = IpHelper::getIp();
 

--- a/plugins/content/joomla/joomla.php
+++ b/plugins/content/joomla/joomla.php
@@ -234,7 +234,7 @@ class PlgContentJoomla extends CMSPlugin
             return true;
         }
 
-        $extension = $this->app->input->getString('extension');
+        $extension = $this->app->getInput()->getString('extension');
 
         // Default to true if not a core extension
         $result = true;

--- a/plugins/content/pagebreak/pagebreak.php
+++ b/plugins/content/pagebreak/pagebreak.php
@@ -74,7 +74,7 @@ class PlgContentPagebreak extends CMSPlugin
         // Expression to search for.
         $regex = '#<hr(.*)class="system-pagebreak"(.*)\/?>#iU';
 
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         $print = $input->getBool('print');
         $showall = $input->getBool('showall');
@@ -263,7 +263,7 @@ class PlgContentPagebreak extends CMSPlugin
     protected function _createToc(&$row, &$matches, &$page)
     {
         $heading     = $row->title ?? Text::_('PLG_CONTENT_PAGEBREAK_NO_TITLE');
-        $input       = Factory::getApplication()->input;
+        $input       = Factory::getApplication()->getInput();
         $limitstart  = $input->getUint('limitstart', 0);
         $showall     = $input->getInt('showall', 0);
         $headingtext = '';

--- a/plugins/content/pagenavigation/pagenavigation.php
+++ b/plugins/content/pagenavigation/pagenavigation.php
@@ -44,8 +44,8 @@ class PlgContentPagenavigation extends CMSPlugin
     public function onContentBeforeDisplay($context, &$row, &$params, $page = 0)
     {
         $app   = Factory::getApplication();
-        $view  = $app->input->get('view');
-        $print = $app->input->getBool('print');
+        $view  = $app->getInput()->get('view');
+        $print = $app->getInput()->getBool('print');
 
         if ($print) {
             return false;

--- a/plugins/content/vote/vote.php
+++ b/plugins/content/vote/vote.php
@@ -130,7 +130,7 @@ class PlgContentVote extends CMSPlugin
         include $path;
         $html = ob_get_clean();
 
-        if ($this->app->input->getString('view', '') === 'article' && $row->state == 1) {
+        if ($this->app->getInput()->getString('view', '') === 'article' && $row->state == 1) {
             // Get the path for the voting form layout file
             $path = PluginHelper::getLayoutPath('content', 'vote', 'vote');
 

--- a/plugins/editors-xtd/fields/fields.php
+++ b/plugins/editors-xtd/fields/fields.php
@@ -53,7 +53,7 @@ class PlgButtonFields extends CMSPlugin
         }
 
         // Guess the field context based on view.
-        $jinput = Factory::getApplication()->input;
+        $jinput = Factory::getApplication()->getInput();
         $context = $jinput->get('option') . '.' . $jinput->get('view');
 
         // Special context for com_categories

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -51,11 +51,11 @@ class PlgButtonImage extends CMSPlugin
         $app       = Factory::getApplication();
         $doc       = $app->getDocument();
         $user      = Factory::getUser();
-        $extension = $app->input->get('option');
+        $extension = $app->getInput()->get('option');
 
         // For categories we check the extension (ex: component.section)
         if ($extension === 'com_categories') {
-            $parts     = explode('.', $app->input->get('extension', 'com_content'));
+            $parts     = explode('.', $app->getInput()->get('extension', 'com_content'));
             $extension = $parts[0];
         }
 

--- a/plugins/installer/folderinstaller/tmpl/default.php
+++ b/plugins/installer/folderinstaller/tmpl/default.php
@@ -34,7 +34,7 @@ $this->app->getDocument()->getWebAssetManager()
     </label>
     <div class="controls">
         <input type="text" id="install_directory" name="install_directory" class="form-control"
-            value="<?php echo $this->app->input->get('install_directory', $this->app->get('tmp_path')); ?>">
+            value="<?php echo $this->app->getInput()->get('install_directory', $this->app->get('tmp_path')); ?>">
     </div>
 </div>
 <div class="control-group">

--- a/plugins/installer/packageinstaller/tmpl/default.php
+++ b/plugins/installer/packageinstaller/tmpl/default.php
@@ -32,7 +32,7 @@ $this->app->getDocument()->getWebAssetManager()
         ['core']
     );
 
-$return = $this->app->input->getBase64('return');
+$return = $this->app->getInput()->getBase64('return');
 $maxSizeBytes = FilesystemHelper::fileUploadMaxSize(false);
 $maxSize = HTMLHelper::_('number.bytes', $maxSizeBytes);
 ?>

--- a/plugins/installer/webinstaller/webinstaller.php
+++ b/plugins/installer/webinstaller/webinstaller.php
@@ -153,7 +153,7 @@ class PlgInstallerWebinstaller extends CMSPlugin
     private function getInstallFrom()
     {
         if ($this->installfrom === null) {
-            $installfrom = base64_decode($this->app->input->getBase64('installfrom', ''));
+            $installfrom = base64_decode($this->app->getInput()->getBase64('installfrom', ''));
 
             $field = new SimpleXMLElement('<field></field>');
 

--- a/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
+++ b/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
@@ -314,7 +314,7 @@ class Webauthn extends CMSPlugin implements SubscriberInterface
         $session          = $this->getApplication()->getSession();
         $pkOptionsEncoded = $session->get('plg_multifactorauth_webauthn.publicKeyCredentialRequestOptions', null);
 
-        $force = $this->getApplication()->input->getInt('force', 0);
+        $force = $this->getApplication()->getInput()->getInt('force', 0);
 
         try {
             if ($force) {

--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -226,12 +226,12 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
         }
 
         // Only on full page requests
-        if ($this->app->input->getCmd('tmpl', 'index') === 'component') {
+        if ($this->app->getInput()->getCmd('tmpl', 'index') === 'component') {
             return false;
         }
 
         // Only to com_cpanel
-        if ($this->app->input->get('option') !== 'com_cpanel') {
+        if ($this->app->getInput()->get('option') !== 'com_cpanel') {
             return false;
         }
 

--- a/plugins/sampledata/blog/blog.php
+++ b/plugins/sampledata/blog/blog.php
@@ -96,7 +96,7 @@ class PlgSampledataBlog extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep1()
     {
-        if (!Session::checkToken('get') || $this->app->input->get('type') != $this->_name) {
+        if (!Session::checkToken('get') || $this->app->getInput()->get('type') != $this->_name) {
             return;
         }
 
@@ -789,7 +789,7 @@ class PlgSampledataBlog extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep2()
     {
-        if (!Session::checkToken('get') || $this->app->input->get('type') != $this->_name) {
+        if (!Session::checkToken('get') || $this->app->getInput()->get('type') != $this->_name) {
             return;
         }
 
@@ -1336,7 +1336,7 @@ class PlgSampledataBlog extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep3()
     {
-        if (!Session::checkToken('get') || $this->app->input->get('type') != $this->_name) {
+        if (!Session::checkToken('get') || $this->app->getInput()->get('type') != $this->_name) {
             return;
         }
 
@@ -1772,7 +1772,7 @@ class PlgSampledataBlog extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep4()
     {
-        if ($this->app->input->get('type') != $this->_name) {
+        if ($this->app->getInput()->get('type') != $this->_name) {
             return;
         }
 

--- a/plugins/sampledata/multilang/multilang.php
+++ b/plugins/sampledata/multilang/multilang.php
@@ -105,7 +105,7 @@ class PlgSampledataMultilang extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep1()
     {
-        if (!Session::checkToken('get') || $this->app->input->get('type') != $this->_name) {
+        if (!Session::checkToken('get') || $this->app->getInput()->get('type') != $this->_name) {
             return;
         }
 
@@ -148,7 +148,7 @@ class PlgSampledataMultilang extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep2()
     {
-        if (!Session::checkToken('get') || $this->app->input->get('type') != $this->_name) {
+        if (!Session::checkToken('get') || $this->app->getInput()->get('type') != $this->_name) {
             return;
         }
 
@@ -189,7 +189,7 @@ class PlgSampledataMultilang extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep3()
     {
-        if (!Session::checkToken('get') || $this->app->input->get('type') != $this->_name) {
+        if (!Session::checkToken('get') || $this->app->getInput()->get('type') != $this->_name) {
             return;
         }
 
@@ -225,7 +225,7 @@ class PlgSampledataMultilang extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep4()
     {
-        if (!Session::checkToken('get') || $this->app->input->get('type') != $this->_name) {
+        if (!Session::checkToken('get') || $this->app->getInput()->get('type') != $this->_name) {
             return;
         }
 
@@ -283,7 +283,7 @@ class PlgSampledataMultilang extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep5()
     {
-        if (!Session::checkToken('get') || $this->app->input->get('type') != $this->_name) {
+        if (!Session::checkToken('get') || $this->app->getInput()->get('type') != $this->_name) {
             return;
         }
 
@@ -323,7 +323,7 @@ class PlgSampledataMultilang extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep6()
     {
-        if (!Session::checkToken('get') || $this->app->input->get('type') != $this->_name) {
+        if (!Session::checkToken('get') || $this->app->getInput()->get('type') != $this->_name) {
             return;
         }
 
@@ -403,7 +403,7 @@ class PlgSampledataMultilang extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep7()
     {
-        if (!Session::checkToken('get') || $this->app->input->get('type') != $this->_name) {
+        if (!Session::checkToken('get') || $this->app->getInput()->get('type') != $this->_name) {
             return;
         }
 
@@ -439,7 +439,7 @@ class PlgSampledataMultilang extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep8()
     {
-        if ($this->app->input->get('type') !== $this->_name) {
+        if ($this->app->getInput()->get('type') !== $this->_name) {
             return;
         }
 

--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -103,7 +103,7 @@ class PlgSampledataTesting extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep1()
     {
-        if ($this->app->input->get('type') !== $this->_name) {
+        if ($this->app->getInput()->get('type') !== $this->_name) {
             return;
         }
 
@@ -200,7 +200,7 @@ class PlgSampledataTesting extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep2()
     {
-        if ($this->app->input->get('type') !== $this->_name) {
+        if ($this->app->getInput()->get('type') !== $this->_name) {
             return;
         }
 
@@ -364,7 +364,7 @@ class PlgSampledataTesting extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep3()
     {
-        if ($this->app->input->get('type') !== $this->_name) {
+        if ($this->app->getInput()->get('type') !== $this->_name) {
             return;
         }
 
@@ -583,7 +583,7 @@ class PlgSampledataTesting extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep4()
     {
-        if ($this->app->input->get('type') !== $this->_name) {
+        if ($this->app->getInput()->get('type') !== $this->_name) {
             return;
         }
 
@@ -992,7 +992,7 @@ class PlgSampledataTesting extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep5()
     {
-        if ($this->app->input->get('type') !== $this->_name) {
+        if ($this->app->getInput()->get('type') !== $this->_name) {
             return;
         }
 
@@ -1319,7 +1319,7 @@ class PlgSampledataTesting extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep6()
     {
-        if ($this->app->input->get('type') !== $this->_name) {
+        if ($this->app->getInput()->get('type') !== $this->_name) {
             return;
         }
 
@@ -1437,7 +1437,7 @@ class PlgSampledataTesting extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep7()
     {
-        if ($this->app->input->get('type') !== $this->_name) {
+        if ($this->app->getInput()->get('type') !== $this->_name) {
             return;
         }
 
@@ -3122,7 +3122,7 @@ class PlgSampledataTesting extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep8()
     {
-        if ($this->app->input->get('type') !== $this->_name) {
+        if ($this->app->getInput()->get('type') !== $this->_name) {
             return;
         }
 

--- a/plugins/system/accessibility/accessibility.php
+++ b/plugins/system/accessibility/accessibility.php
@@ -55,7 +55,7 @@ class PlgSystemAccessibility extends CMSPlugin
         }
 
         // Are we in a modal?
-        if ($this->app->input->get('tmpl', '', 'cmd') === 'component') {
+        if ($this->app->getInput()->get('tmpl', '', 'cmd') === 'component') {
             return;
         }
 

--- a/plugins/system/actionlogs/actionlogs.php
+++ b/plugins/system/actionlogs/actionlogs.php
@@ -110,7 +110,7 @@ class PlgSystemActionLogs extends CMSPlugin
 		}
 
 		// If we are on the save command, no data is passed to $data variable, we need to get it directly from request
-		$jformData = $this->app->input->get('jform', [], 'array');
+		$jformData = $this->app->getInput()->get('jform', [], 'array');
 
 		if ($jformData && !$data)
 		{

--- a/plugins/system/cache/src/Extension/Cache.php
+++ b/plugins/system/cache/src/Extension/Cache.php
@@ -173,7 +173,7 @@ final class Cache extends CMSPlugin implements SubscriberInterface
 		{
 			// Create a document instance and load it into the application.
 			$document = $this->documentFactory
-				->createDocument($this->getApplication()->input->get('format', 'html'));
+				->createDocument($this->getApplication()->getInput()->get('format', 'html'));
 			$this->getApplication()->loadDocument($document);
 
 			if ($this->profiler)
@@ -215,7 +215,7 @@ final class Cache extends CMSPlugin implements SubscriberInterface
 		if ($isSite === null)
 		{
 			$isSite = $this->getApplication()->isClient('site');
-			$isGET  = $this->getApplication()->input->getMethod() === 'GET';
+			$isGET  = $this->getApplication()->getInput()->getMethod() === 'GET';
 		}
 
 		// Boolean short–circuit evaluation means this returns fast false when $isSite is false.

--- a/plugins/system/debug/debug.php
+++ b/plugins/system/debug/debug.php
@@ -200,8 +200,8 @@ class PlgSystemDebug extends CMSPlugin implements SubscriberInterface
         $this->debugBar->setStorage(new FileStorage($storagePath));
         $this->debugBar->setHttpDriver(new JoomlaHttpDriver($this->app));
 
-        $this->isAjax = $this->app->input->get('option') === 'com_ajax'
-            && $this->app->input->get('plugin') === 'debug' && $this->app->input->get('group') === 'system';
+        $this->isAjax = $this->app->getInput()->get('option') === 'com_ajax'
+            && $this->app->getInput()->get('plugin') === 'debug' && $this->app->getInput()->get('group') === 'system';
 
         $this->showLogs = (bool) $this->params->get('logs', true);
 
@@ -378,12 +378,12 @@ class PlgSystemDebug extends CMSPlugin implements SubscriberInterface
             return;
         }
 
-        switch ($this->app->input->get('action')) {
+        switch ($this->app->getInput()->get('action')) {
             case 'openhandler':
                 $result  = $event['result'] ?: [];
                 $handler = new OpenHandler($this->debugBar);
 
-                $result[] = $handler->handle($this->app->input->request->getArray(), false, false);
+                $result[] = $handler->handle($this->app->getInput()->request->getArray(), false, false);
                 $event['result'] = $result;
         }
     }

--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -177,7 +177,7 @@ class PlgSystemFields extends CMSPlugin
 
         $user = Factory::getUser($userData['id']);
 
-        $task = Factory::getApplication()->input->getCmd('task');
+        $task = Factory::getApplication()->getInput()->getCmd('task');
 
         // Skip fields save when we activate a user, because we will lose the saved data
         if (in_array($task, array('activate', 'block', 'unblock'))) {
@@ -250,7 +250,7 @@ class PlgSystemFields extends CMSPlugin
         // When a category is edited, the context is com_categories.categorycom_content
         if (strpos($context, 'com_categories.category') === 0) {
             $context = str_replace('com_categories.category', '', $context) . '.categories';
-            $data    = $data ?: Factory::getApplication()->input->get('jform', [], 'array');
+            $data    = $data ?: Factory::getApplication()->getInput()->get('jform', [], 'array');
 
             // Set the catid on the category to get only the fields which belong to this category
             if (is_array($data) && array_key_exists('id', $data)) {
@@ -268,7 +268,7 @@ class PlgSystemFields extends CMSPlugin
             return true;
         }
 
-        $input = Factory::getApplication()->input;
+        $input = Factory::getApplication()->getInput();
 
         // If we are on the save command we need the actual data
         $jformData = $input->get('jform', array(), 'array');

--- a/plugins/system/highlight/highlight.php
+++ b/plugins/system/highlight/highlight.php
@@ -54,7 +54,7 @@ class PlgSystemHighlight extends CMSPlugin
         }
 
         // Set the variables.
-        $input     = $this->app->input;
+        $input     = $this->app->getInput();
         $extension = $input->get('option', '', 'cmd');
 
         // Check if the highlighter is enabled.

--- a/plugins/system/jooa11y/jooa11y.php
+++ b/plugins/system/jooa11y/jooa11y.php
@@ -107,7 +107,7 @@ class PlgSystemJooa11y extends CMSPlugin implements SubscriberInterface
     public function initJooa11y()
     {
         // Check if we are in a preview modal or the plugin has enforced loading
-        $showJooa11y = $this->app->input->get('jooa11y', $this->params->get('showAlways', 0));
+        $showJooa11y = $this->app->getInput()->get('jooa11y', $this->params->get('showAlways', 0));
 
         // Load the checker if authorised
         if (!$showJooa11y || !$this->isAuthorisedDisplayChecker()) {

--- a/plugins/system/languagefilter/languagefilter.php
+++ b/plugins/system/languagefilter/languagefilter.php
@@ -373,10 +373,10 @@ class PlgSystemLanguageFilter extends CMSPlugin
         // We are called via POST or the nolangfilter url parameter was set. We don't care about the language
         // and simply set the default language as our current language.
         if (
-            $this->app->input->getMethod() === 'POST'
-            || $this->app->input->get('nolangfilter', 0) == 1
-            || count($this->app->input->post) > 0
-            || count($this->app->input->files) > 0
+            $this->app->getInput()->getMethod() === 'POST'
+            || $this->app->getInput()->get('nolangfilter', 0) == 1
+            || count($this->app->getInput()->post) > 0
+            || count($this->app->getInput()->files) > 0
         ) {
             $found = true;
 
@@ -456,7 +456,7 @@ class PlgSystemLanguageFilter extends CMSPlugin
         $this->current_lang = $lang_code;
 
         // Set the request var.
-        $this->app->input->set('language', $lang_code);
+        $this->app->getInput()->set('language', $lang_code);
         $this->app->set('language', $lang_code);
         $language = $this->app->getLanguage();
 
@@ -714,7 +714,7 @@ class PlgSystemLanguageFilter extends CMSPlugin
             }
 
             // Load component associations.
-            $option = $this->app->input->get('option');
+            $option = $this->app->getInput()->get('option');
 
             $component = $this->app->bootComponent($option);
 
@@ -806,7 +806,7 @@ class PlgSystemLanguageFilter extends CMSPlugin
         // If is set to use language cookie for a year in plugin params, save the user language in a new cookie.
         if ((int) $this->params->get('lang_cookie', 0) === 1) {
             // Create a cookie with one year lifetime.
-            $this->app->input->cookie->set(
+            $this->app->getInput()->cookie->set(
                 ApplicationHelper::getHash('language'),
                 $languageCode,
                 time() + 365 * 86400,
@@ -832,7 +832,7 @@ class PlgSystemLanguageFilter extends CMSPlugin
     {
         // Is is set to use a year language cookie in plugin params, get the user language from the cookie.
         if ((int) $this->params->get('lang_cookie', 0) === 1) {
-            $languageCode = $this->app->input->cookie->get(ApplicationHelper::getHash('language'));
+            $languageCode = $this->app->getInput()->cookie->get(ApplicationHelper::getHash('language'));
         } else {
             // Else get the user language from the session.
             $languageCode = $this->app->getSession()->get('plg_system_languagefilter.language');

--- a/plugins/system/logout/logout.php
+++ b/plugins/system/logout/logout.php
@@ -57,9 +57,9 @@ class PlgSystemLogout extends CMSPlugin
 
         $hash  = ApplicationHelper::getHash('PlgSystemLogout');
 
-        if ($this->app->input->cookie->getString($hash)) {
+        if ($this->app->getInput()->cookie->getString($hash)) {
             // Destroy the cookie.
-            $this->app->input->cookie->set(
+            $this->app->getInput()->cookie->set(
                 $hash,
                 '',
                 1,
@@ -83,7 +83,7 @@ class PlgSystemLogout extends CMSPlugin
     {
         if ($this->app->isClient('site')) {
             // Create the cookie.
-            $this->app->input->cookie->set(
+            $this->app->getInput()->cookie->set(
                 ApplicationHelper::getHash('PlgSystemLogout'),
                 true,
                 time() + 86400,

--- a/plugins/system/privacyconsent/privacyconsent.php
+++ b/plugins/system/privacyconsent/privacyconsent.php
@@ -134,9 +134,10 @@ class PlgSystemPrivacyconsent extends CMSPlugin
         }
 
         // Check that the privacy is checked if required ie only in registration from frontend.
-        $option = $this->app->getInput()->get('option');
-        $task   = $this->app->getInput()->post->get('task');
-        $form   = $this->app->getInput()->post->get('jform', [], 'array');
+        $input  = $this->app->getInput();
+        $option = $input->get('option');
+        $task   = $input->post->get('task');
+        $form   = $input->post->get('jform', [], 'array');
 
         if (
             $option == 'com_users' && in_array($task, array('registration.register', 'profile.save'))
@@ -175,9 +176,11 @@ class PlgSystemPrivacyconsent extends CMSPlugin
             return;
         }
 
-        $option = $this->app->getInput()->get('option');
-        $task   = $this->app->getInput()->post->get('task');
-        $form   = $this->app->getInput()->post->get('jform', [], 'array');
+        $input = $this->app->getInput();
+
+        $option = $input->get('option');
+        $task   = $input->post->get('task');
+        $form   = $input->post->get('jform', [], 'array');
 
         if (
             $option == 'com_users'
@@ -187,10 +190,10 @@ class PlgSystemPrivacyconsent extends CMSPlugin
             $userId = ArrayHelper::getValue($data, 'id', 0, 'int');
 
             // Get the user's IP address
-            $ip = $this->app->getInput()->server->get('REMOTE_ADDR', '', 'string');
+            $ip = $input->server->get('REMOTE_ADDR', '', 'string');
 
             // Get the user agent string
-            $userAgent = $this->app->getInput()->server->get('HTTP_USER_AGENT', '', 'string');
+            $userAgent = $input->server->get('HTTP_USER_AGENT', '', 'string');
 
             // Create the user note
             $userNote = (object) [
@@ -284,11 +287,12 @@ class PlgSystemPrivacyconsent extends CMSPlugin
                 return;
             }
 
-            $option = $this->app->getInput()->getCmd('option');
-            $task   = $this->app->getInput()->get('task');
-            $view   = $this->app->getInput()->getString('view', '');
-            $layout = $this->app->getInput()->getString('layout', '');
-            $id     = $this->app->getInput()->getInt('id');
+            $input  = $this->app->getInput();
+            $option = $input->getCmd('option');
+            $task   = $input->get('task');
+            $view   = $input->getString('view', '');
+            $layout = $input->getString('layout', '');
+            $id     = $input->getInt('id');
 
             $privacyArticleId = $this->getPrivacyArticleId();
 

--- a/plugins/system/privacyconsent/privacyconsent.php
+++ b/plugins/system/privacyconsent/privacyconsent.php
@@ -134,9 +134,9 @@ class PlgSystemPrivacyconsent extends CMSPlugin
         }
 
         // Check that the privacy is checked if required ie only in registration from frontend.
-        $option = $this->app->input->get('option');
-        $task   = $this->app->input->post->get('task');
-        $form   = $this->app->input->post->get('jform', [], 'array');
+        $option = $this->app->getInput()->get('option');
+        $task   = $this->app->getInput()->post->get('task');
+        $form   = $this->app->getInput()->post->get('jform', [], 'array');
 
         if (
             $option == 'com_users' && in_array($task, array('registration.register', 'profile.save'))
@@ -175,9 +175,9 @@ class PlgSystemPrivacyconsent extends CMSPlugin
             return;
         }
 
-        $option = $this->app->input->get('option');
-        $task   = $this->app->input->post->get('task');
-        $form   = $this->app->input->post->get('jform', [], 'array');
+        $option = $this->app->getInput()->get('option');
+        $task   = $this->app->getInput()->post->get('task');
+        $form   = $this->app->getInput()->post->get('jform', [], 'array');
 
         if (
             $option == 'com_users'
@@ -187,10 +187,10 @@ class PlgSystemPrivacyconsent extends CMSPlugin
             $userId = ArrayHelper::getValue($data, 'id', 0, 'int');
 
             // Get the user's IP address
-            $ip = $this->app->input->server->get('REMOTE_ADDR', '', 'string');
+            $ip = $this->app->getInput()->server->get('REMOTE_ADDR', '', 'string');
 
             // Get the user agent string
-            $userAgent = $this->app->input->server->get('HTTP_USER_AGENT', '', 'string');
+            $userAgent = $this->app->getInput()->server->get('HTTP_USER_AGENT', '', 'string');
 
             // Create the user note
             $userNote = (object) [
@@ -284,11 +284,11 @@ class PlgSystemPrivacyconsent extends CMSPlugin
                 return;
             }
 
-            $option = $this->app->input->getCmd('option');
-            $task   = $this->app->input->get('task');
-            $view   = $this->app->input->getString('view', '');
-            $layout = $this->app->input->getString('layout', '');
-            $id     = $this->app->input->getInt('id');
+            $option = $this->app->getInput()->getCmd('option');
+            $task   = $this->app->getInput()->get('task');
+            $view   = $this->app->getInput()->getString('view', '');
+            $layout = $this->app->getInput()->getString('layout', '');
+            $id     = $this->app->getInput()->getInt('id');
 
             $privacyArticleId = $this->getPrivacyArticleId();
 

--- a/plugins/system/redirect/redirect.php
+++ b/plugins/system/redirect/redirect.php
@@ -248,7 +248,7 @@ class PlgSystemRedirect extends CMSPlugin implements SubscriberInterface
                 $data = (object) array(
                     'id' => 0,
                     'old_url' => $url,
-                    'referer' => $app->input->server->getString('HTTP_REFERER', ''),
+                    'referer' => $app->getInput()->server->getString('HTTP_REFERER', ''),
                     'hits' => 1,
                     'published' => 0,
                     'created_date' => $nowDate,

--- a/plugins/system/remember/remember.php
+++ b/plugins/system/remember/remember.php
@@ -63,7 +63,7 @@ class PlgSystemRemember extends CMSPlugin
             $cookieName = 'joomla_remember_me_' . UserHelper::getShortHashedUserAgent();
 
             // Check for the cookie
-            if ($this->app->input->cookie->get($cookieName)) {
+            if ($this->app->getInput()->cookie->get($cookieName)) {
                 $this->app->login(['username' => ''], ['silent' => true]);
             }
         }
@@ -87,7 +87,7 @@ class PlgSystemRemember extends CMSPlugin
         $cookieName = 'joomla_remember_me_' . UserHelper::getShortHashedUserAgent();
 
         // Check for the cookie
-        if ($this->app->input->cookie->get($cookieName)) {
+        if ($this->app->getInput()->cookie->get($cookieName)) {
             // Make sure authentication group is loaded to process onUserAfterLogout event
             PluginHelper::importPlugin('authentication');
         }

--- a/plugins/system/schedulerunner/schedulerunner.php
+++ b/plugins/system/schedulerunner/schedulerunner.php
@@ -214,11 +214,11 @@ class PlgSystemSchedulerunner extends CMSPlugin implements SubscriberInterface
             throw new Exception(Text::_('JERROR_ALERTNOAUTHOR'), 403);
         }
 
-        if (!strlen($hash) || $hash !== $this->app->input->get('hash')) {
+        if (!strlen($hash) || $hash !== $this->app->getInput()->get('hash')) {
             throw new Exception(Text::_('JERROR_ALERTNOAUTHOR'), 403);
         }
 
-        $id = (int) $this->app->input->getInt('id', 0);
+        $id = (int) $this->app->getInput()->getInt('id', 0);
 
         $task = $this->runScheduler($id);
 
@@ -246,8 +246,8 @@ class PlgSystemSchedulerunner extends CMSPlugin implements SubscriberInterface
             return;
         }
 
-        $id = (int) $this->app->input->getInt('id');
-        $allowConcurrent = $this->app->input->getBool('allowConcurrent', false);
+        $id = (int) $this->app->getInput()->getInt('id');
+        $allowConcurrent = $this->app->getInput()->getBool('allowConcurrent', false);
 
         $user = Factory::getApplication()->getIdentity();
 
@@ -321,7 +321,7 @@ class PlgSystemSchedulerunner extends CMSPlugin implements SubscriberInterface
 
         if (
             $form->getName() !== 'com_config.component'
-            || $this->app->input->get('component') !== 'com_scheduler'
+            || $this->app->getInput()->get('component') !== 'com_scheduler'
         ) {
             return;
         }

--- a/plugins/system/shortcut/src/Extension/Shortcut.php
+++ b/plugins/system/shortcut/src/Extension/Shortcut.php
@@ -75,7 +75,7 @@ final class Shortcut extends CMSPlugin implements SubscriberInterface
             return;
         }
 
-        $context = $this->getApplication()->input->get('option') . '.' . $this->getApplication()->input->get('view');
+        $context = $this->getApplication()->getInput()->get('option') . '.' . $this->getApplication()->getInput()->get('view');
 
         $shortcuts = [];
 

--- a/plugins/system/skipto/skipto.php
+++ b/plugins/system/skipto/skipto.php
@@ -56,7 +56,7 @@ class PlgSystemSkipto extends CMSPlugin
         }
 
         // Are we in a modal?
-        if ($this->app->input->get('tmpl', '', 'cmd') === 'component') {
+        if ($this->app->getInput()->get('tmpl', '', 'cmd') === 'component') {
             return;
         }
 

--- a/plugins/system/stats/stats.php
+++ b/plugins/system/stats/stats.php
@@ -419,7 +419,7 @@ class PlgSystemStats extends CMSPlugin
      */
     private function isAjaxRequest()
     {
-        return strtolower($this->app->input->server->get('HTTP_X_REQUESTED_WITH', '')) === 'xmlhttprequest';
+        return strtolower($this->app->getInput()->server->get('HTTP_X_REQUESTED_WITH', '')) === 'xmlhttprequest';
     }
 
     /**

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandler.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandler.php
@@ -57,7 +57,7 @@ trait AjaxHandler
      */
     public function onAjaxWebauthn(Ajax $event): void
     {
-        $input = $this->getApplication()->input;
+        $input = $this->getApplication()->getInput();
 
         // Get the return URL from the session
         $returnURL = $this->getApplication()->getSession()->get('plg_system_webauthn.returnUrl', Uri::base());

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerChallenge.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerChallenge.php
@@ -48,7 +48,7 @@ trait AjaxHandlerChallenge
     {
         // Initialize objects
         $session    = $this->getApplication()->getSession();
-        $input      = $this->getApplication()->input;
+        $input      = $this->getApplication()->getInput();
 
         // Retrieve data from the request
         $username  = $input->getUsername('username', '');

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerCreate.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerCreate.php
@@ -75,7 +75,7 @@ trait AjaxHandlerCreate
 
         // Try to validate the browser data. If there's an error I won't save anything and pass the message to the GUI.
         try {
-            $input = $this->getApplication()->input;
+            $input = $this->getApplication()->getInput();
 
             // Retrieve the data sent by the device
             $data = $input->get('data', '', 'raw');

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerDelete.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerDelete.php
@@ -39,7 +39,7 @@ trait AjaxHandlerDelete
     public function onAjaxWebauthnDelete(AjaxDelete $event): void
     {
         // Initialize objects
-        $input      = $this->getApplication()->input;
+        $input      = $this->getApplication()->getInput();
         $repository = $this->authenticationHelper->getCredentialsRepository();
 
         // Retrieve data from the request

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
@@ -299,7 +299,7 @@ trait AjaxHandlerLogin
     {
         // Retrieve data from the request and session
         $pubKeyCredentialSource = $this->authenticationHelper->validateAssertionResponse(
-            $this->getApplication()->input->getBase64('data', ''),
+            $this->getApplication()->getInput()->getBase64('data', ''),
             $user
         );
 

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerSaveLabel.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerSaveLabel.php
@@ -39,7 +39,7 @@ trait AjaxHandlerSaveLabel
     public function onAjaxWebauthnSavelabel(AjaxSaveLabel $event): void
     {
         // Initialize objects
-        $input      = $this->getApplication()->input;
+        $input      = $this->getApplication()->getInput();
         $repository = $this->authenticationHelper->getCredentialsRepository();
 
         // Retrieve data from the request

--- a/plugins/user/joomla/joomla.php
+++ b/plugins/user/joomla/joomla.php
@@ -68,7 +68,7 @@ class PlgUserJoomla extends CMSPlugin
             // In case there is a validation error (like duplicated user), $data is an empty array on save.
             // After returning from error, $data is an array but populated
             if (!$data) {
-                $data = Factory::getApplication()->input->get('jform', array(), 'array');
+                $data = Factory::getApplication()->getInput()->get('jform', array(), 'array');
             }
 
             if (is_array($data)) {
@@ -323,7 +323,7 @@ class PlgUserJoomla extends CMSPlugin
 
         // Add "user state" cookie used for reverse caching proxies like Varnish, Nginx etc.
         if ($this->app->isClient('site')) {
-            $this->app->input->cookie->set(
+            $this->app->getInput()->cookie->set(
                 'joomla_user_state',
                 'logged_in',
                 0,
@@ -380,7 +380,7 @@ class PlgUserJoomla extends CMSPlugin
 
         // Delete "user state" cookie used for reverse caching proxies like Varnish, Nginx etc.
         if ($this->app->isClient('site')) {
-            $this->app->input->cookie->set('joomla_user_state', '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
+            $this->app->getInput()->cookie->set('joomla_user_state', '', 1, $this->app->get('cookie_path', '/'), $this->app->get('cookie_domain', ''));
         }
 
         return true;

--- a/plugins/user/profile/profile.php
+++ b/plugins/user/profile/profile.php
@@ -330,8 +330,8 @@ class PlgUserProfile extends CMSPlugin
         }
 
         // Check that the tos is checked if required ie only in registration from frontend.
-        $task       = $this->app->input->getCmd('task');
-        $option     = $this->app->input->getCmd('option');
+        $task       = $this->app->getInput()->getCmd('task');
+        $option     = $this->app->getInput()->getCmd('option');
         $tosEnabled = ($this->params->get('register-require_tos', 0) == 2);
 
         // Check that the tos is checked.

--- a/plugins/user/terms/terms.php
+++ b/plugins/user/terms/terms.php
@@ -110,9 +110,10 @@ class PlgUserTerms extends CMSPlugin
         }
 
         // Check that the terms is checked if required ie only in registration from frontend.
-        $option = $this->app->getInput()->get('option');
-        $task   = $this->app->getInput()->post->get('task');
-        $form   = $this->app->getInput()->post->get('jform', [], 'array');
+        $input  = $this->app->getInput();
+        $option = $input->get('option');
+        $task   = $input->post->get('task');
+        $form   = $input->post->get('jform', [], 'array');
 
         if ($option == 'com_users' && in_array($task, ['registration.register']) && empty($form['terms']['terms'])) {
             throw new InvalidArgumentException(Text::_('PLG_USER_TERMS_FIELD_ERROR'));

--- a/plugins/user/terms/terms.php
+++ b/plugins/user/terms/terms.php
@@ -110,9 +110,9 @@ class PlgUserTerms extends CMSPlugin
         }
 
         // Check that the terms is checked if required ie only in registration from frontend.
-        $option = $this->app->input->get('option');
-        $task   = $this->app->input->post->get('task');
-        $form   = $this->app->input->post->get('jform', [], 'array');
+        $option = $this->app->getInput()->get('option');
+        $task   = $this->app->getInput()->post->get('task');
+        $form   = $this->app->getInput()->post->get('jform', [], 'array');
 
         if ($option == 'com_users' && in_array($task, ['registration.register']) && empty($form['terms']['terms'])) {
             throw new InvalidArgumentException(Text::_('PLG_USER_TERMS_FIELD_ERROR'));

--- a/plugins/user/token/token.php
+++ b/plugins/user/token/token.php
@@ -164,7 +164,7 @@ class PlgUserToken extends CMSPlugin
          * generic and we run the risk of creating naming clashes. Instead, we manipulate the data
          * directly.
          */
-        if (($context === 'com_users.profile') && ($this->app->input->get('layout') !== 'edit')) {
+        if (($context === 'com_users.profile') && ($this->app->getInput()->get('layout') !== 'edit')) {
             $pluginData = $data->{$this->profileKeyPrefix} ?? [];
             $enabled    = $pluginData['enabled'] ?? false;
             $token      = $pluginData['token'] ?? '';
@@ -208,7 +208,7 @@ class PlgUserToken extends CMSPlugin
         }
 
         // If we are on the save command, no data is passed to $data variable, we need to get it directly from request
-        $jformData = $this->app->input->get('jform', [], 'array');
+        $jformData = $this->app->getInput()->get('jform', [], 'array');
 
         if ($jformData && !$data) {
             $data = $jformData;
@@ -255,7 +255,7 @@ class PlgUserToken extends CMSPlugin
         }
 
         // Remove the Reset field when displaying the user profile form
-        if (($form->getName() === 'com_users.profile') && ($this->app->input->get('layout') !== 'edit')) {
+        if (($form->getName() === 'com_users.profile') && ($this->app->getInput()->get('layout') !== 'edit')) {
             $form->removeField('reset', 'joomlatoken');
         }
 

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -17,15 +17,16 @@ use Joomla\CMS\Uri\Uri;
 
 /** @var Joomla\CMS\Document\ErrorDocument $this */
 
-$app = Factory::getApplication();
-$wa  = $this->getWebAssetManager();
+$app   = Factory::getApplication();
+$input = $app->getInput();
+$wa    = $this->getWebAssetManager();
 
 // Detecting Active Variables
-$option   = $app->getInput()->getCmd('option', '');
-$view     = $app->getInput()->getCmd('view', '');
-$layout   = $app->getInput()->getCmd('layout', '');
-$task     = $app->getInput()->getCmd('task', '');
-$itemid   = $app->getInput()->getCmd('Itemid', '');
+$option   = $input->getCmd('option', '');
+$view     = $input->getCmd('view', '');
+$layout   = $input->getCmd('layout', '');
+$task     = $input->getCmd('task', '');
+$itemid   = $input->getCmd('Itemid', '');
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 $menu     = $app->getMenu()->getActive();
 $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -21,11 +21,11 @@ $app = Factory::getApplication();
 $wa  = $this->getWebAssetManager();
 
 // Detecting Active Variables
-$option   = $app->input->getCmd('option', '');
-$view     = $app->input->getCmd('view', '');
-$layout   = $app->input->getCmd('layout', '');
-$task     = $app->input->getCmd('task', '');
-$itemid   = $app->input->getCmd('Itemid', '');
+$option   = $app->getInput()->getCmd('option', '');
+$view     = $app->getInput()->getCmd('view', '');
+$layout   = $app->getInput()->getCmd('layout', '');
+$task     = $app->getInput()->getCmd('task', '');
+$itemid   = $app->getInput()->getCmd('Itemid', '');
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 $menu     = $app->getMenu()->getActive();
 $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -17,8 +17,9 @@ use Joomla\CMS\Uri\Uri;
 
 /** @var Joomla\CMS\Document\HtmlDocument $this */
 
-$app = Factory::getApplication();
-$wa  = $this->getWebAssetManager();
+$app   = Factory::getApplication();
+$input = $app->getInput();
+$wa    = $this->getWebAssetManager();
 
 // Browsers support SVG favicons
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon.svg', '', [], true, 1), 'icon', 'rel', ['type' => 'image/svg+xml']);
@@ -26,11 +27,11 @@ $this->addHeadLink(HTMLHelper::_('image', 'favicon.ico', '', [], true, 1), 'alte
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon-pinned.svg', '', [], true, 1), 'mask-icon', 'rel', ['color' => '#000']);
 
 // Detecting Active Variables
-$option   = $app->getInput()->getCmd('option', '');
-$view     = $app->getInput()->getCmd('view', '');
-$layout   = $app->getInput()->getCmd('layout', '');
-$task     = $app->getInput()->getCmd('task', '');
-$itemid   = $app->getInput()->getCmd('Itemid', '');
+$option   = $input->getCmd('option', '');
+$view     = $input->getCmd('view', '');
+$layout   = $input->getCmd('layout', '');
+$task     = $input->getCmd('task', '');
+$itemid   = $input->getCmd('Itemid', '');
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 $menu     = $app->getMenu()->getActive();
 $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -26,11 +26,11 @@ $this->addHeadLink(HTMLHelper::_('image', 'favicon.ico', '', [], true, 1), 'alte
 $this->addHeadLink(HTMLHelper::_('image', 'joomla-favicon-pinned.svg', '', [], true, 1), 'mask-icon', 'rel', ['color' => '#000']);
 
 // Detecting Active Variables
-$option   = $app->input->getCmd('option', '');
-$view     = $app->input->getCmd('view', '');
-$layout   = $app->input->getCmd('layout', '');
-$task     = $app->input->getCmd('task', '');
-$itemid   = $app->input->getCmd('Itemid', '');
+$option   = $app->getInput()->getCmd('option', '');
+$view     = $app->getInput()->getCmd('view', '');
+$layout   = $app->getInput()->getCmd('layout', '');
+$task     = $app->getInput()->getCmd('task', '');
+$itemid   = $app->getInput()->getCmd('Itemid', '');
 $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 $menu     = $app->getMenu()->getActive();
 $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';


### PR DESCRIPTION
### Summary of Changes
As directly access the input variable is deprecated since Joomla 4.0 in #28313, the core should not use it anymore. This pr changes the call to the `getInput` function.

### Testing Instructions
Open the back or front end.

### Actual result BEFORE applying this Pull Request
All works.

### Expected result AFTER applying this Pull Request
All works.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
