### PR TITLE
[4.3] Set focus on input in create modal

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/modals/create-folder-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/create-folder-modal.vue
@@ -24,13 +24,13 @@
             <label for="folder">{{ translate('COM_MEDIA_FOLDER_NAME') }}</label>
             <input
               id="folder"
+              ref="input"
               v-model.trim="folder"
               class="form-control"
               type="text"
               required
               autocomplete="off"
               @input="folder = $event.target.value"
-              ref="input"
             >
           </div>
         </form>
@@ -67,6 +67,7 @@ export default {
     };
   },
   watch: {
+    // eslint-disable-next-line
     "$store.state.showCreateFolderModal"(show) {
       this.$nextTick(() => {
         if (show && this.$refs.input) {

--- a/administrator/components/com_media/resources/scripts/components/modals/create-folder-modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/create-folder-modal.vue
@@ -30,6 +30,7 @@
               required
               autocomplete="off"
               @input="folder = $event.target.value"
+              ref="input"
             >
           </div>
         </form>
@@ -64,6 +65,15 @@ export default {
     return {
       folder: '',
     };
+  },
+  watch: {
+    "$store.state.showCreateFolderModal"(show) {
+      this.$nextTick(() => {
+        if (show && this.$refs.input) {
+          this.$refs.input.focus();
+        }
+      });
+    },
   },
   methods: {
     /* Check if the the form is valid */


### PR DESCRIPTION
Pull Request for Issue #36881.

### Summary of Changes
Alternative for #36892. Sets the focus on the input field when the create folder modal is opened.

### Testing Instructions
- Open the media manager
- Click on the "Create folder button"

### Actual result BEFORE applying this Pull Request
Input has no focus.

### Expected result AFTER applying this Pull Request
Input has focus.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
