### PR TITLE
[4.3] Fixing php compatibility issues 1

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -160,7 +160,7 @@ if ($this->type == 'font') {
                                         'resultForIdenticals' => Text::_('COM_TEMPLATES_DIFF_IDENTICAL'),
                                         'detailLevel' => 'word',
                                         'spaceToHtmlTag' => true,
-                                    ],
+                                    ]
                                 );
                             ?>
                             <div class="col-md-12" id="diff-main">

--- a/libraries/src/Application/DaemonApplication.php
+++ b/libraries/src/Application/DaemonApplication.php
@@ -481,7 +481,6 @@ abstract class DaemonApplication extends CliApplication
         }
 
         // Reset Process Information
-        $this->safeMode = !!@ ini_get('safe_mode');
         $this->processId = 0;
         $this->running = false;
 


### PR DESCRIPTION
### Summary of Changes
This is one of several PRs to separate out the fixes from #38471. This fixes 2 issues which aren't compatible with our minimum PHP requirements. PHP 7.2 does not allow a trailing commas in function calls and safe mode was removed in PHP 5.

### Testing Instructions
Code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
