### PR TITLE
Update github actions in workflows

### DIFF
--- a/.github/workflows/cacert-update.yml
+++ b/.github/workflows/cacert-update.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: 3.10-dev
 
@@ -33,7 +33,7 @@ jobs:
         run: cp "libraries/src/Http/Transport/cacert.pem" "libraries/fof/download/adapter/cacert.pem"
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v3
+        uses: peter-evans/create-pull-request@v4
         id: cpr
         with:
           branch: mozilla_ca_update

--- a/.github/workflows/create-translation-pull-request-v4.yml
+++ b/.github/workflows/create-translation-pull-request-v4.yml
@@ -22,13 +22,13 @@ jobs:
     if: ${{ github.repository == 'joomla-translation-bot/joomla-cms' && github.ref == 'refs/heads/translation' }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         # We need the full depth to create / update the pull request against the main repo
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
-          node-version: 12
+          node-version: 16
 
       - name: Fetch latest cms changes
         run: |


### PR DESCRIPTION
Update github actions versions in workflows to fix https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/