### PR TITLE
Allow different table key in FormView

### DIFF
--- a/libraries/src/MVC/View/FormView.php
+++ b/libraries/src/MVC/View/FormView.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\CMS\Table\TableInterface;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -41,6 +42,13 @@ class FormView extends HtmlView
      * @var  object
      */
     protected $item;
+
+    /**
+     * The item primary key name
+     *
+     * @var  string
+     */
+    protected $keyName;
 
     /**
      * The model state
@@ -142,13 +150,13 @@ class FormView extends HtmlView
         $this->form  = $this->get('Form');
         $this->item  = $this->get('Item');
         $this->state = $this->get('State');
+        $table       = $this->get('Table');
+
+        $this->keyName = $table instanceof TableInterface ? $table->getKeyName() : 'id';
+        $action        = empty($this->item->{$this->keyName}) ? '_NEW' : '_EDIT';
 
         // Set default toolbar title
-        if ($this->item->id) {
-            $this->toolbarTitle = Text::_(strtoupper($this->option . '_MANAGER_' . $this->getName() . '_EDIT'));
-        } else {
-            $this->toolbarTitle = Text::_(strtoupper($this->option . '_MANAGER_' . $this->getName() . '_NEW'));
-        }
+        $this->toolbarTitle = Text::_(strtoupper($this->option . '_MANAGER_' . $this->getName() . $action));
     }
 
     /**
@@ -164,7 +172,7 @@ class FormView extends HtmlView
 
         $user       = Factory::getUser();
         $userId     = $user->id;
-        $isNew      = ($this->item->id == 0);
+        $isNew      = empty($this->item->{$this->keyName});
         $viewName   = $this->getName();
         $checkedOut = $this->getModel()->isCheckedOut($this->item);
         $canDo      = $this->canDo;


### PR DESCRIPTION
Joomla allows to use diffrent primary key names for tables. This has not be honored in the `FormView::initializeView()` function.

### Summary of Changes
Load the primary key name from the table provided by the model and use it for the toolbar.


### Testing Instructions
Check if existing edit views makes errors.
if you have a component with a diffrent primary key then 'id' test it.
Most of my components have not `id` as primary key and they work now^^

### Actual result BEFORE applying this Pull Request
No error for existing View
Doesn't work with the new FormView with primary key different then `id`
Warning: Undefined property: Joomla\CMS\Object\CMSObject::$id in ROOT/libraries/src/MVC/View/FormView.php on line 147

Warning: Undefined property: Joomla\CMS\Object\CMSObject::$id in ROOT/libraries/src/MVC/View/FormView.php on line 167


### Expected result AFTER applying this Pull Request
Everything works as before
No Warnings and working title and edit button for `Views` with diffrent primary key column name then `id`


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
