### PR TITLE
[4.2] Debug plugin - fix copyright

### DIFF
--- a/plugins/system/debug/src/DataCollector/RequestDataCollector.php
+++ b/plugins/system/debug/src/DataCollector/RequestDataCollector.php
@@ -4,7 +4,7 @@
  * @package     Joomla.Plugin
  * @subpackage  System.Debug
  *
- * @copyright   (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
@@ -15,7 +15,7 @@ namespace Joomla\Plugin\System\Debug\DataCollector;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * Collects info about the request content while redacting potentially secret contents
+ * Collects info about the request content while redacting potentially secret content
  *
  * @since  4.2.4
  */

--- a/plugins/system/debug/src/DataCollector/UserCollector.php
+++ b/plugins/system/debug/src/DataCollector/UserCollector.php
@@ -4,7 +4,7 @@
  * @package     Joomla.Plugin
  * @subpackage  System.Debug
  *
- * @copyright   (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 


### PR DESCRIPTION
These two files were released today so they are copyright 2022 and not 2018