### PR TITLE
Fix PHPCS failing in drone after release of 4.2.4

### DIFF
--- a/plugins/system/debug/src/DataCollector/RequestDataCollector.php
+++ b/plugins/system/debug/src/DataCollector/RequestDataCollector.php
@@ -41,7 +41,7 @@ class RequestDataCollector extends \DebugBar\DataCollector\RequestDataCollector
 
                 $data = $GLOBALS[$var];
 
-                array_walk_recursive($data, static function(&$value, $key) {
+                array_walk_recursive($data, static function (&$value, $key) {
                     if (!preg_match(self::PROTECTED_KEYS, $key)) {
                         return;
                     }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix code style errors introduced with release of 4.2.4.

### Testing Instructions

Check drone logs for PHPCS checks.

### Actual result BEFORE applying this Pull Request

```
FILE: .../plugins/system/debug/src/DataCollector/RequestDataCollector.php
----------------------------------------------------------------------
FOUND 1 ERROR AND 1 WARNING AFFECTING 2 LINES
----------------------------------------------------------------------
 24 | WARNING | [ ] Visibility must be declared on all constants if
    |         |     your project supports PHP 7.1 or later
 44 | ERROR   | [x] Expected 1 space after FUNCTION keyword; 0 found
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```
### Expected result AFTER applying this Pull Request

The error about missing space has gone. The warning about visibility has to be fixed with another PR since there might be more to be fixed.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
