### PR TITLE
Fix PHPCS from Security Fix

### DIFF
--- a/plugins/system/debug/src/DataCollector/RequestDataCollector.php
+++ b/plugins/system/debug/src/DataCollector/RequestDataCollector.php
@@ -21,8 +21,6 @@ namespace Joomla\Plugin\System\Debug\DataCollector;
  */
 class RequestDataCollector extends \DebugBar\DataCollector\RequestDataCollector
 {
-    const PROTECTED_KEYS = "/password|passwd|pwd|secret|token/i";
-
     /**
      * Called by the DebugBar when data needs to be collected
      *
@@ -41,8 +39,8 @@ class RequestDataCollector extends \DebugBar\DataCollector\RequestDataCollector
 
                 $data = $GLOBALS[$var];
 
-                array_walk_recursive($data, static function(&$value, $key) {
-                    if (!preg_match(self::PROTECTED_KEYS, $key)) {
+                array_walk_recursive($data, static function (&$value, $key) {
+                    if (!preg_match(\PlgSystemDebug::PROTECTED_COLLECTOR_KEYS, $key)) {
                         return;
                     }
 


### PR DESCRIPTION
### Summary of Changes
Fixes improperly applied fix from the security repo (thanks @richard67 for finding this when doing https://github.com/joomla/joomla-cms/pull/39075 and securely raising this when he realised)

Unfortunately the fix from @joomla/security wasn't correctly applied to this repo when combining the 3 parts of the fix. Luckily the important parts were fixed and it's been agreed to fix 'the fix' in the public domain.

This moves the protected keys to the more secure version in the main plugin class, therefore fixing the PHPCS failure too. 

### Testing Instructions
Ensure drone checks now pass, ensure the debug plugin continues to work and only display the correct results in the previous requests log and also displays no secrets in the request data logs

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
