### PR TITLE
[4.3] Drone: Adding curl to image in case of failure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -336,6 +336,7 @@ steps:
       - export PLUGIN_DEST_DIR=$PLUGIN_DEST_DIR/$DRONE_REPO/$DRONE_BRANCH/$DRONE_PULL_REQUEST/system-tests/$DRONE_BUILD_NUMBER
       - echo https://ci.joomla.org$PLUGIN_DEST_DIR
       - /bin/upload.sh
+      - apk add curl
       - 'curl -X POST "https://api.github.com/repos/$DRONE_REPO/statuses/$DRONE_COMMIT" -H "Content-Type: application/json" -H "Authorization: token $GITHUB_TOKEN" -d "{\"state\":\"failure\", \"context\": \"Artifacts from Failure\", \"description\": \"You can find artifacts from the failure of the build here:\", \"target_url\": \"https://ci.joomla.org$PLUGIN_DEST_DIR\"}" > /dev/null'
     when:
       status:
@@ -498,6 +499,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 815e9bc793f593498490dfbc30cdb8311c9af9100e4129c5ca70d52c4f2ab80a
+hmac: cd2cb5b1a980779f3fef1910a8c3c05eb3c51b467c1df4110a625b3484f800bb
 
 ...


### PR DESCRIPTION
In case of a failure in drone, we are trying to post a link back to github, but the image is missing curl right now. This solution isn't ideal, but should solve the issue for the short term until we rewrite this with our packager image or something.