### PR TITLE
[4.3] Update deleted files list in script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6440,7 +6440,6 @@ class JoomlaInstallerScript
             '/plugins/task/checkfiles/checkfiles.php',
             '/plugins/task/demotasks/demotasks.php',
             // From 4.2.0-rc1 to 4.2.0
-            '/build/media_source/com_menus/css/admin-item-edit_modules.css',
             '/administrator/language/en-GB/plg_fields_menuitem.ini',
             '/administrator/language/en-GB/plg_fields_menuitem.sys.ini',
             '/plugins/fields/menuitem/menuitem.php',
@@ -6453,6 +6452,18 @@ class JoomlaInstallerScript
             '/media/vendor/hotkeys.js/LICENSE',
             // From 4.2.1 to 4.2.2
             '/administrator/cache/fido.jwt',
+            // From 4.2 to 4.3
+            '/media/com_menus/css/admin-item-edit_modules.css',
+            '/media/com_menus/css/admin-item-edit_modules.min.css',
+            '/media/com_menus/css/admin-item-edit_modules.min.css.gz',
+            '/media/com_templates/js/admin-template-compare-es5.js',
+            '/media/com_templates/js/admin-template-compare-es5.min.js',
+            '/media/com_templates/js/admin-template-compare-es5.min.js.gz',
+            '/media/com_templates/js/admin-template-compare.js',
+            '/media/com_templates/js/admin-template-compare.min.js',
+            '/media/com_templates/js/admin-template-compare.min.js.gz',
+            '/media/templates/administrator/atum/scss/vendor/bootstrap/_bootstrap-rtl.scss',
+            '/media/templates/site/cassiopeia/scss/vendor/bootstrap/_bootstrap-rtl.scss',
         );
 
         $folders = array(


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/38353#discussion_r1008708235 .

### Summary of Changes

Update to changes from following PRs:
- #38353 - 3 files `/media/com_menus/css/admin-item-edit_modules*.css*`
- #38823 - 6 files `/media/com_templates/js/admin-template-compare*.js*`
- #38412 - 2 files `/media/templates/*/*/scss/vendor/bootstrap/_bootstrap-rtl.scss` for the 2 core templates

Remove wrong file `/build/media_source/com_menus/css/admin-item-edit_modules.css` added with PR #38353 .

### Testing Instructions

Code review.

Or if you want to make a real test, update a current 4.2.4 or a 4.2.5-dev nightly build to the last 4.3 nightly build to get the actual result, and update a current 4.2.4 or a 4.2.5-dev nightly build to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

Files and folders mentioned in the description above are still present after updating from a current 4.2.4 or a 4.2.5-dev nightly build.

### Expected result AFTER applying this Pull Request

All files and folders mentioned in the description above have been deleted after updating from a current 4.2.4 or a 4.2.5-dev nightly build.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
