### PR TITLE
[4] Fix: Table caption "Sorted by" in list views shows the wrong sort direction.

### DIFF
--- a/layouts/joomla/searchtools/grid/sort.php
+++ b/layouts/joomla/searchtools/grid/sort.php
@@ -23,7 +23,7 @@ if ($data->order === $data->selected) :
     $icon = $data->orderIcon;
     $sort = $data->direction === 'asc' ? 'descending' : 'ascending';
     $heading = !empty($data->title) ? Text::_($data->title) : Text::_('JGRID_HEADING_ORDERING');
-    $caption = Text::sprintf('JGRID_HEADING_CAPTION_' . $data->direction, $heading);
+    $caption = Text::sprintf('JGRID_HEADING_CAPTION_' . ($data->direction === 'asc' ? 'desc' : 'asc'), $heading);
     $selected = ' selected';
     $id = 'id="sorted"';
 endif;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/39082 and https://github.com/joomla/joomla-cms/issues/35494.

### Summary of Changes
- Reverse sort direction (`asc` versus `desc`) for language string creation (`JGRID_HEADING_CAPTION_xyz`).

### Testing Instructions
- See issue https://github.com/joomla/joomla-cms/issues/39082

### Actual result BEFORE applying this Pull Request
Wrong language strings `JGRID_HEADING_CAPTION_asc` instead of `JGRID_HEADING_CAPTION_desc` and vice versa.

### Expected result AFTER applying this Pull Request
Right language strings `JGRID_HEADING_CAPTION_asc` and `JGRID_HEADING_CAPTION_desc`.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
