### PR TITLE
Fix TinyMCE loses English language after editing plugin options

### DIFF
--- a/plugins/editors/tinymce/forms/setoptions.xml
+++ b/plugins/editors/tinymce/forms/setoptions.xml
@@ -110,13 +110,14 @@
 			stripext="1"
 			directory="media/vendor/tinymce/langs/"
 			hide_none="1"
-			default="en"
 			hide_default="1"
 			fileFilter="\.js$"
 			exclude="\.min\.js$"
 			showon="lang_mode:0"
 			validate="options"
-		/>
+		>
+			<option value="">en</option>
+		</field>
 
 		<field
 			name="text_direction"


### PR DESCRIPTION
Pull Request for Issue #39121 .

### Summary of Changes

Make sure the form contain EN option.


### Testing Instructions
Apply patch and please follow #39121
Set "Automatic Language Selection" to "Off"


### Actual result BEFORE applying this Pull Request
You get `af` language afer save


### Expected result AFTER applying this Pull Request
You get `en` language afer save


### Link to documentations
Please select:

- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
