### PR TITLE
[4.2] Batch process categories -reverse ordering error

### DIFF
--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -825,7 +825,8 @@ class CategoryModel extends AdminModel
          * Re-order with max - ordering
          */
         foreach ($pks as $id) {
-            $query->select('MAX(' . $db->quoteName('ordering') . ')')
+            $query->clear()
+                ->select('MAX(' . $db->quoteName('ordering') . ')')
                 ->from($db->quoteName('#__content'))
                 ->where($db->quoteName('catid') . ' = :catid')
                 ->bind(':catid', $id, ParameterType::INTEGER);
@@ -835,9 +836,8 @@ class CategoryModel extends AdminModel
             $max = (int) $db->loadResult();
             $max++;
 
-            $query->clear();
-
-            $query->update($db->quoteName('#__content'))
+            $query->clear()
+                ->update($db->quoteName('#__content'))
                 ->set($db->quoteName('ordering') . ' = :max - ' . $db->quoteName('ordering'))
                 ->where($db->quoteName('catid') . ' = :catid')
                 ->bind(':max', $max, ParameterType::INTEGER)


### PR DESCRIPTION
Pull Request for Issue #39133 .

### Summary of Changes

execute `clear` query first, before run new database operation in foreach-loop

### Testing Instructions

see #39133

### Actual result BEFORE applying this Pull Request

Reverse ordering is performed only for the first category
![image](https://user-images.githubusercontent.com/66922325/200360762-d7b0a2c9-66bb-4f60-bae8-c5bd797d3b5a.png)

### Expected result AFTER applying this Pull Request

Reverse ordering is performed for all selected categories
![image](https://user-images.githubusercontent.com/66922325/200360102-f49b9016-a29d-4ac9-bdfd-8cc9a60347e6.png)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
