### PR TITLE
[4.3] remove karma npm script

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "watch:com_media": "node build/build.js --watch-com-media",
     "lint:js": "eslint --config build/.eslintrc --ignore-pattern '/media/' --ext .es6.js,.es6,.vue .",
     "lint:css": "stylelint --config build/.stylelintrc.json \"administrator/components/com_media/resources/**/*.scss\" \"administrator/templates/**/*.scss\" \"build/media_source/**/*.scss\" \"templates/**/*.scss\" \"installation/template/**/*.scss\"",
-    "test": "karma start tests/javascript/karma.conf.js --single-run",
     "install": "node build/build.js --prepare",
     "update": "node build/build.js --copy-assets && node build/build.js --build-pages && node build/build.js --compile-js && node build/build.js --compile-css && node build/build.js --compile-bs && node build/build.js --com-media",
     "gzip": "node build/build.js --gzip",


### PR DESCRIPTION
Pull Request for Pull Request #39037 .

### Summary of Changes

Testing Framework `karma` was removed in #39037. This PR removes the leftover npm script.

### Testing Instructions

Code Review (run `npm test`)

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/66922325/201037502-f6406d69-6fbd-4098-88e8-67d0bd1b0935.png)

### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/66922325/201037752-8bde939e-52fd-4b4b-9c49-2aaf14a82add.png)

cc @HLeithner 
