### PR TITLE
[4.3] Removing references to FoF from comments

### DIFF
--- a/administrator/components/com_postinstall/src/Model/MessagesModel.php
+++ b/administrator/components/com_postinstall/src/Model/MessagesModel.php
@@ -475,8 +475,9 @@ class MessagesModel extends BaseDatabaseModel
     /**
      * Adds or updates a post-installation message (PIM) definition. You can use this in your post-installation script using this code:
      *
-     * require_once JPATH_LIBRARIES . '/fof/include.php';
-     * FOFModel::getTmpInstance('Messages', 'PostinstallModel')->addPostInstallationMessage($options);
+     * Factory::getApplication()->bootComponent('com_postinstall')
+     * ->getMVCFactory()->createModel('Messages', 'Administrator', ['ignore_request' => true])
+     * ->addPostInstallationMessage($options);
      *
      * The $options array contains the following mandatory keys:
      *
@@ -526,8 +527,8 @@ class MessagesModel extends BaseDatabaseModel
      *
      * When type=action the following additional keys are required:
      *
-     * action_file  The RAD path to a PHP file containing a PHP function which performs the action of this PIM. @see FOFTemplateUtils::parsePath()
-     *              for RAD path format. Joomla! will include this file before calling the function defined in the action key below.
+     * action_file  The RAD path to a PHP file containing a PHP function which performs the action of this PIM.
+     *              Joomla! will include this file before calling the function defined in the action key below.
      *              Example:   admin://components/com_foobar/helpers/postinstall.php
      *
      * action       The name of a PHP function which will be used to run the action of this PIM. This must be a simple PHP user function

--- a/administrator/components/com_users/src/Service/Encrypt.php
+++ b/administrator/components/com_users/src/Service/Encrypt.php
@@ -67,7 +67,7 @@ class Encrypt
      * Decrypt the ciphertext, prefixed by ###AES128###, and return the plaintext.
      *
      * @param   string  $data    The ciphertext, prefixed by ###AES128###
-     * @param   bool    $legacy  Use legacy key expansion? Use it to decrypt data encrypted with FOF 3.
+     * @param   bool    $legacy  Use legacy key expansion. We recommend against using it.
      *
      * @return  string  The plaintext data
      *
@@ -86,7 +86,7 @@ class Encrypt
         }
 
         $this->aes->setPassword($this->getPassword(), $legacy);
-        $decrypted = $this->aes->decryptString($data, true, $legacy);
+        $decrypted = $this->aes->decryptString($data, true);
 
         // Decrypted data is null byte padded. We have to remove the padding before proceeding.
         return rtrim($decrypted, "\0");


### PR DESCRIPTION
Pull Request for Issue #36838 .

### Summary of Changes
We aren't shipping Joomla with FoF anymore, so we should remove the comments from the code. The parameter to a call I removed, I removed because the called method doesn't have this parameter. 


### Testing Instructions
Codereview

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
