### PR TITLE
[4.3] Unpublish testing sampledata plugin after installing data

### DIFF
--- a/plugins/sampledata/testing/testing.php
+++ b/plugins/sampledata/testing/testing.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\CMS\Table\Table;
 use Joomla\Component\Categories\Administrator\Model\CategoryModel;
 use Joomla\Database\DatabaseDriver;
 
@@ -4415,6 +4416,14 @@ class PlgSampledataTesting extends CMSPlugin
      */
     public function onAjaxSampledataApplyStep9()
     {
+        if ($this->app->getInput()->get('type') !== $this->_name) {
+            return;
+        }
+
+        $table = Table::getInstance('Extension');
+        $table->load(['element' => $this->_name, 'type' => 'plugin', 'folder' => 'sampledata']);
+        $table->publish(null, 0);
+
         $response['success'] = true;
         $response['message'] = Text::_('PLG_SAMPLEDATA_TESTING_STEP9_SUCCESS');
 


### PR DESCRIPTION
Pull Request for Issue #23633 .

### Summary of Changes
If the data from a sampledata plugin can't be installed twice, it should be unpublished after installing the data. I also added the check for the name. 

### Testing Instructions
Install testing sampledata.

### Actual result BEFORE applying this Pull Request
Testing sampledata is still offered after installing.

### Expected result AFTER applying this Pull Request
Testing sampledata vanishes from list of offered sampledata in backend.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
