### PR TITLE
[4.3] Mark deprecation in DelegatingPsrLogger

### DIFF
--- a/libraries/src/Log/DelegatingPsrLogger.php
+++ b/libraries/src/Log/DelegatingPsrLogger.php
@@ -21,6 +21,8 @@ use Psr\Log\LogLevel;
  * Delegating logger which delegates log messages received from the PSR-3 interface to the Joomla! Log object.
  *
  * @since  3.8.0
+ * @deprecated 5.0 The class will become final.
+ * @internal
  */
 class DelegatingPsrLogger extends AbstractLogger
 {


### PR DESCRIPTION
See https://github.com/joomla/joomla-cms/pull/39134#issuecomment-1316841537

### Summary of Changes

`\Joomla\CMS\Log\DelegatingPsrLogger` was marked `@internal` and a deprecation notice information developers it will be marked final has been added.

### Testing Instructions

None. This PR only changes the DocBlock.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] Pull Request link for manual.joomla.org: [PR 61](https://github.com/joomla/Manual/pull/61)
