### PR TITLE
Nullified text property in com_tags&view=tag PHP 8.1 compat

### DIFF
--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\User\User;
+use Joomla\Event\Event;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -179,7 +180,7 @@ class HtmlView extends BaseHtmlView
 
                 $itemElement->core_params = new Registry($itemElement->core_params);
 
-                $this->dispatchEvent(new Event('onContentPrepare', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0)));
+                $this->dispatchEvent(new Event('onContentPrepare', ['com_tags.tag', &$itemElement, &$itemElement->core_params, 0]));
 
                 $results = Factory::getApplication()->triggerEvent(
                     'onContentAfterTitle',

--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -175,7 +175,7 @@ class HtmlView extends BaseHtmlView
                 $itemElement->event = new \stdClass();
 
                 // Init text property for content plugins.
-                $itemElement->text = empty($itemElement->core_body) ? '' : $itemElement->core_body;
+                $itemElement->text = $itemElement->core_body ?? '';
 
                 $itemElement->core_params = new Registry($itemElement->core_params);
 

--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -174,12 +174,12 @@ class HtmlView extends BaseHtmlView
             foreach ($items as $itemElement) {
                 $itemElement->event = new \stdClass();
 
-                // For some plugins.
-                !empty($itemElement->core_body) ? $itemElement->text = $itemElement->core_body : $itemElement->text = null;
+                // Init text property for content plugins.
+                $itemElement->text = empty($itemElement->core_body) ? '' : $itemElement->core_body;
 
                 $itemElement->core_params = new Registry($itemElement->core_params);
 
-                Factory::getApplication()->triggerEvent('onContentPrepare', ['com_tags.tag', &$itemElement, &$itemElement->core_params, 0]);
+                $this->dispatchEvent(new Event('onContentPrepare', array('com_tags.tag', &$itemElement, &$itemElement->core_params, 0)));
 
                 $results = Factory::getApplication()->triggerEvent(
                     'onContentAfterTitle',


### PR DESCRIPTION
### Summary of Changes

Tag view incorrectly creates $tag->text as NULL on empty core_body, hence the content plugins can raise deprecation warning in PHP 8.1

Old code:

`!empty($itemElement->core_body) ? $itemElement->text = $itemElement->core_body : $itemElement->text = null;`

Even core loadmodule plugin doesn't check if `$article->text` is not null:

`if (strpos($article->text, '{loadposition') === false && strpos($article->text, '{loadmodule') === false) {`

We need to use empty string to satisfy most of plugins which are using `strpos()` and don't check if `$article->text` exists and is actually a string.

Also: updated `onContentPrepare` trigger for each tagged item to a new Event, like in com_content article view.

### Testing Instructions

PHP 8.1, error reporting dev

View a tag page with items, tagged items should have empty description 

### Actual result BEFORE applying this Pull Request

Deprecated: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in \plugins\content\loadmodule\loadmodule.php on line 53

### Expected result AFTER applying this Pull Request

No warnings.
