### PR TITLE
[4.2] Fix upgrade fatal error

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -465,7 +465,9 @@ class JoomlaInstallerScript
 
             try {
                 $db->transactionCommit();
-            } catch (\RuntimeException $e) {
+            }
+            catch (\PDOException $e)
+            {
                 // Ignore "no active transaction" exception
             }
         } catch (\Exception $e) {

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -463,7 +463,13 @@ class JoomlaInstallerScript
             $installer->setDatabase($db);
             $installer->uninstall('plugin', $extensionId);
 
-            $db->transactionCommit();
+            try {
+                $db->transactionCommit();
+            }
+            catch (\PDOException $e)
+            {
+                // Ignore "no active transaction" exception
+            }
         } catch (\Exception $e) {
             $db->transactionRollback();
             throw $e;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -444,7 +444,7 @@ class JoomlaInstallerScript
                         ->update($db->quoteName('#__fields_values'))
                         ->set($db->quoteName('value') . ' = ' . $db->quote(json_encode($newFieldValue)))
                         ->where($db->quoteName('field_id') . ' = ' . $rowFieldValue->field_id)
-                        ->where($db->quoteName('item_id') . ' =' . $rowFieldValue->item_id);
+                        ->where($db->quoteName('item_id') . ' =' . $db->quote($rowFieldValue->item_id));
                     $db->setQuery($query)
                         ->execute();
                 }

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -463,13 +463,7 @@ class JoomlaInstallerScript
             $installer->setDatabase($db);
             $installer->uninstall('plugin', $extensionId);
 
-            try {
-                $db->transactionCommit();
-            }
-            catch (\PDOException $e)
-            {
-                // Ignore "no active transaction" exception
-            }
+            $db->transactionCommit();
         } catch (\Exception $e) {
             $db->transactionRollback();
             throw $e;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -465,9 +465,7 @@ class JoomlaInstallerScript
 
             try {
                 $db->transactionCommit();
-            }
-            catch (\PDOException $e)
-            {
+            } catch (\RuntimeException $e) {
                 // Ignore "no active transaction" exception
             }
         } catch (\Exception $e) {

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -444,7 +444,7 @@ class JoomlaInstallerScript
                         ->update($db->quoteName('#__fields_values'))
                         ->set($db->quoteName('value') . ' = ' . $db->quote(json_encode($newFieldValue)))
                         ->where($db->quoteName('field_id') . ' = ' . $rowFieldValue->field_id)
-                        ->where($db->quoteName('item_id') . ' =' . $db->quote($rowFieldValue->item_id));
+                        ->where($db->quoteName('item_id') . ' = ' . $db->quote($rowFieldValue->item_id));
                     $db->setQuery($query)
                         ->execute();
                 }

--- a/administrator/components/com_joomlaupdate/restore_finalisation.php
+++ b/administrator/components/com_joomlaupdate/restore_finalisation.php
@@ -79,7 +79,7 @@ if (!function_exists('finalizeRestore')) {
      *
      * @return  void
      *
-     * @since   3.5.1
+     * @since   __DEPLOY_VERSION__
      */
     function finalizeRestore(string $siteRoot, string $restorePath): void
     {

--- a/administrator/components/com_joomlaupdate/restore_finalisation.php
+++ b/administrator/components/com_joomlaupdate/restore_finalisation.php
@@ -35,7 +35,7 @@
 
 define('_JOOMLA_UPDATE', 1);
 
-require_once __DIR__ . '/finalisation.php';
+include_once __DIR__ . '/finalisation.php';
 
 if (!function_exists('clearFileInOPCache')) {
     /**
@@ -83,6 +83,8 @@ if (!function_exists('finalizeRestore')) {
      */
     function finalizeRestore(string $siteRoot, string $restorePath): void
     {
-        finalizeUpdate($siteRoot, $restorePath);
+        if (function_exists('finalizeUpdate')) {
+            finalizeUpdate($siteRoot, $restorePath);
+        }
     }
 }

--- a/administrator/components/com_joomlaupdate/restore_finalisation.php
+++ b/administrator/components/com_joomlaupdate/restore_finalisation.php
@@ -47,7 +47,7 @@ if (!function_exists('clearFileInOPCache')) {
      * @param   string  $file  The filepath to clear from OPcache
      *
      * @return  boolean
-     * @since   4.0.4
+     * @since   __DEPLOY_VERSION__
      */
     function clearFileInOPCache(string $file): bool
     {

--- a/administrator/components/com_joomlaupdate/restore_finalisation.php
+++ b/administrator/components/com_joomlaupdate/restore_finalisation.php
@@ -36,3 +36,53 @@
 define('_JOOMLA_UPDATE', 1);
 
 require_once __DIR__ . '/finalisation.php';
+
+if (!function_exists('clearFileInOPCache')) {
+    /**
+     * Invalidate a file in OPcache. We need to define the function here because finalizeUpdate
+     * function called by finalizeRestore function depends on this method
+     *
+     * Only applies if the file has a .php extension.
+     *
+     * @param   string  $file  The filepath to clear from OPcache
+     *
+     * @return  boolean
+     * @since   4.0.4
+     */
+    function clearFileInOPCache(string $file): bool
+    {
+        static $hasOpCache = null;
+
+        if (is_null($hasOpCache)) {
+            $hasOpCache = ini_get('opcache.enable')
+                && function_exists('opcache_invalidate')
+                && (!ini_get('opcache.restrict_api') || stripos(realpath($_SERVER['SCRIPT_FILENAME']), ini_get('opcache.restrict_api')) === 0);
+        }
+
+        if ($hasOpCache && (strtolower(substr($file, -4)) === '.php')) {
+            return opcache_invalidate($file, true);
+        }
+
+        return false;
+    }
+}
+
+if (!function_exists('finalizeRestore')) {
+    /**
+     * Run part of the Joomla! finalisation script, namely the part that cleans up unused files/folders.
+     * We need to define this function here because it is called by restore.php when users update from Joomla older
+     * than 4.0.4 to latest version
+     *
+     *
+     * @param   string  $siteRoot     The root to the Joomla! site
+     * @param   string  $restorePath  The base path to extract.php
+     *
+     * @return  void
+     *
+     * @since   3.5.1
+     */
+    function finalizeRestore(string $siteRoot, string $restorePath): void
+    {
+        finalizeUpdate($siteRoot, $restorePath);
+    }
+}


### PR DESCRIPTION
Pull Request for Issue #37177.

### Summary of Changes
Currently, if someone uses repeatable fields on their Joomla 3 installation, upgrade to Joomla 4.0.4 or newer version will get fatal error as described in the issue https://github.com/joomla/joomla-cms/issues/37177 . This PR fixes that error.

### Testing Instructions
1. Install Joomla 3.10.11 (latest Joomla 3 version)
2. Go to Content -> Fields, add a Repeatable field
3. Go to Content -> Articles, add an article, enter data for that Repeatable field
4. Try to upgrade the site to latest Joomla 4. You will see fatal error. You should make a backup of the current site before upgrading so that you don't have to setup it again for the next step
5. Restore the above site. Try to update your site to the update package generated by this PR which can be downloaded at https://ci.joomla.org/artifacts/joomla/joomla-cms/4.2-dev/39245/downloads/59693/Joomla_4.2.6-dev+pr.39245-Development-Update_Package.zip , or use the custom update URL for that package: https://ci.joomla.org/artifacts/joomla/joomla-cms/4.2-dev/39245/downloads/59693/pr_list.xml . Make sure upgrade went smooth.

### Actual result BEFORE applying this Pull Request
Fatal error.


### Expected result AFTER applying this Pull Request
No fatal error. Upgrade works well.