### PR TITLE
[4.2] Fix logout redirect error on multilingual site

### DIFF
--- a/components/com_users/src/Controller/UserController.php
+++ b/components/com_users/src/Controller/UserController.php
@@ -140,10 +140,11 @@ class UserController extends BaseController
 
         // Check for a simple menu item id
         if (is_numeric($return)) {
-            $return = 'index.php?Itemid=' . $return;
+            $itemId = (int) $return;
+            $return = 'index.php?Itemid=' . $itemId;
 
             if (Multilanguage::isEnabled()) {
-                $language = $this->getModel('Login', 'Site')->getMenuLanguage($return);
+                $language = $this->getModel('Login', 'Site')->getMenuLanguage($itemId);
 
                 if ($language !== '*') {
                     $return .= '&lang=' . $language;


### PR DESCRIPTION
Pull Request for Issue #38720.

### Summary of Changes
This PR fix issue described in https://github.com/joomla/joomla-cms/issues/38720.


### Testing Instructions
1. Prepare a multilingual website
2. Create a menu item link to Login Form menu item type. In that menu item, set Logout Redirect parameter to any menu item
3. Access to that menu item to login
4. After logged in, access to that menu item again and click on Logout button

### Actual result BEFORE applying this Pull Request
You get fatal error, something like:

> Joomla\Component\Users\Site\Model\LoginModel::getMenuLanguage(): Argument #1 ($id) must be of type int, string given....


### Expected result AFTER applying this Pull Request
No error. You are being redirected to the selected menu item on logout.