### PR TITLE
Modify send email copy checkbox in contact form

### DIFF
--- a/components/com_contact/tmpl/contact/default_form.php
+++ b/components/com_contact/tmpl/contact/default_form.php
@@ -31,11 +31,21 @@ HTMLHelper::_('behavior.formvalidator');
                         <legend><?php echo $legend; ?></legend>
                     <?php endif; ?>
                     <?php foreach ($fields as $field) : ?>
-                        <?php echo $field->renderField(); ?>
+                        <?php if ($field->name != 'jform[contact_email_copy]') : ?>
+                            <?php echo $field->renderField(); ?>
+                        <?php else : ?>
+                            <div class="form-check com-contact__copy">
+                                <input class="form-check-input" id="jform_contact_email_copy" type="checkbox" name="jform[contact_email_copy]" value="1">
+                                <label id="jform_contact_email_copy-lbl" class="form-check-label" for="jform_contact_email_copy">
+                                    <?php echo Text::_('COM_CONTACT_CONTACT_EMAIL_A_COPY_LABEL'); ?>
+                                </label>
+                            </div>
+                        <?php endif; ?>
                     <?php endforeach; ?>
                 </fieldset>
             <?php endif; ?>
         <?php endforeach; ?>
+
         <?php if ($this->captchaEnabled) : ?>
             <?php echo $this->form->renderFieldset('captcha'); ?>
         <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #34757.
Probably not the best solution, but the only one a I can think at the moment.

This problem is related to #31218 and is something we need to reconsider for the next major Joomla version.

### Summary of Changes
Modified the way the checkbox "send mail copy" is rendered. It uses now current Bootstrap code to display checkbox and label in a line.


### Testing Instructions
See issue #34757 


### Actual result BEFORE applying this Pull Request
See issue #34757 


### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/9153168/202849320-b5a1adb9-0013-4d85-b6eb-ae5fd09f6a14.png)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
