### PR TITLE
[4.2] Fix save tags assignment

### DIFF
--- a/libraries/src/Form/Field/TagField.php
+++ b/libraries/src/Form/Field/TagField.php
@@ -130,15 +130,6 @@ class TagField extends ListField
 
         // This limit is only used with isRemoteSearch
         $prefillLimit   = 30;
-
-        if (is_array($this->value)) {
-            /**
-             * If there are more than 30 tags selected for certain item, we need to load all of these
-             * selected tags
-             */
-            $prefillLimit = max($prefillLimit, count($this->value));
-        }
-
         $isRemoteSearch = $this->isRemoteSearch();
 
         $db    = $this->getDatabase();
@@ -211,7 +202,8 @@ class TagField extends ListField
             if (!empty($topIds)) {
                 // Filter the ids to the most used tags and the selected tags
                 $preQuery = clone $query;
-                $preQuery->whereIn($db->quoteName('a.id'), $topIds);
+                $preQuery->clear('limit')
+                    ->whereIn($db->quoteName('a.id'), $topIds);
 
                 $db->setQuery($preQuery);
 

--- a/libraries/src/Form/Field/TagField.php
+++ b/libraries/src/Form/Field/TagField.php
@@ -130,6 +130,15 @@ class TagField extends ListField
 
         // This limit is only used with isRemoteSearch
         $prefillLimit   = 30;
+
+        if (is_array($this->value)) {
+            /**
+             * If there are more than 30 tags selected for certain item, we need to load all of these
+             * selected tags
+             */
+            $prefillLimit = max($prefillLimit, count($this->value));
+        }
+
         $isRemoteSearch = $this->isRemoteSearch();
 
         $db    = $this->getDatabase();
@@ -193,8 +202,7 @@ class TagField extends ListField
 
             // Merge the used values into the most used tags
             if (!empty($this->value) && is_array($this->value)) {
-                $topIds = array_merge($topIds, $this->value);
-                $topIds = array_keys(array_flip($topIds));
+                $topIds = array_unique(array_merge($topIds, $this->value));
             }
 
             // Set the default limit for the main query


### PR DESCRIPTION
Pull Request for Issue #39219 (and other similar issues)

### Summary of Changes
When you assign some tags to an item (article for example), if some of these tags are not in **top 30 most used tags**, it won't be displayed as selected when you edit that item. That makes you think that assigned tags assignment are not saved properly for the item (while it is already saved, when you browse the item on frontend of your site, you will see that all selected tags are displayed for the item properly). This PR just fixes that logic error.

### Testing Instructions
1. Create more than 30 tags in your Joomla installation
2. Edit an article, assign more than 30 tags to the article, save it
3. Edit the article again, check the list of assigned tags

### Actual result BEFORE applying this Pull Request
Not all assigned tags are displayed as selected

### Expected result AFTER applying this Pull Request
All assigned tags are displayed as selected