### PR TITLE
API GET - Filter articles marked as "featured"

### DIFF
--- a/api/components/com_content/src/Controller/ArticlesController.php
+++ b/api/components/com_content/src/Controller/ArticlesController.php
@@ -68,7 +68,7 @@ class ArticlesController extends ApiController
         if (\array_key_exists('state', $apiFilterInfo)) {
             $this->modelState->set('filter.published', $filter->clean($apiFilterInfo['state'], 'INT'));
         }
-        
+
         if (\array_key_exists('featured', $apiFilterInfo)) {
             $this->modelState->set('filter.featured', $filter->clean($apiFilterInfo['featured'], 'INT'));
         }

--- a/api/components/com_content/src/Controller/ArticlesController.php
+++ b/api/components/com_content/src/Controller/ArticlesController.php
@@ -68,6 +68,10 @@ class ArticlesController extends ApiController
         if (\array_key_exists('state', $apiFilterInfo)) {
             $this->modelState->set('filter.published', $filter->clean($apiFilterInfo['state'], 'INT'));
         }
+        
+        if (\array_key_exists('featured', $apiFilterInfo)) {
+            $this->modelState->set('filter.featured', $filter->clean($apiFilterInfo['featured'], 'INT'));
+        }
 
         if (\array_key_exists('language', $apiFilterInfo)) {
             $this->modelState->set('filter.language', $filter->clean($apiFilterInfo['language'], 'STRING'));


### PR DESCRIPTION
## Summary of Changes
Adding 'featured' articles filter to the articles controller webservice-api

## Testing Instructions
Make a GET call to .....api/v1/content/articles?filter[featured]=1

## Actual result BEFORE applying this Pull Request 
You cant filter the response by featured articles

## Expected result AFTER applying this Pull Request 
Response with only the articles marked as features (featured=1)

## Link to documentations
Update https://docs.joomla.org/J4.x:Joomla_Core_APIs by adding a new endpoint: **/api/index.php/v1/content/articles?filter[featured]=1** Maybe add the others filters too?
