### PR TITLE
Adding missing rel attributes to URL menu item types

### DIFF
--- a/administrator/components/com_menus/forms/item_url.xml
+++ b/administrator/components/com_menus/forms/item_url.xml
@@ -35,8 +35,10 @@
 				<option value="alternate"/>
 				<option value="author"/>
 				<option value="bookmark"/>
+				<option value="external"/>
 				<option value="help"/>
 				<option value="license"/>
+				<option value="me"/>
 				<option value="next"/>
 				<option value="nofollow"/>
 				<option value="noopener"/>

--- a/administrator/components/com_menus/forms/itemadmin_url.xml
+++ b/administrator/components/com_menus/forms/itemadmin_url.xml
@@ -21,15 +21,20 @@
 				<option value="alternate"/>
 				<option value="author"/>
 				<option value="bookmark"/>
+				<option value="external"/>
 				<option value="help"/>
 				<option value="license"/>
+				<option value="me"/>
 				<option value="next"/>
 				<option value="nofollow"/>
+				<option value="noopener"/>
 				<option value="noreferrer"/>
 				<option value="prefetch"/>
 				<option value="prev"/>
 				<option value="search"/>
+				<option value="sponsored"/>
 				<option value="tag"/>
+				<option value="ugc"/>
 			</field>
 
 			<field


### PR DESCRIPTION
Splitting this out from my other PR #39269 so that these don't get grouped with possibly breaking changes.

### Summary of Changes
The URL menu item type has a field called "Link Rel Attribute".

MDN has a list of valid [link types](https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types). Google also has some [search-engine specific ones](https://developers.google.com/search/docs/crawling-indexing/qualify-outbound-links). 

I compared these with the available options in the menu item and added missing values.

For front end links:
- `me`
- `external`

For back end links:
- `me`
- `external`
- `noopener`
- `sponsored`
- `ugc`

While I don't expect back end menu items to be available for indexing, there might be cases where this happens intentionally (a public menu available in the admin login screen?) so it doesn't hurt to include those values as options in the admin menu item as well.

### Testing Instructions
Create a new menu item type of "URL". 
Go to the "Link Type" tab. 
Open the "link rel attribute" dropdown.


### Actual result BEFORE applying this Pull Request
Missing options.


### Expected result AFTER applying this Pull Request
Options available!


### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed

Yes, documentation is needed because this field is missing altogether from the docs. However, after over an hour fighting with the docs site to register an account and figure out the syntax, and filling out arcane captchas, my suggested edit was blocked as spam. I will not spend more time on this because I am frustrated. If anyone else wants to try, here is what I tried to add on [this page](https://docs.joomla.org/Help4.x:Menu_Item:_URL) before the 'common options' heading:

```
<translate>
===Link Type Tab===
</translate>
<translate>
* '''Link Rel Attribute'''. The rel attribute specifies the relationship between the page you start on and the page the link directs you to. For an in-depth explanation of this attribute and what each option means, please reference the [https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/rel MDN Documentation].
</translate>
```