### PR TITLE
Fix the restore behavior for legacy BS tabs

### DIFF
--- a/build/media_source/legacy/js/tabs-state.es5.js
+++ b/build/media_source/legacy/js/tabs-state.es5.js
@@ -4,7 +4,7 @@
  */
 
 /**
- * JavaScript behavior to allow selected tab to be remained after save or page reload
+ * JavaScript behavior to allow selected tab to be remembered after save or page reload
  * keeping state in sessionStorage with better handling of multiple tab widgets per page
  * and not saving the state if there is no id in the url (like on the CREATE page of content)
  */

--- a/build/media_source/legacy/js/tabs-state.es5.js
+++ b/build/media_source/legacy/js/tabs-state.es5.js
@@ -125,7 +125,7 @@ jQuery(function ($) {
 		var activeTabsHrefs = JSON.parse(sessionStorage.getItem(getStorageKey()));
 
 		// jQuery object with all tabs links
-		var alltabs = $("a[data-toggle='tab']");
+		var alltabs = $("a[data-bs-toggle='tab']");
 
 		// When a tab is clicked, save its state!
 		alltabs.on("click", function (e) {
@@ -150,7 +150,7 @@ jQuery(function ($) {
 
 				// Click the tab
 				var parts = tabFakexPath.split("|");
-				$.findXpath(parts[0]).find("a[data-toggle='tab'][href='" + parts[1] + "']").click();
+				$.findXpath(parts[0]).find("a[data-bs-toggle='tab'][href='" + parts[1] + "']").get(0).click();
 
 			});
 


### PR DESCRIPTION
Pull Request for Issue #39271.

### Summary of Changes
Fixes the tabs state script as it was not compatible with Bootstrap 5.

Added also a solution from https://github.com/twbs/bootstrap/issues/34767.

### Steps to reproduce the issue
- Install DPCalendar Free from this dev release https://joomla.digital-peak.com/download/dpcalendar-development/dpcalendar-development-8.7.0.9526
- Create a location in the component
- Open the event form in the back end
- Go to the location tab
- Select a location

### Actual result BEFORE applying this Pull Request
The page reloads and the first tab is opened.

### Expected result AFTER applying this Pull Request
The page is reloaded and the location tab is opened.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
