### PR TITLE
Add a prefix (editor name) to buttons modal id

### DIFF
--- a/layouts/joomla/editors/buttons/button.php
+++ b/layouts/joomla/editors/buttons/button.php
@@ -18,7 +18,7 @@ if ($button->get('name')) :
     $class   = 'btn btn-secondary';
     $class  .= ($button->get('class')) ? ' ' . $button->get('class') : null;
     $class  .= ($button->get('modal')) ? ' modal-button' : null;
-    $href    = '#' . strtolower($button->get('name')) . '_modal';
+    $href    = '#' . $button->get('editor') . '_' . strtolower($button->get('name')) . '_modal';
     $link    = ($button->get('link')) ? Uri::base() . $button->get('link') : null;
     $onclick = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
     $title   = ($button->get('title')) ? $button->get('title') : $button->get('text');

--- a/layouts/joomla/editors/buttons/modal.php
+++ b/layouts/joomla/editors/buttons/modal.php
@@ -22,7 +22,7 @@ if (!$button->get('modal')) {
 
 $class    = ($button->get('class')) ? $button->get('class') : null;
 $class   .= ($button->get('modal')) ? ' modal-button' : null;
-$href     = '#' . strtolower($button->get('name')) . '_modal';
+$href     = '#' . $button->get('editor') . '_' . strtolower($button->get('name')) . '_modal';
 $link     = ($button->get('link')) ? Uri::base() . $button->get('link') : null;
 $onclick  = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
 $title    = ($button->get('title')) ? $button->get('title') : $button->get('text');
@@ -38,7 +38,7 @@ if (is_array($button->get('options')) && isset($options['confirmText']) && isset
 if (null !== $button->get('id')) {
     $id = str_replace(' ', '', $button->get('id'));
 } else {
-    $id = strtolower($button->get('name')) . '_modal';
+    $id = $button->get('editor') . '_' . strtolower($button->get('name')) . '_modal';
 }
 
 // @todo: J4: Move Make buttons fullscreen on smaller devices per https://github.com/joomla/joomla-cms/pull/23091

--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -251,6 +251,8 @@ class Editor implements DispatcherAwareInterface
                 continue;
             }
 
+            $button->editor = $editor;
+
             $result[] = $button;
         }
 


### PR DESCRIPTION
Pull Request for Issue #39277 .

### Summary of Changes
Noticed that TinyMCE works because it adds a prefix to the ID of the button: https://github.com/joomla/joomla-cms/blob/4.2-dev/plugins/editors/tinymce/src/PluginTraits/XTDButtons.php#L69
So I've globally added the same prefix (the editor ID) to the button modal's ID. This way, Bootstrap::renderModal() will always add the HTML on the page when multiple editors are used.



### Testing Instructions
See #39277 
TLDR: have multiple tabs, an editor on the first tab, a separate editor on the second tab. Second editor buttons (editors-xtd) don't work because first tab is hidden and holds the modal.


### Actual result BEFORE applying this Pull Request
Overlay shows, but no modal (it's hidden by the first tab, where it's located):
![image](https://user-images.githubusercontent.com/1422378/203575529-1a08e431-f101-493b-9a1b-c1ed34bafb86.png)



### Expected result AFTER applying this Pull Request
Works:
![image](https://user-images.githubusercontent.com/1422378/203575878-eef883d3-08a5-433f-a71b-fd68ff6a547a.png)



### Please test with 3rd party editors and editor buttons in case I've broken something, I've only tested with default Joomla! extensions.