### PR TITLE
[4.2] Missing/Incorrect Lang String

### DIFF
--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -560,7 +560,7 @@ class ModuleAdapter extends InstallerAdapter
                 // Install failed, roll back changes
                 throw new \RuntimeException(
                     Text::sprintf(
-                        'JLIB_INSTALLER_ABORT_MOD_INSTALL_ALLREADY_EXISTS',
+                        'JLIB_INSTALLER_ABORT_ALREADY_EXISTS',
                         Text::_('JLIB_INSTALLER_' . $this->route),
                         $this->name
                     )


### PR DESCRIPTION
The key used here does not have a value in any of the language files.

On closer inspection it should simply be using an existing key which is used in identical uses for plugins

Code review should be fine
