### PR TITLE
Fix CodeMirror throwing 404 Not Found on text/html.js

### DIFF
--- a/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
+++ b/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
@@ -63,7 +63,7 @@ class CodemirrorEditor extends HTMLElement {
         // Fix the x-php error
         if (['text/x-php', 'application/x-httpd-php', 'application/x-httpd-php-open'].includes(mode.mime)) {
           editor.setOption('mode', 'php');
-        } else if (mode.mime === 'text/html')
+        } else if (mode.mime === 'text/html') {
           editor.setOption('mode', mode.mode);
         } else {
           editor.setOption('mode', mode.mime);

--- a/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
+++ b/build/media_source/plg_editors_codemirror/js/joomla-editor-codemirror.w-c.es6.js
@@ -63,6 +63,8 @@ class CodemirrorEditor extends HTMLElement {
         // Fix the x-php error
         if (['text/x-php', 'application/x-httpd-php', 'application/x-httpd-php-open'].includes(mode.mime)) {
           editor.setOption('mode', 'php');
+        } else if (mode.mime === 'text/html')
+          editor.setOption('mode', mode.mode);
         } else {
           editor.setOption('mode', mode.mime);
         }


### PR DESCRIPTION
Pull Request for Issue #33542 .

### Summary of Changes
When fixing #39277 this bug resurfaced...
Special handling for text/html to set the editor mode to `mode.mode` which is `htmlmixed`. Inspired from the `x-php` handling... I'm not familiar with how CodeMirror loads modes and why a second instance of the HTML mode would attempt to load "text/html.js" instead of "htmlmixed.js" (the parameters are the same) but this seems to do the trick.


### Testing Instructions
- Set CodeMirror as default editor
- Go to Content - Fields - click New
- Set Type to Editor, add a Title and Save
- Go to Content - Articles - click New. You'll see the main content editor on the first tab and another CodeMirror editor in the Fields tab.

### Actual result BEFORE applying this Pull Request
Second editor instance attempts to load text/html.js which results in a 404 Not Found
![image](https://user-images.githubusercontent.com/1422378/203632253-0bc6fd97-2bf3-49b1-9bff-316f897c75ee.png)



### Expected result AFTER applying this Pull Request
No errors in the console
![image](https://user-images.githubusercontent.com/1422378/203633227-535fbf6e-50c1-4608-9978-9c39038f73d1.png)

### Make sure other instances are not affected: I've verified that highlighting works correctly for .css, .json, .xml, .php files when using the editor from Site Templates > Cassiopeia
