### PR TITLE
Fix PHP 8.1 notice "PHP Deprecated: strpos(): Passing null to parameter #1" when saving an article

### DIFF
--- a/plugins/content/fields/fields.php
+++ b/plugins/content/fields/fields.php
@@ -63,7 +63,7 @@ class PlgContentFields extends CMSPlugin
         }
 
         // Prepare the intro text
-        if (property_exists($item, 'introtext') && strpos($item->introtext, 'field') !== false) {
+        if (property_exists($item, 'introtext') && is_string($item->introtext) && strpos($item->introtext, 'field') !== false) {
             $item->introtext = $this->prepare($item->introtext, $context, $item);
         }
     }


### PR DESCRIPTION
Pull Request for Issue #39298 .

### Summary of Changes

Add `is_string` check before calling `strpos` for the intro text which might be null when no Read More button.

### Testing Instructions

On PHP 8.1 with error reporting set to maximum in Global Configuration and PHP configured to log errors into a log file, edit an article in backend which has no Read More button and so has no intro text. Save the article. Then check the PHP error log file.

### Actual result BEFORE applying this Pull Request

PHP notice `PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /path-to-your-joomla-site/plugins/content/fields/fields.php on line 66`.

### Expected result AFTER applying this Pull Request

No such notice.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
