### PR TITLE
[4.2] Correct exception class in PSR logger

### DIFF
--- a/libraries/src/Log/DelegatingPsrLogger.php
+++ b/libraries/src/Log/DelegatingPsrLogger.php
@@ -77,7 +77,7 @@ class DelegatingPsrLogger extends AbstractLogger
     {
         // Make sure the log level is valid
         if (!\array_key_exists($level, $this->priorityMap)) {
-            throw new \InvalidArgumentException('An invalid log level has been given.');
+            throw new InvalidArgumentException('An invalid log level has been given.');
         }
 
         // Map the level to Joomla's priority
@@ -99,7 +99,7 @@ class DelegatingPsrLogger extends AbstractLogger
         // Joomla's logging API will only process a string or a LogEntry object, if $message is an object without __toString() we can't use it
         if (!\is_string($message) && !($message instanceof LogEntry)) {
             if (!\is_object($message) || !method_exists($message, '__toString')) {
-                throw new \InvalidArgumentException(
+                throw new InvalidArgumentException(
                     'The message must be a string, a LogEntry object, or an object implementing the __toString() method.'
                 );
             }


### PR DESCRIPTION
### Summary of Changes

Corrects exception class thrown in `Joomla\CMS\Log\DelegatingPsrLogger` to adhere to the interface.

### Testing Instructions

Review.
