### PR TITLE
[5.0] Fix class name in Webauthn plugin

### DIFF
--- a/plugins/system/webauthn/src/MetadataRepository.php
+++ b/plugins/system/webauthn/src/MetadataRepository.php
@@ -11,14 +11,10 @@
 namespace Joomla\Plugin\System\Webauthn;
 
 use Exception;
-use Joomla\CMS\Date\Date;
-use Joomla\CMS\Http\HttpFactory;
 use Lcobucci\JWT\Configuration;
 use Lcobucci\JWT\Token\Plain;
-use Webauthn\MetadataService\MetadataStatement;
 use Webauthn\MetadataService\MetadataStatementRepository;
-
-use function defined;
+use Webauthn\MetadataService\Statement\MetadataStatement;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;


### PR DESCRIPTION
### Summary of Changes

`Webauthn\MetadataService\MetadataStatement` was renamed to `Webauthn\MetadataService\Statement\MetadataStatement` in Webauthn v4.

### Testing Instructions

Enable `Attestation Support` in WebAuthn plugin.

### Actual result BEFORE applying this Pull Request

Joomla crashes.

### Expected result AFTER applying this Pull Request

Joomla works.