### PR TITLE
[4.2] missing rel="noopener noreferrer" in link language string

### DIFF
--- a/administrator/language/en-GB/plg_twofactorauth_totp.sys.ini
+++ b/administrator/language/en-GB/plg_twofactorauth_totp.sys.ini
@@ -5,4 +5,4 @@
 ; Obsolete since 4.2.0 -- The entire file must be removed in Joomla 5.0
 
 PLG_TWOFACTORAUTH_TOTP="Two Factor Authentication - Google Authenticator"
-PLG_TWOFACTORAUTH_TOTP_XML_DESCRIPTION="Allows users on your site to use two factor authentication using <a href=\"https://en.wikipedia.org/wiki/Google_Authenticator\" target=\"_blank\" rel=\"noopener noreferrer\">Google Authenticator</a> or other compatible time-based One Time Password generators such as <a href=\"https://freeotp.github.io/\" target=\"_blank\">FreeOTP</a>. To use two factor authentication please edit the user profile and enable two factor authentication."
+PLG_TWOFACTORAUTH_TOTP_XML_DESCRIPTION="Allows users on your site to use two factor authentication using <a href=\"https://en.wikipedia.org/wiki/Google_Authenticator\" target=\"_blank\" rel=\"noopener noreferrer\">Google Authenticator</a> or other compatible time-based One Time Password generators such as <a href=\"https://freeotp.github.io/\" target=\"_blank\" rel=\"noopener noreferrer\">FreeOTP</a>. To use two factor authentication please edit the user profile and enable two factor authentication."


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Add `rel="noopener noreferrer"` in language string

### Testing Instructions

Code review

### Actual result BEFORE applying this Pull Request

Missing `rel="noopener noreferrer"` in the language string, because the link contains `target="_blank"`

### Expected result AFTER applying this Pull Request

Language string contains `rel="noopener noreferrer"`

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed

- [x] No documentation changes for manual.joomla.org needed
