### PR TITLE
Align the browserlist to the advertised support

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "versioning": "node build/build.js --versioning"
   },
   "browserslist": [
-    "last 1 version",
+    "last 1 major version",
     "not ie < 11"
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "versioning": "node build/build.js --versioning"
   },
   "browserslist": [
-    "last 1 major version",
+    "last 2 major version",
     "not ie < 11"
   ],
   "dependencies": {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Following the discussion on the #39315 it's obvious that what is used in the browserlist supported browsers IS NOT what the project actually advertises as the supported browsers.

- Mind that `last 2 versions` for Safari will result to 16.0 and 16.1 (both Chrome based and FF have a few weeks [4 -6] for each0 version which btw is a MAJOR)
- Using `last 2 major versions` for Safari will result to 15.0 and 16.*


### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed


@wilsonge @HLeithner 