### PR TITLE
[4.2] [FIXED]::Responsiveness of User/Groups/Permission table

### DIFF
--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -27,7 +27,7 @@ $wa->useScript('table.columns');
     <div id="j-main-container" class="j-main-container">
         <?php echo LayoutHelper::render('joomla.searchtools.default', array('view' => $this)); ?>
         <div class="table-responsive">
-            <table class="table">
+            <table class="table-sm">
                 <caption class="visually-hidden">
                     <?php echo Text::_('COM_USERS_DEBUG_GROUP_TABLE_CAPTION'); ?>,
                             <span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,

--- a/build/media_source/system/js/table-columns.es6.js
+++ b/build/media_source/system/js/table-columns.es6.js
@@ -44,7 +44,7 @@ class TableColumns {
    */
   createControls() {
     const $divouter = document.createElement('div');
-    $divouter.setAttribute('class', 'dropdown float-end pb-2');
+    $divouter.setAttribute('class', 'dropdown d-flex justify-content-end pb-2');
 
     const $divinner = document.createElement('div');
     $divinner.setAttribute('class', 'dropdown-menu dropdown-menu-end');

--- a/build/media_source/templates/administrator/atum/scss/_variables.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables.scss
@@ -163,8 +163,8 @@ $black-weight:                     900;
 $table-bg:                         var(--white);
 $table-cell-padding-y:             .75rem;
 $table-cell-padding-x:             1rem;
-$table-cell-padding-y-sm:          .3rem;
-$table-cell-padding-x-sm:          .3rem;
+$table-cell-padding-y-sm:          .2rem;
+$table-cell-padding-x-sm:          .2rem;
 $table-group-separator-color:      $gray-300;
 
 // Dropdowns


### PR DESCRIPTION
Pull Request for Issue #38828

### Summary of Changes
On screens above 1950 resolution the responsiveness is good but as you start going below that the UI start breaking.
On my screen (1500 resolution) it looks something like this


https://user-images.githubusercontent.com/91469717/204759328-2cd414e1-c828-458c-8b0c-68f41660f469.mp4


After making changes it look like this
![after3](https://user-images.githubusercontent.com/91469717/204759778-ac4bbdfd-2dfd-4733-9740-6c4434e5b1f8.png)

1. Column selector is easily accessible.
2. There is no horizontal scroll bar on table.
3. There is no horizontal scroll bar on body.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
