### PR TITLE
[RFC] Native dialogs replacing the Bootstrap ones

### DIFF
--- a/build/build-modules-js/javascript/compile-to-es2017.es6.js
+++ b/build/build-modules-js/javascript/compile-to-es2017.es6.js
@@ -53,6 +53,7 @@ module.exports.handleESMFile = async (file) => {
   const minifiedCss = await getWcMinifiedCss(file);
   const bundle = await rollup.rollup({
     input: resolve(file),
+    inlineDynamicImports: true,
     plugins: [
       nodeResolve({
         preferBuiltins: false,

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -6,6 +6,19 @@
 ((tinyMCE, Joomla, window, document) => {
   'use strict';
 
+  function openJoomlaModal(button) {
+    const modalContainer = document.createElement('joomla-modal');
+    modalContainer.setAttribute('id', `tinymce-j-modal`);
+    // modalContainer.setAttribute('class', `maximum header-two-btn`);
+    modalContainer.setAttribute('title', `Select ${button.text}`);
+    modalContainer.setAttribute('url', button.href);
+    modalContainer.setAttribute('close-text', 'Clooooooose');
+    modalContainer.setAttribute('click-outside', false);
+
+    document.body.append(modalContainer);
+    modalContainer.open();
+  }
+
   Joomla.JoomlaTinyMCE = {
     /**
      * Find all TinyMCE elements and initialize TinyMCE instance for each
@@ -98,9 +111,8 @@
         }
 
         if (xtdButton.href) {
-          tmp.onAction = () => {
-            document.getElementById(`${xtdButton.id}_modal`).open();
-          };
+          tmp.href = xtdButton.href;
+          tmp.onAction = () => openJoomlaModal(tmp);
         } else {
           tmp.onAction = () => {
             // eslint-disable-next-line no-new-func

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -17,6 +17,23 @@
 
     document.body.append(modalContainer);
     modalContainer.open();
+    Joomla.Modal.setCurrent(modalContainer)
+
+    const matches = /e_name=(.*?)\&/.exec(button.href)
+    if (matches.length === 2) {
+      const buttonSaveSelectedElement = document.createElement('button');
+      buttonSaveSelectedElement.setAttribute('type', 'button');
+      buttonSaveSelectedElement.textContent = 'Select';
+
+      function onSelected() {
+        Joomla.getImage(parent.window.Joomla.selectedMediaFile, button.id, modalContainer);
+        modalContainer.querySelector('dialog').close();
+        Joomla.Modal.setCurrent(null)
+      }
+
+      buttonSaveSelectedElement.addEventListener('click', onSelected);
+      modalContainer.querySelector('header button').insertAdjacentElement('afterend', buttonSaveSelectedElement);
+    }
   }
 
   Joomla.JoomlaTinyMCE = {
@@ -112,6 +129,8 @@
 
         if (xtdButton.href) {
           tmp.href = xtdButton.href;
+          tmp.editor = element;
+          tmp.id = element.id;
           tmp.onAction = () => openJoomlaModal(tmp);
         } else {
           tmp.onAction = () => {

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -8,7 +8,7 @@
 
   function openJoomlaModal(button) {
     const modalContainer = document.createElement('joomla-modal');
-    modalContainer.setAttribute('id', `tinymce-j-modal`);
+    modalContainer.setAttribute('id', 'tinymce-j-modal');
     // modalContainer.setAttribute('class', `maximum header-two-btn`);
     modalContainer.setAttribute('title', `Select ${button.text}`);
     modalContainer.setAttribute('url', button.href);

--- a/build/media_source/system/css/joomla-modal.css
+++ b/build/media_source/system/css/joomla-modal.css
@@ -1,0 +1,82 @@
+
+dialog:modal {
+  /*
+  From BS 5.2
+  */
+  border-color: grey;
+  border-width: 1px;
+  border-radius: 0.5rem;
+  width: calc(100dvw - 2em);
+  height: calc(100dvw - 4em);
+
+  /* clamp(min(10em, calc(100dvw - 2em)), calc(100dvw - 2em), 40em); */
+}
+
+dialog::backdrop {
+  background-color: black;
+  opacity: .8
+}
+
+dialog:modal iframe {
+  width: 100%;
+  height: 100vh;
+  border: none;
+}
+
+dialog:modal header {
+  margin: -1em;
+  display: flex;
+  align-items: center;
+  justify-items: start;
+  border-bottom: 1px inset grey;
+}
+
+dialog:modal header > *:nth-child(1) {
+  padding-inline-start: 1em;
+}
+
+dialog:modal header > *:nth-child(2) {
+  border: none;
+  background-color: transparent;
+  box-sizing: content-box;
+  width: 1em;
+  height: 1em;
+  padding: .25em .25em;
+  color: #000;
+  background: transparent url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23000'%3e%3cpath d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414z'/%3e%3c/svg%3e") center/1em auto no-repeat;
+  border: 0;
+  border-radius: .375rem;
+  opacity: .5;
+  margin-inline-start: auto;
+  margin-inline-end: 2em;
+}
+
+dialog:modal article {
+  margin-top: 2em;
+}
+
+joomla-modal.maximum.header-two-btn header > *:nth-child(1) {
+  padding-inline-start: 1em;
+}
+
+joomla-modal.maximum.header-two-btn header > *:nth-child(2) {
+  margin-inline-start: auto;
+  margin-inline-end: 1em;
+  background: unset;
+}
+
+
+joomla-modal.maximum.header-two-btn header > *:nth-child(3) {
+  border: none;
+  background-color: transparent;
+  box-sizing: content-box;
+  width: 1em;
+  height: 1em;
+  padding: .25em .25em;
+  color: #000;
+  background: transparent url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23000'%3e%3cpath d='M.293.293a1 1 0 0 1 1.414 0L8 6.586 14.293.293a1 1 0 1 1 1.414 1.414L9.414 8l6.293 6.293a1 1 0 0 1-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 0 1-1.414-1.414L6.586 8 .293 1.707a1 1 0 0 1 0-1.414z'/%3e%3c/svg%3e") center/1em auto no-repeat;
+  border: 0;
+  border-radius: .375rem;
+  opacity: .5;
+  margin-inline-end: 2em;
+}

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -148,8 +148,8 @@ class JoomlaFieldMedia extends HTMLElement {
 
   show() {
     this.modalContainer = document.createElement('joomla-modal');
-    this.modalContainer.setAttribute('id', `media-select-modal`);
-    this.modalContainer.setAttribute('class', `maximum header-two-btn`);
+    this.modalContainer.setAttribute('id', 'media-select-modal');
+    this.modalContainer.setAttribute('class', 'maximum header-two-btn');
     this.modalContainer.setAttribute('title', 'Select Media');
     this.modalContainer.setAttribute('url', this.url);
     this.modalContainer.setAttribute('close-text', 'Clooooooose');
@@ -158,7 +158,7 @@ class JoomlaFieldMedia extends HTMLElement {
     this.append(this.modalContainer);
     this.modalContainer.open();
 
-    this.modalContainer.querySelector('header button').insertAdjacentElement('beforebegin', this.buttonSaveSelectedElement)
+    this.modalContainer.querySelector('header button').insertAdjacentElement('beforebegin', this.buttonSaveSelectedElement);
 
     Joomla.Modal.setCurrent(this.modalContainer.querySelector('dialog'));
     Joomla.selectedMediaFile = {};

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -56,10 +56,6 @@ class JoomlaFieldMedia extends HTMLElement {
 
   set url(value) { this.setAttribute('url', value); }
 
-  get modalContainer() { return this.getAttribute('modal-container'); }
-
-  set modalContainer(value) { this.setAttribute('modal-container', value); }
-
   get input() { return this.getAttribute('input'); }
 
   set input(value) { this.setAttribute('input', value); }
@@ -104,24 +100,16 @@ class JoomlaFieldMedia extends HTMLElement {
     this.button = this.querySelector(this.buttonSelect);
     this.inputElement = this.querySelector(this.input);
     this.buttonClearEl = this.querySelector(this.buttonClear);
-    this.modalElement = this.querySelector('.joomla-modal');
-    this.buttonSaveSelectedElement = this.querySelector(this.buttonSaveSelected);
+    this.buttonSaveSelectedElement = document.createElement('button');
+    this.buttonSaveSelectedElement.setAttribute('type', 'button');
+    this.buttonSaveSelectedElement.textContent = 'Select';
     this.previewElement = this.querySelector('.field-media-preview');
 
-    if (!this.button || !this.inputElement || !this.buttonClearEl || !this.modalElement
-      || !this.buttonSaveSelectedElement) {
+    if (!this.button || !this.inputElement || !this.buttonClearEl || !this.buttonSaveSelectedElement) {
       throw new Error('Misconfiguaration...');
     }
 
     this.button.addEventListener('click', this.show);
-
-    // Bootstrap modal init
-    if (this.modalElement
-      && window.bootstrap
-      && window.bootstrap.Modal
-      && !window.bootstrap.Modal.getInstance(this.modalElement)) {
-      Joomla.initialiseModal(this.modalElement, { isJoomla: true });
-    }
 
     if (this.buttonClearEl) {
       this.buttonClearEl.addEventListener('click', this.clearValue);
@@ -159,8 +147,20 @@ class JoomlaFieldMedia extends HTMLElement {
   }
 
   show() {
-    this.modalElement.open();
+    this.modalContainer = document.createElement('joomla-modal');
+    this.modalContainer.setAttribute('id', `media-select-modal`);
+    this.modalContainer.setAttribute('class', `maximum header-two-btn`);
+    this.modalContainer.setAttribute('title', 'Select Media');
+    this.modalContainer.setAttribute('url', this.url);
+    this.modalContainer.setAttribute('close-text', 'Clooooooose');
+    this.modalContainer.setAttribute('click-outside', false);
 
+    this.append(this.modalContainer);
+    this.modalContainer.open();
+
+    this.modalContainer.querySelector('header button').insertAdjacentElement('beforebegin', this.buttonSaveSelectedElement)
+
+    Joomla.Modal.setCurrent(this.modalContainer.querySelector('dialog'));
     Joomla.selectedMediaFile = {};
 
     this.buttonSaveSelectedElement.addEventListener('click', this.onSelected);
@@ -176,7 +176,9 @@ class JoomlaFieldMedia extends HTMLElement {
     }
 
     Joomla.selectedMediaFile = {};
-    Joomla.Modal.getCurrent().close();
+    this.modalContainer.querySelector('dialog').close();
+    Joomla.Modal.setCurrent(null);
+    // Joomla.Modal.getCurrent().close();
   }
 
   setValue(value) {
@@ -363,4 +365,5 @@ class JoomlaFieldMedia extends HTMLElement {
     }
   }
 }
-customElements.define('joomla-field-media', JoomlaFieldMedia);
+
+customElements.whenDefined('joomla-modal').then(() => customElements.define('joomla-field-media', JoomlaFieldMedia));

--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -151,7 +151,7 @@ class JoomlaFieldMedia extends HTMLElement {
     this.modalContainer.setAttribute('id', 'media-select-modal');
     this.modalContainer.setAttribute('class', 'maximum header-two-btn');
     this.modalContainer.setAttribute('title', 'Select Media');
-    this.modalContainer.setAttribute('url', this.url);
+    this.modalContainer.setAttribute('url', this.url.replace('{field-media-id}', this.inputElement.getAttribute('id')));
     this.modalContainer.setAttribute('close-text', 'Clooooooose');
     this.modalContainer.setAttribute('click-outside', false);
 

--- a/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
@@ -1,152 +1,119 @@
-((customElements, Joomla) => {
-  class JoomlaFieldUser extends HTMLElement {
-    constructor() {
-      super();
 
-      this.onUserSelect = '';
-      this.onchangeStr = '';
+class JoomlaFieldUser extends HTMLElement {
+  constructor() {
+    super();
 
-      // Bind events
-      this.buttonClick = this.buttonClick.bind(this);
-      this.iframeLoad = this.iframeLoad.bind(this);
-      this.modalClose = this.modalClose.bind(this);
-      this.setValue = this.setValue.bind(this);
-    }
+    // Bind events
+    this.modalOpen = this.modalOpen.bind(this);
+    this.buttonClick = this.buttonClick.bind(this);
+    this.iframeLoad = this.iframeLoad.bind(this);
+    this.modalClose = this.modalClose.bind(this);
+    this.setValue = this.setValue.bind(this);
+  }
 
-    static get observedAttributes() {
-      return ['url', 'modal', 'modal-width', 'modal-height', 'input', 'input-name', 'button-select'];
-    }
+  static get observedAttributes() {
+    return ['url', 'modal', 'modal-width', 'modal-height', 'input', 'input-name', 'button-select'];
+  }
 
-    get url() { return this.getAttribute('url'); }
+  get url() { return this.getAttribute('url'); }
 
-    set url(value) { this.setAttribute('url', value); }
+  set url(value) { this.setAttribute('url', value); }
 
-    get modalClass() { return this.getAttribute('modal'); }
+  get modalClass() { return this.getAttribute('modal'); }
 
-    set modalClass(value) { this.setAttribute('modal', value); }
+  set modalClass(value) { this.setAttribute('modal', value); }
 
-    get modalWidth() { return this.getAttribute('modal-width'); }
+  get modalWidth() { return this.getAttribute('modal-width'); }
 
-    set modalWidth(value) { this.setAttribute('modal-width', value); }
+  set modalWidth(value) { this.setAttribute('modal-width', value); }
 
-    get modalHeight() { return this.getAttribute('modal-height'); }
+  get modalHeight() { return this.getAttribute('modal-height'); }
 
-    set modalHeight(value) { this.setAttribute('modal-height', value); }
+  set modalHeight(value) { this.setAttribute('modal-height', value); }
 
-    get inputId() { return this.getAttribute('input'); }
+  get inputId() { return this.getAttribute('input'); }
 
-    set inputId(value) { this.setAttribute('input', value); }
+  set inputId(value) { this.setAttribute('input', value); }
 
-    get inputNameClass() { return this.getAttribute('input-name'); }
+  get inputNameClass() { return this.getAttribute('input-name'); }
 
-    set inputNameClass(value) { this.setAttribute('input-name', value); }
+  set inputNameClass(value) { this.setAttribute('input-name', value); }
 
-    get buttonSelectClass() { return this.getAttribute('button-select'); }
+  get buttonSelectClass() { return this.getAttribute('button-select'); }
 
-    set buttonSelectClass(value) { this.setAttribute('button-select', value); }
+  set buttonSelectClass(value) { this.setAttribute('button-select', value); }
 
-    connectedCallback() {
-      // Set up elements
-      this.modal = this.querySelector(this.modalClass);
-      this.modalBody = this.querySelector('.modal-body');
-      this.input = this.querySelector(this.inputId);
-      this.inputName = this.querySelector(this.inputNameClass);
-      this.buttonSelect = this.querySelector(this.buttonSelectClass);
+  connectedCallback() {
+    this.input = this.querySelector(this.inputId);
+    this.inputName = this.querySelector(this.inputNameClass);
+    this.buttonSelect = this.querySelector(this.buttonSelectClass);
 
-      // Bootstrap modal init
-      if (this.modal
-        && window.bootstrap
-        && window.bootstrap.Modal
-        && !window.bootstrap.Modal.getInstance(this.modal)) {
-        Joomla.initialiseModal(this.modal, { isJoomla: true });
-      }
 
-      if (this.buttonSelect) {
-        this.buttonSelect.addEventListener('click', this.modalOpen.bind(this));
-        this.modal.addEventListener('hide', this.removeIframe.bind(this));
-
-        // Check for onchange callback,
-        this.onchangeStr = this.input.getAttribute('data-onchange');
-        if (this.onchangeStr) {
-          /* eslint-disable */
-          this.onUserSelect = new Function(this.onchangeStr);
-          this.input.addEventListener('change', this.onUserSelect);
-          /* eslint-enable */
-        }
-      }
-    }
-
-    disconnectedCallback() {
-      if (this.onchangeStr && this.input) {
-        this.input.removeEventListener('change', this.onUserSelect);
-      }
-
-      if (this.buttonSelect) {
-        this.buttonSelect.removeEventListener('click', this);
-      }
-
-      if (this.modal) {
-        this.modal.removeEventListener('hide', this);
-      }
-    }
-
-    buttonClick({ target }) {
-      this.setValue(target.getAttribute('data-user-value'), target.getAttribute('data-user-name'));
-      this.modalClose();
-    }
-
-    iframeLoad() {
-      const iframeDoc = this.iframeEl.contentWindow.document;
-      const buttons = [].slice.call(iframeDoc.querySelectorAll('.button-select'));
-
-      buttons.forEach((button) => {
-        button.addEventListener('click', this.buttonClick);
-      });
-    }
-
-    // Opens the modal
-    modalOpen() {
-      // Reconstruct the iframe
-      this.removeIframe();
-      const iframe = document.createElement('iframe');
-      iframe.setAttribute('name', 'field-user-modal');
-      iframe.src = this.url.replace('{field-user-id}', this.input.getAttribute('id'));
-      iframe.setAttribute('width', this.modalWidth);
-      iframe.setAttribute('height', this.modalHeight);
-
-      this.modalBody.appendChild(iframe);
-
-      this.modal.open();
-
-      this.iframeEl = this.modalBody.querySelector('iframe');
-
-      // handle the selection on the iframe
-      this.iframeEl.addEventListener('load', this.iframeLoad);
-    }
-
-    // Closes the modal
-    modalClose() {
-      Joomla.Modal.getCurrent().close();
-      this.modalBody.innerHTML = '';
-    }
-
-    // Remove the iframe
-    removeIframe() {
-      this.modalBody.innerHTML = '';
-    }
-
-    // Sets the value
-    setValue(value, name) {
-      this.input.setAttribute('value', value);
-      this.inputName.setAttribute('value', name || value);
-      // trigger change event both on the input and on the custom element
-      this.input.dispatchEvent(new Event('change'));
-      this.dispatchEvent(new CustomEvent('change', {
-        detail: { value, name },
-        bubbles: true,
-      }));
+    if (this.buttonSelect) {
+      this.buttonSelect.addEventListener('click', this.modalOpen.bind(this));
     }
   }
 
-  customElements.define('joomla-field-user', JoomlaFieldUser);
-})(customElements, Joomla);
+  disconnectedCallback() {
+    if (this.buttonSelect) {
+      this.buttonSelect.removeEventListener('click', this);
+    }
+  }
+
+  buttonClick({ target }) {
+    this.setValue(target.getAttribute('data-user-value'), target.getAttribute('data-user-name'));
+    this.modalClose();
+  }
+
+  iframeLoad() {
+    const iframeDoc = this.iframeEl.contentWindow.document;
+
+    iframeDoc.querySelectorAll('.button-select').forEach((button) => {
+      button.addEventListener('click', this.buttonClick);
+    });
+  }
+
+  // Opens the modal
+  modalOpen() {
+    this.modalContainer = document.createElement('joomla-modal');
+    this.modalContainer.setAttribute('id', `user-select-modal`);
+    this.modalContainer.setAttribute('title', 'Select User');
+    // this.modalContainer.setAttribute('url', this.url);
+    this.modalContainer.setAttribute('url', this.url.replace('{field-user-id}', this.input.getAttribute('id')));
+    this.modalContainer.setAttribute('close-text', 'Clooooooose');
+    this.modalContainer.setAttribute('click-outside', false);
+
+    this.append(this.modalContainer);
+
+    this.modalContainer.open();
+
+    this.modal = this.querySelector('dialog');
+    this.iframeEl = this.querySelector('iframe');
+
+    // handle the selection on the iframe
+    this.iframeEl.addEventListener('load', this.iframeLoad);
+  }
+
+  // Closes the modal
+  modalClose() {
+    // Joomla.Modal.getCurrent().close();
+    if (this.modal) {
+      this.modal.close();
+      this.removeChild(this.modalContainer);
+    }
+  }
+
+  // Sets the value
+  setValue(value, name) {
+    this.input.setAttribute('value', value);
+    this.inputName.setAttribute('value', name || value);
+    // trigger change event both on the input and on the custom element
+    this.input.dispatchEvent(new Event('change'));
+    this.dispatchEvent(new CustomEvent('change', {
+      detail: { value, name },
+      bubbles: true,
+    }));
+  }
+}
+
+customElements.whenDefined('joomla-modal').then(() => customElements.define('joomla-field-user', JoomlaFieldUser));

--- a/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
@@ -1,4 +1,3 @@
-
 class JoomlaFieldUser extends HTMLElement {
   constructor() {
     super();
@@ -48,7 +47,6 @@ class JoomlaFieldUser extends HTMLElement {
     this.inputName = this.querySelector(this.inputNameClass);
     this.buttonSelect = this.querySelector(this.buttonSelectClass);
 
-
     if (this.buttonSelect) {
       this.buttonSelect.addEventListener('click', this.modalOpen.bind(this));
     }
@@ -76,7 +74,7 @@ class JoomlaFieldUser extends HTMLElement {
   // Opens the modal
   modalOpen() {
     this.modalContainer = document.createElement('joomla-modal');
-    this.modalContainer.setAttribute('id', `user-select-modal`);
+    this.modalContainer.setAttribute('id', 'user-select-modal');
     this.modalContainer.setAttribute('title', 'Select User');
     // this.modalContainer.setAttribute('url', this.url);
     this.modalContainer.setAttribute('url', this.url.replace('{field-user-id}', this.input.getAttribute('id')));

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -153,7 +153,7 @@ const insertAsImage = async (media, editor, fieldClass) => {
     let imageElement = '';
 
     if (!isElement(editor)) {
-      const currentModal = fieldClass.closest('.modal-content');
+      const currentModal = fieldClass.querySelector('dialog');
       attribs = currentModal.querySelector('joomla-field-mediamore');
       if (attribs) {
         if (attribs.getAttribute('alt-check') === 'true') {
@@ -387,11 +387,9 @@ class JoomlaFieldMediaOptions extends HTMLElement {
       this.innerHTML = `<details open>
 <summary>${this.summarytext}</summary>
 <div class="">
-  <div class="form-group">
-    <div class="input-group">
-      <label class="input-group-text" for="${this.parentId}-alt">${this.alttext}</label>
-      <input class="form-control" type="text" id="${this.parentId}-alt" data-is="alt-value" />
-    </div>
+  <div class="mb-3">
+    <label class="form-label" for="${this.parentId}-alt">${this.alttext}</label>
+    <input class="form-control" type="text" id="${this.parentId}-alt" data-is="alt-value" />
   </div>
   <div class="form-group">
     <div class="form-check">
@@ -406,23 +404,17 @@ class JoomlaFieldMediaOptions extends HTMLElement {
       <label class="form-check-label" for="${this.parentId}-lazy">${this.lazytext}</label>
     </div>
   </div>
-  <div class="form-group">
-    <div class="input-group">
-      <label class="input-group-text" for="${this.parentId}-classes">${this.classestext}</label>
-      <input class="form-control" type="text" id="${this.parentId}-classes" data-is="img-classes"/>
-    </div>
+  <div class="mb-3">
+    <label class="form-label" for="${this.parentId}-classes">${this.classestext}</label>
+    <input class="form-control" type="text" id="${this.parentId}-classes" data-is="img-classes"/>
   </div>
-  <div class="form-group">
-    <div class="input-group">
-      <label class="input-group-text" for="${this.parentId}-figclasses">${this.figclassestext}</label>
-      <input class="form-control" type="text" id="${this.parentId}-figclasses" data-is="fig-classes"/>
-    </div>
+  <div class="mb-3">
+    <label class="form-label" for="${this.parentId}-figclasses">${this.figclassestext}</label>
+    <input class="form-control" type="text" id="${this.parentId}-figclasses" data-is="fig-classes"/>
   </div>
-  <div class="form-group">
-    <div class="input-group">
-      <label class="input-group-text" for="${this.parentId}-figcaption">${this.figcaptiontext}</label>
-      <input class="form-control" type="text" id="${this.parentId}-figcaption" data-is="fig-caption"/>
-    </div>
+  <div class="mb-3">
+    <label class="form-label" for="${this.parentId}-figcaption">${this.figcaptiontext}</label>
+    <input class="form-control" type="text" id="${this.parentId}-figcaption" data-is="fig-caption"/>
   </div>
 </div>
 </details>`;
@@ -471,25 +463,19 @@ class JoomlaFieldMediaOptions extends HTMLElement {
   </div>
   <div class="toggable-parts" style="display: none">
     <div style="display: ${this.type === 'audios' ? 'none' : 'block'}">
-      <div class="form-group">
-        <div class="input-group">
-          <label class="input-group-text" for="${this.parentId}-width">${this.widthtext}</label>
+        <div class="mb-3">
+          <label class="form-label" for="${this.parentId}-width">${this.widthtext}</label>
           <input class="form-control" type="text" id="${this.parentId}-width" value="800" data-is="width"/>
         </div>
-      </div>
-      <div class="form-group">
-        <div class="input-group">
-          <label class="input-group-text" for="${this.parentId}-height">${this.heighttext}</label>
+        <div class="mb3">
+          <label class="form-label" for="${this.parentId}-height">${this.heighttext}</label>
           <input class="form-control" type="text" id="${this.parentId}-height" value="600" data-is="height"/>
         </div>
-      </div>
       <div style="display: ${this.type === 'document' ? 'block' : 'none'}">
-        <div class="form-group">
-          <div class="input-group">
-            <label class="input-group-text" for="${this.parentId}-title">${this.titletext}</label>
+          <div class="mb-3">
+            <label class="form-label" for="${this.parentId}-title">${this.titletext}</label>
             <input class="form-control" type="text" id="${this.parentId}-title" value="" data-is="title"/>
           </div>
-        </div>
     </div>
   </div>
 </div>

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -32,7 +32,7 @@ if (!Object.keys(supportedExtensions).length) {
 document.addEventListener('onMediaFileSelected', async (e) => {
   Joomla.selectedMediaFile = e.detail;
   const currentModal = Joomla.Modal.getCurrent();
-  const container = currentModal.querySelector('.modal-body');
+  const container = currentModal.querySelector('article');
 
   if (!container) {
     return;

--- a/build/media_source/system/js/joomla-modal.es6.js
+++ b/build/media_source/system/js/joomla-modal.es6.js
@@ -1,0 +1,232 @@
+export class JoomlaModalButton extends HTMLElement {
+  constructor() {
+    super();
+
+    this.onOpen = this.onOpen.bind(this);
+    this.createIframeDialog = this.createIframeDialog.bind(this);
+  }
+
+  observedAttributes = [
+    'type',
+    'id',
+    'title',
+    'url',
+    'close-text',
+    'close-outside',
+  ];
+
+  get type() { return this.getAttribute('type') || 'dialog' };
+  set type(value) { this.setAttribute('type', value); }
+
+  get id() { return this.getAttribute('id') || 'random_id' };
+  set id(value) { this.setAttribute('id', value); }
+
+  get title() { return this.getAttribute('title'); };
+  set title(value) { this.setAttribute('title', value); }
+
+  get url() { return this.getAttribute('url'); };
+  set url(value) { this.setAttribute('url', value); }
+
+  get closeText() { return this.getAttribute('close-text'); };
+  set closeText(value) { this.setAttribute('close-text', value); }
+
+  get clickOutside() { return this.getAttribute('click-outside'); };
+  set clickOutside(value) { this.setAttribute('click-outside', value); }
+
+  connectedCallback() {
+    // Do we have any HTML nodes
+    if (this.children.length) {
+      // Check if a modal wrapper exists
+      if (this.children[1] && this.children[1].nodeName && this.children[1].nodeName === 'JOOMLA-MODAL') {
+        console.log(this.children[1].nodeName)
+
+      }
+      // Check if the opener button/link exist
+      if (this.firstElementChild && this.firstElementChild.nodeName && ['A', 'BUTTON'].includes(this.firstElementChild.nodeName)) {
+        this.opener = this.firstElementChild;
+        this.opener.addEventListener('click', this.onOpen)
+      }
+    }
+
+    // Auto create the modal
+    if (this.url) {
+      // this.createIframeDialog();
+    }
+  }
+
+  disconnectedCallback() {
+
+  }
+
+  attributeChangeCallback() {
+
+  }
+
+  onOpen() {
+    if (this.url) {
+      if (this.children[1] && this.children[1].nodeName && this.children[1].nodeName === 'JOOMLA-MODAL') {
+        this.modalContainer.open();
+        if (Joomla && Joomla.Modal) Joomla.Modal.setCurrent(this.modalContainer);
+      } else {
+        this.createIframeDialog();
+        this.modalContainer.open();
+        if (Joomla && Joomla.Modal) Joomla.Modal.setCurrent(this.modalContainer);
+      }
+
+    }
+  }
+
+  createIframeDialog() {
+    this.modalContainer = document.createElement('joomla-modal');
+    this.modalContainer.setAttribute('id', `${this.id}-modal`);
+    this.modalContainer.setAttribute('title', this.title);
+    this.modalContainer.setAttribute('url', this.url);
+    this.modalContainer.setAttribute('close-text', this.closeText);
+    if (this.clickOutside) this.modalContainer.setAttribute('click-outside', this.clickOutside);
+
+    this.append(this.modalContainer);
+  }
+}
+
+const templateHeader = `<header>
+  <h3></h3>
+  <button></button>
+</header>`;
+const templateArticleIframe = `<article><iframe /></article>`;
+const templateArticle = `<article></article>`;
+const templateFooter = `<footer></footer>`;
+
+export class JoomlaModal extends HTMLElement {
+  constructor() {
+    super();
+
+    this.open = this.open.bind(this);
+    this.close = this.close.bind(this);
+    this.onObserverChange = this.onObserverChange.bind(this);
+    this.clickOutsideFn = this.clickOutsideFn.bind(this);
+    this.onDialogClose = this.onDialogClose.bind(this);
+
+    this.observerConfig = { attributes: true, childList: true, subtree: true };
+    this.observer = new MutationObserver(this.onObserverChange)
+  }
+
+  observedAttributes = [
+    'type',
+    'id',
+    'title',
+    'url',
+    'close-text'
+  ];
+
+  get type() { return this.getAttribute('type') || 'dialog' };
+  set type(value) { this.setAttribute('type', value); }
+
+  get id() { return this.getAttribute('id') || 'random_id' };
+  set id(value) { this.setAttribute('id', value); }
+
+  get title() { return this.getAttribute('title'); };
+  set title(value) { this.setAttribute('title', value); }
+
+  get url() { return this.getAttribute('url'); };
+  set url(value) { this.setAttribute('url', value); }
+
+  get closeText() { return this.getAttribute('close-text') || 'Close'; };
+  set closeText(value) { this.setAttribute('close-text', value); }
+
+  get clickOutside() { return this.getAttribute('click-outside'); };
+  set clickOutside(value) { this.setAttribute('click-outside', value); }
+
+  connectedCallback() {
+    this.dialog = this.querySelector('dialog');
+    // if (this.firstElementChild && ['A', 'BUTTON'].includes(this.firstElementChild.nodeName)) {
+    //   this.opener = this.firstElementChild;
+    //   this.opener.addEventListener('click', this.open)
+    // }
+
+  }
+
+  disconnectedCallback() {
+
+  }
+
+  attributeChangeCallback() {
+
+  }
+
+  open() {
+    if (this.firstElementChild && this.firstElementChild.nodeName === 'DIALOG') {
+      this.dialog.showModal();
+      this.dialog.addEventListener('close', this.onDialogClose);
+
+      if (this.clickOutside) {
+        this.dialog.addEventListener('click', this.clickOutsideFn);
+      }
+    } else {
+      this.createIframeDialog();
+      this.dialog.showModal();
+      this.dialog.addEventListener('close', this.onDialogClose);
+
+      if (this.clickOutside) {
+        this.dialog.addEventListener('click', this.clickOutsideFn);
+      }
+    }
+  }
+
+  close() {
+    if (this.dialog) {
+      this.dialog.close();
+    }
+  }
+
+  onDialogClose() {
+    this.parentNode.removeChild(this);
+  }
+
+  clickOutsideFn(event) {
+    if (event.target === this.dialog) {
+      this.dialog.removeEventListener('click', this.clickOutsideFn);
+      this.dialog.close();
+    }
+  }
+
+  createIframeDialog() {
+    const doc = new DOMParser().parseFromString(`${templateHeader}${this.url ? templateArticleIframe : templateArticle}${templateFooter}`, 'text/html');
+    console.log(doc.documentElement.children[1].children)
+    this.dialog = document.createElement('dialog');
+    this.headerTitleElement = doc.documentElement.querySelector('header > h3');
+    this.closeButton = doc.documentElement.querySelector('header > button');
+    this.closeButton.setAttribute('aria-label', this.closeText);
+    this.closeButton.setAttribute('type', 'button');
+    this.closeButton.addEventListener('click', this.close)
+    this.headerTitleElement.textContent = this.title;
+    this.iframe = doc.documentElement.querySelector('article > iframe');
+    this.iframe.src = this.url;
+
+    [...doc.documentElement.children[1].children].forEach(eee => this.dialog.append(eee))
+
+
+    this.append(this.dialog)
+  }
+
+  onObserverChange(mutationList, observer) {
+    for (const mutation of mutationList) {
+      if (mutation.type === 'childList') {
+        console.log('A child node has been added or removed.');
+      } else if (mutation.type === 'attributes') {
+        console.log(`The ${mutation.attributeName} attribute was modified.`);
+      }
+    }
+  }
+}
+
+function registerElements() {
+  customElements.define('joomla-modal-button', JoomlaModalButton);
+  customElements.define('joomla-modal', JoomlaModal);
+}
+
+if (window.HTMLDialogElement === undefined) {
+  // polyfill required
+    import('./polyfill.js').then(registerElements);
+} else {
+  registerElements();
+}

--- a/build/media_source/system/js/joomla-modal.es6.js
+++ b/build/media_source/system/js/joomla-modal.es6.js
@@ -1,3 +1,4 @@
+/* eslint max-classes-per-file: ["error", 2] */
 export class JoomlaModalButton extends HTMLElement {
   constructor() {
     super();
@@ -6,45 +7,50 @@ export class JoomlaModalButton extends HTMLElement {
     this.createIframeDialog = this.createIframeDialog.bind(this);
   }
 
-  observedAttributes = [
-    'type',
-    'id',
-    'title',
-    'url',
-    'close-text',
-    'close-outside',
-  ];
+  static get observedAttributes() {
+    return [
+      'type',
+      'id',
+      'title',
+      'url',
+      'close-text',
+      'close-outside',
+    ];
+  }
 
-  get type() { return this.getAttribute('type') || 'dialog' };
+  get type() { return this.getAttribute('type') || 'dialog'; }
+
   set type(value) { this.setAttribute('type', value); }
 
-  get id() { return this.getAttribute('id') || 'random_id' };
+  get id() { return this.getAttribute('id') || 'random_id'; }
+
   set id(value) { this.setAttribute('id', value); }
 
-  get title() { return this.getAttribute('title'); };
+  get title() { return this.getAttribute('title'); }
+
   set title(value) { this.setAttribute('title', value); }
 
-  get url() { return this.getAttribute('url'); };
+  get url() { return this.getAttribute('url'); }
+
   set url(value) { this.setAttribute('url', value); }
 
-  get closeText() { return this.getAttribute('close-text'); };
+  get closeText() { return this.getAttribute('close-text'); }
+
   set closeText(value) { this.setAttribute('close-text', value); }
 
-  get clickOutside() { return this.getAttribute('click-outside'); };
+  get clickOutside() { return this.getAttribute('click-outside'); }
+
   set clickOutside(value) { this.setAttribute('click-outside', value); }
 
   connectedCallback() {
     // Do we have any HTML nodes
     if (this.children.length) {
       // Check if a modal wrapper exists
-      if (this.children[1] && this.children[1].nodeName && this.children[1].nodeName === 'JOOMLA-MODAL') {
-        console.log(this.children[1].nodeName)
-
-      }
+      // if (this.children[1] && this.children[1].nodeName && this.children[1].nodeName === 'JOOMLA-MODAL') {}
       // Check if the opener button/link exist
       if (this.firstElementChild && this.firstElementChild.nodeName && ['A', 'BUTTON'].includes(this.firstElementChild.nodeName)) {
         this.opener = this.firstElementChild;
-        this.opener.addEventListener('click', this.onOpen)
+        this.opener.addEventListener('click', this.onOpen);
       }
     }
 
@@ -52,14 +58,6 @@ export class JoomlaModalButton extends HTMLElement {
     if (this.url) {
       // this.createIframeDialog();
     }
-  }
-
-  disconnectedCallback() {
-
-  }
-
-  attributeChangeCallback() {
-
   }
 
   onOpen() {
@@ -72,7 +70,6 @@ export class JoomlaModalButton extends HTMLElement {
         this.modalContainer.open();
         if (Joomla && Joomla.Modal) Joomla.Modal.setCurrent(this.modalContainer);
       }
-
     }
   }
 
@@ -92,9 +89,9 @@ const templateHeader = `<header>
   <h3></h3>
   <button></button>
 </header>`;
-const templateArticleIframe = `<article><iframe /></article>`;
-const templateArticle = `<article></article>`;
-const templateFooter = `<footer></footer>`;
+const templateArticleIframe = '<article><iframe /></article>';
+const templateArticle = '<article></article>';
+const templateFooter = '<footer></footer>';
 
 export class JoomlaModal extends HTMLElement {
   constructor() {
@@ -102,55 +99,49 @@ export class JoomlaModal extends HTMLElement {
 
     this.open = this.open.bind(this);
     this.close = this.close.bind(this);
-    this.onObserverChange = this.onObserverChange.bind(this);
     this.clickOutsideFn = this.clickOutsideFn.bind(this);
     this.onDialogClose = this.onDialogClose.bind(this);
 
-    this.observerConfig = { attributes: true, childList: true, subtree: true };
-    this.observer = new MutationObserver(this.onObserverChange)
+    // this.observerConfig = { attributes: true, childList: true, subtree: true };
+    // this.observer = new MutationObserver(this.onObserverChange);
   }
 
-  observedAttributes = [
-    'type',
-    'id',
-    'title',
-    'url',
-    'close-text'
-  ];
+  static get observedAttributes() {
+    return [
+      'type',
+      'id',
+      'title',
+      'url',
+      'close-text',
+    ];
+  }
 
-  get type() { return this.getAttribute('type') || 'dialog' };
+  get type() { return this.getAttribute('type') || 'dialog'; }
+
   set type(value) { this.setAttribute('type', value); }
 
-  get id() { return this.getAttribute('id') || 'random_id' };
+  get id() { return this.getAttribute('id') || 'random_id'; }
+
   set id(value) { this.setAttribute('id', value); }
 
-  get title() { return this.getAttribute('title'); };
+  get title() { return this.getAttribute('title'); }
+
   set title(value) { this.setAttribute('title', value); }
 
-  get url() { return this.getAttribute('url'); };
+  get url() { return this.getAttribute('url'); }
+
   set url(value) { this.setAttribute('url', value); }
 
-  get closeText() { return this.getAttribute('close-text') || 'Close'; };
+  get closeText() { return this.getAttribute('close-text') || 'Close'; }
+
   set closeText(value) { this.setAttribute('close-text', value); }
 
-  get clickOutside() { return this.getAttribute('click-outside'); };
+  get clickOutside() { return this.getAttribute('click-outside'); }
+
   set clickOutside(value) { this.setAttribute('click-outside', value); }
 
   connectedCallback() {
     this.dialog = this.querySelector('dialog');
-    // if (this.firstElementChild && ['A', 'BUTTON'].includes(this.firstElementChild.nodeName)) {
-    //   this.opener = this.firstElementChild;
-    //   this.opener.addEventListener('click', this.open)
-    // }
-
-  }
-
-  disconnectedCallback() {
-
-  }
-
-  attributeChangeCallback() {
-
   }
 
   open() {
@@ -191,31 +182,19 @@ export class JoomlaModal extends HTMLElement {
 
   createIframeDialog() {
     const doc = new DOMParser().parseFromString(`${templateHeader}${this.url ? templateArticleIframe : templateArticle}${templateFooter}`, 'text/html');
-    console.log(doc.documentElement.children[1].children)
     this.dialog = document.createElement('dialog');
     this.headerTitleElement = doc.documentElement.querySelector('header > h3');
     this.closeButton = doc.documentElement.querySelector('header > button');
     this.closeButton.setAttribute('aria-label', this.closeText);
     this.closeButton.setAttribute('type', 'button');
-    this.closeButton.addEventListener('click', this.close)
+    this.closeButton.addEventListener('click', this.close);
     this.headerTitleElement.textContent = this.title;
     this.iframe = doc.documentElement.querySelector('article > iframe');
     this.iframe.src = this.url;
 
-    [...doc.documentElement.children[1].children].forEach(eee => this.dialog.append(eee))
+    [...doc.documentElement.children[1].children].forEach((eee) => this.dialog.append(eee));
 
-
-    this.append(this.dialog)
-  }
-
-  onObserverChange(mutationList, observer) {
-    for (const mutation of mutationList) {
-      if (mutation.type === 'childList') {
-        console.log('A child node has been added or removed.');
-      } else if (mutation.type === 'attributes') {
-        console.log(`The ${mutation.attributeName} attribute was modified.`);
-      }
-    }
+    this.append(this.dialog);
   }
 }
 
@@ -226,7 +205,7 @@ function registerElements() {
 
 if (window.HTMLDialogElement === undefined) {
   // polyfill required
-    import('./polyfill.js').then(registerElements);
+  import('./polyfill.js').then(registerElements);
 } else {
   registerElements();
 }

--- a/build/media_source/system/js/polyfill.js
+++ b/build/media_source/system/js/polyfill.js
@@ -1,0 +1,858 @@
+// nb. This is for IE10 and lower _only_.
+var supportCustomEvent = window.CustomEvent;
+if (!supportCustomEvent || typeof supportCustomEvent === 'object') {
+  supportCustomEvent = function CustomEvent(event, x) {
+    x = x || {};
+    var ev = document.createEvent('CustomEvent');
+    ev.initCustomEvent(event, !!x.bubbles, !!x.cancelable, x.detail || null);
+    return ev;
+  };
+  supportCustomEvent.prototype = window.Event.prototype;
+}
+
+/**
+ * Dispatches the passed event to both an "on<type>" handler as well as via the
+ * normal dispatch operation. Does not bubble.
+ *
+ * @param {!EventTarget} target
+ * @param {!Event} event
+ * @return {boolean}
+ */
+function safeDispatchEvent(target, event) {
+  var check = 'on' + event.type.toLowerCase();
+  if (typeof target[check] === 'function') {
+    target[check](event);
+  }
+  return target.dispatchEvent(event);
+}
+
+/**
+ * @param {Element} el to check for stacking context
+ * @return {boolean} whether this el or its parents creates a stacking context
+ */
+function createsStackingContext(el) {
+  while (el && el !== document.body) {
+    var s = window.getComputedStyle(el);
+    var invalid = function(k, ok) {
+      return !(s[k] === undefined || s[k] === ok);
+    };
+
+    if (s.opacity < 1 ||
+        invalid('zIndex', 'auto') ||
+        invalid('transform', 'none') ||
+        invalid('mixBlendMode', 'normal') ||
+        invalid('filter', 'none') ||
+        invalid('perspective', 'none') ||
+        s['isolation'] === 'isolate' ||
+        s.position === 'fixed' ||
+        s.webkitOverflowScrolling === 'touch') {
+      return true;
+    }
+    el = el.parentElement;
+  }
+  return false;
+}
+
+/**
+ * Finds the nearest <dialog> from the passed element.
+ *
+ * @param {Element} el to search from
+ * @return {HTMLDialogElement} dialog found
+ */
+function findNearestDialog(el) {
+  while (el) {
+    if (el.localName === 'dialog') {
+      return /** @type {HTMLDialogElement} */ (el);
+    }
+    if (el.parentElement) {
+      el = el.parentElement;
+    } else if (el.parentNode) {
+      el = el.parentNode.host;
+    } else {
+      el = null;
+    }
+  }
+  return null;
+}
+
+/**
+ * Blur the specified element, as long as it's not the HTML body element.
+ * This works around an IE9/10 bug - blurring the body causes Windows to
+ * blur the whole application.
+ *
+ * @param {Element} el to blur
+ */
+function safeBlur(el) {
+  // Find the actual focused element when the active element is inside a shadow root
+  while (el && el.shadowRoot && el.shadowRoot.activeElement) {
+    el = el.shadowRoot.activeElement;
+  }
+
+  if (el && el.blur && el !== document.body) {
+    el.blur();
+  }
+}
+
+/**
+ * @param {!NodeList} nodeList to search
+ * @param {Node} node to find
+ * @return {boolean} whether node is inside nodeList
+ */
+function inNodeList(nodeList, node) {
+  for (var i = 0; i < nodeList.length; ++i) {
+    if (nodeList[i] === node) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * @param {HTMLFormElement} el to check
+ * @return {boolean} whether this form has method="dialog"
+ */
+function isFormMethodDialog(el) {
+  if (!el || !el.hasAttribute('method')) {
+    return false;
+  }
+  return el.getAttribute('method').toLowerCase() === 'dialog';
+}
+
+/**
+ * @param {!DocumentFragment|!Element} hostElement
+ * @return {?Element}
+ */
+function findFocusableElementWithin(hostElement) {
+  // Note that this is 'any focusable area'. This list is probably not exhaustive, but the
+  // alternative involves stepping through and trying to focus everything.
+  var opts = ['button', 'input', 'keygen', 'select', 'textarea'];
+  var query = opts.map(function(el) {
+    return el + ':not([disabled])';
+  });
+  // TODO(samthor): tabindex values that are not numeric are not focusable.
+  query.push('[tabindex]:not([disabled]):not([tabindex=""])');  // tabindex != "", not disabled
+  var target = hostElement.querySelector(query.join(', '));
+
+  if (!target && 'attachShadow' in Element.prototype) {
+    // If we haven't found a focusable target, see if the host element contains an element
+    // which has a shadowRoot.
+    // Recursively search for the first focusable item in shadow roots.
+    var elems = hostElement.querySelectorAll('*');
+    for (var i = 0; i < elems.length; i++) {
+      if (elems[i].tagName && elems[i].shadowRoot) {
+        target = findFocusableElementWithin(elems[i].shadowRoot);
+        if (target) {
+          break;
+        }
+      }
+    }
+  }
+  return target;
+}
+
+/**
+ * Determines if an element is attached to the DOM.
+ * @param {Element} element to check
+ * @return {boolean} whether the element is in DOM
+ */
+function isConnected(element) {
+  return element.isConnected || document.body.contains(element);
+}
+
+/**
+ * @param {!Event} event
+ * @return {?Element}
+ */
+function findFormSubmitter(event) {
+  if (event.submitter) {
+    return event.submitter;
+  }
+
+  var form = event.target;
+  if (!(form instanceof HTMLFormElement)) {
+    return null;
+  }
+
+  var submitter = dialogPolyfill.formSubmitter;
+  if (!submitter) {
+    var target = event.target;
+    var root = ('getRootNode' in target && target.getRootNode() || document);
+    submitter = root.activeElement;
+  }
+
+  if (!submitter || submitter.form !== form) {
+    return null;
+  }
+  return submitter;
+}
+
+/**
+ * @param {!Event} event
+ */
+function maybeHandleSubmit(event) {
+  if (event.defaultPrevented) {
+    return;
+  }
+  var form = /** @type {!HTMLFormElement} */ (event.target);
+
+  // We'd have a value if we clicked on an imagemap.
+  var value = dialogPolyfill.imagemapUseValue;
+  var submitter = findFormSubmitter(event);
+  if (value === null && submitter) {
+    value = submitter.value;
+  }
+
+  // There should always be a dialog as this handler is added specifically on them, but check just
+  // in case.
+  var dialog = findNearestDialog(form);
+  if (!dialog) {
+    return;
+  }
+
+  // Prefer formmethod on the button.
+  var formmethod = submitter && submitter.getAttribute('formmethod') || form.getAttribute('method');
+  if (formmethod !== 'dialog') {
+    return;
+  }
+  event.preventDefault();
+
+  if (value != null) {
+    // nb. we explicitly check against null/undefined
+    dialog.close(value);
+  } else {
+    dialog.close();
+  }
+}
+
+/**
+ * @param {!HTMLDialogElement} dialog to upgrade
+ * @constructor
+ */
+function dialogPolyfillInfo(dialog) {
+  this.dialog_ = dialog;
+  this.replacedStyleTop_ = false;
+  this.openAsModal_ = false;
+
+  // Set a11y role. Browsers that support dialog implicitly know this already.
+  if (!dialog.hasAttribute('role')) {
+    dialog.setAttribute('role', 'dialog');
+  }
+
+  dialog.show = this.show.bind(this);
+  dialog.showModal = this.showModal.bind(this);
+  dialog.close = this.close.bind(this);
+
+  dialog.addEventListener('submit', maybeHandleSubmit, false);
+
+  if (!('returnValue' in dialog)) {
+    dialog.returnValue = '';
+  }
+
+  if ('MutationObserver' in window) {
+    var mo = new MutationObserver(this.maybeHideModal.bind(this));
+    mo.observe(dialog, {attributes: true, attributeFilter: ['open']});
+  } else {
+    // IE10 and below support. Note that DOMNodeRemoved etc fire _before_ removal. They also
+    // seem to fire even if the element was removed as part of a parent removal. Use the removed
+    // events to force downgrade (useful if removed/immediately added).
+    var removed = false;
+    var cb = function() {
+      removed ? this.downgradeModal() : this.maybeHideModal();
+      removed = false;
+    }.bind(this);
+    var timeout;
+    var delayModel = function(ev) {
+      if (ev.target !== dialog) { return; }  // not for a child element
+      var cand = 'DOMNodeRemoved';
+      removed |= (ev.type.substr(0, cand.length) === cand);
+      window.clearTimeout(timeout);
+      timeout = window.setTimeout(cb, 0);
+    };
+    ['DOMAttrModified', 'DOMNodeRemoved', 'DOMNodeRemovedFromDocument'].forEach(function(name) {
+      dialog.addEventListener(name, delayModel);
+    });
+  }
+  // Note that the DOM is observed inside DialogManager while any dialog
+  // is being displayed as a modal, to catch modal removal from the DOM.
+
+  Object.defineProperty(dialog, 'open', {
+    set: this.setOpen.bind(this),
+    get: dialog.hasAttribute.bind(dialog, 'open')
+  });
+
+  this.backdrop_ = document.createElement('div');
+  this.backdrop_.className = 'backdrop';
+  this.backdrop_.addEventListener('mouseup'  , this.backdropMouseEvent_.bind(this));
+  this.backdrop_.addEventListener('mousedown', this.backdropMouseEvent_.bind(this));
+  this.backdrop_.addEventListener('click'    , this.backdropMouseEvent_.bind(this));
+}
+
+dialogPolyfillInfo.prototype = /** @type {HTMLDialogElement.prototype} */ ({
+
+  get dialog() {
+    return this.dialog_;
+  },
+
+  /**
+   * Maybe remove this dialog from the modal top layer. This is called when
+   * a modal dialog may no longer be tenable, e.g., when the dialog is no
+   * longer open or is no longer part of the DOM.
+   */
+  maybeHideModal: function() {
+    if (this.dialog_.hasAttribute('open') && isConnected(this.dialog_)) { return; }
+    this.downgradeModal();
+  },
+
+  /**
+   * Remove this dialog from the modal top layer, leaving it as a non-modal.
+   */
+  downgradeModal: function() {
+    if (!this.openAsModal_) { return; }
+    this.openAsModal_ = false;
+    this.dialog_.style.zIndex = '';
+
+    // This won't match the native <dialog> exactly because if the user set top on a centered
+    // polyfill dialog, that top gets thrown away when the dialog is closed. Not sure it's
+    // possible to polyfill this perfectly.
+    if (this.replacedStyleTop_) {
+      this.dialog_.style.top = '';
+      this.replacedStyleTop_ = false;
+    }
+
+    // Clear the backdrop and remove from the manager.
+    this.backdrop_.parentNode && this.backdrop_.parentNode.removeChild(this.backdrop_);
+    dialogPolyfill.dm.removeDialog(this);
+  },
+
+  /**
+   * @param {boolean} value whether to open or close this dialog
+   */
+  setOpen: function(value) {
+    if (value) {
+      this.dialog_.hasAttribute('open') || this.dialog_.setAttribute('open', '');
+    } else {
+      this.dialog_.removeAttribute('open');
+      this.maybeHideModal();  // nb. redundant with MutationObserver
+    }
+  },
+
+  /**
+   * Handles mouse events ('mouseup', 'mousedown', 'click') on the fake .backdrop element, redirecting them as if
+   * they were on the dialog itself.
+   *
+   * @param {!Event} e to redirect
+   */
+  backdropMouseEvent_: function(e) {
+    if (!this.dialog_.hasAttribute('tabindex')) {
+      // Clicking on the backdrop should move the implicit cursor, even if dialog cannot be
+      // focused. Create a fake thing to focus on. If the backdrop was _before_ the dialog, this
+      // would not be needed - clicks would move the implicit cursor there.
+      var fake = document.createElement('div');
+      this.dialog_.insertBefore(fake, this.dialog_.firstChild);
+      fake.tabIndex = -1;
+      fake.focus();
+      this.dialog_.removeChild(fake);
+    } else {
+      this.dialog_.focus();
+    }
+
+    var redirectedEvent = document.createEvent('MouseEvents');
+    redirectedEvent.initMouseEvent(e.type, e.bubbles, e.cancelable, window,
+        e.detail, e.screenX, e.screenY, e.clientX, e.clientY, e.ctrlKey,
+        e.altKey, e.shiftKey, e.metaKey, e.button, e.relatedTarget);
+    this.dialog_.dispatchEvent(redirectedEvent);
+    e.stopPropagation();
+  },
+
+  /**
+   * Focuses on the first focusable element within the dialog. This will always blur the current
+   * focus, even if nothing within the dialog is found.
+   */
+  focus_: function() {
+    // Find element with `autofocus` attribute, or fall back to the first form/tabindex control.
+    var target = this.dialog_.querySelector('[autofocus]:not([disabled])');
+    if (!target && this.dialog_.tabIndex >= 0) {
+      target = this.dialog_;
+    }
+    if (!target) {
+      target = findFocusableElementWithin(this.dialog_);
+    }
+    safeBlur(document.activeElement);
+    target && target.focus();
+  },
+
+  /**
+   * Sets the zIndex for the backdrop and dialog.
+   *
+   * @param {number} dialogZ
+   * @param {number} backdropZ
+   */
+  updateZIndex: function(dialogZ, backdropZ) {
+    if (dialogZ < backdropZ) {
+      throw new Error('dialogZ should never be < backdropZ');
+    }
+    this.dialog_.style.zIndex = dialogZ;
+    this.backdrop_.style.zIndex = backdropZ;
+  },
+
+  /**
+   * Shows the dialog. If the dialog is already open, this does nothing.
+   */
+  show: function() {
+    if (!this.dialog_.open) {
+      this.setOpen(true);
+      this.focus_();
+    }
+  },
+
+  /**
+   * Show this dialog modally.
+   */
+  showModal: function() {
+    if (this.dialog_.hasAttribute('open')) {
+      throw new Error('Failed to execute \'showModal\' on dialog: The element is already open, and therefore cannot be opened modally.');
+    }
+    if (!isConnected(this.dialog_)) {
+      throw new Error('Failed to execute \'showModal\' on dialog: The element is not in a Document.');
+    }
+    if (!dialogPolyfill.dm.pushDialog(this)) {
+      throw new Error('Failed to execute \'showModal\' on dialog: There are too many open modal dialogs.');
+    }
+
+    if (createsStackingContext(this.dialog_.parentElement)) {
+      console.warn('A dialog is being shown inside a stacking context. ' +
+          'This may cause it to be unusable. For more information, see this link: ' +
+          'https://github.com/GoogleChrome/dialog-polyfill/#stacking-context');
+    }
+
+    this.setOpen(true);
+    this.openAsModal_ = true;
+
+    // Optionally center vertically, relative to the current viewport.
+    if (dialogPolyfill.needsCentering(this.dialog_)) {
+      dialogPolyfill.reposition(this.dialog_);
+      this.replacedStyleTop_ = true;
+    } else {
+      this.replacedStyleTop_ = false;
+    }
+
+    // Insert backdrop.
+    this.dialog_.parentNode.insertBefore(this.backdrop_, this.dialog_.nextSibling);
+
+    // Focus on whatever inside the dialog.
+    this.focus_();
+  },
+
+  /**
+   * Closes this HTMLDialogElement. This is optional vs clearing the open
+   * attribute, however this fires a 'close' event.
+   *
+   * @param {string=} opt_returnValue to use as the returnValue
+   */
+  close: function(opt_returnValue) {
+    if (!this.dialog_.hasAttribute('open')) {
+      throw new Error('Failed to execute \'close\' on dialog: The element does not have an \'open\' attribute, and therefore cannot be closed.');
+    }
+    this.setOpen(false);
+
+    // Leave returnValue untouched in case it was set directly on the element
+    if (opt_returnValue !== undefined) {
+      this.dialog_.returnValue = opt_returnValue;
+    }
+
+    // Triggering "close" event for any attached listeners on the <dialog>.
+    var closeEvent = new supportCustomEvent('close', {
+      bubbles: false,
+      cancelable: false
+    });
+    safeDispatchEvent(this.dialog_, closeEvent);
+  }
+
+});
+
+var dialogPolyfill = {};
+
+dialogPolyfill.reposition = function(element) {
+  var scrollTop = document.body.scrollTop || document.documentElement.scrollTop;
+  var topValue = scrollTop + (window.innerHeight - element.offsetHeight) / 2;
+  element.style.top = Math.max(scrollTop, topValue) + 'px';
+};
+
+dialogPolyfill.isInlinePositionSetByStylesheet = function(element) {
+  for (var i = 0; i < document.styleSheets.length; ++i) {
+    var styleSheet = document.styleSheets[i];
+    var cssRules = null;
+    // Some browsers throw on cssRules.
+    try {
+      cssRules = styleSheet.cssRules;
+    } catch (e) {}
+    if (!cssRules) { continue; }
+    for (var j = 0; j < cssRules.length; ++j) {
+      var rule = cssRules[j];
+      var selectedNodes = null;
+      // Ignore errors on invalid selector texts.
+      try {
+        selectedNodes = document.querySelectorAll(rule.selectorText);
+      } catch(e) {}
+      if (!selectedNodes || !inNodeList(selectedNodes, element)) {
+        continue;
+      }
+      var cssTop = rule.style.getPropertyValue('top');
+      var cssBottom = rule.style.getPropertyValue('bottom');
+      if ((cssTop && cssTop !== 'auto') || (cssBottom && cssBottom !== 'auto')) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+
+dialogPolyfill.needsCentering = function(dialog) {
+  var computedStyle = window.getComputedStyle(dialog);
+  if (computedStyle.position !== 'absolute') {
+    return false;
+  }
+
+  // We must determine whether the top/bottom specified value is non-auto.  In
+  // WebKit/Blink, checking computedStyle.top == 'auto' is sufficient, but
+  // Firefox returns the used value. So we do this crazy thing instead: check
+  // the inline style and then go through CSS rules.
+  if ((dialog.style.top !== 'auto' && dialog.style.top !== '') ||
+      (dialog.style.bottom !== 'auto' && dialog.style.bottom !== '')) {
+    return false;
+  }
+  return !dialogPolyfill.isInlinePositionSetByStylesheet(dialog);
+};
+
+/**
+ * @param {!Element} element to force upgrade
+ */
+dialogPolyfill.forceRegisterDialog = function(element) {
+  if (window.HTMLDialogElement || element.showModal) {
+    console.warn('This browser already supports <dialog>, the polyfill ' +
+        'may not work correctly', element);
+  }
+  if (element.localName !== 'dialog') {
+    throw new Error('Failed to register dialog: The element is not a dialog.');
+  }
+  new dialogPolyfillInfo(/** @type {!HTMLDialogElement} */ (element));
+};
+
+/**
+ * @param {!Element} element to upgrade, if necessary
+ */
+dialogPolyfill.registerDialog = function(element) {
+  if (!element.showModal) {
+    dialogPolyfill.forceRegisterDialog(element);
+  }
+};
+
+/**
+ * @constructor
+ */
+dialogPolyfill.DialogManager = function() {
+  /** @type {!Array<!dialogPolyfillInfo>} */
+  this.pendingDialogStack = [];
+
+  var checkDOM = this.checkDOM_.bind(this);
+
+  // The overlay is used to simulate how a modal dialog blocks the document.
+  // The blocking dialog is positioned on top of the overlay, and the rest of
+  // the dialogs on the pending dialog stack are positioned below it. In the
+  // actual implementation, the modal dialog stacking is controlled by the
+  // top layer, where z-index has no effect.
+  this.overlay = document.createElement('div');
+  this.overlay.className = '_dialog_overlay';
+  this.overlay.addEventListener('click', function(e) {
+    this.forwardTab_ = undefined;
+    e.stopPropagation();
+    checkDOM([]);  // sanity-check DOM
+  }.bind(this));
+
+  this.handleKey_ = this.handleKey_.bind(this);
+  this.handleFocus_ = this.handleFocus_.bind(this);
+
+  this.zIndexLow_ = 100000;
+  this.zIndexHigh_ = 100000 + 150;
+
+  this.forwardTab_ = undefined;
+
+  if ('MutationObserver' in window) {
+    this.mo_ = new MutationObserver(function(records) {
+      var removed = [];
+      records.forEach(function(rec) {
+        for (var i = 0, c; c = rec.removedNodes[i]; ++i) {
+          if (!(c instanceof Element)) {
+            continue;
+          } else if (c.localName === 'dialog') {
+            removed.push(c);
+          }
+          removed = removed.concat(c.querySelectorAll('dialog'));
+        }
+      });
+      removed.length && checkDOM(removed);
+    });
+  }
+};
+
+/**
+ * Called on the first modal dialog being shown. Adds the overlay and related
+ * handlers.
+ */
+dialogPolyfill.DialogManager.prototype.blockDocument = function() {
+  document.documentElement.addEventListener('focus', this.handleFocus_, true);
+  document.addEventListener('keydown', this.handleKey_);
+  this.mo_ && this.mo_.observe(document, {childList: true, subtree: true});
+};
+
+/**
+ * Called on the first modal dialog being removed, i.e., when no more modal
+ * dialogs are visible.
+ */
+dialogPolyfill.DialogManager.prototype.unblockDocument = function() {
+  document.documentElement.removeEventListener('focus', this.handleFocus_, true);
+  document.removeEventListener('keydown', this.handleKey_);
+  this.mo_ && this.mo_.disconnect();
+};
+
+/**
+ * Updates the stacking of all known dialogs.
+ */
+dialogPolyfill.DialogManager.prototype.updateStacking = function() {
+  var zIndex = this.zIndexHigh_;
+
+  for (var i = 0, dpi; dpi = this.pendingDialogStack[i]; ++i) {
+    dpi.updateZIndex(--zIndex, --zIndex);
+    if (i === 0) {
+      this.overlay.style.zIndex = --zIndex;
+    }
+  }
+
+  // Make the overlay a sibling of the dialog itself.
+  var last = this.pendingDialogStack[0];
+  if (last) {
+    var p = last.dialog.parentNode || document.body;
+    p.appendChild(this.overlay);
+  } else if (this.overlay.parentNode) {
+    this.overlay.parentNode.removeChild(this.overlay);
+  }
+};
+
+/**
+ * @param {Element} candidate to check if contained or is the top-most modal dialog
+ * @return {boolean} whether candidate is contained in top dialog
+ */
+dialogPolyfill.DialogManager.prototype.containedByTopDialog_ = function(candidate) {
+  while (candidate = findNearestDialog(candidate)) {
+    for (var i = 0, dpi; dpi = this.pendingDialogStack[i]; ++i) {
+      if (dpi.dialog === candidate) {
+        return i === 0;  // only valid if top-most
+      }
+    }
+    candidate = candidate.parentElement;
+  }
+  return false;
+};
+
+dialogPolyfill.DialogManager.prototype.handleFocus_ = function(event) {
+  var target = event.composedPath ? event.composedPath()[0] : event.target;
+
+  if (this.containedByTopDialog_(target)) { return; }
+
+  if (document.activeElement === document.documentElement) { return; }
+
+  event.preventDefault();
+  event.stopPropagation();
+  safeBlur(/** @type {Element} */ (target));
+
+  if (this.forwardTab_ === undefined) { return; }  // move focus only from a tab key
+
+  var dpi = this.pendingDialogStack[0];
+  var dialog = dpi.dialog;
+  var position = dialog.compareDocumentPosition(target);
+  if (position & Node.DOCUMENT_POSITION_PRECEDING) {
+    if (this.forwardTab_) {
+      // forward
+      dpi.focus_();
+    } else if (target !== document.documentElement) {
+      // backwards if we're not already focused on <html>
+      document.documentElement.focus();
+    }
+  }
+
+  return false;
+};
+
+dialogPolyfill.DialogManager.prototype.handleKey_ = function(event) {
+  this.forwardTab_ = undefined;
+  if (event.keyCode === 27) {
+    event.preventDefault();
+    event.stopPropagation();
+    var cancelEvent = new supportCustomEvent('cancel', {
+      bubbles: false,
+      cancelable: true
+    });
+    var dpi = this.pendingDialogStack[0];
+    if (dpi && safeDispatchEvent(dpi.dialog, cancelEvent)) {
+      dpi.dialog.close();
+    }
+  } else if (event.keyCode === 9) {
+    this.forwardTab_ = !event.shiftKey;
+  }
+};
+
+/**
+ * Finds and downgrades any known modal dialogs that are no longer displayed. Dialogs that are
+ * removed and immediately readded don't stay modal, they become normal.
+ *
+ * @param {!Array<!HTMLDialogElement>} removed that have definitely been removed
+ */
+dialogPolyfill.DialogManager.prototype.checkDOM_ = function(removed) {
+  // This operates on a clone because it may cause it to change. Each change also calls
+  // updateStacking, which only actually needs to happen once. But who removes many modal dialogs
+  // at a time?!
+  var clone = this.pendingDialogStack.slice();
+  clone.forEach(function(dpi) {
+    if (removed.indexOf(dpi.dialog) !== -1) {
+      dpi.downgradeModal();
+    } else {
+      dpi.maybeHideModal();
+    }
+  });
+};
+
+/**
+ * @param {!dialogPolyfillInfo} dpi
+ * @return {boolean} whether the dialog was allowed
+ */
+dialogPolyfill.DialogManager.prototype.pushDialog = function(dpi) {
+  var allowed = (this.zIndexHigh_ - this.zIndexLow_) / 2 - 1;
+  if (this.pendingDialogStack.length >= allowed) {
+    return false;
+  }
+  if (this.pendingDialogStack.unshift(dpi) === 1) {
+    this.blockDocument();
+  }
+  this.updateStacking();
+  return true;
+};
+
+/**
+ * @param {!dialogPolyfillInfo} dpi
+ */
+dialogPolyfill.DialogManager.prototype.removeDialog = function(dpi) {
+  var index = this.pendingDialogStack.indexOf(dpi);
+  if (index === -1) { return; }
+
+  this.pendingDialogStack.splice(index, 1);
+  if (this.pendingDialogStack.length === 0) {
+    this.unblockDocument();
+  }
+  this.updateStacking();
+};
+
+dialogPolyfill.dm = new dialogPolyfill.DialogManager();
+dialogPolyfill.formSubmitter = null;
+dialogPolyfill.imagemapUseValue = null;
+
+/**
+ * Installs global handlers, such as click listers and native method overrides. These are needed
+ * even if a no dialog is registered, as they deal with <form method="dialog">.
+ */
+if (window.HTMLDialogElement === undefined) {
+
+  /**
+   * If HTMLFormElement translates method="DIALOG" into 'get', then replace the descriptor with
+   * one that returns the correct value.
+   */
+  var testForm = document.createElement('form');
+  testForm.setAttribute('method', 'dialog');
+  if (testForm.method !== 'dialog') {
+    var methodDescriptor = Object.getOwnPropertyDescriptor(HTMLFormElement.prototype, 'method');
+    if (methodDescriptor) {
+      // nb. Some older iOS and older PhantomJS fail to return the descriptor. Don't do anything
+      // and don't bother to update the element.
+      var realGet = methodDescriptor.get;
+      methodDescriptor.get = function() {
+        if (isFormMethodDialog(this)) {
+          return 'dialog';
+        }
+        return realGet.call(this);
+      };
+      var realSet = methodDescriptor.set;
+      /** @this {HTMLElement} */
+      methodDescriptor.set = function(v) {
+        if (typeof v === 'string' && v.toLowerCase() === 'dialog') {
+          return this.setAttribute('method', v);
+        }
+        return realSet.call(this, v);
+      };
+      Object.defineProperty(HTMLFormElement.prototype, 'method', methodDescriptor);
+    }
+  }
+
+  /**
+   * Global 'click' handler, to capture the <input type="submit"> or <button> element which has
+   * submitted a <form method="dialog">. Needed as Safari and others don't report this inside
+   * document.activeElement.
+   */
+  document.addEventListener('click', function(ev) {
+    dialogPolyfill.formSubmitter = null;
+    dialogPolyfill.imagemapUseValue = null;
+    if (ev.defaultPrevented) { return; }  // e.g. a submit which prevents default submission
+
+    var target = /** @type {Element} */ (ev.target);
+    if ('composedPath' in ev) {
+      var path = ev.composedPath();
+      target = path.shift() || target;
+    }
+    if (!target || !isFormMethodDialog(target.form)) { return; }
+
+    var valid = (target.type === 'submit' && ['button', 'input'].indexOf(target.localName) > -1);
+    if (!valid) {
+      if (!(target.localName === 'input' && target.type === 'image')) { return; }
+      // this is a <input type="image">, which can submit forms
+      dialogPolyfill.imagemapUseValue = ev.offsetX + ',' + ev.offsetY;
+    }
+
+    var dialog = findNearestDialog(target);
+    if (!dialog) { return; }
+
+    dialogPolyfill.formSubmitter = target;
+
+  }, false);
+
+  /**
+   * Global 'submit' handler. This handles submits of `method="dialog"` which are invalid, i.e.,
+   * outside a dialog. They get prevented.
+   */
+  document.addEventListener('submit', function(ev) {
+    var form = ev.target;
+    var dialog = findNearestDialog(form);
+    if (dialog) {
+      return;  // ignore, handle there
+    }
+
+    var submitter = findFormSubmitter(ev);
+    var formmethod = submitter && submitter.getAttribute('formmethod') || form.getAttribute('method');
+    if (formmethod === 'dialog') {
+      ev.preventDefault();
+    }
+  });
+
+  /**
+   * Replace the native HTMLFormElement.submit() method, as it won't fire the
+   * submit event and give us a chance to respond.
+   */
+  var nativeFormSubmit = HTMLFormElement.prototype.submit;
+  var replacementFormSubmit = function () {
+    if (!isFormMethodDialog(this)) {
+      return nativeFormSubmit.call(this);
+    }
+    var dialog = findNearestDialog(this);
+    dialog && dialog.close();
+  };
+  HTMLFormElement.prototype.submit = replacementFormSubmit;
+}
+
+export default dialogPolyfill;

--- a/layouts/joomla/editors/buttons.php
+++ b/layouts/joomla/editors/buttons.php
@@ -19,7 +19,6 @@ $buttons = $displayData;
     <?php if ($buttons) : ?>
         <?php foreach ($buttons as $button) : ?>
             <?php echo $this->sublayout('button', $button); ?>
-            <?php echo $this->sublayout('modal', $button); ?>
         <?php endforeach; ?>
     <?php endif; ?>
 </div>

--- a/layouts/joomla/editors/buttons/button.php
+++ b/layouts/joomla/editors/buttons/button.php
@@ -10,22 +10,36 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 
 $button = $displayData;
 
-if ($button->get('name')) :
-    $class   = 'btn btn-secondary';
-    $class  .= ($button->get('class')) ? ' ' . $button->get('class') : null;
-    $class  .= ($button->get('modal')) ? ' modal-button' : null;
-    $href    = '#' . strtolower($button->get('name')) . '_modal';
-    $link    = ($button->get('link')) ? Uri::base() . $button->get('link') : null;
-    $onclick = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
-    $title   = ($button->get('title')) ? $button->get('title') : $button->get('text');
-    $icon    = ($button->get('icon')) ? $button->get('icon') : $button->get('name');
-    ?>
-<button type="button" data-bs-target="<?php echo $href; ?>" class="xtd-button btn btn-secondary <?php echo $class; ?>" <?php echo $button->get('modal') ? 'data-bs-toggle="modal"' : '' ?> title="<?php echo $title; ?>" <?php echo $onclick; ?>>
-    <span class="icon-<?php echo $icon; ?>" aria-hidden="true"></span>
-    <?php echo $button->get('text'); ?>
-</button>
+if (!$button->get('name')) {
+    return;
+}
+
+
+$class   = 'btn btn-secondary';
+$class  .= ($button->get('class')) ? ' ' . $button->get('class') : null;
+$class  .= ($button->get('modal')) ? ' modal-button' : null;
+$href    = '#' . strtolower($button->get('name')) . '_modal';
+$link    = ($button->get('link')) ? Uri::base() . $button->get('link') : null;
+$onclick = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
+$title   = ($button->get('title')) ? $button->get('title') : $button->get('text');
+$icon    = ($button->get('icon')) ? $button->get('icon') : $button->get('name');
+
+if (!$button->get('modal')) :
+?>
+    <button type="button" data-bs-target="<?php echo $href; ?>" class="xtd-button btn btn-secondary <?php echo $class; ?>" <?php echo $button->get('modal') ? 'data-bs-toggle="modal"' : '' ?> title="<?php echo $title; ?>" <?php echo $onclick; ?>>
+        <span class="icon-<?php echo $icon; ?>" aria-hidden="true"></span>
+        <?php echo $button->get('text'); ?>
+    </button>
+<?php else : ?>
+    <joomla-modal-button title="<?= $title; ?>" url="<?= $link; ?>" close-text="<?= Text::_('JLIB_HTML_BEHAVIOR_CLOSE'); ?>" click-outside="true">
+        <button type="button" class="xtd-button btn btn-secondary <?php echo $class; ?>" title="<?php echo $title; ?>" <?php echo $onclick; ?>>
+            <span class="icon-<?php echo $icon; ?>" aria-hidden="true"></span>
+            <?php echo $button->get('text'); ?>
+        </button>
+    </joomla-modal-button>
 <?php endif; ?>

--- a/layouts/joomla/editors/buttons/button.php
+++ b/layouts/joomla/editors/buttons/button.php
@@ -19,7 +19,6 @@ if (!$button->get('name')) {
     return;
 }
 
-
 $class   = 'btn btn-secondary';
 $class  .= ($button->get('class')) ? ' ' . $button->get('class') : null;
 $class  .= ($button->get('modal')) ? ' modal-button' : null;
@@ -28,10 +27,9 @@ $link    = ($button->get('link')) ? Uri::base() . $button->get('link') : null;
 $onclick = ($button->get('onclick')) ? ' onclick="' . $button->get('onclick') . '"' : '';
 $title   = ($button->get('title')) ? $button->get('title') : $button->get('text');
 $icon    = ($button->get('icon')) ? $button->get('icon') : $button->get('name');
-
-if (!$button->get('modal')) :
 ?>
-    <button type="button" data-bs-target="<?php echo $href; ?>" class="xtd-button btn btn-secondary <?php echo $class; ?>" <?php echo $button->get('modal') ? 'data-bs-toggle="modal"' : '' ?> title="<?php echo $title; ?>" <?php echo $onclick; ?>>
+<?php if (!$button->get('modal')) : ?>
+    <button type="button" class="xtd-button btn btn-secondary <?php echo $class; ?>" title="<?php echo $title; ?>" <?php echo $onclick; ?>>
         <span class="icon-<?php echo $icon; ?>" aria-hidden="true"></span>
         <?php echo $button->get('text'); ?>
     </button>

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -117,6 +117,8 @@ $doc = Factory::getDocument();
 $wam = $doc->getWebAssetManager();
 
 $wam->useScript('webcomponent.media-select');
+$wam->registerAndUseScript('joomla-modal', 'system/joomla-modal.min.js', [], ['type' => 'module'], []);
+$wam->registerAndUseStyle('joomla-modal', 'system/joomla-modal.min.css', [], [], []);
 
 Text::script('JFIELD_MEDIA_LAZY_LABEL');
 Text::script('JFIELD_MEDIA_ALT_LABEL');
@@ -139,21 +141,21 @@ Text::script('JFIELD_MEDIA_DOWNLOAD_FILE');
 Text::script('JLIB_APPLICATION_ERROR_SERVER');
 Text::script('JLIB_FORM_MEDIA_PREVIEW_EMPTY', true);
 
-$modalHTML = HTMLHelper::_(
-    'bootstrap.renderModal',
-    'imageModal_' . $id,
-    [
-        'url'         => $url,
-        'title'       => Text::_('JLIB_FORM_CHANGE_IMAGE'),
-        'closeButton' => true,
-        'height'      => '100%',
-        'width'       => '100%',
-        'modalWidth'  => '80',
-        'bodyHeight'  => '60',
-        'footer'      => '<button type="button" class="btn btn-success button-save-selected">' . Text::_('JSELECT') . '</button>'
-            . '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' . Text::_('JCANCEL') . '</button>',
-    ]
-);
+// $modalHTML = HTMLHelper::_(
+//     'bootstrap.renderModal',
+//     'imageModal_' . $id,
+//     [
+//         'url'         => $url,
+//         'title'       => Text::_('JLIB_FORM_CHANGE_IMAGE'),
+//         'closeButton' => true,
+//         'height'      => '100%',
+//         'width'       => '100%',
+//         'modalWidth'  => '80',
+//         'bodyHeight'  => '60',
+//         'footer'      => '<button type="button" class="btn btn-success button-save-selected">' . Text::_('JSELECT') . '</button>'
+//             . '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' . Text::_('JCANCEL') . '</button>',
+//     ]
+// );
 
 $wam->useStyle('webcomponent.field-media')
     ->useScript('webcomponent.field-media');
@@ -168,24 +170,23 @@ if (count($doc->getScriptOptions('media-picker')) === 0) {
 }
 
 ?>
-<joomla-field-media class="field-media-wrapper" type="image" <?php // @TODO add this attribute to the field in order to use it for all media types ?> 
-    base-path="<?php echo Uri::root(); ?>" 
-    root-folder="<?php echo ComponentHelper::getParams('com_media')->get('file_path', 'images'); ?>" 
-    url="<?php echo $url; ?>" 
-    modal-container=".modal" 
-    modal-width="100%" 
-    modal-height="400px" 
-    input=".field-media-input" 
-    button-select=".button-select" 
-    button-clear=".button-clear" 
+<joomla-field-media class="field-media-wrapper" type="image" <?php // @TODO add this attribute to the field in order to use it for all media types ?>
+    base-path="<?php echo Uri::root(); ?>"
+    root-folder="<?php echo ComponentHelper::getParams('com_media')->get('file_path', 'images'); ?>"
+    url="<?php echo $url; ?>"
+    modal-container=".modal"
+    modal-width="100%"
+    modal-height="400px"
+    input=".field-media-input"
+    button-select=".button-select"
+    button-clear=".button-clear"
     button-save-selected=".button-save-selected"
-    preview="static" 
-    preview-container=".field-media-preview" 
-    preview-width="<?php echo $previewWidth; ?>" 
-    preview-height="<?php echo $previewHeight; ?>" 
+    preview="static"
+    preview-container=".field-media-preview"
+    preview-width="<?php echo $previewWidth; ?>"
+    preview-height="<?php echo $previewHeight; ?>"
     supported-extensions="<?php echo str_replace('"', '&quot;', json_encode(['images' => $imagesAllowedExt, 'audios' => $audiosAllowedExt, 'videos' => $videosAllowedExt, 'documents' => $documentsAllowedExt])); ?>
 ">
-    <?php echo $modalHTML; ?>
     <?php if ($showPreview) : ?>
         <div class="field-media-preview">
             <?php echo ' ' . $previewImgEmpty; ?>

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -141,22 +141,6 @@ Text::script('JFIELD_MEDIA_DOWNLOAD_FILE');
 Text::script('JLIB_APPLICATION_ERROR_SERVER');
 Text::script('JLIB_FORM_MEDIA_PREVIEW_EMPTY', true);
 
-// $modalHTML = HTMLHelper::_(
-//     'bootstrap.renderModal',
-//     'imageModal_' . $id,
-//     [
-//         'url'         => $url,
-//         'title'       => Text::_('JLIB_FORM_CHANGE_IMAGE'),
-//         'closeButton' => true,
-//         'height'      => '100%',
-//         'width'       => '100%',
-//         'modalWidth'  => '80',
-//         'bodyHeight'  => '60',
-//         'footer'      => '<button type="button" class="btn btn-success button-save-selected">' . Text::_('JSELECT') . '</button>'
-//             . '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' . Text::_('JCANCEL') . '</button>',
-//     ]
-// );
-
 $wam->useStyle('webcomponent.field-media')
     ->useScript('webcomponent.field-media');
 

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -89,21 +89,6 @@ if (!$readonly) {
 }
 
 if (!$readonly) {
-    //     $modalHTML = HTMLHelper::_(
-    //         'bootstrap.renderModal',
-    //         'userModal_' . $id,
-    //         array(
-    //             'url'         => $uri,
-    //             'title'       => Text::_('JLIB_FORM_CHANGE_USER'),
-    //             'closeButton' => true,
-    //             'height'      => '100%',
-    //             'width'       => '100%',
-    //             'modalWidth'  => 80,
-    //             'bodyHeight'  => 60,
-    //             'footer'      => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' . Text::_('JCANCEL') . '</button>',
-    //         )
-    //     );
-
     $wa = Factory::getDocument()->getWebAssetManager();
     $wa->registerAndUseScript('joomla-modal', 'system/joomla-modal.min.js', [], ['type' => 'module'], []);
     $wa->registerAndUseStyle('joomla-modal', 'system/joomla-modal.min.css', [], [], []);

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -89,34 +89,30 @@ if (!$readonly) {
 }
 
 if (!$readonly) {
-    $modalHTML = HTMLHelper::_(
-        'bootstrap.renderModal',
-        'userModal_' . $id,
-        array(
-            'url'         => $uri,
-            'title'       => Text::_('JLIB_FORM_CHANGE_USER'),
-            'closeButton' => true,
-            'height'      => '100%',
-            'width'       => '100%',
-            'modalWidth'  => 80,
-            'bodyHeight'  => 60,
-            'footer'      => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' . Text::_('JCANCEL') . '</button>',
-        )
-    );
+    //     $modalHTML = HTMLHelper::_(
+    //         'bootstrap.renderModal',
+    //         'userModal_' . $id,
+    //         array(
+    //             'url'         => $uri,
+    //             'title'       => Text::_('JLIB_FORM_CHANGE_USER'),
+    //             'closeButton' => true,
+    //             'height'      => '100%',
+    //             'width'       => '100%',
+    //             'modalWidth'  => 80,
+    //             'bodyHeight'  => 60,
+    //             'footer'      => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' . Text::_('JCANCEL') . '</button>',
+    //         )
+    //     );
 
-    Factory::getDocument()->getWebAssetManager()
-        ->useScript('webcomponent.field-user');
+    $wa = Factory::getDocument()->getWebAssetManager();
+    $wa->registerAndUseScript('joomla-modal', 'system/joomla-modal.min.js', [], ['type' => 'module'], []);
+    $wa->registerAndUseStyle('joomla-modal', 'system/joomla-modal.min.css', [], [], []);
+    $wa->useScript('webcomponent.field-user');
 }
 ?>
-<?php // Create a dummy text field with the user name. ?>
-<joomla-field-user class="field-user-wrapper"
-        url="<?php echo (string) $uri; ?>"
-        modal=".modal"
-        modal-width="100%"
-        modal-height="400px"
-        input=".field-user-input"
-        input-name=".field-user-input-name"
-        button-select=".button-select">
+<?php // Create a dummy text field with the user name.
+?>
+<joomla-field-user class="field-user-wrapper" url="<?php echo (string) $uri; ?>" modal=".modal" modal-width="100%" modal-height="400px" input=".field-user-input" input-name=".field-user-input-name" button-select=".button-select">
     <div class="input-group">
         <input <?php echo ArrayHelper::toString($inputAttributes), $dataAttribute; ?> readonly>
         <?php if (!$readonly) : ?>
@@ -126,11 +122,9 @@ if (!$readonly) {
             </button>
         <?php endif; ?>
     </div>
-    <?php // Create the real field, hidden, that stored the user id. ?>
+    <?php // Create the real field, hidden, that stored the user id.
+    ?>
     <?php if (!$readonly) : ?>
-        <input type="hidden" id="<?php echo $id; ?>_id" name="<?php echo $name; ?>" value="<?php echo $this->escape($value); ?>"
-            class="field-user-input <?php echo $class ? (string) $class : ''?>"
-            data-onchange="<?php echo $this->escape($onchange); ?>">
-        <?php echo $modalHTML; ?>
+        <input type="hidden" id="<?php echo $id; ?>_id" name="<?php echo $name; ?>" value="<?php echo $this->escape($value); ?>" class="field-user-input <?php echo $class ? (string) $class : '' ?>" onchange="<?php echo $this->escape($onchange); ?>">
     <?php endif; ?>
 </joomla-field-user>

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -33,7 +33,6 @@ extract($displayData, EXTR_OVERWRITE);
 $wa = Factory::getDocument()->getWebAssetManager();
 
 $wa->useScript('core');
-// ->useScript('webcomponent.toolbar-button')
 $wa->registerAndUseScript('joomla-modal', 'system/joomla-modal.min.js', [], ['type' => 'module'], []);
 $wa->registerAndUseStyle('joomla-modal', 'system/joomla-modal.min.css', [], [], []);
 

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -11,6 +11,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Utilities\ArrayHelper;
 
 extract($displayData, EXTR_OVERWRITE);
@@ -29,27 +30,23 @@ extract($displayData, EXTR_OVERWRITE);
  * @var   string  $htmlAttributes
  */
 
-Factory::getDocument()->getWebAssetManager()
-    ->useScript('core')
-    ->useScript('webcomponent.toolbar-button');
+$wa = Factory::getDocument()->getWebAssetManager();
+
+$wa->useScript('core');
+// ->useScript('webcomponent.toolbar-button')
+$wa->registerAndUseScript('joomla-modal', 'system/joomla-modal.min.js', [], ['type' => 'module'], []);
+$wa->registerAndUseStyle('joomla-modal', 'system/joomla-modal.min.css', [], [], []);
 
 $tagName = $tagName ?? 'button';
-
-$modalAttrs['data-bs-toggle'] = 'modal';
-$modalAttrs['data-bs-target'] = '#' . $selector;
-
 $idAttr   = !empty($id)        ? ' id="' . $id . '"' : '';
 $listAttr = !empty($listCheck) ? ' list-selection' : '';
-
 ?>
-<joomla-toolbar-button <?php echo $idAttr . $listAttr; ?>>
+<joomla-modal-button <?php echo $idAttr . $listAttr . ' url="' . $url . '" title="' . $text . '"'; ?>>
 <<?php echo $tagName; ?>
-    value="<?php echo $doTask; ?>"
     class="<?php echo $btnClass; ?>"
     <?php echo $htmlAttributes; ?>
-    <?php echo ArrayHelper::toString($modalAttrs); ?>
 >
     <span class="<?php echo $class; ?>" aria-hidden="true"></span>
     <?php echo $text; ?>
 </<?php echo $tagName; ?>>
-</joomla-toolbar-button>
+</joomla-modal-button>

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -31,10 +31,22 @@ extract($displayData, EXTR_OVERWRITE);
 $wa = Factory::getDocument()->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_contenthistory');
 
-$wa->useScript('core')
-    ->useScript('webcomponent.toolbar-button')
-    ->useScript('com_contenthistory.admin-history-versions');
+$wa->useScript('core');
+// ->useScript('webcomponent.toolbar-button')
+$wa->registerAndUseScript('joomla-modal', 'system/joomla-modal.min.js', [], ['type' => 'module'], []);
+$wa->registerAndUseStyle('joomla-modal', 'system/joomla-modal.min.css', [], [], []);
+$wa->useScript('com_contenthistory.admin-history-versions');
 
+$url = 'index.php?' . http_build_query([
+    'option' => 'com_contenthistory',
+    'view' => 'history',
+    'layout' => 'modal',
+    'tmpl' => 'component',
+    'item_id' => $itemId,
+    Session::getFormToken() => 1
+]);
+
+/*
 echo HTMLHelper::_(
     'bootstrap.renderModal',
     'versionsModal',
@@ -58,14 +70,19 @@ echo HTMLHelper::_(
             . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
     )
 );
-?>
+
 <joomla-toolbar-button id="toolbar-versions">
-    <button
-        class="btn btn-primary"
-        type="button"
-        data-bs-target="#versionsModal"
-        data-bs-toggle="modal">
+    <button class="btn btn-primary" type="button" data-bs-target="#versionsModal" data-bs-toggle="modal">
         <span class="icon-code-branch" aria-hidden="true"></span>
         <?php echo $title; ?>
     </button>
 </joomla-toolbar-button>
+
+*/
+?>
+<joomla-modal-button id="jooml-modal-button-preview" title="<?= $title; ?>" url="<?= $url; ?>" close-text="<?= Text::_('JLIB_HTML_BEHAVIOR_CLOSE'); ?>" click-outside="true">
+    <button class="btn btn-primary" type="button">
+        <span class="icon-code-branch" aria-hidden="true"></span>
+        <?php echo $title; ?>
+    </button>
+</joomla-modal-button>

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -32,7 +32,6 @@ $wa = Factory::getDocument()->getWebAssetManager();
 $wa->getRegistry()->addExtensionRegistryFile('com_contenthistory');
 
 $wa->useScript('core');
-// ->useScript('webcomponent.toolbar-button')
 $wa->registerAndUseScript('joomla-modal', 'system/joomla-modal.min.js', [], ['type' => 'module'], []);
 $wa->registerAndUseStyle('joomla-modal', 'system/joomla-modal.min.css', [], [], []);
 $wa->useScript('com_contenthistory.admin-history-versions');
@@ -45,40 +44,6 @@ $url = 'index.php?' . http_build_query([
     'item_id' => $itemId,
     Session::getFormToken() => 1
 ]);
-
-/*
-echo HTMLHelper::_(
-    'bootstrap.renderModal',
-    'versionsModal',
-    array(
-        'url'    => 'index.php?' . http_build_query(
-            [
-                'option' => 'com_contenthistory',
-                'view' => 'history',
-                'layout' => 'modal',
-                'tmpl' => 'component',
-                'item_id' => $itemId,
-                Session::getFormToken() => 1
-            ]
-        ),
-        'title'  => $title,
-        'height' => '100%',
-        'width'  => '100%',
-        'modalWidth'  => '80',
-        'bodyHeight'  => '60',
-        'footer' => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-hidden="true">'
-            . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-    )
-);
-
-<joomla-toolbar-button id="toolbar-versions">
-    <button class="btn btn-primary" type="button" data-bs-target="#versionsModal" data-bs-toggle="modal">
-        <span class="icon-code-branch" aria-hidden="true"></span>
-        <?php echo $title; ?>
-    </button>
-</joomla-toolbar-button>
-
-*/
 ?>
 <joomla-modal-button id="jooml-modal-button-preview" title="<?= $title; ?>" url="<?= $url; ?>" close-text="<?= Text::_('JLIB_HTML_BEHAVIOR_CLOSE'); ?>" click-outside="true">
     <button class="btn btn-primary" type="button">

--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -136,61 +136,6 @@ class PopupButton extends ToolbarButton
     protected function renderButton(array &$options): string
     {
         return parent::renderButton($options);
-
-//         if ((string) $this->getUrl() !== '') {
-//             // Build the options array for the modal
-//             $params = array();
-//             $params['title']      = $options['title'] ?? $options['text'];
-//             $params['url']        = $this->getUrl();
-//             $params['height']     = $options['iframeHeight'] ?? 480;
-//             $params['width']      = $options['iframeWidth'] ?? 640;
-//             $params['bodyHeight'] = $options['bodyHeight'] ?? null;
-//             $params['modalWidth'] = $options['modalWidth'] ?? null;
-
-//             // Place modal div and scripts in a new div
-//             $html[] = '<div class="btn-group" style="width: 0; margin: 0; padding: 0;">';
-
-//             $selector = $options['selector'];
-
-//             $footer = $this->getFooter();
-
-//             if ($footer !== null) {
-//                 $params['footer'] = $footer;
-//             }
-
-//             $html[] = HTMLHelper::_('bootstrap.renderModal', $selector, $params);
-
-//             $html[] = '</div>';
-
-//             // We have to move the modal, otherwise we get problems with the backdrop
-//             // @todo: There should be a better workaround than this
-//             Factory::getDocument()->addScriptDeclaration(
-//                 <<<JS
-// document.addEventListener('DOMContentLoaded', function() {
-//   var modal =document.getElementById('{$options['selector']}');
-//   document.body.appendChild(modal);
-//   if (Joomla && Joomla.Bootstrap && Joomla.Bootstrap.Methods && Joomla.Bootstrap.Methods.Modal) {
-//     Joomla.Bootstrap.Methods.Initialise.Modal(modal);
-//   }
-// });
-// JS
-//             );
-//         }
-
-//         // If an $onClose event is passed, add it to the modal JS object
-//         if ((string) $this->getOnclose() !== '') {
-//             Factory::getDocument()->addScriptDeclaration(
-//                 <<<JS
-// document.addEventListener('DOMContentLoaded', function() {
-// 	document.querySelector('#{$options['selector']}').addEventListener('hide.bs.modal', function() {
-// 	    {$options['onclose']}
-// 	});
-// });
-// JS
-//             );
-//         }
-
-        return implode("\n", $html);
     }
 
     /**

--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -135,62 +135,60 @@ class PopupButton extends ToolbarButton
      */
     protected function renderButton(array &$options): string
     {
-        $html = [];
+        return parent::renderButton($options);
 
-        $html[] = parent::renderButton($options);
+//         if ((string) $this->getUrl() !== '') {
+//             // Build the options array for the modal
+//             $params = array();
+//             $params['title']      = $options['title'] ?? $options['text'];
+//             $params['url']        = $this->getUrl();
+//             $params['height']     = $options['iframeHeight'] ?? 480;
+//             $params['width']      = $options['iframeWidth'] ?? 640;
+//             $params['bodyHeight'] = $options['bodyHeight'] ?? null;
+//             $params['modalWidth'] = $options['modalWidth'] ?? null;
 
-        if ((string) $this->getUrl() !== '') {
-            // Build the options array for the modal
-            $params = array();
-            $params['title']      = $options['title'] ?? $options['text'];
-            $params['url']        = $this->getUrl();
-            $params['height']     = $options['iframeHeight'] ?? 480;
-            $params['width']      = $options['iframeWidth'] ?? 640;
-            $params['bodyHeight'] = $options['bodyHeight'] ?? null;
-            $params['modalWidth'] = $options['modalWidth'] ?? null;
+//             // Place modal div and scripts in a new div
+//             $html[] = '<div class="btn-group" style="width: 0; margin: 0; padding: 0;">';
 
-            // Place modal div and scripts in a new div
-            $html[] = '<div class="btn-group" style="width: 0; margin: 0; padding: 0;">';
+//             $selector = $options['selector'];
 
-            $selector = $options['selector'];
+//             $footer = $this->getFooter();
 
-            $footer = $this->getFooter();
+//             if ($footer !== null) {
+//                 $params['footer'] = $footer;
+//             }
 
-            if ($footer !== null) {
-                $params['footer'] = $footer;
-            }
+//             $html[] = HTMLHelper::_('bootstrap.renderModal', $selector, $params);
 
-            $html[] = HTMLHelper::_('bootstrap.renderModal', $selector, $params);
+//             $html[] = '</div>';
 
-            $html[] = '</div>';
+//             // We have to move the modal, otherwise we get problems with the backdrop
+//             // @todo: There should be a better workaround than this
+//             Factory::getDocument()->addScriptDeclaration(
+//                 <<<JS
+// document.addEventListener('DOMContentLoaded', function() {
+//   var modal =document.getElementById('{$options['selector']}');
+//   document.body.appendChild(modal);
+//   if (Joomla && Joomla.Bootstrap && Joomla.Bootstrap.Methods && Joomla.Bootstrap.Methods.Modal) {
+//     Joomla.Bootstrap.Methods.Initialise.Modal(modal);
+//   }
+// });
+// JS
+//             );
+//         }
 
-            // We have to move the modal, otherwise we get problems with the backdrop
-            // @todo: There should be a better workaround than this
-            Factory::getDocument()->addScriptDeclaration(
-                <<<JS
-document.addEventListener('DOMContentLoaded', function() {
-  var modal =document.getElementById('{$options['selector']}');
-  document.body.appendChild(modal);
-  if (Joomla && Joomla.Bootstrap && Joomla.Bootstrap.Methods && Joomla.Bootstrap.Methods.Modal) {
-    Joomla.Bootstrap.Methods.Initialise.Modal(modal);
-  }
-});
-JS
-            );
-        }
-
-        // If an $onClose event is passed, add it to the modal JS object
-        if ((string) $this->getOnclose() !== '') {
-            Factory::getDocument()->addScriptDeclaration(
-                <<<JS
-document.addEventListener('DOMContentLoaded', function() {
-	document.querySelector('#{$options['selector']}').addEventListener('hide.bs.modal', function() {
-	    {$options['onclose']}
-	});
-});
-JS
-            );
-        }
+//         // If an $onClose event is passed, add it to the modal JS object
+//         if ((string) $this->getOnclose() !== '') {
+//             Factory::getDocument()->addScriptDeclaration(
+//                 <<<JS
+// document.addEventListener('DOMContentLoaded', function() {
+// 	document.querySelector('#{$options['selector']}').addEventListener('hide.bs.modal', function() {
+// 	    {$options['onclose']}
+// 	});
+// });
+// JS
+//             );
+//         }
 
         return implode("\n", $html);
     }

--- a/plugins/editors-xtd/article/article.php
+++ b/plugins/editors-xtd/article/article.php
@@ -62,8 +62,8 @@ class PlgButtonArticle extends CMSPlugin
             return;
         }
 
-        $link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;'
-            . Session::getFormToken() . '=1&amp;editor=' . $name;
+        $link = 'index.php?option=com_content&view=articles&layout=modal&tmpl=component&'
+            . Session::getFormToken() . '=1&editor=' . $name;
 
         $button = new CMSObject();
         $button->modal   = true;

--- a/plugins/editors-xtd/contact/contact.php
+++ b/plugins/editors-xtd/contact/contact.php
@@ -54,8 +54,8 @@ class PlgButtonContact extends CMSPlugin
             || $user->authorise('core.edit.own', 'com_contact')
         ) {
             // The URL for the contacts list
-            $link = 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component&amp;'
-                . Session::getFormToken() . '=1&amp;editor=' . $name;
+            $link = 'index.php?option=com_contact&view=contacts&layout=modal&tmpl=component&'
+                . Session::getFormToken() . '=1&editor=' . $name;
 
             $button = new CMSObject();
             $button->modal   = true;

--- a/plugins/editors-xtd/fields/fields.php
+++ b/plugins/editors-xtd/fields/fields.php
@@ -61,8 +61,8 @@ class PlgButtonFields extends CMSPlugin
             $context = $jinput->get('extension', 'com_content') . '.categories';
         }
 
-        $link = 'index.php?option=com_fields&amp;view=fields&amp;layout=modal&amp;tmpl=component&amp;context='
-            . $context . '&amp;editor=' . $name . '&amp;' . Session::getFormToken() . '=1';
+        $link = 'index.php?option=com_fields&view=fields&layout=modal&tmpl=component&context='
+            . $context . '&editor=' . $name . '&' . Session::getFormToken() . '=1';
 
         $button = new CMSObject();
         $button->modal   = true;

--- a/plugins/editors-xtd/menu/menu.php
+++ b/plugins/editors-xtd/menu/menu.php
@@ -55,8 +55,8 @@ class PlgButtonMenu extends CMSPlugin
             $user->authorise('core.create', 'com_menus')
             || $user->authorise('core.edit', 'com_menus')
         ) {
-            $link = 'index.php?option=com_menus&amp;view=items&amp;layout=modal&amp;tmpl=component&amp;'
-            . Session::getFormToken() . '=1&amp;editor=' . $name;
+            $link = 'index.php?option=com_menus&view=items&layout=modal&tmpl=component&'
+            . Session::getFormToken() . '=1&editor=' . $name;
 
             $button = new CMSObject();
             $button->modal   = true;

--- a/plugins/editors-xtd/module/module.php
+++ b/plugins/editors-xtd/module/module.php
@@ -57,8 +57,8 @@ class PlgButtonModule extends CMSPlugin
             || $user->authorise('core.edit', 'com_modules')
             || $user->authorise('core.edit.own', 'com_modules')
         ) {
-            $link = 'index.php?option=com_modules&amp;view=modules&amp;layout=modal&amp;tmpl=component&amp;editor='
-                    . $name . '&amp;' . Session::getFormToken() . '=1';
+            $link = 'index.php?option=com_modules&view=modules&layout=modal&tmpl=component&editor='
+                    . $name . '&' . Session::getFormToken() . '=1';
             $button = new CMSObject();
             $button->modal   = true;
             $button->link    = $link;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/discussions/32473 .

### Summary of Changes

This is just a rough implementation nowhere near production!!!

The styling is extremely basic!!! 

FWIW editing an article in com_content is the way to test this. That view went from 11 modals depending on Bootstrap to vanilla `dialog` with a little wrapper.

Also the DOM nodes went from
![Screenshot 2022-12-02 at 12 35 15](https://user-images.githubusercontent.com/3889375/205358157-afd03c72-2253-4b3d-9e0a-2814fa6ef3da.png)

to 
![Screenshot 2022-12-02 at 18 50 35](https://user-images.githubusercontent.com/3889375/205358245-dccf5508-063a-43ef-8878-1f67c81b6db9.png)


### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request

Publishing tab, Select user
![Screenshot 2022-12-02 at 19 39 02](https://user-images.githubusercontent.com/3889375/205363317-c93ba555-e9dc-437f-b3e0-c377e91cc99a.png)

Images & links, media select
![Screenshot 2022-12-02 at 19 40 31](https://user-images.githubusercontent.com/3889375/205363771-5664fe39-e9a9-4f81-ae45-1ac43445b323.png)

Content tab, tinyMCE buttons:
![Screenshot 2022-12-02 at 19 43 34](https://user-images.githubusercontent.com/3889375/205363867-dd3d1249-05ac-4f54-a638-fa4d4c0fd8b1.png)
![Screenshot 2022-12-02 at 19 43 26](https://user-images.githubusercontent.com/3889375/205363936-9697f8f9-27cb-4d36-b721-fcf44f864723.png)

Content tab, CodeMirror buttons:
![Screenshot 2022-12-02 at 19 45 43](https://user-images.githubusercontent.com/3889375/205364170-ad5eb34b-16f6-4927-9d41-d178431c0750.png)
![Screenshot 2022-12-02 at 19 43 26](https://user-images.githubusercontent.com/3889375/205363936-9697f8f9-27cb-4d36-b721-fcf44f864723.png)

Toolbar buttons versions:
![Screenshot 2022-12-02 at 19 46 17](https://user-images.githubusercontent.com/3889375/205364258-2d1b418a-dc3f-4e9c-b163-2e7703fa050d.png)

Toolbar buttons preview:
![Screenshot 2022-12-02 at 19 46 56](https://user-images.githubusercontent.com/3889375/205364339-70350757-d962-4856-be8d-d0e20f157313.png)

Toolbar buttons a11y check:
![Screenshot 2022-12-02 at 19 47 36](https://user-images.githubusercontent.com/3889375/205364452-1d056f7c-6567-4033-80f6-c4b666b4a792.png)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed

@Fedik @brianteeman any comments here would be nice