### PR TITLE
[4.3] Fix SQL custom field default value validation

### DIFF
--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -318,7 +318,19 @@ class FieldModel extends AdminModel
 
         try {
             // Perform the check
-            $result = $rule->test(simplexml_import_dom($node->firstChild), $data['default_value']);
+            $element = simplexml_import_dom($node->firstChild);
+            $value   = $data['default_value'];
+
+            if ($data['type'] === 'checkboxes') {
+                $value = explode(',', $value);
+            } elseif ($element['multiple'] && \is_string($value) && \is_array(json_decode($value, true))) {
+                $value = (array)json_decode($value);
+            }
+
+            $form->load($dom->saveXML());
+
+            // Perform the check
+            $result = $rule->test($element, $value, null, null, $form);
 
             // Check if the test succeeded
             return $result === true ? : Text::_('COM_FIELDS_FIELD_INVALID_DEFAULT_VALUE');


### PR DESCRIPTION
Pull Request for Issue #29565.

### Summary of Changes
Some of our **List** base custom fields like SQL uses `OptionsRule` https://github.com/joomla/joomla-cms/blob/4.2-dev/libraries/src/Form/Rule/OptionsRule.php to validate it's data. This rule requires a valid `$form` object to validate data in case the options for the field not defined in XML but dynamic defined (for example, from database) via `getOptions` method of the field type

This PR changes logic of `checkDefaultValue` method in `FieldModel` class to handle default value properly for these kind of custom fields. It is a bug fix, but I decided to implement the change to 4.3 branch so that we have more time for reviewing and testing the change. I also includes the change from PR https://github.com/joomla/joomla-cms/pull/39354 (for 4.2 branch) so to avoid merge conflict.

Ping @laoneo for checking this change.

### Testing Instructions
1. Use Joomla 4.3
2. Follow instructions at https://github.com/joomla/joomla-cms/issues/29565 , confirm the issue
3. Apply patch, confirm the issue fixed.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
