### PR TITLE
[4.3] fix typo

### DIFF
--- a/tests/Unit/Plugin/Authentication/Ldap/LdapPluginTest.php
+++ b/tests/Unit/Plugin/Authentication/Ldap/LdapPluginTest.php
@@ -131,7 +131,7 @@ class LdapPluginTest extends UnitTestCase
     }
 
     /**
-     * @testdox  can perform an authentication using anynomous search
+     * @testdox  can perform an authentication using anonymous search
      *
      * @return  void
      *
@@ -186,7 +186,7 @@ class LdapPluginTest extends UnitTestCase
     }
 
     /**
-     * @testdox  can perform an authentication using anynomous search
+     * @testdox  can perform an authentication using anonymous search
      *
      * @return  void
      *
@@ -209,7 +209,7 @@ class LdapPluginTest extends UnitTestCase
     }
 
     /**
-     * @testdox  can perform an authentication using anynomous search
+     * @testdox  can perform an authentication using anonymous search
      *
      * @return  void
      *


### PR DESCRIPTION
In the new unit test got the ldap plugin there is a typo. This PR fixes that.

code review only
