### PR TITLE
Fix contact category association

### DIFF
--- a/administrator/components/com_categories/src/Helper/CategoryAssociationHelper.php
+++ b/administrator/components/com_categories/src/Helper/CategoryAssociationHelper.php
@@ -53,9 +53,17 @@ abstract class CategoryAssociationHelper
                 if (class_exists($helperClassname) && \is_callable(array($helperClassname, 'getCategoryRoute'))) {
                     $return[$tag] = $helperClassname::getCategoryRoute($item, $tag, $layout);
                 } else {
-                    $viewLayout = $layout ? '&layout=' . $layout : '';
+                    $link = 'index.php?option=' . $extension . '&view=category&id=' . $item;
 
-                    $return[$tag] = 'index.php?option=' . $extension . '&view=category&id=' . $item . $viewLayout;
+                    if ($tag && $tag !== '*') {
+                        $link .= '&lang=' . $tag;
+                    }
+
+                    if ($layout) {
+                        $link .= '&layout=' . $layout;
+                    }
+                    
+                    $return[$tag] = $link;
                 }
             }
         }

--- a/administrator/components/com_categories/src/Helper/CategoryAssociationHelper.php
+++ b/administrator/components/com_categories/src/Helper/CategoryAssociationHelper.php
@@ -62,7 +62,7 @@ abstract class CategoryAssociationHelper
                     if ($layout) {
                         $link .= '&layout=' . $layout;
                     }
-                    
+
                     $return[$tag] = $link;
                 }
             }


### PR DESCRIPTION
Fixes #39346.

### Summary of Changes
This PR fixes wrong link generated by Language Switcher module for contact category association. Please look at https://github.com/joomla/joomla-cms/issues/39346 to understand the issue.


### Testing Instructions
1. Setup a sample multilingual website using Joomla 4.2
2. Follow the instructions at https://github.com/joomla/joomla-cms/issues/39346 , confirm the issue.
3. Apply patch, confirm the issue fixed.

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed

- [x] No documentation changes for manual.joomla.org needed
