### PR TITLE
Added title to awesomplete results list

### DIFF
--- a/build/media_source/com_finder/js/finder.es6.js
+++ b/build/media_source/com_finder/js/finder.es6.js
@@ -68,6 +68,7 @@
       // Handle the auto suggestion
       if (Joomla.getOptions('finder-search')) {
         searchword.awesomplete = new Awesomplete(searchword);
+        searchword.awesomplete.ul.setAttribute('title', 'Results list'); // Temporary accessibility fix
 
         // If the current value is empty, set the previous value.
         searchword.addEventListener('input', onInputChange);


### PR DESCRIPTION
### Summary of Changes
Awesomplete is raising a Serious issue in axe for a missing title / aria-label attribute.

![image](https://user-images.githubusercontent.com/55460781/205988857-c7e936ef-cbea-48b5-a0db-dd2910ae18d8.png)

Added title attribute to results list.

There is an [open issue](https://github.com/LeaVerou/awesomplete/issues/17200) about this, a fix looks to be implemented with the `listLabel` property, but it is currently unreleased.

### Testing Instructions

- Setup `Smart Search > Search` menu item (`Smart Search > Search Suggestions` global setting must be enabled)
- Run axe browser plugin / find awesomplete list ul and check for title / aria-label attribute


### Actual result BEFORE applying this Pull Request
No title / aria-label attribute present on Awesomplete list


### Expected result AFTER applying this Pull Request
Title attribute present on Awesomplete list


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
