### PR TITLE
Add PHP 8.2 to PHP version check plugin

### DIFF
--- a/plugins/quickicon/phpversioncheck/phpversioncheck.php
+++ b/plugins/quickicon/phpversioncheck/phpversioncheck.php
@@ -133,6 +133,10 @@ class PlgQuickiconPhpVersionCheck extends CMSPlugin
                 'security' => '2023-11-25',
                 'eos'      => '2024-11-25',
             ),
+            '8.2' => array(
+                'security' => '2024-12-08',
+                'eos'      => '2025-12-08',
+            ),
         );
 
         // Fill our return array with default values


### PR DESCRIPTION
### Summary of Changes

Adds PHP 8.2 to PHP version check plugin

### Testing Instructions

Review.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
