### PR TITLE
[5.0] Remove IE9 code, don't force download of JSON documents

### DIFF
--- a/libraries/src/Document/JsonDocument.php
+++ b/libraries/src/Document/JsonDocument.php
@@ -43,16 +43,7 @@ class JsonDocument extends Document
         parent::__construct($options);
 
         // Set mime type
-        if (
-            isset($_SERVER['HTTP_ACCEPT'])
-            && strpos($_SERVER['HTTP_ACCEPT'], 'application/json') === false
-            && strpos($_SERVER['HTTP_ACCEPT'], 'text/html') !== false
-        ) {
-            // Internet Explorer < 10
-            $this->_mime = 'text/plain';
-        } else {
-            $this->_mime = 'application/json';
-        }
+        $this->_mime = 'application/json';
 
         // Set document type
         $this->_type = 'json';

--- a/libraries/src/Document/JsonDocument.php
+++ b/libraries/src/Document/JsonDocument.php
@@ -66,11 +66,6 @@ class JsonDocument extends Document
 
         $app->allowCache($cache);
 
-        if ($this->_mime === 'application/json') {
-            // Browser other than Internet Explorer < 10
-            $app->setHeader('Content-Disposition', 'attachment; filename="' . $this->getName() . '.json"', true);
-        }
-
         parent::render($cache, $params);
 
         return $this->getBuffer();


### PR DESCRIPTION
### Summary of Changes

Removes some IE9 code which is causing modern browsers to render JSON documents as plaintext. Also removes forcing file download, which wasn't working anyway because of the first part of code.

### Testing Instructions

Enter a JSON page, e.g. `index.php?option=com_ajax&format=json`. Confirm that JSON is rendered in the browser.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
