### PR TITLE
[6.2] Use static closures in service providers

### DIFF
--- a/administrator/components/com_actionlogs/services/provider.php
+++ b/administrator/components/com_actionlogs/services/provider.php
@@ -42,7 +42,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_admin/services/provider.php
+++ b/administrator/components/com_admin/services/provider.php
@@ -43,7 +43,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new AdminComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_associations/services/provider.php
+++ b/administrator/components/com_associations/services/provider.php
@@ -42,7 +42,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_banners/services/provider.php
+++ b/administrator/components/com_banners/services/provider.php
@@ -49,7 +49,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new BannersComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setRegistry($container->get(Registry::class));

--- a/administrator/components/com_cache/services/provider.php
+++ b/administrator/components/com_cache/services/provider.php
@@ -42,7 +42,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_categories/services/provider.php
+++ b/administrator/components/com_categories/services/provider.php
@@ -43,7 +43,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new CategoriesComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_checkin/services/provider.php
+++ b/administrator/components/com_checkin/services/provider.php
@@ -42,7 +42,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_config/services/provider.php
+++ b/administrator/components/com_config/services/provider.php
@@ -45,7 +45,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new ConfigComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_contact/services/provider.php
+++ b/administrator/components/com_contact/services/provider.php
@@ -53,7 +53,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new ContactComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setRegistry($container->get(Registry::class));

--- a/administrator/components/com_content/services/provider.php
+++ b/administrator/components/com_content/services/provider.php
@@ -53,7 +53,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new ContentComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setRegistry($container->get(Registry::class));

--- a/administrator/components/com_contenthistory/services/provider.php
+++ b/administrator/components/com_contenthistory/services/provider.php
@@ -42,7 +42,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_cpanel/services/provider.php
+++ b/administrator/components/com_cpanel/services/provider.php
@@ -42,7 +42,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_fields/services/provider.php
+++ b/administrator/components/com_fields/services/provider.php
@@ -45,7 +45,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new FieldsComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_finder/services/provider.php
+++ b/administrator/components/com_finder/services/provider.php
@@ -46,7 +46,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new FinderComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
                 $component->setRouterFactory($container->get(RouterFactoryInterface::class));

--- a/administrator/components/com_installer/services/provider.php
+++ b/administrator/components/com_installer/services/provider.php
@@ -43,7 +43,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new InstallerComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
                 $component->setRegistry($container->get(Registry::class));

--- a/administrator/components/com_joomlaupdate/services/provider.php
+++ b/administrator/components/com_joomlaupdate/services/provider.php
@@ -42,7 +42,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_languages/services/provider.php
+++ b/administrator/components/com_languages/services/provider.php
@@ -43,7 +43,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new LanguagesComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
                 $component->setRegistry($container->get(Registry::class));

--- a/administrator/components/com_login/services/provider.php
+++ b/administrator/components/com_login/services/provider.php
@@ -41,7 +41,7 @@ return new class implements ServiceProviderInterface
         $container->registerServiceProvider(new ComponentDispatcherFactory('\\Joomla\\Component\\Login'));
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
 

--- a/administrator/components/com_mails/services/provider.php
+++ b/administrator/components/com_mails/services/provider.php
@@ -42,7 +42,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_media/services/provider.php
+++ b/administrator/components/com_media/services/provider.php
@@ -42,7 +42,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_menus/services/provider.php
+++ b/administrator/components/com_menus/services/provider.php
@@ -47,7 +47,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MenusComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setRegistry($container->get(Registry::class));

--- a/administrator/components/com_messages/services/provider.php
+++ b/administrator/components/com_messages/services/provider.php
@@ -43,7 +43,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MessagesComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
                 $component->setRegistry($container->get(Registry::class));

--- a/administrator/components/com_modules/services/provider.php
+++ b/administrator/components/com_modules/services/provider.php
@@ -43,7 +43,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new ModulesComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_newsfeeds/services/provider.php
+++ b/administrator/components/com_newsfeeds/services/provider.php
@@ -53,7 +53,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new NewsfeedsComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setRegistry($container->get(Registry::class));

--- a/administrator/components/com_plugins/services/provider.php
+++ b/administrator/components/com_plugins/services/provider.php
@@ -41,7 +41,7 @@ return new class implements ServiceProviderInterface
         $container->registerServiceProvider(new ComponentDispatcherFactory('\\Joomla\\Component\\Plugins'));
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
 

--- a/administrator/components/com_postinstall/services/provider.php
+++ b/administrator/components/com_postinstall/services/provider.php
@@ -41,7 +41,7 @@ return new class implements ServiceProviderInterface
         $container->registerServiceProvider(new ComponentDispatcherFactory('\\Joomla\\Component\\Postinstall'));
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
 

--- a/administrator/components/com_privacy/services/provider.php
+++ b/administrator/components/com_privacy/services/provider.php
@@ -46,7 +46,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new PrivacyComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_redirect/services/provider.php
+++ b/administrator/components/com_redirect/services/provider.php
@@ -43,7 +43,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new RedirectComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
                 $component->setRegistry($container->get(Registry::class));

--- a/administrator/components/com_scheduler/services/provider.php
+++ b/administrator/components/com_scheduler/services/provider.php
@@ -52,7 +52,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new SchedulerComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setRegistry($container->get(Registry::class));

--- a/administrator/components/com_tags/services/provider.php
+++ b/administrator/components/com_tags/services/provider.php
@@ -44,7 +44,7 @@ return new class implements ServiceProviderInterface
         $container->registerServiceProvider(new RouterFactory('\\Joomla\\Component\\Tags'));
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new TagsComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
                 $component->setRouterFactory($container->get(RouterFactoryInterface::class));

--- a/administrator/components/com_templates/services/provider.php
+++ b/administrator/components/com_templates/services/provider.php
@@ -43,7 +43,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new TemplatesComponent($container->get(ComponentDispatcherFactoryInterface::class));
 
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));

--- a/administrator/components/com_users/services/provider.php
+++ b/administrator/components/com_users/services/provider.php
@@ -46,7 +46,7 @@ return new class implements ServiceProviderInterface
 
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new UsersComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
                 $component->setRouterFactory($container->get(RouterFactoryInterface::class));

--- a/administrator/components/com_workflow/services/provider.php
+++ b/administrator/components/com_workflow/services/provider.php
@@ -41,7 +41,7 @@ return new class implements ServiceProviderInterface
         $container->registerServiceProvider(new ComponentDispatcherFactory('\\Joomla\\Component\\Workflow'));
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new MVCComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
 

--- a/administrator/components/com_wrapper/services/provider.php
+++ b/administrator/components/com_wrapper/services/provider.php
@@ -44,7 +44,7 @@ return new class implements ServiceProviderInterface
         $container->registerServiceProvider(new RouterFactory('\\Joomla\\Component\\Wrapper'));
         $container->set(
             ComponentInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $component = new WrapperComponent($container->get(ComponentDispatcherFactoryInterface::class));
                 $component->setMVCFactory($container->get(MVCFactoryInterface::class));
                 $component->setRouterFactory($container->get(RouterFactoryInterface::class));

--- a/installation/src/Service/Provider/Application.php
+++ b/installation/src/Service/Provider/Application.php
@@ -41,7 +41,7 @@ class Application implements ServiceProviderInterface
     {
         $container->share(
             InstallationApplication::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $app = new InstallationApplication(null, $container->get('config'), null, $container);
 
                 // The session service provider needs Factory::$application, set it if still null
@@ -61,7 +61,7 @@ class Application implements ServiceProviderInterface
         // Inject a custom JSON error renderer
         $container->share(
             JsonRenderer::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new \Joomla\CMS\Installation\Error\Renderer\JsonRenderer();
             }
         );

--- a/libraries/src/Service/Provider/Application.php
+++ b/libraries/src/Service/Provider/Application.php
@@ -74,7 +74,7 @@ class Application implements ServiceProviderInterface
         $container->alias(AdministratorApplication::class, 'JApplicationAdministrator')
             ->share(
                 'JApplicationAdministrator',
-                function (Container $container) {
+                static function (Container $container) {
                     $app = new AdministratorApplication(null, $container->get('config'), null, $container);
 
                     // The session service provider needs Factory::$application, set it if still null
@@ -96,7 +96,7 @@ class Application implements ServiceProviderInterface
         $container->alias(SiteApplication::class, 'JApplicationSite')
             ->share(
                 'JApplicationSite',
-                function (Container $container) {
+                static function (Container $container) {
                     $app = new SiteApplication(null, $container->get('config'), null, $container);
 
                     // The session service provider needs Factory::$application, set it if still null
@@ -119,7 +119,7 @@ class Application implements ServiceProviderInterface
         $container->alias(ConsoleApplication::class, BaseConsoleApplication::class)
             ->share(
                 BaseConsoleApplication::class,
-                function (Container $container) {
+                static function (Container $container) {
                     $dispatcher = $container->get(DispatcherInterface::class);
 
                     // Console uses the default system language
@@ -151,7 +151,7 @@ class Application implements ServiceProviderInterface
             ->alias(WritableLoaderInterface::class, LoaderInterface::class)
             ->share(
                 LoaderInterface::class,
-                function (Container $container) {
+                static function (Container $container) {
                     $mapping = [
                         SessionGcCommand::getDefaultName()                => SessionGcCommand::class,
                         SessionMetadataGcCommand::getDefaultName()        => SessionMetadataGcCommand::class,
@@ -183,7 +183,7 @@ class Application implements ServiceProviderInterface
         $container->alias(ApiApplication::class, 'JApplicationApi')
             ->share(
                 'JApplicationApi',
-                function (Container $container) {
+                static function (Container $container) {
                     $app = new ApiApplication(null, $container->get('config'), null, $container);
 
                     // The session service provider needs Factory::$application, set it if still null

--- a/libraries/src/Service/Provider/Authentication.php
+++ b/libraries/src/Service/Provider/Authentication.php
@@ -47,7 +47,7 @@ class Authentication implements ServiceProviderInterface
             ->alias(BaseArgon2iHandler::class, Argon2iHandler::class)
             ->share(
                 Argon2iHandler::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new Argon2iHandler();
                 },
                 true
@@ -57,7 +57,7 @@ class Authentication implements ServiceProviderInterface
             ->alias(BaseArgon2idHandler::class, Argon2idHandler::class)
             ->share(
                 Argon2idHandler::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new Argon2idHandler();
                 },
                 true
@@ -66,7 +66,7 @@ class Authentication implements ServiceProviderInterface
         $container->alias('password.handler.chained', ChainedHandler::class)
             ->share(
                 ChainedHandler::class,
-                function (Container $container) {
+                static function (Container $container) {
                     $handler = new ChainedHandler();
 
                     // Load the chain with supported core handlers
@@ -94,7 +94,7 @@ class Authentication implements ServiceProviderInterface
             ->alias('password.handler.bcrypt', BCryptHandler::class)
             ->share(
                 BCryptHandler::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new BCryptHandler();
                 },
                 true
@@ -103,7 +103,7 @@ class Authentication implements ServiceProviderInterface
         $container->alias('password.handler.md5', MD5Handler::class)
             ->share(
                 MD5Handler::class,
-                function (Container $container) {
+                static function (Container $container) {
                     @trigger_error(
                         sprintf(
                             'The "%1$s" class service is deprecated, use the "%2$s" service for the active password handler instead.',
@@ -121,7 +121,7 @@ class Authentication implements ServiceProviderInterface
         $container->alias('password.handler.phpass', PHPassHandler::class)
             ->share(
                 PHPassHandler::class,
-                function (Container $container) {
+                static function (Container $container) {
                     @trigger_error(
                         sprintf(
                             'The "%1$s" class service is deprecated, use the "%2$s" service for the active password handler instead.',

--- a/libraries/src/Service/Provider/CacheController.php
+++ b/libraries/src/Service/Provider/CacheController.php
@@ -40,7 +40,7 @@ class CacheController implements ServiceProviderInterface
             ->alias(CacheControllerFactory::class, CacheControllerFactoryInterface::class)
             ->share(
                 CacheControllerFactoryInterface::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new CacheControllerFactory();
                 },
                 true

--- a/libraries/src/Service/Provider/Config.php
+++ b/libraries/src/Service/Provider/Config.php
@@ -38,7 +38,7 @@ class Config implements ServiceProviderInterface
         $container->alias('config', 'JConfig')
             ->share(
                 'JConfig',
-                function (Container $container) {
+                static function (Container $container) {
                     if (!is_file(JPATH_CONFIGURATION . '/configuration.php')) {
                         return new Registry();
                     }

--- a/libraries/src/Service/Provider/Console.php
+++ b/libraries/src/Service/Provider/Console.php
@@ -58,7 +58,7 @@ class Console implements ServiceProviderInterface
     {
         $container->share(
             SessionGcCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 /*
                  * The command will need the same session handler that web apps use to run correctly,
                  * since this is based on an option we need to inject the container
@@ -73,7 +73,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             SessionMetadataGcCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new SessionMetadataGcCommand($container->get('session'), $container->get(MetadataManager::class));
             },
             true
@@ -81,7 +81,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             ExportCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new ExportCommand($container->get('db'));
             },
             true
@@ -89,7 +89,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             ImportCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new ImportCommand($container->get('db'));
             },
             true
@@ -97,7 +97,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             SiteDownCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new SiteDownCommand();
             },
             true
@@ -105,7 +105,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             SiteUpCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new SiteUpCommand();
             },
             true
@@ -113,7 +113,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             SetConfigurationCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new SetConfigurationCommand();
             },
             true
@@ -121,7 +121,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             GetConfigurationCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new GetConfigurationCommand();
             },
             true
@@ -129,7 +129,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             ExtensionsListCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new ExtensionsListCommand($container->get('db'));
             },
             true
@@ -137,7 +137,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             CheckJoomlaUpdatesCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new CheckJoomlaUpdatesCommand();
             },
             true
@@ -145,7 +145,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             ExtensionRemoveCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new ExtensionRemoveCommand($container->get(DatabaseInterface::class));
             },
             true
@@ -153,7 +153,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             ExtensionInstallCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new ExtensionInstallCommand();
             },
             true
@@ -161,7 +161,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             ExtensionDiscoverCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new ExtensionDiscoverCommand();
             },
             true
@@ -169,7 +169,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             ExtensionDiscoverInstallCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new ExtensionDiscoverInstallCommand($container->get('db'));
             },
             true
@@ -177,7 +177,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             ExtensionDiscoverListCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new ExtensionDiscoverListCommand($container->get('db'));
             },
             true
@@ -185,7 +185,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             UpdateCoreCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new UpdateCoreCommand($container->get('db'));
             },
             true
@@ -193,7 +193,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             FinderIndexCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new FinderIndexCommand($container->get('db'));
             },
             true
@@ -201,7 +201,7 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             TasksListCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new TasksListCommand();
             },
             true
@@ -209,14 +209,14 @@ class Console implements ServiceProviderInterface
 
         $container->share(
             TasksRunCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new TasksRunCommand();
             }
         );
 
         $container->share(
             TasksStateCommand::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new TasksStateCommand();
             }
         );

--- a/libraries/src/Service/Provider/Database.php
+++ b/libraries/src/Service/Provider/Database.php
@@ -43,7 +43,7 @@ class Database implements ServiceProviderInterface
             ->alias(DatabaseDriver::class, DatabaseInterface::class)
             ->share(
                 DatabaseInterface::class,
-                function (Container $container) {
+                static function (Container $container) {
                     $conf = $container->get('config');
 
                     /**

--- a/libraries/src/Service/Provider/Dispatcher.php
+++ b/libraries/src/Service/Provider/Dispatcher.php
@@ -40,7 +40,7 @@ class Dispatcher implements ServiceProviderInterface
             ->alias(EventDispatcher::class, EventDispatcherInterface::class)
             ->share(
                 EventDispatcherInterface::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new EventDispatcher();
                 },
                 true

--- a/libraries/src/Service/Provider/Document.php
+++ b/libraries/src/Service/Provider/Document.php
@@ -41,7 +41,7 @@ class Document implements ServiceProviderInterface
             ->alias(Factory::class, FactoryInterface::class)
             ->share(
                 FactoryInterface::class,
-                function (Container $container) {
+                static function (Container $container) {
                     $factory = new Factory();
                     $factory->setCacheControllerFactory($container->get(CacheControllerFactoryInterface::class));
 

--- a/libraries/src/Service/Provider/Form.php
+++ b/libraries/src/Service/Provider/Form.php
@@ -41,7 +41,7 @@ class Form implements ServiceProviderInterface
             ->alias(FormFactory::class, FormFactoryInterface::class)
             ->share(
                 FormFactoryInterface::class,
-                function (Container $container) {
+                static function (Container $container) {
                     $factory = new FormFactory();
                     $factory->setDatabase($container->get(DatabaseInterface::class));
 

--- a/libraries/src/Service/Provider/HTMLRegistry.php
+++ b/libraries/src/Service/Provider/HTMLRegistry.php
@@ -37,7 +37,7 @@ class HTMLRegistry implements ServiceProviderInterface
     {
         $container->share(
             Registry::class,
-            function (Container $container) {
+            static function (Container $container) {
                 return new Registry();
             },
             true

--- a/libraries/src/Service/Provider/Language.php
+++ b/libraries/src/Service/Provider/Language.php
@@ -40,7 +40,7 @@ class Language implements ServiceProviderInterface
             ->alias(CachingLanguageFactory::class, LanguageFactoryInterface::class)
             ->share(
                 LanguageFactoryInterface::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new CachingLanguageFactory();
                 },
                 true

--- a/libraries/src/Service/Provider/Logger.php
+++ b/libraries/src/Service/Provider/Logger.php
@@ -39,7 +39,7 @@ class Logger implements ServiceProviderInterface
         $container->alias('logger', LoggerInterface::class)
             ->share(
                 LoggerInterface::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return Log::createDelegatedLogger();
                 },
                 true

--- a/libraries/src/Service/Provider/Menu.php
+++ b/libraries/src/Service/Provider/Menu.php
@@ -42,7 +42,7 @@ class Menu implements ServiceProviderInterface
             ->alias(MenuFactory::class, MenuFactoryInterface::class)
             ->share(
                 MenuFactoryInterface::class,
-                function (Container $container) {
+                static function (Container $container) {
                     $factory = new MenuFactory();
                     $factory->setCacheControllerFactory($container->get(CacheControllerFactoryInterface::class));
                     $factory->setDatabase($container->get(DatabaseInterface::class));

--- a/libraries/src/Service/Provider/Pathway.php
+++ b/libraries/src/Service/Provider/Pathway.php
@@ -41,7 +41,7 @@ class Pathway implements ServiceProviderInterface
             ->alias('pathway.site', SitePathway::class)
             ->share(
                 SitePathway::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new SitePathway($container->get(SiteApplication::class));
                 },
                 true
@@ -52,7 +52,7 @@ class Pathway implements ServiceProviderInterface
             ->alias('pathway', \Joomla\CMS\Pathway\Pathway::class)
             ->share(
                 \Joomla\CMS\Pathway\Pathway::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new \Joomla\CMS\Pathway\Pathway();
                 },
                 true

--- a/libraries/src/Service/Provider/Router.php
+++ b/libraries/src/Service/Provider/Router.php
@@ -43,7 +43,7 @@ class Router implements ServiceProviderInterface
             ->alias('JRouterSite', SiteRouter::class)
             ->share(
                 SiteRouter::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new SiteRouter($container->get(SiteApplication::class));
                 },
                 true
@@ -53,7 +53,7 @@ class Router implements ServiceProviderInterface
             ->alias('JRouterAdministrator', AdministratorRouter::class)
             ->share(
                 AdministratorRouter::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new AdministratorRouter();
                 },
                 true
@@ -62,7 +62,7 @@ class Router implements ServiceProviderInterface
         $container->alias('ApiRouter', ApiRouter::class)
             ->share(
                 ApiRouter::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new ApiRouter($container->get(ApiApplication::class));
                 },
                 true

--- a/libraries/src/Service/Provider/Session.php
+++ b/libraries/src/Service/Provider/Session.php
@@ -59,7 +59,7 @@ class Session implements ServiceProviderInterface
     {
         $container->share(
             'session.web.administrator',
-            function (Container $container) {
+            static function (Container $container) {
                 /** @var Registry $config */
                 $config = $container->get('config');
                 $app    = Factory::getApplication();
@@ -83,10 +83,10 @@ class Session implements ServiceProviderInterface
                 $handler = $container->get('session.factory')->createSessionHandler($options);
 
                 if (!$container->has('session.handler')) {
-                    $this->registerSessionHandlerAsService($container, $handler);
+                    self::registerSessionHandlerAsService($container, $handler);
                 }
 
-                return $this->buildSession(
+                return self::buildSession(
                     new JoomlaStorage($app->input, $handler, $options),
                     $app,
                     $container->get(DispatcherInterface::class),
@@ -98,7 +98,7 @@ class Session implements ServiceProviderInterface
 
         $container->share(
             'session.web.installation',
-            function (Container $container) {
+            static function (Container $container) {
                 /** @var Registry $config */
                 $config = $container->get('config');
                 $app    = Factory::getApplication();
@@ -128,10 +128,10 @@ class Session implements ServiceProviderInterface
                 $handler = $container->get('session.factory')->createSessionHandler($options);
 
                 if (!$container->has('session.handler')) {
-                    $this->registerSessionHandlerAsService($container, $handler);
+                    self::registerSessionHandlerAsService($container, $handler);
                 }
 
-                return $this->buildSession(
+                return self::buildSession(
                     new JoomlaStorage($app->input, $handler),
                     $app,
                     $container->get(DispatcherInterface::class),
@@ -143,7 +143,7 @@ class Session implements ServiceProviderInterface
 
         $container->share(
             'session.web.site',
-            function (Container $container) {
+            static function (Container $container) {
                 /** @var Registry $config */
                 $config = $container->get('config');
                 $app    = Factory::getApplication();
@@ -167,10 +167,10 @@ class Session implements ServiceProviderInterface
                 $handler = $container->get('session.factory')->createSessionHandler($options);
 
                 if (!$container->has('session.handler')) {
-                    $this->registerSessionHandlerAsService($container, $handler);
+                    self::registerSessionHandlerAsService($container, $handler);
                 }
 
-                return $this->buildSession(
+                return self::buildSession(
                     new JoomlaStorage($app->input, $handler, $options),
                     $app,
                     $container->get(DispatcherInterface::class),
@@ -182,7 +182,7 @@ class Session implements ServiceProviderInterface
 
         $container->share(
             'session.cli',
-            function (Container $container) {
+            static function (Container $container) {
                 /** @var Registry $config */
                 $config = $container->get('config');
                 $app    = Factory::getApplication();
@@ -207,10 +207,10 @@ class Session implements ServiceProviderInterface
                 $handler = $container->get('session.factory')->createSessionHandler($options);
 
                 if (!$container->has('session.handler')) {
-                    $this->registerSessionHandlerAsService($container, $handler);
+                    self::registerSessionHandlerAsService($container, $handler);
                 }
 
-                return $this->buildSession(
+                return self::buildSession(
                     new RuntimeStorage(),
                     $app,
                     $container->get(DispatcherInterface::class),
@@ -223,7 +223,7 @@ class Session implements ServiceProviderInterface
         $container->alias(SessionFactory::class, 'session.factory')
             ->share(
                 'session.factory',
-                function (Container $container) {
+                static function (Container $container) {
                     $factory = new SessionFactory();
                     $factory->setContainer($container);
 
@@ -235,7 +235,7 @@ class Session implements ServiceProviderInterface
         $container->alias(SessionManager::class, 'session.manager')
             ->share(
                 'session.manager',
-                function (Container $container) {
+                static function (Container $container) {
                     if (!$container->has('session.handler')) {
                         throw new DependencyResolutionException(
                             'The "session.handler" service has not been created, make sure you have created the "session" service first.'
@@ -250,7 +250,7 @@ class Session implements ServiceProviderInterface
         $container->alias(MetadataManager::class, 'session.metadata_manager')
             ->share(
                 'session.metadata_manager',
-                function (Container $container) {
+                static function (Container $container) {
                     /*
                      * Normally we should inject the application as a dependency via $container->get() however there is not
                      * a 'app' or CMSApplicationInterface::class key for the primary application of the request so we need to
@@ -273,7 +273,7 @@ class Session implements ServiceProviderInterface
         $container->alias(MetadataManagerListener::class, 'session.event_listener.metadata_manager')
             ->share(
                 'session.event_listener.metadata_manager',
-                function (Container $container) {
+                static function (Container $container) {
                     return new MetadataManagerListener($container->get(MetadataManager::class), $container->get('config'));
                 },
                 true
@@ -298,7 +298,7 @@ class Session implements ServiceProviderInterface
      *
      * @since   4.0.0
      */
-    private function buildSession(
+    private static function buildSession(
         StorageInterface $storage,
         CMSApplicationInterface $app,
         DispatcherInterface $dispatcher,
@@ -325,7 +325,7 @@ class Session implements ServiceProviderInterface
      *
      * @since   4.0.0
      */
-    private function registerSessionHandlerAsService(Container $container, \SessionHandlerInterface $sessionHandler): void
+    private static function registerSessionHandlerAsService(Container $container, \SessionHandlerInterface $sessionHandler): void
     {
         // Alias the session handler to the core SessionHandlerInterface for improved autowiring and discoverability
         $container->alias(\SessionHandlerInterface::class, 'session.handler')

--- a/libraries/src/Service/Provider/Toolbar.php
+++ b/libraries/src/Service/Provider/Toolbar.php
@@ -40,7 +40,7 @@ class Toolbar implements ServiceProviderInterface
             ->alias(ContainerAwareToolbarFactory::class, ToolbarFactoryInterface::class)
             ->share(
                 ToolbarFactoryInterface::class,
-                function (Container $container) {
+                static function (Container $container) {
                     $factory = new ContainerAwareToolbarFactory();
                     $factory->setContainer($container);
 

--- a/libraries/src/Service/Provider/User.php
+++ b/libraries/src/Service/Provider/User.php
@@ -41,7 +41,7 @@ class User implements ServiceProviderInterface
             ->alias(UserFactory::class, UserFactoryInterface::class)
             ->share(
                 UserFactoryInterface::class,
-                function (Container $container) {
+                static function (Container $container) {
                     return new UserFactory($container->get(DatabaseInterface::class));
                 },
                 true

--- a/libraries/src/Service/Provider/WebAssetRegistry.php
+++ b/libraries/src/Service/Provider/WebAssetRegistry.php
@@ -38,7 +38,7 @@ class WebAssetRegistry implements ServiceProviderInterface
         $container->alias('webassetregistry', Registry::class)
             ->share(
                 Registry::class,
-                function (Container $container) {
+                static function (Container $container) {
                     $registry = new Registry();
 
                     // Add Core registry files

--- a/plugins/actionlog/joomla/services/provider.php
+++ b/plugins/actionlog/joomla/services/provider.php
@@ -34,7 +34,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $plugin = new Joomla(
                     $container->get(DispatcherInterface::class),
                     (array) PluginHelper::getPlugin('actionlog', 'joomla')

--- a/plugins/api-authentication/basic/services/provider.php
+++ b/plugins/api-authentication/basic/services/provider.php
@@ -35,7 +35,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $plugin = new Basic(
                     $container->get(DispatcherInterface::class),
                     (array) PluginHelper::getPlugin('api-authentication', 'basic'),

--- a/plugins/api-authentication/token/services/provider.php
+++ b/plugins/api-authentication/token/services/provider.php
@@ -36,7 +36,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $plugin = new Token(
                     $container->get(DispatcherInterface::class),
                     (array) PluginHelper::getPlugin('api-authentication', 'token'),

--- a/plugins/behaviour/taggable/services/provider.php
+++ b/plugins/behaviour/taggable/services/provider.php
@@ -32,7 +32,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $dispatcher = $container->get(DispatcherInterface::class);
                 $plugin     = new Taggable(
                     $dispatcher,

--- a/plugins/behaviour/versionable/services/provider.php
+++ b/plugins/behaviour/versionable/services/provider.php
@@ -35,7 +35,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $dispatcher = $container->get(DispatcherInterface::class);
                 $plugin     = new Versionable(
                     $dispatcher,

--- a/plugins/multifactorauth/email/services/provider.php
+++ b/plugins/multifactorauth/email/services/provider.php
@@ -33,7 +33,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $config  = (array) PluginHelper::getPlugin('multifactorauth', 'email');
                 $subject = $container->get(DispatcherInterface::class);
 

--- a/plugins/multifactorauth/fixed/services/provider.php
+++ b/plugins/multifactorauth/fixed/services/provider.php
@@ -32,7 +32,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $config  = (array) PluginHelper::getPlugin('multifactorauth', 'fixed');
                 $subject = $container->get(DispatcherInterface::class);
 

--- a/plugins/multifactorauth/totp/services/provider.php
+++ b/plugins/multifactorauth/totp/services/provider.php
@@ -33,7 +33,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $config  = (array) PluginHelper::getPlugin('multifactorauth', 'totp');
                 $subject = $container->get(DispatcherInterface::class);
 

--- a/plugins/multifactorauth/webauthn/services/provider.php
+++ b/plugins/multifactorauth/webauthn/services/provider.php
@@ -33,7 +33,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $config  = (array) PluginHelper::getPlugin('multifactorauth', 'webauthn');
                 $subject = $container->get(DispatcherInterface::class);
 

--- a/plugins/multifactorauth/yubikey/services/provider.php
+++ b/plugins/multifactorauth/yubikey/services/provider.php
@@ -33,7 +33,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $config  = (array) PluginHelper::getPlugin('multifactorauth', 'yubikey');
                 $subject = $container->get(DispatcherInterface::class);
 

--- a/plugins/quickicon/joomlaupdate/services/provider.php
+++ b/plugins/quickicon/joomlaupdate/services/provider.php
@@ -32,7 +32,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 // @Todo This needs to be changed to a proper factory
                 $plugin = \Joomla\CMS\Plugin\PluginHelper::getPlugin('quickicon', 'joomlaupdate');
 

--- a/plugins/system/cache/services/provider.php
+++ b/plugins/system/cache/services/provider.php
@@ -34,7 +34,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container)
+            static function (Container $container)
             {
                 $plugin                 = PluginHelper::getPlugin('system', 'cache');
                 $dispatcher             = $container->get(DispatcherInterface::class);

--- a/plugins/system/shortcut/services/provider.php
+++ b/plugins/system/shortcut/services/provider.php
@@ -33,7 +33,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $dispatcher = $container->get(DispatcherInterface::class);
                 $plugin     = new Shortcut(
                     $dispatcher,

--- a/plugins/system/webauthn/services/provider.php
+++ b/plugins/system/webauthn/services/provider.php
@@ -45,7 +45,7 @@ return new class implements ServiceProviderInterface
                 $subject = $container->get(DispatcherInterface::class);
 
                 $app     = Factory::getApplication();
-                $session = $container->has('session') ? $container->get('session') : $this->getSession($app);
+                $session = $container->has('session') ? $container->get('session') : self::getSession($app);
 
                 $db                    = $container->get('DatabaseDriver');
                 $credentialsRepository = $container->has(PublicKeyCredentialSourceRepository::class)
@@ -82,7 +82,7 @@ return new class implements ServiceProviderInterface
      *
      * @since  4.2.0
      */
-    private function getSession(ApplicationInterface $app)
+    private static function getSession(ApplicationInterface $app)
     {
         return $app instanceof SessionAwareWebApplicationInterface ? $app->getSession() : null;
     }

--- a/plugins/system/webauthn/services/provider.php
+++ b/plugins/system/webauthn/services/provider.php
@@ -40,7 +40,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $config  = (array) PluginHelper::getPlugin('system', 'webauthn');
                 $subject = $container->get(DispatcherInterface::class);
 

--- a/plugins/task/checkfiles/services/provider.php
+++ b/plugins/task/checkfiles/services/provider.php
@@ -33,7 +33,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $plugin = new Checkfiles(
                     $container->get(DispatcherInterface::class),
                     (array) PluginHelper::getPlugin('task', 'checkfiles'),

--- a/plugins/task/demotasks/services/provider.php
+++ b/plugins/task/demotasks/services/provider.php
@@ -33,7 +33,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $dispatcher = $container->get(DispatcherInterface::class);
 
                 $plugin = new DemoTasks(

--- a/plugins/task/requests/services/provider.php
+++ b/plugins/task/requests/services/provider.php
@@ -34,7 +34,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $plugin = new Requests(
                     $container->get(DispatcherInterface::class),
                     (array) PluginHelper::getPlugin('task', 'requests'),

--- a/plugins/task/sitestatus/services/provider.php
+++ b/plugins/task/sitestatus/services/provider.php
@@ -34,7 +34,7 @@ return new class implements ServiceProviderInterface
     {
         $container->set(
             PluginInterface::class,
-            function (Container $container) {
+            static function (Container $container) {
                 $plugin = new SiteStatus(
                     $container->get(DispatcherInterface::class),
                     (array) PluginHelper::getPlugin('task', 'sitestatus'),


### PR DESCRIPTION
### Summary of Changes

Use static closures in service providers in service providers. This allows provider instances to be discarded after use.

### Testing Instructions

Test that Joomla still works.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
