### PR TITLE
[4.3] Fix broken package build after merge of PR #39374

### DIFF
--- a/build/media_source/com_users/joomla.asset.json
+++ b/build/media_source/com_users/joomla.asset.json
@@ -29,29 +29,6 @@
       }
     },
     {
-      "name": "com_users.admin-users-mail.es5",
-      "type": "script",
-      "uri": "com_users/admin-users-mail-es5.min.js",
-      "dependencies": [
-        "core"
-      ],
-      "attributes": {
-        "nomodule": true,
-        "defer": true
-      }
-    },
-    {
-      "name": "com_users.admin-users-mail",
-      "type": "script",
-      "uri": "com_users/admin-users-mail.min.js",
-      "dependencies": [
-        "com_users.admin-users-mail.es5"
-      ],
-      "attributes": {
-        "type": "module"
-      }
-    },
-    {
       "name": "com_users.two-factor-focus.es5",
       "type": "script",
       "uri": "com_users/two-factor-focus-es5.min.js",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

After PR #39374 has been merged, the package build e.g. with `php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2` fails at the versioning step for the assets because PR #39374 has removed some JS but hasn't removed it from file `build/media_source/com_users/joomla.asset.json`.

This PR here fixes that.

It was partly also my fault. I should have noticed this when reviewing that PR, but well, nobody's perfect.

But when testing the PR it was not obvious because package building doesn't belong to our usual testing instructions and also not to the automated CI tests, and the package build which drone runs for building the testing packages seem not to include that versioning step because it hasn't failed for that PR. Everything was green.

Pinging @Hackwar just for information.

### Testing Instructions

It requires a development environment (Git clone of this repo, composer, npm) either on Linux or on Windows with WSL to run the build.php script.

1. Checkout the current 4.3-dev branch where #39374 has been merged in today.
2. Run `php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2`.
Result: See section "Actual result BEFORE applying this Pull Request" below.
3. Clean up everything with `git clean -d -x -f` and `git checkout .`.
4. Checkout the branch of this PR. You can do that with commands `git fetch upstream pull/39408/head:test-pr-39408` and then `git checkout test-pr-39408`.
5. Repeat step 2.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

At the end of the output in the command window:

```
> joomla@4.0.0 versioning
> node build/build.js --versioning

[Error: ENOENT: no such file or directory, lstat '/home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670929783/media/com_users/js/admin-users-mail-es5.min.js'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: '/home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670929783/media/com_users/js/admin-users-mail-es5.min.js'
}
`npm run versioning` did not complete as expected.
```

### Expected result AFTER applying this Pull Request

At the end of the output in the command window:

```
> joomla@4.0.0 versioning
> node build/build.js --versioning

Timer: Versioning finished in 160 ms
Cleaning checkout in /home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670930708.
Cleaning vendors.
Cleanup complete.
Generating optimized autoload files
Generated optimized autoload files containing 2381 classes
Cleaning Composer manifests in /home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670930708.
Cleanup complete.
Workspace built.
Create list of changed files from git repository for version 4.3.0-alpha2-dev.
Delete folders not included in packages.
Build full package files.
Building Joomla_4.3.0-alpha2-dev-Development-Full_Package.zip... done.
Build full update package.
Building Joomla_4.3.0-alpha2-dev-Development-Update_Package.zip... done.
Build of version 4.3.0-alpha2-dev complete!
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
