### PR TITLE
[4.3] Handle missing file in updateAsset method of the versioning js when building packages

### DIFF
--- a/build/build-modules-js/versioning.es6.js
+++ b/build/build-modules-js/versioning.es6.js
@@ -56,7 +56,6 @@ const updateAsset = async (asset, directory) => {
   try {
     jAssetFile = await lstat(path);
   } catch (err) {
-    final[directory].push(asset);
     return;
   }
 

--- a/build/build-modules-js/versioning.es6.js
+++ b/build/build-modules-js/versioning.es6.js
@@ -55,7 +55,7 @@ const updateAsset = async (asset, directory) => {
   let jAssetFile;
   try {
     jAssetFile = await lstat(path);
-  } catch(err) {
+  } catch (err) {
     final[directory].push(asset);
     return;
   }

--- a/build/build-modules-js/versioning.es6.js
+++ b/build/build-modules-js/versioning.es6.js
@@ -52,7 +52,13 @@ const updateAsset = async (asset, directory) => {
     }
   }
 
-  const jAssetFile = await lstat(path);
+  let jAssetFile;
+  try {
+    jAssetFile = await lstat(path);
+  } catch(err) {
+    final[directory].push(asset);
+    return;
+  }
 
   if (!jAssetFile.isFile()) {
     final[directory].push(asset);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

After PR #39374 has been merged, the package build e.g. with `php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2` fails at the versioning step for the assets because PR #39374 has removed some JS but hasn't removed it from file `build/media_source/com_users/joomla.asset.json`.

It was partly also my fault. I should have noticed this when reviewing that PR, but well, nobody's perfect.

But when testing the PR it was not obvious because package building doesn't belong to our usual testing instructions and also not to the automated CI tests, and the package build which drone runs for building the testing packages seem not to include that versioning step because it hasn't failed for that PR. Everything was green.

Pinging @Hackwar just for information.

This PR here fixes the issue by changing the versioning js so that it can handle missing files for assets referred to in a joomla.asset.json file. Thanks to @dgrammatiko for the code snippet.

Removing the obsolete assets from the `joomla.asset.json` would cause exceptions by the web asset manager when a 3rd party template would still try to use that asset. That's why it can't be done this way. Thanks @SharkyKZ for pointing to that in my previous PR #39408 for this issue. I hope you see that giving comments with additional info to a thumb down helps. It might be more time consuming for you than just giving an uncommented thumb down, but the result for the CMS is definitely better, and I assume you want to help the CMS, or not?

### Testing Instructions

It requires a development environment (Git clone of this repo, composer, npm) either on Linux or on Windows with WSL to run the build.php script.

1. Checkout the current 4.3-dev branch where #39374 has been merged in today.
2. Run `php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2`.
Result: See section "Actual result BEFORE applying this Pull Request" below.
3. Clean up everything with `git clean -d -x -f` and `git checkout .`.
4. Checkout the branch of this PR. You can do that with commands `git fetch upstream pull/39413/head:test-pr-39413` and then `git checkout test-pr-39413`.
5. Repeat step 2.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

At the end of the output in the command window:

```
> joomla@4.0.0 versioning
> node build/build.js --versioning

[Error: ENOENT: no such file or directory, lstat '/home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670929783/media/com_users/js/admin-users-mail-es5.min.js'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: '/home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670929783/media/com_users/js/admin-users-mail-es5.min.js'
}
`npm run versioning` did not complete as expected.
```

### Expected result AFTER applying this Pull Request

At the end of the output in the command window:

```
> joomla@4.0.0 versioning
> node build/build.js --versioning

Timer: Versioning finished in 160 ms
Cleaning checkout in /home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670930708.
Cleaning vendors.
Cleanup complete.
Generating optimized autoload files
Generated optimized autoload files containing 2381 classes
Cleaning Composer manifests in /home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670930708.
Cleanup complete.
Workspace built.
Create list of changed files from git repository for version 4.3.0-alpha2-dev.
Delete folders not included in packages.
Build full package files.
Building Joomla_4.3.0-alpha2-dev-Development-Full_Package.zip... done.
Build full update package.
Building Joomla_4.3.0-alpha2-dev-Development-Update_Package.zip... done.
Build of version 4.3.0-alpha2-dev complete!
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
