### PR TITLE
Fix @return type in PHPDoc

### DIFF
--- a/components/com_tags/src/Model/TagsModel.php
+++ b/components/com_tags/src/Model/TagsModel.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Database\ParameterType;
+use Joomla\Database\QueryInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -85,7 +86,7 @@ class TagsModel extends ListModel
     /**
      * Method to build an SQL query to load the list data.
      *
-     * @return  string  An SQL query
+     * @return  QueryInterface  An SQL query
      *
      * @since   1.6
      */


### PR DESCRIPTION
### Summary of Changes

This PR fixes the @return type in the PHPDoc of the `getListQuery()` function.

### Testing Instructions

No testing needed.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
