### PR TITLE
[4.3] Restore js files deleted with PR's #38823 and #39374 in order to be b/c for layout overrides

### DIFF
--- a/build/media_source/com_templates/joomla.asset.json
+++ b/build/media_source/com_templates/joomla.asset.json
@@ -6,6 +6,30 @@
   "license": "GPL-2.0-or-later",
   "assets": [
     {
+      "name": "com_templates.admin-template-compare.es5",
+      "type": "script",
+      "uri": "com_templates/admin-template-compare-es5.min.js",
+      "dependencies": [
+        "core",
+        "diff"
+      ],
+      "attributes": {
+        "nomodule": true,
+        "defer": true
+      }
+    },
+    {
+      "name": "com_templates.admin-template-compare",
+      "type": "script",
+      "uri": "com_templates/admin-template-compare.min.js",
+      "dependencies": [
+        "com_templates.admin-template-compare.es5"
+      ],
+      "attributes": {
+        "type": "module"
+      }
+    },
+    {
       "name": "com_templates.admin-template-toggle-assignment.es5",
       "type": "script",
       "uri": "com_templates/admin-template-toggle-assignment-es5.min.js",

--- a/build/media_source/com_templates/js/admin-template-compare.es6.js
+++ b/build/media_source/com_templates/js/admin-template-compare.es6.js
@@ -1,6 +1,8 @@
 /**
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @deprecated  This file is deprecated and will be removed with Joomla 5.0
  */
 (() => {
   'use strict';

--- a/build/media_source/com_templates/js/admin-template-compare.es6.js
+++ b/build/media_source/com_templates/js/admin-template-compare.es6.js
@@ -2,3 +2,5 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
+
+/* empty statement */;

--- a/build/media_source/com_templates/js/admin-template-compare.es6.js
+++ b/build/media_source/com_templates/js/admin-template-compare.es6.js
@@ -2,5 +2,60 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
+(() => {
+  'use strict';
 
-/* empty statement */;
+  document.addEventListener('DOMContentLoaded', () => {
+    const decodeHtmlspecialChars = (text) => {
+      const map = {
+        '&amp;': '&',
+        '&#038;': '&',
+        '&lt;': '<',
+        '&gt;': '>',
+        '&quot;': '"',
+        '&#039;': "'",
+        '&#8217;': '’',
+        '&#8216;': '‘',
+        '&#8211;': '–',
+        '&#8212;': '—',
+        '&#8230;': '…',
+        '&#8221;': '”',
+      };
+
+      /* eslint-disable */
+      return text.replace(/\&[\w\d\#]{2,5}\;/g, (m) => { const n = map[m]; return n; });
+    };
+
+    const compare = (original, changed) => {
+      const display = changed.nextElementSibling;
+      let color = '';
+      let pre = null;
+      const diff = Diff.diffLines(original.innerHTML, changed.innerHTML);
+      const fragment = document.createDocumentFragment();
+
+      /* eslint-enable */
+
+      diff.forEach((part) => {
+        if (part.added) {
+          color = '#a6f3a6';
+        } else if (part.removed) {
+          color = '#f8cbcb';
+        } else {
+          color = '';
+        }
+        pre = document.createElement('pre');
+        pre.style.backgroundColor = color;
+        pre.className = 'diffview';
+        pre.appendChild(document.createTextNode(decodeHtmlspecialChars(part.value)));
+        fragment.appendChild(pre);
+      });
+
+      display.appendChild(fragment);
+    };
+
+    const diffs = [].slice.call(document.querySelectorAll('#original'));
+    for (let i = 0, l = diffs.length; i < l; i += 1) {
+      compare(diffs[i], diffs[i].nextElementSibling);
+    }
+  });
+})();

--- a/build/media_source/com_templates/js/admin-template-compare.es6.js
+++ b/build/media_source/com_templates/js/admin-template-compare.es6.js
@@ -1,0 +1,4 @@
+/**
+ * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */

--- a/build/media_source/com_users/js/admin-users-mail.es6.js
+++ b/build/media_source/com_users/js/admin-users-mail.es6.js
@@ -1,6 +1,8 @@
 /**
  * @copyright   (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @deprecated  This file is deprecated and will be removed with Joomla 5.0
  */
 
 (() => {

--- a/build/media_source/com_users/js/admin-users-mail.es6.js
+++ b/build/media_source/com_users/js/admin-users-mail.es6.js
@@ -3,4 +3,32 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-/* empty statement */;
+(() => {
+  'use strict';
+
+  document.addEventListener('DOMContentLoaded', () => {
+    Joomla.submitbutton = (pressbutton) => {
+      const form = document.adminForm;
+      const html = document.createElement('joomla-alert');
+
+      if (pressbutton === 'mail.cancel') {
+        Joomla.submitform(pressbutton);
+        return;
+      }
+
+      // do field validation
+      if (form.jform_subject.value === '') {
+        html.innerText = Joomla.Text._('COM_USERS_MAIL_PLEASE_FILL_IN_THE_SUBJECT');
+        form.insertAdjacentElement('afterbegin', html);
+      } else if (form.jform_group.value < 0) {
+        html.innerText = Joomla.Text._('COM_USERS_MAIL_PLEASE_SELECT_A_GROUP');
+        form.insertAdjacentElement('afterbegin', html);
+      } else if (form.jform_message.value === '') {
+        html.innerText = Joomla.Text._('COM_USERS_MAIL_PLEASE_FILL_IN_THE_MESSAGE');
+        form.insertAdjacentElement('afterbegin', html);
+      } else {
+        Joomla.submitform(pressbutton);
+      }
+    };
+  });
+})();

--- a/build/media_source/com_users/js/admin-users-mail.es6.js
+++ b/build/media_source/com_users/js/admin-users-mail.es6.js
@@ -1,0 +1,4 @@
+/**
+ * @copyright   (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */

--- a/build/media_source/com_users/js/admin-users-mail.es6.js
+++ b/build/media_source/com_users/js/admin-users-mail.es6.js
@@ -2,3 +2,5 @@
  * @copyright   (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
+
+/* empty statement */;


### PR DESCRIPTION
Pull Request for Issue #39408 .

Replacement for PR's #39408 and #39413 .

### Summary of Changes

This pull request (PR) adds back the javascript files which have been removed by PR's #38823 and #39374 because they might still be used in layout overrides.

This also fixes the currently failing versioning step of the package build which currently also causes the 4.3 nightly builds to fail.

That was caused by PR #38823 not having them removed from file `build/media_source/com_users/joomla.asset.json`.

So this PR doesn't need to modify that file, it only needs to add back the js files from that PR, while from the other PR it also need to add back the assets to file `build/media_source/com_templates/joomla.asset.json`.

A `@deprecated` comment is added to the top doc block of each restored js file.

### Testing Instructions

#### Test 1 - Package Build

It requires a development environment (Git clone of this repo, composer, npm) either on Linux or on Windows with WSL to run the build.php script.

1. Checkout the current 4.3-dev branch where #39374 has been merged in on December 13, 2022.
2. Run `php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2`.
Result: See section "Actual result BEFORE applying this Pull Request" below.
3. Clean up everything with `git clean -d -x -f` and `git checkout .`.
4. Checkout the branch of this PR. You can do that with commands `git fetch upstream pull/39431/head:test-pr-39431` and then `git checkout test-pr-39431`.
5. Repeat step 2.
Result: See section "Expected result AFTER applying this Pull Request" below.

#### Test 2 - Updating from 4.2.6 with Layout Overrides

1. Install Joomla 4.2.6.

2. Create following layout overrides:
- com_templates/template
- com_users/mail

3. Update to the patched package for this PR by using this custom update URL https://ci.joomla.org/artifacts/joomla/joomla-cms/4.3-dev/39431/downloads/60159/pr_list.xml or this package download https://ci.joomla.org/artifacts/joomla/joomla-cms/4.3-dev/39431/downloads/60159/Joomla_4.3.0-alpha2-dev+pr.39431-Development-Update_Package.zip .
Result: The update succeeds.

4. Verify that the layout overrides which you have created in step 2 are still working as before.
Result: The layout overrides work as before.

### Actual result BEFORE applying this Pull Request

#### Test 1 - Package Build

At the end of the output in the command window:

```
> joomla@4.0.0 versioning
> node build/build.js --versioning

[Error: ENOENT: no such file or directory, lstat '/home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670929783/media/com_users/js/admin-users-mail-es5.min.js'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: '/home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670929783/media/com_users/js/admin-users-mail-es5.min.js'
}
`npm run versioning` did not complete as expected.
```

### Expected result AFTER applying this Pull Request

#### Test 1 - Package Build

At the end of the output in the command window:

```
> joomla@4.0.0 versioning
> node build/build.js --versioning

Timer: Versioning finished in 160 ms
Cleaning checkout in /home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670930708.
Cleaning vendors.
Cleanup complete.
Generating optimized autoload files
Generated optimized autoload files containing 2381 classes
Cleaning Composer manifests in /home/richard/lamp/public_html/joomla-cms-4.3-dev/build/tmp/1670930708.
Cleanup complete.
Workspace built.
Create list of changed files from git repository for version 4.3.0-alpha2-dev.
Delete folders not included in packages.
Build full package files.
Building Joomla_4.3.0-alpha2-dev-Development-Full_Package.zip... done.
Build full update package.
Building Joomla_4.3.0-alpha2-dev-Development-Update_Package.zip... done.
Build of version 4.3.0-alpha2-dev complete!
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed

The deprecation of these js files has to be documented on manual.joomla.org . But since it was PR's #38823 and #39374 which made these files obsolete and so deprecated, it is not subject of this PR here to do that. Clarifications among maintainers is ongoing, and the deprecations will be documented at the end.