### PR TITLE
Fix $language default parameter

### DIFF
--- a/components/com_content/src/Helper/RouteHelper.php
+++ b/components/com_content/src/Helper/RouteHelper.php
@@ -29,14 +29,14 @@ abstract class RouteHelper
      *
      * @param   integer  $id        The route of the content item.
      * @param   integer  $catid     The category ID.
-     * @param   integer  $language  The language code.
+     * @param   string   $language  The language code.
      * @param   string   $layout    The layout value.
      *
      * @return  string  The article route.
      *
      * @since   1.5
      */
-    public static function getArticleRoute($id, $catid = 0, $language = 0, $layout = null)
+    public static function getArticleRoute($id, $catid = 0, $language = null, $layout = null)
     {
         // Create the link
         $link = 'index.php?option=com_content&view=article&id=' . $id;
@@ -45,7 +45,7 @@ abstract class RouteHelper
             $link .= '&catid=' . $catid;
         }
 
-        if ($language && $language !== '*' && Multilanguage::isEnabled()) {
+        if (!empty($language) && $language !== '*' && Multilanguage::isEnabled()) {
             $link .= '&lang=' . $language;
         }
 


### PR DESCRIPTION
This PR fixes the default value for the $language parameter. It makes it equal to `Joomla\CMS\Helper\RouteHelper` found in `libraries/src/Helper/RouteHelper.php`.

I am not sure if this is documented somewhere and that documentation would need to be updated.
