### PR TITLE
[J4][libraries]Correction of the lack of the possibility of using custom View in the content component with custom ItemMenu.

### DIFF
--- a/libraries/src/Component/Router/RouterView.php
+++ b/libraries/src/Component/Router/RouterView.php
@@ -222,15 +222,14 @@ abstract class RouterView extends RouterBase
      */
     public function build(&$query)
     {
-		$view = $query['view'] ?? false;
+        $view = $query['view'] ?? false;
 
         // Use the processing of a custom view added by the user.
-		if($view && empty($this->getViews()[$view]))
+        if($view && empty($this->getViews()[$view]))
         {
-			$this->registerView(new RouterViewConfiguration($view));
-		}
-        
-        
+            $this->registerView(new RouterViewConfiguration($view));
+        }
+
         $segments = array();
 
         // Process the parsed variables based on custom defined rules

--- a/libraries/src/Component/Router/RouterView.php
+++ b/libraries/src/Component/Router/RouterView.php
@@ -225,7 +225,7 @@ abstract class RouterView extends RouterBase
         $view = $query['view'] ?? false;
 
         // Use the processing of a custom view added by the user.
-        if($view && empty($this->getViews()[$view])) { 
+        if ($view && empty($this->getViews()[$view])) {
             $this->registerView(new RouterViewConfiguration($view));
         }
 

--- a/libraries/src/Component/Router/RouterView.php
+++ b/libraries/src/Component/Router/RouterView.php
@@ -48,26 +48,6 @@ abstract class RouterView extends RouterBase
     protected $views = array();
 
     /**
-     * Class constructor.
-     *
-     * @param   \Joomla\CMS\Application\CMSApplication  $app   Application-object that the router should use
-     * @param   \Joomla\CMS\Menu\AbstractMenu           $menu  Menu-object that the router should use
-     *
-     * @since   3.4
-     */
-    public function __construct($app = null, $menu = null)
-    {   
-		$view = $query['view'] ?? false;
-
-		if($view && empty($this->getViews()[$view])){
-			$this->registerView(new RouterViewConfiguration($view));
-		}
-
-        parent::__construct($app, $menu);
-    }
-    
-    
-    /**
      * Register the views of a component
      *
      * @param   RouterViewConfiguration  $view  View configuration object
@@ -242,6 +222,15 @@ abstract class RouterView extends RouterBase
      */
     public function build(&$query)
     {
+		$view = $query['view'] ?? false;
+
+        // Use the processing of a custom view added by the user.
+		if($view && empty($this->getViews()[$view]))
+        {
+			$this->registerView(new RouterViewConfiguration($view));
+		}
+        
+        
         $segments = array();
 
         // Process the parsed variables based on custom defined rules

--- a/libraries/src/Component/Router/RouterView.php
+++ b/libraries/src/Component/Router/RouterView.php
@@ -225,8 +225,7 @@ abstract class RouterView extends RouterBase
         $view = $query['view'] ?? false;
 
         // Use the processing of a custom view added by the user.
-        if($view && empty($this->getViews()[$view]))
-        {
+        if($view && empty($this->getViews()[$view])) { 
             $this->registerView(new RouterViewConfiguration($view));
         }
 

--- a/libraries/src/Component/Router/RouterView.php
+++ b/libraries/src/Component/Router/RouterView.php
@@ -48,6 +48,26 @@ abstract class RouterView extends RouterBase
     protected $views = array();
 
     /**
+     * Class constructor.
+     *
+     * @param   \Joomla\CMS\Application\CMSApplication  $app   Application-object that the router should use
+     * @param   \Joomla\CMS\Menu\AbstractMenu           $menu  Menu-object that the router should use
+     *
+     * @since   3.4
+     */
+    public function __construct($app = null, $menu = null)
+    {   
+		$view = $query['view'] ?? false;
+
+		if($view && empty($this->getViews()[$view])){
+			$this->registerView(new RouterViewConfiguration($view));
+		}
+
+        parent::__construct($app, $menu);
+    }
+    
+    
+    /**
      * Register the views of a component
      *
      * @param   RouterViewConfiguration  $view  View configuration object


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Correction of the lack of the possibility of using custom View in the content component with custom ItemMenu.



### Testing Instructions
1. Add Custom Model `CustomModel.php` in `JROOT\components\com_content\src\Model\`
2. Add Custom View `HtmlView.php` in `JROOT\components\com_content\src\View\Custom\`
3. Add Custom ItemMenu `default.xml` in `JROOT\components\com_content\tmpl\custom\`
3. Add Custom ItemMenu `default.php` in `JROOT\components\com_content\tmpl\custom\`
4. Enable error display mode.
5. Enable switch mode "`Search Engine Friendly URLs`"(SEO) in "`Yes`" in "`Global Configuration`" panel.
6. Create a new menu item in the main menu for a new custom item.
7. Open the user's page using a new custom link.
8. Make sure that the error call is displayed in the file on the user's page. 

https://github.com/joomla/joomla-cms/blob/b7df9eb7233407e065d4c5e64bc6f468034b5f6c/libraries/src/Component/Router/Rules/StandardRules.php#L194


### Actual result BEFORE applying this Pull Request

Adding a menu item of its own type to the Content component caused an error.
There was NO such problem in the old Joomla 3.
### The problem is relevant only for Joomla 4

### Expected result AFTER applying this Pull Request

As well as the new fix, in the future developers in this repository will be able to add a new menu item without having to search for an error. By the way, it took me a week of working time to find the error. The location of the error correction is very difficult to determine, although the idea of the problem is immediately clear.

Also, this fix may in the future create a new menu item for the mod_category_tags module https://github.com/joomla/joomla-cms/pull/38752

.

### Link to documentations
Please select:
- [V] No documentation changes for docs.joomla.org needed
- [V] No documentation changes for manual.joomla.org needed

The problem is that php rules cause an error for views that are not specified in the file
`JROOT\components\com_content\src\Service\Router.php`

**That is, this file has hard-coded representations that can be used without causing any errors. There was no such behavior in the old Joomla. Each developer could add their own views. And also I have repeatedly read tutorials on how to add a new type of custom menu item. This is not possible with Joomla 4. I suggest fixing this problem by simply adding 3 lines of code.**

### By the way, this error problem occurs only when the switch mode is turned on "`Search Engine Friendly URLs`"(SEO) in "`Yes`" in "`Global Configuration`" panel. 
**Of course, this mode is always on for everyone. So this fix is necessary for everyone who wants to add a new type of menu item. It is necessary for the future to upgrade J4.**