### PR TITLE
Add missing help for disable-patch-packages parameter of the build.php script

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -35,12 +35,13 @@ function usage(string $command)
     echo PHP_EOL;
     echo 'Usage: php ' . $command . ' [options]' . PHP_EOL;
     echo PHP_TAB . '[options]:' . PHP_EOL;
-    echo PHP_TAB . PHP_TAB . '--remote=<remote>:' . PHP_TAB . 'The git remote reference to build from (ex: `tags/3.8.6`, `4.0-dev`), defaults to the most recent tag for the repository' . PHP_EOL;
-    echo PHP_TAB . PHP_TAB . '--exclude-zip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .zip packages' . PHP_EOL;
-    echo PHP_TAB . PHP_TAB . '--exclude-gzip:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .tar.gz packages' . PHP_EOL;
-    echo PHP_TAB . PHP_TAB . '--exclude-bzip2:' . PHP_TAB . 'Exclude the generation of .tar.bz2 packages' . PHP_EOL;
-    echo PHP_TAB . PHP_TAB . '--include-zstd:' . PHP_TAB . 'Include the generation of .tar.zst packages' . PHP_EOL;
-    echo PHP_TAB . PHP_TAB . '--help:' . PHP_TAB . PHP_TAB . PHP_TAB . 'Show this help output' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--remote=<remote>:' . PHP_TAB . PHP_TAB . 'The git remote reference to build from (ex: `tags/3.8.6`, `4.0-dev`), defaults to the most recent tag for the repository' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--exclude-zip:' . PHP_TAB . PHP_TAB . PHP_TAB . 'Exclude the generation of .zip packages' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--exclude-gzip:' . PHP_TAB . PHP_TAB . PHP_TAB . 'Exclude the generation of .tar.gz packages' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--exclude-bzip2:' . PHP_TAB . PHP_TAB . 'Exclude the generation of .tar.bz2 packages' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--include-zstd:' . PHP_TAB . PHP_TAB . PHP_TAB . 'Include the generation of .tar.zst packages' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--disable-patch-packages:' . PHP_TAB . 'Disable the generation of patch packages' . PHP_EOL;
+    echo PHP_TAB . PHP_TAB . '--help:' . PHP_TAB . PHP_TAB . PHP_TAB . PHP_TAB . 'Show this help output' . PHP_EOL;
     echo PHP_EOL;
 }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

The build script includes a call parameter `disable-patch-packages` which is defined here https://github.com/joomla/joomla-cms/blob/4.2-dev/build/build.php#L225 and used here https://github.com/joomla/joomla-cms/blob/4.2-dev/build/build.php#L232 and this is then used here https://github.com/joomla/joomla-cms/blob/4.2-dev/build/build.php#L443 for not building patch packages like e.g. currently 4.2.6 to 4.2.7 and 4.2.x to 4.2.7 because these packages might not be complete in Joomla 4, which is a know issue and for which this parameter is a temporary workaround.

But the help of the build script doesn't tell anything about that parameter.

This PR here fixes that by adding the missing information and properly aligning the output with tabulators to that long parameter name.

### Testing Instructions

The test requires a development environment on a git clone with PHP CLI either on Linux or an other Unixoid, or when on Windows it requires WSL.

Run `php ./build/build.php --help` in a command shell on your Joomla root.

### Actual result BEFORE applying this Pull Request

No information about the `disable-patch-packages` parameter, and the output is not properly aligned with tabs.
```
Usage: php ./build/build.php [options]
	[options]:
		--remote=<remote>:	The git remote reference to build from (ex: `tags/3.8.6`, `4.0-dev`), defaults to the most recent tag for the repository
		--exclude-zip:		Exclude the generation of .zip packages
		--exclude-gzip:		Exclude the generation of .tar.gz packages
		--exclude-bzip2:	Exclude the generation of .tar.bz2 packages
		--include-zstd:	Include the generation of .tar.zst packages
		--help:			Show this help output
```

### Expected result AFTER applying this Pull Request

Information about the `disable-patch-packages` parameter, and the output is properly aligned with tabs.
```
Usage: php ./build/build.php [options]
	[options]:
		--remote=<remote>:		The git remote reference to build from (ex: `tags/3.8.6`, `4.0-dev`), defaults to the most recent tag for the repository
		--exclude-zip:			Exclude the generation of .zip packages
		--exclude-gzip:			Exclude the generation of .tar.gz packages
		--exclude-bzip2:		Exclude the generation of .tar.bz2 packages
		--include-zstd:			Include the generation of .tar.zst packages
		--disable-patch-packages:	Disable the generation of patch packages
		--help:				Show this help output
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
