### PR TITLE
[5.0]New method BaseController->prepareViewModel() to set the View Models,

### DIFF
--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -1078,6 +1078,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
         if (!method_exists($view, 'setModel')) {
             return;
         }
+
         $viewName = $view->getName();
 
         // Get/Create the model

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -1067,14 +1067,17 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
      * In case you want to set several Models for your view,
      * you will need to override it in your DisplayController controller.
      *
-     * @param   AbstractView  $view  The view Object
+     * @param   ViewInterface  $view  The view Object
      *
      * @return  void
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function prepareViewModel($view)
+    protected function prepareViewModel(ViewInterface $view)
     {
+        if (!method_exists($view, 'setModel')) {
+            return;
+        }
         $viewName = $view->getName();
 
         // Get/Create the model

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -601,11 +601,8 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
 
         $view = $this->getView($viewName, $viewType, '', array('base_path' => $this->basePath, 'layout' => $viewLayout));
 
-        // Get/Create the model
-        if ($model = $this->getModel($viewName, '', array('base_path' => $this->basePath))) {
-            // Push the model into the view (as default)
-            $view->setModel($model, true);
-        }
+        // Set models for the View
+        $this->prepareViewModel($view);
 
         $view->document = $document;
 
@@ -1060,5 +1057,30 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
         }
 
         return $this;
+    }
+
+    /**
+     * Method to set the View Models
+     *
+     * This function is provided as a default implementation,
+     * and only set one Model in the view (that with the same prefix/sufix than the view).
+     * In case you want to set several Models for your view,
+     * you will need to override it in your DisplayController controller.
+     *
+     * @param   AbstractView  $view  The view Object
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function prepareViewModel($view)
+    {
+        $viewName = $view->getName();
+
+        // Get/Create the model
+        if ($model = $this->getModel($viewName, '', array('base_path' => $this->basePath))) {
+            // Push the model into the view (as default)
+            $view->setModel($model, true);
+        }
     }
 }

--- a/libraries/src/MVC/View/ViewInterface.php
+++ b/libraries/src/MVC/View/ViewInterface.php
@@ -43,4 +43,13 @@ interface ViewInterface
      * @since   3.0
      */
     public function getModel($name = null);
+
+    /**
+     * Method to get the view name
+     *
+     * @return  string  The name of the view
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getName();
 }


### PR DESCRIPTION
### Summary of Changes

Changes to ease the use of multiple models in one view for custom (or core) components in Joomla 4.

By moving just three lines of code from `BaseController->display()` 
to a new method `BaseController->setViewModel($view)`,
you can easily assign the models you want to any of your views. 

Everything works exactly the same. The method is called at the same point the lines were before.
But the diference is: 
* now you can overwrite the new method in the `DisplayController` of your custom component like this:

```PHP
    public function display($cachable = false, $urlparams = [])
    {
         return parent::display();
    }


    protected function prepareViewModel($view)
    {
        parent::prepareViewModel($view);

        $viewName = $view->getName();

        // Push the Second model into the Foos view
        if ($viewName == strtolower("Foos") && ($model = $this->getModel('Second'))) {
            $view->setModel($model);
        }

        // Push the Third model into the Foos view
        if ($viewName == strtolower("Foos") && ($model = $this->getModel('Third'))) {
            $view->setModel($model);
        }
    }
    }
```
Here you see that you don't need to touch your `DisplayController->display()` method to assign the models.
Nor call to Factories. All you need is already in the `DisplayController` with minimum code.
You only overwrite the `DisplayController->setViewModel()`, call the parent (that assigns the default model as usual),
and assigns a couple of new models to the "Foos" view.

Now you only have to call it properly and easily in your view, like this:
```PHP
	public function display($tpl = null)
	{
            $this->msg  = $this->get('Msg');
            $this->msg2 = $this->get('Msg', 'Second');
            $this->msg3 = $this->get('Msg', 'Third');
        
	    return parent::display($tpl);
	}
```
Here you see how to call the methods of the Second and Third Model.

Just like it is described here: [Using multiple models in an MVC component](https://docs.joomla.org/Using_multiple_models_in_an_MVC_component)
Only now, you don't need to care about custom `display()` methods in your views.
The default `display()` works perfectly fine.

### Testing Instructions

I developed this little [Component com_foos](https://github.com/framontb/joomla42_test_setViewModels) to test the changes.
You only need to apply the changes to your Joomla 5 installation and install the component as usual.

### Actual result BEFORE applying this Pull Request

Break MVC model to call several models for one view, using factories called in helpers,
or need to rewrite your own `DisplayController->display()`.

See [How can I use two models in my custom component view in Joomla4?](https://joomla.stackexchange.com/questions/32431/how-can-i-use-two-models-in-my-custom-component-view-in-joomla4)

### Expected result AFTER applying this Pull Request

If you pick in the **Backend** > Component > COM_FOOS menu link, you will see:

```
Hello Foo from the model: DEFAULT
Hello FOOS from the ADMINISTRATOR model: SECOND
Hello FOOS from the ADMINISTRATOR model: THIRD
```

Each one of this messages, coming from a different model attached to the Foos View.

If you create a menu link in the FronEnd of the testing site, for the com_foos component as usual, you will see:

```
Hello FOO from the SITE model: DEFAULT
Hello FOO from the SITE model: SECOND
Hello FOOS from the ADMINISTRATOR model: THIRD
```

Each one of this messages, coming from a different model attached to the Foo View.

Note that the THIRD model is a backend model. You can assign it exactly the same way.

### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: Not specified yet
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
