### PR TITLE
Fix subform multiple tinymce elements

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -60,11 +60,10 @@
         return;
       }
 
-      const name = element ? element.getAttribute('name').replace(/\[\]|\]/g, '').split('[').pop() : 'default'; // Get Editor name
       const tinyMCEOptions = pluginOptions ? pluginOptions.tinyMCE || {} : {};
       const defaultOptions = tinyMCEOptions.default || {};
       // Check specific options by the name
-      let options = tinyMCEOptions[name] ? tinyMCEOptions[name] : defaultOptions;
+      let options = tinyMCEOptions[element.id] ? tinyMCEOptions[element.id] : defaultOptions;
 
       // Avoid an unexpected changes, and copy the options object
       if (options.joomlaMergeDefaults) {

--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -98,30 +98,30 @@ trait DisplayTrait
         $editor .= '</div>';
 
         // Prepare the instance specific options
-        if (empty($options['tinyMCE'][$fieldName])) {
-            $options['tinyMCE'][$fieldName] = [];
+        if (empty($options['tinyMCE'][$id])) {
+            $options['tinyMCE'][$id] = [];
         }
 
         // Width and height
-        if ($width && empty($options['tinyMCE'][$fieldName]['width'])) {
-            $options['tinyMCE'][$fieldName]['width'] = $width;
+        if ($width && empty($options['tinyMCE'][$id]['width'])) {
+            $options['tinyMCE'][$id]['width'] = $width;
         }
 
-        if ($height && empty($options['tinyMCE'][$fieldName]['height'])) {
-            $options['tinyMCE'][$fieldName]['height'] = $height;
+        if ($height && empty($options['tinyMCE'][$id]['height'])) {
+            $options['tinyMCE'][$id]['height'] = $height;
         }
 
         // Set editor to readonly mode
         if (!empty($params['readonly'])) {
-            $options['tinyMCE'][$fieldName]['readonly'] = 1;
+            $options['tinyMCE'][$id]['readonly'] = 1;
         }
 
         // The ext-buttons
-        if (empty($options['tinyMCE'][$fieldName]['joomlaExtButtons'])) {
+        if (empty($options['tinyMCE'][$id]['joomlaExtButtons'])) {
             $btns = $this->tinyButtons($id, $buttons);
 
-            $options['tinyMCE'][$fieldName]['joomlaMergeDefaults'] = true;
-            $options['tinyMCE'][$fieldName]['joomlaExtButtons']    = $btns;
+            $options['tinyMCE'][$id]['joomlaMergeDefaults'] = true;
+            $options['tinyMCE'][$id]['joomlaExtButtons']    = $btns;
         }
 
         $doc->addScriptOptions('plg_editor_tinymce', $options, false);


### PR DESCRIPTION
Pull Request for Issue #39416 .

There is a minor B/C break here in that the options are injectable by other components and this does change that ID - however there isn't another way to make this work for subform fields. The only other way I can make this work is to code a b/c break that would be more specific to subform fields with tiny (by detecting the property in the url or similar). Either way there's going to be a b/c break. However we don't guarentee b/c breaks in extensions so the impact should be limited and hence I've targeted 4.3 rather than 4.2 even though this is also a bug fix

### Summary of Changes
Changes the property used to inject tinymce options from the last element in the name to the id of the element. This is because in subform fields (with a tinymce custom field) the final element is the id of the field (e.g. `field5`) and the one before that is the row number which differentiates the fields

### Testing Instructions
Follow the instructions in the linked issue to test the patch before applying the PR. Apply the PR (remember to run `npm run build:js` to compile the javascript if using patchtester. Else use the upgrade package from drone. Then retest and find things work as expected

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
