### PR TITLE
[4.2] Fix restore category from version history

### DIFF
--- a/administrator/components/com_contenthistory/src/View/History/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/History/HtmlView.php
@@ -93,15 +93,21 @@ class HtmlView extends BaseHtmlView
         $token = Session::getFormToken();
 
         // Clean up input to ensure a clean url.
-        $aliasArray = explode('.', $this->state->item_id);
-        $option     = $aliasArray[1] == 'category'
-            ? 'com_categories&amp;extension=' . implode('.', array_slice($aliasArray, 0, count($aliasArray) - 2))
-            : $aliasArray[0];
         $filter     = InputFilter::getInstance();
+        $aliasArray = explode('.', $this->state->item_id);
+
+        if ($aliasArray[1] === 'category') {
+            $option = 'com_categories';
+            $append = '&amp;extension=' . $filter->clean($aliasArray[0], 'cmd');
+        } else {
+            $option = $aliasArray[0];
+            $append = '';
+        }
+
         $task       = $filter->clean($aliasArray[1], 'cmd') . '.loadhistory';
 
         // Build the final urls.
-        $loadUrl    = Route::_('index.php?option=' . $filter->clean($option, 'cmd') . '&amp;task=' . $task . '&amp;' . $token . '=1');
+        $loadUrl    = Route::_('index.php?option=' . $filter->clean($option, 'cmd') . $append . '&amp;task=' . $task . '&amp;' . $token . '=1');
         $previewUrl = Route::_('index.php?option=com_contenthistory&view=preview&layout=preview&tmpl=component&' . $token . '=1');
         $compareUrl = Route::_('index.php?option=com_contenthistory&view=compare&layout=compare&tmpl=component&' . $token . '=1');
 


### PR DESCRIPTION
Pull Request for Issue #39404.

### Summary of Changes
This PR fixes **404 Component not found** error when admin tries to restore a category from version history. See https://github.com/joomla/joomla-cms/issues/39404 for detailed issue description.

### Testing Instructions

1. Use Joomla 4.2
2. Go to Content -> Categories, click on a category to edit. Try to change the category data, save it so that versions history is stored for that category.
3. On category edit screen, click on Versions button and try to restore the category to one of the saved version. You get **404 Component not found** error
4. Apply patch, confirm that the error is gone. The category is restored to the selected version.
5. Try to restore an article from one of it's version history, confirm that it is still working OK

### Actual result BEFORE applying this Pull Request
You get **404 Component not found** error



### Expected result AFTER applying this Pull Request
No error, category is successfully restored to the selected version.

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed

- [x] No documentation changes for manual.joomla.org needed