### PR TITLE
[4.2] Fix delete category custom fields value

### DIFF
--- a/plugins/system/fields/fields.php
+++ b/plugins/system/fields/fields.php
@@ -200,6 +200,11 @@ class PlgSystemFields extends CMSPlugin
      */
     public function onContentAfterDelete($context, $item): void
     {
+        // Set correct context for category
+        if ($context === 'com_categories.category') {
+            $context = $item->extension . '.categories';
+        }
+
         $parts = FieldsHelper::extract($context, $item);
 
         if (!$parts || empty($item->id)) {


### PR DESCRIPTION
Pull Request for Issue #38379.

### Summary of Changes
Currently, delete a category does not delete custom fields value associated with that category. This PR just fixes that wrong behavior. See https://github.com/joomla/joomla-cms/issues/38379 for detailed issue description.


### Testing Instructions
1. Go to Content -> Fields, create a custom field for category 
2. Go to Content -> Categories, edit a category, look at Fields tab, enter data for the custom field which you created above
3. Access to your site database (via phpmyadmin for example), look at `#__fields_values` table, you should see a record contains data for custom field which you entered for category above
4. Trash the category, then delete the category from the system

### Actual result BEFORE applying this Pull Request
The record which store custom fields data for category is not deleted from `#__fields_values` table

### Expected result AFTER applying this Pull Request
The record which store custom fields data for category is deleted from `#__fields_values` table

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed