### PR TITLE
[4.3] Remove cypress.config.js from package

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -400,6 +400,7 @@ $doNotPackage = array(
     'composer.json',
     'composer.lock',
     'crowdin.yml',
+    'cypress.config.js',
     'package-lock.json',
     'package.json',
     'phpunit-pgsql.xml.dist',


### PR DESCRIPTION
### Summary of Changes

It is not necessary that `cypress.config.js` is included in the package

### Testing Instructions

Check if prebuilt packages contain the mentioned file

### Actual result BEFORE applying this Pull Request

Joomla! 4.3 [Nightly Builds](https://developer.joomla.org/nightly-builds.html)
![image](https://user-images.githubusercontent.com/66922325/209197162-78486f83-193d-4921-b4a3-e5ad93384b71.png)

### Expected result AFTER applying this Pull Request

Prebuilt package of this Pull Request
![image](https://user-images.githubusercontent.com/66922325/209199092-cfeb295a-d6d6-4a3d-b96e-ea022803eb32.png)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed

@richard67 Is it necessary to add this file to `com_admin/script.php` since alpha1 has already been released?