### PR TITLE
[4.2] fix admin module popular

### DIFF
--- a/administrator/modules/mod_popular/src/Helper/PopularHelper.php
+++ b/administrator/modules/mod_popular/src/Helper/PopularHelper.php
@@ -44,7 +44,7 @@ abstract class PopularHelper
 
         // Set List SELECT
         $model->setState('list.select', 'a.id, a.title, a.checked_out, a.checked_out_time, ' .
-            ' a.publish_up, a.hits');
+            ' a.created_by, a.publish_up, a.hits');
 
         // Set Ordering filter
         $model->setState('list.ordering', 'a.hits');


### PR DESCRIPTION
### Summary of Changes

Add `created_by` to list select query to get article items.

The `created_by` property is required if the `core.edit` permission is not allowed. Function was added with #36559.
https://github.com/joomla/joomla-cms/blob/e9b9263a34ad919c7a8e6b817074f53eb1997565/administrator/modules/mod_popular/src/Helper/PopularHelper.php#L88-L91

### Testing Instructions

Check the admin dashboard with a user with these permissions on com_content:
![image](https://user-images.githubusercontent.com/66922325/209372854-d3c73492-c2c0-42e3-a346-93a0647afe3f.png)

### Actual result BEFORE applying this Pull Request

PHP Warning: `Undefined property: stdClass::$created_by in [ROOT]\administrator\modules\mod_popular\src\Helper\PopularHelper.php on line 90`
![image](https://user-images.githubusercontent.com/66922325/209371978-90306111-3272-4d56-b13a-bd5ee0befbdf.png)

### Expected result AFTER applying this Pull Request

Link to edit own article is displayed (and no PHP warning)
![image](https://user-images.githubusercontent.com/66922325/209372287-9c3ab4af-e6d7-4cc7-86f1-2d201f0f8768.png)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
