### PR TITLE
[4.2] Fix move user to group

### DIFF
--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -771,7 +771,7 @@ class UserModel extends AdminModel
             } elseif ($doDelete === 'all') {
                 $query = $db->getQuery(true);
                 $query->delete($db->quoteName('#__user_usergroup_map'))
-                    ->whereIn($db->quoteName('user_id'), $users);
+                    ->whereIn($db->quoteName('user_id'), $userIds);
             }
             $db->setQuery($query);
 


### PR DESCRIPTION
### Summary of Changes

The feature to move an user to a group is broken after #38596.

Variable `$users` is not assigned in this if-case. Use the correct variable `$userIds` like it was before #38596

https://github.com/joomla/joomla-cms/blob/f520c98c64efb538e70e918acffb60d07e4d6b1e/administrator/components/com_users/src/Model/UserModel.php#L725-L727

### Testing Instructions

Try moving a user to a group using the batch command.
![image](https://user-images.githubusercontent.com/66922325/209379657-38c0a399-b4eb-4991-86c9-7adcbbf2778f.png)

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/66922325/209379174-2726196b-66d5-44be-b8ea-b1f990b790e1.png)

### Expected result AFTER applying this Pull Request

The user is moved to the new group.
![image](https://user-images.githubusercontent.com/66922325/209379505-b1573aff-e887-4cd3-988a-39ff9469bf37.png)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
