### PR TITLE
[4.2] PHP8.2 deprecated dynamic properties

### DIFF
--- a/libraries/src/Installer/Adapter/PluginAdapter.php
+++ b/libraries/src/Installer/Adapter/PluginAdapter.php
@@ -32,6 +32,14 @@ use Joomla\Database\ParameterType;
 class PluginAdapter extends InstallerAdapter
 {
     /**
+     * Group of the plugin
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $group;
+
+    /**
      * `<scriptfile>` element of the extension manifest
      *
      * @var    object


### PR DESCRIPTION
### Summary of Changes

> The creation of dynamic properties is deprecated

https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties

### Testing Instructions

Install a extension of type plugin

### Actual result BEFORE applying this Pull Request

PHP Deprecated:  Creation of dynamic property `Joomla\CMS\Installer\Adapter\PluginAdapter::$group` is deprecated in `libraries/src/Installer/Adapter/PluginAdapter.php` on line 373

### Expected result AFTER applying this Pull Request

No deprecated message

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
