### PR TITLE
[4.2] PHP8.2 deprecated dynamic properties

### DIFF
--- a/libraries/src/Helper/HelperFactoryAwareTrait.php
+++ b/libraries/src/Helper/HelperFactoryAwareTrait.php
@@ -27,7 +27,7 @@ trait HelperFactoryAwareTrait
      *
      * @since  4.2.0
      */
-    private $helperFactory;
+    private $helper;
 
     /**
      * Get the HelperFactory.


### PR DESCRIPTION
### Summary of Changes

> The creation of dynamic properties is deprecated

https://www.php.net/manual/en/migration82.deprecated.php#migration82.deprecated.core.dynamic-properties

### Testing Instructions

Open frontend where `mod_articles_latest` and/or `mod_articles_news` are displayed

### Actual result BEFORE applying this Pull Request

PHP Deprecated:  Creation of dynamic property `Joomla\Module\ArticlesLatest\Site\Dispatcher\Dispatcher::$helper` is deprecated in `libraries/src/Helper/HelperFactoryAwareTrait.php` on line 61
PHP Deprecated:  Creation of dynamic property `Joomla\Module\ArticlesNews\Site\Dispatcher\Dispatcher::$helper` is deprecated in `libraries/src/Helper/HelperFactoryAwareTrait.php` on line 61

### Expected result AFTER applying this Pull Request

No deprecated message

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org:
- [ ] No documentation changes for manual.joomla.org needed

ping @laoneo who introduced helper factory aware interface in #37445
I'm not sure if this the "right" fix for b/c, also the variable names of the interface and trait do not match:

https://github.com/joomla/joomla-cms/blob/e9b9263a34ad919c7a8e6b817074f53eb1997565/libraries/src/Helper/HelperFactoryAwareInterface.php#L32
https://github.com/joomla/joomla-cms/blob/e9b9263a34ad919c7a8e6b817074f53eb1997565/libraries/src/Helper/HelperFactoryAwareTrait.php#L59