### PR TITLE
[4.2.6] Email cloaking fails.

### DIFF
--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -444,11 +444,11 @@ class PlgContentEmailcloak extends CMSPlugin
         $pattern = '~<[^<]*(?<!\/)>(*SKIP)(*F)|<[^>]+?(\w*=\"' . $searchEmail . '\")[^>]*\/>~i';
 
         while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
-            $mail = $regs[1][0];
+            $mail = $regs[0][0];
             $replacement = HTMLHelper::_('email.cloak', $mail, 0, $mail);
 
             // Replace the found address with the js cloaked email
-            $text = substr_replace($text, $replacement, $regs[1][1], strlen($mail));
+            $text = substr_replace($text, $replacement, $regs[0][1], strlen($mail));
         }
 
         /*

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -451,31 +451,29 @@ class PlgContentEmailcloak extends CMSPlugin
             $text = substr_replace($text, $replacement, $regs[1][1], strlen($mail));
         }
 
-        /* 
+        /*
          * Search for plain text email addresses, such as email@example.org but within HTML attributes:
          * <a title="email@example.org" href="#">email</a> or <li title="email@example.org">email</li>
          */
         $pattern = '(<[^>]+?(\w*=\"' . $searchEmail . '")[^>]*>[^<]+<[^<]+>)';
-      
-        while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
 
+        while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
             $mail = $regs[0][0];
             $replacement =  HTMLHelper::_('email.cloak', $mail, 0, $mail);
 
             // Replace the found address with the js cloaked email
             $text = substr_replace($text, $replacement, $regs[0][1], strlen($mail));
         }
-      
+
         /*
         * Search for plain text email addresses, such as email@example.org but not within HTML tags:
         * <p>email@example.org</p>
         * The '<[^<]*>(*SKIP)(*F)|' trick is used to exclude this kind of occurrences
         */
-       
+
         $pattern = '~<[^<]*(?<!\/)>(*SKIP)(*F)|' . $searchEmail . '~i';
 
-        while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {	
-
+        while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
             $mail = $regs[1][0];
             $replacement = HTMLHelper::_('email.cloak', $mail, $mode, $mail);
 

--- a/plugins/content/emailcloak/emailcloak.php
+++ b/plugins/content/emailcloak/emailcloak.php
@@ -437,15 +437,47 @@ class PlgContentEmailcloak extends CMSPlugin
         }
 
         /*
-         * Search for plain text email addresses, such as email@example.org but not within HTML tags:
+         * Search for plain text email addresses, such as email@example.org but within HTML tags:
          * <img src="..." title="email@example.org"> or <input type="text" placeholder="email@example.org">
          * The '<[^<]*>(*SKIP)(*F)|' trick is used to exclude this kind of occurrences
          */
-        $pattern = '~<[^<]*(?<!\/)>(*SKIP)(*F)|(<\w.*\"' . $searchEmail . '\".*\/\>)~i';
+        $pattern = '~<[^<]*(?<!\/)>(*SKIP)(*F)|<[^>]+?(\w*=\"' . $searchEmail . '\")[^>]*\/>~i';
 
         while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
             $mail = $regs[1][0];
             $replacement = HTMLHelper::_('email.cloak', $mail, 0, $mail);
+
+            // Replace the found address with the js cloaked email
+            $text = substr_replace($text, $replacement, $regs[1][1], strlen($mail));
+        }
+
+        /* 
+         * Search for plain text email addresses, such as email@example.org but within HTML attributes:
+         * <a title="email@example.org" href="#">email</a> or <li title="email@example.org">email</li>
+         */
+        $pattern = '(<[^>]+?(\w*=\"' . $searchEmail . '")[^>]*>[^<]+<[^<]+>)';
+      
+        while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {
+
+            $mail = $regs[0][0];
+            $replacement =  HTMLHelper::_('email.cloak', $mail, 0, $mail);
+
+            // Replace the found address with the js cloaked email
+            $text = substr_replace($text, $replacement, $regs[0][1], strlen($mail));
+        }
+      
+        /*
+        * Search for plain text email addresses, such as email@example.org but not within HTML tags:
+        * <p>email@example.org</p>
+        * The '<[^<]*>(*SKIP)(*F)|' trick is used to exclude this kind of occurrences
+        */
+       
+        $pattern = '~<[^<]*(?<!\/)>(*SKIP)(*F)|' . $searchEmail . '~i';
+
+        while (preg_match($pattern, $text, $regs, PREG_OFFSET_CAPTURE)) {	
+
+            $mail = $regs[1][0];
+            $replacement = HTMLHelper::_('email.cloak', $mail, $mode, $mail);
 
             // Replace the found address with the js cloaked email
             $text = substr_replace($text, $replacement, $regs[1][1], strlen($mail));


### PR DESCRIPTION
Pull Request for Issue #39422 .

### Summary of Changes
a) modification of the last pattern
b) added more patterns


### Testing Instructions
create article with

for the last pattern:
```
<img class="img-thumbnail" style="border: 1px solid #00f;" title="email@example.org" src="/www/j4test/images/joomla_black.png" alt="" />
<input type="text" placeholder="email@example.org" />
```

for the new pattern (email as plain text within html-attributes):
```
<a class="btn btn-danger" style="border: 2px solid #f00;" title="email@example.org" href="#">email</a>
<a title="email@example.org" href="#">email</a>
<ul>
<li title="email-1@example.org">email 1</li>
<li title="email-2@example.org">email 2</li>
</ul>
```

for the new last pattern (email as plain text but not within HTML tags):
```
<span>email--1@example.org</span>
<ul>
<li>email-0@example.org</li>
<li>email-1@example.org</li>
</ul>
```

### Actual result BEFORE applying this Pull Request
a) the pattern was too hungry
b) emails as plain text within html-attributes and not within html-tags was not cloaked

### Expected result AFTER applying this Pull Request
a) the pattern was not too hungry
b) emails as plain text within html-attributes and not within html-tags was cloaked


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x ] No documentation changes for manual.joomla.org needed
