### PR TITLE
[4.3] Add support for namespaced template helper (com_ajax)

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -149,6 +149,7 @@ if (!$format) {
 
     if ($templateId && $table->load($templateId) && $table->enabled) {
         $basePath   = ($table->client_id) ? JPATH_ADMINISTRATOR : JPATH_SITE;
+        $baseClient = ($table->client_id) ? 'Administrator' : 'Site';
         $helperFile = $basePath . '/templates/' . $template . '/helper.php';
 
         if (strpos($template, '_')) {
@@ -169,11 +170,19 @@ if (!$format) {
             $class = 'Tpl' . ucfirst($template) . 'Helper';
         }
 
-        $method = $input->get('method') ?: 'get';
+        $method     = $input->get('method') ?: 'get';
+        $fileExists = false;
+        $xmlData    = simplexml_load_file($basePath . '/templates/' . $template . '/templateDetails.xml');
 
-        if (is_file($helperFile)) {
+        if ($xmlData && isset($xmlData->namespace) && class_exists((string) $xmlData->namespace . '\\' . $baseClient . '\Helper\\' . ucfirst($template) . 'Helper')) {
+            $class = (string) $xmlData->namespace . '\\' . $baseClient . '\Helper\\' . ucfirst($template) . 'Helper';
+            $fileExists = true;
+        } elseif (is_file($helperFile)) {
             JLoader::register($class, $helperFile);
+            $fileExists = true;
+        }
 
+        if ($fileExists) {
             if (method_exists($class, $method . 'Ajax')) {
                 // Load language file for template
                 $lang = Factory::getLanguage();

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -174,8 +174,8 @@ if (!$format) {
         $fileExists = false;
         $xmlData    = simplexml_load_file($basePath . '/templates/' . $template . '/templateDetails.xml');
 
-        if ($xmlData && isset($xmlData->namespace) && class_exists((string) $xmlData->namespace . '\\' . $baseClient . '\Helper\\' . ucfirst($template) . 'Helper')) {
-            $class = (string) $xmlData->namespace . '\\' . $baseClient . '\Helper\\' . ucfirst($template) . 'Helper';
+        if ($xmlData && isset($xmlData->namespace) && class_exists((string) $xmlData->namespace . '\\' . $baseClient . '\Helper\AjaxHelper')) {
+            $class = (string) $xmlData->namespace . '\\' . $baseClient . '\Helper\AjaxHelper';
             $fileExists = true;
         } elseif (is_file($helperFile)) {
             JLoader::register($class, $helperFile);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

The PR https://github.com/joomla/joomla-cms/pull/39011 introduced namespace to the templates. This obviously solves the Fields problem but there is one more that needs to be tackled: `com_ajax`.
This PR is using the existing conventions but allows to load the namespaced helper


### Testing Instructions
#### Existing functionality Front end templates
- Add a file named `helper.php` in the `templates\cassiopeia` folder with the following content

```php
<?php

defined('_JEXEC') || die;


class TplCassiopeiaHelper
{
    public static function templateAjax(): array
    {
        return ['is' => true, 'namespaced' => false];
    }
}
```

- point your browser to `index.php?option=com_ajax&method=template&format=json&template=cassiopeia` and you should have a message: `{"success":true,"message":null,"messages":null,"data":{"is":true,"namespaced":false}}`

#### Proposed code

- Add `<namespace path="src">Joomla\Template\Cassiopeia</namespace>` to the templateDetails.xml of Cassiopeia
- Delete the file `administrator/cache/autoload_psr4.php`
- create a file named `templates/cassiopeia/src/Helper/AjaxHelper.php` with the following contents:

```php
<?php

namespace Joomla\Template\Cassiopeia\Site\Helper;

defined('_JEXEC') || die;


class AjaxHelper
{
    public static function templateAjax(): array
    {
        return ['is' => true, 'namespaced' => true];
    }
}

```

- visit again the same URL as before `index.php?option=com_ajax&method=template&format=json&template=cassiopeia` and you should have a message: `{"success":true,"message":null,"messages":null,"data":{"is":true,"namespaced":true}}`

#### Existing functionality Back end templates

- Add a file named `helper.php` in the `administrator/templates/atum` folder
- Add the following content

```php
<?php

defined('_JEXEC') || die;


class TplAtumHelper
{
    public static function templateAjax(): array
    {
        return ['is' => true, 'namespaced' => false];
    }
}
```

- point your browser to `administrator/index.php?option=com_ajax&method=template&format=json&template=atum` and you should have a message: `{"success":true,"message":null,"messages":null,"data":{"is":true,"namespaced":false}}`

#### Proposed code

- Add `<namespace path="src">Joomla\Template\Atum</namespace>` to the templateDetails.xml of the Atum template
- Delete the file `administrator/cache/autoload_psr4.php`
- create a file named `administrator/templates/atum/src/Helper/AjaxHelper.php` with the following contents:

```php
<?php

namespace Joomla\Template\Atum\Administrator\Helper;

defined('_JEXEC') || die;


class AjaxHelper
{
    public static function templateAjax(): array
    {
        return ['is' => true, 'namespaced' => true];
    }
}

```

- visit again the same URL as before `administrator/index.php?option=com_ajax&method=template&format=json&template=atum` and you should have a message: `{"success":true,"message":null,"messages":null,"data":{"is":true,"namespaced":true}}`


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed

Requesting a review from @HLeithner @laoneo @wilsonge 