### PR TITLE
Pull request for issue #39514 strpos deprecated warning

### DIFF
--- a/plugins/content/loadmodule/loadmodule.php
+++ b/plugins/content/loadmodule/loadmodule.php
@@ -50,7 +50,7 @@ class PlgContentLoadmodule extends CMSPlugin
         }
 
         // Only execute if $article is an object and has a text property
-        if (!is_object($article) || !property_exists($article, 'text')) {
+        if (!is_object($article) || !property_exists($article, 'text') || is_null($article->text)) {
             return;
         }
 


### PR DESCRIPTION
Pull Request for issue [#39514](https://github.com/joomla/joomla-cms/issues/39514)

**Summary of Changes** 
Add is_null check before calling str_pos which pass null value  when text is null when doing dump of $article in the plugin 

**Testing Instruction** 
Enable error log maximum in Global Configuration and check php error log ,When dump a article in plugin

**Result before appling this PR**

In php error log :Deprecated: strpos(): Passing null to parameter # 1 ($haystack) of type string is deprecated in [root]/plugins/content/loadmodule/loadmodule.php on line 58

**Expected result after this PR**
No error in php error log

### Link to documentations
Please select:
-  No documentation changes for docs.joomla.org needed

- No documentation changes for manual.joomla.org needed
