### PR TITLE
[5.0] Remove all return type will change annotations

### DIFF
--- a/administrator/components/com_users/src/DataShape/DataShapeObject.php
+++ b/administrator/components/com_users/src/DataShape/DataShapeObject.php
@@ -131,8 +131,7 @@ abstract class DataShapeObject implements \ArrayAccess
      * @return  boolean  Does it exist in the object?
      * @since 4.2.0
      */
-    #[\ReturnTypeWillChange]
-    public function __isset($name)
+    public function __isset($name): bool
     {
         $methodName = 'get' . ucfirst($name);
 
@@ -147,8 +146,7 @@ abstract class DataShapeObject implements \ArrayAccess
      * @return  boolean
      * @since 4.2.0
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->{$offset});
     }
@@ -161,8 +159,7 @@ abstract class DataShapeObject implements \ArrayAccess
      * @return  mixed
      * @since 4.2.0
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->{$offset};
     }
@@ -176,8 +173,7 @@ abstract class DataShapeObject implements \ArrayAccess
      * @return void
      * @since 4.2.0
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         $this->{$offset} = $value;
     }
@@ -187,11 +183,10 @@ abstract class DataShapeObject implements \ArrayAccess
      *
      * @param   string  $offset  Property name
      *
-     * @return  mixed
+     * @return  void
      * @since 4.2.0
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new \LogicException(sprintf('You cannot unset members of %s', __CLASS__));
     }

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -288,8 +288,7 @@ class Date extends \DateTime
      *
      * @since   1.7.0
      */
-    #[\ReturnTypeWillChange]
-    public function format($format, $local = false, $translate = true)
+    public function format($format, $local = false, $translate = true): string
     {
         if ($translate) {
             // Do string replacements for date format options that can be translated.
@@ -397,8 +396,7 @@ class Date extends \DateTime
      * @since   1.7.0
      * @note    This method can't be type hinted due to a PHP bug: https://bugs.php.net/bug.php?id=61483
      */
-    #[\ReturnTypeWillChange]
-    public function setTimezone($tz)
+    public function setTimezone($tz): \Datetime
     {
         $this->tz = $tz;
 

--- a/libraries/src/Document/JsonapiDocument.php
+++ b/libraries/src/Document/JsonapiDocument.php
@@ -158,8 +158,7 @@ class JsonapiDocument extends JsonDocument implements \JsonSerializable
      *
      * @since  4.0.0
      */
-    #[\ReturnTypeWillChange]
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->toArray();
     }

--- a/libraries/src/Feed/Feed.php
+++ b/libraries/src/Feed/Feed.php
@@ -187,8 +187,7 @@ class Feed implements \ArrayAccess, \Countable
      *
      * @return  integer number of entries in the feed.
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
         return \count($this->entries);
     }
@@ -204,8 +203,7 @@ class Feed implements \ArrayAccess, \Countable
      * @see     ArrayAccess::offsetExists()
      * @since   3.1.4
      */
-    #[\ReturnTypeWillChange]
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return isset($this->entries[$offset]);
     }
@@ -220,8 +218,7 @@ class Feed implements \ArrayAccess, \Countable
      * @see     ArrayAccess::offsetGet()
      * @since   3.1.4
      */
-    #[\ReturnTypeWillChange]
-    public function offsetGet($offset)
+    public function offsetGet($offset): mixed
     {
         return $this->entries[$offset];
     }
@@ -232,14 +229,13 @@ class Feed implements \ArrayAccess, \Countable
      * @param   mixed      $offset  The offset to assign the value to.
      * @param   FeedEntry  $value   The JFeedEntry to set.
      *
-     * @return  boolean
+     * @return  void
      *
      * @see     ArrayAccess::offsetSet()
      * @since   3.1.4
      * @throws  \InvalidArgumentException
      */
-    #[\ReturnTypeWillChange]
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         if (!($value instanceof FeedEntry)) {
             throw new \InvalidArgumentException(
@@ -252,8 +248,6 @@ class Feed implements \ArrayAccess, \Countable
         }
 
         $this->entries[$offset] = $value;
-
-        return true;
     }
 
     /**
@@ -266,8 +260,7 @@ class Feed implements \ArrayAccess, \Countable
      * @see     ArrayAccess::offsetUnset()
      * @since   3.1.4
      */
-    #[\ReturnTypeWillChange]
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         unset($this->entries[$offset]);
     }


### PR DESCRIPTION
### Summary of Changes
All these return types were introduced to bridge the non-return typed functions in < PHP 8.1 and the typed versions in >= 8.1.

Now 5.0 requires PHP 8.1 and higher we can use the native typed versions

### Testing Instructions
Code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/73
- [ ] No documentation changes for manual.joomla.org needed
