### PR TITLE
Fix deprecated warning in user level

### DIFF
--- a/administrator/components/com_users/src/Model/LevelModel.php
+++ b/administrator/components/com_users/src/Model/LevelModel.php
@@ -154,8 +154,10 @@ class LevelModel extends AdminModel
     {
         $result = parent::getItem($pk);
 
-        // Convert the params field to an array.
-        $result->rules = json_decode($result->rules);
+        if (!empty($result->rules)) {
+            // Convert the params field to an array.
+            $result->rules = json_decode($result->rules);
+        }
 
         return $result;
     }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fix Deprecated warning in PHP 8.1

### Testing Instructions
Inspect code 
or
set error-reporting to "maximum", go to users - access levels.
Add a new level


### Actual result BEFORE applying this Pull Request
![grafik](https://user-images.githubusercontent.com/1035262/211102709-97abf7de-9fd3-4be3-b958-42b12e8cff67.png)



### Expected result AFTER applying this Pull Request
No warning


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
