### PR TITLE
[4.x] Change the button class in the pagebreak plugin

### DIFF
--- a/plugins/content/pagebreak/tmpl/navigation.php
+++ b/plugins/content/pagebreak/tmpl/navigation.php
@@ -21,14 +21,14 @@ use Joomla\CMS\Router\Route;
 
 $lang = Factory::getLanguage();
 ?>
-<ul class="pagination">
+<ul class="pagination p-1">
     <li class="previous page-item">
         <?php if ($links['previous']) :
             $direction = $lang->isRtl() ? 'right' : 'left';
             $title = htmlspecialchars($this->list[$page]->title, ENT_QUOTES, 'UTF-8');
             $ariaLabel = Text::_('JPREVIOUS') . ': ' . $title . ' (' . Text::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', $page, $n) . ')';
             ?>
-        <a class="page-link" href="<?php echo Route::_($links['previous']); ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="prev">
+        <a class="p-2 btn btn-sm btn-secondary" href="<?php echo Route::_($links['previous']); ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="prev">
             <?php echo '<span class="icon-chevron-' . $direction . '" aria-hidden="true"></span> ' . Text::_('JPREV'); ?>
         </a>
         <?php endif; ?>
@@ -39,7 +39,7 @@ $lang = Factory::getLanguage();
             $title = htmlspecialchars($this->list[$page + 2]->title, ENT_QUOTES, 'UTF-8');
             $ariaLabel = Text::_('JNEXT') . ': ' . $title . ' (' . Text::sprintf('JLIB_HTML_PAGE_CURRENT_OF_TOTAL', ($page + 2), $n) . ')';
             ?>
-        <a class="page-link" href="<?php echo Route::_($links['next']); ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="next">
+        <a class="p-2 btn btn-sm btn-secondary" href="<?php echo Route::_($links['next']); ?>" title="<?php echo $title; ?>" aria-label="<?php echo $ariaLabel; ?>" rel="next">
             <?php echo Text::_('JNEXT') . ' <span class="icon-chevron-' . $direction . '" aria-hidden="true"></span>'; ?>
         </a>
         <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

The button class corresponds to that of the page navigation, so that the same style here is used.
The dimensions of the button are slightly larger than those of the page navigation.

### Testing Instructions
- Make a page break and check out the new buttons
- Code review

![issue_next-button](https://user-images.githubusercontent.com/9271775/211146366-45c960d0-71f7-4553-89b8-84e039786f52.png)

![issue_prev-button](https://user-images.githubusercontent.com/9271775/211146348-59d19b23-340b-4ee8-ab56-cc61213fd606.png)


### Actual result BEFORE applying this Pull Request

The button class corresponds NOT to that of the page navigation.

### Expected result AFTER applying this Pull Request

The button class corresponds to that of the page navigation.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
