### PR TITLE
Fixed select colour bleed (ultrawide screens)

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/_variables.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables.scss
@@ -240,7 +240,7 @@ $input-btn-submenu-icon-distance:   1rem;
 // Custom form
 $form-select-indicator-padding:    3rem;
 $form-select-bg:                   var(--template-bg-light);
-$form-select-bg-size:              116rem;
+$form-select-bg-size:              calc(max(100%, 116rem));
 $form-select-indicator:            url("../images/select-bg.svg");
 $form-select-indicator-rtl:        url("../images/select-bg-rtl.svg");
 $form-select-indicator-active:     url("../../../images/select-bg.svg");


### PR DESCRIPTION
Pull Request for Issue #34682.

### Summary of Changes

Adjusted select background size to prevent bleeding.

### Testing Instructions

1. Login to the Joomla 4 backend
2. Go to Components -> Banners
3. Create a new banner
4. Click on the banner details tab
5. Increase screen dimensions to atleast 2400px

### Actual result BEFORE applying this Pull Request

Background on selects begin to bleed at ~ 2400px
![image](https://user-images.githubusercontent.com/55460781/211172246-30172482-1f53-4126-a122-3644413340b2.png)

### Expected result AFTER applying this Pull Request

Backgrounds no longer bleed on selects at ~ 2400px+
![image](https://user-images.githubusercontent.com/55460781/211172348-87a0b83f-af32-486f-8c05-2e19e3cb7fbf.png)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
