### PR TITLE
[4.2] Fix Feature start and end date on category blog

### DIFF
--- a/components/com_content/src/Model/ArticlesModel.php
+++ b/components/com_content/src/Model/ArticlesModel.php
@@ -347,7 +347,17 @@ class ArticlesModel extends ListModel
 
         switch ($featured) {
             case 'hide':
-                $query->where($db->quoteName('a.featured') . ' = 0');
+                $query->extendWhere(
+                    'AND',
+                    [
+                        $db->quoteName('a.featured') . ' = 0',
+                        '(' . $db->quoteName('fp.featured_up') . ' IS NOT NULL AND ' . $db->quoteName('fp.featured_up') . ' >= :featuredUp)',
+                        '(' . $db->quoteName('fp.featured_down') . ' IS NOT NULL AND ' . $db->quoteName('fp.featured_down') . ' <= :featuredDown)',
+                    ],
+                    'OR'
+                )
+                    ->bind(':featuredUp', $nowDate)
+                    ->bind(':featuredDown', $nowDate);
                 break;
 
             case 'only':


### PR DESCRIPTION
Pull Request for Issue #39562.

### Summary of Changes
This PR fixes feature start and end date don't affect blog view as described in the issue https://github.com/joomla/joomla-cms/issues/39562 . Please read the issue description to understand more about it if needed.

### Testing Instructions
1. Use Joomla 4.2
2. Create an article, set Featured to Yes, but Start Featured is greater than current date or Finish Featured is less than current date (or both). So the article is marked as featured but it is not really featured for the moment of testing.
3. Create a menu item to link to **Category Blog** menu item type. Select the category which the article belongs to in the menu item parameter. In Blog Layout tab of the menu item, set **Featured Articles** parameter to **Hide**
4. Access to that menu item

### Actual result BEFORE applying this Pull Request
The article is not being displayed.


### Expected result AFTER applying this Pull Request
The article is now being displayed. It is correct behavior because at the moment of testing, it is not featured (current time is not in the featured duration settings controlled by Start Featured and Finish Featured).


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
