### PR TITLE
[4.2] Fix radio form field required validation

### DIFF
--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -64,6 +64,10 @@ if (!empty($autofocus)) {
     $attribs[] = 'autofocus';
 }
 
+if ($required) {
+    $attribs[] = 'class="required radio"';
+}
+
 if ($readonly || $disabled) {
     $attribs[] = 'style="pointer-events: none"';
 }


### PR DESCRIPTION
Pull Request for Issue #39496.

### Summary of Changes
Base on code at https://github.com/joomla/joomla-cms/blob/4.2-dev/build/media_source/system/js/fields/validate.es6.js#L192 and https://github.com/joomla/joomla-cms/blob/4.2-dev/build/media_source/system/js/fields/validate.es6.js#L194 , to validate  a radio form field as required, the fieldset element in radio form field layout must has class attribute contains **radio** . The element also need to have **required** attribute or **required** in it's class.

Since **required** is not a valid attribute for fieldset element, I set **class="required radio"** when the field is required to address the issue.

### Testing Instructions
1. Open the file **administrator/components/com_content/forms/article.xml**, add the below code after id field:

```xml
<field name="status" id="status" type="radio" class="btn-group"
			label="HISTORY_STATUS" 
			description="HISTORY_STATUS" 
		        required="true"
			default="0"
		>
			<option value="1">In Process</option>
  			<option value="2">Return</option>
			<option value="3">Sent</option>
		</field>
```
2. Edit the file administrator/components/com_content/tmpl/article/edit.php, add this line of code below after this line https://github.com/joomla/joomla-cms/blob/4.2-dev/administrator/components/com_content/tmpl/article/edit.php#L66 to render the new field

```html
<div class="row"><?php echo $this->form->getInput('status'); ?></div>
```

3. Create a new article, try to save the article without choosing an option from the new field above

### Actual result BEFORE applying this Pull Request

The form is submitted even the radio field is a required field.


### Expected result AFTER applying this Pull Request

Form is not submitted, an error message like below will be displayed:

**The form cannot be submitted as it's missing required data.
Please correct the marked fields and try again.**


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
