### PR TITLE
Newsflash module change name of style

### DIFF
--- a/modules/mod_articles_news/tmpl/horizontal.php
+++ b/modules/mod_articles_news/tmpl/horizontal.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Helper\ModuleHelper;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $app->getDocument()->getWebAssetManager();
-$wa->registerAndUseStyle('mod_modules', 'mod_articles_news/template.css');
+$wa->registerAndUseStyle('mod_articles_news_horizontal', 'mod_articles_news/template.css');
 
 if (empty($list)) {
     return;

--- a/modules/mod_articles_news/tmpl/vertical.php
+++ b/modules/mod_articles_news/tmpl/vertical.php
@@ -14,7 +14,7 @@ use Joomla\CMS\Helper\ModuleHelper;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $app->getDocument()->getWebAssetManager();
-$wa->registerAndUseStyle('mod_modules', 'mod_articles_news/template-vert.css');
+$wa->registerAndUseStyle('mod_articles_news_vertical', 'mod_articles_news/template-vert.css');
 
 if (!$list) {
     return;


### PR DESCRIPTION
Pull Request for Issue #39584 .

### Summary of Changes
Changed the name of the styles for the web assets manager to avoid overwriting if several modules are present on a page.


### Testing Instructions
Create two newsflash modules, one with horizontal and one with vertical layout.
See issue for more details.


### Actual result BEFORE applying this Pull Request

If the vertical layout is loaded as latest the module with the horizontal layout will be also displayed as vertical, because the css is missing.

### Expected result AFTER applying this Pull Request

Horizontal layout won't be overwritten by the vertical module.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
