### PR TITLE
[4.2] PHP8.2 Allow dynamic properties for Table, MenuItem and CMSObject

### DIFF
--- a/libraries/src/Menu/MenuItem.php
+++ b/libraries/src/Menu/MenuItem.php
@@ -22,6 +22,7 @@ use Joomla\Registry\Registry;
  *
  * @since  3.7.0
  */
+#[\AllowDynamicProperties]
 class MenuItem implements NodeInterface
 {
     use NodeTrait;

--- a/libraries/src/Object/CMSObject.php
+++ b/libraries/src/Object/CMSObject.php
@@ -22,6 +22,7 @@ namespace Joomla\CMS\Object;
  * @since       1.7.0
  * @deprecated  4.0.0  Use \stdClass or \Joomla\Registry\Registry instead.
  */
+#[\AllowDynamicProperties]
 class CMSObject
 {
     /**

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -33,6 +33,7 @@ use Joomla\String\StringHelper;
  *
  * @since  1.7.0
  */
+#[\AllowDynamicProperties]
 abstract class Table extends CMSObject implements TableInterface, DispatcherAwareInterface
 {
     use DispatcherAwareTrait;


### PR DESCRIPTION
### Summary of Changes
Adds the `AllowDynamicProperties` attribute to the core classes `Table`, `MenuItem` and `CMSObject` to mark them as classes which do use dynamic properties.

### Testing Instructions
Open the back end with PHP 8.2.

### Actual result BEFORE applying this Pull Request
Tons of deprecated warnings like:
`Deprecated: Creation of dynamic property ...... is deprecated in`

### Expected result AFTER applying this Pull Request
No warning in the mentioned classes.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
