### PR TITLE
Meta desc hard length limit

### DIFF
--- a/administrator/components/com_categories/forms/category.xml
+++ b/administrator/components/com_categories/forms/category.xml
@@ -141,7 +141,6 @@
 		label="JFIELD_META_DESCRIPTION_LABEL"
 		rows="3"
 		cols="40"
-		maxlength="160"
 		charcounter="true"
 	/>
 

--- a/administrator/components/com_categories/forms/category.xml
+++ b/administrator/components/com_categories/forms/category.xml
@@ -141,7 +141,6 @@
 		label="JFIELD_META_DESCRIPTION_LABEL"
 		rows="3"
 		cols="40"
-		charcounter="true"
 	/>
 
 	<field

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -628,7 +628,6 @@
 			filter="string"
 			cols="60"
 			rows="3"
-			maxlength="160"
 			charcounter="true"
 		/>
 

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -628,7 +628,6 @@
 			filter="string"
 			cols="60"
 			rows="3"
-			charcounter="true"
 		/>
 
 		<field

--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -175,7 +175,6 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			maxlength="160"
 			charcounter="true"
 		/>
 

--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -175,7 +175,6 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			charcounter="true"
 		/>
 
 		<field

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -208,7 +208,6 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			maxlength="160"
 			charcounter="true"
 		/>
 

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -208,7 +208,6 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			charcounter="true"
 		/>
 
 		<field

--- a/administrator/components/com_languages/forms/language.xml
+++ b/administrator/components/com_languages/forms/language.xml
@@ -94,8 +94,6 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			maxlength="160"
-			charcounter="true"
 		/>
 	</fieldset>
 	<fieldset name="site_name" label="COM_LANGUAGES_FIELDSET_SITE_NAME_LABEL">

--- a/administrator/components/com_menus/forms/item_component.xml
+++ b/administrator/components/com_menus/forms/item_component.xml
@@ -106,7 +106,6 @@
 				label="JFIELD_META_DESCRIPTION_LABEL"
 				rows="3"
 				cols="40"
-				charcounter="true"
 			/>
 
 			<field

--- a/administrator/components/com_menus/forms/item_component.xml
+++ b/administrator/components/com_menus/forms/item_component.xml
@@ -106,7 +106,6 @@
 				label="JFIELD_META_DESCRIPTION_LABEL"
 				rows="3"
 				cols="40"
-				maxlength="160"
 				charcounter="true"
 			/>
 

--- a/administrator/components/com_newsfeeds/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/forms/newsfeed.xml
@@ -231,7 +231,6 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			maxlength="160"
 			charcounter="true"
 		/>
 

--- a/administrator/components/com_newsfeeds/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/forms/newsfeed.xml
@@ -231,7 +231,6 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			charcounter="true"
 		/>
 
 		<fields name="images">

--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -131,7 +131,6 @@
 		label="JFIELD_META_DESCRIPTION_LABEL"
 		rows="3"
 		cols="40"
-		maxlength="160"
 		charcounter="true"
 	/>
 

--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -131,7 +131,6 @@
 		label="JFIELD_META_DESCRIPTION_LABEL"
 		rows="3"
 		cols="40"
-		charcounter="true"
 	/>
 
 	<field

--- a/components/com_config/forms/config.xml
+++ b/components/com_config/forms/config.xml
@@ -10,8 +10,6 @@
 			filter="string"
 			cols="60"
 			rows="3"
-			maxlength="160"
-			charcounter="true"
 		/>
 
 		<field

--- a/components/com_contact/forms/form.xml
+++ b/components/com_contact/forms/form.xml
@@ -333,8 +333,6 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			maxlength="160"
-			charcounter="true"
 		/>
 
 		<field

--- a/components/com_content/forms/article.xml
+++ b/components/com_content/forms/article.xml
@@ -192,8 +192,6 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="5"
 			cols="50"
-			maxlength="160"
-			charcounter="true"
 		/>
 
 		<field


### PR DESCRIPTION
Pull Request for Issue #36939 .

### Summary of Changes

Removed all instances of client-side meta description hard-coded limitations to 160 characters.

### Testing Instructions

A character counter appears, and input length is limited to 160 characters, when editing the meta description for:

- a category
- an article
- a menun item
- a contact
- a tag
- a newsfeed item
- the Global Configuration

Try to enter a description longer than 160 characters.

### Actual result BEFORE applying this Pull Request

The counter, corresponding message and input length limitation are present, and your input text is truncated to 160 characters.

### Expected result AFTER applying this Pull Request

The counter, corresponding message and input length limitation are removed. Your input text is not limited to 160 characters.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
