### PR TITLE
[4.2] PHP8.2 Allow dynamic properties in Log class

### DIFF
--- a/libraries/src/Log/LogEntry.php
+++ b/libraries/src/Log/LogEntry.php
@@ -24,6 +24,7 @@ use Joomla\CMS\Filesystem\Path;
  *
  * @since  1.7.0
  */
+#[\AllowDynamicProperties]
 class LogEntry
 {
     /**


### PR DESCRIPTION
### Summary of Changes
Allows dynamic properties on log entries so different formatters can add custom properties.

### Testing Instructions
Open the article form on the PHP 8.2 on the front end with debug enabled.

### Actual result BEFORE applying this Pull Request
The following warning is shown:
`Creation of dynamic property Joomla\CMS\Log\LogEntry::$clientIP is deprecated`

### Expected result AFTER applying this Pull Request
No warning.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
