### PR TITLE
[4.2] PHP8.2 Define tags variable in helper class

### DIFF
--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -65,9 +65,9 @@ class TagsHelper extends CMSHelper
     public $itemTags;
 
     /**
-     * The tags  as comma separated string.
+     * The tags as comma separated string or array.
      *
-     * @var    string
+     * @var    mixed
      * @since  __DEPLOY_VERSION__
      */
     public $tags;

--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -65,6 +65,14 @@ class TagsHelper extends CMSHelper
     public $itemTags;
 
     /**
+     * The tags  as comma separated string.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    public $tags;
+
+    /**
      * Method to add tag rows to mapping table.
      *
      * @param   integer         $ucmId  ID of the #__ucm_content item being tagged

--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -73,6 +73,22 @@ class TagsHelper extends CMSHelper
     public $tags;
 
     /**
+     * The new tags as comma separated string or array.
+     *
+     * @var    mixed
+     * @since  __DEPLOY_VERSION__
+     */
+    public $newTags;
+
+    /**
+     * The old tags as comma separated string or array.
+     *
+     * @var    mixed
+     * @since  __DEPLOY_VERSION__
+     */
+    public $oldTags;
+
+    /**
      * Method to add tag rows to mapping table.
      *
      * @param   integer         $ucmId  ID of the #__ucm_content item being tagged


### PR DESCRIPTION
### Summary of Changes
Define the tags property in the TagsHelper class to prevent deprecation notice on PHP 8.2.

### Testing Instructions
Open the article form on the PHP 8.2 on the front end with debug enabled.

### Actual result BEFORE applying this Pull Request
The following warning is shown:
` Creation of dynamic property Joomla\CMS\Helper\TagsHelper::$tags is deprecated in`

### Expected result AFTER applying this Pull Request
No warning.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
