### PR TITLE
[4.2] PHP8.2 Use the params correctly in the article form layout

### DIFF
--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -29,11 +29,9 @@ $this->useCoreUI = true;
 // Create shortcut to parameters.
 $params = $this->state->get('params');
 
-// This checks if the editor config options have ever been saved. If they haven't they will fall back to the original settings.
-$editoroptions = isset($params->show_publishing_options);
-
-if (!$editoroptions) {
-    $params->show_urls_images_frontend = '0';
+// This checks if the editor config options have ever been saved. If they haven't they will fall back to the original settings
+if (!$params->exists('show_publishing_options')) {
+    $params->set('show_urls_images_frontend', '0');
 }
 ?>
 <div class="edit item-page">


### PR DESCRIPTION
### Summary of Changes
The front from layout file uses the params data as direct attributes and not from the internal data store. This pr fixes it.

### Testing Instructions
Open the article form on the PHP 8.2 on the front end with debug enabled.

### Actual result BEFORE applying this Pull Request
The following warning is shown:
` Creation of dynamic property Joomla\Registry\Registry::$show_urls_images_frontend is deprecated in`

### Expected result AFTER applying this Pull Request
No warning.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
