### PR TITLE
[4.2] PHP8.2 Define the folder property in the media form field

### DIFF
--- a/libraries/src/Form/Field/MediaField.php
+++ b/libraries/src/Form/Field/MediaField.php
@@ -107,6 +107,14 @@ class MediaField extends FormField
     protected $previewHeight;
 
     /**
+     * The folder.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $folder;
+
+    /**
      * Comma separated types of files for Media Manager
      * Possible values: images,audios,videos,documents
      *
@@ -152,6 +160,7 @@ class MediaField extends FormField
             case 'directory':
             case 'previewWidth':
             case 'previewHeight':
+            case 'folder':
             case 'types':
                 return $this->$name;
         }
@@ -179,6 +188,7 @@ class MediaField extends FormField
             case 'height':
             case 'preview':
             case 'directory':
+            case 'folder':
             case 'types':
                 $this->$name = (string) $value;
                 break;


### PR DESCRIPTION
### Summary of Changes
Define the folder property in the MediaField class to prevent deprecation notice on PHP 8.2.

### Testing Instructions
Open the article form on the PHP 8.2 on the back end with debug enabled.

### Actual result BEFORE applying this Pull Request
The following warning is shown:
`  Creation of dynamic property Joomla\CMS\Form\Field\MediaField::$folder is deprecated in`

### Expected result AFTER applying this Pull Request
No warning.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
