### PR TITLE
[4.2] PHP8.2 Add the missing props to the captcha form field

### DIFF
--- a/libraries/src/Form/Field/CaptchaField.php
+++ b/libraries/src/Form/Field/CaptchaField.php
@@ -44,7 +44,7 @@ class CaptchaField extends FormField
      * The namespace of the captcha field.
      *
      * @var    string
-     * @since  _DEPLOY_VERSION__
+     * @since  __DEPLOY_VERSION__
      */
     protected $namespace;
 

--- a/libraries/src/Form/Field/CaptchaField.php
+++ b/libraries/src/Form/Field/CaptchaField.php
@@ -36,7 +36,7 @@ class CaptchaField extends FormField
      * The plugin of the captcha field.
      *
      * @var    string
-     * @since  _DEPLOY_VERSION__
+     * @since  __DEPLOY_VERSION__
      */
     protected $plugin;
 

--- a/libraries/src/Form/Field/CaptchaField.php
+++ b/libraries/src/Form/Field/CaptchaField.php
@@ -33,6 +33,22 @@ class CaptchaField extends FormField
     protected $type = 'Captcha';
 
     /**
+     * The plugin of the captcha field.
+     *
+     * @var    string
+     * @since  _DEPLOY_VERSION__
+     */
+    protected $plugin;
+
+    /**
+     * The namespace of the captcha field.
+     *
+     * @var    string
+     * @since  _DEPLOY_VERSION__
+     */
+    protected $namespace;
+
+    /**
      * The captcha base instance of our type.
      *
      * @var Captcha


### PR DESCRIPTION
### Summary of Changes
Define the plugin and namespace property in the CaptchaField class to prevent deprecation notice on PHP 8.2.

### Testing Instructions
- Setup a captcha plugin
- Open the article form on the PHP 8.2 on the front end with debug enabled

### Actual result BEFORE applying this Pull Request
The following warning is shown:
`Creation of dynamic property Joomla\CMS\Form\Field\CaptchaField::$plugin is deprecated in`

### Expected result AFTER applying this Pull Request
No warning.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
