### PR TITLE
[4.2] PHP8.2 Define the threshold in cache

### DIFF
--- a/libraries/src/Cache/CacheStorage.php
+++ b/libraries/src/Cache/CacheStorage.php
@@ -84,7 +84,7 @@ class CacheStorage
      * @var    integer
      * @since  __DEPLOY_VERSION__
      */
-    protected $_threshold;
+    public $_threshold;
 
     /**
      * Constructor

--- a/libraries/src/Cache/CacheStorage.php
+++ b/libraries/src/Cache/CacheStorage.php
@@ -79,6 +79,14 @@ class CacheStorage
     public $_hash;
 
     /**
+     * The threshold
+     *
+     * @var    integer
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $_threshold;
+
+    /**
      * Constructor
      *
      * @param   array  $options  Optional parameters


### PR DESCRIPTION
### Summary of Changes
Define the threshold property in the CacheStorage class to prevent deprecation notice on PHP 8.2.
This must be tested by code review as it only happens when I want to install the DPCalendar sample data. But it is pretty obvious.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
