### PR TITLE
[4.2] PHP8.2 Add the missing props to the calendar form field

### DIFF
--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -86,6 +86,54 @@ class CalendarField extends FormField
     protected $maxyear;
 
     /**
+     * The today button flag
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $todaybutton;
+
+    /**
+     * The week numbers flag
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $weeknumbers;
+
+    /**
+     * The show time flag
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $showtime;
+
+    /**
+     * The fill table flag
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $filltable;
+
+    /**
+     * The time format
+     *
+     * @var    integer
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $timeformat;
+
+    /**
+     * The single header flag
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $singleheader;
+
+    /**
      * Name of the layout being used to render the field
      *
      * @var    string


### PR DESCRIPTION
### Summary of Changes
Define the missing properties in the CalendarField class to prevent deprecation notice on PHP 8.2.

### Testing Instructions
Open the Publishing tab in the article form on PHP 8.2 on the back end with debug enabled.

### Actual result BEFORE applying this Pull Request
The following warning is shown:
`Creation of dynamic property Joomla\CMS\Form\Field\CalendarField::$todaybutton is deprecated in`

### Expected result AFTER applying this Pull Request
No warning.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
