### PR TITLE
[4.2] PHP8.2 Add the missing props to the rules form field

### DIFF
--- a/libraries/src/Form/Field/RulesField.php
+++ b/libraries/src/Form/Field/RulesField.php
@@ -68,6 +68,62 @@ class RulesField extends FormField
     protected $assetField;
 
     /**
+     * The flag which indicates if it is the global config
+     *
+     * @var    bool
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $isGlobalConfig;
+
+    /**
+     * The asset rules
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $assetRules;
+
+    /**
+     * The actions
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $actions;
+
+    /**
+     * The groups
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $groups;
+
+    /**
+     * The asset Id
+     *
+     * @var    int
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $assetId;
+
+    /**
+     * The parent asset Id
+     *
+     * @var    int
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $parentAssetId;
+
+    /**
+     * The flag to indicate that it is a new item
+     *
+     * @var    bool
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $newItem;
+
+    /**
      * The parent class of the field
      *
      * @var  string


### PR DESCRIPTION
### Summary of Changes
Define the missing properties in the RulesField class to prevent deprecation notice on PHP 8.2.

### Testing Instructions
Open the Permissions tab in the article form on PHP 8.2 on the back end with debug enabled.

### Actual result BEFORE applying this Pull Request
The following warning is shown:
`Creation of dynamic property Joomla\CMS\Form\Field\RulesField::$groups is deprecated in`

### Expected result AFTER applying this Pull Request
No warning.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed


### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
