### PR TITLE
[4.2] PHP8.2 Add the missing props to the password form field

### DIFF
--- a/libraries/src/Form/Field/PasswordField.php
+++ b/libraries/src/Form/Field/PasswordField.php
@@ -44,12 +44,52 @@ class PasswordField extends FormField
     protected $threshold = 66;
 
     /**
+     * The allowable minimum length of password.
+     *
+     * @var    integer
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $minLength;
+
+    /**
      * The allowable maxlength of password.
      *
      * @var    integer
      * @since  3.2
      */
     protected $maxLength;
+
+    /**
+     * The allowable minimum length of integers.
+     *
+     * @var    integer
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $minIntegers;
+
+    /**
+     * The allowable minimum length of symbols.
+     *
+     * @var    integer
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $minSymbols;
+
+    /**
+     * The allowable minimum length of upper case characters.
+     *
+     * @var    integer
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $minUppercase;
+
+    /**
+     * The allowable minimum length of lower case characters.
+     *
+     * @var    integer
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $minLowercase;
 
     /**
      * Whether to attach a password strength meter or not.

--- a/libraries/src/Form/Field/PasswordField.php
+++ b/libraries/src/Form/Field/PasswordField.php
@@ -68,6 +68,14 @@ class PasswordField extends FormField
     protected $force = false;
 
     /**
+     * The rules flag.
+     *
+     * @var    bool
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $rules = false;
+
+    /**
      * Name of the layout being used to render the field
      *
      * @var    string


### PR DESCRIPTION
### Summary of Changes
Define the missing properties in the PasswordField class to prevent deprecation notice on PHP 8.2.

Test by code review.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed


### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
