### PR TITLE
[RFC] Fix subform multiple tinymce elements alternative

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -23,195 +23,14 @@ template.innerHTML = `
 </div>`;
 
 /**
- * Find all TinyMCE elements and initialize TinyMCE instance for each
+ * Applies Joomla specific attributes to a Bootstrap modal
+ * It's almost identical to build/media_source/vendor/bootstrap/js/modal.es6.js Joomla.initialiseModal
  *
- * @param {HTMLElement}  target  Target Element where to search for the editor element
- *
- * @since 3.7.0
- */
-function setupEditors(target) {
-  const container = target || document;
-  const pluginOptions = Joomla.getOptions ? Joomla.getOptions('plg_editor_tinymce', {})
-    : (Joomla.optionsStorage.plg_editor_tinymce || {});
-  const editors = [].slice.call(container.querySelectorAll('.js-editor-tinymce'));
-
-  editors.forEach((editor) => {
-    const currentEditor = editor.querySelector('textarea');
-    const toggleButton = editor.querySelector('.js-tiny-toggler-button');
-    const toggleIcon = editor.querySelector('.icon-eye');
-
-    // Setup the editor
-    setupEditor(currentEditor, pluginOptions);
-
-    // Setup the toggle button
-    if (toggleButton) {
-      toggleButton.removeAttribute('disabled');
-      toggleButton.addEventListener('click', () => {
-        if (Joomla.editors.instances[currentEditor.id].instance.isHidden()) {
-          Joomla.editors.instances[currentEditor.id].instance.show();
-        } else {
-          Joomla.editors.instances[currentEditor.id].instance.hide();
-        }
-
-        if (toggleIcon) {
-          toggleIcon.setAttribute('class', Joomla.editors.instances[currentEditor.id].instance.isHidden() ? 'icon-eye' : 'icon-eye-slash');
-        }
-      });
-    }
-  });
-};
-
-/**
- * Initialize TinyMCE editor instance
- *
- * @param {HTMLElement}  element
- * @param {Object}       pluginOptions
- *
- * @since 3.7.0
- */
-function setupEditor(element, pluginOptions) {
-  // Check whether the editor already has ben set
-  if (Joomla.editors.instances[element.id]) {
-    return;
-  }
-
-  const name = element ? element.getAttribute('name').replace(/\[\]|\]/g, '').split('[').pop() : 'default'; // Get Editor name
-  const tinyMCEOptions = pluginOptions ? pluginOptions.tinyMCE || {} : {};
-  const defaultOptions = tinyMCEOptions.default || {};
-  // Check specific options by the name
-  let options = tinyMCEOptions[name] ? tinyMCEOptions[name] : defaultOptions;
-
-  // Avoid an unexpected changes, and copy the options object
-  if (options.joomlaMergeDefaults) {
-    options = Joomla.extend(Joomla.extend({}, defaultOptions), options);
-  } else {
-    options = Joomla.extend({}, options);
-  }
-
-  if (element) {
-    // We already have the Target, so reset the selector and assign given element as target
-    options.selector = null;
-    options.target = element;
-  }
-
-  const buttonValues = [];
-  const icons = {
-    joomla: '<svg viewBox="0 0 32 32" width="24" height="24"><path d="M8.313 8.646c1.026-1.026 2.688-1.026 3.713-0.001l0.245 0.246 3.159-3.161-0.246-0.246c-1.801-1.803-4.329-2.434-6.638-1.891-0.331-2.037-2.096-3.591-4.224-3.592-2.364 0-4.28 1.92-4.28 4.286 0 2.042 1.425 3.75 3.333 4.182-0.723 2.42-0.133 5.151 1.776 7.062l7.12 7.122 3.156-3.163-7.119-7.121c-1.021-1.023-1.023-2.691 0.006-3.722zM31.96 4.286c0-2.368-1.916-4.286-4.281-4.286-2.164 0-3.952 1.608-4.24 3.695-2.409-0.708-5.118-0.109-7.020 1.794l-7.12 7.122 3.159 3.162 7.118-7.12c1.029-1.030 2.687-1.028 3.709-0.006 1.025 1.026 1.025 2.691-0.001 3.717l-0.244 0.245 3.157 3.164 0.246-0.248c1.889-1.893 2.49-4.586 1.8-6.989 2.098-0.276 3.717-2.074 3.717-4.25zM28.321 23.471c0.566-2.327-0.062-4.885-1.878-6.703l-7.109-7.125-3.159 3.16 7.11 7.125c1.029 1.031 1.027 2.691 0.006 3.714-1.025 1.025-2.688 1.025-3.714-0.001l-0.243-0.243-3.156 3.164 0.242 0.241c1.922 1.925 4.676 2.514 7.105 1.765 0.395 1.959 2.123 3.431 4.196 3.431 2.363 0 4.28-1.917 4.28-4.285 0-2.163-1.599-3.952-3.679-4.244zM19.136 16.521l-7.111 7.125c-1.022 1.024-2.689 1.026-3.717-0.004-1.026-1.028-1.026-2.691-0.001-3.718l0.244-0.243-3.159-3.16-0.242 0.241c-1.836 1.838-2.455 4.432-1.858 6.781-1.887 0.446-3.292 2.145-3.292 4.172-0.001 2.367 1.917 4.285 4.281 4.285 2.034-0.001 3.737-1.419 4.173-3.324 2.334 0.58 4.906-0.041 6.729-1.867l7.109-7.124-3.157-3.163z"></path></svg>',
-  };
-
-  Object.keys(options.joomlaExtButtons.names)
-  .map((key) => options.joomlaExtButtons.names[key])
-  .forEach((xtdButton) => {
-    console.log(xtdButton);
-    const tmp = {
-      text: xtdButton.name,
-      icon: xtdButton.icon,
-      type: 'menuitem',
-    };
-
-    if (xtdButton.iconSVG) {
-      icons[tmp.icon] = xtdButton.iconSVG;
-    }
-
-    if (xtdButton.href) {
-      tmp.onAction = () => {
-        createAndOpenModal({editor: element, button: xtdButton});
-      };
-    } else {
-      tmp.onAction = () => {
-        // eslint-disable-next-line no-new-func
-        new Function(xtdButton.click.replace('{{editor}}', editor.id))();
-      };
-    }
-
-    buttonValues.push(tmp);
-  });
-
-  // Ensure tinymce is initialised in readonly mode if the textarea has readonly applied
-  let readOnlyMode = false;
-
-  if (element) {
-    readOnlyMode = element.readOnly;
-  }
-
-  if (buttonValues.length) {
-    options.setup = (editor) => {
-      editor.settings.readonly = readOnlyMode;
-
-      Object.keys(icons).forEach((icon) => {
-        editor.ui.registry.addIcon(icon, icons[icon]);
-      });
-
-      editor.ui.registry.addMenuButton('jxtdbuttons', {
-        text: Joomla.Text._('PLG_TINY_CORE_BUTTONS'),
-        icon: 'joomla',
-        fetch: (callback) => callback(buttonValues),
-      });
-    };
-  } else {
-    options.setup = (editor) => {
-      editor.settings.readonly = readOnlyMode;
-    };
-  }
-
-  // We'll take over the onSubmit event
-  options.init_instance_callback = (editor) => editor.on('submit', () => {
-    if (editor.isHidden()) {
-      editor.show();
-    }
-  }, true);
-
-  // Create a new instance
-  // eslint-disable-next-line no-undef
-  const ed = new tinyMCE.Editor(element.id, options, tinymce.EditorManager);
-  ed.render();
-
-  /** Register the editor's instance to Joomla Object */
-  Joomla.editors.instances[element.id] = {
-    // Required by Joomla's API for the XTD-Buttons
-    getValue: () => Joomla.editors.instances[element.id].instance.getContent(),
-    setValue: (text) => Joomla.editors.instances[element.id].instance.setContent(text),
-    getSelection: () => Joomla.editors.instances[element.id].instance.selection.getContent({ format: 'text' }),
-    replaceSelection: (text) => Joomla.editors.instances[element.id].instance.execCommand('mceInsertContent', false, text),
-    // Required by Joomla's API for Mail Component Integration
-    disable: (disabled) => Joomla.editors.instances[element.id].instance.setMode(disabled ? 'readonly' : 'design'),
-    // Some extra instance dependent
-    id: element.id,
-    instance: ed,
-  };
-}
-
-/**
- * Creates a Bootstrap modal and open it
- *
+ * @param {HTMLElement}  modal
  * @param {Object}  options
  *
  * @since __DEPLOY_VERSION__
  */
-function createAndOpenModal(options) {
-  let url;
-  const {editor, button} = options;
-  const inst = template.content.cloneNode(true);
-  const modal = inst.querySelector('.modal');
-  modal.id = `${button.id}_modal`;
-
-  // Update the editor url parameter of the modal
-  if (button.href) {
-    url = new URL(button.href);
-    url.searchParams.delete('editor');
-    url.searchParams.append('editor', editor.id);
-  }
-
-  // Update the nodes
-  modal.querySelector('.modal-header').innerHTML = button.header;
-  modal.querySelector('.modal-footer').innerHTML = button.footer.replace('{{editor}}', editor.id);
-  modal.querySelector('.modal-body').innerHTML = button.body ? button.body : Joomla.sanitizeHtml(`<iframe class="iframe" src="${url.toString()}" name="${button.title}"; title="${button.title}" height="${button.height}" width="${button.width}"></iframe>`, { iframe: ['src', 'name', 'width', 'height'] });
-
-  document.body.appendChild(inst);
-  initialiseModal(modal, button.modalOptions);
-  modal.open();
-}
-
 function initialiseModal(modal, options) {
   if (!(modal instanceof Element)) {
     return;
@@ -274,7 +93,196 @@ function initialiseModal(modal, options) {
     Joomla.Modal.setCurrent('');
     modal.remove();
   });
-};
+}
+
+/**
+ * Creates a Bootstrap modal and open it
+ *
+ * @param {Object}  options
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function createAndOpenModal(options) {
+  let url;
+  const { editor, button } = options;
+  const inst = template.content.cloneNode(true);
+  const modal = inst.querySelector('.modal');
+  modal.id = `${button.id}_modal`;
+
+  // Update the editor url parameter of the modal
+  if (button.href) {
+    url = new URL(button.href);
+    url.searchParams.delete('editor');
+    url.searchParams.append('editor', editor.id);
+  }
+
+  // Update the nodes
+  modal.querySelector('.modal-header').innerHTML = button.header;
+  modal.querySelector('.modal-footer').innerHTML = button.footer.replace('{{editor}}', editor.id);
+  modal.querySelector('.modal-body').innerHTML = button.body ? button.body : Joomla.sanitizeHtml(`<iframe class="iframe" src="${url.toString()}" name="${button.title}"; title="${button.title}" height="${button.height}" width="${button.width}"></iframe>`, { iframe: ['src', 'name', 'width', 'height'] });
+
+  document.body.appendChild(inst);
+  initialiseModal(modal, button.modalOptions);
+  modal.open();
+}
+
+/**
+ * Initialize TinyMCE editor instance
+ *
+ * @param {HTMLElement}  element
+ * @param {Object}       pluginOptions
+ *
+ * @since 3.7.0
+ */
+function setupEditor(element, pluginOptions) {
+  // Check whether the editor already has ben set
+  if (Joomla.editors.instances[element.id]) {
+    return;
+  }
+
+  const name = element ? element.getAttribute('name').replace(/\[\]|\]/g, '').split('[').pop() : 'default'; // Get Editor name
+  const tinyMCEOptions = pluginOptions ? pluginOptions.tinyMCE || {} : {};
+  const defaultOptions = tinyMCEOptions.default || {};
+  // Check specific options by the name
+  let options = tinyMCEOptions[name] ? tinyMCEOptions[name] : defaultOptions;
+
+  // Avoid an unexpected changes, and copy the options object
+  if (options.joomlaMergeDefaults) {
+    options = Joomla.extend(Joomla.extend({}, defaultOptions), options);
+  } else {
+    options = Joomla.extend({}, options);
+  }
+
+  if (element) {
+    // We already have the Target, so reset the selector and assign given element as target
+    options.selector = null;
+    options.target = element;
+  }
+
+  const buttonValues = [];
+  const icons = {
+    joomla: '<svg viewBox="0 0 32 32" width="24" height="24"><path d="M8.313 8.646c1.026-1.026 2.688-1.026 3.713-0.001l0.245 0.246 3.159-3.161-0.246-0.246c-1.801-1.803-4.329-2.434-6.638-1.891-0.331-2.037-2.096-3.591-4.224-3.592-2.364 0-4.28 1.92-4.28 4.286 0 2.042 1.425 3.75 3.333 4.182-0.723 2.42-0.133 5.151 1.776 7.062l7.12 7.122 3.156-3.163-7.119-7.121c-1.021-1.023-1.023-2.691 0.006-3.722zM31.96 4.286c0-2.368-1.916-4.286-4.281-4.286-2.164 0-3.952 1.608-4.24 3.695-2.409-0.708-5.118-0.109-7.020 1.794l-7.12 7.122 3.159 3.162 7.118-7.12c1.029-1.030 2.687-1.028 3.709-0.006 1.025 1.026 1.025 2.691-0.001 3.717l-0.244 0.245 3.157 3.164 0.246-0.248c1.889-1.893 2.49-4.586 1.8-6.989 2.098-0.276 3.717-2.074 3.717-4.25zM28.321 23.471c0.566-2.327-0.062-4.885-1.878-6.703l-7.109-7.125-3.159 3.16 7.11 7.125c1.029 1.031 1.027 2.691 0.006 3.714-1.025 1.025-2.688 1.025-3.714-0.001l-0.243-0.243-3.156 3.164 0.242 0.241c1.922 1.925 4.676 2.514 7.105 1.765 0.395 1.959 2.123 3.431 4.196 3.431 2.363 0 4.28-1.917 4.28-4.285 0-2.163-1.599-3.952-3.679-4.244zM19.136 16.521l-7.111 7.125c-1.022 1.024-2.689 1.026-3.717-0.004-1.026-1.028-1.026-2.691-0.001-3.718l0.244-0.243-3.159-3.16-0.242 0.241c-1.836 1.838-2.455 4.432-1.858 6.781-1.887 0.446-3.292 2.145-3.292 4.172-0.001 2.367 1.917 4.285 4.281 4.285 2.034-0.001 3.737-1.419 4.173-3.324 2.334 0.58 4.906-0.041 6.729-1.867l7.109-7.124-3.157-3.163z"></path></svg>',
+  };
+
+  Object.keys(options.joomlaExtButtons.names)
+    .map((key) => options.joomlaExtButtons.names[key])
+    .forEach((xtdButton) => {
+      const tmp = {
+        text: xtdButton.name,
+        icon: xtdButton.icon,
+        type: 'menuitem',
+      };
+
+      if (xtdButton.iconSVG) {
+        icons[tmp.icon] = xtdButton.iconSVG;
+      }
+
+      if (xtdButton.href) {
+        tmp.onAction = () => {
+          createAndOpenModal({ editor: element, button: xtdButton });
+        };
+      } else {
+        tmp.onAction = () => {
+        // eslint-disable-next-line no-new-func
+          new Function(xtdButton.click.replace('{{editor}}', element.id))();
+        };
+      }
+
+      buttonValues.push(tmp);
+    });
+
+  // Ensure tinymce is initialised in readonly mode if the textarea has readonly applied
+  let readOnlyMode = false;
+
+  if (element) {
+    readOnlyMode = element.readOnly;
+  }
+
+  if (buttonValues.length) {
+    options.setup = (editor) => {
+      editor.settings.readonly = readOnlyMode;
+
+      Object.keys(icons).forEach((icon) => {
+        editor.ui.registry.addIcon(icon, icons[icon]);
+      });
+
+      editor.ui.registry.addMenuButton('jxtdbuttons', {
+        text: Joomla.Text._('PLG_TINY_CORE_BUTTONS'),
+        icon: 'joomla',
+        fetch: (callback) => callback(buttonValues),
+      });
+    };
+  } else {
+    options.setup = (editor) => {
+      editor.settings.readonly = readOnlyMode;
+    };
+  }
+
+  // We'll take over the onSubmit event
+  options.init_instance_callback = (editor) => editor.on('submit', () => {
+    if (editor.isHidden()) {
+      editor.show();
+    }
+  }, true);
+
+  // Create a new instance
+  // eslint-disable-next-line no-undef
+  const ed = new tinyMCE.Editor(element.id, options, tinymce.EditorManager);
+  ed.render();
+
+  /** Register the editor's instance to Joomla Object */
+  Joomla.editors.instances[element.id] = {
+    // Required by Joomla's API for the XTD-Buttons
+    getValue: () => Joomla.editors.instances[element.id].instance.getContent(),
+    setValue: (text) => Joomla.editors.instances[element.id].instance.setContent(text),
+    getSelection: () => Joomla.editors.instances[element.id].instance.selection.getContent({ format: 'text' }),
+    replaceSelection: (text) => Joomla.editors.instances[element.id].instance.execCommand('mceInsertContent', false, text),
+    // Required by Joomla's API for Mail Component Integration
+    disable: (disabled) => Joomla.editors.instances[element.id].instance.setMode(disabled ? 'readonly' : 'design'),
+    // Some extra instance dependent
+    id: element.id,
+    instance: ed,
+  };
+}
+
+/**
+ * Find all TinyMCE elements and initialize TinyMCE instance for each
+ *
+ * @param {HTMLElement}  target  Target Element where to search for the editor element
+ *
+ * @since 3.7.0
+ */
+function setupEditors(target) {
+  const container = target || document;
+  const pluginOptions = Joomla.getOptions ? Joomla.getOptions('plg_editor_tinymce', {})
+    : (Joomla.optionsStorage.plg_editor_tinymce || {});
+  const editors = [].slice.call(container.querySelectorAll('.js-editor-tinymce'));
+
+  editors.forEach((editor) => {
+    const currentEditor = editor.querySelector('textarea');
+    const toggleButton = editor.querySelector('.js-tiny-toggler-button');
+    const toggleIcon = editor.querySelector('.icon-eye');
+
+    // Setup the editor
+    setupEditor(currentEditor, pluginOptions);
+
+    // Setup the toggle button
+    if (toggleButton) {
+      toggleButton.removeAttribute('disabled');
+      toggleButton.addEventListener('click', () => {
+        if (Joomla.editors.instances[currentEditor.id].instance.isHidden()) {
+          Joomla.editors.instances[currentEditor.id].instance.show();
+        } else {
+          Joomla.editors.instances[currentEditor.id].instance.hide();
+        }
+
+        if (toggleIcon) {
+          toggleIcon.setAttribute('class', Joomla.editors.instances[currentEditor.id].instance.isHidden() ? 'icon-eye' : 'icon-eye-slash');
+        }
+      });
+    }
+  });
+}
 
 /**
  * Initialize at an initial page load

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -244,6 +244,24 @@ function setupEditor(element, pluginOptions) {
     id: element.id,
     instance: ed,
   };
+
+  // Setup the toggle button
+  if (!('maxTouchPoints' in navigator && navigator.maxTouchPoints > 0) && window.innerWidth > 768) {
+    const parent = element.closest('.js-editor-tinymce');
+    parent.insertAdjacentHTML('beforeend', Joomla.sanitizeHtml(options.toggleButtonHTML));
+    const toggleIcon = parent.querySelector('.icon-eye');
+    parent.querySelector('.js-tiny-toggler-button').addEventListener('click', () => {
+      if (Joomla.editors.instances[element.id].instance.isHidden()) {
+        Joomla.editors.instances[element.id].instance.show();
+      } else {
+        Joomla.editors.instances[element.id].instance.hide();
+      }
+
+      if (toggleIcon) {
+        toggleIcon.setAttribute('class', Joomla.editors.instances[element.id].instance.isHidden() ? 'icon-eye' : 'icon-eye-slash');
+      }
+    });
+  }
 }
 
 /**
@@ -255,34 +273,10 @@ function setupEditor(element, pluginOptions) {
  */
 function setupEditors(target) {
   const container = target || document;
-  const pluginOptions = Joomla.getOptions ? Joomla.getOptions('plg_editor_tinymce', {})
-    : (Joomla.optionsStorage.plg_editor_tinymce || {});
-  const editors = [].slice.call(container.querySelectorAll('.js-editor-tinymce'));
+  const pluginOptions = Joomla.getOptions('plg_editor_tinymce', {});
 
-  editors.forEach((editor) => {
-    const currentEditor = editor.querySelector('textarea');
-    const toggleButton = editor.querySelector('.js-tiny-toggler-button');
-    const toggleIcon = editor.querySelector('.icon-eye');
-
-    // Setup the editor
-    setupEditor(currentEditor, pluginOptions);
-
-    // Setup the toggle button
-    if (toggleButton) {
-      toggleButton.removeAttribute('disabled');
-      toggleButton.addEventListener('click', () => {
-        if (Joomla.editors.instances[currentEditor.id].instance.isHidden()) {
-          Joomla.editors.instances[currentEditor.id].instance.show();
-        } else {
-          Joomla.editors.instances[currentEditor.id].instance.hide();
-        }
-
-        if (toggleIcon) {
-          toggleIcon.setAttribute('class', Joomla.editors.instances[currentEditor.id].instance.isHidden() ? 'icon-eye' : 'icon-eye-slash');
-        }
-      });
-    }
-  });
+  // Setup the editor
+  [].slice.call(container.querySelectorAll('.js-editor-tinymce')).forEach((editor) => setupEditor(editor.querySelector('textarea'), pluginOptions));
 }
 
 /**

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -2,179 +2,286 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
+if (!Joomla) {
+  throw new Error('Joomla API is not properly initialized');
+}
+if (!bootstrap) {
+  throw new Error('Bootstrap Modal is not loaded but it is required');
+}
 
-((tinyMCE, Joomla, window, document) => {
-  'use strict';
+// A modal sceleton for clonning
+const template = document.createElement('template');
+template.innerHTML = `
+<div role="dialog" tabindex="-1" class="joomla-modal modal fade">
+  <div class="modal-dialog modal-lg jviewport-width80">
+    <div class="modal-content">
+      <div class="modal-header"></div>
+      <div class="modal-body jviewport-height70"></div>
+      <div class="modal-footer"></div>
+    </div>
+  </div>
+</div>`;
 
-  Joomla.JoomlaTinyMCE = {
-    /**
-     * Find all TinyMCE elements and initialize TinyMCE instance for each
-     *
-     * @param {HTMLElement}  target  Target Element where to search for the editor element
-     *
-     * @since 3.7.0
-     */
-    setupEditors: (target) => {
-      const container = target || document;
-      const pluginOptions = Joomla.getOptions ? Joomla.getOptions('plg_editor_tinymce', {})
-        : (Joomla.optionsStorage.plg_editor_tinymce || {});
-      const editors = [].slice.call(container.querySelectorAll('.js-editor-tinymce'));
+/**
+ * Find all TinyMCE elements and initialize TinyMCE instance for each
+ *
+ * @param {HTMLElement}  target  Target Element where to search for the editor element
+ *
+ * @since 3.7.0
+ */
+function setupEditors(target) {
+  const container = target || document;
+  const pluginOptions = Joomla.getOptions ? Joomla.getOptions('plg_editor_tinymce', {})
+    : (Joomla.optionsStorage.plg_editor_tinymce || {});
+  const editors = [].slice.call(container.querySelectorAll('.js-editor-tinymce'));
 
-      editors.forEach((editor) => {
-        const currentEditor = editor.querySelector('textarea');
-        const toggleButton = editor.querySelector('.js-tiny-toggler-button');
-        const toggleIcon = editor.querySelector('.icon-eye');
+  editors.forEach((editor) => {
+    const currentEditor = editor.querySelector('textarea');
+    const toggleButton = editor.querySelector('.js-tiny-toggler-button');
+    const toggleIcon = editor.querySelector('.icon-eye');
 
-        // Setup the editor
-        Joomla.JoomlaTinyMCE.setupEditor(currentEditor, pluginOptions);
+    // Setup the editor
+    setupEditor(currentEditor, pluginOptions);
 
-        // Setup the toggle button
-        if (toggleButton) {
-          toggleButton.removeAttribute('disabled');
-          toggleButton.addEventListener('click', () => {
-            if (Joomla.editors.instances[currentEditor.id].instance.isHidden()) {
-              Joomla.editors.instances[currentEditor.id].instance.show();
-            } else {
-              Joomla.editors.instances[currentEditor.id].instance.hide();
-            }
-
-            if (toggleIcon) {
-              toggleIcon.setAttribute('class', Joomla.editors.instances[currentEditor.id].instance.isHidden() ? 'icon-eye' : 'icon-eye-slash');
-            }
-          });
-        }
-      });
-    },
-
-    /**
-     * Initialize TinyMCE editor instance
-     *
-     * @param {HTMLElement}  element
-     * @param {Object}       pluginOptions
-     *
-     * @since 3.7.0
-     */
-    setupEditor: (element, pluginOptions) => {
-      // Check whether the editor already has ben set
-      if (Joomla.editors.instances[element.id]) {
-        return;
-      }
-
-      const name = element ? element.getAttribute('name').replace(/\[\]|\]/g, '').split('[').pop() : 'default'; // Get Editor name
-      const tinyMCEOptions = pluginOptions ? pluginOptions.tinyMCE || {} : {};
-      const defaultOptions = tinyMCEOptions.default || {};
-      // Check specific options by the name
-      let options = tinyMCEOptions[name] ? tinyMCEOptions[name] : defaultOptions;
-
-      // Avoid an unexpected changes, and copy the options object
-      if (options.joomlaMergeDefaults) {
-        options = Joomla.extend(Joomla.extend({}, defaultOptions), options);
-      } else {
-        options = Joomla.extend({}, options);
-      }
-
-      if (element) {
-        // We already have the Target, so reset the selector and assign given element as target
-        options.selector = null;
-        options.target = element;
-      }
-
-      const buttonValues = [];
-      const arr = Object.keys(options.joomlaExtButtons.names)
-        .map((key) => options.joomlaExtButtons.names[key]);
-
-      const icons = {
-        joomla: '<svg viewBox="0 0 32 32" width="24" height="24"><path d="M8.313 8.646c1.026-1.026 2.688-1.026 3.713-0.001l0.245 0.246 3.159-3.161-0.246-0.246c-1.801-1.803-4.329-2.434-6.638-1.891-0.331-2.037-2.096-3.591-4.224-3.592-2.364 0-4.28 1.92-4.28 4.286 0 2.042 1.425 3.75 3.333 4.182-0.723 2.42-0.133 5.151 1.776 7.062l7.12 7.122 3.156-3.163-7.119-7.121c-1.021-1.023-1.023-2.691 0.006-3.722zM31.96 4.286c0-2.368-1.916-4.286-4.281-4.286-2.164 0-3.952 1.608-4.24 3.695-2.409-0.708-5.118-0.109-7.020 1.794l-7.12 7.122 3.159 3.162 7.118-7.12c1.029-1.030 2.687-1.028 3.709-0.006 1.025 1.026 1.025 2.691-0.001 3.717l-0.244 0.245 3.157 3.164 0.246-0.248c1.889-1.893 2.49-4.586 1.8-6.989 2.098-0.276 3.717-2.074 3.717-4.25zM28.321 23.471c0.566-2.327-0.062-4.885-1.878-6.703l-7.109-7.125-3.159 3.16 7.11 7.125c1.029 1.031 1.027 2.691 0.006 3.714-1.025 1.025-2.688 1.025-3.714-0.001l-0.243-0.243-3.156 3.164 0.242 0.241c1.922 1.925 4.676 2.514 7.105 1.765 0.395 1.959 2.123 3.431 4.196 3.431 2.363 0 4.28-1.917 4.28-4.285 0-2.163-1.599-3.952-3.679-4.244zM19.136 16.521l-7.111 7.125c-1.022 1.024-2.689 1.026-3.717-0.004-1.026-1.028-1.026-2.691-0.001-3.718l0.244-0.243-3.159-3.16-0.242 0.241c-1.836 1.838-2.455 4.432-1.858 6.781-1.887 0.446-3.292 2.145-3.292 4.172-0.001 2.367 1.917 4.285 4.281 4.285 2.034-0.001 3.737-1.419 4.173-3.324 2.334 0.58 4.906-0.041 6.729-1.867l7.109-7.124-3.157-3.163z"></path></svg>',
-      };
-
-      arr.forEach((xtdButton) => {
-        const tmp = {};
-        tmp.text = xtdButton.name;
-        tmp.icon = xtdButton.icon;
-        tmp.type = 'menuitem';
-
-        if (xtdButton.iconSVG) {
-          icons[tmp.icon] = xtdButton.iconSVG;
-        }
-
-        if (xtdButton.href) {
-          tmp.onAction = () => {
-            document.getElementById(`${xtdButton.id}_modal`).open();
-          };
+    // Setup the toggle button
+    if (toggleButton) {
+      toggleButton.removeAttribute('disabled');
+      toggleButton.addEventListener('click', () => {
+        if (Joomla.editors.instances[currentEditor.id].instance.isHidden()) {
+          Joomla.editors.instances[currentEditor.id].instance.show();
         } else {
-          tmp.onAction = () => {
-            // eslint-disable-next-line no-new-func
-            new Function(xtdButton.click)();
-          };
+          Joomla.editors.instances[currentEditor.id].instance.hide();
         }
 
-        buttonValues.push(tmp);
+        if (toggleIcon) {
+          toggleIcon.setAttribute('class', Joomla.editors.instances[currentEditor.id].instance.isHidden() ? 'icon-eye' : 'icon-eye-slash');
+        }
       });
+    }
+  });
+};
 
-      // Ensure tinymce is initialised in readonly mode if the textarea has readonly applied
-      let readOnlyMode = false;
+/**
+ * Initialize TinyMCE editor instance
+ *
+ * @param {HTMLElement}  element
+ * @param {Object}       pluginOptions
+ *
+ * @since 3.7.0
+ */
+function setupEditor(element, pluginOptions) {
+  // Check whether the editor already has ben set
+  if (Joomla.editors.instances[element.id]) {
+    return;
+  }
 
-      if (element) {
-        readOnlyMode = element.readOnly;
-      }
+  const name = element ? element.getAttribute('name').replace(/\[\]|\]/g, '').split('[').pop() : 'default'; // Get Editor name
+  const tinyMCEOptions = pluginOptions ? pluginOptions.tinyMCE || {} : {};
+  const defaultOptions = tinyMCEOptions.default || {};
+  // Check specific options by the name
+  let options = tinyMCEOptions[name] ? tinyMCEOptions[name] : defaultOptions;
 
-      if (buttonValues.length) {
-        options.setup = (editor) => {
-          editor.settings.readonly = readOnlyMode;
+  // Avoid an unexpected changes, and copy the options object
+  if (options.joomlaMergeDefaults) {
+    options = Joomla.extend(Joomla.extend({}, defaultOptions), options);
+  } else {
+    options = Joomla.extend({}, options);
+  }
 
-          Object.keys(icons).forEach((icon) => {
-            editor.ui.registry.addIcon(icon, icons[icon]);
-          });
+  if (element) {
+    // We already have the Target, so reset the selector and assign given element as target
+    options.selector = null;
+    options.target = element;
+  }
 
-          editor.ui.registry.addMenuButton('jxtdbuttons', {
-            text: Joomla.Text._('PLG_TINY_CORE_BUTTONS'),
-            icon: 'joomla',
-            fetch: (callback) => callback(buttonValues),
-          });
-        };
-      } else {
-        options.setup = (editor) => {
-          editor.settings.readonly = readOnlyMode;
-        };
-      }
-
-      // We'll take over the onSubmit event
-      options.init_instance_callback = (editor) => {
-        editor.on('submit', () => {
-          if (editor.isHidden()) {
-            editor.show();
-          }
-        }, true);
-      };
-
-      // Create a new instance
-      // eslint-disable-next-line no-undef
-      const ed = new tinyMCE.Editor(element.id, options, tinymce.EditorManager);
-      ed.render();
-
-      /** Register the editor's instance to Joomla Object */
-      Joomla.editors.instances[element.id] = {
-        // Required by Joomla's API for the XTD-Buttons
-        getValue: () => Joomla.editors.instances[element.id].instance.getContent(),
-        setValue: (text) => Joomla.editors.instances[element.id].instance.setContent(text),
-        getSelection: () => Joomla.editors.instances[element.id].instance.selection.getContent({ format: 'text' }),
-        replaceSelection: (text) => Joomla.editors.instances[element.id].instance.execCommand('mceInsertContent', false, text),
-        // Required by Joomla's API for Mail Component Integration
-        disable: (disabled) => Joomla.editors.instances[element.id].instance.setMode(disabled ? 'readonly' : 'design'),
-        // Some extra instance dependent
-        id: element.id,
-        instance: ed,
-      };
-    },
+  const buttonValues = [];
+  const icons = {
+    joomla: '<svg viewBox="0 0 32 32" width="24" height="24"><path d="M8.313 8.646c1.026-1.026 2.688-1.026 3.713-0.001l0.245 0.246 3.159-3.161-0.246-0.246c-1.801-1.803-4.329-2.434-6.638-1.891-0.331-2.037-2.096-3.591-4.224-3.592-2.364 0-4.28 1.92-4.28 4.286 0 2.042 1.425 3.75 3.333 4.182-0.723 2.42-0.133 5.151 1.776 7.062l7.12 7.122 3.156-3.163-7.119-7.121c-1.021-1.023-1.023-2.691 0.006-3.722zM31.96 4.286c0-2.368-1.916-4.286-4.281-4.286-2.164 0-3.952 1.608-4.24 3.695-2.409-0.708-5.118-0.109-7.020 1.794l-7.12 7.122 3.159 3.162 7.118-7.12c1.029-1.030 2.687-1.028 3.709-0.006 1.025 1.026 1.025 2.691-0.001 3.717l-0.244 0.245 3.157 3.164 0.246-0.248c1.889-1.893 2.49-4.586 1.8-6.989 2.098-0.276 3.717-2.074 3.717-4.25zM28.321 23.471c0.566-2.327-0.062-4.885-1.878-6.703l-7.109-7.125-3.159 3.16 7.11 7.125c1.029 1.031 1.027 2.691 0.006 3.714-1.025 1.025-2.688 1.025-3.714-0.001l-0.243-0.243-3.156 3.164 0.242 0.241c1.922 1.925 4.676 2.514 7.105 1.765 0.395 1.959 2.123 3.431 4.196 3.431 2.363 0 4.28-1.917 4.28-4.285 0-2.163-1.599-3.952-3.679-4.244zM19.136 16.521l-7.111 7.125c-1.022 1.024-2.689 1.026-3.717-0.004-1.026-1.028-1.026-2.691-0.001-3.718l0.244-0.243-3.159-3.16-0.242 0.241c-1.836 1.838-2.455 4.432-1.858 6.781-1.887 0.446-3.292 2.145-3.292 4.172-0.001 2.367 1.917 4.285 4.281 4.285 2.034-0.001 3.737-1.419 4.173-3.324 2.334 0.58 4.906-0.041 6.729-1.867l7.109-7.124-3.157-3.163z"></path></svg>',
   };
 
-  /**
-   * Initialize at an initial page load
-   */
-  document.addEventListener('DOMContentLoaded', () => { Joomla.JoomlaTinyMCE.setupEditors(document); });
+  Object.keys(options.joomlaExtButtons.names)
+  .map((key) => options.joomlaExtButtons.names[key])
+  .forEach((xtdButton) => {
+    console.log(xtdButton);
+    const tmp = {
+      text: xtdButton.name,
+      icon: xtdButton.icon,
+      type: 'menuitem',
+    };
 
-  /**
-   * Initialize when a part of the page was updated
-   */
-  document.addEventListener('joomla:updated', ({ target }) => Joomla.JoomlaTinyMCE.setupEditors(target));
-})(window.tinyMCE, Joomla, window, document);
+    if (xtdButton.iconSVG) {
+      icons[tmp.icon] = xtdButton.iconSVG;
+    }
+
+    if (xtdButton.href) {
+      tmp.onAction = () => {
+        createAndOpenModal({editor: element, button: xtdButton});
+      };
+    } else {
+      tmp.onAction = () => {
+        // eslint-disable-next-line no-new-func
+        new Function(xtdButton.click.replace('{{editor}}', editor.id))();
+      };
+    }
+
+    buttonValues.push(tmp);
+  });
+
+  // Ensure tinymce is initialised in readonly mode if the textarea has readonly applied
+  let readOnlyMode = false;
+
+  if (element) {
+    readOnlyMode = element.readOnly;
+  }
+
+  if (buttonValues.length) {
+    options.setup = (editor) => {
+      editor.settings.readonly = readOnlyMode;
+
+      Object.keys(icons).forEach((icon) => {
+        editor.ui.registry.addIcon(icon, icons[icon]);
+      });
+
+      editor.ui.registry.addMenuButton('jxtdbuttons', {
+        text: Joomla.Text._('PLG_TINY_CORE_BUTTONS'),
+        icon: 'joomla',
+        fetch: (callback) => callback(buttonValues),
+      });
+    };
+  } else {
+    options.setup = (editor) => {
+      editor.settings.readonly = readOnlyMode;
+    };
+  }
+
+  // We'll take over the onSubmit event
+  options.init_instance_callback = (editor) => editor.on('submit', () => {
+    if (editor.isHidden()) {
+      editor.show();
+    }
+  }, true);
+
+  // Create a new instance
+  // eslint-disable-next-line no-undef
+  const ed = new tinyMCE.Editor(element.id, options, tinymce.EditorManager);
+  ed.render();
+
+  /** Register the editor's instance to Joomla Object */
+  Joomla.editors.instances[element.id] = {
+    // Required by Joomla's API for the XTD-Buttons
+    getValue: () => Joomla.editors.instances[element.id].instance.getContent(),
+    setValue: (text) => Joomla.editors.instances[element.id].instance.setContent(text),
+    getSelection: () => Joomla.editors.instances[element.id].instance.selection.getContent({ format: 'text' }),
+    replaceSelection: (text) => Joomla.editors.instances[element.id].instance.execCommand('mceInsertContent', false, text),
+    // Required by Joomla's API for Mail Component Integration
+    disable: (disabled) => Joomla.editors.instances[element.id].instance.setMode(disabled ? 'readonly' : 'design'),
+    // Some extra instance dependent
+    id: element.id,
+    instance: ed,
+  };
+}
+
+/**
+ * Creates a Bootstrap modal and open it
+ *
+ * @param {Object}  options
+ *
+ * @since __DEPLOY_VERSION__
+ */
+function createAndOpenModal(options) {
+  let url;
+  const {editor, button} = options;
+  const inst = template.content.cloneNode(true);
+  const modal = inst.querySelector('.modal');
+  modal.id = `${button.id}_modal`;
+
+  // Update the editor url parameter of the modal
+  if (button.href) {
+    url = new URL(button.href);
+    url.searchParams.delete('editor');
+    url.searchParams.append('editor', editor.id);
+  }
+
+  // Update the nodes
+  modal.querySelector('.modal-header').innerHTML = button.header;
+  modal.querySelector('.modal-footer').innerHTML = button.footer.replace('{{editor}}', editor.id);
+  modal.querySelector('.modal-body').innerHTML = button.body ? button.body : Joomla.sanitizeHtml(`<iframe class="iframe" src="${url.toString()}" name="${button.title}"; title="${button.title}" height="${button.height}" width="${button.width}"></iframe>`, { iframe: ['src', 'name', 'width', 'height'] });
+
+  document.body.appendChild(inst);
+  initialiseModal(modal, button.modalOptions);
+  modal.open();
+}
+
+function initialiseModal(modal, options) {
+  if (!(modal instanceof Element)) {
+    return;
+  }
+
+  // eslint-disable-next-line no-new
+  new window.bootstrap.Modal(modal, options.modal);
+
+  // Comply with the Joomla API - Bound element.open/close
+  modal.open = () => { window.bootstrap.Modal.getInstance(modal).show(modal); };
+  modal.close = () => { window.bootstrap.Modal.getInstance(modal).hide(); };
+
+  // Do some Joomla specific changes
+  modal.addEventListener('show.bs.modal', () => {
+    // Comply with the Joomla API - Set the current Modal ID
+    Joomla.Modal.setCurrent(modal);
+  });
+
+  modal.addEventListener('shown.bs.modal', () => {
+    const modalBody = modal.querySelector('.modal-body');
+    const modalHeader = modal.querySelector('.modal-header');
+    const modalFooter = modal.querySelector('.modal-footer');
+    let modalHeaderHeight = 0;
+    let modalFooterHeight = 0;
+    let maxModalBodyHeight = 0;
+    let modalBodyPadding = 0;
+    let modalBodyHeightOuter = 0;
+
+    if (modalBody) {
+      if (modalHeader) {
+        const modalHeaderRects = modalHeader.getBoundingClientRect();
+        modalHeaderHeight = modalHeaderRects.height;
+        modalBodyHeightOuter = modalBody.offsetHeight;
+      }
+      if (modalFooter) {
+        modalFooterHeight = parseFloat(getComputedStyle(modalFooter, null).height.replace('px', ''));
+      }
+
+      const modalBodyHeight = parseFloat(getComputedStyle(modalBody, null).height.replace('px', ''));
+      const padding = modalBody.offsetTop;
+      const maxModalHeight = parseFloat(getComputedStyle(document.body, null).height.replace('px', '')) - (padding * 2);
+      modalBodyPadding = modalBodyHeightOuter - modalBodyHeight;
+      maxModalBodyHeight = maxModalHeight - (modalHeaderHeight + modalFooterHeight + modalBodyPadding);
+    }
+
+    const iframeEl = modal.querySelector('iframe');
+
+    if (iframeEl) {
+      const iframeHeight = parseFloat(getComputedStyle(iframeEl, null).height.replace('px', ''));
+      if (iframeHeight > maxModalBodyHeight) {
+        modalBody.style.maxHeight = maxModalBodyHeight;
+        modalBody.style.overflowY = 'auto';
+        iframeEl.style.maxHeight = maxModalBodyHeight - modalBodyPadding;
+      }
+    }
+  });
+
+  // Comply with the Joomla API - Remove the current Modal ID
+  modal.addEventListener('hidden.bs.modal', () => {
+    Joomla.Modal.setCurrent('');
+    modal.remove();
+  });
+};
+
+/**
+ * Initialize at an initial page load
+ */
+setupEditors(document);
+
+/**
+ * Initialize when a part of the page was updated
+ */
+document.addEventListener('joomla:updated', ({ target }) => setupEditors(target));

--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -13,7 +13,7 @@ if (!bootstrap) {
 const template = document.createElement('template');
 template.innerHTML = `
 <div role="dialog" tabindex="-1" class="joomla-modal modal fade">
-  <div class="modal-dialog modal-lg jviewport-width80">
+  <div class="modal-dialog jviewport-width80">
     <div class="modal-content">
       <div class="modal-header"></div>
       <div class="modal-body jviewport-height70"></div>
@@ -120,7 +120,8 @@ function createAndOpenModal(options) {
   modal.querySelector('.modal-header').innerHTML = button.header;
   modal.querySelector('.modal-footer').innerHTML = button.footer.replace('{{editor}}', editor.id);
   modal.querySelector('.modal-body').innerHTML = button.body ? button.body : Joomla.sanitizeHtml(`<iframe class="iframe" src="${url.toString()}" name="${button.title}"; title="${button.title}" height="${button.height}" width="${button.width}"></iframe>`, { iframe: ['src', 'name', 'width', 'height'] });
-
+  modal.querySelector('.modal-body').classList.add(`jviewport-height${button.modalOptions.bodyHeight}`);
+  modal.querySelector('.modal-dialog').classList.add(`jviewport-width${button.modalOptions.modalWidth}`);
   document.body.appendChild(inst);
   initialiseModal(modal, button.modalOptions);
   modal.open();

--- a/layouts/joomla/tinymce/textarea.php
+++ b/layouts/joomla/tinymce/textarea.php
@@ -15,12 +15,11 @@ use Joomla\CMS\Factory;
 $data = $displayData;
 $wa   = Factory::getDocument()->getWebAssetManager();
 
-if (!$wa->assetExists('script', 'tinymce')) {
-    $wa->registerScript('tinymce', 'media/vendor/tinymce/tinymce.min.js', [], ['defer' => true]);
-}
-
 if (!$wa->assetExists('script', 'plg_editors_tinymce')) {
-    $wa->registerScript('plg_editors_tinymce', 'plg_editors_tinymce/tinymce.min.js', [], ['defer' => true], ['core', 'tinymce']);
+    if (!$wa->assetExists('script', 'tinymce')) {
+        $wa->registerScript('tinymce', 'media/vendor/tinymce/tinymce.min.js', [], ['defer' => true]);
+    }
+    $wa->registerScript('plg_editors_tinymce', 'plg_editors_tinymce/tinymce.min.js', [], ['type' => 'module'], ['core', 'tinymce']);
 }
 
 $wa->useScript('tinymce')->useScript('plg_editors_tinymce');

--- a/layouts/joomla/tinymce/textarea.php
+++ b/layouts/joomla/tinymce/textarea.php
@@ -19,7 +19,7 @@ if (!$wa->assetExists('script', 'plg_editors_tinymce')) {
     if (!$wa->assetExists('script', 'tinymce')) {
         $wa->registerScript('tinymce', 'media/vendor/tinymce/tinymce.min.js', [], ['defer' => true]);
     }
-    $wa->registerScript('plg_editors_tinymce', 'plg_editors_tinymce/tinymce.min.js', [], ['type' => 'module'], ['core', 'tinymce']);
+    $wa->registerScript('plg_editors_tinymce', 'plg_editors_tinymce/tinymce.min.js', [], ['type' => 'module'], ['core', 'tinymce', 'bootstrap.modal']);
 }
 
 $wa->useScript('tinymce')->useScript('plg_editors_tinymce');

--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -94,7 +94,6 @@ trait DisplayTrait
         // Render Editor markup
         $editor = '<div class="js-editor-tinymce">';
         $editor .= LayoutHelper::render('joomla.tinymce.textarea', $textarea);
-        $editor .= !$this->app->client->mobile ? LayoutHelper::render('joomla.tinymce.togglebutton') : '';
         $editor .= '</div>';
 
         // Prepare the instance specific options
@@ -478,6 +477,9 @@ trait DisplayTrait
 
                 // Disable TinyMCE Branding
                 'branding'   => false,
+
+                // The toggle button bellow the editor
+                'toggleButtonHTML' => LayoutHelper::render('joomla.tinymce.togglebutton')
             ]
         );
 

--- a/plugins/editors/tinymce/src/PluginTraits/XTDButtons.php
+++ b/plugins/editors/tinymce/src/PluginTraits/XTDButtons.php
@@ -60,19 +60,32 @@ trait XTDButtons
             foreach ($buttons as $i => $button) {
                 $button->id = $name . '_' . $button->name . '_modal';
 
-                echo LayoutHelper::render('joomla.editors.buttons.modal', $button);
-
+                // echo LayoutHelper::render('joomla.editors.buttons.modal', $button);
                 if ($button->get('name')) {
-                    $coreButton            = [];
-                    $coreButton['name']    = $button->get('text');
-                    $coreButton['href']    = $button->get('link') !== '#' ? Uri::base() . $button->get('link') : null;
-                    $coreButton['id']      = $name . '_' . $button->name;
-                    $coreButton['icon']    = $button->get('icon');
-                    $coreButton['click']   = $button->get('onclick') ?: null;
-                    $coreButton['iconSVG'] = $button->get('iconSVG');
+                    $options = is_array($button->get('options')) ? $button->get('options') : array();
+                    $id = null !== $button->get('id') ? str_replace(' ', '', $button->get('id')) : $button->get('editor') . '_' . strtolower($button->get('name')) . '_modal';
+                    $confirmCallback = isset($options['confirmCallback']) ? str_replace($name, '{{editor}}', $options['confirmCallback']) : null;
+                    $confirm = isset($options['confirmText']) && $confirmCallback
+                        ? '<button type="button" class="btn btn-success" data-bs-dismiss="modal" onclick="' . $confirmCallback . '">' . $options['confirmText'] . ' </button>'
+                        : '';
 
                     // The array with the toolbar buttons
-                    $btnsNames[] = $coreButton;
+                    $btnsNames[] = [
+                        'name'         => $button->get('text'),
+                        'href'         => $button->get('link') !== '#' ? Uri::base() . str_replace('&amp;', '&', $button->get('link')) : null,
+                        'id'           => $name . '_' . $button->name,
+                        'icon'         => $button->get('icon'),
+                        'click'        => $button->get('onclick') ? str_replace($name, '{{editor}}', $button->get('onclick')) : null,
+                        'iconSVG'      => $button->get('iconSVG'),
+                        'header'       => '<h3 class="modal-title">' . ($button->get('title') ? $button->get('title') : $button->get('text')) . '</h3><button type="button" class="btn-close novalidate" data-bs-dismiss="modal" aria-label="' . Text::_('JCLOSE') . '"></button>',
+                        'footer'       => $confirm . '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
+                        'modalOptions' => [
+                            'height'     => array_key_exists('height', $options) ? $options['height'] : '400px',
+                            'width'      => array_key_exists('width', $options) ? $options['width'] : '800px',
+                            'bodyHeight' => array_key_exists('bodyHeight', $options) ? $options['bodyHeight'] : '70',
+                            'modalWidth' => array_key_exists('modalWidth', $options) ? $options['modalWidth'] : '80',
+                        ],
+                    ];
                 }
             }
 


### PR DESCRIPTION
Pull Request is an alternative to https://github.com/joomla/joomla-cms/pull/39449 which is for Issue https://github.com/joomla/joomla-cms/issues/39416 .

### Summary of Changes

- The buttons PHP code has been reworked to pass data to JS
- There is no server side rendering of the modals, it would happen on the fly, when a user requests a modal
- There is some code that tries to replace the `editor` id both for click action and for the modals callback, etc
- due to CSR all the ids **should** be always correct for any subform combination


### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request


https://user-images.githubusercontent.com/3889375/211921318-4078e2ba-a434-413a-87e4-f985d6d9012f.mov



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

@wilsonge @Fedik what do you think?