### PR TITLE
[4.2] content history alerts

### DIFF
--- a/build/media_source/com_contenthistory/js/admin-history-modal.es6.js
+++ b/build/media_source/com_contenthistory/js/admin-history-modal.es6.js
@@ -55,8 +55,9 @@
         const windowSizeArray = ['width=1000, height=600, resizable=yes, scrollbars=yes'];
         const ids = document.querySelectorAll('input[id*="cb"]:checked');
         if (ids.length === 0) {
-          // @todo use the CE Modal here
-          alert(Joomla.Text._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST'));
+          Joomla.renderMessages({
+            error: [Joomla.Text._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')],
+          });
         } else if (ids.length === 2) {
           // Add version item ids to URL
           const url = `${toolbarCompare.childNodes[1].getAttribute('data-url')}&id1=${ids[0].value}&id2=${ids[1].value}`;

--- a/build/media_source/com_contenthistory/js/admin-history-modal.es6.js
+++ b/build/media_source/com_contenthistory/js/admin-history-modal.es6.js
@@ -21,8 +21,9 @@
             window.parent.location = url;
           }
         } else {
-          // @todo use the CE Modal here
-          alert(Joomla.Text._('COM_CONTENTHISTORY_BUTTON_SELECT_ONE_VERSION'));
+          Joomla.renderMessages({
+            error: [Joomla.Text._('COM_CONTENTHISTORY_BUTTON_SELECT_ONE_VERSION')],
+          });
         }
       }
       return false;
@@ -40,8 +41,9 @@
             window.open(url, '', windowSizeArray.toString());
           }
         } else {
-          // @todo use the CE Modal here
-          alert(Joomla.Text._('COM_CONTENTHISTORY_BUTTON_SELECT_ONE_VERSION'));
+          Joomla.renderMessages({
+            error: [Joomla.Text._('COM_CONTENTHISTORY_BUTTON_SELECT_ONE_VERSION')],
+          });
         }
       }
       return false;
@@ -62,8 +64,9 @@
             window.open(url, '', windowSizeArray.toString());
           }
         } else {
-          // @todo use the CE Modal here
-          alert(Joomla.Text._('COM_CONTENTHISTORY_BUTTON_SELECT_TWO_VERSIONS'));
+          Joomla.renderMessages({
+            error: [Joomla.Text._('COM_CONTENTHISTORY_BUTTON_SELECT_TWO_VERSIONS')],
+          });
         }
       }
       return false;


### PR DESCRIPTION
Converts from the ugly browser dependent alerts to use the joomla rendermessage

## To test
run npm build:js or use a prebuilt package

Create and save an article and then edit it and save again Click on Versions
Click on all versions and then preview
Click on all versions and then restore
Click on one version and then compare

### before - ugly alerts
![image](https://user-images.githubusercontent.com/1296369/211999330-67c0a2e8-2dc0-4b6a-9230-1ccbec5a9372.png)

### after - joomla less ugly

![image](https://user-images.githubusercontent.com/1296369/211999279-23d28164-ea1f-4c4d-923b-292b21e8c198.png)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
