### PR TITLE
[4.2] PHP8.2 Remove the not used method assignment in mm API

### DIFF
--- a/administrator/components/com_media/src/Controller/ApiController.php
+++ b/administrator/components/com_media/src/Controller/ApiController.php
@@ -48,8 +48,7 @@ class ApiController extends BaseController
     {
         $method = $this->input->getMethod();
 
-        $this->task   = $task;
-        $this->method = $method;
+        $this->task = $task;
 
         try {
             // Check token for requests which do modify files (all except get requests)


### PR DESCRIPTION
### Summary of Changes
Removes the not used method variable in the media manager APIController.

### Testing Instructions
Open the media manager on PHP 8.2

### Actual result BEFORE applying this Pull Request
Media data is not loaded.

### Expected result AFTER applying this Pull Request
Media data is loaded.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
