### PR TITLE
Encode path parameters in MM API calls

### DIFF
--- a/administrator/components/com_media/resources/scripts/app/Api.es6.js
+++ b/administrator/components/com_media/resources/scripts/app/Api.es6.js
@@ -52,7 +52,7 @@ class Api {
       }
 
       // eslint-disable-next-line no-underscore-dangle
-      let url = `${this._baseUrl}&task=api.files&path=${dir}`;
+      let url = `${this._baseUrl}&task=api.files&path=${encodeURIComponent(dir)}`;
 
       if (full) {
         url += `&url=${full}`;
@@ -88,7 +88,7 @@ class Api {
     // Wrap the ajax call into a real promise
     return new Promise((resolve, reject) => {
       // eslint-disable-next-line no-underscore-dangle
-      const url = `${this._baseUrl}&task=api.files&path=${parent}`;
+      const url = `${this._baseUrl}&task=api.files&path=${encodeURIComponent(parent)}`;
       // eslint-disable-next-line no-underscore-dangle
       const data = { [this._csrfToken]: '1', name };
 
@@ -123,7 +123,7 @@ class Api {
     // Wrap the ajax call into a real promise
     return new Promise((resolve, reject) => {
       // eslint-disable-next-line no-underscore-dangle
-      const url = `${this._baseUrl}&task=api.files&path=${parent}`;
+      const url = `${this._baseUrl}&task=api.files&path=${encodeURIComponent(parent)}`;
       const data = {
         // eslint-disable-next-line no-underscore-dangle
         [this._csrfToken]: '1',
@@ -165,7 +165,7 @@ class Api {
     // Wrap the ajax call into a real promise
     return new Promise((resolve, reject) => {
       // eslint-disable-next-line no-underscore-dangle
-      const url = `${this._baseUrl}&task=api.files&path=${path}`;
+      const url = `${this._baseUrl}&task=api.files&path=${encodeURIComponent(path)}`;
       const data = {
         // eslint-disable-next-line no-underscore-dangle
         [this._csrfToken]: '1',
@@ -201,7 +201,7 @@ class Api {
     // Wrap the ajax call into a real promise
     return new Promise((resolve, reject) => {
       // eslint-disable-next-line no-underscore-dangle
-      const url = `${this._baseUrl}&task=api.files&path=${path}`;
+      const url = `${this._baseUrl}&task=api.files&path=${encodeURIComponent(path)}`;
       // eslint-disable-next-line no-underscore-dangle
       const data = { [this._csrfToken]: '1' };
 

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -279,7 +279,7 @@ const getUrl = (isModal) => {
 
 // Customize the Toolbar buttons behavior
 Joomla.submitbutton = (task) => {
-  const url = new URL(`${Joomla.MediaManager.Edit.options.apiBaseUrl}&task=api.files&path=${encodeURIComponent(Joomla.MediaManager.Edit.options.uploadPath)}`);
+  const url = new URL(`${Joomla.MediaManager.Edit.options.apiBaseUrl}&task=api.files&path=${Joomla.MediaManager.Edit.options.uploadPath}`);
   switch (task) {
     case 'apply':
       Joomla.MediaManager.Edit.upload(url, null);

--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -279,7 +279,7 @@ const getUrl = (isModal) => {
 
 // Customize the Toolbar buttons behavior
 Joomla.submitbutton = (task) => {
-  const url = new URL(`${Joomla.MediaManager.Edit.options.apiBaseUrl}&task=api.files&path=${Joomla.MediaManager.Edit.options.uploadPath}`);
+  const url = new URL(`${Joomla.MediaManager.Edit.options.apiBaseUrl}&task=api.files&path=${encodeURIComponent(Joomla.MediaManager.Edit.options.uploadPath)}`);
   switch (task) {
     case 'apply':
       Joomla.MediaManager.Edit.upload(url, null);

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -317,7 +317,7 @@ Joomla.getMedia = (data, editor, fieldClass) => new Promise((resolve, reject) =>
     return;
   }
 
-  const url = `${Joomla.getOptions('system.paths').baseFull}index.php?option=com_media&task=api.files&url=true&path=${data.path}&mediatypes=0,1,2,3&${Joomla.getOptions('csrf.token')}=1&format=json`;
+  const url = `${Joomla.getOptions('system.paths').baseFull}index.php?option=com_media&task=api.files&url=true&path=${encodeURIComponent(data.path)}&mediatypes=0,1,2,3&${Joomla.getOptions('csrf.token')}=1&format=json`;
   fetch(
     url,
     {


### PR DESCRIPTION
### Summary of Changes
The media manager crashes on several places when folders or files have special characters like "+" in their filename. This pr fixes this issue.

@dgrammatiko can you review this one?

### Testing Instructions
- Create by FTP or whatever you use images within folders with special characters like the "+"
- Open the media manager
- Rename such an image with a special character (don't worry, the character get removed, because of security in joomla, but this is ok)
- Delete such an image
- Select such an image in the article form for an article

### Actual result BEFORE applying this Pull Request
Errors like file not found are thrown.

### Expected result AFTER applying this Pull Request
All operations are working.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
