### PR TITLE
[4.3] add missing deprecated note for #39453

### DIFF
--- a/language/en-GB/com_media.ini
+++ b/language/en-GB/com_media.ini
@@ -52,7 +52,9 @@ COM_MEDIA_FIELD_CHECK_MIME_DESC="Use MIME Magic or Fileinfo to try to verify fil
 COM_MEDIA_FIELD_CHECK_MIME_LABEL="Check MIME Types"
 COM_MEDIA_FIELD_IGNORED_EXTENSIONS_DESC="Ignored file extensions for MIME type checking and restricted uploads."
 COM_MEDIA_FIELD_IGNORED_EXTENSIONS_LABEL="Ignored Extensions"
+; Deprecated, will be removed with 5.0
 COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_DESC="A comma separated list of forbidden MIME types to upload."
+; Deprecated, will be removed with 5.0
 COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_LABEL="Forbidden MIME Types"
 COM_MEDIA_FIELD_LEGAL_EXTENSIONS_DESC="Extensions (file types) you are allowed to upload (comma separated)."
 COM_MEDIA_FIELD_LEGAL_EXTENSIONS_LABEL="Legal Extensions (File Types)"


### PR DESCRIPTION
Pull Request addon for PR #39453 .

### Summary of Changes

With PR #39453, the two strings COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_DESC and COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_LABEL were deleted in the config and designated as deprecated in the administrator ini file.
The deprecated note is missing in the frontend language file.

This PR also adds the message in the frontend ini file.

### Testing Instructions

code review

### Actual result BEFORE applying this Pull Request

```
COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_DESC="A comma separated list of forbidden MIME types to upload."
COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_LABEL="Forbidden MIME Types"
```
### Expected result AFTER applying this Pull Request

```
; Deprecated, will be removed with 5.0
COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_DESC="A comma separated list of forbidden MIME types to upload."
; Deprecated, will be removed with 5.0
COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_LABEL="Forbidden MIME Types"
```
### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
