### PR TITLE
[4.3] PHP8.2 Dynamic property warning in User class

### DIFF
--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -220,7 +220,7 @@ class User extends CMSObject
      */
     protected static $instances = array();
 
-     /**
+    /**
      * The asset id
      *
      * @var    integer

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -220,6 +220,14 @@ class User extends CMSObject
      */
     protected static $instances = array();
 
+     /**
+     * aid
+     *
+     * @var    integer
+     * @since  __DEPLOY_VERSION__
+     */
+    public $aid = null;
+
     /**
      * Constructor activating the default information of the language
      *

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -221,7 +221,7 @@ class User extends CMSObject
     protected static $instances = array();
 
     /**
-     * The asset id
+     * The access level id
      *
      * @var    integer
      * @since  __DEPLOY_VERSION__

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -221,7 +221,7 @@ class User extends CMSObject
     protected static $instances = array();
 
      /**
-     * aid
+     * asset id
      *
      * @var    integer
      * @since  __DEPLOY_VERSION__

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -221,7 +221,7 @@ class User extends CMSObject
     protected static $instances = array();
 
      /**
-     * asset id
+     * The asset id
      *
      * @var    integer
      * @since  __DEPLOY_VERSION__


### PR DESCRIPTION
Pull Request for Issue php 8.2 -  dynamic property Deprecated

### Summary of Changes
declared property


### Testing Instructions
open frontend with php 8.2 with Error Reporting = maximum


### Actual result BEFORE applying this Pull Request
Deprecated: Creation of dynamic property Joomla\CMS\User\User::$aid is deprecated in /shared/httpd/dev4/joomla-cms/libraries/src/User/User.php on line 871


### Expected result AFTER applying this Pull Request
no more deprecation


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
