### PR TITLE
Converts tinymce to service providers

### DIFF
--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -18,7 +18,6 @@ use Joomla\Event\AbstractEvent;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
 use Joomla\Event\DispatcherInterface;
-use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('JPATH_PLATFORM') or die;

--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -280,45 +280,19 @@ class Editor implements DispatcherAwareInterface
 
         // Boot the editor plugin
         $this->_editor = Factory::getApplication()->bootPlugin($name, 'editors');
-        if ($this->_editor) {
-            $this->initialise();
-            PluginHelper::importPlugin('editors-xtd');
 
-            return true;
-        }
-
-        $path = JPATH_PLUGINS . '/editors/' . $name . '/' . $name . '.php';
-
-        if (!is_file($path)) {
+        // Check if the editor can be loaded
+        if (!$this->_editor) {
             Log::add(Text::_('JLIB_HTML_EDITOR_CANNOT_LOAD'), Log::WARNING, 'jerror');
 
             return false;
         }
 
-        // Require plugin file
-        require_once $path;
+        $this->_editor->params->loadArray($config);
 
-        // Get the plugin
-        $plugin = PluginHelper::getPlugin('editors', $this->_name);
+        $this->initialise();
+        PluginHelper::importPlugin('editors-xtd');
 
-        // If no plugin is published we get an empty array and there not so much to do with it
-        if (empty($plugin)) {
-            return false;
-        }
-
-        $params = new Registry($plugin->params);
-        $params->loadArray($config);
-        $plugin->params = $params;
-
-        // Build editor plugin classname
-        $name = 'PlgEditor' . $this->_name;
-
-        $dispatcher = $this->getDispatcher();
-
-        if ($this->_editor = new $name($dispatcher, (array) $plugin)) {
-            // Load plugin parameters
-            $this->initialise();
-            PluginHelper::importPlugin('editors-xtd');
-        }
+        return true;
     }
 }

--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -277,6 +277,16 @@ class Editor implements DispatcherAwareInterface
 
         // Build the path to the needed editor plugin
         $name = InputFilter::getInstance()->clean($this->_name, 'cmd');
+
+        // Boot the editor plugin
+        $this->_editor = Factory::getApplication()->bootPlugin($name, 'editors');
+        if ($this->_editor) {
+            $this->initialise();
+            PluginHelper::importPlugin('editors-xtd');
+
+            return true;
+        }
+
         $path = JPATH_PLUGINS . '/editors/' . $name . '/' . $name . '.php';
 
         if (!is_file($path)) {

--- a/libraries/src/Extension/ExtensionManagerTrait.php
+++ b/libraries/src/Extension/ExtensionManagerTrait.php
@@ -216,8 +216,13 @@ trait ExtensionManagerTrait
         // Compile the classname
         $className = 'Plg' . str_replace('-', '', $type) . $plugin;
 
+        // Editors don't follow the convention
+        if ($type === 'editors') {
+            $className = 'PlgEditor' . ucfirst($plugin);
+        }
+
+        // Editor buttons don't follow the convention
         if ($type === 'editors-xtd') {
-            // This type doesn't follow the convention
             $className = 'PlgEditorsXtd' . $plugin;
 
             if (!class_exists($className)) {

--- a/plugins/editors/tinymce/services/provider.php
+++ b/plugins/editors/tinymce/services/provider.php
@@ -36,6 +36,7 @@ return new class implements ServiceProviderInterface
             PluginInterface::class,
             function (Container $container) {
                 $dispatcher = $container->get(DispatcherInterface::class);
+
                 $plugin     = new TinyMCE(
                     $dispatcher,
                     (array) PluginHelper::getPlugin('editors', 'tinymce')

--- a/plugins/editors/tinymce/services/provider.php
+++ b/plugins/editors/tinymce/services/provider.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors.tinymce
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Database\DatabaseInterface;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\Editors\TinyMCE\Extension\TinyMCE;
+
+return new class implements ServiceProviderInterface
+{
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+                $plugin     = new TinyMCE(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('editors', 'tinymce')
+                );
+                $plugin->setApplication(Factory::getApplication());
+                $plugin->setDatabase($container->get(DatabaseInterface::class));
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plugins/editors/tinymce/src/Extension/TinyMCE.php
+++ b/plugins/editors/tinymce/src/Extension/TinyMCE.php
@@ -6,11 +6,12 @@
  *
  * @copyright   (C) 2006 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
+namespace Joomla\Plugin\Editors\TinyMCE\Extension;
+
 use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Plugin\Editors\TinyMCE\PluginTraits\DisplayTrait;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -22,9 +23,10 @@ use Joomla\Plugin\Editors\TinyMCE\PluginTraits\DisplayTrait;
  *
  * @since  1.5
  */
-class PlgEditorTinymce extends CMSPlugin
+final class TinyMCE extends CMSPlugin
 {
     use DisplayTrait;
+    use DatabaseAwareTrait;
 
     /**
      * Base path for editor files
@@ -44,15 +46,7 @@ class PlgEditorTinymce extends CMSPlugin
     protected $autoloadLanguage = true;
 
     /**
-     * Loads the application object
-     *
-     * @var    \Joomla\CMS\Application\CMSApplication
-     * @since  3.2
-     */
-    protected $app = null;
-
-    /**
-     * Initialises the Editor.
+     * Initializes the Editor.
      *
      * @return  void
      *

--- a/plugins/editors/tinymce/src/Extension/TinyMCE.php
+++ b/plugins/editors/tinymce/src/Extension/TinyMCE.php
@@ -29,15 +29,6 @@ final class TinyMCE extends CMSPlugin
     use DatabaseAwareTrait;
 
     /**
-     * Base path for editor files
-     *
-     * @since  3.5
-     *
-     * @deprecated 5.0
-     */
-    protected $_basePath = 'media/vendor/tinymce';
-
-    /**
      * Load the language file on instantiation.
      *
      * @var    boolean

--- a/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
+++ b/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Plugin\Content\Contact\Extension\TinyMCE;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -74,9 +75,6 @@ class TinymcebuilderField extends FormField
             $data['value'] = array();
         }
 
-        // Get the plugin
-        require_once JPATH_PLUGINS . '/editors/tinymce/tinymce.php';
-
         $menus = array(
             'edit'   => array('label' => 'Edit'),
             'insert' => array('label' => 'Insert'),
@@ -89,9 +87,9 @@ class TinymcebuilderField extends FormField
 
         $data['menus']         = $menus;
         $data['menubarSource'] = array_keys($menus);
-        $data['buttons']       = \PlgEditorTinymce::getKnownButtons();
+        $data['buttons']       = TinyMCE::getKnownButtons();
         $data['buttonsSource'] = array_keys($data['buttons']);
-        $data['toolbarPreset'] = \PlgEditorTinymce::getToolbarPreset();
+        $data['toolbarPreset'] = TinyMCE::getToolbarPreset();
         $data['setsAmount']    = $setsAmount;
 
         // Get array of sets names

--- a/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
+++ b/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\Plugin\Content\Contact\Extension\TinyMCE;
+use Joomla\Plugin\Editors\TinyMCE\Extension\TinyMCE;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;

--- a/plugins/editors/tinymce/src/PluginTraits/ActiveSiteTemplate.php
+++ b/plugins/editors/tinymce/src/PluginTraits/ActiveSiteTemplate.php
@@ -34,7 +34,7 @@ trait ActiveSiteTemplate
      */
     protected function getActiveSiteTemplate()
     {
-        $db    = Factory::getContainer()->get('db');
+        $db    = $this->getDatabase();
         $query = $db->getQuery(true)
             ->select('*')
             ->from($db->quoteName('#__template_styles'))
@@ -50,7 +50,7 @@ trait ActiveSiteTemplate
         try {
             return $db->loadObject();
         } catch (RuntimeException $e) {
-            $this->app->enqueueMessage(Text::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
+            $this->getApplication()->enqueueMessage(Text::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
             return new \stdClass();
         }

--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -68,9 +68,9 @@ trait DisplayTrait
         $params = []
     ) {
         $id              = empty($id) ? $name : $id;
-        $user            = $this->app->getIdentity();
-        $language        = $this->app->getLanguage();
-        $doc             = $this->app->getDocument();
+        $user            = $this->getApplication()->getIdentity();
+        $language        = $this->getApplication()->getLanguage();
+        $doc             = $this->getApplication()->getDocument();
         $id              = preg_replace('/(\s|[^A-Za-z0-9_])+/', '_', $id);
         $nameGroup       = explode('[', preg_replace('/\[\]|\]/', '', $name));
         $fieldName       = end($nameGroup);
@@ -94,7 +94,7 @@ trait DisplayTrait
         // Render Editor markup
         $editor = '<div class="js-editor-tinymce">';
         $editor .= LayoutHelper::render('joomla.tinymce.textarea', $textarea);
-        $editor .= !$this->app->client->mobile ? LayoutHelper::render('joomla.tinymce.togglebutton') : '';
+        $editor .= !$this->getApplication()->client->mobile ? LayoutHelper::render('joomla.tinymce.togglebutton') : '';
         $editor .= '</div>';
 
         // Prepare the instance specific options
@@ -176,7 +176,7 @@ trait DisplayTrait
         $levelParams->loadObject($extraOptions);
 
         // Set the selected skin
-        $skin = $levelParams->get($this->app->isClient('administrator') ? 'skin_admin' : 'skin', 'oxide');
+        $skin = $levelParams->get($this->getApplication()->isClient('administrator') ? 'skin_admin' : 'skin', 'oxide');
 
         // Check that selected skin exists.
         $skin = Folder::exists(JPATH_ROOT . '/media/vendor/tinymce/skins/ui/' . $skin) ? $skin : 'oxide';
@@ -362,7 +362,7 @@ trait DisplayTrait
         if ($dragdrop && $user->authorise('core.create', 'com_media')) {
             $externalPlugins['jdragndrop'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/dragdrop/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
             $uploadUrl                     = Uri::base(false) . 'index.php?option=com_media&format=json&url=1&task=api.files';
-            $uploadUrl                     = $this->app->isClient('site') ? htmlentities($uploadUrl, ENT_NOQUOTES, 'UTF-8', false) : $uploadUrl;
+            $uploadUrl                     = $this->getApplication()->isClient('site') ? htmlentities($uploadUrl, ENT_NOQUOTES, 'UTF-8', false) : $uploadUrl;
 
             Text::script('PLG_TINY_ERR_UNSUPPORTEDBROWSER');
             Text::script('ERROR');

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -11,8 +11,8 @@
 	<description>PLG_TINY_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\Editors\TinyMCE</namespace>
 	<files>
-		<filename plugin="tinymce">tinymce.php</filename>
 		<folder>forms</folder>
+		<folder plugin="tinymce">services</folder>
 		<folder>src</folder>
 	</files>
 	<media destination="editors" folder="media">


### PR DESCRIPTION
### Summary of Changes
Converts the tinymce editor to service providers.

### Testing Instructions
- Make sure TinyMCE is the default editor
- Edit an article

Also test if the other editors do still work

### Actual result BEFORE applying this Pull Request
All works.

### Expected result AFTER applying this Pull Request
All works.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
