### PR TITLE
REDO #39353 - Values not translated in com_finder search result

### DIFF
--- a/components/com_finder/tmpl/search/default_result.php
+++ b/components/com_finder/tmpl/search/default_result.php
@@ -116,7 +116,7 @@ if ($this->params->get('show_url', 1)) {
                     <?php if (count($taxonomy_text)) : ?>
                         <li class="result__taxonomy-item result__taxonomy--<?php echo $type; ?>">
                             <span><?php echo Text::_(LanguageHelper::branchSingular($type)); ?>:</span>
-                            <?php echo Text::_(LanguageHelper::branchSingular(implode(',', $taxonomy_text)); ?>
+                            <?php echo Text::_(LanguageHelper::branchSingular(implode(',', $taxonomy_text))); ?>
                         </li>
                     <?php endif; ?>
                 <?php endif; ?>

--- a/components/com_finder/tmpl/search/default_result.php
+++ b/components/com_finder/tmpl/search/default_result.php
@@ -115,7 +115,8 @@ if ($this->params->get('show_url', 1)) {
                     <?php endforeach; ?>
                     <?php if (count($taxonomy_text)) : ?>
                         <li class="result__taxonomy-item result__taxonomy--<?php echo $type; ?>">
-                            <span><?php echo Text::_(LanguageHelper::branchSingular($type)); ?>:</span> <?php echo implode(',', $taxonomy_text); ?>
+                            <span><?php echo Text::_(LanguageHelper::branchSingular($type)); ?>:</span>
+                            <?php echo Text::_(LanguageHelper::branchSingular(implode(',', $taxonomy_text)); ?>
                         </li>
                     <?php endif; ?>
                 <?php endif; ?>


### PR DESCRIPTION
REDO #39353 
Pull Request for Issue #38846.

### Summary of Changes
Translate missing translations of values in search results.


### Testing Instructions
- Needs a multi-language site.
- Search in frontend.
- For example with en-GB, fr-FR, de-DE, with a search for Type: Categories.


### Actual result BEFORE applying this Pull Request
Before PR, Type: Category for all languages (_Category_ not translated):

en-GB
![Capture d’écran 2022-12-04 à 02 19 55](https://user-images.githubusercontent.com/2385058/205469444-4a890431-8219-470a-8540-a8b2c3d8722e.png)

fr-FR
![Capture d’écran 2022-12-04 à 02 20 54](https://user-images.githubusercontent.com/2385058/205469455-f0fa89a9-4564-4613-8ab0-235d54a234f6.png)

de-DE
![Capture d’écran 2022-12-04 à 02 19 43](https://user-images.githubusercontent.com/2385058/205469457-48b71242-67bf-4b73-adb9-1f5378f895c5.png)



### Expected result AFTER applying this Pull Request
After PR, _Category_ is translated:

en-GB
![Capture d’écran 2022-12-04 à 02 16 16](https://user-images.githubusercontent.com/2385058/205469381-345667e8-650c-4acd-b230-d76ab29eab0d.png)

fr-FR
![Capture d’écran 2022-12-04 à 02 15 47](https://user-images.githubusercontent.com/2385058/205469389-f1e4d7da-ce97-4657-86d5-467aeb4f0108.png)

de-DE
![Capture d’écran 2022-12-04 à 02 16 37](https://user-images.githubusercontent.com/2385058/205469390-a08541d9-8e5e-456d-824d-1c27ee827024.png)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

