### PR TITLE
Do not hardcode the media manager API url to select an image

### DIFF
--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -318,7 +318,7 @@ Joomla.getMedia = (data, editor, fieldClass) => new Promise((resolve, reject) =>
   }
 
   // Compile the url
-  const url = new URL(Joomla.getOptions('media-picker-api').apiBaseUrl ? Joomla.getOptions('media-picker-api').apiBaseUrl : Joomla.getOptions('system.paths').baseFull +'index.php?option=com_media&format=json');
+  const url = new URL(Joomla.getOptions('media-picker-api').apiBaseUrl ? Joomla.getOptions('media-picker-api').apiBaseUrl : Joomla.getOptions('system.paths').baseFull + 'index.php?option=com_media&format=json');
   url.searchParams.append('task', 'api.files');
   url.searchParams.append('url', true);
   url.searchParams.append('path', data.path);

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -318,7 +318,7 @@ Joomla.getMedia = (data, editor, fieldClass) => new Promise((resolve, reject) =>
   }
 
   // Compile the url
-  const url = new URL(Joomla.getOptions('media-picker-api').apiBaseUrl ? Joomla.getOptions('media-picker-api').apiBaseUrl : Joomla.getOptions('system.paths').baseFull + 'index.php?option=com_media&format=json');
+  const url = new URL(Joomla.getOptions('media-picker-api').apiBaseUrl ? Joomla.getOptions('media-picker-api').apiBaseUrl : `${Joomla.getOptions('system.paths').baseFull}index.php?option=com_media&format=json`);
   url.searchParams.append('task', 'api.files');
   url.searchParams.append('url', true);
   url.searchParams.append('path', encodeURIComponent(data.path));

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -321,7 +321,7 @@ Joomla.getMedia = (data, editor, fieldClass) => new Promise((resolve, reject) =>
   const url = new URL(Joomla.getOptions('media-picker-api').apiBaseUrl ? Joomla.getOptions('media-picker-api').apiBaseUrl : `${Joomla.getOptions('system.paths').baseFull}index.php?option=com_media&format=json`);
   url.searchParams.append('task', 'api.files');
   url.searchParams.append('url', true);
-  url.searchParams.append('path', encodeURIComponent(data.path));
+  url.searchParams.append('path', data.path);
   url.searchParams.append('mediatypes', '0,1,2,3');
   url.searchParams.append(Joomla.getOptions('csrf.token'), 1);
 

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -317,7 +317,8 @@ Joomla.getMedia = (data, editor, fieldClass) => new Promise((resolve, reject) =>
     return;
   }
 
-  const url = `${Joomla.getOptions('system.paths').baseFull}index.php?option=com_media&task=api.files&url=true&path=${encodeURIComponent(data.path)}&mediatypes=0,1,2,3&${Joomla.getOptions('csrf.token')}=1&format=json`;
+  let url = `&task=api.files&url=true&path=${encodeURIComponent(data.path)}&mediatypes=0,1,2,3&${Joomla.getOptions('csrf.token')}=1`;
+  url = (Joomla.getOptions('media-picker-api').apiBaseUrl ? Joomla.getOptions('media-picker-api').apiBaseUrl : Joomla.getOptions('system.paths').baseFull +'index.php?option=com_media&format=json') + url;
   fetch(
     url,
     {

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -321,7 +321,7 @@ Joomla.getMedia = (data, editor, fieldClass) => new Promise((resolve, reject) =>
   const url = new URL(Joomla.getOptions('media-picker-api').apiBaseUrl ? Joomla.getOptions('media-picker-api').apiBaseUrl : Joomla.getOptions('system.paths').baseFull + 'index.php?option=com_media&format=json');
   url.searchParams.append('task', 'api.files');
   url.searchParams.append('url', true);
-  url.searchParams.append('path', data.path);
+  url.searchParams.append('path', encodeURIComponent(data.path));
   url.searchParams.append('mediatypes', '0,1,2,3');
   url.searchParams.append(Joomla.getOptions('csrf.token'), 1);
 

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -317,8 +317,14 @@ Joomla.getMedia = (data, editor, fieldClass) => new Promise((resolve, reject) =>
     return;
   }
 
-  let url = `&task=api.files&url=true&path=${encodeURIComponent(data.path)}&mediatypes=0,1,2,3&${Joomla.getOptions('csrf.token')}=1`;
-  url = (Joomla.getOptions('media-picker-api').apiBaseUrl ? Joomla.getOptions('media-picker-api').apiBaseUrl : Joomla.getOptions('system.paths').baseFull +'index.php?option=com_media&format=json') + url;
+  // Compile the url
+  const url = new URL(Joomla.getOptions('media-picker-api').apiBaseUrl ? Joomla.getOptions('media-picker-api').apiBaseUrl : Joomla.getOptions('system.paths').baseFull +'index.php?option=com_media&format=json');
+  url.searchParams.append('task', 'api.files');
+  url.searchParams.append('url', true);
+  url.searchParams.append('path', data.path);
+  url.searchParams.append('mediatypes', '0,1,2,3');
+  url.searchParams.append(Joomla.getOptions('csrf.token'), 1);
+
   fetch(
     url,
     {

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -117,6 +117,7 @@ $doc = Factory::getDocument();
 $wam = $doc->getWebAssetManager();
 
 $wam->useScript('webcomponent.media-select');
+$doc->addScriptOptions('media-picker-api', ['apiBaseUrl' => Uri::base() . 'index.php?option=com_media&format=json']);
 
 Text::script('JFIELD_MEDIA_LAZY_LABEL');
 Text::script('JFIELD_MEDIA_ALT_LABEL');
@@ -168,21 +169,21 @@ if (count($doc->getScriptOptions('media-picker')) === 0) {
 }
 
 ?>
-<joomla-field-media class="field-media-wrapper" type="image" <?php // @TODO add this attribute to the field in order to use it for all media types ?> 
-    base-path="<?php echo Uri::root(); ?>" 
-    root-folder="<?php echo ComponentHelper::getParams('com_media')->get('file_path', 'images'); ?>" 
-    url="<?php echo $url; ?>" 
-    modal-container=".modal" 
-    modal-width="100%" 
-    modal-height="400px" 
-    input=".field-media-input" 
-    button-select=".button-select" 
-    button-clear=".button-clear" 
+<joomla-field-media class="field-media-wrapper" type="image" <?php // @TODO add this attribute to the field in order to use it for all media types ?>
+    base-path="<?php echo Uri::root(); ?>"
+    root-folder="<?php echo ComponentHelper::getParams('com_media')->get('file_path', 'images'); ?>"
+    url="<?php echo $url; ?>"
+    modal-container=".modal"
+    modal-width="100%"
+    modal-height="400px"
+    input=".field-media-input"
+    button-select=".button-select"
+    button-clear=".button-clear"
     button-save-selected=".button-save-selected"
-    preview="static" 
-    preview-container=".field-media-preview" 
-    preview-width="<?php echo $previewWidth; ?>" 
-    preview-height="<?php echo $previewHeight; ?>" 
+    preview="static"
+    preview-container=".field-media-preview"
+    preview-width="<?php echo $previewWidth; ?>"
+    preview-height="<?php echo $previewHeight; ?>"
     supported-extensions="<?php echo str_replace('"', '&quot;', json_encode(['images' => $imagesAllowedExt, 'audios' => $audiosAllowedExt, 'videos' => $videosAllowedExt, 'documents' => $documentsAllowedExt])); ?>
 ">
     <?php echo $modalHTML; ?>

--- a/plugins/editors-xtd/image/image.php
+++ b/plugins/editors-xtd/image/image.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\CMS\Uri\Uri;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -74,9 +75,8 @@ class PlgButtonImage extends CMSPlugin
                 ->useScript('webcomponent.field-media')
                 ->useStyle('webcomponent.media-select');
 
-            $doc->addScriptOptions('xtdImageModal', [
-                $name . '_ImageModal',
-            ]);
+            $doc->addScriptOptions('xtdImageModal', [$name . '_ImageModal']);
+            $doc->addScriptOptions('media-picker-api', ['apiBaseUrl' => Uri::base() . 'index.php?option=com_media&format=json']);
 
             if (count($doc->getScriptOptions('media-picker')) === 0) {
                 $imagesExt = array_map(


### PR DESCRIPTION
### Summary of Changes
The media manager is loading their API urls from the JS config store, expect when selecting files in the media form field. This pr extends the media manager the way that the API url is passed to the media field. For backwards compatibility it does a fallback to the old url when it doesn't exist already. This situation can be for older overrides.

@dgrammatiko can you review?

### Testing Instructions
Select an intro or full image in the images field.

### Actual result BEFORE applying this Pull Request
All works.

### Expected result AFTER applying this Pull Request
All works.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
