### PR TITLE
[4.3] Converts editor buttons to service providers

### DIFF
--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -70,7 +70,7 @@ class Editor implements DispatcherAwareInterface
      * @var    Editor[]
      * @since  2.5
      */
-    protected static $instances = array();
+    protected static $instances = [];
 
     /**
      * Constructor
@@ -93,12 +93,10 @@ class Editor implements DispatcherAwareInterface
         $this->getDispatcher()->addListener(
             'getButtons',
             function (AbstractEvent $event) {
-                $editor = $event->getArgument('editor', null);
-                $buttons = $event->getArgument('buttons', null);
-                $result = $event->getArgument('result', []);
-                $newResult = $this->getButtons($editor, $buttons);
-                $newResult = (array) $newResult;
-                $event['result'] = array_merge($result, $newResult);
+                $event['result'] = (array) $this->getButtons(
+                    $event->getArgument('editor', null),
+                    $event->getArgument('buttons', null)
+                );
             }
         );
     }
@@ -192,7 +190,7 @@ class Editor implements DispatcherAwareInterface
         $args['author'] = $author;
         $args['params'] = $params;
 
-        return \call_user_func_array(array($this->_editor, 'onDisplay'), $args);
+        return \call_user_func_array([$this->_editor, 'onDisplay'], $args);
     }
 
     /**
@@ -208,7 +206,7 @@ class Editor implements DispatcherAwareInterface
      */
     public function getButtons($editor, $buttons = true)
     {
-        $result = array();
+        $result = [];
 
         if (\is_bool($buttons) && !$buttons) {
             return $result;
@@ -222,16 +220,10 @@ class Editor implements DispatcherAwareInterface
                 continue;
             }
 
-            PluginHelper::importPlugin('editors-xtd', $plugin->name, false);
-            $className = 'PlgEditorsXtd' . $plugin->name;
+            $plugin = Factory::getApplication()->bootPlugin($plugin->name, 'editors-xtd');
 
-            if (!class_exists($className)) {
-                $className = 'PlgButton' . $plugin->name;
-            }
-
-            if (class_exists($className)) {
-                $dispatcher = $this->getDispatcher();
-                $plugin = new $className($dispatcher, (array) $plugin);
+            if (!$plugin) {
+                return $result;
             }
 
             // Try to authenticate

--- a/plugins/editors-xtd/article/article.xml
+++ b/plugins/editors-xtd/article/article.xml
@@ -11,8 +11,8 @@
 	<description>PLG_ARTICLE_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\EditorsXtd\Article</namespace>
 	<files>
-		<folder>services</folder>
-		<folder plugin="article">src</folder>
+		<folder plugin="article">services</folder>
+		<folder>src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_article.ini</language>

--- a/plugins/editors-xtd/article/article.xml
+++ b/plugins/editors-xtd/article/article.xml
@@ -9,8 +9,10 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>PLG_ARTICLE_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\EditorsXtd\Article</namespace>
 	<files>
-		<filename plugin="article">article.php</filename>
+		<folder>services</folder>
+		<folder plugin="article">src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_article.ini</language>

--- a/plugins/editors-xtd/article/services/provider.php
+++ b/plugins/editors-xtd/article/services/provider.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors-xtd.article
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\EditorsXtd\Article\Extension\Article;
+
+return new class implements ServiceProviderInterface
+{
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+
+                $plugin     = new Article(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('editors-xtd', 'article')
+                );
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plugins/editors-xtd/article/src/Extension/Article.php
+++ b/plugins/editors-xtd/article/src/Extension/Article.php
@@ -6,9 +6,9 @@
  *
  * @copyright   (C) 2009 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
+
+namespace Joomla\Plugin\EditorsXtd\Article\Extension;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -25,7 +25,7 @@ use Joomla\CMS\Session\Session;
  *
  * @since  1.5
  */
-class PlgButtonArticle extends CMSPlugin
+final class Article extends CMSPlugin
 {
     /**
      * Load the language file on instantiation.
@@ -46,14 +46,14 @@ class PlgButtonArticle extends CMSPlugin
      */
     public function onDisplay($name)
     {
-        $user  = Factory::getUser();
+        $user  = $this->getApplication()->getIdentity();
 
         // Can create in any category (component permission) or at least in one category
         $canCreateRecords = $user->authorise('core.create', 'com_content')
             || count($user->getAuthorisedCategories('com_content', 'core.create')) > 0;
 
         // Instead of checking edit on all records, we can use **same** check as the form editing view
-        $values = (array) Factory::getApplication()->getUserState('com_content.edit.article.id');
+        $values = (array) $this->getApplication()->getUserState('com_content.edit.article.id');
         $isEditingRecords = count($values);
 
         // This ACL check is probably a double-check (form view already performed checks)
@@ -72,7 +72,7 @@ class PlgButtonArticle extends CMSPlugin
         $button->name    = $this->_type . '_' . $this->_name;
         $button->icon    = 'file-add';
         $button->iconSVG = '<svg viewBox="0 0 32 32" width="24" height="24"><path d="M28 24v-4h-4v4h-4v4h4v4h4v-4h4v-4zM2 2h18v6h6v10h2v-10l-8-'
-                                . '8h-20v32h18v-2h-16z"></path></svg>';
+            . '8h-20v32h18v-2h-16z"></path></svg>';
         $button->options = [
             'height'     => '300px',
             'width'      => '800px',

--- a/plugins/editors-xtd/article/src/Extension/Article.php
+++ b/plugins/editors-xtd/article/src/Extension/Article.php
@@ -10,7 +10,6 @@
 
 namespace Joomla\Plugin\EditorsXtd\Article\Extension;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;

--- a/plugins/editors-xtd/contact/contact.xml
+++ b/plugins/editors-xtd/contact/contact.xml
@@ -9,8 +9,10 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.7.0</version>
 	<description>PLG_EDITORS-XTD_CONTACT_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\EditorsXtd\Contact</namespace>
 	<files>
-		<filename plugin="contact">contact.php</filename>
+		<folder>services</folder>
+		<folder plugin="contact">src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_contact.ini</language>

--- a/plugins/editors-xtd/contact/contact.xml
+++ b/plugins/editors-xtd/contact/contact.xml
@@ -11,8 +11,8 @@
 	<description>PLG_EDITORS-XTD_CONTACT_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\EditorsXtd\Contact</namespace>
 	<files>
-		<folder>services</folder>
-		<folder plugin="contact">src</folder>
+		<folder plugin="contact">services</folder>
+		<folder>src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_contact.ini</language>

--- a/plugins/editors-xtd/contact/services/provider.php
+++ b/plugins/editors-xtd/contact/services/provider.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors-xtd.contact
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\EditorsXtd\Contact\Extension\Contact;
+
+return new class implements ServiceProviderInterface
+{
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+
+                $plugin     = new Contact(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('editors-xtd', 'contact')
+                );
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plugins/editors-xtd/contact/src/Extension/Contact.php
+++ b/plugins/editors-xtd/contact/src/Extension/Contact.php
@@ -6,9 +6,9 @@
  *
  * @copyright   (C) 2016 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
+
+namespace Joomla\Plugin\EditorsXtd\Contact\Extension;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -25,7 +25,7 @@ use Joomla\CMS\Session\Session;
  *
  * @since  3.7.0
  */
-class PlgButtonContact extends CMSPlugin
+final class Contact extends CMSPlugin
 {
     /**
      * Load the language file on instantiation.

--- a/plugins/editors-xtd/contact/src/Extension/Contact.php
+++ b/plugins/editors-xtd/contact/src/Extension/Contact.php
@@ -10,7 +10,6 @@
 
 namespace Joomla\Plugin\EditorsXtd\Contact\Extension;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -46,7 +45,7 @@ final class Contact extends CMSPlugin
      */
     public function onDisplay($name)
     {
-        $user  = Factory::getUser();
+        $user  = $this->getApplication()->getIdentity();
 
         if (
             $user->authorise('core.create', 'com_contact')

--- a/plugins/editors-xtd/fields/fields.xml
+++ b/plugins/editors-xtd/fields/fields.xml
@@ -11,8 +11,8 @@
 	<description>PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\EditorsXtd\Fields</namespace>
 	<files>
-		<folder>services</folder>
-		<folder plugin="fields">src</folder>
+		<folder plugin="fields">services</folder>
+		<folder>src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_fields.ini</language>

--- a/plugins/editors-xtd/fields/fields.xml
+++ b/plugins/editors-xtd/fields/fields.xml
@@ -9,8 +9,10 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.7.0</version>
 	<description>PLG_EDITORS-XTD_FIELDS_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\EditorsXtd\Fields</namespace>
 	<files>
-		<filename plugin="fields">fields.php</filename>
+		<folder>services</folder>
+		<folder plugin="fields">src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_fields.ini</language>

--- a/plugins/editors-xtd/fields/services/provider.php
+++ b/plugins/editors-xtd/fields/services/provider.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors-xtd.fields
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\EditorsXtd\Fields\Extension\Fields;
+
+return new class implements ServiceProviderInterface
+{
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+
+                $plugin     = new Fields(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('editors-xtd', 'fields')
+                );
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plugins/editors-xtd/fields/src/Extension/Fields.php
+++ b/plugins/editors-xtd/fields/src/Extension/Fields.php
@@ -6,12 +6,11 @@
  *
  * @copyright   (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
+namespace Joomla\Plugin\EditorsXtd\Fields\Extension;
+
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -26,7 +25,7 @@ use Joomla\CMS\Session\Session;
  *
  * @since  3.7.0
  */
-class PlgButtonFields extends CMSPlugin
+final class Fields extends CMSPlugin
 {
     /**
      * Load the language file on instantiation.
@@ -53,7 +52,7 @@ class PlgButtonFields extends CMSPlugin
         }
 
         // Guess the field context based on view.
-        $jinput = Factory::getApplication()->getInput();
+        $jinput = $this->getApplication()->getInput();
         $context = $jinput->get('option') . '.' . $jinput->get('view');
 
         // Special context for com_categories

--- a/plugins/editors-xtd/image/image.xml
+++ b/plugins/editors-xtd/image/image.xml
@@ -9,8 +9,10 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>PLG_IMAGE_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\EditorsXtd\Image</namespace>
 	<files>
-		<filename plugin="image">image.php</filename>
+		<folder>services</folder>
+		<folder plugin="image">src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_image.ini</language>

--- a/plugins/editors-xtd/image/image.xml
+++ b/plugins/editors-xtd/image/image.xml
@@ -11,8 +11,8 @@
 	<description>PLG_IMAGE_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\EditorsXtd\Image</namespace>
 	<files>
-		<folder>services</folder>
-		<folder plugin="image">src</folder>
+		<folder plugin="image">services</folder>
+		<folder>src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_image.ini</language>

--- a/plugins/editors-xtd/image/services/provider.php
+++ b/plugins/editors-xtd/image/services/provider.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors-xtd.image
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\EditorsXtd\Image\Extension\Image;
+
+return new class implements ServiceProviderInterface
+{
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+
+                $plugin     = new Image(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('editors-xtd', 'image')
+                );
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plugins/editors-xtd/image/src/Extension/Image.php
+++ b/plugins/editors-xtd/image/src/Extension/Image.php
@@ -11,7 +11,6 @@
 namespace Joomla\Plugin\EditorsXtd\Image\Extension;
 
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -48,14 +47,13 @@ final class Image extends CMSPlugin
      */
     public function onDisplay($name, $asset, $author)
     {
-        $app       = Factory::getApplication();
-        $doc       = $app->getDocument();
-        $user      = Factory::getUser();
-        $extension = $app->getInput()->get('option');
+        $doc       = $this->getApplication()->getDocument();
+        $user      = $this->getApplication()->getIdentity();
+        $extension = $this->getApplication()->getInput()->get('option');
 
         // For categories we check the extension (ex: component.section)
         if ($extension === 'com_categories') {
-            $parts     = explode('.', $app->getInput()->get('extension', 'com_content'));
+            $parts     = explode('.', $this->getApplication()->getInput()->get('extension', 'com_content'));
             $extension = $parts[0];
         }
 

--- a/plugins/editors-xtd/image/src/Extension/Image.php
+++ b/plugins/editors-xtd/image/src/Extension/Image.php
@@ -6,9 +6,9 @@
  *
  * @copyright   (C) 2006 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
+
+namespace Joomla\Plugin\EditorsXtd\Image\Extension;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
@@ -25,7 +25,7 @@ use Joomla\CMS\Plugin\CMSPlugin;
  *
  * @since  1.5
  */
-class PlgButtonImage extends CMSPlugin
+final class Image extends CMSPlugin
 {
     /**
      * Load the language file on instantiation.

--- a/plugins/editors-xtd/menu/menu.xml
+++ b/plugins/editors-xtd/menu/menu.xml
@@ -11,8 +11,8 @@
 	<description>PLG_EDITORS-XTD_MENU_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\EditorsXtd\Menu</namespace>
 	<files>
-		<folder>services</folder>
-		<folder plugin="menu">src</folder>
+		<folder plugin="menu">services</folder>
+		<folder>src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_menu.ini</language>

--- a/plugins/editors-xtd/menu/menu.xml
+++ b/plugins/editors-xtd/menu/menu.xml
@@ -9,8 +9,10 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.7.0</version>
 	<description>PLG_EDITORS-XTD_MENU_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\EditorsXtd\Menu</namespace>
 	<files>
-		<filename plugin="menu">menu.php</filename>
+		<folder>services</folder>
+		<folder plugin="menu">src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_menu.ini</language>

--- a/plugins/editors-xtd/menu/services/provider.php
+++ b/plugins/editors-xtd/menu/services/provider.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors-xtd.article
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\EditorsXtd\Menu\Extension\Menu;
+
+return new class implements ServiceProviderInterface
+{
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+
+                $plugin     = new Menu(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('editors-xtd', 'menu')
+                );
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plugins/editors-xtd/menu/src/Extension/Menu.php
+++ b/plugins/editors-xtd/menu/src/Extension/Menu.php
@@ -6,9 +6,9 @@
  *
  * @copyright   (C) 2016 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
+
+namespace Joomla\Plugin\EditorsXtd\Menu\Extension;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -25,7 +25,7 @@ use Joomla\CMS\Session\Session;
  *
  * @since  3.7.0
  */
-class PlgButtonMenu extends CMSPlugin
+final class Menu extends CMSPlugin
 {
     /**
      * Load the language file on instantiation.

--- a/plugins/editors-xtd/menu/src/Extension/Menu.php
+++ b/plugins/editors-xtd/menu/src/Extension/Menu.php
@@ -10,7 +10,6 @@
 
 namespace Joomla\Plugin\EditorsXtd\Menu\Extension;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -49,7 +48,7 @@ final class Menu extends CMSPlugin
          * Use the built-in element view to select the menu item.
          * Currently uses blank class.
          */
-        $user  = Factory::getUser();
+        $user  = $this->getApplication()->getIdentity();
 
         if (
             $user->authorise('core.create', 'com_menus')

--- a/plugins/editors-xtd/module/module.xml
+++ b/plugins/editors-xtd/module/module.xml
@@ -11,8 +11,8 @@
 	<description>PLG_MODULE_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\EditorsXtd\Module</namespace>
 	<files>
-		<folder>services</folder>
-		<folder plugin="module">src</folder>
+		<folder plugin="module">services</folder>
+		<folder>src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_module.ini</language>

--- a/plugins/editors-xtd/module/module.xml
+++ b/plugins/editors-xtd/module/module.xml
@@ -9,8 +9,10 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.5.0</version>
 	<description>PLG_MODULE_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\EditorsXtd\Module</namespace>
 	<files>
-		<filename plugin="module">module.php</filename>
+		<folder>services</folder>
+		<folder plugin="module">src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_module.ini</language>

--- a/plugins/editors-xtd/module/services/provider.php
+++ b/plugins/editors-xtd/module/services/provider.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors-xtd.article
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\EditorsXtd\Module\Extension\Module;
+
+return new class implements ServiceProviderInterface
+{
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+
+                $plugin     = new Module(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('editors-xtd', 'module')
+                );
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plugins/editors-xtd/module/src/Extension/Module.php
+++ b/plugins/editors-xtd/module/src/Extension/Module.php
@@ -10,7 +10,6 @@
 
 namespace Joomla\Plugin\EditorsXtd\Module\Extension;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -50,7 +49,7 @@ final class Module extends CMSPlugin
          * Use the built-in element view to select the module.
          * Currently uses blank class.
          */
-        $user  = Factory::getUser();
+        $user  = $this->getApplication()->getIdentity();
 
         if (
             $user->authorise('core.create', 'com_modules')

--- a/plugins/editors-xtd/module/src/Extension/Module.php
+++ b/plugins/editors-xtd/module/src/Extension/Module.php
@@ -6,9 +6,9 @@
  *
  * @copyright   (C) 2015 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
+
+namespace Joomla\Plugin\EditorsXtd\Module\Extension;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -25,7 +25,7 @@ use Joomla\CMS\Session\Session;
  *
  * @since  3.5
  */
-class PlgButtonModule extends CMSPlugin
+final class Module extends CMSPlugin
 {
     /**
      * Load the language file on instantiation.

--- a/plugins/editors-xtd/readmore/readmore.xml
+++ b/plugins/editors-xtd/readmore/readmore.xml
@@ -9,8 +9,10 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>3.0.0</version>
 	<description>PLG_READMORE_XML_DESCRIPTION</description>
+	<namespace path="src">Joomla\Plugin\EditorsXtd\ReadMore</namespace>
 	<files>
-		<filename plugin="readmore">readmore.php</filename>
+		<folder>services</folder>
+		<folder plugin="readmore">src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_readmore.ini</language>

--- a/plugins/editors-xtd/readmore/readmore.xml
+++ b/plugins/editors-xtd/readmore/readmore.xml
@@ -11,8 +11,8 @@
 	<description>PLG_READMORE_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\EditorsXtd\ReadMore</namespace>
 	<files>
-		<folder>services</folder>
-		<folder plugin="readmore">src</folder>
+		<folder plugin="readmore">services</folder>
+		<folder>src</folder>
 	</files>
 	<languages>
 		<language tag="en-GB">language/en-GB/plg_editors-xtd_readmore.ini</language>

--- a/plugins/editors-xtd/readmore/services/provider.php
+++ b/plugins/editors-xtd/readmore/services/provider.php
@@ -1,0 +1,49 @@
+<?php
+
+/**
+ * @package     Joomla.Plugin
+ * @subpackage  Editors-xtd.article
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Extension\PluginInterface;
+use Joomla\CMS\Factory;
+use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\DI\Container;
+use Joomla\DI\ServiceProviderInterface;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\EditorsXtd\ReadMore\Extension\ReadMore;
+
+return new class implements ServiceProviderInterface
+{
+    /**
+     * Registers the service provider with a DI container.
+     *
+     * @param   Container  $container  The DI container.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function register(Container $container)
+    {
+        $container->set(
+            PluginInterface::class,
+            function (Container $container) {
+                $dispatcher = $container->get(DispatcherInterface::class);
+
+                $plugin     = new ReadMore(
+                    $dispatcher,
+                    (array) PluginHelper::getPlugin('editors-xtd', 'readmore')
+                );
+                $plugin->setApplication(Factory::getApplication());
+
+                return $plugin;
+            }
+        );
+    }
+};

--- a/plugins/editors-xtd/readmore/src/Extension/ReadMore.php
+++ b/plugins/editors-xtd/readmore/src/Extension/ReadMore.php
@@ -6,9 +6,9 @@
  *
  * @copyright   (C) 2006 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
+
+namespace Joomla\Plugin\EditorsXtd\ReadMore\Extension;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
@@ -23,7 +23,7 @@ use Joomla\CMS\Plugin\CMSPlugin;
  *
  * @since  1.5
  */
-class PlgButtonReadmore extends CMSPlugin
+final class ReadMore extends CMSPlugin
 {
     /**
      * Load the language file on instantiation.

--- a/plugins/editors-xtd/readmore/src/Extension/ReadMore.php
+++ b/plugins/editors-xtd/readmore/src/Extension/ReadMore.php
@@ -34,14 +34,6 @@ final class ReadMore extends CMSPlugin
     protected $autoloadLanguage = true;
 
     /**
-     * Application object.
-     *
-     * @var    \Joomla\CMS\Application\CMSApplication
-     * @since  4.0.0
-     */
-    protected $app;
-
-    /**
      * Readmore button
      *
      * @param   string  $name  The name of the button to add
@@ -52,7 +44,7 @@ final class ReadMore extends CMSPlugin
      */
     public function onDisplay($name)
     {
-        $doc = $this->app->getDocument();
+        $doc = $this->getApplication()->getDocument();
         $doc->getWebAssetManager()
             ->registerAndUseScript('com_content.admin-article-readmore', 'com_content/admin-article-readmore.min.js', [], ['defer' => true], ['core']);
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- Move all editor buttons except page break (for testing purposes) to service providers


### Testing Instructions

- Apply the PR
- Delete the file `administrator/cache/autoload_psr4.php`
- Check that all buttons work correctly for all the editors (tinyMCE, Codemirror, None)


### Actual result BEFORE applying this Pull Request

Works

### Expected result AFTER applying this Pull Request

Works

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

@laoneo 