### PR TITLE
[4.3][bug] Refresh list of parent menu items after menu selection has been changed

### DIFF
--- a/administrator/components/com_menus/src/Field/MenuParentField.php
+++ b/administrator/components/com_menus/src/Field/MenuParentField.php
@@ -43,8 +43,6 @@ class MenuParentField extends ListField
      */
     protected function getOptions()
     {
-        Text::script('JGLOBAL_ROOT_PARENT');
-
         $options = array();
 
         $db = $this->getDatabase();

--- a/administrator/components/com_menus/src/Field/MenuParentField.php
+++ b/administrator/components/com_menus/src/Field/MenuParentField.php
@@ -43,6 +43,8 @@ class MenuParentField extends ListField
      */
     protected function getOptions()
     {
+        Text::script('JGLOBAL_ROOT_PARENT');
+
         $options = array();
 
         $db = $this->getDatabase();

--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -21,6 +21,7 @@ $this->useCoreUI = true;
 
 Text::script('ERROR');
 Text::script('JGLOBAL_VALIDATION_FORM_FAILED');
+Text::script('JGLOBAL_ROOT_PARENT');
 
 $this->document->addScriptOptions('menu-item', ['itemId' => (int) $this->item->id]);
 

--- a/build/media_source/com_menus/js/admin-item-edit.es6.js
+++ b/build/media_source/com_menus/js/admin-item-edit.es6.js
@@ -48,20 +48,20 @@
 
       onSuccess(response) {
         const data = JSON.parse(response);
-        const list = [].slice.call(document.querySelectorAll('#jform_parent_id option'));
+        const fancySelect = document.getElementById('jform_parent_id').closest('joomla-field-fancy-select');
 
-        list.forEach((item) => {
-          if (item.value !== '1') {
-            item.parentNode.removeChild(item);
-          }
-        });
+        fancySelect.choicesInstance.clearChoices();
+        fancySelect.choicesInstance.setChoices([{id:'1', text: Joomla.Text._('JGLOBAL_ROOT_PARENT')}],'id','text', false);
 
-        data.forEach((value) => {
-          const option = document.createElement('option');
+        data.forEach(value => {
+          const option = {}
           option.innerText = value.title;
           option.id = value.id;
-          document.getElementById('jform_parent_id').appendChild(option);
+
+          fancySelect.choicesInstance.setChoices([option],'id','innerText', false);
         });
+
+        fancySelect.choicesInstance.setChoiceByValue('1');
 
         const newEvent = document.createEvent('HTMLEvents');
         newEvent.initEvent('change', true, false);

--- a/build/media_source/com_menus/js/admin-item-edit.es6.js
+++ b/build/media_source/com_menus/js/admin-item-edit.es6.js
@@ -51,7 +51,7 @@
         const fancySelect = document.getElementById('jform_parent_id').closest('joomla-field-fancy-select');
 
         fancySelect.choicesInstance.clearChoices();
-        fancySelect.choicesInstance.setChoices([{ id: '1', text: Joomla.Text._('JGLOBAL_ROOT_PARENT') }],'id', 'text',  false);
+        fancySelect.choicesInstance.setChoices([{ id: '1', text: Joomla.Text._('JGLOBAL_ROOT_PARENT') }], 'id', 'text', false);
 
         data.forEach((value) => {
           const option = {};

--- a/build/media_source/com_menus/js/admin-item-edit.es6.js
+++ b/build/media_source/com_menus/js/admin-item-edit.es6.js
@@ -51,14 +51,14 @@
         const fancySelect = document.getElementById('jform_parent_id').closest('joomla-field-fancy-select');
 
         fancySelect.choicesInstance.clearChoices();
-        fancySelect.choicesInstance.setChoices([{id:'1', text: Joomla.Text._('JGLOBAL_ROOT_PARENT')}],'id','text', false);
+        fancySelect.choicesInstance.setChoices([{ id: '1', text: Joomla.Text._('JGLOBAL_ROOT_PARENT') }],'id', 'text',  false);
 
-        data.forEach(value => {
-          const option = {}
+        data.forEach((value) => {
+          const option = {};
           option.innerText = value.title;
           option.id = value.id;
 
-          fancySelect.choicesInstance.setChoices([option],'id','innerText', false);
+          fancySelect.choicesInstance.setChoices([option], 'id', 'innerText', false);
         });
 
         fancySelect.choicesInstance.setChoiceByValue('1');


### PR DESCRIPTION
Pull Request for Issue #38792

### Summary of Changes
This patch correctly refreshes the list of available parent menu item after the actual menu assignment has been changed. This prevents an incorrect configuration (parent menu item selected which does not belong to the selected menu) being stored.


### Testing Instructions
* Creata a J4 site with at least two menus and at least one menu item each
* Change the menu assignment of one menu item
* Check the available options in the parent menu item select


### Actual result BEFORE applying this Pull Request
Parent menu select shows menu items of the old menu assignment.


### Expected result AFTER applying this Pull Request
Parent menu select shows menu items of the new menu assignment.


### Link to documentations
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
