### PR TITLE
[4.2] PHP8.2 Add the missing properties to the installation JSON response

### DIFF
--- a/installation/src/Response/JsonResponse.php
+++ b/installation/src/Response/JsonResponse.php
@@ -26,6 +26,62 @@ use Joomla\CMS\Session\Session;
 class JsonResponse
 {
     /**
+     * The security token.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    public $token;
+
+    /**
+     * The language tag
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    public $lang;
+
+    /**
+     * The message
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    public $message;
+
+    /**
+     * The messages array
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     */
+    public $messages;
+
+    /**
+     * The error message
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    public $error;
+
+    /**
+     * The header
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    public $header;
+
+    /**
+     * The data
+     *
+     * @var    mixed
+     * @since  __DEPLOY_VERSION__
+     */
+    public $data;
+
+    /**
      * Constructor for the JSON response
      *
      * @param   mixed  $data  Exception if there is an error, otherwise, the session data


### PR DESCRIPTION
Pull Request for Issue #39655.

### Summary of Changes
Adds the missing properties to the installation JSON response.

### Testing Instructions
Install Joomla on PHP 8.2.

### Actual result BEFORE applying this Pull Request
Deprecate warnings in the Installation step when all data is entered.

### Expected result AFTER applying this Pull Request
Joomla installs fine.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
