### PR TITLE
Convert array to comma separated list for assigned menu ids in module edit form

### DIFF
--- a/administrator/components/com_modules/src/Controller/ModuleController.php
+++ b/administrator/components/com_modules/src/Controller/ModuleController.php
@@ -214,6 +214,14 @@ class ModuleController extends FormController
     {
         $this->checkToken();
 
+        //Convert comma separated list to array
+        $data  = $this->input->post->get('jform', array(), 'array');
+        if (!empty($data['assigned'])) {
+            $data['assigned'] = explode(',', $data['assigned']);
+            $data['assigned'] = array_map('intval', $data['assigned']);
+            $this->input->post->set('jform', $data);
+        }
+
         if ($this->app->getDocument()->getType() == 'json') {
             $model = $this->getModel();
             $data  = $this->input->post->get('jform', [], 'array');

--- a/administrator/components/com_modules/tmpl/module/edit_assignment.php
+++ b/administrator/components/com_modules/tmpl/module/edit_assignment.php
@@ -36,6 +36,7 @@ $this->document->getWebAssetManager()
     <label id="jform_menuselect-lbl" class="control-label" for="jform_menuselect"><?php echo Text::_('JGLOBAL_MENU_SELECTION'); ?></label>
     <div id="jform_menuselect" class="controls">
         <?php if (!empty($menuTypes)) : ?>
+        <input type="hidden" name="jform[assigned]" value="" />
         <div class="card-header">
             <section class="d-flex align-items-center flex-wrap w-100" aria-label="<?php echo Text::_('COM_MODULES_GLOBAL'); ?>">
                 <div class="d-flex align-items-center flex-fill mb-1" role="group" aria-label="<?php echo Text::_('COM_MODULES_GLOBAL_ASSIGN'); ?>"><?php echo Text::_('COM_MODULES_GLOBAL_ASSIGN'); ?>
@@ -92,7 +93,7 @@ $this->document->getWebAssetManager()
                                     $uselessMenuItem = in_array($link->type, ['separator', 'heading', 'alias', 'url']);
                                     $id = 'jform_menuselect';
                                     ?>
-                                    <input type="checkbox" class="novalidate form-check-input" name="jform[assigned][]" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : '';
+                                    <input type="checkbox" class="novalidate form-check-input jform-assigned" id="<?php echo $id . $link->value; ?>" value="<?php echo (int) $link->value; ?>"<?php echo $selected ? ' checked="checked"' : '';
                                     echo $uselessMenuItem ? ' disabled="disabled"' : ''; ?>>
                                     <label for="<?php echo $id . $link->value; ?>" class="">
                                         <?php echo $link->text; ?>

--- a/build/media_source/com_modules/js/admin-module-edit.es6.js
+++ b/build/media_source/com_modules/js/admin-module-edit.es6.js
@@ -9,6 +9,11 @@ Joomla = window.Joomla || {};
 
   Joomla.submitbutton = (task) => {
     if (task === 'module.cancel' || document.formvalidator.isValid(document.getElementById('module-form'))) {
+
+      /* Convert array to comma separated list for assigned menu ids */
+      var assignedCheckboxes = [].slice.call(document.querySelectorAll('input.jform-assigned'));
+      document.querySelector('input[name="jform[assigned]"]').value = assignedCheckboxes.filter(e => e.checked).map(e => e.value).join();
+
       Joomla.submitform(task, document.getElementById('module-form'));
 
       const options = Joomla.getOptions('module-edit');
@@ -24,9 +29,9 @@ Joomla = window.Joomla || {};
           const tmpRow = window.parent.document.getElementById(`tr-${options.itemId}`);
           const tmpStatus = window.parent.document.getElementById(`status-${options.itemId}`);
           window.parent.inMenus = [];
-          window.parent.numMenus = [].slice.call(document.querySelectorAll('input[name="jform[assigned][]"]')).length;
+          window.parent.numMenus = assignedCheckboxes.length;
 
-          [].slice.call(document.querySelectorAll('input[name="jform[assigned][]"]')).forEach((element) => {
+          assignedCheckboxes.forEach((element) => {
             if (updMenus > 0) {
               if (element.checked) {
                 window.parent.inMenus.push(parseInt(element.value, 10));

--- a/build/media_source/com_modules/js/admin-module-edit.es6.js
+++ b/build/media_source/com_modules/js/admin-module-edit.es6.js
@@ -9,10 +9,9 @@ Joomla = window.Joomla || {};
 
   Joomla.submitbutton = (task) => {
     if (task === 'module.cancel' || document.formvalidator.isValid(document.getElementById('module-form'))) {
-
       /* Convert array to comma separated list for assigned menu ids */
-      var assignedCheckboxes = [].slice.call(document.querySelectorAll('input.jform-assigned'));
-      document.querySelector('input[name="jform[assigned]"]').value = assignedCheckboxes.filter(e => e.checked).map(e => e.value).join();
+      const assignedCheckboxes = [].slice.call(document.querySelectorAll('input.jform-assigned'));
+      document.querySelector('input[name="jform[assigned]"]').value = assignedCheckboxes.filter((e) => e.checked).map((e) => e.value).join();
 
       Joomla.submitform(task, document.getElementById('module-form'));
 


### PR DESCRIPTION
Pull Request for Issue #39672 .

### Summary of Changes
Convert array to comma separated list for assigned menu ids in module edit form
Purpose : reducing the number of elements of post array

### Testing Instructions
Manuel Testing;
- Create more than 1K menu items if max_input_vars is 1K 
- Save a module with assigned menu items

### Actual result BEFORE applying this Pull Request
You cannot save any modules because of restriction of max_input_vars


### Expected result AFTER applying this Pull Request
You can save any modules although restriction of max_input_vars
 

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
