### PR TITLE
[4.3][RFC][WIP] Make list views CSP strict

### DIFF
--- a/administrator/components/com_content/forms/filter_articles.xml
+++ b/administrator/components/com_content/forms/filter_articles.xml
@@ -12,9 +12,9 @@
 
 		<field
 			name="featured"
+			class="js-select-submit-on-change"
 			type="list"
 			label="JFEATURED"
-			onchange="this.form.submit();"
 			default=""
 			validate="options"
 			>
@@ -25,9 +25,9 @@
 
 		<field
 			name="stage"
+			class="js-select-submit-on-change"
 			type="workflowstage"
 			label="JOPTION_SELECT_STAGE"
-			onchange="this.form.submit();"
 			activeonly="true"
 			extension="com_content.article"
 			>
@@ -36,9 +36,9 @@
 
 		<field
 			name="published"
+			class="js-select-submit-on-change"
 			type="status"
 			label="JOPTION_SELECT_PUBLISHED"
-			onchange="this.form.submit();"
 			extension="com_content"
 			>
 			<option value="">JOPTION_SELECT_PUBLISHED</option>
@@ -46,34 +46,34 @@
 
 		<field
 			name="category_id"
+			class="js-select-submit-on-change"
 			type="category"
 			label="JCATEGORY"
 			multiple="true"
 			extension="com_content"
 			layout="joomla.form.field.list-fancy-select"
 			hint="JOPTION_SELECT_CATEGORY"
-			onchange="this.form.submit();"
 			published="0,1,2"
 		/>
 
 		<field
 			name="access"
+			class="js-select-submit-on-change"
 			type="accesslevel"
 			label="JGRID_HEADING_ACCESS"
 			multiple="true"
 			layout="joomla.form.field.list-fancy-select"
 			hint="JOPTION_SELECT_ACCESS"
-			onchange="this.form.submit();"
 		/>
 
 		<field
 			name="author_id"
+			class="js-select-submit-on-change"
 			type="author"
 			label="JOPTION_SELECT_AUTHOR"
 			multiple="true"
 			layout="joomla.form.field.list-fancy-select"
 			hint="JOPTION_SELECT_AUTHOR"
-			onchange="this.form.submit();"
 			>
 			<option value="0">JNONE</option>
 			<option value="by_me">COM_CONTENT_FILTER_AUTHORS_BY_ME</option>
@@ -81,9 +81,9 @@
 
 		<field
 			name="language"
+			class="js-select-submit-on-change"
 			type="contentlanguage"
 			label="JGRID_HEADING_LANGUAGE"
-			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_LANGUAGE</option>
 			<option value="*">JALL</option>
@@ -91,24 +91,24 @@
 
 		<field
 			name="tag"
+			class="js-select-submit-on-change"
 			type="tag"
 			multiple="true"
 			label="JTAG"
 			hint="JOPTION_SELECT_TAG"
 			mode="nested"
 			custom="false"
-			onchange="this.form.submit();"
 		/>
 
 		<field
 			name="level"
+			class="js-select-submit-on-change"
 			type="integer"
 			label="JGLOBAL_MAXLEVEL_LABEL"
 			first="1"
 			last="10"
 			step="1"
 			languages="*"
-			onchange="this.form.submit();"
 			>
 			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
 		</field>
@@ -117,9 +117,9 @@
 	<fields name="list">
 		<field
 			name="fullordering"
+			class="js-select-submit-on-change"
 			type="list"
 			label="JGLOBAL_SORT_BY"
-			onchange="this.form.submit();"
 			default="a.id DESC"
 			validate="options"
 			>
@@ -162,10 +162,10 @@
 
 		<field
 			name="limit"
+			class="js-select-submit-on-change"
 			type="limitbox"
 			label="JGLOBAL_LIST_LIMIT"
 			default="25"
-			onchange="this.form.submit();"
 		/>
 	</fields>
 </form>

--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -593,6 +593,17 @@
       "dependencies": [
         "webcomponent.toolbar-button-legacy"
       ]
+    },
+    {
+      "name": "list-view",
+      "type": "script",
+      "uri": "system/list-view.min.js",
+      "attributes": {
+        "type": "module"
+      },
+      "dependencies": [
+        "core"
+      ]
     }
   ]
 }

--- a/build/media_source/system/js/core.es6.js
+++ b/build/media_source/system/js/core.es6.js
@@ -394,6 +394,8 @@ window.Joomla.Modal = window.Joomla.Modal || {
    * @param {string} stub     An alternative field name
    *
    * @return {boolean}
+   *
+   * @deprecated without replacement. List views could use list-view.js
    */
   Joomla.checkAll = (checkbox, stub) => {
     if (!checkbox.form) {
@@ -433,6 +435,8 @@ window.Joomla.Modal = window.Joomla.Modal || {
    * @param  {node}     form         The form
    *
    * @return  {void}
+   *
+   * @deprecated without replacement. List views could use list-view.js
    */
   Joomla.isChecked = (isitchecked, form) => {
     let newForm = form;
@@ -484,7 +488,9 @@ window.Joomla.Modal = window.Joomla.Modal || {
    * @param  {string}  task   The task
    * @param  {node}    form   The form
    *
-   * return  {void}
+   * @return  {void}
+   *
+   * @deprecated without replacement. List views could use list-view.js
    */
   Joomla.tableOrdering = (order, dir, task, form) => {
     let newForm = form;
@@ -507,6 +513,8 @@ window.Joomla.Modal = window.Joomla.Modal || {
    * @param  {string}  form  The optional form
    *
    * @return {boolean}
+   *
+   * @deprecated without replacement. List views could use list-view.js
    */
   Joomla.listItemTask = (id, task, form = null) => {
     let newForm = form;

--- a/build/media_source/system/js/list-view.es6.js
+++ b/build/media_source/system/js/list-view.es6.js
@@ -172,9 +172,9 @@ function gridItemAction(event) {
     return;
   }
 
-  const itemId = item.dataset.itemId;
-  const itemTask = item.dataset.itemTask;
-  const itemFormId = item.dataset.itemFormId;
+  const { itemId } = item.dataset;
+  const { itemTask } = item.dataset;
+  const { itemFormId } = item.dataset;
 
   if (itemFormId) {
     Joomla.listItemTask(itemId, itemTask);
@@ -186,15 +186,15 @@ function gridItemAction(event) {
 }
 
 function gridTransitionItemAction(event) {
-  let item = event.target;
+  const item = event.target;
 
   if (item.nodeName !== 'SELECT' || item.hasAttribute('disabled')) {
     return;
   }
 
-  const itemId = item.dataset.itemId;
-  const itemTask = item.dataset.itemTask;
-  const itemFormId = item.dataset.itemFormId;
+  const { itemId } = item.dataset;
+  const { itemTask } = item.dataset;
+  const { itemFormId } = item.dataset;
 
   item.form.transition_id.value = item.value;
 
@@ -218,22 +218,22 @@ function gridTransitionButtonAction(event) {
     return;
   }
 
-  Joomla.toggleAllNextElements(item, 'd-none')
+  Joomla.toggleAllNextElements(item, 'd-none');
 }
 
 function applyIsChecked(event) {
-  let item = event.target;
+  const item = event.target;
   const itemFormId = item.dataset.itemFormId || '';
 
   if (itemFormId) {
-    Joomla.isChecked(item.checked, itemTask);
+    Joomla.isChecked(item.checked, itemFormId);
   } else {
     Joomla.isChecked(item.checked);
   }
 }
 
-document.querySelectorAll('.js-checkbox-check-all').forEach((element) => element.addEventListener('click', (event) => Joomla.checkAll(event.target)))
-document.querySelectorAll('.js-checkbox-is-checked').forEach((element) => element.addEventListener('click', applyIsChecked))
-document.querySelectorAll('.js-grid-item-action').forEach((element) => element.addEventListener('click', gridItemAction))
-document.querySelectorAll('.js-grid-transition-item-action').forEach((element) => element.addEventListener('change', gridTransitionItemAction))
-document.querySelectorAll('.js-grid-transition-button-action').forEach((element) => element.addEventListener('click', gridTransitionButtonAction))
+document.querySelectorAll('.js-checkbox-check-all').forEach((element) => element.addEventListener('click', (event) => Joomla.checkAll(event.target)));
+document.querySelectorAll('.js-checkbox-is-checked').forEach((element) => element.addEventListener('click', applyIsChecked));
+document.querySelectorAll('.js-grid-item-action').forEach((element) => element.addEventListener('click', gridItemAction));
+document.querySelectorAll('.js-grid-transition-item-action').forEach((element) => element.addEventListener('change', gridTransitionItemAction));
+document.querySelectorAll('.js-grid-transition-button-action').forEach((element) => element.addEventListener('click', gridTransitionButtonAction));

--- a/build/media_source/system/js/list-view.es6.js
+++ b/build/media_source/system/js/list-view.es6.js
@@ -1,0 +1,239 @@
+/**
+ * Toggles the check state of a group of boxes
+ *
+ * Checkboxes must have an id attribute in the form cb0, cb1...
+ *
+ * @param {mixed}  checkbox The number of box to 'check', for a checkbox element
+ * @param {string} stub     An alternative field name
+ *
+ * @return {boolean}
+ */
+Joomla.checkAll = (checkbox, stub) => {
+  if (!checkbox.form) {
+    return false;
+  }
+
+  const currentStab = stub || 'cb';
+  const elements = [].slice.call(checkbox.form.elements);
+  let state = 0;
+
+  elements.forEach((element) => {
+    if (element.type === checkbox.type && element.id.indexOf(currentStab) === 0) {
+      element.checked = checkbox.checked;
+      state += element.checked ? 1 : 0;
+    }
+  });
+
+  if (checkbox.form.boxchecked) {
+    checkbox.form.boxchecked.value = state;
+    checkbox.form.boxchecked.dispatchEvent(new CustomEvent('change', {
+      bubbles: true,
+      cancelable: true,
+    }));
+  }
+
+  return true;
+};
+
+/**
+ * USED IN: administrator/components/com_cache/views/cache/tmpl/default.php
+ * administrator/components/com_installer/views/discover/tmpl/default_item.php
+ * administrator/components/com_installer/views/update/tmpl/default_item.php
+ * administrator/components/com_languages/helpers/html/languages.php
+ * libraries/joomla/html/html/grid.php
+ *
+ * @param  {boolean}  isitchecked  Flag for checked
+ * @param  {node}     form         The form
+ *
+ * @return  {void}
+ */
+Joomla.isChecked = (isitchecked, form) => {
+  let newForm = form;
+  if (typeof newForm === 'undefined') {
+    newForm = document.getElementById('adminForm');
+  } else if (typeof form === 'string') {
+    newForm = document.getElementById(form);
+  }
+
+  newForm.boxchecked.value = isitchecked
+    ? parseInt(newForm.boxchecked.value, 10) + 1
+    : parseInt(newForm.boxchecked.value, 10) - 1;
+
+  newForm.boxchecked.dispatchEvent(new CustomEvent('change', {
+    bubbles: true,
+    cancelable: true,
+  }));
+
+  // If we don't have a checkall-toggle, done.
+  if (!newForm.elements['checkall-toggle']) {
+    return;
+  }
+
+  // Toggle main toggle checkbox depending on checkbox selection
+  let c = true;
+  let i;
+  let e;
+  let n;
+
+  // eslint-disable-next-line no-plusplus
+  for (i = 0, n = newForm.elements.length; i < n; i++) {
+    e = newForm.elements[i];
+
+    if (e.type === 'checkbox' && e.name !== 'checkall-toggle' && !e.checked) {
+      c = false;
+      break;
+    }
+  }
+
+  newForm.elements['checkall-toggle'].checked = c;
+};
+
+/**
+ * USED IN: libraries/joomla/html/html/grid.php
+ * In other words, on any reorderable table
+ *
+ * @param  {string}  order  The order value
+ * @param  {string}  dir    The direction
+ * @param  {string}  task   The task
+ * @param  {node}    form   The form
+ *
+ * return  {void}
+ */
+Joomla.tableOrdering = (order, dir, task, form) => {
+  let newForm = form;
+  if (typeof newForm === 'undefined') {
+    newForm = document.getElementById('adminForm');
+  } else if (typeof form === 'string') {
+    newForm = document.getElementById(form);
+  }
+
+  newForm.filter_order.value = order;
+  newForm.filter_order_Dir.value = dir;
+  Joomla.submitform(task, newForm);
+};
+
+/**
+ * USED IN: all over :)
+ *
+ * @param  {string}  id    The id
+ * @param  {string}  task  The task
+ * @param  {string}  form  The optional form
+ *
+ * @return {boolean}
+ */
+Joomla.listItemTask = (id, task, form = null) => {
+  let newForm = form;
+  if (form !== null) {
+    newForm = document.getElementById(form);
+  } else {
+    newForm = document.adminForm;
+  }
+
+  const cb = newForm[id];
+  let i = 0;
+  let cbx;
+
+  if (!cb) {
+    return false;
+  }
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    cbx = newForm[`cb${i}`];
+
+    if (!cbx) {
+      break;
+    }
+
+    cbx.checked = false;
+
+    i += 1;
+  }
+
+  cb.checked = true;
+  newForm.boxchecked.value = 1;
+  Joomla.submitform(task, newForm);
+
+  return false;
+};
+
+function gridItemAction(event) {
+  let item = event.target;
+
+  if (item.nodeName === 'SPAN' && ['A', 'BUTTON'].includes(item.parentNode.nodeName)) {
+    item = item.parentNode;
+  }
+
+  if (item.nodeName === 'A') {
+    event.preventDefault();
+  }
+
+  if (item.hasAttribute('disabled')) {
+    return;
+  }
+
+  const itemId = item.dataset.itemId;
+  const itemTask = item.dataset.itemTask;
+  const itemFormId = item.dataset.itemFormId;
+
+  if (itemFormId) {
+    Joomla.listItemTask(itemId, itemTask);
+  } else {
+    Joomla.listItemTask(itemId, itemTask);
+  }
+
+  Joomla.submitform(itemTask, item.form);
+}
+
+function gridTransitionItemAction(event) {
+  let item = event.target;
+
+  if (item.nodeName !== 'SELECT' || item.hasAttribute('disabled')) {
+    return;
+  }
+
+  const itemId = item.dataset.itemId;
+  const itemTask = item.dataset.itemTask;
+  const itemFormId = item.dataset.itemFormId;
+
+  item.form.transition_id.value = item.value;
+
+  if (itemFormId) {
+    Joomla.listItemTask(itemId, itemTask);
+  } else {
+    Joomla.listItemTask(itemId, itemTask);
+  }
+
+  Joomla.submitform(itemTask, item.form);
+}
+
+function gridTransitionButtonAction(event) {
+  let item = event.target;
+
+  if (item.nodeName === 'SPAN' && item.parentNode.nodeName === 'BUTTON') {
+    item = item.parentNode;
+  }
+
+  if (item.hasAttribute('disabled')) {
+    return;
+  }
+
+  Joomla.toggleAllNextElements(item, 'd-none')
+}
+
+function applyIsChecked(event) {
+  let item = event.target;
+  const itemFormId = item.dataset.itemFormId || '';
+
+  if (itemFormId) {
+    Joomla.isChecked(item.checked, itemTask);
+  } else {
+    Joomla.isChecked(item.checked);
+  }
+}
+
+document.querySelectorAll('.js-checkbox-check-all').forEach((element) => element.addEventListener('click', (event) => Joomla.checkAll(event.target)))
+document.querySelectorAll('.js-checkbox-is-checked').forEach((element) => element.addEventListener('click', applyIsChecked))
+document.querySelectorAll('.js-grid-item-action').forEach((element) => element.addEventListener('click', gridItemAction))
+document.querySelectorAll('.js-grid-transition-item-action').forEach((element) => element.addEventListener('change', gridTransitionItemAction))
+document.querySelectorAll('.js-grid-transition-button-action').forEach((element) => element.addEventListener('click', gridTransitionButtonAction))

--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -80,7 +80,7 @@ Joomla = window.Joomla || {};
         // Extra
         clearListOptions: false,
 
-        listSelectAutoSubmit: 'js-select-submit-on-change'
+        listSelectAutoSubmit: 'js-select-submit-on-change',
       };
 
       this.element = elem;

--- a/build/media_source/system/js/searchtools.es6.js
+++ b/build/media_source/system/js/searchtools.es6.js
@@ -79,6 +79,8 @@ Joomla = window.Joomla || {};
 
         // Extra
         clearListOptions: false,
+
+        listSelectAutoSubmit: 'js-select-submit-on-change'
       };
 
       this.element = elem;
@@ -178,6 +180,9 @@ Joomla = window.Joomla || {};
         self.checkFilter(i);
         i.addEventListener('change', () => {
           self.checkFilter(i);
+          if (i.classList.contains(this.options.listSelectAutoSubmit)) {
+            i.form.submit();
+          }
         });
       });
 

--- a/layouts/joomla/button/action-button.php
+++ b/layouts/joomla/button/action-button.php
@@ -31,14 +31,14 @@ $taskPrefix = $options['task_prefix'];
 $checkboxName = $options['checkbox_name'];
 $id = $options['id'];
 $tipTitle = $options['tip_title'];
-
 ?>
-<button type="submit" class="tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?>"
-        aria-labelledby="<?php echo $id; ?>"
-        <?php echo $disabled ? 'disabled' : ''; ?>
-        <?php if (!empty($task) && empty($disabled)) : ?>
-            onclick="return Joomla.listItemTask('<?php echo $checkboxName . $this->escape($row ?? ''); ?>', '<?php echo $this->escape(isset($task) ? $taskPrefix . $task : ''); ?>')"
-        <?php endif; ?>
+<button type="button" class="js-grid-item-action tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?>"
+    aria-labelledby="<?php echo $id; ?>"
+    <?php echo $disabled ? 'disabled' : ''; ?>
+    <?php if (!empty($task) && empty($disabled)) : ?>
+        data-item-id="<?php echo $checkboxName . $this->escape($row ?? ''); ?>"
+        data-item-task="<?php echo $this->escape(isset($task) ? $taskPrefix . $task : ''); ?>"
+    <?php endif; ?>
 >
     <span class="<?php echo $this->escape($icon ?? ''); ?>" aria-hidden="true"></span>
 </button>

--- a/layouts/joomla/button/transition-button.php
+++ b/layouts/joomla/button/transition-button.php
@@ -35,12 +35,10 @@ $checkboxName = $options['checkbox_name'];
 $task = $options['task'];
 
 ?>
-<button type="button" class="tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?>"
+<button type="button"
+        class="js-grid-transition-button-action tbody-icon data-state-<?php echo $this->escape($value ?? ''); ?>"
         aria-labelledby="<?php echo $id; ?>"
         <?php echo $disabled ? 'disabled' : ''; ?>
-        <?php if (!$disabled) : ?>
-            onclick="Joomla.toggleAllNextElements(this, 'd-none')"
-        <?php endif; ?>
     >
     <span class="<?php echo $this->escape($icon ?? ''); ?>" aria-hidden="true"></span>
 </button>
@@ -67,8 +65,10 @@ $task = $options['task'];
             $attribs = [
                 'id'        => 'transition-select_' . (int) $row ?? '',
                 'list.attr' => [
-                    'class'    => 'form-select form-select-sm w-auto',
-                    'onchange' => "this.form.transition_id.value=this.value;Joomla.listItemTask('" . $checkboxName . $this->escape($row ?? '') . "', '" . $task . "')"]
+                        'class'          => 'js-grid-transition-item-action form-select form-select-sm w-auto',
+                        'data-item-id'   => $checkboxName . $this->escape($row ?? ''),
+                        'data-item-task' => $task,
+                    ]
                 ];
 
             echo HTMLHelper::_('select.genericlist', $transitions, '', $attribs);

--- a/layouts/joomla/searchtools/grid/sort.php
+++ b/layouts/joomla/searchtools/grid/sort.php
@@ -29,7 +29,7 @@ if ($data->order === $data->selected) :
 endif;
 ?>
 
-<a href="" onclick="return false;" class="js-stools-column-order<?php echo $selected; ?> js-stools-button-sort"
+<a href="#" class="js-stools-column-order<?php echo $selected; ?> js-stools-button-sort"
     <?php echo $id; ?>
     data-order="<?php echo $data->order; ?>"
     data-direction="<?php echo strtoupper($data->direction); ?>"

--- a/libraries/src/HTML/Helpers/Grid.php
+++ b/libraries/src/HTML/Helpers/Grid.php
@@ -83,17 +83,27 @@ abstract class Grid
      * Method to check all checkboxes in a grid
      *
      * @param   string  $name    The name of the form element
-     * @param   string  $action  The action to perform on clicking the checkbox
+     * @param   string  $action  @deprecated The action to perform on clicking the checkbox
      *
      * @return  string
      *
      * @since   3.1.2
+     *
+     * The second param ($action) will be removed in v6 without a replacement, due to CSP strict rules. If you
+     * need custom functionality attach it to the class `js-checkbox-check-all`
      */
     public static function checkall($name = 'checkall-toggle', $action = 'Joomla.checkAll(this)')
     {
         HTMLHelper::_('behavior.core');
+        Factory::getDocument()->getWebAssetManager()->useScript('list-view');
 
-        return '<input class="form-check-input" autocomplete="off" type="checkbox" name="' . $name . '" value="" title="' . Text::_('JGLOBAL_CHECK_ALL') . '" onclick="' . $action . '">';
+        if ($action !== 'Joomla.checkAll(this)') {
+            $action = ' onclick="' . $action . '"';
+        } else {
+            $action = '';
+        }
+
+        return '<input class="js-checkbox-check-all form-check-input" autocomplete="off" type="checkbox" name="' . $name . '" value="" title="' . Text::_('JGLOBAL_CHECK_ALL') . '"' . $action . '>';
     }
 
     /**
@@ -113,17 +123,12 @@ abstract class Grid
      */
     public static function id($rowNum, $recId, $checkedOut = false, $name = 'cid', $stub = 'cb', $title = '', $formId = null)
     {
-        if ($formId !== null) {
-            return $checkedOut ? '' : '<label for="' . $stub . $rowNum . '"><span class="visually-hidden">' . Text::_('JSELECT')
-                . ' ' . htmlspecialchars($title, ENT_COMPAT, 'UTF-8') . '</span></label>'
-                . '<input class="form-check-input" type="checkbox" id="' . $stub . $rowNum . '" name="' . $name . '[]" value="' . $recId
-                . '" onclick="Joomla.isChecked(this.checked, \'' . $formId . '\');">';
-        }
+        Factory::getDocument()->getWebAssetManager()->useScript('list-view');
 
         return $checkedOut ? '' : '<label for="' . $stub . $rowNum . '"><span class="visually-hidden">' . Text::_('JSELECT')
             . ' ' . htmlspecialchars($title, ENT_COMPAT, 'UTF-8') . '</span></label>'
-            . '<input class="form-check-input" autocomplete="off" type="checkbox" id="' . $stub . $rowNum . '" name="' . $name . '[]" value="' . $recId
-            . '" onclick="Joomla.isChecked(this.checked);">';
+            . '<input class="js-checkbox-is-checked form-check-input" autocomplete="off" type="checkbox" id="' . $stub . $rowNum . '" name="' . $name . '[]" value="' . $recId
+            . '"' . ($formId !== null ? ' data-form-id="' . $formId . '"' : '') . '>';
     }
 
     /**
@@ -174,6 +179,8 @@ abstract class Grid
      */
     public static function published($value, $i, $img1 = 'tick.png', $img0 = 'publish_x.png', $prefix = '')
     {
+        Factory::getDocument()->getWebAssetManager()->useScript('list-view');
+
         if (is_object($value)) {
             $value = $value->published;
         }
@@ -183,7 +190,7 @@ abstract class Grid
         $alt = $value ? Text::_('JPUBLISHED') : Text::_('JUNPUBLISHED');
         $action = $value ? Text::_('JLIB_HTML_UNPUBLISH_ITEM') : Text::_('JLIB_HTML_PUBLISH_ITEM');
 
-        return '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $prefix . $task . '\')" title="' . $action . '">'
+        return '<a href="#" class="js-grid-item-action" data-item-id="cb' . $i . '" data-item-task="' . $prefix . $task . '" title="' . $action . '">'
             . HTMLHelper::_('image', 'admin/' . $img, $alt, null, true) . '</a>';
     }
 

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -85,15 +85,10 @@ abstract class JGrid
         }
 
         if ($enabled) {
-            $html[] = '<a class="tbody-icon' . ($activeClass === 'publish' ? ' active' : '') . '"';
+            Factory::getDocument()->getWebAssetManager()->useScript('list-view');
 
-            if ($formId !== null) {
-                $html[] = ' href="javascript:void(0);" onclick="return Joomla.listItemTask(\'' . $checkbox . $i . '\',\'' . $prefix .
-                    $task . '\',\'' . $formId . '\')"';
-            } else {
-                $html[] = ' href="javascript:void(0);" onclick="return Joomla.listItemTask(\'' . $checkbox . $i . '\',\'' . $prefix . $task . '\')"';
-            }
-
+            $html[] = '<a href="#" class="js-grid-item-action tbody-icon' . ($activeClass === 'publish' ? ' active' : '') . '"';
+            $html[] = ' data-item-id="' . $checkbox . $i . '" data-item-task="' . $prefix . $task . '" data-item-form-id="' . $formId . '"';
             $html[] = $tip ? ' aria-labelledby="' . $ariaid . '"' : '';
             $html[] = '>';
             $html[] = LayoutHelper::render('joomla.icon.iconclass', ['icon' => $activeClass]);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
- Decouple some code from the core.js to a new file `list-view.js` that would be loaded in the list views
- For the time code coexists in both files, v6 should have a way leaner core.js (renamed to something different so 100% b/c could be maintained) with only the API parts, the storage and the translation
- touch the Grid and JGrid classes to eliminate most of the inline `onclick`
- touch the searchtools layout to eliminate the `onchange` for the lists
- the searchtools form changes applied only to the articles view, so check only that one!

### Testing Instructions

WIP

### Actual result BEFORE applying this Pull Request

- 44 `onclick`
![Screenshot 2023-01-20 at 17 43 18](https://user-images.githubusercontent.com/3889375/213754881-e502b607-cb13-4650-80ee-73df569e20e7.png)

- 9 `onchange`
![Screenshot 2023-01-20 at 17 43 37](https://user-images.githubusercontent.com/3889375/213754888-1437b4d5-84b7-4d3c-8d02-ead8425d9a40.png)


### Expected result AFTER applying this Pull Request

- 1 `onclick` (from, the toolbar)
![Screenshot 2023-01-20 at 17 42 18](https://user-images.githubusercontent.com/3889375/213754937-ecafdf2d-e5a7-4b61-a857-cae5db64ef5a.png)

- 0 `onchange`
![Screenshot 2023-01-20 at 17 42 32](https://user-images.githubusercontent.com/3889375/213754933-a72b453c-b743-4505-834c-997644602ab2.png)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
