### PR TITLE
[4.2] Inconsistency in permission rules - configure options only - API

### DIFF
--- a/api/language/en-GB/joomla.ini
+++ b/api/language/en-GB/joomla.ini
@@ -164,7 +164,7 @@ JACTION_LOGIN_OFFLINE="Offline Access"
 JACTION_LOGIN_SITE="Site Login"
 JACTION_MANAGE="Access Administration Interface"
 JACTION_MANAGEWORKFLOW="Manage Workflows"
-JACTION_OPTIONS="Configure Options Only"
+JACTION_OPTIONS="Configure Options"
 JACTION_UNPUBLISH="Unpublish"
 
 JBROWSERTARGET_DOWNLOAD="Download %s in new window"


### PR DESCRIPTION
Add-on Pull Request for PR #38781 .

### Summary of Changes

remove "Only" in API.
See PR #38781

### Testing Instructions

code review

### Actual result BEFORE applying this Pull Request

JACTION_OPTIONS="Configure Options Only"

### Expected result AFTER applying this Pull Request

JACTION_OPTIONS="Configure Options"

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed

- [x] No documentation changes for manual.joomla.org needed
