### PR TITLE
[4.2] Update deleted files list in script.php for upcoming 4.2.7

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6463,6 +6463,8 @@ class JoomlaInstallerScript
             '/media/vendor/hotkeys.js/LICENSE',
             // From 4.2.1 to 4.2.2
             '/administrator/cache/fido.jwt',
+            // From 4.2.6 to 4.2.7
+            '/libraries/vendor/maximebf/debugbar/src/DebugBar/DataFormatter/VarDumper/SeekingData.php',
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in file "administrator/components/com_admin/script.php" to recent changes in the 4.2-dev branch in preparation for the upcoming 4.2.7 release.

There is only one file from the debugbar dependency to be deleted on update. This is caused by PR #39594 which updated the dependency to a new version. The deleted file has been removed because it belonged to code for PHP versions older than 7.1, which are not supported anymore by the dependency and are also older than the minimum required 7.2 for J4. See this comment here in their PR: https://github.com/maximebf/php-debugbar/pull/497#issuecomment-1034325929

### Testing Instructions

Code review.

Or if you want to make a real test, update a 4.2.6 or any older 4.x version to the last 4.2-dev nightly build to get the actual result, and update a 4.2.6 or any older 4.x version to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

File "libraries/vendor/maximebf/debugbar/src/DebugBar/DataFormatter/VarDumper/SeekingData.php" is still present after the update.

### Expected result AFTER applying this Pull Request

File "libraries/vendor/maximebf/debugbar/src/DebugBar/DataFormatter/VarDumper/SeekingData.php" has been deleted with the update.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
