### PR TITLE
We will be able to use the calendar field normally in subform.

### DIFF
--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -84,7 +84,7 @@ if (!empty($groupByFieldset)) {
         button-add=".group-add" button-remove=".group-remove" button-move="<?php echo empty($buttons['move']) ? '' : '.group-move' ?>"
         repeatable-element=".subform-repeatable-group"
         rows-container="tbody.subform-repeatable-container" minimum="<?php echo $min; ?>" maximum="<?php echo $max; ?>">
-        <div class="table-responsive">
+        <div class="table-responsive" style="overflow: visible;">
             <table class="table" id="subfieldList_<?php echo $fieldId; ?>">
                 <caption class="visually-hidden">
                     <?php echo Text::_('JGLOBAL_REPEATABLE_FIELDS_TABLE_CAPTION'); ?>


### PR DESCRIPTION
Pull Request for Issue #38443.

### Summary of Changes
Replaced `overflow-x:auto` by `overflow:visible`  rule on the `<div class="table-responsive">` , it fixed the display of the calendar.


### Testing Instructions
Create a calendar custom field.
Create a repeatable subform custom field.
Add the calendar field to the subform field. Save and close.

Open an article where you can edit the subform field and add some items.


### Actual result BEFORE applying this Pull Request


https://user-images.githubusercontent.com/91016907/213930711-f3ae8e33-dc95-4d7f-bb19-e5052d9d6a7d.mov



### Expected result AFTER applying this Pull Request
![Screenshot (53)](https://user-images.githubusercontent.com/91016907/213930944-704d03cd-c738-41ec-bec4-48c3a767d287.png)



### Link to documentations

- No documentation changes for docs.joomla.org needed
- No documentation changes for manual.joomla.org needed
