### PR TITLE
remove unused variable

### DIFF
--- a/components/com_contact/src/Model/CategoryModel.php
+++ b/components/com_contact/src/Model/CategoryModel.php
@@ -42,13 +42,6 @@ class CategoryModel extends ListModel
     protected $_item;
 
     /**
-     * Array of contacts in the category
-     *
-     * @var    \stdClass[]
-     */
-    protected $_articles;
-
-    /**
      * Category left and right of this one
      *
      * @var    CategoryNode[]|null


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Remove a copy/paste error. 
com_contact does not use $_articles nor $_contacts, 
As comment and variable name are different, this seems to be a copy/paste error. 


### Testing Instructions
Code review should be sufficient. 
Or set error-reporting at maximum, play with contacts in frontend.


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request
Contacts  in fronted are displayed as without patch, no error, no warning.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
