### PR TITLE
Sort the Media files from the Media list.

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/browser.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/browser.vue
@@ -32,30 +32,35 @@
             <th
               class="name"
               scope="col"
+              @click="sort('name')"
             >
               {{ translate('COM_MEDIA_MEDIA_NAME') }}
             </th>
             <th
               class="size"
               scope="col"
+              @click="sort('size')"
             >
               {{ translate('COM_MEDIA_MEDIA_SIZE') }}
             </th>
             <th
               class="dimension"
               scope="col"
+              @click="sort('dimension')"
             >
               {{ translate('COM_MEDIA_MEDIA_DIMENSION') }}
             </th>
             <th
               class="created"
               scope="col"
+              @click="sort('created')"
             >
               {{ translate('COM_MEDIA_MEDIA_DATE_CREATED') }}
             </th>
             <th
               class="modified"
               scope="col"
+              @click="sort('modified')"
             >
               {{ translate('COM_MEDIA_MEDIA_DATE_MODIFIED') }}
             </th>
@@ -94,19 +99,27 @@ import * as types from '../../store/mutation-types.es6';
 
 export default {
   name: 'MediaBrowser',
+  data() {
+    return {
+      currentSort: 'name',
+      currentSortDir: 'asc',
+    };
+  },
   computed: {
     /* Get the contents of the currently selected directory */
     items() {
       // eslint-disable-next-line vue/no-side-effects-in-computed-properties
+      let modifier = 1;
+      if (this.currentSortDir === 'desc') modifier = -1;
       const directories = this.$store.getters.getSelectedDirectoryDirectories
         // Sort by type and alphabetically
-        .sort((a, b) => ((a.name.toUpperCase() < b.name.toUpperCase()) ? -1 : 1))
+        .sort((a, b) => (a[this.currentSort] < b[this.currentSort] ? -1 : 1) * modifier)
         .filter((dir) => dir.name.toLowerCase().includes(this.$store.state.search.toLowerCase()));
 
       // eslint-disable-next-line vue/no-side-effects-in-computed-properties
       const files = this.$store.getters.getSelectedDirectoryFiles
         // Sort by type and alphabetically
-        .sort((a, b) => ((a.name.toUpperCase() < b.name.toUpperCase()) ? -1 : 1))
+        .sort((a, b) => (a[this.currentSort] < b[this.currentSort] ? -1 : 1) * modifier)
         .filter((file) => file.name.toLowerCase().includes(this.$store.state.search.toLowerCase()));
 
       return [...directories, ...files];
@@ -158,6 +171,12 @@ export default {
     document.body.removeEventListener('click', this.unselectAllBrowserItems, false);
   },
   methods: {
+    sort(s) {
+      if (s === this.currentSort) {
+        this.currentSortDir = this.currentSortDir === 'asc' ? 'desc' : 'asc';
+      }
+      this.currentSort = s;
+    },
     /* Unselect all browser items */
     unselectAllBrowserItems(event) {
       const clickedDelete = !!((event.target.id !== undefined && event.target.id === 'mediaDelete'));

--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -326,18 +326,25 @@
 }
 
 .media-browser-table {
+  .name {
+    cursor: pointer;
+  }
   .size {
     width: 10%;
     text-align: right;
+    cursor: pointer;
   }
   .dimension {
     width: 15%;
+    cursor: pointer;
   }
   .created {
     width: 15%;
+    cursor: pointer;
   }
   .modified {
     width: 15%;
+    cursor: pointer;
   }
   .type {
     position: relative;


### PR DESCRIPTION
Adding sorting feature in media files

Pull Request for Issue #31347

### Summary of Changes
Added some extra sorting techniques in Media files 

### Testing Instructions

- Go to media 
- Select List View
- click on name or size or dimension or date created or date modified


### Actual result BEFORE applying this Pull Request
No sorting happens


### Expected result AFTER applying this Pull Request
You can sort the media files by name or size .... by clicking on respective column heading
Sorting will be first ascending and after clicking again sorting will be descending


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed

### Before Sorting
![sort1](https://user-images.githubusercontent.com/115709571/214380888-21c36ff0-211f-4e74-b0da-0f9505274ac3.jpg)

### After Sorting By Name In Descending Order
![sort 2](https://user-images.githubusercontent.com/115709571/214381114-204d22c9-c972-41fb-8b87-2053523c3e8e.jpg)
