### PR TITLE
Update Version.php

### DIFF
--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -177,7 +177,7 @@ class Cache
     /**
      * Set cache lifetime
      *
-     * @param   integer  $lt  Cache lifetime
+     * @param   integer  $lt  Cache lifetime in minutes
      *
      * @return  void
      *

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -310,7 +310,7 @@ final class Version
         $cache = Factory::getContainer()->get(CacheControllerFactoryInterface::class)
             ->createCacheController('callback', ['defaultgroup' => '_media_version', 'caching' => true]);
 
-        $cache->setLifeTime(315576000);
+        $cache->setLifeTime(5259600);
 
         // Disable cache when Debug is enabled
         if (JDEBUG) {


### PR DESCRIPTION
Cache LifeTime is in minutes, not seconds, 10 years value should be 5 259 600, not 315 576 000.

### Summary of Changes
Change cache time to correct number,

### Testing Instructions
PHP 7.4.4, 32bits (yeah, not proud of it, just terrible hosting), Memcached enabled

### Actual result BEFORE applying this Pull Request
As cache time is multiplied by 60 in CacheStorage constructor, setting to 315 576 000 to 18 934 560 000, 
which on 32bits PHP was converted to float, giving 
PHP Warning: Memcached::set() expects parameter 3 to be int, float given in /libraries/src/Cache/Storage/MemcachedStorage.php on line 260

### Expected result AFTER applying this Pull Request
No warning.

### Additional info
Introduced by #38490, @alikon please review this, thanks