### PR TITLE
Change foldernames in .gitignore for cypress tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,10 +103,10 @@ RoboFile.ini
 /media/com_media/css/mediamanager.min.css.map
 
 #cypress
-/tests/cypress/screenshots
-!/tests/cypress/screenshots/.gitkeep
-/tests/cypress/videos
-!/tests/cypress/videos/.gitkeep
+/tests/cypress/output/screenshots
+!/tests/cypress/output/screenshots/.gitkeep
+/tests/cypress/output/videos
+!/tests/cypress/output/videos/.gitkeep
 
 # WebAuthn FIDO metadata cache
 /plugins/system/webauthn/fido.jwt


### PR DESCRIPTION
In my case, the data was stored in the output subdirectory. Is this due to my environment or is the entry in the .gitignore incorrect?

