### PR TITLE
[4.2] Fix batch categories move error

### DIFF
--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -1123,6 +1123,8 @@ class CategoryModel extends AdminModel
         // We are going to store all the children and just move the category
         $children = [];
 
+        $table = $this->getTable();
+
         // Parent exists so let's proceed
         foreach ($pks as $pk) {
             // Check that the row actually exists
@@ -1171,7 +1173,7 @@ class CategoryModel extends AdminModel
                     'extension' => $extension,
                 ];
 
-                if ($this->table->load($conditions)) {
+                if ($table->load($conditions)) {
                     $this->setError(Text::_('JLIB_DATABASE_ERROR_CATEGORY_UNIQUE_ALIAS'));
 
                     return false;


### PR DESCRIPTION
Pull Request for Issue #39742.

### Summary of Changes
This PR fixes batch categories move error as described here https://github.com/joomla/joomla-cms/issues/39742 . Please read the issue description to understand the problem.

### Testing Instructions
1. See https://github.com/joomla/joomla-cms/issues/39742 , confirm the issue
2. Apply patch, confirm that the issue fixed
3. Also, check and make sure that if the category you are moving has same alias with one of the children categories of the category you are moving to, you will get error like below and the category won't be moved:

> Batch process failed with following error: Another category with the same parent category has the same alias


### Actual result BEFORE applying this Pull Request
Error batch move categories.


### Expected result AFTER applying this Pull Request
No error, categories are successfully moved.

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
