### PR TITLE
Do not do trailing commas in function call

### DIFF
--- a/administrator/components/com_workflow/src/View/Transitions/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Transitions/HtmlView.php
@@ -170,7 +170,7 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->link(
             'JTOOLBAR_BACK',
-            Route::_('index.php?option=com_workflow&view=workflows&extension=' . $this->escape($this->workflow->extension)),
+            Route::_('index.php?option=com_workflow&view=workflows&extension=' . $this->escape($this->workflow->extension))
         )
             ->icon('icon-' . $arrow);
 


### PR DESCRIPTION
Followup of #39537.

### Summary of Changes
Trailing commas are not allowed in PHP < 7.3.

Can be merged by review...