### PR TITLE
[4.2] Highlight Plugin: Exit if app not site

### DIFF
--- a/plugins/system/highlight/highlight.php
+++ b/plugins/system/highlight/highlight.php
@@ -49,7 +49,7 @@ class PlgSystemHighlight extends CMSPlugin
     public function onAfterDispatch()
     {
         // Check that we are in the site application.
-        if ($this->app->isClient('administrator')) {
+        if (!$this->app->isClient('site')) {
             return;
         }
 


### PR DESCRIPTION
### Summary of Changes
While doing some debugging, I stumbled upon this one. The comment itself says, that it should only act on the site application and nothing else. The code however only exits when in the administrator application. This could be a problem in the CLI or other application contexts.


### Testing Instructions
Codereview.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
