### PR TITLE
[4.2.7] Fix PHP 7.2 compatibility of new actionlogs dispatcher - no comma after last method call argument

### DIFF
--- a/administrator/components/com_actionlogs/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_actionlogs/src/Dispatcher/Dispatcher.php
@@ -36,7 +36,7 @@ class Dispatcher extends ComponentDispatcher
         $user = $this->app->getIdentity();
 
         // Access check
-        if (!$user->authorise('core.admin', )) {
+        if (!$user->authorise('core.admin')) {
             throw new NotAllowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
         }
     }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With the 4.2.7 security fixes a method call was introduced which has a comma after the last argument. This is not supported with PHP 7.2.

This PR here fixes it.

### Testing Instructions

Code review, or verify that action logs are still working on PHP 7.2.

### Actual result BEFORE applying this Pull Request

PHP error on PHP 7.2.

### Expected result AFTER applying this Pull Request

No PHP error on PHP 7.2.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
