### PR TITLE
[4.2] - Admin login - set max width on image

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -39,7 +39,6 @@
     img {
       max-width: 100%;
       height: auto;
-      max-height: 4.4rem;
     }
 
     .logo {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -37,6 +37,7 @@
     }
 
     img {
+      max-width: 100%;
       max-height: 4.4rem;
     }
 

--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -38,6 +38,7 @@
 
     img {
       max-width: 100%;
+      height: auto;
       max-height: 4.4rem;
     }
 

--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -37,8 +37,8 @@
     }
 
     img {
-      max-width: 100%;
-      height: auto;
+      max-height: 4.4rem;
+      width: auto;
     }
 
     .logo {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -37,8 +37,8 @@
     }
 
     img {
-      max-height: 4.4rem;
       width: auto;
+      max-height: 4.4rem;
     }
 
     .logo {


### PR DESCRIPTION
### Summary of Changes
After updating to 4.2.7, I noticed my custom login images were going outside of the bounds of the box, due to Joomla writing the width in line. I applied a max-width to that image as a possible fix.

### Actual result BEFORE applying this Pull Request
Images larger than the login box go outside of the bounding box.


### Expected result AFTER applying this Pull Request
Images larger than the bounding box on login fit within the box.
