### PR TITLE
Add the correct properties to the finder response class

### DIFF
--- a/administrator/components/com_finder/src/Response/Response.php
+++ b/administrator/components/com_finder/src/Response/Response.php
@@ -48,7 +48,7 @@ class Response
      * @var    bool
      * @since  __DEPLOY_VERSION__
      */
-    private $error;
+    public $error;
 
     /**
      * The header
@@ -56,7 +56,7 @@ class Response
      * @var    string
      * @since  __DEPLOY_VERSION__
      */
-    private $header;
+    public $header;
 
     /**
      * The message
@@ -64,7 +64,7 @@ class Response
      * @var    string
      * @since  __DEPLOY_VERSION__
      */
-    private $message;
+    public $message;
 
     /**
      * The batch size
@@ -72,7 +72,7 @@ class Response
      * @var    int
      * @since  __DEPLOY_VERSION__
      */
-    private $batchSize;
+    public $batchSize;
 
     /**
      * The batch offset
@@ -80,7 +80,7 @@ class Response
      * @var    int
      * @since  __DEPLOY_VERSION__
      */
-    private $batchOffset;
+    public $batchOffset;
 
     /**
      * The total items
@@ -88,7 +88,7 @@ class Response
      * @var    int
      * @since  __DEPLOY_VERSION__
      */
-    private $totalItems;
+    public $totalItems;
 
     /**
      * The plugin state
@@ -96,7 +96,7 @@ class Response
      * @var    string
      * @since  __DEPLOY_VERSION__
      */
-    private $pluginState;
+    public $pluginState;
 
     /**
      * The start time
@@ -104,7 +104,7 @@ class Response
      * @var    string
      * @since  __DEPLOY_VERSION__
      */
-    private $startTime;
+    public $startTime;
 
     /**
      * The end time
@@ -112,7 +112,7 @@ class Response
      * @var    string
      * @since  __DEPLOY_VERSION__
      */
-    private $endTime;
+    public $endTime;
 
     /**
      * The start
@@ -120,7 +120,7 @@ class Response
      * @var    int
      * @since  __DEPLOY_VERSION__
      */
-    private $start;
+    public $start;
 
     /**
      * The complete
@@ -128,7 +128,7 @@ class Response
      * @var    int
      * @since  __DEPLOY_VERSION__
      */
-    private $complete;
+    public $complete;
 
     /**
      * Class Constructor

--- a/administrator/components/com_finder/src/Response/Response.php
+++ b/administrator/components/com_finder/src/Response/Response.php
@@ -27,6 +27,110 @@ use Joomla\CMS\Log\Log;
 class Response
 {
     /**
+     * The buffer
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    public $buffer;
+
+    /**
+     * The memory
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    public $memory;
+
+    /**
+     * If it has an error
+     *
+     * @var    bool
+     * @since  __DEPLOY_VERSION__
+     */
+    private $error;
+
+    /**
+     * The header
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    private $header;
+
+    /**
+     * The message
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    private $message;
+
+    /**
+     * The batch size
+     *
+     * @var    int
+     * @since  __DEPLOY_VERSION__
+     */
+    private $batchSize;
+
+    /**
+     * The batch offset
+     *
+     * @var    int
+     * @since  __DEPLOY_VERSION__
+     */
+    private $batchOffset;
+
+    /**
+     * The total items
+     *
+     * @var    int
+     * @since  __DEPLOY_VERSION__
+     */
+    private $totalItems;
+
+    /**
+     * The plugin state
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    private $pluginState;
+
+    /**
+     * The start time
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    private $startTime;
+
+    /**
+     * The end time
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    private $endTime;
+
+    /**
+     * The start
+     *
+     * @var    int
+     * @since  __DEPLOY_VERSION__
+     */
+    private $start;
+
+    /**
+     * The complete
+     *
+     * @var    int
+     * @since  __DEPLOY_VERSION__
+     */
+    private $complete;
+
+    /**
      * Class Constructor
      *
      * @param   mixed  $state  The processing state for the indexer


### PR DESCRIPTION
### Summary of Changes
When running the indexer of smart search on PHP 8.2 we get a missing properties deprecated warning.

### Testing Instructions
Rebuild the index in smart search on PHP 8.2 with error reporting to maximum and debug mode on.

### Actual result BEFORE applying this Pull Request
Indexer never finishes.

### Expected result AFTER applying this Pull Request
Indexer shows finished result.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
