### PR TITLE
[4.2]Corrected different multi-select behavior in media manage

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
@@ -143,8 +143,25 @@ export default {
       }
 
       // Handle clicks when the item was not selected
+      const startindex = this.$store.getters.getSelectedDirectoryContents.indexOf(this.$store.state.selectedItems[0]);
+      const endindex = this.$store.getters.getSelectedDirectoryContents.indexOf(this.item);
       if (!this.isSelected()) {
-        this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
+        if ((event.shiftKey || event.keyCode === 13)) {
+          if (startindex < endindex) {
+            for (let i = startindex; i <= endindex; i += 1) {
+              this.$store.commit(types.SELECT_BROWSER_ITEM, this.$store.getters.getSelectedDirectoryContents[i]);
+            }
+          } else {
+            for (let i = startindex; i >= endindex; i -= 1) {
+              this.$store.commit(types.SELECT_BROWSER_ITEM, this.$store.getters.getSelectedDirectoryContents[i]);
+            }
+          }
+        } else if ((event.ctrlKey || event.keyCode === 17)) {
+          this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
+        } else {
+          this.$store.commit(types.UNSELECT_ALL_BROWSER_ITEMS);
+          this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
+        }
         return;
       }
       this.$store.dispatch('toggleBrowserItemSelect', this.item);

--- a/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
@@ -144,11 +144,6 @@ export default {
 
       // Handle clicks when the item was not selected
       if (!this.isSelected()) {
-        // Unselect all other selected items,
-        // if the shift key was not pressed during the click event
-        if (!(event.shiftKey || event.keyCode === 13)) {
-          this.$store.commit(types.UNSELECT_ALL_BROWSER_ITEMS);
-        }
         this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
         return;
       }

--- a/administrator/components/com_media/resources/scripts/components/browser/items/row.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/row.vue
@@ -122,11 +122,6 @@ export default {
 
       // Handle clicks when the item was not selected
       if (!this.isSelected()) {
-        // Unselect all other selected items,
-        // if the shift key was not pressed during the click event
-        if (!(event.shiftKey || event.keyCode === 13)) {
-          this.$store.commit(types.UNSELECT_ALL_BROWSER_ITEMS);
-        }
         this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
         return;
       }

--- a/administrator/components/com_media/resources/scripts/components/browser/items/row.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/row.vue
@@ -121,8 +121,25 @@ export default {
       }
 
       // Handle clicks when the item was not selected
+      const startindex = this.$store.getters.getSelectedDirectoryContents.indexOf(this.$store.state.selectedItems[0]);
+      const endindex = this.$store.getters.getSelectedDirectoryContents.indexOf(this.item);
       if (!this.isSelected()) {
-        this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
+        if ((event.shiftKey || event.keyCode === 13)) {
+          if (startindex < endindex) {
+            for (let i = startindex; i <= endindex; i += 1) {
+              this.$store.commit(types.SELECT_BROWSER_ITEM, this.$store.getters.getSelectedDirectoryContents[i]);
+            }
+          } else {
+            for (let i = startindex; i >= endindex; i -= 1) {
+              this.$store.commit(types.SELECT_BROWSER_ITEM, this.$store.getters.getSelectedDirectoryContents[i]);
+            }
+          }
+        } else if ((event.ctrlKey || event.keyCode === 17)) {
+          this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
+        } else {
+          this.$store.commit(types.UNSELECT_ALL_BROWSER_ITEMS);
+          this.$store.commit(types.SELECT_BROWSER_ITEM, this.item);
+        }
         return;
       }
 


### PR DESCRIPTION
Pull Request #33637

Summary of Changes
Multi select without using shift key

### Testing Instructions
Open Media
Try to Select media manager files.

### Actual result BEFORE applying this Pull Request
You can not select multiple items without holding the shift key.

### Expected result AFTER applying this Pull Request
You can select multiple items by holding `ctrl key` & clicking on items.
You can also select all files between two selected files by holding `shift key`.

https://user-images.githubusercontent.com/115709571/216755468-f55e3c02-a972-448f-87d1-0a3c9ec364fe.mp4

