### PR TITLE
[4.3] Update deleted files list in script.php for upcoming 4.3.0-beta1

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6508,6 +6508,25 @@ class JoomlaInstallerScript
             '/plugins/editors-xtd/module/module.php',
             '/plugins/editors-xtd/readmore/readmore.php',
             '/plugins/editors/tinymce/tinymce.php',
+            // From 4.3.0-alpha3 to 4.3.0-beta1
+            '/plugins/editors/codemirror/codemirror.php',
+            '/plugins/editors/none/none.php',
+            '/plugins/fields/calendar/calendar.php',
+            '/plugins/fields/checkboxes/checkboxes.php',
+            '/plugins/fields/color/color.php',
+            '/plugins/fields/editor/editor.php',
+            '/plugins/fields/imagelist/imagelist.php',
+            '/plugins/fields/integer/integer.php',
+            '/plugins/fields/list/list.php',
+            '/plugins/fields/media/media.php',
+            '/plugins/fields/radio/radio.php',
+            '/plugins/fields/sql/sql.php',
+            '/plugins/fields/subform/subform.php',
+            '/plugins/fields/text/text.php',
+            '/plugins/fields/textarea/textarea.php',
+            '/plugins/fields/url/url.php',
+            '/plugins/fields/user/user.php',
+            '/plugins/fields/usergrouplist/usergrouplist.php',
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in file "administrator/components/com_admin/script.php" to recent changes in the 4.3-dev branch in preparation for the upcoming 4.3.0-beta1 release.

In detail deleted files from following PR's are added:

- PR #39638 :
'/plugins/editors/codemirror/codemirror.php',
- PR #39639 :
'/plugins/editors/none/none.php',
- PR #39670 :
'/plugins/fields/calendar/calendar.php',
'/plugins/fields/checkboxes/checkboxes.php',
'/plugins/fields/color/color.php',
'/plugins/fields/editor/editor.php',
'/plugins/fields/imagelist/imagelist.php',
'/plugins/fields/integer/integer.php',
'/plugins/fields/list/list.php',
'/plugins/fields/media/media.php',
'/plugins/fields/radio/radio.php',
'/plugins/fields/sql/sql.php',
'/plugins/fields/subform/subform.php',
'/plugins/fields/text/text.php',
'/plugins/fields/textarea/textarea.php',
'/plugins/fields/url/url.php',
'/plugins/fields/user/user.php',
'/plugins/fields/usergrouplist/usergrouplist.php',


### Testing Instructions

Code review.

Or if you want to make a real test, update a 4.3.0-alpha3 or any older 4.x version to the last 4.3 nightly build to get the actual result, and update a 4.3.0-alpha3 or any older 4.x version to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

The files mentioned above are still present after updating from a 4.3.0-alpha3 or any older 4.x version.

### Expected result AFTER applying this Pull Request

The files mentioned above have been deleted after updating from a 4.3.0-alpha3 or any older 4.x version.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
