### PR TITLE
Typo in DEPLOY_VERSION preventing replacement

### DIFF
--- a/administrator/components/com_menus/src/Model/MenusModel.php
+++ b/administrator/components/com_menus/src/Model/MenusModel.php
@@ -268,7 +268,7 @@ class MenusModel extends ListModel
      *
      * @return  array
      *
-     * @since   __DEPLOY_VERSION__
+     * @since   4.2.0
      */
     public function getMissingModuleLanguages(): array
     {

--- a/administrator/components/com_menus/src/Model/MenusModel.php
+++ b/administrator/components/com_menus/src/Model/MenusModel.php
@@ -268,7 +268,7 @@ class MenusModel extends ListModel
      *
      * @return  array
      *
-     * @since   _DEPLOY_VERSION__
+     * @since   __DEPLOY_VERSION__
      */
     public function getMissingModuleLanguages(): array
     {


### PR DESCRIPTION
DEPLOY_VERSION is not replaced because of typo

### Summary of Changes

Added a missing _ 

### Testing Instructions

Build a new version and check the comment @since of getMissingModuleLanguages().

### Actual result BEFORE applying this Pull Request

DEPLOY_VERSION is not replaced once the version is built.

### Expected result AFTER applying this Pull Request

DEPLOY_VERSION is replaced with the current version number.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
