### PR TITLE
Typo in DEPLOY_VERSION preventing replacement

### DIFF
--- a/libraries/src/Form/Field/ModuleorderField.php
+++ b/libraries/src/Form/Field/ModuleorderField.php
@@ -43,7 +43,7 @@ class ModuleorderField extends FormField
      * The linked property
      *
      * @var    string
-     * @since  __DEPLOY_VERSION_
+     * @since  __DEPLOY_VERSION__
      */
     protected $linked;
 


### PR DESCRIPTION
DEPLOY_VERSION is not replaced because of typo.

### Summary of Changes

Added a missing _

### Testing Instructions

Build a new version and check the comment @since of $linked.

### Actual result BEFORE applying this Pull Request

DEPLOY_VERSION is not replaced once the version is built.

### Expected result AFTER applying this Pull Request

DEPLOY_VERSION is replaced with the current version number.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
