### PR TITLE
[4.3] Routing: enforcing segment comparison for categories

### DIFF
--- a/components/com_contact/src/Service/Router.php
+++ b/components/com_contact/src/Service/Router.php
@@ -211,7 +211,7 @@ class Router extends RouterView
                             return $child->id;
                         }
                     } else {
-                        if ($child->id == (int) $segment) {
+                        if ($child->id . ':' . $child->alias == $segment) {
                             return $child->id;
                         }
                     }

--- a/components/com_content/src/Service/Router.php
+++ b/components/com_content/src/Service/Router.php
@@ -212,7 +212,7 @@ class Router extends RouterView
                             return $child->id;
                         }
                     } else {
-                        if ($child->id == (int) $segment) {
+                        if ($child->id . ':' . $child->alias == $segment) {
                             return $child->id;
                         }
                     }

--- a/components/com_newsfeeds/src/Service/Router.php
+++ b/components/com_newsfeeds/src/Service/Router.php
@@ -192,7 +192,7 @@ class Router extends RouterView
                             return $child->id;
                         }
                     } else {
-                        if ($child->id == (int) $segment) {
+                        if ($child->id . ':' . $child->alias == $segment) {
                             return $child->id;
                         }
                     }


### PR DESCRIPTION
### Summary of Changes
The content component routers have a situation where they behave unintentional. When a category has a subcategory and a content item (for example an article) with the same ID and the "remove IDs" option is disabled, the router will choose the subcategory over the content item, regardless of the alias. This is because the router compares the current segment it processes against the available childcategories and only if that fails, it switches over to checking against the articles.

Up till now, the check only compared the leading ID of the segment and not the complete segment with ID **AND** alias. This PR changes that and tightens the comparison. This would fix the above mentioned issue and prevent broken URLs from working. That last part however is also the biggest issue. If people actually rely on broken URLs (for example pasting them into a field which actually isn't long enough for the pasted content.) this would break those URLs.

Unfortunately an automatic fallback is not possible. If we have this new behavior and then fall back on the old behavior when no match was made, we would end up at exactly the same point we are now. I also would strongly vote against adding another option for this, because I don't think we can convoy the function of such an option to our users. It would lead to some cargo cult behavior, I fear.

Since this is a potential backwards compatibility issue, I'm asking for a vote from the production department on this PR.


### Testing Instructions
1. Create a category (henceforth named A) with another category as subcategory (henceforth named B).
2. Create articles in the category A until you have one with the same ID as the subcategory.
3. Create a menu item to the category A
4. Try to navigate to category B


### Actual result BEFORE applying this Pull Request
The article with the same ID is displayed.


### Expected result AFTER applying this Pull Request
The correct subcategory is displayed.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
