### PR TITLE
[Cassiopeia] Add an additional position above the  element

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -129,6 +129,12 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
     . $hasClass
     . ($this->direction == 'rtl' ? ' rtl' : '');
 ?>">
+    <?php if ($this->countModules('above-header', true)) : ?>
+        <div class="container-above-header grid-child above-header full-width">
+            <jdoc:include type="modules" name="above-header" style="none" />
+        </div>
+    <?php endif; ?>
+
     <header class="header container-header full-width<?php echo $stickyHeader ? ' ' . $stickyHeader : ''; ?>">
 
         <?php if ($this->countModules('topbar')) : ?>

--- a/templates/cassiopeia/templateDetails.xml
+++ b/templates/cassiopeia/templateDetails.xml
@@ -24,6 +24,7 @@
 		<folder>images</folder>
 	</media>
 	<positions>
+		<position>above-header</position>
 		<position>topbar</position>
 		<position>below-top</position>
 		<position>menu</position>


### PR DESCRIPTION
Please see https://github.com/joomla/joomla-cms/pull/39805#issuecomment-1426699917

The `<header>` element represents a container for introductory content or a set of navigational links. Sometimes you want to display other content above it. For example, a banner. See https://magazine.joomla.org/all-issues/september-2021/joomla-4-tweak-cassiopeia-with-a-top-banner-and-horizontal-navigation.

In the case of the banner, you usually want the banner not to remain fixed when you select in the template the option  `sticky header`. 

In the linked magazine article I described a workaround for this (at the end under the heading sticky header). Unfortunately, I have not found a solution how to achieve this without changing the `index.php` file. 

Changing the` index.php` file means that you either have to continue working with 

- a **copy of Cassiopeia** 
- or you need a **child template that changes the complete `index.php`**. 

> An additional position above the `<header>` element would make this much easier.


### Summary of Changes
Add an additional position above the `<header>` element


### Testing Instructions

See https://magazine.joomla.org/all-issues/september-2021/joomla-4-tweak-cassiopeia-with-a-top-banner-and-horizontal-navigation

