### PR TITLE
Update ModuleorderField.php with typo fix

### DIFF
--- a/libraries/src/Form/Field/ModuleorderField.php
+++ b/libraries/src/Form/Field/ModuleorderField.php
@@ -43,7 +43,7 @@ class ModuleorderField extends FormField
      * The linked property
      *
      * @var    string
-     * @since  __DEPLOY_VERSION_
+     * @since  __DEPLOY_VERSION__
      */
     protected $linked;
 

--- a/libraries/src/Form/Field/ModuleorderField.php
+++ b/libraries/src/Form/Field/ModuleorderField.php
@@ -43,7 +43,7 @@ class ModuleorderField extends FormField
      * The linked property
      *
      * @var    string
-     * @since  __DEPLOY_VERSION__
+     * @since  4.2.7
      */
     protected $linked;
 


### PR DESCRIPTION
### Summary of Changes

Typo in DEPLOY_VERSION, missing _

### Testing Instructions

Install a new build and see if DEPLOY_VERSION is replaced with version number

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
