### PR TITLE
Typo in JLIB_FILESYSTEM_ERROR_FILE_FIND_COPY

### DIFF
--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -122,7 +122,7 @@ class File
 
         // Check src path
         if (!is_readable($src)) {
-            Log::add(Text::sprintf('LIB_FILESYSTEM_ERROR_JFILE_FIND_COPY', __METHOD__, $src), Log::WARNING, 'jerror');
+            Log::add(Text::sprintf('JLIB_FILESYSTEM_ERROR_FILE_FIND_COPY', __METHOD__, $src), Log::WARNING, 'jerror');
 
             return false;
         }


### PR DESCRIPTION
### Summary of Changes

Changed LIB_FILESYSTEM_ERROR_JFILE_FIND_COPY into JLIB_FILESYSTEM_ERROR_FILE_FIND_COPY

### Testing Instructions

A check into the joomla.ini file should be enough.

### Actual result BEFORE applying this Pull Request

When a file is copied and the copy fails, it returns the message 'JLIB_FILESYSTEM_ERROR_FILE_FIND_COPY'

### Expected result AFTER applying this Pull Request

When a file is copied and the copy fails, it returns the message '... : Can't find or read file: ...'

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
