### PR TITLE
[3.10] with PHP8.x  the expression throw a TypeError

### DIFF
--- a/libraries/vendor/simplepie/simplepie/library/SimplePie/Parse/Date.php
+++ b/libraries/vendor/simplepie/simplepie/library/SimplePie/Parse/Date.php
@@ -689,7 +689,7 @@ class SimplePie_Parse_Date
 			}
 
 			// Convert the number of seconds to an integer, taking decimals into account
-			$second = round($match[6] + $match[7] / pow(10, strlen($match[7])));
+			$second = round((int)$match[6] + (int)$match[7] / pow(10, strlen($match[7])));
 
 			return gmmktime($match[4], $match[5], $second, $match[2], $match[3], $match[1]) - $timezone;
 		}


### PR DESCRIPTION
No more "Deprecate" warning in numeric expression with not numeric string like before in PHP 7.x. 
In PHP 8.0 with empty string we get a TypeError.

Pull Request for Issue # .

### Summary of Changes
Cast to integer numeric string.


### Testing Instructions
I've got the error using the Gavick module news_show_pro_gk5  


### Actual result BEFORE applying this Pull Request
Got error page "0 - Unsupported operand types: string / int"



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
