### PR TITLE
[4.3] Media manager better breadcrumb

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/breadcrumb/breadcrumb.vue
+++ b/administrator/components/com_media/resources/scripts/components/breadcrumb/breadcrumb.vue
@@ -20,7 +20,7 @@
   </nav>
   <select
     v-if="crumbs.length > 1"
-    class="form-select media-breadcrumb"
+    class="form-select form-select-sm media-breadcrumb"
     :aria-label="translate('COM_MEDIA_BREADCRUMB_LABEL')"
     @change="onCrumbSelect"
   >

--- a/administrator/components/com_media/resources/scripts/components/breadcrumb/breadcrumb.vue
+++ b/administrator/components/com_media/resources/scripts/components/breadcrumb/breadcrumb.vue
@@ -1,5 +1,6 @@
 <template>
   <nav
+    v-if="crumbs.length === 1"
     class="media-breadcrumb"
     :aria-label="translate('COM_MEDIA_BREADCRUMB_LABEL')"
   >
@@ -17,6 +18,22 @@
       </li>
     </ol>
   </nav>
+  <select
+    v-if="crumbs.length > 1"
+    class="form-select media-breadcrumb"
+    :aria-label="translate('COM_MEDIA_BREADCRUMB_LABEL')"
+    @change="onCrumbSelect"
+  >
+    <option
+      v-for="(val, index) in crumbs"
+      :key="index"
+      class="media-breadcrumb-item"
+      :selected="isSelected(index)"
+      :value="index"
+    >
+      {{ val.name }}
+    </option>
+  </select>
 </template>
 
 <script>
@@ -73,6 +90,9 @@ export default {
         ),
       );
     },
+    onCrumbSelect(event) {
+      return this.onCrumbClick(this.crumbs[event.target.value]);
+    },
     findDrive(adapter) {
       let driveObject = null;
 
@@ -85,6 +105,9 @@ export default {
       });
 
       return driveObject;
+    },
+    isSelected(index) {
+      return index === this.crumbs.length - 1;
     },
   },
 };

--- a/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
@@ -199,6 +199,7 @@ export default {
       [
         h(this.itemType(), {
           item: this.item,
+          focused: false,
           onToggleSettings: this.toggleSettings,
         }),
       ],

--- a/administrator/components/com_media/resources/scripts/components/tree/disk.vue
+++ b/administrator/components/com_media/resources/scripts/components/tree/disk.vue
@@ -31,8 +31,8 @@ export default {
       default: () => {},
     },
     uid: {
-      type: String,
-      default: '',
+      type: Number,
+      default: NaN,
     },
   },
   computed: {

--- a/build/media_source/com_media/scss/components/_media-breadcrumb.scss
+++ b/build/media_source/com_media/scss/components/_media-breadcrumb.scss
@@ -9,6 +9,8 @@
 
   &.form-select {
     width: initial;
+    height: 2rem;
+    margin: auto auto auto 0;
   }
 
   ol {

--- a/build/media_source/com_media/scss/components/_media-breadcrumb.scss
+++ b/build/media_source/com_media/scss/components/_media-breadcrumb.scss
@@ -7,6 +7,10 @@
   background: transparent;
   border-inline-start: 1px solid $border-color;
 
+  &.form-select {
+    width: initial;
+  }
+
   ol {
     display: flex;
     padding: 0;

--- a/build/media_source/com_media/scss/components/_media-breadcrumb.scss
+++ b/build/media_source/com_media/scss/components/_media-breadcrumb.scss
@@ -10,7 +10,8 @@
   &.form-select {
     width: initial;
     height: 2rem;
-    margin: auto auto auto 0;
+    margin-block-start: auto;
+    margin-block-end: auto;
   }
 
   ol {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- Switch breadcrumbs to select element to fix the width on many nested paths

### Testing Instructions

- Apply the patch and run `npm ci`
- Check that the breadcrumbs work (try many nested folders)

### Actual result BEFORE applying this Pull Request

Broken layout

### Expected result AFTER applying this Pull Request

![Screenshot 2023-02-10 at 11 00 53](https://user-images.githubusercontent.com/3889375/218063023-61e91643-c959-43da-bbb1-041f28becd92.png)
![Screenshot 2023-02-10 at 11 01 24](https://user-images.githubusercontent.com/3889375/218063072-79210a7a-285c-4967-9197-cd40b7d8aa7c.png)


![Screenshot 2023-02-10 at 11 01 12](https://user-images.githubusercontent.com/3889375/218062637-8ed1e6a1-efaa-4ab8-bb8c-d9f8f75a91d6.png)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed


Also just for clarification, this should solve some a11y problems with breadcrumbs and the design and idea for the select menu comes directly from the Apple Finder (the File Explorer of MacOS):
![Screenshot 2023-02-11 at 13 14 04](https://user-images.githubusercontent.com/3889375/218257463-4bb532b4-74c1-4ac5-b73e-c6a3841e64c7.png)

