### PR TITLE
[4.3] Media manager: add the missing lock component

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/modals/modal.vue
+++ b/administrator/components/com_media/resources/scripts/components/modals/modal.vue
@@ -8,7 +8,7 @@
       style="display: flex"
       @click.stop
     >
-      <tab-lock>
+      <Lock>
         <div
           class="modal-dialog"
           :class="modalClass"
@@ -35,14 +35,19 @@
             </div>
           </div>
         </div>
-      </tab-lock>
+      </Lock>
     </div>
   </div>
 </template>
 
 <script>
+import Lock from 'vue-focus-lock/src/Lock.vue';
+
 export default {
   name: 'MediaModal',
+  components: {
+    Lock,
+  },
   props: {
     /* Whether or not the close button in the header should be shown */
     showClose: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,9 +37,10 @@
         "qrcode-generator": "^1.4.4",
         "roboto-fontface": "^0.10.0",
         "short-and-sweet": "^1.0.4",
-        "skipto": "^4.1.6",
+        "skipto": "^4.1.7",
         "tinymce": "^5.10.2",
         "vue": "3.2.45",
+        "vue-focus-lock": "^2.0.1",
         "vuex": "^4.0.2",
         "vuex-persist": "^3.1.3"
       },
@@ -84,6 +85,9 @@
       "engines": {
         "node": ">=16",
         "npm": ">=8.5.5"
+      },
+      "optionalDependencies": {
+        "sass-embedded-linux-x64": "^1.57.1"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -4762,6 +4766,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
+    "node_modules/focus-lock": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.5.4.tgz",
+      "integrity": "sha512-A9ngdb0NyI6UygBQ0eD+p8SpLWTkdEDn67I3EGUUcDUfxH694mLA/xBWwhWhoj/2YLtsv2EoQdAx9UOKs8d/ZQ=="
+    },
     "node_modules/focus-visible": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
@@ -8191,7 +8200,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -9371,6 +9379,49 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/vue-focus-lock": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vue-focus-lock/-/vue-focus-lock-2.0.1.tgz",
+      "integrity": "sha512-FyKtzY+n1DgwDjp0u3GiAcIMTo9eoCTkAcF4jDpXd+dktLPAp55o0kOh+W+1YX3fc45Ws8CqyP5Ee2/1ABGPUg==",
+      "dependencies": {
+        "focus-lock": "^0.5.4",
+        "vue-demi": "^0.12.1"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^2.5.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-focus-lock/node_modules/vue-demi": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.5.tgz",
+      "integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/vuex": {
       "version": "4.1.0",
@@ -12981,6 +13032,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
+    "focus-lock": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.5.4.tgz",
+      "integrity": "sha512-A9ngdb0NyI6UygBQ0eD+p8SpLWTkdEDn67I3EGUUcDUfxH694mLA/xBWwhWhoj/2YLtsv2EoQdAx9UOKs8d/ZQ=="
+    },
     "focus-visible": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.2.0.tgz",
@@ -15435,7 +15491,6 @@
       "version": "1.57.1",
       "resolved": "https://registry.npmjs.org/sass-embedded-linux-x64/-/sass-embedded-linux-x64-1.57.1.tgz",
       "integrity": "sha512-AI6CrcuLWP22RXhVrZUN2JfdQ7YdFR30dA4twYwp/Q4hUfj85dJrVD5ORi8G04haMWPOQiFV6pBcMgzpiY2Bog==",
-      "dev": true,
       "optional": true
     },
     "sass-embedded-win32-ia32": {
@@ -16318,6 +16373,23 @@
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
           "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
+        }
+      }
+    },
+    "vue-focus-lock": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/vue-focus-lock/-/vue-focus-lock-2.0.1.tgz",
+      "integrity": "sha512-FyKtzY+n1DgwDjp0u3GiAcIMTo9eoCTkAcF4jDpXd+dktLPAp55o0kOh+W+1YX3fc45Ws8CqyP5Ee2/1ABGPUg==",
+      "requires": {
+        "focus-lock": "^0.5.4",
+        "vue-demi": "^0.12.1"
+      },
+      "dependencies": {
+        "vue-demi": {
+          "version": "0.12.5",
+          "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.5.tgz",
+          "integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==",
+          "requires": {}
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "skipto": "^4.1.7",
     "tinymce": "^5.10.2",
     "vue": "3.2.45",
+    "vue-focus-lock": "^2.0.1",
     "vuex": "^4.0.2",
     "vuex-persist": "^3.1.3"
   },
@@ -108,6 +109,6 @@
     "terser": "^5.7.0"
   },
   "optionalDependencies": {
-     "sass-embedded-linux-x64": "^1.57.1"
-   }
+    "sass-embedded-linux-x64": "^1.57.1"
+  }
 }

--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_codemirror</name>
-	<version>5.65.9</version>
+	<version>5.65.11</version>
 	<creationDate>28 March 2011</creationDate>
 	<author>Marijn Haverbeke</author>
 	<authorEmail>marijnh@gmail.com</authorEmail>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- Adds the missing tabs-lock component
- Fixes accessibility issues on media manager modals

### Testing Instructions

- Apply the PR and run `npm ci`
- Open the rename, create new folder, preview, get link and delete modals and check that the tab is locked inside the modal. That's it

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed


Side effect the codemirror is updated because of the ranges in the package.json