### PR TITLE
[4.3] Admin modules and xtd-editor plugins

### DIFF
--- a/administrator/components/com_modules/forms/moduleadmin.xml
+++ b/administrator/components/com_modules/forms/moduleadmin.xml
@@ -123,7 +123,7 @@
 			label="COM_MODULES_FIELD_CONTENT_LABEL"
 			buttons="true"
 			filter="JComponentHelper::filterText"
-			hide="readmore,pagebreak,module"
+			hide="readmore,pagebreak,module,menu,fields,contact,article"
 		/>
 
 		<field name="assignment" type="hidden" />


### PR DESCRIPTION
### Summary of Changes
Remove xtd-editors from the text area when used in an admin module eg the admin version of mod_custom as only the media plugin will actually work
fields -> fails as there is no context
articles, contacts and menus -> fail as they are generating frontend links but as they are absolute they will either 404 or 500 missing layout

### Testing Instructions
create a new administrator module of type custom
click on the cms-content button in the wysiwyg toolbar


### Actual result BEFORE applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/218109443-b5cd8676-731c-49ec-bbbd-bc8204f6c9f8.png)



### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/218109281-d59c86c0-569d-4418-bb2a-32fedeaf7f9e.png)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
