### PR TITLE
Correct name of cypress.config in `build/build.php`

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -400,7 +400,7 @@ $doNotPackage = [
     'composer.json',
     'composer.lock',
     'crowdin.yml',
-    'cypress.config.js',
+    'cypress.config.dist.js',
     'package-lock.json',
     'package.json',
     'phpunit-pgsql.xml.dist',


### PR DESCRIPTION
`cypress.config.js` was removed from package in #39478
Then the file was renamed in https://github.com/joomla/joomla-cms/pull/39722
