### PR TITLE
Focus hiccup

### DIFF
--- a/build/media_source/system/js/fields/validate.es6.js
+++ b/build/media_source/system/js/fields/validate.es6.js
@@ -105,29 +105,33 @@ class JFormValidator {
     element.parentNode.classList.add('has-danger');
     element.setAttribute('aria-invalid', 'true');
 
-    // Display custom message
-    let mesgCont;
-    const message = element.getAttribute('data-validation-text');
-
-    if (label) {
-      mesgCont = label.querySelector('span.form-control-feedback');
-    }
-
-    if (!mesgCont) {
-      const elMsg = document.createElement('span');
-      elMsg.classList.add('form-control-feedback');
-      if (empty && empty === 'checkbox') {
-        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_CHECK'));
-      } else if (empty && empty === 'value') {
-        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_VALUE'));
-      } else {
-        elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_INVALID_VALUE'));
-      }
+    function displayMessage() {
+      // Display custom message
+      let mesgCont;
+      const message = element.getAttribute('data-validation-text');
 
       if (label) {
-        label.appendChild(elMsg);
+        mesgCont = label.querySelector('span.form-control-feedback');
+      }
+
+      if (!mesgCont) {
+        const elMsg = document.createElement('span');
+        elMsg.classList.add('form-control-feedback');
+        if (empty && empty === 'checkbox') {
+          elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_CHECK'));
+        } else if (empty && empty === 'value') {
+          elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_REQUIRED_VALUE'));
+        } else {
+          elMsg.innerHTML = message !== null ? Joomla.sanitizeHtml(message) : Joomla.sanitizeHtml(Joomla.Text._('JLIB_FORM_FIELD_INVALID_VALUE'));
+        }
+
+        if (label) {
+          label.appendChild(elMsg);
+        }
       }
     }
+
+    requestAnimationFrame(() => requestAnimationFrame(displayMessage));
 
     // Mark the Label as well
     if (label) {


### PR DESCRIPTION
Pull Request is alternative to #39838 .

### Summary of Changes

- Using the double rAF trick to ensure no racing condition when the invalid message is displayed. The difference with #39838 is that this PR is not using some out of the blue delay but using the rAF...


### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
