### PR TITLE
[4] PHP8. Argument #1 ($string) must be of type string. JLayout form.field.text.

### DIFF
--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -96,7 +96,7 @@ $addonAfterHtml  = '<span class="input-group-text">' . Text::_($addonAfter) . '<
         type="text"
         name="<?php echo $name; ?>"
         id="<?php echo $id; ?>"
-        value="<?php echo htmlspecialchars($value, ENT_COMPAT, 'UTF-8'); ?>"
+        value="<?php echo htmlspecialchars(is_string($value) ? $value : '', ENT_COMPAT, 'UTF-8'); ?>"
         <?php echo $dirname; ?>
         <?php echo implode(' ', $attributes); ?>>
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/39854.

### Summary of Changes
Add is_string() check inside htmlspecialchars.

### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/39854#issue-1581885557

### Actual result BEFORE applying this Pull Request
PHP8 error `htmlspecialchars(): Argument #1 ($string) must be of type string, array given` Line 99.

### Expected result AFTER applying this Pull Request
No error.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
