### PR TITLE
[4] PHP8. Update ExtensionAdapter. Error: Attempt to assign property "name" on null.

### DIFF
--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -65,6 +65,8 @@ class ExtensionAdapter extends UpdateAdapter
                 break;
 
             default:
+                $this->currentUpdate = Table::getInstance('update');
+
                 if (\in_array($name, $this->updatecols)) {
                     $name = strtolower($name);
                     $this->currentUpdate->$name = '';


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/39789.

### Summary of Changes
Define `$this->currentUpdate` if needed in code afterwards.

### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/39789#issue-1570979327

Code review. Check that `$this->currentUpdate` is not defined in `switch case default:` before first usage.

### Actual result BEFORE applying this Pull Request
under certain circumstances: `Error: Attempt to assign property "name" on null. File: .../libraries/src/Updater/Adapter/ExtensionAdapter.php:70`

### Expected result AFTER applying this Pull Request
No error.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
