### PR TITLE
[4.2] Fix warning when null is passed to  FieldsHelper::extract method

### DIFF
--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -56,7 +56,7 @@ class FieldsHelper
      */
     public static function extract($contextString, $item = null)
     {
-        if ($contextString === null){
+        if ($contextString === null) {
             return null;
         }
 

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -56,6 +56,10 @@ class FieldsHelper
      */
     public static function extract($contextString, $item = null)
     {
+        if ($contextString === null){
+            return null;
+        }
+
         $parts = explode('.', $contextString, 2);
 
         if (count($parts) < 2) {


### PR DESCRIPTION
Pull Request for Issue #39719 and #39858.

### Summary of Changes
Currently, if null is passed to FieldsHelper::extract  method call, there will be deprecated warnings. This tiny PR just fixes that.

### Testing Instructions
As this does not happen in the core, code review should be enough.

### Actual result BEFORE applying this Pull Request
Warnings in some third party extensions when null is passed to the method call

### Expected result AFTER applying this Pull Request
No warnings anymore.


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed

- [x] No documentation changes for manual.joomla.org needed
