### PR TITLE
[4.3] Allow ico files uploads

### DIFF
--- a/administrator/components/com_templates/src/Helper/TemplateHelper.php
+++ b/administrator/components/com_templates/src/Helper/TemplateHelper.php
@@ -96,7 +96,7 @@ abstract class TemplateHelper
         $fontTypes    = explode(',', $params->get('font_formats'));
         $archiveTypes = explode(',', $params->get('compressed_formats'));
 
-        $allowable = array_merge($imageTypes, $sourceTypes, $fontTypes, $archiveTypes);
+        $allowable = array_merge($imageTypes, $sourceTypes, $fontTypes, $archiveTypes, ['ico']);
 
         if ($format == '' || $format == false || (!in_array($format, $allowable))) {
             $app = Factory::getApplication();

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1779,7 +1779,7 @@ class TemplateModel extends FormModel
             $fontTypes    = explode(',', $params->get('font_formats'));
             $archiveTypes = explode(',', $params->get('compressed_formats'));
 
-            $this->allowedFormats = array_merge($imageTypes, $sourceTypes, $fontTypes, $archiveTypes);
+            $this->allowedFormats = array_merge($imageTypes, $sourceTypes, $fontTypes,$archiveTypes, ['ico']);
             $this->allowedFormats = array_map('strtolower', $this->allowedFormats);
         }
 

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1779,7 +1779,7 @@ class TemplateModel extends FormModel
             $fontTypes    = explode(',', $params->get('font_formats'));
             $archiveTypes = explode(',', $params->get('compressed_formats'));
 
-            $this->allowedFormats = array_merge($imageTypes, $sourceTypes, $fontTypes,$archiveTypes, ['ico']);
+            $this->allowedFormats = array_merge($imageTypes, $sourceTypes, $fontTypes, $archiveTypes, ['ico']);
             $this->allowedFormats = array_map('strtolower', $this->allowedFormats);
         }
 

--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -199,6 +199,8 @@ class HtmlView extends BaseHtmlView
         } elseif (in_array($ext, $archiveTypes)) {
             $this->archive = $this->get('Archive');
             $this->type    = 'archive';
+        } elseif (in_array($ext, ['ico'])) {
+            $this->type   = 'icon';
         } else {
             $this->type = 'home';
         }

--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -146,23 +146,23 @@ if ($this->type == 'font') {
                                 </div>
                             </div>
                             <?php
-                                $difference = DiffHelper::calculateFiles(
-                                    $this->source->coreFile,
-                                    $this->source->filePath,
-                                    ComponentHelper::getParams('com_templates')->get('difference', 'SideByside'),
-                                    ['context' => 1],
-                                    [
-                                        'language' => [
-                                            'old_version' => Text::_('COM_TEMPLATES_DIFF_CORE'),
-                                            'new_version' => Text::_('COM_TEMPLATES_DIFF_OVERRIDE'),
-                                            'differences' => Text::_('COM_TEMPLATES_DIFF_DIFFERENCES'),
-                                        ],
-                                        'resultForIdenticals' => Text::_('COM_TEMPLATES_DIFF_IDENTICAL'),
-                                        'detailLevel' => 'word',
-                                        'spaceToHtmlTag' => true,
-                                        'wrapperClasses' => ['diff-wrapper', 'columns-order-ignore'],
-                                    ]
-                                );
+                            $difference = DiffHelper::calculateFiles(
+                                $this->source->coreFile,
+                                $this->source->filePath,
+                                ComponentHelper::getParams('com_templates')->get('difference', 'SideByside'),
+                                ['context' => 1],
+                                [
+                                    'language' => [
+                                        'old_version' => Text::_('COM_TEMPLATES_DIFF_CORE'),
+                                        'new_version' => Text::_('COM_TEMPLATES_DIFF_OVERRIDE'),
+                                        'differences' => Text::_('COM_TEMPLATES_DIFF_DIFFERENCES'),
+                                    ],
+                                    'resultForIdenticals' => Text::_('COM_TEMPLATES_DIFF_IDENTICAL'),
+                                    'detailLevel' => 'word',
+                                    'spaceToHtmlTag' => true,
+                                    'wrapperClasses' => ['diff-wrapper', 'columns-order-ignore'],
+                                ]
+                            );
                             ?>
                             <div class="col-md-12" id="diff-main">
                                 <h2><?php echo Text::_('COM_TEMPLATES_FILE_COMPARE_PANE'); ?></h2>
@@ -187,6 +187,12 @@ if ($this->type == 'font') {
                                 </li>
                             <?php endforeach; ?>
                         </ul>
+                        <input type="hidden" name="task" value="">
+                        <?php echo HTMLHelper::_('form.token'); ?>
+                    </form>
+                <?php elseif ($this->type == 'icon') : ?>
+                    <legend><?php echo Text::_('Display of ico files is not supported'); ?></legend>
+                    <form action="<?php echo Route::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file . '&isMedia=' . $input->get('isMedia', 0)); ?>" method="post" name="adminForm" id="adminForm">
                         <input type="hidden" name="task" value="">
                         <?php echo HTMLHelper::_('form.token'); ?>
                     </form>


### PR DESCRIPTION
Pull Request for Issue #39861 (partially, it allows upload but not delete or any other process) .

### Summary of Changes

- ico files are NOT images both for the HTML and the PHP tools
- allow them as exception


### Testing Instructions

Try to upload an ico file in the template file manager

### Actual result BEFORE applying this Pull Request

Upload successful

### Expected result AFTER applying this Pull Request

Not allowed

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed


@brianteeman I'm not really interested to push this any further, just opened the PR as a base for the solution. You're more than welcome to add the missing pieces...