### PR TITLE
[4.2] Prevent fatal error when Itemid from query is invalid

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -407,7 +407,10 @@ class SiteRouter extends Router
         ) {
             // Get the active menu item
             $item = $this->menu->getItem($query['Itemid']);
-            $query = array_merge($item->query, $query);
+
+            if ($item !== null) {
+                $query = array_merge($item->query, $query);
+            }
         }
 
         $uri->setQuery($query);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR adds a check to make sure Itemid from request points to a valid menu item before merging it's query data with the query from previous process to prevent fatal error.

### Testing Instructions
1. Type this link directly in the browser http://localhost/joomla/index.php?option=com_content&Itemid=1000 (Note Itemid=1000, there is no menu item with ID = 1000 in the setup, you can replace it with any invalid menu item id)

### Actual result BEFORE applying this Pull Request
You get fatal error:

`0 array_merge(): Argument #1 must be of type array, null given`

### Expected result AFTER applying this Pull Request
No fatal error, page displayed OK


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed

@Hackwar Is it OK to add this check ? In theory, `getItem` method from calling code could return null, so I think it makes sense to add the check (we have other similar check in the same class)