### PR TITLE
Fix deprecation warning (PHP 8.1+)

### DIFF
--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -891,7 +891,7 @@ class MenusHelper extends ContentHelper
             $item->link    = str_replace("{sql:$var}", $val, $item->link);
             $item->class   = str_replace("{sql:$var}", $val, $item->class);
             $item->icon    = str_replace("{sql:$var}", $val, $item->icon);
-            $params->set('menu-quicktask', str_replace("{sql:$var}", $val, $params->get('menu-quicktask')));
+            $params->set('menu-quicktask', str_replace("{sql:$var}", $val, $params->get('menu-quicktask', '')));
         }
 
         $item->setParams($params);


### PR DESCRIPTION
Fix deprecation warning with PHP 8.1+

### Summary of Changes

If a replacement string is used, but no 'quicktask' is defined `$params->get('menu-quicktask')` will return `null` which triggers:

`Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in administrator/components/com_menus/src/Helper/MenusHelper.php on line 894`

### Actual result BEFORE applying this Pull Request

deprecation warning with PHP 8.1+

### Expected result AFTER applying this Pull Request

No deprecation warning with PHP 8.1+

### Link to documentations

- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
