### PR TITLE
[4.3] Update deleted files list in script.php for upcoming 4.3.0-beta3

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6530,6 +6530,11 @@ class JoomlaInstallerScript
             // From 4.3.0-beta2 to 4.3.0-beta3
             '/cypress.config.dist.js',
             '/plugins/filesystem/local/local.php',
+            '/plugins/finder/categories/categories.php',
+            '/plugins/finder/contacts/contacts.php',
+            '/plugins/finder/content/content.php',
+            '/plugins/finder/newsfeeds/newsfeeds.php',
+            '/plugins/finder/tags/tags.php',
         ];
 
         $folders = [

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6529,6 +6529,8 @@ class JoomlaInstallerScript
             '/plugins/fields/usergrouplist/usergrouplist.php',
             // From 4.3.0-beta2 to 4.3.0-beta3
             '/cypress.config.dist.js',
+            '/plugins/captcha/recaptcha/recaptcha.php',
+            '/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php',
             '/plugins/filesystem/local/local.php',
             '/plugins/finder/categories/categories.php',
             '/plugins/finder/contacts/contacts.php',

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6527,6 +6527,9 @@ class JoomlaInstallerScript
             '/plugins/fields/url/url.php',
             '/plugins/fields/user/user.php',
             '/plugins/fields/usergrouplist/usergrouplist.php',
+            // From 4.3.0-beta2 to 4.3.0-beta3
+            '/cypress.config.dist.js',
+            '/plugins/filesystem/local/local.php',
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in file "administrator/components/com_admin/script.php" to recent changes in the 4.3-dev branch in preparation for the upcoming 4.3.0-beta3 release.

In detail deleted files from following PR's are added:

- PR #39841 :
'/cypress.config.dist.js',
- PR #39729 :
'/plugins/captcha/recaptcha/recaptcha.php',
'/plugins/captcha/recaptcha_invisible/recaptcha_invisible.php',
- PR #39642 :
'/plugins/filesystem/local/local.php',
- PR #39770 :
'/plugins/finder/categories/categories.php',
'/plugins/finder/contacts/contacts.php',
'/plugins/finder/content/content.php',
'/plugins/finder/newsfeeds/newsfeeds.php',
'/plugins/finder/tags/tags.php',

### Testing Instructions

Code review.

Or if you want to make a real test, update a 4.3.0-beta2 to the last 4.3 nightly build to get the actual result, and update a 4.3.0-beta2 or any older 4.x version to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

The files mentioned above are still present after updating from a 4.3.0-beta2.

### Expected result AFTER applying this Pull Request

The files mentioned above have been deleted after updating from a 4.3.0-beta2.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
