### PR TITLE
[4.2] module position string

### DIFF
--- a/administrator/components/com_modules/layouts/joomla/form/field/modulespositionedit.php
+++ b/administrator/components/com_modules/layouts/joomla/form/field/modulespositionedit.php
@@ -53,7 +53,7 @@ extract($displayData);
 $attributes = [
     'class="' . $class . '"',
     ' allow-custom',
-    ' search-placeholder="' . $this->escape(Text::_('JGLOBAL_TYPE_OR_SELECT_SOME_OPTIONS')) . '" ',
+    ' search-placeholder="' . $this->escape(Text::_('COM_MODULES_TYPE_OR_SELECT_POSITION')) . '" ',
 ];
 
 $selectAttr = [

--- a/administrator/language/en-GB/com_modules.ini
+++ b/administrator/language/en-GB/com_modules.ini
@@ -189,7 +189,7 @@ COM_MODULES_SELECT_MODULE="Select module, %s"
 COM_MODULES_SUBITEMS="Sub-items"
 COM_MODULES_TABLE_CAPTION="Modules"
 COM_MODULES_TYPE_CHOOSE="Select a Module Type"
-COM_MODULES_TYPE_OR_SELECT_POSITION="Type or Select a Position"
+COM_MODULES_TYPE_OR_SELECT_POSITION="Type or select a Position"
 COM_MODULES_XML_DESCRIPTION="Component for module management in the Administrator Backend."
 
 JLIB_RULES_SETTING_NOTES_COM_MODULES="Changes apply to this component only.<br><em><strong>Inherited</strong></em> - a Global Configuration setting or higher level setting is applied.<br><em><strong>Denied</strong></em> always wins - whatever is set at the Global or higher level and applies to all child elements.<br><em><strong>Allowed</strong></em> will enable the action for this component unless overruled by a Global Configuration setting." ; Alternate language strings for the rules form field


### PR DESCRIPTION
The wrong string was being used in the dropdown to select a module position

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/1296369/221135571-dcdfe694-3dd2-4a1d-a72d-79f8a4a0feef.png)


### Expected result AFTER applying this Pull Request
![image](https://user-images.githubusercontent.com/1296369/221135556-044949b1-b102-4e8d-af85-6c0fec5280b6.png)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
