### PR TITLE
[4.3] List all Categories in an Article Category tree

### DIFF
--- a/components/com_content/tmpl/categories/default.xml
+++ b/components/com_content/tmpl/categories/default.xml
@@ -101,7 +101,17 @@
 	</fieldset>
 
 	<fieldset name="category" label="JGLOBAL_CATEGORY_OPTIONS" description="JGLOBAL_SUBSLIDER_DRILL_CATEGORIES_LABEL">
-
+			<field
+				name="category_layout"
+				type="componentlayout"
+				label="JGLOBAL_FIELD_LAYOUT_LABEL"
+				description="JGLOBAL_FIELD_LAYOUT_DESC"
+				class="form-select"
+				menuitems="true"
+				extension="com_content"
+				view="category"
+				useglobal="true"
+			/>
 			<field
 				name="show_category_title"
 				type="list"
@@ -245,6 +255,25 @@
 			/>
 
 			<field
+				name="num_columns"
+				type="number"
+				label="JGLOBAL_NUM_COLUMNS_LABEL"
+				filter="integer"
+				useglobal="true"
+			/>
+
+			<field
+				name="multi_column_order"
+				type="list"
+				label="JGLOBAL_MULTI_COLUMN_ORDER_LABEL"
+				useglobal="true"
+				validate="options"
+				>
+				<option value="0">JGLOBAL_BLOG_DOWN_OPTION</option>
+				<option value="1">JGLOBAL_BLOG_ACROSS_OPTION</option>
+			</field>
+
+			<field
 				name="show_subcategory_content"
 				type="list"
 				label="JGLOBAL_SHOW_SUBCATEGORY_CONTENT_LABEL"
@@ -258,6 +287,17 @@
 				<option value="3">J3</option>
 				<option value="4">J4</option>
 				<option value="5">J5</option>
+			</field>
+
+			<field
+				name="link_intro_image"
+				type="list"
+				label="JGLOBAL_LINKED_INTRO_IMAGE_LABEL"
+				useglobal="true"
+				validate="options"
+				>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
 			</field>
 
 			<field


### PR DESCRIPTION
Pull Request for Issue #39911 .

### Summary of Changes
Updates the menu item to include several missingh settings


### Testing Instructions
Steps to reproduce the issue
On a clean site

create the following category structure and add at least one article into each category
Category1
-- Subcategory 1-1
Category 2
-- Subcategory 2-1

create a menu item of type _ List All Categories in an Article Category Tree_

configure the blog layouts tab as normal - note there is no option for number of  columns or column direction so it can only use the component settings or those of another menu item for the same category

there is no option to select either the blog or list layouts when you have clicked on a category it will only use the component settings


### Apply the PR
You now have all the same options you have for a category blog and category list menu item
The first field in the categories tab lets you chose the layout (blog, list) for each category

### B/C
No problems
 
### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
