### PR TITLE
[4.3] fix namespace captcha unit tests

### DIFF
--- a/tests/Unit/Plugin/Captcha/InvisibleRecaptcha/Extension/InvisibleRecaptchaPluginTest.php
+++ b/tests/Unit/Plugin/Captcha/InvisibleRecaptcha/Extension/InvisibleRecaptchaPluginTest.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-namespace Joomla\Tests\Unit\Plugin\Task\Checkfiles\Extension;
+namespace Joomla\Tests\Unit\Plugin\Captcha\InvisibleRecaptcha\Extension;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Application\CMSWebApplicationInterface;

--- a/tests/Unit/Plugin/Captcha/InvisibleRecaptcha/Extension/InvisibleRecaptchaPluginTest.php
+++ b/tests/Unit/Plugin/Captcha/InvisibleRecaptcha/Extension/InvisibleRecaptchaPluginTest.php
@@ -64,12 +64,12 @@ class InvisibleRecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can init the captcha
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can init the captcha
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testInit()
     {
         $document = new HtmlDocument();
@@ -89,12 +89,12 @@ class InvisibleRecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can init the captcha with a wrong application
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can init the captcha with a wrong application
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testInitWrongApplication()
     {
         $plugin = new InvisibleReCaptcha(new Dispatcher(), ['params' => ['public_key' => 'test']], $this->createStub(RequestMethod::class));
@@ -104,12 +104,12 @@ class InvisibleRecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can init the captcha with an empty public key
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can init the captcha with an empty public key
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testInitEmptyPublicKey()
     {
         $language = $this->createStub(Language::class);
@@ -127,12 +127,12 @@ class InvisibleRecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can display the captcha
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can display the captcha
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testDisplay()
     {
         $plugin = new InvisibleReCaptcha(new Dispatcher(), ['params' => []], $this->createStub(RequestMethod::class));
@@ -145,12 +145,12 @@ class InvisibleRecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can check successful answer
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can check successful answer
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testResponse()
     {
         $language = $this->createStub(Language::class);
@@ -170,12 +170,12 @@ class InvisibleRecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can check answer with an empty private key
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can check answer with an empty private key
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testResponseEmptyPrivateKey()
     {
         $language = $this->createStub(Language::class);
@@ -193,12 +193,12 @@ class InvisibleRecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can detect spam
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can detect spam
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testResponseSpam()
     {
         $language = $this->createStub(Language::class);
@@ -217,12 +217,12 @@ class InvisibleRecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can check successful answer
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can check successful answer
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testFailedResponse()
     {
         $language = $this->createStub(Language::class);
@@ -244,12 +244,12 @@ class InvisibleRecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can setup field
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can setup field
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testSetupField()
     {
         $plugin = new InvisibleReCaptcha(new Dispatcher(), ['params' => ['private_key' => 'test']], $this->createStub(RequestMethod::class));
@@ -259,12 +259,12 @@ class InvisibleRecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can return admin capabilities
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can return admin capabilities
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testPrivacy()
     {
         $language = $this->createStub(Language::class);

--- a/tests/Unit/Plugin/Captcha/InvisibleRecaptcha/Extension/InvisibleRecaptchaPluginTest.php
+++ b/tests/Unit/Plugin/Captcha/InvisibleRecaptcha/Extension/InvisibleRecaptchaPluginTest.php
@@ -4,7 +4,7 @@
  * @package     Joomla.UnitTest
  * @subpackage  Extension
  *
- * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/tests/Unit/Plugin/Captcha/Recaptcha/Extension/RecaptchaPluginTest.php
+++ b/tests/Unit/Plugin/Captcha/Recaptcha/Extension/RecaptchaPluginTest.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-namespace Joomla\Tests\Unit\Plugin\Task\Checkfiles\Extension;
+namespace Joomla\Tests\Unit\Plugin\Captcha\Recaptcha\Extension;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Application\CMSWebApplicationInterface;

--- a/tests/Unit/Plugin/Captcha/Recaptcha/Extension/RecaptchaPluginTest.php
+++ b/tests/Unit/Plugin/Captcha/Recaptcha/Extension/RecaptchaPluginTest.php
@@ -62,12 +62,12 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can init the captcha
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can init the captcha
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testInit()
     {
         $document = new HtmlDocument();
@@ -87,12 +87,12 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can init the captcha with a wrong application
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can init the captcha with a wrong application
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testInitWrongApplication()
     {
         $plugin = new ReCaptcha(new Dispatcher(), ['params' => ['public_key' => 'test']], $this->createStub(RequestMethod::class));
@@ -102,12 +102,12 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can init the captcha with an empty public key
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can init the captcha with an empty public key
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testInitEmptyPublicKey()
     {
         $language = $this->createStub(Language::class);
@@ -125,12 +125,12 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can display the captcha
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can display the captcha
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testDisplay()
     {
         $plugin = new ReCaptcha(new Dispatcher(), ['params' => []], $this->createStub(RequestMethod::class));
@@ -143,12 +143,12 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can check successful answer
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can check successful answer
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testResponse()
     {
         $language = $this->createStub(Language::class);
@@ -168,12 +168,12 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can check successful answer
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can check successful answer
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testResponseWithCode()
     {
         $language = $this->createStub(Language::class);
@@ -192,12 +192,12 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can check answer with an empty private key
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can check answer with an empty private key
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testResponseEmptyPrivateKey()
     {
         $language = $this->createStub(Language::class);
@@ -215,12 +215,12 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can detect spam
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can detect spam
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testResponseSpam()
     {
         $language = $this->createStub(Language::class);
@@ -239,12 +239,12 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can check successful answer
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can check successful answer
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testFailedResponse()
     {
         $language = $this->createStub(Language::class);
@@ -266,12 +266,12 @@ class RecaptchaPluginTest extends UnitTestCase
     }
 
     /**
-      * @testdox  can return admin capabilities
-      *
-      * @return  void
-      *
-      * @since   4.3.0
-      */
+     * @testdox  can return admin capabilities
+     *
+     * @return  void
+     *
+     * @since   4.3.0
+     */
     public function testPrivacy()
     {
         $language = $this->createStub(Language::class);

--- a/tests/Unit/Plugin/Captcha/Recaptcha/Extension/RecaptchaPluginTest.php
+++ b/tests/Unit/Plugin/Captcha/Recaptcha/Extension/RecaptchaPluginTest.php
@@ -4,7 +4,7 @@
  * @package     Joomla.UnitTest
  * @subpackage  Extension
  *
- * @copyright   (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 


### PR DESCRIPTION
### Summary of Changes

- Fix namespace for `tests/Unit/Plugin/Captcha/InvisibleRecaptcha/Extension/InvisibleRecaptchaPluginTest.php` and `tests/Unit/Plugin/Captcha/Recaptcha/Extension/RecaptchaPluginTest.php`
- Correct indent for php doc blocks

### Testing Instructions

Run composer install
Run unit tests


### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/66922325/221356711-d0bd5af8-9c99-474a-a374-80d69e620346.png)

```
Class Joomla\Tests\Unit\Plugin\Task\Checkfiles\Extension\InvisibleRecaptchaPluginTest located in ./tests/Unit/Plugin/Captcha/InvisibleRecaptcha/Extension/InvisibleRecaptchaPluginTest.php does not comply with psr-4 autoloading standard. Skipping.
Class Joomla\Tests\Unit\Plugin\Task\Checkfiles\Extension\RecaptchaPluginTest located in ./tests/Unit/Plugin/Captcha/Recaptcha/Extension/RecaptchaPluginTest.php does not comply with psr-4 autoloading standard. Skipping.
```

### Expected result AFTER applying this Pull Request

No warning when generating optimized autoload files during composer install
Unit tests are still successful

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
