### PR TITLE
[5.0] Filter by category - levels

### DIFF
--- a/administrator/components/com_categories/forms/filter_categories.xml
+++ b/administrator/components/com_categories/forms/filter_categories.xml
@@ -63,6 +63,18 @@
 			>
 			<option value="">JOPTION_SELECT_MAX_LEVELS</option>
 		</field>
+
+		<field
+			name="category_id"
+			type="category"
+			label="JOPTION_SELECT_CATEGORY"
+			multiple="true"
+			extension="dynamic"
+			layout="joomla.form.field.list-fancy-select"
+			hint="JOPTION_SELECT_CATEGORY"
+			published="0,1,2"
+			class="js-select-submit-on-change"
+		/>
 	</fields>
 
 	<fields name="list">

--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -254,8 +254,8 @@ class CategoriesModel extends ListModel
             $categoryTable    = Table::getInstance('Category', 'JTable');
             $subCatItemsWhere = [];
 
-            foreach ($categoryId as $filter_catid) {
-                $categoryTable->load($filter_catid);
+            foreach ($categoryId as $filterCatId) {
+                $categoryTable->load($filterCatId);
                 $subCatItemsWhere[] = '(' .
                     ($level ? 'a.level <= ' . ((int) $level + (int) $categoryTable->level - 1) . ' AND ' : '') .
                     'a.lft >= ' . (int) $categoryTable->lft . ' AND ' .

--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -263,10 +263,9 @@ class CategoriesModel extends ListModel
             }
 
             $query->where('(' . implode(' OR ', $subCatItemsWhere) . ')');
-        }
 
-        // Case: Using only the by level filter
-        elseif ($level) {
+            // Case: Using only the by level filter
+            } elseif ($level) {
             $query->where($db->quoteName('a.level') . ' <= :level')
                 ->bind(':level', $level, ParameterType::INTEGER);
         }

--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -264,8 +264,8 @@ class CategoriesModel extends ListModel
 
             $query->where('(' . implode(' OR ', $subCatItemsWhere) . ')');
 
-            // Case: Using only the by level filter
-            } elseif ($level) {
+        // Case: Using only the by level filter
+        } elseif ($level) {
             $query->where($db->quoteName('a.level') . ' <= :level')
                 ->bind(':level', $level, ParameterType::INTEGER);
         }

--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -242,35 +242,32 @@ class CategoriesModel extends ListModel
         }
 
         // Filter by categories and by level
-		$categoryId = $this->getState('filter.category_id', []);
-		$level = $this->getState('filter.level');
+        $categoryId = $this->getState('filter.category_id', []);
+        $level = $this->getState('filter.level');
 
-		if (!is_array($categoryId))
-		{
-			$categoryId = $categoryId ? array($categoryId) : [];
-		}
+        if (!is_array($categoryId)) {
+            $categoryId = $categoryId ? array($categoryId) : [];
+        }
 
-		// Case: Using both categories filter and by level filter
-		if (count($categoryId))
-		{
-			$categoryTable = Table::getInstance('Category', 'JTable');
-			$subCatItemsWhere = [];
+        // Case: Using both categories filter and by level filter
+        if (count($categoryId)) {
+            $categoryTable = Table::getInstance('Category', 'JTable');
+            $subCatItemsWhere = [];
 
-			foreach ($categoryId as $filter_catid)
-			{
-				$categoryTable->load($filter_catid);
-				$subCatItemsWhere[] = '(' .
-					($level ? 'a.level <= ' . ((int) $level + (int) $categoryTable->level - 1) . ' AND ' : '') .
-					'a.lft >= ' . (int) $categoryTable->lft . ' AND ' .
-					'a.rgt <= ' . (int) $categoryTable->rgt . ')';
-			}
+            foreach ($categoryId as $filter_catid)
+            {
+                $categoryTable->load($filter_catid);
+                $subCatItemsWhere[] = '(' .
+                    ($level ? 'a.level <= ' . ((int) $level + (int) $categoryTable->level - 1) . ' AND ' : '') .
+                    'a.lft >= ' . (int) $categoryTable->lft . ' AND ' .
+                    'a.rgt <= ' . (int) $categoryTable->rgt . ')';
+            }
 
-			$query->where('(' . implode(' OR ', $subCatItemsWhere) . ')');
-		}
+            $query->where('(' . implode(' OR ', $subCatItemsWhere) . ')');
+        }
 
-		// Case: Using only the by level filter
-		elseif ($level)
-        {
+        // Case: Using only the by level filter
+        elseif ($level) {
             $query->where($db->quoteName('a.level') . ' <= :level')
                 ->bind(':level', $level, ParameterType::INTEGER);
         }
@@ -385,25 +382,25 @@ class CategoriesModel extends ListModel
 
         // Group by on Categories for \JOIN with component tables to count items
         $query->group('a.id,
-				a.title,
-				a.alias,
-				a.note,
-				a.published,
-				a.access,
-				a.checked_out,
-				a.checked_out_time,
-				a.created_user_id,
-				a.path,
-				a.parent_id,
-				a.level,
-				a.lft,
-				a.rgt,
-				a.language,
-				l.title,
-				l.image,
-				uc.name,
-				ag.title,
-				ua.name');
+                a.title,
+                a.alias,
+                a.note,
+                a.published,
+                a.access,
+                a.checked_out,
+                a.checked_out_time,
+                a.created_user_id,
+                a.path,
+                a.parent_id,
+                a.level,
+                a.lft,
+                a.rgt,
+                a.language,
+                l.title,
+                l.image,
+                uc.name,
+                ag.title,
+                ua.name');
 
         return $query;
     }

--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -243,19 +243,18 @@ class CategoriesModel extends ListModel
 
         // Filter by categories and by level
         $categoryId = $this->getState('filter.category_id', []);
-        $level = $this->getState('filter.level');
+        $level      = $this->getState('filter.level');
 
         if (!is_array($categoryId)) {
-            $categoryId = $categoryId ? array($categoryId) : [];
+            $categoryId = $categoryId ? [$categoryId] : [];
         }
 
         // Case: Using both categories filter and by level filter
         if (count($categoryId)) {
-            $categoryTable = Table::getInstance('Category', 'JTable');
+            $categoryTable    = Table::getInstance('Category', 'JTable');
             $subCatItemsWhere = [];
 
-            foreach ($categoryId as $filter_catid)
-            {
+            foreach ($categoryId as $filter_catid) {
                 $categoryTable->load($filter_catid);
                 $subCatItemsWhere[] = '(' .
                     ($level ? 'a.level <= ' . ((int) $level + (int) $categoryTable->level - 1) . ' AND ' : '') .

--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -138,6 +138,10 @@ class HtmlView extends BaseHtmlView
             }
         }
 
+        // If filter by category is active we need to know the extension name to filter the categories
+        $extensionName = $this->escape($this->state->get('filter.extension'));
+        $this->filterForm->setFieldAttribute('category_id', 'extension', $extensionName, 'filter');
+
         parent::display($tpl);
     }
 


### PR DESCRIPTION
pr for #38881

On a complex site with a lot of categories it can be very difficult to sort the categories using drag and drop because you cannot get the relevant tree on the same page.

This adds a new filter to com_category that allows you to select the parent category. It's particularly useful when used with the max levels filter.

Testing is easiest if you have the test sample data installed as that has a lot of categories

_This is a remake of 27486 to support all components that use categories_

### Example with no filter
![image](https://user-images.githubusercontent.com/1296369/72210588-78490e00-34b5-11ea-81fa-f96e3798aada.png)

### Example with category filter
![image](https://user-images.githubusercontent.com/1296369/72210593-88f98400-34b5-11ea-917f-751c83d45202.png)

### Example with category and level filter
![image](https://user-images.githubusercontent.com/1296369/72210596-97e03680-34b5-11ea-91df-f63c3ee2c2f0.png)

### Example with TWO category filters and level filter
![image](https://user-images.githubusercontent.com/1296369/72210610-d4139700-34b5-11ea-9971-7050e5105506.png)
