### PR TITLE
[4.3] PHP8.2: Updating voku/portable-utf8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,8 @@
         "lcobucci/jwt": "^3.4.6",
         "web-token/signature-pack": "^2.2.11",
         "phpseclib/bcmath_compat": "^2.0.1",
-        "jfcherng/php-diff": "^6.10.8"
+        "jfcherng/php-diff": "^6.10.8",
+        "voku/portable-utf8": "6.0.12 as 5.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.32",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b8894d29b80e6d4ab002da3172aed264",
+    "content-hash": "dc01dab47679873cf96a6ab67b348137",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -5463,16 +5463,16 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "1.5.6",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "80953678b19901e5165c56752d087fc11526017c"
+                "reference": "b56450eed252f6801410d810c8e1727224ae0743"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/80953678b19901e5165c56752d087fc11526017c",
-                "reference": "80953678b19901e5165c56752d087fc11526017c",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b56450eed252f6801410d810c8e1727224ae0743",
+                "reference": "b56450eed252f6801410d810c8e1727224ae0743",
                 "shasum": ""
             },
             "require": {
@@ -5509,7 +5509,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/1.5.6"
+                "source": "https://github.com/voku/portable-ascii/tree/2.0.1"
             },
             "funding": [
                 {
@@ -5533,20 +5533,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-11-12T00:07:28+00:00"
+            "time": "2022-03-08T17:03:00+00:00"
         },
         {
             "name": "voku/portable-utf8",
-            "version": "5.4.51",
+            "version": "6.0.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-utf8.git",
-                "reference": "578f5266725dc9880483d24ad0cfb39f8ce170f7"
+                "reference": "db0583727bb17666bbd2ba238c85babb973fd165"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-utf8/zipball/578f5266725dc9880483d24ad0cfb39f8ce170f7",
-                "reference": "578f5266725dc9880483d24ad0cfb39f8ce170f7",
+                "url": "https://api.github.com/repos/voku/portable-utf8/zipball/db0583727bb17666bbd2ba238c85babb973fd165",
+                "reference": "db0583727bb17666bbd2ba238c85babb973fd165",
                 "shasum": ""
             },
             "require": {
@@ -5556,10 +5556,14 @@
                 "symfony/polyfill-intl-normalizer": "~1.0",
                 "symfony/polyfill-mbstring": "~1.0",
                 "symfony/polyfill-php72": "~1.0",
-                "voku/portable-ascii": "~1.5.6"
+                "voku/portable-ascii": "~2.0.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpstan/phpstan": "1.9.*@dev",
+                "phpstan/phpstan-strict-rules": "1.4.*@dev",
+                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0",
+                "thecodingmachine/phpstan-strict-rules": "1.0.*@dev",
+                "voku/phpstan-rules": "3.1.*@dev"
             },
             "suggest": {
                 "ext-ctype": "Use Ctype for e.g. hexadecimal digit detection",
@@ -5608,7 +5612,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-utf8/issues",
-                "source": "https://github.com/voku/portable-utf8/tree/5.4.51"
+                "source": "https://github.com/voku/portable-utf8/tree/6.0.12"
             },
             "funding": [
                 {
@@ -5632,7 +5636,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-12-02T01:58:49+00:00"
+            "time": "2023-01-11T12:26:16+00:00"
         },
         {
             "name": "wamania/php-stemmer",
@@ -12053,7 +12057,14 @@
             "time": "2022-08-31T12:59:22+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "voku/portable-utf8",
+            "version": "6.0.12.0",
+            "alias": "5.4.0",
+            "alias_normalized": "5.4.0.0"
+        }
+    ],
     "minimum-stability": "stable",
     "stability-flags": {
         "maximebf/debugbar": 20,


### PR DESCRIPTION
Pull Request for Issue #39512.

### Summary of Changes
Our wamania/php-stemmer requires voku/portable-utf8, which in the 5.4 version is not compatible with PHP 8.2. Version 6.0 actually is and since the code for the stemmer is compatible, we can thus update voku/portable-utf8 now with this. php-stemmer will most likely not update it for the 2.x version we are using. For Joomla 5 this is probably going to be done through our dependency updates.


### Testing Instructions
Apply the change (together with composer install) and then run the indexer of smart search and afterwards search something in the frontend. Make sure that the stemmer is selected in the global options of Smart Search by setting "Default Language" to "Default Site Language". All of this in PHP 8.2


### Actual result BEFORE applying this Pull Request
You see a notice.


### Expected result AFTER applying this Pull Request
You don't see a notice.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
