### PR TITLE
[plgTinyMCE] Error correction. Now you can drag and drop images into the article so that the image is saved to a custom directory.

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
@@ -38,13 +38,7 @@
       var _data;
       
       var url = editor.settings.uploadUri + "&path=" + editor.settings.comMediaAdapter + editor.settings.parentUploadFolder;
-      
-      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.context =  window.location.pathname, _data);
-
-      if(window.location.search){
-        var _pathObj = window.location.search.split('#',1).pop().split('?').pop().split('&').map(m=>m.split('=')).reduce((o,v) => ({...o,[v[0]??'']:v[1]??''}),{});
-        data.context = (_pathObj.option??'') + '.' + (_pathObj.view??'') + ':' + (_pathObj.id??'');
-      }
+      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data);
 
       Joomla.request({
         url: url,

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
@@ -42,8 +42,8 @@
       var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.conxext =  window.location.pathname, _data);
 
       if(window.location.search){
-		let _pathObj = window.location.search.split('#',1).pop().split('?').pop().split('&').map(m=>m.split('=')).reduce((o,v) => ({...o,[v[0]??'']:v[1]??''}),{});
-	    data.context = (_pathObj.option??'') + '.' + (_pathObj.view??'') + ':' + (_pathObj.id??'');
+        var _pathObj = window.location.search.split('#',1).pop().split('?').pop().split('&').map(m=>m.split('=')).reduce((o,v) => ({...o,[v[0]??'']:v[1]??''}),{});
+        data.context = (_pathObj.option??'') + '.' + (_pathObj.view??'') + ':' + (_pathObj.id??'');
       }
 
       Joomla.request({

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
@@ -38,8 +38,14 @@
       var _data;
       
       var url = editor.settings.uploadUri + "&path=" + editor.settings.comMediaAdapter + editor.settings.parentUploadFolder;
-      var context = window.location.search ? window.location.search.split('#',1).pop().split('?').pop().split('&').map(m=>m.split('=')).reduce((o,v) => ({...o, [v]:v}),{}) : window.location.pathname;
-      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.conxext = context, _data);
+      
+      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.conxext =  window.location.pathname, _data);
+
+      if(window.location.search){
+		let _pathObj = window.location.search.split('#',1).pop().split('?').pop().split('&').map(m=>m.split('=')).reduce((o,v) => ({...o,[v[0]??'']:v[1]??''}),{});
+	    data.context = (_pathObj.option??'') + '.' + (_pathObj.view??'') + ':' + (_pathObj.id??'');
+      }
+
       Joomla.request({
         url: url,
         method: 'POST',

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
@@ -36,9 +36,10 @@
 
     function uploadFile(name, content) {
       var _data;
-
-      var url = editor.settings.uploadUri + "&path=" + editor.settings.comMediaAdapter;
-      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data);
+      
+      var url = editor.settings.uploadUri + "&path=" + editor.settings.comMediaAdapter + editor.settings.parentUploadFolder;
+      var context = window.location.search ? window.location.search.split('#',1).pop().split('?').pop().split('&').map(m=>m.split('=')).reduce((o,v) => ({...o, [v]:v}),{}) : window.location.pathname;
+      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.conxext = context, _data);
       Joomla.request({
         url: url,
         method: 'POST',

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
@@ -39,7 +39,7 @@
       
       var url = editor.settings.uploadUri + "&path=" + editor.settings.comMediaAdapter + editor.settings.parentUploadFolder;
       
-      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.conxext =  window.location.pathname, _data);
+      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.context =  window.location.pathname, _data);
 
       if(window.location.search){
         var _pathObj = window.location.search.split('#',1).pop().split('?').pop().split('&').map(m=>m.split('=')).reduce((o,v) => ({...o,[v[0]??'']:v[1]??''}),{});

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
@@ -36,10 +36,9 @@
 
     function uploadFile(name, content) {
       var _data;
-      
+
       var url = editor.settings.uploadUri + "&path=" + editor.settings.comMediaAdapter + editor.settings.parentUploadFolder;
       var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data);
-
       Joomla.request({
         url: url,
         method: 'POST',


### PR DESCRIPTION
If you are in the plugin `TinyeMCE` settings, select a subdirectory for saving images. Then when you drag the image into the article editor, the image will not be saved to the selected user subdirectory, but will be saved as before to the parent `/images` directory. 
But now the images will be saved to the selected user under the directory in the `/images` directory.

Before POST/GET request
```JS
option: com_media
format: json
url: 1
task: api.files
path: local-images:

content: "imageData"
name: "____Image.jpg"
parent: "publicacations_2023"
```
After Fix POST/GET request
```JS
option: com_media
format: json
url: 1
task: api.files
path: local-images:publications_2023

content: "imageData"
name: "____Image.jpg"
parent: "publicacations_2023"
```
The problem of saving the image to a subdirectory was in the absence of the name of the subdirectory in the `path:` parameter.
Because it is in the component that the images are saved to the subdirectory that is specified in the `path:` parameter of the POST request.
`administrator/components/com_media/src/Controller/ApiController.php`
In method `ApiController->getPath()`

Can you tell me if this PR needed to be added to [4.3-dev]?