### PR TITLE
[6.2] Add text context info for post request for dragging image in editor in article

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
@@ -38,7 +38,13 @@
       var _data;
 
       var url = editor.settings.uploadUri + "&path=" + editor.settings.comMediaAdapter;
-      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data);
+      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.context =  window.location.pathname, _data);
+
+      if(window.location.search){
+        var _pathObj = window.location.search.split('#',1).pop().split('?').pop().split('&').map(m=>m.split('=')).reduce((o,v) => ({...o,[v[0]??'']:v[1]??''}),{});
+        data.context = (_pathObj.option??'') + '.' + (_pathObj.view??'') + ':' + (_pathObj.id??'');
+      }
+
       Joomla.request({
         url: url,
         method: 'POST',

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
@@ -41,8 +41,8 @@
       var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.context =  window.location.pathname, _data);
 
       if (window.location.search) {
-        var _pathObj = window.location.search.split('#',1).pop().split('?').pop().split('&').map(m=>m.split('=')).reduce((o,v) => ({...o,[v[0]??'']:v[1]??''}),{});
-        data.context = (_pathObj.option??'') + '.' + (_pathObj.view??'') + ':' + (_pathObj.id??'');
+        var pathObj = new URLSearchParams(location.search);
+        data.context = `${pathObj.get('option') ?? ''}.${pathObj.get('view') ?? ''}:${pathObj.get('id') ?? ''}`;
       }
 
       Joomla.request({

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
@@ -40,7 +40,7 @@
       var url = editor.settings.uploadUri + "&path=" + editor.settings.comMediaAdapter;
       var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.context =  window.location.pathname, _data);
 
-      if(window.location.search){
+      if (window.location.search) {
         var _pathObj = window.location.search.split('#',1).pop().split('?').pop().split('&').map(m=>m.split('=')).reduce((o,v) => ({...o,[v[0]??'']:v[1]??''}),{});
         data.context = (_pathObj.option??'') + '.' + (_pathObj.view??'') + ':' + (_pathObj.id??'');
       }

--- a/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/dragdrop/plugin.es5.js
@@ -38,9 +38,9 @@
       var _data;
 
       var url = editor.settings.uploadUri + "&path=" + editor.settings.comMediaAdapter;
-      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.context =  window.location.pathname, _data);
+      var data = (_data = {}, _data[editor.settings.csrfToken] = '1', _data.name = name, _data.content = content, _data.parent = editor.settings.parentUploadFolder, _data.context =  location.pathname, _data);
 
-      if (window.location.search) {
+      if (location.search) {
         var pathObj = new URLSearchParams(location.search);
         data.context = `${pathObj.get('option') ?? ''}.${pathObj.get('view') ?? ''}:${pathObj.get('id') ?? ''}`;
       }


### PR DESCRIPTION
When dragging an image in the article editor, a POST request is sent. I added a context with information about the article ID to this POST request. This will allow on the server side to give names to pictures with the content of the article ID. In general, it is useful for the component to know which article this picture belongs to.


Before POST/GET request
```JS
option: com_media
format: json
url: 1
task: api.files
path: local-images:

content: "imageData"
name: "____Image.jpg"
parent: "publicacations_2023"
```
After Fix POST/GET request
```JS
option: com_media
format: json
url: 1
task: api.files
path: local-images:

content: "imageData"
name: "____Image.jpg"
parent: "publicacations_2023"

context: "com_content.article:23"
```
This context will allow you to dynamically manage the saved files when inserting them into the article editor.
1. Manage the directory depending on which directory the article is saved in. For example, it allows you to automatically store news image files separately in the news directory and separately image files of products and goods separately from each other.
2. Allows you to set the article ID or module ID in the file name. That will allow you to know the ownership of the image.

And how to find out the ownership and refactoring of a folder of pictures if it's just a bunch of sketched different files.
A specialist site manager in the modern world does not have to worry about the file name, the file should automatically be named itself and saved in the right directory. The site manager should only think about the description of the photo.

This PR does not provide new features. But it gives an additional line of information for plugins and components to implement broad functionality. If even now it will seem superfluous. Then in the near future, administrators will be able to at least download a plugin to manage the location of images. Now every social network uploads images simply. The user has nothing to do with the location of the images on the social network server. We have to take the same step in Joomla

I wanted to add this PR together with https://github.com/joomla/joomla-cms/pull/39957 please support this PR
