### PR TITLE
[5.0] Smart Search: Preventing stemmer exception

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Language.php
+++ b/administrator/components/com_finder/src/Indexer/Language.php
@@ -75,7 +75,12 @@ class Language
         }
 
         try {
-            $this->stemmer = StemmerFactory::create($this->language);
+            foreach (StemmerFactory::LANGS as $classname => $isoCodes) {
+                if (in_array($this->language, $isoCodes)) {
+                    $this->stemmer = StemmerFactory::create($this->language);
+                    break;
+                }
+            }
         } catch (NotFoundException $e) {
             // We don't have a stemmer for the language
         }


### PR DESCRIPTION
Pull Request for Issue #30372.

### Summary of Changes
The stemmer in Smart Search throws an exception when there is no stemmer for that language. We catch that exception successfully, but when debugging with xdebug, the exception stops execution anyway. This change first checks if the language should be available before calling the stemmer factory.


### Testing Instructions
Set the language for an item to *, start a debugging session with xdebug, save the item.


### Actual result BEFORE applying this Pull Request
Xdebug stops execution with a NotFoundException exception.


### Expected result AFTER applying this Pull Request
Xdebug does not stop.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
