### PR TITLE
[5.0] Smart Search: Only add published taxonomies

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -459,6 +459,10 @@ class Indexer
                     $nodeId = Taxonomy::addNode($branch, $node->title, $node->state, $node->access, $node->language);
                 }
 
+                if (!$nodeId) {
+                    continue;
+                }
+
                 // Add the link => node map.
                 Taxonomy::addMap($linkId, $nodeId);
                 $node->id = $nodeId;

--- a/administrator/components/com_finder/src/Indexer/Taxonomy.php
+++ b/administrator/components/com_finder/src/Indexer/Taxonomy.php
@@ -65,7 +65,6 @@ class Taxonomy
     {
         $node            = new \stdClass();
         $node->title     = $title;
-        $node->state     = $state;
         $node->access    = $access;
         $node->parent_id = 1;
         $node->language  = '';
@@ -89,12 +88,15 @@ class Taxonomy
      */
     public static function addNode($branch, $title, $state = 1, $access = 1, $language = '')
     {
+        if ($state != 1) {
+            return 0;
+        }
+
         // Get the branch id, insert it if it does not exist.
         $branchId = static::addBranch($branch);
 
         $node            = new \stdClass();
         $node->title     = $title;
-        $node->state     = $state;
         $node->access    = $access;
         $node->parent_id = $branchId;
         $node->language  = $language;
@@ -118,6 +120,10 @@ class Taxonomy
      */
     public static function addNestedNode($branch, NodeInterface $node, $state = 1, $access = 1, $language = '', $branchId = null)
     {
+        if ($state != 1) {
+            return 0;
+        }
+
         if (!$branchId) {
             // Get the branch id, insert it if it does not exist.
             $branchId = static::addBranch($branch);
@@ -125,15 +131,22 @@ class Taxonomy
 
         $parent = $node->getParent();
 
+        $pstate    = $node->state ?? ($node->published ?? $state);
+        $paccess   = $node->access ?? $access;
+        $planguage = $node->language ?? $language;
+
         if ($parent && $parent->title != 'ROOT') {
-            $parentId = self::addNestedNode($branch, $parent, $state, $access, $language, $branchId);
+            $parentId = self::addNestedNode($branch, $parent, $pstate, $paccess, $planguage, $branchId);
         } else {
             $parentId = $branchId;
         }
 
+        if (!$parentId) {
+            return 0;
+        }
+
         $temp            = new \stdClass();
         $temp->title     = $node->title;
-        $temp->state     = $state;
         $temp->access    = $access;
         $temp->parent_id = $parentId;
         $temp->language  = $language;
@@ -174,7 +187,7 @@ class Taxonomy
         $result = $db->loadObject();
 
         // Check if the database matches the input data.
-        if ((bool) $result && $result->state == $node->state && $result->access == $node->access) {
+        if ((bool) $result && $result->access == $node->access) {
             // The data matches, add the item to the cache.
             static::$nodes[$parentId . ':' . $node->title] = $result;
 
@@ -192,7 +205,6 @@ class Taxonomy
         if (empty($result)) {
             // Prepare the node object.
             $nodeTable->title    = $node->title;
-            $nodeTable->state    = (int) $node->state;
             $nodeTable->access   = (int) $node->access;
             $nodeTable->language = $node->language;
             $nodeTable->setLocation((int) $parentId, 'last-child');
@@ -200,7 +212,6 @@ class Taxonomy
             // Prepare the node object.
             $nodeTable->id       = (int) $result->id;
             $nodeTable->title    = $result->title;
-            $nodeTable->state    = (int) ($node->state > 0 ? $node->state : $result->state);
             $nodeTable->access   = (int) $result->access;
             $nodeTable->language = $node->language;
             $nodeTable->setLocation($result->parent_id, 'last-child');


### PR DESCRIPTION
Pull Request for Issue #36980.

### Summary of Changes
While fixing the issue of #39944, it became clear that not only the content in the index had the issue that you couldn't reliably unpublish it, but that also the taxonomies had an issue with its state. Taxonomies tried to copy over the state from their input data and used that as state for the taxonomie itself. That means, that unpublished categories would have had been added as unpublished taxonomies to a content item. Now if you wanted to prevent a taxonomie to show up in the frontend, you were able to unpublish (or publish) the taxonomie, thus unsyncing the taxonomie and its datasource. You basically were able to set a category to unpublished, index an article from that category and in the resulting taxonomie, you would then be able to enable that again. 

At the same time, the state of the taxonomie was changed back to its datasource when the original content item was indexed again. So you unpublished a taxonomie, then edited an article and those taxonomies would be published again. This PR changes this now.

With this PR, Taxonomies now have their own, exclusive state and are either published or unpublished and that state is preserved across several indexing runs. At the same time, taxonomies are only added to the index when they are published, thus having state = 1. Since only published taxonomies show up in the frontend anyway, this doesn't change anything to existing sites.

Furthermore, this PR ensures that languages and access levels are set properly from the datasource and not just from the given method inputs. This specifically means, that the specific language of a category does not overwrite the "all" language of its parent category for example.  


### Testing Instructions
1. Create a category with language "all".
2. Create a second category inside the first with a specific language, like "english".
3. Create an article inside the second category with a specific language.
4. Enable the languagefilter plugin.
5. Go to the Content Maps of Smart Search and unpublish one of the categories.
6. Clear index and Reindex
7. Unpublish one of the categories in the category manager.
8. Clear index and Reindex

### Actual result BEFORE applying this Pull Request
Before the patch, the first category would also have the language "english". After reindexing, the unpublished category in the Content Maps is published again. After the second reindexing, the unpublished category and all its children is still listed as a taxonomy.


### Expected result AFTER applying this Pull Request
After the patch, the first category has the correct language "all". After reindexing, the unpublished in Content maps is still unpublished. After the second reindexing, the unpublished category and all its children are not listed as taxonomies anymore.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
