### PR TITLE
Fix TinyMCE images directory options if '/administrator/images' exists

### DIFF
--- a/plugins/editors/tinymce/src/Field/UploaddirsField.php
+++ b/plugins/editors/tinymce/src/Field/UploaddirsField.php
@@ -48,7 +48,7 @@ class UploaddirsField extends FolderlistField
         $return = parent::setup($element, $value, $group);
 
         // Get the path in which to search for file options.
-        $this->directory   = ComponentHelper::getParams('com_media')->get('image_path');
+        $this->directory   = JPATH_ROOT . '/' . ComponentHelper::getParams('com_media')->get('image_path');
         $this->recursive   = true;
         $this->hideDefault = true;
 


### PR DESCRIPTION
By creating the IMAGES directories in the ADMINISTRATOR directory. 
Create the TEST subdirectory in the IMAGES directory. 
Go to the settings of the Editor Tinymce plugin and select a subfolder to save images. 
We see that the list for selecting subfolders is limited to only one TEST folder. 
Thus, the list of the directory from the administrator folder is displayed in the plugin settings. But when saving image files in the materials manager, the files are still saved to the standard image folder. The presence of the IMAGES folder in the Admin folder breaks the configuration setting of the Tinymce editor plugin.

Fix bug fo ISSUE https://github.com/joomla/joomla-cms/issues/39946

Addition: 
# You need to test with having previously created the IMAGES directory in the ADMINISTRATOR directory. Otherwise, there is no point in testing.

### Addition @brianteeman

For others looking at this. It is an obscure but valid bug.

The images directory option in TinyMCE should look something like this

![Image](https://user-images.githubusercontent.com/1296369/221668182-fe376f5a-5e83-43bb-a200-a34215f0623d.png)

In other words it should be displaying the /images directory and all subdirectories.

The bug occurs if you also have a folder /administrator/images

That should have no effect on the field in tiinymce but as shown below it does
![Image](https://user-images.githubusercontent.com/1296369/221668638-ddc17961-ee6c-4141-b2c4-5ddc0ca0b767.png)
image