### PR TITLE
[4.3] Appveyor: Fixing openldap startup

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,8 +61,8 @@ before_test:
       $Counter=0
       $Found=$false
       While ( ! $Found -and $Counter -lt 60 ) {
-        docker logs openldap
-        $Found = ( docker logs openldap 2>&1 | Select-String -Quiet "\*\* slapd starting \*\*" )
+        docker logs openldap 2>&1 | Select-String -Quiet "\*\* Starting slapd \*\*"
+        $Found = ( docker logs openldap 2>&1 | Select-String -Quiet "\*\* Starting slapd \*\*" )
         Start-Sleep -Seconds 1
         $Counter++
         "$Counter Waiting for slapd"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,7 +61,7 @@ before_test:
       $Counter=0
       $Found=$false
       While ( ! $Found -and $Counter -lt 60 ) {
-        $Found = ( docker logs openldap 2>&1 | Select-String -Quiet "\*\* Starting slapd \*\*" )
+        $Found = ( docker logs openldap 2>&1 | Select-String -Quiet "\*\* slapd starting \*\*" )
         Start-Sleep -Seconds 1
         $Counter++
         "$Counter Waiting for slapd"

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -61,6 +61,7 @@ before_test:
       $Counter=0
       $Found=$false
       While ( ! $Found -and $Counter -lt 60 ) {
+        docker logs openldap
         $Found = ( docker logs openldap 2>&1 | Select-String -Quiet "\*\* slapd starting \*\*" )
         Start-Sleep -Seconds 1
         $Counter++


### PR DESCRIPTION
### Summary of Changes
Currently the appveyor builds fail because bitnami/openldap changed their startup text from "Starting slapd" to "slapd starting". This PR fixes that.


### Testing Instructions
Codereview.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
