### PR TITLE
Improve Finder ajax error handling

### DIFF
--- a/administrator/components/com_finder/tmpl/indexer/default.php
+++ b/administrator/components/com_finder/tmpl/indexer/default.php
@@ -13,7 +13,11 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
-Text::script('COM_FINDER_INDEXER_MESSAGE_COMPLETE', true);
+Text::script('COM_FINDER_INDEXER_MESSAGE_COMPLETE');
+Text::script('COM_FINDER_AN_ERROR_HAS_OCCURRED');
+Text::script('COM_FINDER_MESSAGE_RETURNED');
+Text::script('JLIB_JS_AJAX_ERROR_OTHER');
+Text::script('JLIB_JS_AJAX_ERROR_PARSE');
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();

--- a/build/media_source/com_finder/js/finder.es6.js
+++ b/build/media_source/com_finder/js/finder.es6.js
@@ -16,21 +16,21 @@
 
       Joomla.request({
         url: `${Joomla.getOptions('finder-search').url}&q=${target.value}`,
-        method: 'GET',
-        data: { q: target.value },
-        perform: true,
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        onSuccess: (resp) => {
-          const response = JSON.parse(resp);
-          if (Object.prototype.toString.call(response.suggestions) === '[object Array]') {
-            target.awesomplete.list = response.suggestions;
-          }
-        },
-        onError: (xhr) => {
-          if (xhr.status > 0) {
-            Joomla.renderMessages(Joomla.ajaxErrorsMessages(xhr));
-          }
-        },
+        promise: true,
+      }).then((xhr) => {
+        let response;
+        try {
+          response = JSON.parse(xhr.responseText);
+        } catch (e) {
+          Joomla.renderMessages(Joomla.ajaxErrorsMessages(xhr, 'parsererror'));
+          return;
+        }
+
+        if (Object.prototype.toString.call(response.suggestions) === '[object Array]') {
+          target.awesomplete.list = response.suggestions;
+        }
+      }).catch((xhr) => {
+        Joomla.renderMessages(Joomla.ajaxErrorsMessages(xhr));
       });
     }
   };

--- a/build/media_source/com_finder/js/indexer.es6.js
+++ b/build/media_source/com_finder/js/indexer.es6.js
@@ -142,7 +142,7 @@
         data = div.innerHTML;
 
         if (error instanceof SyntaxError) {
-          data = Joomla.Text._('JLIB_JS_AJAX_ERROR_PARSE').replace('%s', data)
+          data = Joomla.Text._('JLIB_JS_AJAX_ERROR_PARSE').replace('%s', data);
         }
       } else if (typeof error === 'object' && error.responseText) {
         data = error.responseText;

--- a/build/media_source/com_finder/js/indexer.es6.js
+++ b/build/media_source/com_finder/js/indexer.es6.js
@@ -130,17 +130,33 @@
       return true;
     };
 
-    const handleFailure = (xhr) => {
+    const handleFailure = (error) => {
       const progressHeader = document.getElementById('finder-progress-header');
       const progressMessage = document.getElementById('finder-progress-message');
+      let data;
 
-      let data = (typeof xhr === 'object' && xhr.responseText) ? xhr.responseText : null;
-      data = data ? JSON.parse(data) : null;
+      if (error instanceof Error) {
+        // Encode any html in the message
+        const div = document.createElement('div');
+        div.textContent = error.message;
+        data = div.innerHTML;
+
+        if (error instanceof SyntaxError) {
+          data = Joomla.Text._('JLIB_JS_AJAX_ERROR_PARSE').replace('%s', data)
+        }
+      } else if (typeof error === 'object' && error.responseText) {
+        data = error.responseText;
+        try {
+          data = JSON.parse(data);
+        } catch (e) {
+          data = Joomla.Text._('JLIB_JS_AJAX_ERROR_OTHER').replace('%s', error.status);
+        }
+      }
 
       removeElement('progress');
 
-      const header = data ? data.header : Joomla.Text._('COM_FINDER_AN_ERROR_HAS_OCCURRED');
-      const message = data ? data.message : `${Joomla.Text._('COM_FINDER_MESSAGE_RETURNED')}<br>${data}`;
+      const header = data && data.header ? data.header : Joomla.Text._('COM_FINDER_AN_ERROR_HAS_OCCURRED');
+      const message = data && data.message ? data.message : `${Joomla.Text._('COM_FINDER_MESSAGE_RETURNED')}<br>${data}`;
 
       if (progressHeader) {
         progressHeader.innerText = header;
@@ -155,16 +171,11 @@
     getRequest = (task) => {
       Joomla.request({
         url: `${path}&task=${task}${token}`,
-        method: 'GET',
-        data: '',
-        perform: true,
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-        onSuccess: (response) => {
-          handleResponse(JSON.parse(response));
-        },
-        onError: (xhr) => {
-          handleFailure(xhr);
-        },
+        promise: true,
+      }).then((xhr) => {
+        handleResponse(JSON.parse(xhr.responseText));
+      }).catch((error) => {
+        handleFailure(error);
       });
     };
 

--- a/components/com_finder/tmpl/search/default_form.php
+++ b/components/com_finder/tmpl/search/default_form.php
@@ -20,6 +20,9 @@ use Joomla\CMS\Router\Route;
 if ($this->params->get('show_autosuggest', 1)) {
     $this->document->getWebAssetManager()->usePreset('awesomplete');
     $this->document->addScriptOptions('finder-search', ['url' => Route::_('index.php?option=com_finder&task=suggestions.suggest&format=json&tmpl=component', false)]);
+
+    Text::script('JLIB_JS_AJAX_ERROR_OTHER');
+    Text::script('JLIB_JS_AJAX_ERROR_PARSE');
 }
 
 ?>

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -39,7 +39,7 @@ if ($params->get('show_button', 0)) {
     $output .= $input;
 }
 
-Text::script('MOD_FINDER_SEARCH_VALUE', true);
+Text::script('MOD_FINDER_SEARCH_VALUE');
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $app->getDocument()->getWebAssetManager();
@@ -51,6 +51,9 @@ $wa->getRegistry()->addExtensionRegistryFile('com_finder');
 if ($params->get('show_autosuggest', 1)) {
     $wa->usePreset('awesomplete');
     $app->getDocument()->addScriptOptions('finder-search', ['url' => Route::_('index.php?option=com_finder&task=suggestions.suggest&format=json&tmpl=component', false)]);
+
+    Text::script('JLIB_JS_AJAX_ERROR_OTHER');
+    Text::script('JLIB_JS_AJAX_ERROR_PARSE');
 }
 
 $wa->useScript('com_finder.finder');


### PR DESCRIPTION
Pull Request for Issue #39717 and #39965 .

### Summary of Changes

Catch broken json and show an error message.
For Finder indexer, and for Finder autocomplete.


### Testing Instructions
Apply patch, run `npm install`.

1) Repeat test from #39965
Go to a finder plugin, for example `/plugins/finder/content/src/Extension/Content.php` and trigger any output in the `index()` method. For example you can add `var_dump($item->title)`.
In the Smart Search component in the backend click on "Index".

2) And similar for Autocomplete.
Add `var_dump(['error'])` somewhere here https://github.com/joomla/joomla-cms/blob/10f250f418851674c2e4104b6b39b9b665496544/components/com_finder/src/Controller/SuggestionsController.php#L34-L38
Make sure autocomplete is enabled, then go to site search page, and try to search something.


### Actual result BEFORE applying this Pull Request
The ajax stops without any visible signs of life.


### Expected result AFTER applying this Pull Request
You should get an error message.


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
