### PR TITLE
[4.3] Updating cypress to 12.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,7 @@
         "commander": "^8.3.0",
         "core-js": "^3.19.3",
         "cssnano": "^5.0.12",
-        "cypress": "^10.3.1",
+        "cypress": "^12.7.0",
         "eslint": "^8.4.1",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.25.3",
@@ -3494,9 +3494,9 @@
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg=="
     },
     "node_modules/cypress": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.11.0.tgz",
-      "integrity": "sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -3517,7 +3517,7 @@
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",
@@ -3547,7 +3547,7 @@
         "cypress": "bin/cypress"
       },
       "engines": {
-        "node": ">=12.0.0"
+        "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
       }
     },
     "node_modules/cypress/node_modules/@types/node": {
@@ -12066,9 +12066,9 @@
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg=="
     },
     "cypress": {
-      "version": "10.11.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-10.11.0.tgz",
-      "integrity": "sha512-lsaE7dprw5DoXM00skni6W5ElVVLGAdRUUdZjX2dYsGjbY/QnpzWZ95Zom1mkGg0hAaO/QVTZoFVS7Jgr/GUPA==",
+      "version": "12.7.0",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.7.0.tgz",
+      "integrity": "sha512-7rq+nmhzz0u6yabCFyPtADU2OOrYt6pvUau9qV7xyifJ/hnsaw/vkr0tnLlcuuQKUAOC1v1M1e4Z0zG7S0IAvA==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",
@@ -12088,7 +12088,7 @@
         "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "dayjs": "^1.10.4",
-        "debug": "^4.3.2",
+        "debug": "^4.3.4",
         "enquirer": "^2.3.6",
         "eventemitter2": "6.4.7",
         "execa": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "commander": "^8.3.0",
     "core-js": "^3.19.3",
     "cssnano": "^5.0.12",
-    "cypress": "^10.3.1",
+    "cypress": "^12.7.0",
     "eslint": "^8.4.1",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.25.3",


### PR DESCRIPTION
So, cypress 10.11.0 was the last release in the 10.x series and in the meantime they released not one, but two major releases... This updates cypress to 12.7.0, which is completely compatible with our system and still has lower requirements than we have for Joomla. https://docs.cypress.io/guides/references/changelog