### PR TITLE
[4.3] Smart Search: Fixing toolbar button name

### DIFF
--- a/administrator/components/com_finder/src/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Index/HtmlView.php
@@ -215,7 +215,7 @@ class HtmlView extends BaseHtmlView
                 $childBar = $dropdown->getChildToolbar();
 
                 $childBar->standardButton('cog', 'COM_FINDER_INDEX_TOOLBAR_OPTIMISE', 'index.optimise', false);
-                $childBar->confirmButton('index.purge', 'COM_FINDER_INDEX_TOOLBAR_PURGE', 'index.purge')
+                $childBar->confirmButton('index-purge', 'COM_FINDER_INDEX_TOOLBAR_PURGE', 'index.purge')
                     ->message('COM_FINDER_INDEX_CONFIRM_PURGE_PROMPT')
                     ->icon('icon-trash');
             }


### PR DESCRIPTION
### Summary of Changes
The "Clear Index" button currently has the name `index.purge`, which results in a class with the name `button-index.purge`. Notice the . in the class name, which is an invalid class name. This PR renames that button to `index-purge`.


### Testing Instructions
Codereview.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
