### PR TITLE
[4.2] Update deleted files and folders lists in script.php for upcoming 4.2.9

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6465,6 +6465,10 @@ class JoomlaInstallerScript
             '/administrator/cache/fido.jwt',
             // From 4.2.6 to 4.2.7
             '/libraries/vendor/maximebf/debugbar/src/DebugBar/DataFormatter/VarDumper/SeekingData.php',
+            // From 4.2.8 to 4.2.9
+            '/administrator/components/com_scheduler/tmpl/select/modal.php',
+            '/components/com_contact/layouts/field/render.php',
+            '/components/com_contact/layouts/fields/render.php',
         ];
 
         $folders = [
@@ -7839,6 +7843,10 @@ class JoomlaInstallerScript
             '/media/vendor/hotkeys.js/js',
             '/media/vendor/hotkeys.js',
             '/libraries/vendor/symfony/string/Resources/bin',
+            // From 4.2.8 to 4.2.9
+            '/components/com_contact/layouts/fields',
+            '/components/com_contact/layouts/field',
+            '/components/com_contact/layouts',
         ];
 
         $status['files_checked'] = $files;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in file "administrator/components/com_admin/script.php" to recent changes in the 4.2-dev branch in preparation for the upcoming 4.2.9 release.

In detail deleted files from following PR's are added:

- PR #38959 :
file '/administrator/components/com_scheduler/tmpl/select/modal.php'
- PR #37716 :
files '/components/com_contact/layouts/field/render.php' and '/components/com_contact/layouts/fields/render.php'
and folder '/components/com_contact/layouts' with its subfolders 'field' and 'fields'

### Testing Instructions

Code review.

Or if you want to make a real test, update a 4.2.8 or any older 4.x version to the last 4.2-dev nightly build to get the actual result, and update a 4.2.8 or any older 4.x version to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

The files and folders mentioned above are still present after updating from a 4.2.8 or any older 4.x version.

### Expected result AFTER applying this Pull Request

The files and folders mentioned above have been deleted after updating from a 4.2.8 or any older 4.x version.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
