### PR TITLE
[5.x] jexit never return

### DIFF
--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -691,12 +691,12 @@ if (!function_exists('jexit')) {
      *
      * @param   mixed  $message  Exit code or string. Defaults to zero.
      *
-     * @return  void
+     * @return  never
      *
      * @codeCoverageIgnore
      * @since   1.7.0
      */
-    function jexit($message = 0)
+    function jexit($message = 0): never
     {
         exit($message);
     }


### PR DESCRIPTION
Add type hint to jexit because it will never return

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
