### PR TITLE
In com_tags, a tagged element's text-variable is transformed into nul…

### DIFF
--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -190,7 +190,7 @@ class HtmlView extends BaseHtmlView
             $itemElement->event = new \stdClass();
 
             // For some plugins.
-            $itemElement->text = !empty($itemElement->core_body) ? $itemElement->core_body : null;
+            $itemElement->text = !empty($itemElement->core_body) ? $itemElement->core_body : '';
 
             $itemElement->core_params = new Registry($itemElement->core_params);
 


### PR DESCRIPTION
Deprecation messages are shown for some tagged elements: 
![image](https://user-images.githubusercontent.com/3834825/212553903-d29d036f-ff70-429c-b25c-89a189a5365f.png)

### Summary of Changes
In com_tags, a tagged element's text-variable is transformed into null if the value is empty. 
That causes deprecation messages in plugins like loadmodules and emailcloak. They usually don't need to check for null values in $article->text. 

### Testing Instructions

1. configure PHP to show deprecation messages
2. create a new contact using com_contact: just enter a name and tag it with "testtag"
3. open the frontend /index.php?option=com_tags&view=tags
4. click on the new tag 'testtag'.
5. see the deprecation messages.


### Actual result BEFORE applying this Pull Request

Following the test instructions, deprecation messages are shown


### Expected result AFTER applying this Pull Request

Following the test instructions, deprecation messages are now shown


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
