### PR TITLE
Changing the order of calling events for fields. FieldsHelper.php

### DIFF
--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -176,6 +176,8 @@ class FieldsHelper
 
             $new = [];
 
+            $render = [];
+
             foreach ($fields as $key => $original) {
                 /*
                  * Doing a clone, otherwise fields for different items will
@@ -207,24 +209,36 @@ class FieldsHelper
                      */
                     Factory::getApplication()->triggerEvent('onCustomFieldsBeforePrepareField', [$context, $item, &$field]);
 
-                    // Gathering the value for the field
-                    $value = Factory::getApplication()->triggerEvent('onCustomFieldsPrepareField', [$context, $item, &$field]);
-
-                    if (is_array($value)) {
-                        $value = implode(' ', $value);
-                    }
-
-                    /*
-                     * On after field render
-                     * Event allows plugins to modify the output of the prepared field
-                     */
-                    Factory::getApplication()->triggerEvent('onCustomFieldsAfterPrepareField', [$context, $item, $field, &$value]);
-
-                    // Assign the value
-                    $field->value = $value;
+                    $render[$key] = $field;
                 }
 
                 $new[$key] = $field;
+            }
+
+            foreach ($render as $key => &$field) {
+                // Gathering the value for the field
+                $value = Factory::getApplication()->triggerEvent('onCustomFieldsPrepareField', [$context, $item, &$field]);
+
+                if (is_array($value)) {
+                    $value = implode(' ', $value);
+                }
+
+                $contents[$key] = $value;
+            }
+
+            foreach ($render as $key => &$field) {
+                $value = $contents[$key];
+                /*
+                 * On after field render
+                 * Event allows plugins to modify the output of the prepared field
+                 */
+                Factory::getApplication()->triggerEvent('onCustomFieldsAfterPrepareField', [$context, $item, $field, &$value]);
+
+                // Assign the value
+                $field->value = $value;
+
+                // Assign the render value
+                $field->content = &$field->value;
             }
 
             $fields = $new;


### PR DESCRIPTION
`Due to my confusion with the branches, I have recreated a new PR.` https://github.com/joomla/joomla-cms/pull/37765

Pull Request for Issue # .
Changed the call of the methods of the event manager.
 It was previously done so that for each field 3 dispatcher events were called. For each field, all three events were called at once.  After calling 3 events occurs for each new field.
In the new PR, the call of events will be called in a new order.
 At the beginning, the first event will be called for all fields. Then, for all fields, a second event is called. And then for all fields calling the third event.

### Summary of Changes
Instead of one `foreach()` in which 3 events are called.
I made 3`foreach()` in each call one event.

When you open a list of materials on the site. For each material, the same field is displayed. In the case when it is required to have dynamic field data for each material in the list of materials. It may be necessary for the field to have data not only of its material, but also data of all materials. For example, so that each field in the list of materials can have the total value of all data from other fields of the same type

### Testing Instructions
```PHP
class PlgFieldsText extends \Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin{
	public $summ = 0;
	public function onCustomFieldsBeforePrepareField($context, $item, $field){
		if($field->type != 'text')
			return;
		$this->summ += (int)$field->value;
	}
	public function onCustomFieldsAfterPrepareField($context, $item, $field, &$value){
		if($field->type != 'text')
			return;
		$value .= ' - Total amount: '. $this->summ;
	}
}
```
It should be borne in mind that the value of the text field must be a number.
This example shows the possibilities.


### Actual result BEFORE applying this Pull Request
```PHP
// Result field for article 1:  1 - Total amount: 1
// Result field for article 2:  2 - Total amount: 2
// Result field for article 3:  3 - Total amount: 3
```

### Expected result AFTER applying this Pull Request

```PHP
// Result field for article 1:  1 - Total amount: 6
// Result field for article 2:  2 - Total amount: 6
// Result field for article 3:  3 - Total amount: 6
```


### Documentation Changes Required
Not Required


The procedure for calling methods before
Field Article 1 - onCustomFieldsBeforePrepareField()
Field Article 1 - onCustomFieldsAfterPrepareField()
Field Article 2 - onCustomFieldsBeforePrepareField()
Field Article 2 - onCustomFieldsAfterPrepareField()

The procedure for calling methods after
Field Article 1 - onCustomFieldsBeforePrepareField()
Field Article 2 - onCustomFieldsBeforePrepareField()
Field Article 1 - onCustomFieldsAfterPrepareField()
Field Article 2 - onCustomFieldsAfterPrepareField()

The bottom line is that calls should not depend on the order. I completely agree with this. But in cases where it requires the output of fields on the page with a dependency on the order, there is no way to do this. This is required for dynamic data output. In cases where the order of output on the page depends on the content of the data.

This does not violate backward compatibility. Since all static values are rendered in exactly the same way. Also, it does not violate the output of dynamic values. Since if someone outputs dynamic values, then he does not use the existing output order.

This PR is based on making 2 small FORECH out of one FOREACH. By separating plugin calls in separate iterations.

This PR is based on a closed PR https://github.com/joomla/joomla-cms/pull/37765
I inform all participants of the last PR
@laoneo  @HLeithner  
