### PR TITLE
Default the ordering parameter in the latest articles module

### DIFF
--- a/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
+++ b/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
@@ -124,7 +124,7 @@ class ArticlesLatestHelper implements DatabaseAwareInterface
             'random' => $db->getQuery(true)->rand(),
         ];
 
-        $ordering = ArrayHelper::getValue($order_map, $params->get('ordering'), 'a.publish_up');
+        $ordering = ArrayHelper::getValue($order_map, $params->get('ordering', 'p_dsc'), 'a.publish_up');
         $dir      = 'DESC';
 
         $model->setState('list.ordering', $ordering);

--- a/tests/cypress/integration/site/modules/mod_articles_latest/Default.cy.js
+++ b/tests/cypress/integration/site/modules/mod_articles_latest/Default.cy.js
@@ -1,7 +1,7 @@
 describe('Test that the latest articles module', () => {
   it('can load in frontend without ordering parameter', () => {
     cy.db_createArticle({ title: 'automated test article' })
-      .then(() => cy.db_createModule({ module: 'mod_articles_latest'}))
+      .then(() => cy.db_createModule({ module: 'mod_articles_latest' }))
       .then(() => {
         cy.visit('/');
 

--- a/tests/cypress/integration/site/modules/mod_articles_latest/Default.cy.js
+++ b/tests/cypress/integration/site/modules/mod_articles_latest/Default.cy.js
@@ -1,0 +1,11 @@
+describe('Test that the latest articles module', () => {
+  it('can load in frontend without ordering parameter', () => {
+    cy.db_createArticle({ title: 'automated test article' })
+      .then(() => cy.db_createModule({ module: 'mod_articles_latest'}))
+      .then(() => {
+        cy.visit('/');
+
+        cy.contains('li', 'automated test article');
+      });
+  });
+});


### PR DESCRIPTION
### Summary of Changes
When no ordering parameter exists in the latest module configuration, then is the following deprecated warning displayed:

_strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in /libraries/vendor/joomla/utilities/src/ArrayHelper.php on line 368_

### Testing Instructions
- Create some articles
- Create a latest articles module
- Delete the params value in the modules table for the newly created module
- Open the front end

### Actual result BEFORE applying this Pull Request
The deprecated warning mentioned before is displayed.

### Expected result AFTER applying this Pull Request
No warning is displayed.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
