### PR TITLE
[4.3][Guided Tours] Fix DESCRIPTION: search

### DIFF
--- a/administrator/components/com_guidedtours/src/Model/StepsModel.php
+++ b/administrator/components/com_guidedtours/src/Model/StepsModel.php
@@ -193,7 +193,7 @@ class StepsModel extends ListModel
                 $query->where($db->quoteName('a.id') . ' = :search')
                     ->bind(':search', $search, ParameterType::INTEGER);
             } elseif (stripos($search, 'description:') === 0) {
-                $search = '%' . substr($search, 8) . '%';
+                $search = '%' . substr($search, 12) . '%';
                 $query->where('(' . $db->quoteName('a.description') . ' LIKE :search1)')
                     ->bind([':search1'], $search);
             } else {

--- a/administrator/components/com_guidedtours/src/Model/ToursModel.php
+++ b/administrator/components/com_guidedtours/src/Model/ToursModel.php
@@ -213,7 +213,7 @@ class ToursModel extends ListModel
                 $query->where($db->quoteName('a.id') . ' = :search')
                     ->bind(':search', $search, ParameterType::INTEGER);
             } elseif (stripos($search, 'description:') === 0) {
-                $search = '%' . substr($search, 8) . '%';
+                $search = '%' . substr($search, 12) . '%';
                 $query->where('(' . $db->quoteName('a.description') . ' LIKE :search1)')
                     ->bind([':search1'], $search);
             } else {


### PR DESCRIPTION
### Summary of Changes
`DESCRIPTION:` length is 12 and not 8. Probably a copy/paste error from `CONTENT:`


### Testing Instructions
Code review.
or
Go to System > Guided Tours.
In the search box, enter `DESCRIPTION:article`.


### Actual result BEFORE applying this Pull Request
No match results.


### Expected result AFTER applying this Pull Request
1 found.
