### PR TITLE
Prevent Exception

### DIFF
--- a/plugins/content/fields/src/Extension/Fields.php
+++ b/plugins/content/fields/src/Extension/Fields.php
@@ -91,7 +91,7 @@ final class Fields extends CMSPlugin
 
         $parts = FieldsHelper::extract($context);
 
-        if ($parts && count($parts) < 2) {
+        if (!$parts || count($parts) < 2) {
             return $string;
         }
 

--- a/plugins/content/fields/src/Extension/Fields.php
+++ b/plugins/content/fields/src/Extension/Fields.php
@@ -91,7 +91,7 @@ final class Fields extends CMSPlugin
 
         $parts = FieldsHelper::extract($context);
 
-        if (count($parts) < 2) {
+        if ($parts && count($parts) < 2) {
             return $string;
         }
 


### PR DESCRIPTION
If $parts is `null` this will throw an exception in PHP 8+, a warning in PHP 7.

```count(): Argument #1 ($value) must be of type Countable|array, null given```

This can happen if the context is e.g. the default context `text` from the `Joomla\CMS\HTML\Helpers\Content::prepare()` function.

Pull Request for Issue #40121.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
