### PR TITLE
[4.4] Add text deprecated version + description to actual status in module helper

### DIFF
--- a/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
+++ b/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
@@ -156,7 +156,11 @@ class ArticlesLatestHelper implements DatabaseAwareInterface
      *
      * @since   1.6
      *
-     * @deprecated 5.0 Use the none static function getArticles
+     * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
+     *             Use the none static method getArticles
+     *             Example: Factory::getApplication()->bootModule('mod_articles_latest', 'site')
+     *                          ->getHelper('ArticlesLatestHelper')
+     *                          ->getArticles($params, Factory::getApplication())
      */
     public static function getList(Registry $params, ArticlesModel $model)
     {

--- a/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
+++ b/modules/mod_articles_latest/src/Helper/ArticlesLatestHelper.php
@@ -157,7 +157,7 @@ class ArticlesLatestHelper implements DatabaseAwareInterface
      * @since   1.6
      *
      * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
-     *             Use the none static method getArticles
+     *             Use the non-static method getArticles
      *             Example: Factory::getApplication()->bootModule('mod_articles_latest', 'site')
      *                          ->getHelper('ArticlesLatestHelper')
      *                          ->getArticles($params, Factory::getApplication())

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -197,7 +197,7 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
      * @since 1.6
      *
      * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
-     *             Use the none static method getArticles
+     *             Use the non-static method getArticles
      *             Example: Factory::getApplication()->bootModule('mod_articles_news', 'site')
      *                          ->getHelper('ArticlesNewsHelper')
      *                          ->getArticles($params, Factory::getApplication())

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -196,7 +196,11 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
      *
      * @since 1.6
      *
-     * @deprecated 5.0 Use the none static function getArticles
+     * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
+     *             Use the none static method getArticles
+     *             Example: Factory::getApplication()->bootModule('mod_articles_news', 'site')
+     *                          ->getHelper('ArticlesNewsHelper')
+     *                          ->getArticles($params, Factory::getApplication())
      */
     public static function getList(&$params)
     {

--- a/modules/mod_articles_popular/src/Helper/ArticlesPopularHelper.php
+++ b/modules/mod_articles_popular/src/Helper/ArticlesPopularHelper.php
@@ -171,7 +171,11 @@ class ArticlesPopularHelper
      *
      * @since  4.3.0
      *
-     * @deprecated 5.0 Use the none static function getArticles
+     * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
+     *             Use the none static method getArticles
+     *             Example: Factory::getApplication()->bootModule('mod_articles_popular', 'site')
+     *                          ->getHelper('ArticlesPopularHelper')
+     *                          ->getArticles($params, Factory::getApplication())
      */
     public static function getList(&$params)
     {

--- a/modules/mod_articles_popular/src/Helper/ArticlesPopularHelper.php
+++ b/modules/mod_articles_popular/src/Helper/ArticlesPopularHelper.php
@@ -172,7 +172,7 @@ class ArticlesPopularHelper
      * @since  4.3.0
      *
      * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
-     *             Use the none static method getArticles
+     *             Use the non-static method getArticles
      *             Example: Factory::getApplication()->bootModule('mod_articles_popular', 'site')
      *                          ->getHelper('ArticlesPopularHelper')
      *                          ->getArticles($params, Factory::getApplication())

--- a/modules/mod_users_latest/src/Helper/UsersLatestHelper.php
+++ b/modules/mod_users_latest/src/Helper/UsersLatestHelper.php
@@ -86,7 +86,7 @@ class UsersLatestHelper implements DatabaseAwareInterface
      * @since   1.6
      *
      * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
-     *             Use the none static method getLatestUsers
+     *             Use the non-static method getLatestUsers
      *             Example: Factory::getApplication()->bootModule('mod_users_latest', 'site')
      *                          ->getHelper('UsersLatestHelper')
      *                          ->getLatestUsers($params, Factory::getApplication())


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Some modules (site) have already been rebuilt to the new joomla structure.
We keep the static method in Helper class for backward compatible purpose.

The version and the text of the deprecated description was recently changed. 
See: _Make UsersLatestHelper backward compatible_ #40143 (file: UsersLatestHelper.php)

This PR adjusts the description in the other relevant modules.
Files: ArticlesLatestHelper.php, ArticlesNewsHelper.php, ArticlesPopularHelper.php

Also has been changed: file UsersLatestHelper.php

### Testing Instructions

Code review

### Actual result BEFORE applying this Pull Request

Class DocBlock Headers: @deprecated are NOT up-to-date and NOT consistent

### Expected result AFTER applying this Pull Request

Class DocBlock Headers: @deprecated are up-to-date and consistent

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

[EDIT]