### PR TITLE
[5.0] Remove obsolete dropUtf8ConversionTable function from script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1140,26 +1140,6 @@ class JoomlaInstallerScript
     }
 
     /**
-     * This method drops the #__utf8_conversion table
-     *
-     * @return  boolean  True on success
-     *
-     * @since   4.0.0
-     */
-    private function dropUtf8ConversionTable()
-    {
-        $db = Factory::getDbo();
-
-        try {
-            $db->setQuery('DROP TABLE ' . $db->quoteName('#__utf8_conversion') . ';')->execute();
-        } catch (Exception $e) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
      * Called after any type of action
      *
      * @param   string     $action     Which action is happening (install|uninstall|discover_install|update)


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) removes the private function "dropUtf8ConversionTable" from the script.php file.

I have simply overlooked that when I made my meanwhile merged PR #38406 for removing the utf8mb4 conversion in Joomla 5.

### Testing Instructions

Code review:

Verify on the 5.0-dev branch that function "dropUtf8ConversionTable" is not called anywhere.

### Actual result BEFORE applying this Pull Request

Obsolete private function "dropUtf8ConversionTable" present in script.php.

### Expected result AFTER applying this Pull Request

Obsolete private function "dropUtf8ConversionTable" not present in script.php.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
