### PR TITLE
[5.2] Category Item count takes publish dates into account

### DIFF
--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -360,6 +360,7 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
                     'OR'
                 );
 
+                $now = Factory::getDate()->toSql();
                 $query->bind(':publishUp', $now);
                 $query->bind(':publishDown', $now);
             }

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -342,7 +342,26 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
                 ->where($db->quoteName($db->escape('i.' . $this->_field)) . ' = ' . $db->quoteName('c.id'));
 
             if ($this->_options['published'] == 1) {
-                $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1');
+                $subQuery->where($db->quoteName($db->escape('i.' . $this->_statefield)) . ' = 1')
+                ->extendWhere(
+                    'AND',
+                    [
+                        $db->quoteName('i.publish_up') . ' IS NULL',
+                        $db->quoteName('i.publish_up') . ' <= :publishUp',
+                    ],
+                    'OR'
+                )
+                ->extendWhere(
+                    'AND',
+                    [
+                        $db->quoteName('i.publish_down') . ' IS NULL',
+                        $db->quoteName('i.publish_down') . ' >= :publishDown',
+                    ],
+                    'OR'
+                );
+
+                $query->bind(':publishUp', $now);
+                $query->bind(':publishDown', $now);
             }
 
             if ($this->_options['currentlang'] !== 0) {


### PR DESCRIPTION
### Summary of Changes
Item count on a category takes the publish_up and publish_down dates into account.


### Actual result BEFORE applying this Pull Request
When setting a publish_down date in the past to unpublish an article the item count on a category will still count this article as published. And vice versa with  a publish_up date in the future. The Categories view shows a different amount of articles than actually visible on the Category Blog view


### Expected result AFTER applying this Pull Request
Categories view will show the exact number of articles published in a category.
