### PR TITLE
[4.3] Revert CSP related changes in Grid.php (back to inline scripts)

### DIFF
--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -50,18 +50,6 @@ if (substr($className, -1) === 's') {
 }
 
 $tagsData = $category->tags->itemTags;
-
-$app->getDocument()->getWebAssetManager()->addInlineScript(
-    <<<JS
-document.querySelectorAll('.js-column-order').forEach((item) => item.addEventListener('click', (event) => {
-    event.preventDefault();
-    const element = event.target.tagName.toLowerCase() === 'span' ? event.target.parentNode : event.target;
-    Joomla.tableOrdering(element.getAttribute('data-ordering-order'), element.getAttribute('data-ordering-direction'), element.getAttribute('data-ordering-task'), element.closest('form'));
-}));
-JS,
-    [],
-    ['type' => 'module']
-);
 ?>
 <div class="<?php echo $className . '-category' . $displayData->pageclass_sfx; ?>">
     <?php if ($params->get('show_page_heading')) : ?>

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -50,6 +50,17 @@ if (substr($className, -1) === 's') {
 }
 
 $tagsData = $category->tags->itemTags;
+
+$app->getDocument()->getWebAssetManager()->addInlineScript(<<<JS
+document.querySelectorAll('.js-column-order').forEach((item) => item.addEventListener('click', (event) => {
+    event.preventDefault();
+    const element = event.target.tagName.toLowerCase() === 'span' ? event.target.parentNode : event.target;
+    Joomla.tableOrdering(element.getAttribute('data-ordering-order'), element.getAttribute('data-ordering-direction'), element.getAttribute('data-ordering-task'), element.closest('form'));
+}));
+JS,
+    [],
+    ['type' => 'module']
+);
 ?>
 <div class="<?php echo $className . '-category' . $displayData->pageclass_sfx; ?>">
     <?php if ($params->get('show_page_heading')) : ?>

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -51,7 +51,8 @@ if (substr($className, -1) === 's') {
 
 $tagsData = $category->tags->itemTags;
 
-$app->getDocument()->getWebAssetManager()->addInlineScript(<<<JS
+$app->getDocument()->getWebAssetManager()->addInlineScript(
+    <<<JS
 document.querySelectorAll('.js-column-order').forEach((item) => item.addEventListener('click', (event) => {
     event.preventDefault();
     const element = event.target.tagName.toLowerCase() === 'span' ? event.target.parentNode : event.target;

--- a/libraries/src/HTML/Helpers/Grid.php
+++ b/libraries/src/HTML/Helpers/Grid.php
@@ -43,7 +43,6 @@ abstract class Grid
      */
     public static function sort($title, $order, $direction = 'asc', $selected = '', $task = null, $newDirection = 'asc', $tip = '', $form = null)
     {
-        Factory::getDocument()->getWebAssetManager()->useScript('list-view');
         HTMLHelper::_('bootstrap.tooltip', '.hasTooltip');
 
         $direction = strtolower($direction);
@@ -56,12 +55,12 @@ abstract class Grid
             $direction = $direction === 'desc' ? 'asc' : 'desc';
         }
 
-        $html = '<a href="#" class="hasTooltip js-column-order" title="' . htmlspecialchars(Text::_('JGLOBAL_CLICK_TO_SORT_THIS_COLUMN')) . '"'
-            . ' data-ordering-order="' . $order . '"'
-            . ' data-ordering-direction="' . $direction . '"'
-            . ' data-ordering-task="' . $task . '"'
-            . ' data-ordering-form="' . (isset($form) ? $form : '') . '"'
-            . ' data-bs-placement="top">';
+        if ($form) {
+            $form = ', document.getElementById(\'' . $form . '\')';
+        }
+
+        $html = '<a href="#" onclick="Joomla.tableOrdering(\'' . $order . '\',\'' . $direction . '\',\'' . $task . '\'' . $form . ');return false;"'
+        . ' class="hasTooltip" title="' . htmlspecialchars(Text::_('JGLOBAL_CLICK_TO_SORT_THIS_COLUMN')) . '" data-bs-placement="top">';
 
         if (isset($title['0']) && $title['0'] === '<') {
             $html .= $title;
@@ -90,15 +89,9 @@ abstract class Grid
      */
     public static function checkall($name = 'checkall-toggle', $action = 'Joomla.checkAll(this)')
     {
-        Factory::getDocument()->getWebAssetManager()->useScript('list-view');
+        HTMLHelper::_('behavior.core');
 
-        if ($action !== 'Joomla.checkAll(this)') {
-            $action = ' onclick="' . $action . '"';
-        } else {
-            $action = '';
-        }
-
-        return '<input class="js-grid-item-check-all form-check-input" autocomplete="off" type="checkbox" name="' . $name . '" value="" title="' . Text::_('JGLOBAL_CHECK_ALL') . '"' . $action . '>';
+        return '<input class="form-check-input" autocomplete="off" type="checkbox" name="' . $name . '" value="" title="' . Text::_('JGLOBAL_CHECK_ALL') . '" onclick="' . $action . '">';
     }
 
     /**
@@ -118,12 +111,17 @@ abstract class Grid
      */
     public static function id($rowNum, $recId, $checkedOut = false, $name = 'cid', $stub = 'cb', $title = '', $formId = null)
     {
-        Factory::getDocument()->getWebAssetManager()->useScript('list-view');
+        if ($formId !== null) {
+            return $checkedOut ? '' : '<label for="' . $stub . $rowNum . '"><span class="visually-hidden">' . Text::_('JSELECT')
+            . ' ' . htmlspecialchars($title, ENT_COMPAT, 'UTF-8') . '</span></label>'
+            . '<input class="form-check-input" type="checkbox" id="' . $stub . $rowNum . '" name="' . $name . '[]" value="' . $recId
+                . '" onclick="Joomla.isChecked(this.checked, \'' . $formId . '\');">';
+        }
 
         return $checkedOut ? '' : '<label for="' . $stub . $rowNum . '"><span class="visually-hidden">' . Text::_('JSELECT')
         . ' ' . htmlspecialchars($title, ENT_COMPAT, 'UTF-8') . '</span></label>'
-        . '<input class="js-grid-item-is-checked form-check-input" autocomplete="off" type="checkbox" id="' . $stub . $rowNum . '" name="' . $name . '[]" value="' . $recId
-            . '"' . ($formId !== null ? ' data-form-id="' . $formId . '"' : '') . '>';
+        . '<input class="form-check-input" autocomplete="off" type="checkbox" id="' . $stub . $rowNum . '" name="' . $name . '[]" value="' . $recId
+            . '" onclick="Joomla.isChecked(this.checked);">';
     }
 
     /**
@@ -174,8 +172,6 @@ abstract class Grid
      */
     public static function published($value, $i, $img1 = 'tick.png', $img0 = 'publish_x.png', $prefix = '')
     {
-        Factory::getDocument()->getWebAssetManager()->useScript('list-view');
-
         if (is_object($value)) {
             $value = $value->published;
         }
@@ -185,7 +181,7 @@ abstract class Grid
         $alt    = $value ? Text::_('JPUBLISHED') : Text::_('JUNPUBLISHED');
         $action = $value ? Text::_('JLIB_HTML_UNPUBLISH_ITEM') : Text::_('JLIB_HTML_PUBLISH_ITEM');
 
-        return '<a href="#" class="js-grid-item-action" data-item-id="cb' . $i . '" data-item-task="' . $prefix . $task . '" title="' . $action . '">'
+        return '<a href="#" onclick="return Joomla.listItemTask(\'cb' . $i . '\',\'' . $prefix . $task . '\')" title="' . $action . '">'
             . HTMLHelper::_('image', 'admin/' . $img, $alt, null, true) . '</a>';
     }
 
@@ -220,9 +216,9 @@ abstract class Grid
             $state,
             'filter_state',
             [
-                'list.attr'   => 'class="form-select" size="1" onchange="Joomla.submitform();"',
+                'list.attr' => 'class="form-select" size="1" onchange="Joomla.submitform();"',
                 'list.select' => $filterState,
-                'option.key'  => null,
+                'option.key' => null,
             ]
         );
     }

--- a/libraries/src/HTML/Helpers/Grid.php
+++ b/libraries/src/HTML/Helpers/Grid.php
@@ -216,9 +216,9 @@ abstract class Grid
             $state,
             'filter_state',
             [
-                'list.attr' => 'class="form-select" size="1" onchange="Joomla.submitform();"',
+                'list.attr'   => 'class="form-select" size="1" onchange="Joomla.submitform();"',
                 'list.select' => $filterState,
-                'option.key' => null,
+                'option.key'  => null,
             ]
         );
     }

--- a/libraries/src/HTML/Helpers/Grid.php
+++ b/libraries/src/HTML/Helpers/Grid.php
@@ -56,7 +56,7 @@ abstract class Grid
             $direction = $direction === 'desc' ? 'asc' : 'desc';
         }
 
-        $html = '<a href="#" class="hasTooltip" title="' . htmlspecialchars(Text::_('JGLOBAL_CLICK_TO_SORT_THIS_COLUMN')) . '"'
+        $html = '<a href="#" class="hasTooltip js-column-order" title="' . htmlspecialchars(Text::_('JGLOBAL_CLICK_TO_SORT_THIS_COLUMN')) . '"'
             . ' data-ordering-order="' . $order . '"'
             . ' data-ordering-direction="' . $direction . '"'
             . ' data-ordering-task="' . $task . '"'


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/39730#discussion_r1148170984 .

### Summary of Changes

- Revert the CSP removal of inline scripts for the Grid.php

### Testing Instructions

Check that in the `\Home\Sample Layouts\Category List` front end route, the table could sort against any of the table headers

### Actual result BEFORE applying this Pull Request

Nothing

### Expected result AFTER applying this Pull Request

Works

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
