### PR TITLE
Fix incorrect HTML rendering

### DIFF
--- a/administrator/templates/atum/html/layouts/status.php
+++ b/administrator/templates/atum/html/layouts/status.php
@@ -32,7 +32,11 @@ foreach ($modules as $key => $mod) {
             $dom->loadHTML('<?xml encoding="utf-8" ?>' . $out);
             $els = $dom->getElementsByTagName('a');
 
-            $moduleCollapsedHtml[] = $dom->saveHTML($els[0]); //$els[0]->nodeValue;
+            if ($els[0]) {
+                $moduleCollapsedHtml[] = $dom->saveHTML($els[0]);
+            } else {
+                $moduleCollapsedHtml[] = $out;
+            }
         } else {
             $moduleCollapsedHtml[] = $out;
         }


### PR DESCRIPTION
Pull Request for Issue #40185 .

### Summary of Changes

Fixing incorect HTML rendering 


### Testing Instructions
Please follow #40185


### Actual result BEFORE applying this Pull Request
You get double `<body>` tag


### Expected result AFTER applying this Pull Request
There only 1 `<body>` tag


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
