### PR TITLE
[4.3] Add Create and Edit Own permissions for tours

### DIFF
--- a/administrator/components/com_guidedtours/access.xml
+++ b/administrator/components/com_guidedtours/access.xml
@@ -11,8 +11,10 @@
 		<action name="core.edit.own" title="JACTION_EDITOWN" />
 	</section>
 	<section name="tour">
+		<action name="core.create" title="JACTION_CREATE" />
 		<action name="core.delete" title="JACTION_DELETE" />
 		<action name="core.edit" title="JACTION_EDIT" />
 		<action name="core.edit.state" title="JACTION_EDITSTATE" />
+		<action name="core.edit.own" title="JACTION_EDITOWN" />
 	</section>
 </access>

--- a/administrator/components/com_guidedtours/src/Controller/StepController.php
+++ b/administrator/components/com_guidedtours/src/Controller/StepController.php
@@ -11,6 +11,7 @@
 namespace Joomla\Component\Guidedtours\Administrator\Controller;
 
 use Joomla\CMS\MVC\Controller\FormController;
+use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -23,4 +24,67 @@ use Joomla\CMS\MVC\Controller\FormController;
  */
 class StepController extends FormController
 {
+    /**
+     * Method override to check if you can add a new record.
+     *
+     * @param   array  $data  An array of input data.
+     *
+     * @return  boolean
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function allowAdd($data = [])
+    {
+        $tourId = ArrayHelper::getValue($data, 'tour_id', $this->app->getUserState('com_guidedtours.tour_id', 0), 'int');
+
+        if ($tourId) {
+            // If the category has been passed in the data or URL check it.
+            return $this->app->getIdentity()->authorise('core.create', 'com_guidedtours.tour.' . $tourId);
+        }
+
+        // In the absence of better information, revert to the component permissions.
+        return parent::allowAdd();
+    }
+
+    /**
+     * Method override to check if you can edit an existing record.
+     *
+     * @param   array   $data  An array of input data.
+     * @param   string  $key   The name of the key for the primary key.
+     *
+     * @return  boolean
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function allowEdit($data = [], $key = 'id')
+    {
+        $recordId = (int)$data[$key] ?? 0;
+        $user     = $this->app->getIdentity();
+        $tourId   = (int)$data['tour_id'] ?? $this->app->getUserState('com_guidedtours.tour_id', 0);
+
+        // Zero record (id:0), return component edit permission by calling parent controller method
+        if (!$recordId) {
+            return parent::allowEdit($data, $key);
+        }
+
+        // Check edit on the record asset
+        if ($user->authorise('core.edit', 'com_guidedtours.tour.' . $tourId)) {
+            return true;
+        }
+
+        // Check edit own on the record asset
+        if ($user->authorise('core.edit.own', 'com_guidedtours.tour.' . $tourId)) {
+            // Existing record already has an owner, get it
+            $record = $this->getModel()->getItem($recordId);
+
+            if (empty($record)) {
+                return false;
+            }
+
+            // Grant if current user is owner of the record
+            return $user->id == $record->created_by;
+        }
+
+        return false;
+    }
 }

--- a/administrator/components/com_guidedtours/src/Controller/TourController.php
+++ b/administrator/components/com_guidedtours/src/Controller/TourController.php
@@ -23,4 +23,54 @@ use Joomla\CMS\MVC\Controller\FormController;
  */
 class TourController extends FormController
 {
+    /**
+     * Method to check if you can add a new record.
+     *
+     * @param   array  $data  An array of input data.
+     *
+     * @return  boolean
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function allowAdd($data = [])
+    {
+        return $this->app->getIdentity()->authorise('core.create', $this->option);
+    }
+
+    /**
+     * Method to check if you can edit a record.
+     *
+     * @param   array   $data  An array of input data.
+     * @param   string  $key   The name of the key for the primary key.
+     *
+     * @return  boolean
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function allowEdit($data = [], $key = 'id')
+    {
+        $recordId = (int)$data[$key] ?? 0;
+        $user     = $this->app->getIdentity();
+
+        // Check "edit" permission on record asset
+        if ($user->authorise('core.edit', 'com_guidedtours.tour.' . $recordId)) {
+            return true;
+        }
+
+        // Check "edit own" permission on record asset
+        if ($user->authorise('core.edit.own', 'com_guidedtours.tour.' . $recordId)) {
+            // Need to do a lookup from the model to get the owner
+            $record = $this->getModel()->getItem($recordId);
+
+            if (empty($record)) {
+                return false;
+            }
+
+            if ($record->created_by == $user->id) {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/administrator/components/com_guidedtours/src/View/Step/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Step/HtmlView.php
@@ -97,7 +97,7 @@ class HtmlView extends BaseHtmlView
         $userId     = $user->id;
         $isNew      = empty($this->item->id);
 
-        $canDo = ContentHelper::getActions('com_guidedtours');
+        $canDo = ContentHelper::getActions('com_guidedtours', 'tour', $this->item->tour_id);
 
         ToolbarHelper::title(Text::_('COM_GUIDEDTOURS') . ' - ' . ($isNew ? Text::_('COM_GUIDEDTOURS_MANAGER_STEP_NEW') : Text::_('COM_GUIDEDTOURS_MANAGER_STEP_EDIT')), 'map-signs');
 

--- a/administrator/components/com_guidedtours/src/View/Steps/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Steps/HtmlView.php
@@ -122,7 +122,7 @@ class HtmlView extends BaseHtmlView
         // Get the toolbar object instance
         $toolbar = Toolbar::getInstance('toolbar');
 
-        $canDo = ContentHelper::getActions('com_guidedtours');
+        $canDo = ContentHelper::getActions('com_guidedtours', 'tour', $this->state->get('filter.tour_id', 0));
         $app   = Factory::getApplication();
         $user  = $app->getIdentity();
 

--- a/administrator/components/com_guidedtours/src/View/Tour/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Tour/HtmlView.php
@@ -94,13 +94,11 @@ class HtmlView extends BaseHtmlView
     {
         Factory::getApplication()->input->set('hidemainmenu', true);
 
-        $user       = Factory::getUser();
+        $user       = Factory::getApplication()->getIdentity();
         $userId     = $user->id;
         $isNew      = empty($this->item->id);
 
-        $canDo = ContentHelper::getActions('com_guidedtours');
-
-        $toolbar = Toolbar::getInstance();
+        $canDo = ContentHelper::getActions('com_guidedtours', 'tour', $this->item->id);
 
         ToolbarHelper::title(Text::_('COM_GUIDEDTOURS') . ' - ' . ($isNew ? Text::_('COM_GUIDEDTOURS_MANAGER_TOUR_NEW') : Text::_('COM_GUIDEDTOURS_MANAGER_TOUR_EDIT')), 'map-signs');
 

--- a/administrator/components/com_guidedtours/tmpl/steps/default.php
+++ b/administrator/components/com_guidedtours/tmpl/steps/default.php
@@ -136,9 +136,10 @@ if ($saveOrder && !empty($this->items)) {
                     class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true" <?php
                        endif; ?>>
                 <?php foreach ($this->items as $i => $item) :
-                    $canEdit = $user->authorise('core.edit', 'com_guidedtours' . '.step.' . $item->id);
+                    $canEdit    = $user->authorise('core.edit', 'com_guidedtours.tour.' . $item->tour_id);
+                    $canEditOwn = $user->authorise('core.edit.own', 'com_guidedtours.tour.' . $item->tour_id) && $item->created_by == $userId;
                     $canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || is_null($item->checked_out);
-                    $canChange = $user->authorise('core.edit.state', 'com_guidedtours' . '.step.' . $item->id) && $canCheckin;
+                    $canChange  = $user->authorise('core.edit.state', 'com_guidedtours' . '.step.' . $item->id) && $canCheckin;
                     ?>
 
                     <!-- Row begins -->
@@ -186,7 +187,7 @@ if ($saveOrder && !empty($this->items)) {
                                 <?php if ($item->checked_out) : ?>
                                     <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'steps.', $canCheckin); ?>
                                 <?php endif; ?>
-                                <?php if ($canEdit) : ?>
+                                <?php if ($canEdit || $canEditOwn) : ?>
                                     <a href="<?php echo Route::_('index.php?option=com_guidedtours&task=step.edit&id=' . $item->id); ?> " title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo $this->escape($item->title); ?>">
                                         <?php echo $this->escape($item->title); ?>
                                     </a>

--- a/administrator/components/com_guidedtours/tmpl/tours/default.php
+++ b/administrator/components/com_guidedtours/tmpl/tours/default.php
@@ -148,9 +148,10 @@ if ($saveOrder && !empty($this->items)) {
                     class="js-draggable" data-url="<?php echo $saveOrderingUrl; ?>" data-direction="<?php echo strtolower($listDirn); ?>" data-nested="true" <?php
                        endif; ?>>
                 <?php foreach ($this->items as $i => $item) :
-                    $canEdit = $user->authorise('core.edit', 'com_guidedtours' . '.tour.' . $item->id);
+                    $canEdit    = $user->authorise('core.edit', 'com_guidedtours.tour.' . $item->id);
+                    $canEditOwn = $user->authorise('core.edit.own', 'com_guidedtours.tour.' . $item->id) && $item->created_by == $userId;
                     $canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || is_null($item->checked_out);
-                    $canChange = $user->authorise('core.edit.state', 'com_guidedtours' . '.tour.' . $item->id) && $canCheckin;
+                    $canChange  = $user->authorise('core.edit.state', 'com_guidedtours' . '.tour.' . $item->id) && $canCheckin;
                     ?>
 
                     <!-- Row begins -->
@@ -197,7 +198,7 @@ if ($saveOrder && !empty($this->items)) {
                                 <?php if ($item->checked_out) : ?>
                                     <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'tours.', $canCheckin); ?>
                                 <?php endif; ?>
-                                <?php if ($canEdit) : ?>
+                                <?php if ($canEdit || $canEditOwn) : ?>
                                     <a href="<?php echo Route::_('index.php?option=com_guidedtours&task=tour.edit&id=' . $item->id); ?>" title="<?php echo Text::_('JACTION_EDIT'); ?> <?php echo $this->escape($item->title); ?>">
                                         <?php echo $this->escape($item->title); ?>
                                     </a>

--- a/administrator/components/com_guidedtours/tmpl/tours/default.php
+++ b/administrator/components/com_guidedtours/tmpl/tours/default.php
@@ -151,7 +151,7 @@ if ($saveOrder && !empty($this->items)) {
                     $canEdit    = $user->authorise('core.edit', 'com_guidedtours.tour.' . $item->id);
                     $canEditOwn = $user->authorise('core.edit.own', 'com_guidedtours.tour.' . $item->id) && $item->created_by == $userId;
                     $canCheckin = $user->authorise('core.manage', 'com_checkin') || $item->checked_out == $userId || is_null($item->checked_out);
-                    $canChange  = $user->authorise('core.edit.state', 'com_guidedtours' . '.tour.' . $item->id) && $canCheckin;
+                    $canChange  = $user->authorise('core.edit.state', 'com_guidedtours.tour.' . $item->id) && $canCheckin;
                     ?>
 
                     <!-- Row begins -->


### PR DESCRIPTION
Pull Request for Issue #40200.

### Summary of Changes
This PR does several things :

1. Add missing **Create** and **Edit Own** permissions for tours.
2. Handle these new permissions properly for tours.
3. Make sure steps inherit permissions properly from tour it belong to

### Testing Instructions
1. Use Joomla 4.3 nightly build
2. Apply PR https://github.com/joomla/joomla-cms/pull/40208 first (this PR depends on that PR)
3. Apply patch, make sure Create and Edit Own permissions are working properly for tours.
4. Make sure steps inherit Create and Edit Own permissions properly from tour it belong to.

### Actual result BEFORE applying this Pull Request
- The permissions are missing for tours
-  Steps are not inherited permissions properly from the tour it belong to


### Expected result AFTER applying this Pull Request
- The missing  permissions are added.
-  Steps inherit permissions properly from the tour it belong to.

### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: Documentation has to be modified for permissions in https://docs.joomla.org/Help4.x:Guided_Tours:_New_or_Edit_Tour
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed