### PR TITLE
Set a higher timeout for cypress verification

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -188,6 +188,8 @@ steps:
     volumes:
       - name: cypress-cache
         path: /root/.cache/Cypress
+    environment:
+      CYPRESS_VERIFY_TIMEOUT: 100000
     commands:
       - mv cypress.config.dist.js cypress.config.js
       - npx cypress install
@@ -453,6 +455,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 3457679ef0cd23bde8dd9900016aba663a279aa0c32049c8e37db56676cadd38
+hmac: 7abf75de936f722f96087502541c671a0ea093bc7022efe933003353505d30be
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -192,8 +192,8 @@ steps:
       CYPRESS_VERIFY_TIMEOUT: 100000
     commands:
       - mv cypress.config.dist.js cypress.config.js
-      - cypress install
-      - cypress verify
+      - npx cypress install
+      - npx cypress verify
 
   - name: phpmin-system-mysql
     depends_on:
@@ -455,6 +455,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 55944c92a9ca2c9662eb6b405e60b10f55fd1a6ac4cc119ff31631347208b049
+hmac: 7abf75de936f722f96087502541c671a0ea093bc7022efe933003353505d30be
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -191,10 +191,9 @@ steps:
     environment:
       CYPRESS_VERIFY_TIMEOUT: 100000
     commands:
-      - env
       - mv cypress.config.dist.js cypress.config.js
-      - npx cypress install
-      - npx cypress verify
+      - cypress install
+      - cypress verify
 
   - name: phpmin-system-mysql
     depends_on:
@@ -456,6 +455,6 @@ trigger:
 
 ---
 kind: signature
-hmac: e81bd49df3124dcde928c2473bd63899a0b2f28342798393efc7f09a06fb0ac0
+hmac: 55944c92a9ca2c9662eb6b405e60b10f55fd1a6ac4cc119ff31631347208b049
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -189,8 +189,9 @@ steps:
       - name: cypress-cache
         path: /root/.cache/Cypress
     environment:
-      CYPRESS_VERIFY_TIMEOUT: 100000
+      - CYPRESS_VERIFY_TIMEOUT=100000
     commands:
+      - env
       - mv cypress.config.dist.js cypress.config.js
       - npx cypress install
       - npx cypress verify
@@ -455,6 +456,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 7abf75de936f722f96087502541c671a0ea093bc7022efe933003353505d30be
+hmac: f05b233012303306ae8fdf3732ae2734ae1dcefc9a00de69aa6cbc929a8a3e54
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -189,7 +189,7 @@ steps:
       - name: cypress-cache
         path: /root/.cache/Cypress
     environment:
-      - CYPRESS_VERIFY_TIMEOUT=100000
+      CYPRESS_VERIFY_TIMEOUT: 100000
     commands:
       - env
       - mv cypress.config.dist.js cypress.config.js
@@ -456,6 +456,6 @@ trigger:
 
 ---
 kind: signature
-hmac: f05b233012303306ae8fdf3732ae2734ae1dcefc9a00de69aa6cbc929a8a3e54
+hmac: e81bd49df3124dcde928c2473bd63899a0b2f28342798393efc7f09a06fb0ac0
 
 ...


### PR DESCRIPTION
The cypress verify command sometimes times out on drone. To fix this, cypress supports the environment `CYPRESS_VERIFY_TIMEOUT` variable to increase the timeout value for he verify command. This pr adds that variable to the drone system tests setup task.

![image](https://user-images.githubusercontent.com/251072/228189663-152502ed-2f88-443d-a003-07977c6a6c2e.png)
