### PR TITLE
[4.3] Fixing comparison in Url Filter

### DIFF
--- a/libraries/src/Form/Filter/UrlFilter.php
+++ b/libraries/src/Form/Filter/UrlFilter.php
@@ -62,7 +62,7 @@ class UrlFilter implements FormFilterInterface
         // we assume that it is an external URL and prepend http://
         if (
             ((string) $element['type'] === 'url' && !$protocol && !$element['relative'])
-            || (!(string) $element['type'] === 'url' && !$protocol)
+            || (!((string) $element['type'] === 'url') && !$protocol)
         ) {
             $protocol = 'http';
 

--- a/libraries/src/Form/Filter/UrlFilter.php
+++ b/libraries/src/Form/Filter/UrlFilter.php
@@ -62,7 +62,7 @@ class UrlFilter implements FormFilterInterface
         // we assume that it is an external URL and prepend http://
         if (
             ((string) $element['type'] === 'url' && !$protocol && !$element['relative'])
-            || (!((string) $element['type'] === 'url') && !$protocol)
+            || ((string) $element['type'] !== 'url' && !$protocol)
         ) {
             $protocol = 'http';
 


### PR DESCRIPTION
### Summary of Changes
phpstan reported an issue. The comparison in the changed line is currently broken. The way the operators are used, the type attribute is first cast from a SimpleXMLElement to a string, then negated as a boolean and then compared against a string. Thus the comparison is always wrong. With the added parentheses, the comparison is actually working again.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
