### PR TITLE
Fix compatibility break in validation.js

### DIFF
--- a/build/media_source/system/js/fields/validate.es6.js
+++ b/build/media_source/system/js/fields/validate.es6.js
@@ -249,10 +249,15 @@ class JFormValidator {
     let valid = true;
     let message;
     let error;
+    let fields;
     const invalid = [];
 
     // Validate form fields
-    const fields = [].slice.call(form.elements);
+    if (form.nodeName === 'FORM') {
+      fields = [].slice.call(form.elements);
+    } else {
+      fields = [].slice.call(form.querySelectorAll('input, textarea, select, button, fieldset'));
+    }
     fields.forEach((field) => {
       if (this.validate(field) === false) {
         valid = false;
@@ -284,7 +289,13 @@ class JFormValidator {
 
   attachToForm(form) {
     const inputFields = [];
-    const elements = [].slice.call(form.elements);
+    let elements;
+
+    if (form.nodeName === 'FORM') {
+      elements = [].slice.call(form.elements);
+    } else {
+      elements = [].slice.call(form.querySelectorAll('input, textarea, select, button, fieldset'));
+    }
 
     // Iterate through the form object and attach the validate method to all input fields.
     elements.forEach((element) => {


### PR DESCRIPTION
### Summary of Changes

As result of #39350 it become impossible to use validation over non `<form>` element.
Hovewer some extensions use this feature to validate form "per section".


### Testing Instructions
Apply patch. Run `npm install`
Open a form for "New article".
In Browser console, run 2 commands (one by one):
```javascript
document.formvalidator.isValid(window['item-form']);

document.formvalidator.isValid(window['item-form'].parentElement);
```


### Actual result BEFORE applying this Pull Request
First command executed, and you get a validation message.
Second command throws an error


### Expected result AFTER applying this Pull Request
Both commands works, and shows validation message


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
