### PR TITLE
[4.4] Replace JPATH_PLATFORM with _JEXEC in plugin code

### DIFF
--- a/plugins/authentication/ldap/src/Factory/LdapFactory.php
+++ b/plugins/authentication/ldap/src/Factory/LdapFactory.php
@@ -13,7 +13,7 @@ use Symfony\Component\Ldap\Ldap;
 use Symfony\Component\Ldap\LdapInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**

--- a/plugins/authentication/ldap/src/Factory/LdapFactoryInterface.php
+++ b/plugins/authentication/ldap/src/Factory/LdapFactoryInterface.php
@@ -12,7 +12,7 @@ namespace Joomla\Plugin\Authentication\Ldap\Factory;
 use Symfony\Component\Ldap\LdapInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**

--- a/plugins/content/confirmconsent/src/Field/ConsentBoxField.php
+++ b/plugins/content/confirmconsent/src/Field/ConsentBoxField.php
@@ -21,7 +21,7 @@ use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**

--- a/plugins/system/privacyconsent/src/Field/PrivacyField.php
+++ b/plugins/system/privacyconsent/src/Field/PrivacyField.php
@@ -18,7 +18,7 @@ use Joomla\Component\Content\Site\Helper\RouteHelper;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**

--- a/plugins/user/profile/src/Field/TosField.php
+++ b/plugins/user/profile/src/Field/TosField.php
@@ -20,7 +20,7 @@ use Joomla\Component\Content\Site\Helper\RouteHelper;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**

--- a/plugins/user/terms/src/Field/TermsField.php
+++ b/plugins/user/terms/src/Field/TermsField.php
@@ -18,7 +18,7 @@ use Joomla\Component\Content\Site\Helper\RouteHelper;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

The constant `JPATH_PLATFORM` is a history thing and should not be used in the plugin code
This pr replaces this with `_JEXEC` , and makes the code consistent with that of the other plugins.

Related to #39997

### Testing Instructions

- Works
- Code review

### Actual result BEFORE applying this Pull Request

Code: `\defined('JPATH_PLATFORM') or die;`

### Expected result AFTER applying this Pull Request

Code: `\defined('_JEXEC') or die;`

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

@laoneo please take a look 