### PR TITLE
[4.3] Fix wrong lft and rgt values in assets table

### DIFF
--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -25,7 +25,7 @@ CREATE TABLE IF NOT EXISTS `#__assets` (
 --
 
 INSERT INTO `#__assets` (`id`, `parent_id`, `lft`, `rgt`, `level`, `name`, `title`, `rules`) VALUES
-(1, 0, 0, 175, 0, 'root.1', 'Root Asset', '{"core.login.site":{"6":1,"2":1},"core.login.admin":{"6":1},"core.login.api":{"8":1},"core.login.offline":{"6":1},"core.admin":{"8":1},"core.manage":{"7":1},"core.create":{"6":1,"3":1},"core.delete":{"6":1},"core.edit":{"6":1,"4":1},"core.edit.state":{"6":1,"5":1},"core.edit.own":{"6":1,"3":1}}'),
+(1, 0, 0, 177, 0, 'root.1', 'Root Asset', '{"core.login.site":{"6":1,"2":1},"core.login.admin":{"6":1},"core.login.api":{"8":1},"core.login.offline":{"6":1},"core.admin":{"8":1},"core.manage":{"7":1},"core.create":{"6":1,"3":1},"core.delete":{"6":1},"core.edit":{"6":1,"4":1},"core.edit.state":{"6":1,"5":1},"core.edit.own":{"6":1,"3":1}}'),
 (2, 1, 1, 2, 1, 'com_admin', 'com_admin', '{}'),
 (3, 1, 3, 6, 1, 'com_banners', 'com_banners', '{"core.admin":{"7":1},"core.manage":{"6":1}}'),
 (4, 1, 7, 8, 1, 'com_cache', 'com_cache', '{"core.admin":{"7":1},"core.manage":{"7":1}}'),
@@ -86,8 +86,8 @@ INSERT INTO `#__assets` (`id`, `parent_id`, `lft`, `rgt`, `level`, `name`, `titl
 (64, 56, 35, 36, 3, 'com_content.transition.7', 'Publish & Feature', '{}'),
 (65, 1, 143, 144, 1, 'com_privacy', 'com_privacy', '{}'),
 (66, 1, 145, 146, 1, 'com_actionlogs', 'com_actionlogs', '{}'),
-(67, 18, 74, 75, 2, 'com_modules.module.88', 'Latest Actions', '{}'),
-(68, 18, 76, 77, 2, 'com_modules.module.89', 'Privacy Dashboard', '{}'),
+(67, 18, 76, 77, 2, 'com_modules.module.88', 'Latest Actions', '{}'),
+(68, 18, 78, 79, 2, 'com_modules.module.89', 'Privacy Dashboard', '{}'),
 (70, 18, 88, 89, 2, 'com_modules.module.103', 'Site', '{}'),
 (71, 18, 92, 93, 2, 'com_modules.module.104', 'System', '{}'),
 (72, 18, 96, 97, 2, 'com_modules.module.91', 'System Dashboard', '{}'),

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -31,7 +31,7 @@ COMMENT ON COLUMN "#__assets"."rules" IS 'JSON encoded access control.';
 --
 
 INSERT INTO "#__assets" ("id", "parent_id", "lft", "rgt", "level", "name", "title", "rules") VALUES
-(1, 0, 0, 175, 0, 'root.1', 'Root Asset', '{"core.login.site":{"6":1,"2":1},"core.login.admin":{"6":1},"core.login.api":{"8":1},"core.login.offline":{"6":1},"core.admin":{"8":1},"core.manage":{"7":1},"core.create":{"6":1,"3":1},"core.delete":{"6":1},"core.edit":{"6":1,"4":1},"core.edit.state":{"6":1,"5":1},"core.edit.own":{"6":1,"3":1}}'),
+(1, 0, 0, 177, 0, 'root.1', 'Root Asset', '{"core.login.site":{"6":1,"2":1},"core.login.admin":{"6":1},"core.login.api":{"8":1},"core.login.offline":{"6":1},"core.admin":{"8":1},"core.manage":{"7":1},"core.create":{"6":1,"3":1},"core.delete":{"6":1},"core.edit":{"6":1,"4":1},"core.edit.state":{"6":1,"5":1},"core.edit.own":{"6":1,"3":1}}'),
 (2, 1, 1, 2, 1, 'com_admin', 'com_admin', '{}'),
 (3, 1, 3, 6, 1, 'com_banners', 'com_banners', '{"core.admin":{"7":1},"core.manage":{"6":1}}'),
 (4, 1, 7, 8, 1, 'com_cache', 'com_cache', '{"core.admin":{"7":1},"core.manage":{"7":1}}'),
@@ -92,8 +92,8 @@ INSERT INTO "#__assets" ("id", "parent_id", "lft", "rgt", "level", "name", "titl
 (64, 56, 35, 36, 3, 'com_content.transition.7', 'Publish & Feature', '{}'),
 (65, 1, 143, 144, 1, 'com_privacy', 'com_privacy', '{}'),
 (66, 1, 145, 146, 1, 'com_actionlogs', 'com_actionlogs', '{}'),
-(67, 18, 74, 75, 2, 'com_modules.module.88', 'Latest Actions', '{}'),
-(68, 18, 76, 77, 2, 'com_modules.module.89', 'Privacy Dashboard', '{}'),
+(67, 18, 76, 77, 2, 'com_modules.module.88', 'Latest Actions', '{}'),
+(68, 18, 78, 79, 2, 'com_modules.module.89', 'Privacy Dashboard', '{}'),
 (70, 18, 88, 89, 2, 'com_modules.module.103', 'Site', '{}'),
 (71, 18, 92, 93, 2, 'com_modules.module.104', 'System', '{}'),
 (72, 18, 96, 97, 2, 'com_modules.module.91', 'System Dashboard', '{}'),


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/pull/40208#issuecomment-1484764871 .

### Summary of Changes

This pull request (PR) corrects the following two mistakes with lft and rgt values for the nested `#__assets` table for new installations:

1. There are two assets with IDs 46 and 67 which have the same lft value 74 and rgt value 75.
https://github.com/joomla/joomla-cms/blob/4.3-dev/installation/sql/mysql/base.sql#L70
https://github.com/joomla/joomla-cms/blob/4.3-dev/installation/sql/mysql/base.sql#L89
Both are assets for single modules on level 2 below the 'com_modules' asset.
This error was introduced with PR #30178 , possibly not with the initial version of that PR but when resolving merge conflicts with the base branch.
Because the same PR had removed some obsolete assets, we are lucky and the lft and rgt values 78 and 79 are not used, so they are a gap on that level with that parent, which as such is not a problem but helps here to fix the issue. We can change the the lft and rgt values of asset ID 67 and 68 to the previous values plus one, and so that gap is filled, too, and the nested table is correct.
2. The rgt value of the root asset, which is the parent of all others, has to be equal to the rgt value of it's last child plus one, so currently it should be 177, see these two places for the root item and the last child:
https://github.com/joomla/joomla-cms/blob/4.3-dev/installation/sql/mysql/base.sql#L28
https://github.com/joomla/joomla-cms/blob/4.3-dev/installation/sql/mysql/base.sql#L115
This error was introduced with PR #39902 .
When the rgt value of the root asset is smaller than the one of the last child, it is not updated to a new value when a new asset is added for something, e.g. by creating a new category or installing a new module and then editing that asset. This can also be seen when reproducing issue #40199 .

### Testing Instructions

Testers need to know and have understood the principles of hierarchical tables using the nested set model as described here:

https://en.wikipedia.org/wiki/Nested_set_model

The `#__assets` table uses an extended model which saves as redundant information also `parent_id` and `level` in addition to `lft` and `rgt` for speeding up certain queries.

As the structure of the assets table is only a few levels deep, the nested table can be easily verified in tools like phpMyAdmin or phpPgAdmin.

For this you can either make a new installation with the branch of this PR, or you simply use an empty database and execute the statements to create the assets table and insert the records from the base.sql file of this PR.

Then you select _all records from the table and order by the `lft` column in ascending order_. Make sure that really all records are shown.

Then go through the lft and rgt values from top to bottom and lft to rgt, and when at the end of a child level from the last rgt value on that level back to the rgt value of the parent further above. So just follow the lft and rgt values as described on [this Wikipedia page about the nested model](https://en.wikipedia.org/wiki/Nested_set_model). Check that the sequence of lft and rgt values is according to that model and that the parent ID and the level are correct, too.

Check that the changes of this PR are correct.

For issue 2. you can also add a new asset e.g. by adding a new category or by reproducing issue #40199 . Make sure that the rgt value of the root asset is updated, too, when the new asset is added.

### Actual result BEFORE applying this Pull Request

1. There are 2 assets with the same lft and rgt values 74 and 75: Asset ID 46 and asset ID 67. There is no asset with lft and rgt values 78 and 79.
2. The rgt value 175 of the root asset is smaller than the rgt value 176 of its last child, which is asset ID 95. So when a new assets is created, the rgt value of the root item is not updated.

### Expected result AFTER applying this Pull Request

1. There are no assets with the same lft and rgt values as other assets have. All lft and rgt combinations are unique and follow the [nested set model](https://en.wikipedia.org/wiki/Nested_set_model), and there is no gap, at least not within the modules assets.
2. The rgt value 177 of the root asset is equal to one plus the rgt value 176 of its last child, which is asset ID 95. So when a new assets is created, the rgt value of the root item is updated.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
