### PR TITLE
[4.4] Fixes to Form Filter classes from static code analysis

### DIFF
--- a/libraries/src/Form/Filter/IntarrayFilter.php
+++ b/libraries/src/Form/Filter/IntarrayFilter.php
@@ -33,8 +33,8 @@ class IntarrayFilter implements FormFilterInterface
      * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
-     * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
-     * @param   Form               $form     The form object for which the field is being tested.
+     * @param   ?Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
+     * @param   ?Form              $form     The form object for which the field is being tested.
      *
      * @return  mixed   The filtered value.
      *

--- a/libraries/src/Form/Filter/RawFilter.php
+++ b/libraries/src/Form/Filter/RawFilter.php
@@ -32,8 +32,8 @@ class RawFilter implements FormFilterInterface
      * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
-     * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
-     * @param   Form               $form     The form object for which the field is being tested.
+     * @param   ?Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
+     * @param   ?Form              $form     The form object for which the field is being tested.
      *
      * @return  mixed   The filtered value.
      *

--- a/libraries/src/Form/Filter/RulesFilter.php
+++ b/libraries/src/Form/Filter/RulesFilter.php
@@ -32,8 +32,8 @@ class RulesFilter implements FormFilterInterface
      * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
-     * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
-     * @param   Form               $form     The form object for which the field is being tested.
+     * @param   ?Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
+     * @param   ?Form              $form     The form object for which the field is being tested.
      *
      * @return  mixed   The filtered value.
      *

--- a/libraries/src/Form/Filter/SafehtmlFilter.php
+++ b/libraries/src/Form/Filter/SafehtmlFilter.php
@@ -33,8 +33,8 @@ class SafehtmlFilter implements FormFilterInterface
      * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
-     * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
-     * @param   Form               $form     The form object for which the field is being tested.
+     * @param   ?Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
+     * @param   ?Form              $form     The form object for which the field is being tested.
      *
      * @return  mixed   The filtered value.
      *

--- a/libraries/src/Form/Filter/TelFilter.php
+++ b/libraries/src/Form/Filter/TelFilter.php
@@ -32,8 +32,8 @@ class TelFilter implements FormFilterInterface
      * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
-     * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
-     * @param   Form               $form     The form object for which the field is being tested.
+     * @param   ?Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
+     * @param   ?Form              $form     The form object for which the field is being tested.
      *
      * @return  mixed   The filtered value.
      *

--- a/libraries/src/Form/Filter/UnsetFilter.php
+++ b/libraries/src/Form/Filter/UnsetFilter.php
@@ -32,8 +32,8 @@ class UnsetFilter implements FormFilterInterface
      * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
-     * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
-     * @param   Form               $form     The form object for which the field is being tested.
+     * @param   ?Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
+     * @param   ?Form              $form     The form object for which the field is being tested.
      *
      * @return  mixed   The filtered value.
      *

--- a/libraries/src/Form/Filter/UrlFilter.php
+++ b/libraries/src/Form/Filter/UrlFilter.php
@@ -35,8 +35,8 @@ class UrlFilter implements FormFilterInterface
      * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
-     * @param   Registry           $input    An optional Registry object with the entire data set to validate against the entire form.
-     * @param   Form               $form     The form object for which the field is being tested.
+     * @param   ?Registry          $input    An optional Registry object with the entire data set to validate against the entire form.
+     * @param   ?Form              $form     The form object for which the field is being tested.
      *
      * @return  mixed   The filtered value.
      *


### PR DESCRIPTION
### Summary of Changes
These are several fixes to the `Joomla\CMS\Form\Filter` classes based on static code analysis.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
