### PR TITLE
[5.0] Remove child template conversion of core templates from script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -60,9 +60,6 @@ class JoomlaInstallerScript
                 if (array_key_exists('version', $manifestValues)) {
                     $this->fromVersion = $manifestValues['version'];
 
-                    // Ensure templates are moved to the correct mode
-                    $this->fixTemplateMode();
-
                     return true;
                 }
             }
@@ -1058,8 +1055,6 @@ class JoomlaInstallerScript
             }
         }
 
-        $this->moveRemainingTemplateFiles();
-
         foreach ($folders as $folder) {
             if ($folderExists = Folder::exists(JPATH_ROOT . $folder)) {
                 $status['folders_exist'][] = $folder;
@@ -1642,84 +1637,6 @@ class JoomlaInstallerScript
                 }
             }
         }
-    }
-
-    /**
-     * Move core template (s)css or js or image files which are left after deleting
-     * obsolete core files to the right place in media folder.
-     *
-     * @return  void
-     *
-     * @since   4.1.0
-     */
-    protected function moveRemainingTemplateFiles()
-    {
-        $folders = [
-            '/administrator/templates/atum/css'    => '/media/templates/administrator/atum/css',
-            '/administrator/templates/atum/images' => '/media/templates/administrator/atum/images',
-            '/administrator/templates/atum/js'     => '/media/templates/administrator/atum/js',
-            '/administrator/templates/atum/scss'   => '/media/templates/administrator/atum/scss',
-            '/templates/cassiopeia/css'            => '/media/templates/site/cassiopeia/css',
-            '/templates/cassiopeia/images'         => '/media/templates/site/cassiopeia/images',
-            '/templates/cassiopeia/js'             => '/media/templates/site/cassiopeia/js',
-            '/templates/cassiopeia/scss'           => '/media/templates/site/cassiopeia/scss',
-        ];
-
-        foreach ($folders as $oldFolder => $newFolder) {
-            if (Folder::exists(JPATH_ROOT . $oldFolder)) {
-                $oldPath   = realpath(JPATH_ROOT . $oldFolder);
-                $newPath   = realpath(JPATH_ROOT . $newFolder);
-                $directory = new \RecursiveDirectoryIterator($oldPath);
-                $directory->setFlags(RecursiveDirectoryIterator::SKIP_DOTS);
-                $iterator  = new \RecursiveIteratorIterator($directory);
-
-                // Handle all files in this folder and all sub-folders
-                foreach ($iterator as $oldFile) {
-                    if ($oldFile->isDir()) {
-                        continue;
-                    }
-
-                    $newFile = $newPath . substr($oldFile, strlen($oldPath));
-
-                    // Create target folder and parent folders if they don't exist yet
-                    if (is_dir(dirname($newFile)) || @mkdir(dirname($newFile), 0755, true)) {
-                        File::move($oldFile, $newFile);
-                    }
-                }
-            }
-        }
-    }
-
-    /**
-     * Ensure the core templates are correctly moved to the new mode.
-     *
-     * @return  void
-     *
-     * @since   4.1.0
-     */
-    protected function fixTemplateMode(): void
-    {
-        $db = Factory::getContainer()->get('DatabaseDriver');
-
-        array_map(
-            function ($template) use ($db) {
-                $clientId = $template === 'atum' ? 1 : 0;
-                $query = $db->getQuery(true)
-                    ->update($db->quoteName('#__template_styles'))
-                    ->set($db->quoteName('inheritable') . ' = 1')
-                    ->where($db->quoteName('template') . ' = ' . $db->quote($template))
-                    ->where($db->quoteName('client_id') . ' = ' . $clientId);
-
-                try {
-                    $db->setQuery($query)->execute();
-                } catch (Exception $e) {
-                    echo Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br>';
-
-                    return;
-                }
-            },
-            ['atum', 'cassiopeia']
-        );
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) removes the conversion of the 4.x core templates "Atum" and "Cassiopeia" from old style templates to child templates from script.php which once had been added with PR's #35874 and #36585 . 

The update SQL scripts have already been removed with PR https://github.com/joomla/joomla-cms/pull/40083 . This PR here removes the rest.

The PR is one in a sequence of PR's for removing obsolete actions from script.php which are not relevant anymore because updates to 5.x will have to be done from a 4.4 version, like it is now with 4.x from 3.10.

### Testing Instructions

Code review: Make sure that the removed methods are not called anywhere else and that they do something which is definitely not needed when updating from 4.4 to 5.

Optional real test: Make sure that updating the latest 4.4-dev nightly build to the update package created by drone works when using the upload & update method.

### Actual result BEFORE applying this Pull Request

Obsolete code for migrating the core templates "Atum" and "Cassiopeia" to child templates when updating from 4.0.x to 4.1.0 or a later 4.x is present in script.php.

### Expected result AFTER applying this Pull Request

Obsolete code for migrating the core templates "Atum" and "Cassiopeia" to child templates when updating from 4.0.x to 4.1.0 or a later 4.x is not present anymore in script.php.

Updating from a 4.4-dev nightly build works.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
