### PR TITLE
[4.3] Help button link urls

### DIFF
--- a/libraries/src/Toolbar/Button/HelpButton.php
+++ b/libraries/src/Toolbar/Button/HelpButton.php
@@ -91,10 +91,7 @@ class HelpButton extends BasicButton
     protected function _getCommand()
     {
         // Get Help URL
-        $url = Help::createUrl($this->getRef(), $this->getUseComponent(), $this->getUrl(), $this->getComponent());
-        $url = json_encode(htmlspecialchars($url, ENT_QUOTES), JSON_HEX_APOS);
-
-        return substr($url, 1, -1);
+        return Help::createUrl($this->getRef(), $this->getUseComponent(), $this->getUrl(), $this->getComponent());
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #40268 .

### Summary of Changes

- The URL for the help pages has escaped forward slashes

### Testing Instructions

Navigate anywhere in the backend where the toolbar has a help button and click on it

### Actual result BEFORE applying this Pull Request

Broken

### Expected result AFTER applying this Pull Request

The help popup should return a 404 page (this is a different problem)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [X] No documentation changes for manual.joomla.org needed


@obuisard I guess this is a release blocker