### PR TITLE
[4.3] fix factory class

### DIFF
--- a/administrator/components/com_redirect/layouts/toolbar/batch.php
+++ b/administrator/components/com_redirect/layouts/toolbar/batch.php
@@ -11,7 +11,7 @@
 defined('_JEXEC') or die;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
-$wa = \Joomla\CMS\Factory\Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa = \Joomla\CMS\Factory::getApplication()->getDocument()->getWebAssetManager();
 $wa->useScript('core');
 
 $title = $displayData['title'];


### PR DESCRIPTION
Follow up Pull Request #38328 .

### Summary of Changes

class `\Joomla\CMS\Factory\Factory` do not exist

### Testing Instructions

copy following code
```
// Instantiate a new FileLayout instance and render the batch button
$layout = new \Joomla\CMS\Layout\FileLayout('toolbar.batch');
$dhtml  = $layout->render(['title' => Text::_('JTOOLBAR_BULK_IMPORT')]);
$toolbar->appendButton('Custom', $dhtml, 'batch');
```
an put it here because the layout is no longer used in joomla core
https://github.com/joomla/joomla-cms/blob/280c0b8f327f3709d09228b7e7aef929fc099cd6/administrator/components/com_redirect/src/View/Links/HtmlView.php#L206-L210

now visit `/administrator/index.php?option=com_redirect`

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/66922325/229181172-b039eca8-4814-44c2-8966-3f6039754da9.png)

### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/66922325/229181186-586c62a6-0097-4875-96db-b7c1161e9e52.png)

### Link to documentations
Please select:

- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
