### PR TITLE
Preload all categories in content router

### DIFF
--- a/components/com_content/src/Service/Router.php
+++ b/components/com_content/src/Service/Router.php
@@ -115,7 +115,7 @@ class Router extends RouterView
      */
     public function getCategorySegment($id, $query)
     {
-        $category = $this->getCategories(['access' => true])->get($id);
+        $category = $this->getCategories(['access' => true, 'preload' => true])->get($id);
 
         if ($category) {
             $path    = array_reverse($category->getPath(), true);
@@ -203,7 +203,7 @@ class Router extends RouterView
     public function getCategoryId($segment, $query)
     {
         if (isset($query['id'])) {
-            $category = $this->getCategories(['access' => false])->get($query['id']);
+            $category = $this->getCategories(['access' => false, 'preload' => true])->get($query['id']);
 
             if ($category) {
                 foreach ($category->getChildren() as $child) {

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -121,8 +121,14 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
         $options['published']   = isset($options['published']) ? $options['published'] : 1;
         $options['countItems']  = isset($options['countItems']) ? $options['countItems'] : 0;
         $options['currentlang'] = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : 0;
+        $options['preload']     = $options['countItems'] ?? false;
 
         $this->_options = $options;
+
+        // Preload all categories
+        if ($options['preload']) {
+            $this->get();
+        }
     }
 
     /**

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -121,7 +121,7 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
         $options['published']   = isset($options['published']) ? $options['published'] : 1;
         $options['countItems']  = isset($options['countItems']) ? $options['countItems'] : 0;
         $options['currentlang'] = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : 0;
-        $options['preload']     = $options['countItems'] ?? false;
+        $options['preload']     = $options['preload'] ?? false;
 
         $this->_options = $options;
 


### PR DESCRIPTION
### Summary of Changes

Currently, each category URL produces a separate SQL query to load a category.
We can significantly speed-up this by preloading all categories.

### Testing Instructions

Create Articles Categories module with lots of categories

### Actual result BEFORE applying this Pull Request

See lots of SQL queries to `#__categories` table.

### Expected result AFTER applying this Pull Request

See much less queries.

### Link to documentations

No documentation changes for docs.joomla.org needed
No documentation changes for manual.joomla.org needed
