### PR TITLE
[4.3] Guided Tours fix js error

### DIFF
--- a/build/media_source/plg_system_guidedtours/js/guidedtours.es6.js
+++ b/build/media_source/plg_system_guidedtours/js/guidedtours.es6.js
@@ -441,7 +441,7 @@ document.querySelector('body').addEventListener('click', (event) => {
 
   // Click button but missing data-id
   if (typeof event.target.getAttribute('data-id') === 'undefined' || event.target.getAttribute('data-id') <= 0) {
-    Joomla.renderMessages([Joomla.Text._('PLG_SYSTEM_GUIDEDTOURS_COULD_NOT_LOAD_THE_TOUR')]);
+    Joomla.renderMessages({ error: [Joomla.Text._('PLG_SYSTEM_GUIDEDTOURS_COULD_NOT_LOAD_THE_TOUR')] });
     return;
   }
 


### PR DESCRIPTION
### Summary of Changes

fix call of `Joomla.renderMessages`

### Testing Instructions

set an invalid `data-id` for example `data-id="0"`
https://github.com/joomla/joomla-cms/blob/338a9402a2702fa5d30bd16acf61138558bcf18f/administrator/modules/mod_guidedtours/tmpl/default.php#L73

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/66922325/229301044-d9db2b77-32ae-4a3f-920e-a8116864b0f8.png)

### Expected result AFTER applying this Pull Request

error message is rendered without js error
![image](https://user-images.githubusercontent.com/66922325/229301055-da7387e7-5d10-4b07-bc17-0bedde12680f.png)

### Link to documentations
Please select:

- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
