### PR TITLE
[4.3] Fix SQL error "Can't Drop 'asset_id'; check that column/key exists" and checked out Guided Tours module when updating from 4.2.9 or older

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/4.3.0-2023-02-15.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.3.0-2023-02-15.sql
@@ -209,6 +209,6 @@ INSERT INTO `#__extensions` (`package_id`, `name`, `type`, `element`, `folder`, 
 (0, 'plg_system_guidedtours', 'plugin', 'guidedtours', 'system', 0, 1, 1, 0, 1, '', '{}', '', 0, 0);
 
 INSERT INTO `#__modules` (`title`, `note`, `content`, `ordering`, `position`, `checked_out`, `checked_out_time`, `publish_up`, `publish_down`, `published`, `module`, `access`, `showtitle`, `params`, `client_id`, `language`) VALUES
-('Guided Tours', '', '', 1, 'status', 0, NULL, NULL, NULL, 1, 'mod_guidedtours', 1, 1, '', 1, '*');
+('Guided Tours', '', '', 1, 'status', NULL, NULL, NULL, NULL, 1, 'mod_guidedtours', 1, 1, '', 1, '*');
 
 INSERT INTO `#__modules_menu` (`moduleid`, `menuid`) VALUES (LAST_INSERT_ID(), 0);

--- a/administrator/components/com_admin/sql/updates/mysql/4.3.0-2023-03-28.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.3.0-2023-03-28.sql
@@ -1,3 +1,3 @@
-ALTER TABLE `#__guidedtours` DROP COLUMN `asset_id`;
+ALTER TABLE `#__guidedtours` DROP COLUMN `asset_id` /** CAN FAIL **/;
 
 DELETE FROM `#__assets` WHERE `name` LIKE 'com_guidedtours.tour.%';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.3.0-2023-02-15.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.3.0-2023-02-15.sql
@@ -216,6 +216,6 @@ INSERT INTO "#__extensions" ("package_id", "name", "type", "element", "folder", 
 (0, 'plg_system_guidedtours', 'plugin', 'guidedtours', 'system', 0, 1, 1, 0, 1, '', '{}', '', 0, 0);
 
 INSERT INTO "#__modules" ("title", "note", "content", "ordering", "position", "checked_out", "checked_out_time", "publish_up", "publish_down", "published", "module", "access", "showtitle", "params", "client_id", "language") VALUES
-('Guided Tours', '', '', 1, 'status', 0, NULL, NULL, NULL, 1, 'mod_guidedtours', 1, 1, '', 1, '*');
+('Guided Tours', '', '', 1, 'status', NULL, NULL, NULL, NULL, 1, 'mod_guidedtours', 1, 1, '', 1, '*');
 
 INSERT INTO "#__modules_menu" ("moduleid", "menuid") VALUES (currval(pg_get_serial_sequence('#__modules','id')), 0);

--- a/administrator/components/com_admin/sql/updates/postgresql/4.3.0-2023-03-28.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.3.0-2023-03-28.sql
@@ -1,3 +1,3 @@
-ALTER TABLE "#__guidedtours" DROP COLUMN "asset_id";
+ALTER TABLE "#__guidedtours" DROP COLUMN "asset_id" /** CAN FAIL **/;
 
 DELETE FROM "#__assets" WHERE "name" LIKE 'com_guidedtours.tour.%';


### PR DESCRIPTION
Pull Request for Issue #40284 .

### Summary of Changes

This pull request (PR) adds the "CAN FAIL" installer hint to the drop column statement in the "4.3.0-2023-03-28.sql" update script.

The reason is that with PR #40228 the update SQL script "4.3.0-2023-02-15.sql" has been changed, too, so the column does not exist when not updating from a 4.3.0 beta 4 or rc 1 but an older version.

In addition, this PR fixes the value of the checked out column of the Guided Tours module installed with the "4.3.0-2023-02-15.sql" script on update.

### Testing Instructions

Update from a 4.2.9 or a current 4.2-dev branch to the last 4.3-dev nightly build to reproduce the issue, and to the update package or custom update URL built by drone for this PR to test the fix.

### Actual result BEFORE applying this Pull Request

SQL error about column not existing.

Com_checkin shows something checked out in the modules table. Checking in database shows that it is the Guided Tours module.

### Expected result AFTER applying this Pull Request

No SQL error.

Nothing is checked out in com_checkin after the update.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
