### PR TITLE
[5.0] Update versions in codemirror.xml and tinymce.xml

### DIFF
--- a/plugins/editors/codemirror/codemirror.xml
+++ b/plugins/editors/codemirror/codemirror.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_codemirror</name>
-	<version>5.65.9</version>
+	<version>5.65.12</version>
 	<creationDate>28 March 2011</creationDate>
 	<author>Marijn Haverbeke</author>
 	<authorEmail>marijnh@gmail.com</authorEmail>

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_tinymce</name>
-	<version>6.2.0</version>
+	<version>6.4.0</version>
 	<creationDate>2005-08</creationDate>
 	<author>Tiny Technologies, Inc</author>
 	<authorEmail>N/A</authorEmail>


### PR DESCRIPTION
Pull Request for Issue #40285 .

### Summary of Changes

This pull request (PR) updates the version numbers in files "plugins/editors/codemirror/codemirror.xml" and "plugins/editors/tinymce/tinymce.xml", which has obviously been forgotten with a pervious update of these dependencies.

### Testing Instructions

Code review: Check that the version number in the changed xml files fit to what is in file "package-lock.json".

For codemirror see https://github.com/joomla/joomla-cms/blob/5.0-dev/package-lock.json#L11934 .

For tinymce see https://github.com/joomla/joomla-cms/blob/5.0-dev/package-lock.json#L16196 .

### Actual result BEFORE applying this Pull Request

Codemirror has 5.65.9 and tinymce has 6.2.0 in the XML file.

### Expected result AFTER applying this Pull Request

Codemirror has 5.65.12 and tinymce has 6.4.0 in the XML file.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
