### PR TITLE
[5.0] Adapt postflight method in script.php to the new major version 5

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -882,9 +882,11 @@ class JoomlaInstallerScript
             return true;
         }
 
-        if (empty($this->fromVersion) || version_compare($this->fromVersion, '4.0.0', 'ge')) {
+        if (empty($this->fromVersion) || version_compare($this->fromVersion, '5.0.0', 'ge')) {
             return true;
         }
+
+        // Add here code which shall be executed only when updating from an older version than 5.0.0
 
         return true;
     }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Now as my 2 pull requests (PR's) #40280 and #40281 for removing obsolete code for updating from 3.10 to 4.x have been merged, the "postflight" method in file "script.php" does not do anymore anything.

However, this method is public and called from the update model of the Joomla Update component after the database updates, so it should not be deleted but be changed for the new major version 5.

This is what this PR here does.

In addition, it adds a comment as placeholder for code to be added when necessary.

### Testing Instructions

Code review: Check that the "postflight" method in file "script.php" in the 5.0-dev branch does not do anything after checking the action and the version. Check that this PR changes the version number in the version_compare in the right way and the added placeholder comment is right.

### Actual result BEFORE applying this Pull Request

"postflight" method still checks for major version 4 and does not really do anything.

### Expected result AFTER applying this Pull Request

"postflight" method checks for major version 5 and has a comment which shows where to add code when necessary so the method will really do something.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
