### PR TITLE
[5.0] remove deprecated strings

### DIFF
--- a/administrator/language/en-GB/com_media.ini
+++ b/administrator/language/en-GB/com_media.ini
@@ -43,10 +43,6 @@ COM_MEDIA_FIELD_CHECK_MIME_DESC="Use MIME Magic or Fileinfo to attempt to verify
 COM_MEDIA_FIELD_CHECK_MIME_LABEL="Check MIME Types"
 COM_MEDIA_FIELD_IGNORED_EXTENSIONS_DESC="Ignored file extensions for MIME type checking and restricted uploads."
 COM_MEDIA_FIELD_IGNORED_EXTENSIONS_LABEL="Ignored Extensions"
-; Deprecated, will be removed with 5.0
-COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_DESC="A comma separated list of forbidden MIME types to upload."
-; Deprecated, will be removed with 5.0
-COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_LABEL="Forbidden MIME Types"
 COM_MEDIA_FIELD_LEGAL_AUDIO_EXTENSIONS_DESC="Audio extensions (file types) you are allowed to upload (comma separated). These are used to check for valid audio headers."
 COM_MEDIA_FIELD_LEGAL_AUDIO_EXTENSIONS_LABEL="Legal Audio Extensions (File Types)"
 COM_MEDIA_FIELD_LEGAL_DOCUMENT_EXTENSIONS_DESC="Document extensions (file types) you are allowed to upload (comma separated). These are used to check for valid document headers."

--- a/administrator/language/en-GB/com_users.ini
+++ b/administrator/language/en-GB/com_users.ini
@@ -219,6 +219,14 @@ COM_USERS_MAIL_MASSMAIL_MAIL_TITLE="Users: Mass Mail Users"
 COM_USERS_MAIL_NO_USERS_COULD_BE_FOUND_IN_THIS_GROUP="No users could be found in this group."
 COM_USERS_MAIL_ONLY_YOU_COULD_BE_FOUND_IN_THIS_GROUP="You are the only user in this group."
 COM_USERS_MAIL_PASSWORD_RESET_DESC="Sent to a user by the &quot;Forgot your password?&quot; link eg in a login form."
+COM_USERS_MAIL_PASSWORD_RESET_TITLE="Users: Password Reset"
+; Deprecated, will be removed with 5.0
+COM_USERS_MAIL_PLEASE_FILL_IN_THE_FORM_CORRECTLY="Please fill in the form correctly."
+; Deprecated, will be removed with 5.0
+COM_USERS_MAIL_PLEASE_FILL_IN_THE_MESSAGE="Please enter a message"
+; Deprecated, will be removed with 5.0
+COM_USERS_MAIL_PLEASE_FILL_IN_THE_SUBJECT="Please enter a subject"
+; Deprecated, will be removed with 5.0
 COM_USERS_MAIL_PLEASE_SELECT_A_GROUP="Please select a Group"
 COM_USERS_MAIL_REGISTRATION_ADMIN_NEW_NOTIFICATION_DESC="Notification to the admin that a new, activated account has been created."
 COM_USERS_MAIL_REGISTRATION_ADMIN_NEW_NOTIFICATION_TITLE="Users: New account notification to admin"

--- a/administrator/language/en-GB/com_users.ini
+++ b/administrator/language/en-GB/com_users.ini
@@ -219,14 +219,6 @@ COM_USERS_MAIL_MASSMAIL_MAIL_TITLE="Users: Mass Mail Users"
 COM_USERS_MAIL_NO_USERS_COULD_BE_FOUND_IN_THIS_GROUP="No users could be found in this group."
 COM_USERS_MAIL_ONLY_YOU_COULD_BE_FOUND_IN_THIS_GROUP="You are the only user in this group."
 COM_USERS_MAIL_PASSWORD_RESET_DESC="Sent to a user by the &quot;Forgot your password?&quot; link eg in a login form."
-COM_USERS_MAIL_PASSWORD_RESET_TITLE="Users: Password Reset"
-; Deprecated, will be removed with 5.0
-COM_USERS_MAIL_PLEASE_FILL_IN_THE_FORM_CORRECTLY="Please fill in the form correctly."
-; Deprecated, will be removed with 5.0
-COM_USERS_MAIL_PLEASE_FILL_IN_THE_MESSAGE="Please enter a message"
-; Deprecated, will be removed with 5.0
-COM_USERS_MAIL_PLEASE_FILL_IN_THE_SUBJECT="Please enter a subject"
-; Deprecated, will be removed with 5.0
 COM_USERS_MAIL_PLEASE_SELECT_A_GROUP="Please select a Group"
 COM_USERS_MAIL_REGISTRATION_ADMIN_NEW_NOTIFICATION_DESC="Notification to the admin that a new, activated account has been created."
 COM_USERS_MAIL_REGISTRATION_ADMIN_NEW_NOTIFICATION_TITLE="Users: New account notification to admin"

--- a/administrator/language/en-GB/com_users.ini
+++ b/administrator/language/en-GB/com_users.ini
@@ -219,15 +219,7 @@ COM_USERS_MAIL_MASSMAIL_MAIL_TITLE="Users: Mass Mail Users"
 COM_USERS_MAIL_NO_USERS_COULD_BE_FOUND_IN_THIS_GROUP="No users could be found in this group."
 COM_USERS_MAIL_ONLY_YOU_COULD_BE_FOUND_IN_THIS_GROUP="You are the only user in this group."
 COM_USERS_MAIL_PASSWORD_RESET_DESC="Sent to a user by the &quot;Forgot your password?&quot; link eg in a login form."
-COM_USERS_MAIL_PASSWORD_RESET_TITLE="Users: Password Reset"
-; Deprecated, will be removed with 5.0
 COM_USERS_MAIL_PLEASE_FILL_IN_THE_FORM_CORRECTLY="Please fill in the form correctly."
-; Deprecated, will be removed with 5.0
-COM_USERS_MAIL_PLEASE_FILL_IN_THE_MESSAGE="Please enter a message"
-; Deprecated, will be removed with 5.0
-COM_USERS_MAIL_PLEASE_FILL_IN_THE_SUBJECT="Please enter a subject"
-; Deprecated, will be removed with 5.0
-COM_USERS_MAIL_PLEASE_SELECT_A_GROUP="Please select a Group"
 COM_USERS_MAIL_REGISTRATION_ADMIN_NEW_NOTIFICATION_DESC="Notification to the admin that a new, activated account has been created."
 COM_USERS_MAIL_REGISTRATION_ADMIN_NEW_NOTIFICATION_TITLE="Users: New account notification to admin"
 COM_USERS_MAIL_REGISTRATION_ADMIN_VERIFICATION_REQUEST_DESC="Notification to admins to verify a new, verified account."

--- a/administrator/language/en-GB/joomla.ini
+++ b/administrator/language/en-GB/joomla.ini
@@ -203,14 +203,8 @@ JFIELD_ALIAS_LABEL="Alias"
 JFIELD_ALIAS_PLACEHOLDER="Auto-generate from title"
 JFIELD_ALT_COMPONENT_LAYOUT_DESC="Use a layout from the supplied component view or overrides in the templates."
 JFIELD_ALT_LAYOUT_LABEL="Layout"
-; Deprecated, will be removed with 5.0
-JFIELD_ALT_MODULE_LAYOUT_DESC="Use a layout from the supplied module or overrides in the templates."
 JFIELD_ALT_PAGE_TITLE_DESC="An optional alternative page title to set that will change the TITLE tag in the HTML output."
 JFIELD_ALT_PAGE_TITLE_LABEL="Alternative Page Title"
-; Deprecated, will be removed with 5.0
-JFIELD_ASSET_ID_DESC="Asset ID"
-; Deprecated, will be removed with 5.0
-JFIELD_ASSET_ID_LABEL="Asset ID"
 JFIELD_BASIC_LOGIN_DESCRIPTION_LABEL="Login Description Text"
 JFIELD_BASIC_LOGIN_DESCRIPTION_SHOW_LABEL="Login Description"
 JFIELD_BASIC_LOGOUT_DESCRIPTION_LABEL="Logout Description Text"

--- a/api/language/en-GB/joomla.ini
+++ b/api/language/en-GB/joomla.ini
@@ -201,14 +201,8 @@ JFIELD_ALIAS_LABEL="Alias"
 JFIELD_ALIAS_PLACEHOLDER="Auto-generate from title"
 JFIELD_ALT_COMPONENT_LAYOUT_DESC="Use a layout from the supplied component view or overrides in the templates."
 JFIELD_ALT_LAYOUT_LABEL="Layout"
-; Deprecated, will be removed with 5.0
-JFIELD_ALT_MODULE_LAYOUT_DESC="Use a layout from the supplied module or overrides in the templates."
 JFIELD_ALT_PAGE_TITLE_DESC="An optional alternative page title to set that will change the TITLE tag in the HTML output."
 JFIELD_ALT_PAGE_TITLE_LABEL="Alternative Page Title"
-; Deprecated, will be removed with 5.0
-JFIELD_ASSET_ID_DESC="Asset ID"
-; Deprecated, will be removed with 5.0
-JFIELD_ASSET_ID_LABEL="Asset ID"
 JFIELD_BASIC_LOGIN_DESCRIPTION_LABEL="Login Description Text"
 JFIELD_BASIC_LOGIN_DESCRIPTION_SHOW_LABEL="Login Description"
 JFIELD_BASIC_LOGOUT_DESCRIPTION_LABEL="Logout Description Text"

--- a/language/en-GB/com_media.ini
+++ b/language/en-GB/com_media.ini
@@ -53,10 +53,6 @@ COM_MEDIA_FIELD_CHECK_MIME_DESC="Use MIME Magic or Fileinfo to try to verify fil
 COM_MEDIA_FIELD_CHECK_MIME_LABEL="Check MIME Types"
 COM_MEDIA_FIELD_IGNORED_EXTENSIONS_DESC="Ignored file extensions for MIME type checking and restricted uploads."
 COM_MEDIA_FIELD_IGNORED_EXTENSIONS_LABEL="Ignored Extensions"
-; Deprecated, will be removed with 5.0
-COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_DESC="A comma separated list of forbidden MIME types to upload."
-; Deprecated, will be removed with 5.0
-COM_MEDIA_FIELD_ILLEGAL_MIME_TYPES_LABEL="Forbidden MIME Types"
 COM_MEDIA_FIELD_LEGAL_EXTENSIONS_DESC="Extensions (file types) you are allowed to upload (comma separated)."
 COM_MEDIA_FIELD_LEGAL_EXTENSIONS_LABEL="Legal Extensions (File Types)"
 COM_MEDIA_FIELD_LEGAL_IMAGE_EXTENSIONS_DESC="Image extensions (file types) you are allowed to upload (comma separated). These are used to check for valid image headers."


### PR DESCRIPTION
This PR removes language strings marked for deprecation in 5.0

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
