### PR TITLE
[4.3] Guided Tours remove description of permissions fieldset

### DIFF
--- a/administrator/components/com_guidedtours/config.xml
+++ b/administrator/components/com_guidedtours/config.xml
@@ -3,7 +3,6 @@
 	<fieldset
 		name="permissions"
 		label="JCONFIG_PERMISSIONS_LABEL"
-		description="JCONFIG_PERMISSIONS_DESC"
 		>
 		<field
 			name="rules"


### PR DESCRIPTION
### Summary of Changes

Remove additional description like #37875. After #40228 is merged no longer item level permissions are present.

### Testing Instructions

check `Guided Tours: Options`

### Actual result BEFORE applying this Pull Request

![image](https://user-images.githubusercontent.com/66922325/229354874-2a23a54b-0034-4787-89e7-97985ea0dc0d.png)


### Expected result AFTER applying this Pull Request

![image](https://user-images.githubusercontent.com/66922325/229354884-b52acf5d-9b09-4973-998b-01d16431cdee.png)

### Link to documentations
Please select:

- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
