### PR TITLE
[4.4] replace deprecated access of input property

### DIFF
--- a/libraries/src/Dispatcher/ComponentDispatcherFactory.php
+++ b/libraries/src/Dispatcher/ComponentDispatcherFactory.php
@@ -80,6 +80,6 @@ class ComponentDispatcherFactory implements ComponentDispatcherFactoryInterface
             }
         }
 
-        return new $className($application, $input ?: $application->input, $this->mvcFactory);
+        return new $className($application, $input ?: $application->getInput(), $this->mvcFactory);
     }
 }

--- a/libraries/src/Dispatcher/ModuleDispatcherFactory.php
+++ b/libraries/src/Dispatcher/ModuleDispatcherFactory.php
@@ -69,6 +69,6 @@ class ModuleDispatcherFactory implements ModuleDispatcherFactoryInterface
             $className = ModuleDispatcher::class;
         }
 
-        return new $className($module, $application, $input ?: $application->input);
+        return new $className($module, $application, $input ?: $application->getInput());
     }
 }

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -740,7 +740,7 @@ abstract class Factory
 
         $lang = self::getLanguage();
 
-        $input = self::getApplication()->input;
+        $input = self::getApplication()->getInput();
         $type  = $input->get('format', 'html', 'cmd');
 
         $version = new Version();


### PR DESCRIPTION
### Summary of Changes

> As directly access the input variable is deprecated since Joomla 4.0 in https://github.com/joomla/joomla-cms/pull/28313, the core should not use it anymore. This pr changes the call to the getInput function.

Missed by PR #39029

### Testing Instructions

Open backend

### Actual result BEFORE applying this Pull Request

Use of deprecated access to the application's input property

### Expected result AFTER applying this Pull Request

All works like before, but without using deprecated access to the application's input property

### Link to documentations
Please select:

- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
