### PR TITLE
[4.4] com_messages deprecated toolbar api

### DIFF
--- a/administrator/components/com_messages/src/View/Messages/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Messages/HtmlView.php
@@ -152,8 +152,9 @@ class HtmlView extends BaseHtmlView
             }
         }
 
-        $toolbar->appendButton('Link', 'cog', 'COM_MESSAGES_TOOLBAR_MY_SETTINGS', 'index.php?option=com_messages&amp;view=config');
-        ToolbarHelper::divider();
+        $toolbar->linkButton('cog', 'COM_MESSAGES_TOOLBAR_MY_SETTINGS')
+            ->url('index.php?option=com_messages&amp;view=config');
+        $toolbar->divider();
 
         if (!$this->isEmptyState && $this->state->get('filter.state') == -2 && $canDo->get('core.delete')) {
             $toolbar->delete('messages.delete')


### PR DESCRIPTION
### Summary of Changes

Migrate com_messages "My Settings" button and divider to new toolbar API
more information: #39537

### Testing Instructions

open `Private Messages` and check `My Settings` in toolbar (function and display)
![image](https://user-images.githubusercontent.com/66922325/229541834-4149fcba-c095-419e-9a90-001e319c7971.png)


### Actual result BEFORE applying this Pull Request

deprecate message from toolbar
`Joomla\CMS\Toolbar\Toolbar::appendButton()` should only accept `Joomla\CMS\Toolbar\ToolbarButton` instance

### Expected result AFTER applying this Pull Request

no deprecate message from toolbar and button still works

### Link to documentations
Please select:

- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
