### PR TITLE
[4.3] spelling directoy/directory

### DIFF
--- a/tests/Unit/Plugin/Filesystem/Local/Extension/LocalPluginTest.php
+++ b/tests/Unit/Plugin/Filesystem/Local/Extension/LocalPluginTest.php
@@ -118,7 +118,7 @@ class LocalPluginTest extends UnitTestCase
      *
      * @since   4.3.0
      */
-    public function testAdaptersInvalidDirectoy()
+    public function testAdaptersInvalidDirectory()
     {
         $this->expectException(InvalidArgumentException::class);
         $dispatcher = new Dispatcher();


### PR DESCRIPTION
simple spelling correction

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
