### PR TITLE
Deprecate the platform define

### DIFF
--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
  * Set the platform root path as a constant if necessary.
  *
  * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
- *             Use defined('_JEXEC') or die; to detect if the CMS is correctly loaded
+ *             Use defined('_JEXEC') or die; to detect if the CMS is loaded correctly
  **/
 defined('JPATH_PLATFORM') or define('JPATH_PLATFORM', __DIR__);
 

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -13,7 +13,7 @@ defined('_JEXEC') or die;
 /**
  * Set the platform root path as a constant if necessary.
  *
- * @deprecated __DEPLOY_VERSION__ will be remove in 6.0
+ * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
  *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
  **/
 defined('JPATH_PLATFORM') or define('JPATH_PLATFORM', __DIR__);

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -26,7 +26,7 @@ defined('IS_UNIX') or define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')));
 
 // Import the library loader if necessary.
 if (!class_exists('JLoader')) {
-    require_once JPATH_LIBRARIES . '/loader.php';
+    require_once JPATH_PLATFORM . '/loader.php';
 
     // If JLoader still does not exist panic.
     if (!class_exists('JLoader')) {
@@ -85,7 +85,7 @@ if (array_key_exists('REQUEST_METHOD', $_SERVER)) {
 }
 
 // Register the Crypto lib
-JLoader::register('Crypto', JPATH_LIBRARIES . '/php-encryption/Crypto.php');
+JLoader::register('Crypto', JPATH_PLATFORM . '/php-encryption/Crypto.php');
 
 // Register the PasswordHash library.
-JLoader::register('PasswordHash', JPATH_LIBRARIES . '/phpass/PasswordHash.php');
+JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -10,7 +10,12 @@
 
 defined('_JEXEC') or die;
 
-// Set the platform root path as a constant if necessary.
+/**
+ * Set the platform root path as a constant if necessary.
+ *
+ * @deprecated __DEPLOY_VERSION__ will be remove in 6.0
+ *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
+ **/
 defined('JPATH_PLATFORM') or define('JPATH_PLATFORM', __DIR__);
 
 // Detect the native operating system type.
@@ -21,7 +26,7 @@ defined('IS_UNIX') or define('IS_UNIX', (($os !== 'MAC') && ($os !== 'WIN')));
 
 // Import the library loader if necessary.
 if (!class_exists('JLoader')) {
-    require_once JPATH_PLATFORM . '/loader.php';
+    require_once JPATH_LIBRARIES . '/loader.php';
 
     // If JLoader still does not exist panic.
     if (!class_exists('JLoader')) {
@@ -80,7 +85,7 @@ if (array_key_exists('REQUEST_METHOD', $_SERVER)) {
 }
 
 // Register the Crypto lib
-JLoader::register('Crypto', JPATH_PLATFORM . '/php-encryption/Crypto.php');
+JLoader::register('Crypto', JPATH_LIBRARIES . '/php-encryption/Crypto.php');
 
 // Register the PasswordHash library.
-JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');
+JLoader::register('PasswordHash', JPATH_LIBRARIES . '/phpass/PasswordHash.php');

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
  * Set the platform root path as a constant if necessary.
  *
  * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
- *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
+ *             Use defined('_JEXEC') or die; to detect if the CMS is correctly loaded
  **/
 defined('JPATH_PLATFORM') or define('JPATH_PLATFORM', __DIR__);
 

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -22,7 +22,7 @@ trigger_error(
  * Set the platform root path as a constant if necessary.
  *
  * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
- *             Use defined('_JEXEC') or die; to detect if the CMS is correctly loaded
+ *             Use defined('_JEXEC') or die; to detect if the CMS is loaded correctly
  **/
 if (!defined('JPATH_PLATFORM')) {
     define('JPATH_PLATFORM', __DIR__);

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -30,7 +30,7 @@ if (!defined('JPATH_PLATFORM')) {
 
 // Import the library loader if necessary
 if (!class_exists('JLoader')) {
-    require_once JPATH_LIBRARIES . '/loader.php';
+    require_once JPATH_PLATFORM . '/loader.php';
 }
 
 // Make sure that the Joomla Platform has been successfully loaded
@@ -77,4 +77,4 @@ if (array_key_exists('REQUEST_METHOD', $_SERVER)) {
 }
 
 // Register the Crypto lib
-JLoader::register('Crypto', JPATH_LIBRARIES . '/php-encryption/Crypto.php');
+JLoader::register('Crypto', JPATH_PLATFORM . '/php-encryption/Crypto.php');

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -18,14 +18,19 @@ trigger_error(
     E_USER_DEPRECATED
 );
 
-// Set the platform root path as a constant if necessary
+/**
+ * Set the platform root path as a constant if necessary.
+ *
+ * @deprecated __DEPLOY_VERSION__ will be remove in 6.0
+ *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
+ **/
 if (!defined('JPATH_PLATFORM')) {
     define('JPATH_PLATFORM', __DIR__);
 }
 
 // Import the library loader if necessary
 if (!class_exists('JLoader')) {
-    require_once JPATH_PLATFORM . '/loader.php';
+    require_once JPATH_LIBRARIES . '/loader.php';
 }
 
 // Make sure that the Joomla Platform has been successfully loaded
@@ -72,4 +77,4 @@ if (array_key_exists('REQUEST_METHOD', $_SERVER)) {
 }
 
 // Register the Crypto lib
-JLoader::register('Crypto', JPATH_PLATFORM . '/php-encryption/Crypto.php');
+JLoader::register('Crypto', JPATH_LIBRARIES . '/php-encryption/Crypto.php');

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -21,7 +21,7 @@ trigger_error(
 /**
  * Set the platform root path as a constant if necessary.
  *
- * @deprecated __DEPLOY_VERSION__ will be remove in 6.0
+ * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
  *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
  **/
 if (!defined('JPATH_PLATFORM')) {

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -22,7 +22,7 @@ trigger_error(
  * Set the platform root path as a constant if necessary.
  *
  * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
- *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
+ *             Use defined('_JEXEC') or die; to detect if the CMS is correctly loaded
  **/
 if (!defined('JPATH_PLATFORM')) {
     define('JPATH_PLATFORM', __DIR__);

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -40,7 +40,7 @@ if (!defined('IS_UNIX')) {
 
 // Import the library loader if necessary.
 if (!class_exists('JLoader')) {
-    require_once JPATH_LIBRARIES . '/loader.php';
+    require_once JPATH_PLATFORM . '/loader.php';
 }
 
 // Make sure that the Joomla Loader has been successfully loaded.
@@ -52,4 +52,4 @@ if (!class_exists('JLoader')) {
 JLoader::setup();
 
 // Register the PasswordHash lib
-JLoader::register('PasswordHash', JPATH_LIBRARIES . '/phpass/PasswordHash.php');
+JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -20,7 +20,7 @@ trigger_error(
 /**
  * Set the platform root path as a constant if necessary.
  *
- * @deprecated __DEPLOY_VERSION__ will be remove in 6.0
+ * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
  *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
  **/
 if (!defined('JPATH_PLATFORM')) {

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -17,7 +17,12 @@ trigger_error(
     E_USER_DEPRECATED
 );
 
-// Set the platform root path as a constant if necessary.
+/**
+ * Set the platform root path as a constant if necessary.
+ *
+ * @deprecated __DEPLOY_VERSION__ will be remove in 6.0
+ *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
+ **/
 if (!defined('JPATH_PLATFORM')) {
     define('JPATH_PLATFORM', __DIR__);
 }
@@ -35,7 +40,7 @@ if (!defined('IS_UNIX')) {
 
 // Import the library loader if necessary.
 if (!class_exists('JLoader')) {
-    require_once JPATH_PLATFORM . '/loader.php';
+    require_once JPATH_LIBRARIES . '/loader.php';
 }
 
 // Make sure that the Joomla Loader has been successfully loaded.
@@ -47,4 +52,4 @@ if (!class_exists('JLoader')) {
 JLoader::setup();
 
 // Register the PasswordHash lib
-JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');
+JLoader::register('PasswordHash', JPATH_LIBRARIES . '/phpass/PasswordHash.php');

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -21,7 +21,7 @@ trigger_error(
  * Set the platform root path as a constant if necessary.
  *
  * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
- *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
+ *             Use defined('_JEXEC') or die; to detect if the CMS is correctly loaded
  **/
 if (!defined('JPATH_PLATFORM')) {
     define('JPATH_PLATFORM', __DIR__);

--- a/libraries/import.legacy.php
+++ b/libraries/import.legacy.php
@@ -21,7 +21,7 @@ trigger_error(
  * Set the platform root path as a constant if necessary.
  *
  * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
- *             Use defined('_JEXEC') or die; to detect if the CMS is correctly loaded
+ *             Use defined('_JEXEC') or die; to detect if the CMS is loaded correctly
  **/
 if (!defined('JPATH_PLATFORM')) {
     define('JPATH_PLATFORM', __DIR__);

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -40,7 +40,7 @@ if (!defined('IS_UNIX')) {
 
 // Import the library loader if necessary.
 if (!class_exists('JLoader')) {
-    require_once JPATH_LIBRARIES . '/loader.php';
+    require_once JPATH_PLATFORM . '/loader.php';
 }
 
 // Make sure that the Joomla Platform has been successfully loaded.
@@ -52,4 +52,4 @@ if (!class_exists('JLoader')) {
 JLoader::setup();
 
 // Register the PasswordHash lib
-JLoader::register('PasswordHash', JPATH_LIBRARIES . '/phpass/PasswordHash.php');
+JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -20,7 +20,7 @@ trigger_error(
 /**
  * Set the platform root path as a constant if necessary.
  *
- * @deprecated __DEPLOY_VERSION__ will be remove in 6.0
+ * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
  *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
  **/
 if (!defined('JPATH_PLATFORM')) {

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -17,7 +17,12 @@ trigger_error(
     E_USER_DEPRECATED
 );
 
-// Set the platform root path as a constant if necessary.
+/**
+ * Set the platform root path as a constant if necessary.
+ *
+ * @deprecated __DEPLOY_VERSION__ will be remove in 6.0
+ *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
+ **/
 if (!defined('JPATH_PLATFORM')) {
     define('JPATH_PLATFORM', __DIR__);
 }
@@ -35,7 +40,7 @@ if (!defined('IS_UNIX')) {
 
 // Import the library loader if necessary.
 if (!class_exists('JLoader')) {
-    require_once JPATH_PLATFORM . '/loader.php';
+    require_once JPATH_LIBRARIES . '/loader.php';
 }
 
 // Make sure that the Joomla Platform has been successfully loaded.
@@ -47,4 +52,4 @@ if (!class_exists('JLoader')) {
 JLoader::setup();
 
 // Register the PasswordHash lib
-JLoader::register('PasswordHash', JPATH_PLATFORM . '/phpass/PasswordHash.php');
+JLoader::register('PasswordHash', JPATH_LIBRARIES . '/phpass/PasswordHash.php');

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -21,7 +21,7 @@ trigger_error(
  * Set the platform root path as a constant if necessary.
  *
  * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
- *             Use defined('_JEXEC') or die; if the CMS is correctly loaded
+ *             Use defined('_JEXEC') or die; to detect if the CMS is correctly loaded
  **/
 if (!defined('JPATH_PLATFORM')) {
     define('JPATH_PLATFORM', __DIR__);

--- a/libraries/import.php
+++ b/libraries/import.php
@@ -21,7 +21,7 @@ trigger_error(
  * Set the platform root path as a constant if necessary.
  *
  * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
- *             Use defined('_JEXEC') or die; to detect if the CMS is correctly loaded
+ *             Use defined('_JEXEC') or die; to detect if the CMS is loaded correctly
  **/
 if (!defined('JPATH_PLATFORM')) {
     define('JPATH_PLATFORM', __DIR__);

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -36,7 +36,7 @@ if (!defined('JPATH_ROOT')) {
 }
 
 /**
- * @deprecated __DEPLOY_VERSION__ will be remove in 6.0
+ * @deprecated __DEPLOY_VERSION__ will be removed in 6.0
  **/
 if (!defined('JPATH_PLATFORM')) {
     define('JPATH_PLATFORM', JPATH_BASE . DIRECTORY_SEPARATOR . 'libraries');

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -88,7 +88,7 @@ if (!defined('JDEBUG')) {
 
 // Import the library loader if necessary.
 if (!class_exists('JLoader')) {
-    require_once JPATH_LIBRARIES . '/loader.php';
+    require_once JPATH_PLATFORM . '/loader.php';
 
     // If JLoader still does not exist panic.
     if (!class_exists('JLoader')) {

--- a/tests/Unit/bootstrap.php
+++ b/tests/Unit/bootstrap.php
@@ -35,6 +35,9 @@ if (!defined('JPATH_ROOT')) {
     define('JPATH_ROOT', JPATH_BASE);
 }
 
+/**
+ * @deprecated __DEPLOY_VERSION__ will be remove in 6.0
+ **/
 if (!defined('JPATH_PLATFORM')) {
     define('JPATH_PLATFORM', JPATH_BASE . DIRECTORY_SEPARATOR . 'libraries');
 }
@@ -85,7 +88,7 @@ if (!defined('JDEBUG')) {
 
 // Import the library loader if necessary.
 if (!class_exists('JLoader')) {
-    require_once JPATH_PLATFORM . '/loader.php';
+    require_once JPATH_LIBRARIES . '/loader.php';
 
     // If JLoader still does not exist panic.
     if (!class_exists('JLoader')) {


### PR DESCRIPTION
### Summary of Changes
Deprecates the variable `JPATH_PLATFORM` and changes the libraries setup files usage to `_JEXEC`. `JPATH_PLATFORM` is an old variable where there was an idea to split the CMS into a platform which got abandoned on some point.

To simplify the code, we should concentrate only on one variable. Please use from now on only `defined('_JEXEC') or die;`.

### Testing Instructions
Open the back and front end.

### Actual result BEFORE applying this Pull Request
All works.

### Expected result AFTER applying this Pull Request
All works.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/109
- [ ] No documentation changes for manual.joomla.org needed
