### PR TITLE
[4.3] Fix category toolbar save button

### DIFF
--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -197,7 +197,7 @@ class HtmlView extends BaseHtmlView
             $saveGroup->configure(
                 function (Toolbar $childBar) {
                     $childBar->save('category.save');
-                    $childBar->save('category.save2new');
+                    $childBar->save2new('category.save2new');
                 }
             );
 


### PR DESCRIPTION
### Summary of Changes

Fix broken toolbar by PR #39537, similar to #40381.
@obuisard Maybe that's a release blocker too?

### Testing Instructions

Open the form for add a new category (to any component)
Check the dropdown of the save button

### Actual result BEFORE applying this Pull Request

2x `Save&Close`
![image](https://user-images.githubusercontent.com/66922325/232069344-d18476f1-cfd3-432f-a335-9d6ef67537b4.png)

### Expected result AFTER applying this Pull Request

1x `Save&Close` & 1x `Save&New`
![image](https://user-images.githubusercontent.com/66922325/232069381-b0db7f42-c59c-4612-a85b-1ead02e60adf.png)

### Link to documentations
Please select:

- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
