### PR TITLE
Add a forward slash in front of the cypress visit calls

### DIFF
--- a/tests/System/integration/administrator/components/com_categories/Categories.cy.js
+++ b/tests/System/integration/administrator/components/com_categories/Categories.cy.js
@@ -1,7 +1,7 @@
 describe('Test in backend that the categories list', () => {
   beforeEach(() => {
     cy.doAdministratorLogin();
-    cy.visit('administrator/index.php?option=com_categories&view=categories&extension=com_content&filter=');
+    cy.visit('/administrator/index.php?option=com_categories&view=categories&extension=com_content&filter=');
   });
 
   it('has a title', () => {

--- a/tests/System/integration/administrator/components/com_categories/Category.cy.js
+++ b/tests/System/integration/administrator/components/com_categories/Category.cy.js
@@ -3,7 +3,7 @@ describe('Test in backend that the category form', () => {
   afterEach(() => cy.task('queryDB', "DELETE FROM #__categories WHERE title = 'Test category'"));
 
   it('can create a category', () => {
-    cy.visit('administrator/index.php?option=com_categories&task=category.add&extension=com_content');
+    cy.visit('/administrator/index.php?option=com_categories&task=category.add&extension=com_content');
     cy.get('#jform_title').should('exist').type('Test category');
     cy.clickToolbarButton('Save & Close');
 

--- a/tests/System/integration/administrator/components/com_content/Article.cy.js
+++ b/tests/System/integration/administrator/components/com_content/Article.cy.js
@@ -3,7 +3,7 @@ describe('Test in backend that the article form', () => {
   afterEach(() => cy.task('queryDB', "DELETE FROM #__content WHERE title = 'Test article'"));
 
   it('can create an article', () => {
-    cy.visit('administrator/index.php?option=com_content&task=article.add');
+    cy.visit('/administrator/index.php?option=com_content&task=article.add');
     cy.get('#jform_title').clear().type('Test article');
     cy.clickToolbarButton('Save & Close');
 

--- a/tests/System/integration/administrator/components/com_content/Articles.cy.js
+++ b/tests/System/integration/administrator/components/com_content/Articles.cy.js
@@ -1,7 +1,7 @@
 describe('Test in backend that the articles list', () => {
   beforeEach(() => {
     cy.doAdministratorLogin();
-    cy.visit('administrator/index.php?option=com_content&view=articles&filter=');
+    cy.visit('/administrator/index.php?option=com_content&view=articles&filter=');
   });
 
   it('has a title', () => {

--- a/tests/System/integration/administrator/components/com_fields/Field.cy.js
+++ b/tests/System/integration/administrator/components/com_fields/Field.cy.js
@@ -3,7 +3,7 @@ describe('Test in backend that the field form', () => {
   afterEach(() => cy.task('queryDB', "DELETE FROM #__fields WHERE title = 'Test field'"));
 
   it('can create a field', () => {
-    cy.visit('administrator/index.php?option=com_fields&task=field.add&context=com_content.article');
+    cy.visit('/administrator/index.php?option=com_fields&task=field.add&context=com_content.article');
     cy.get('#jform_title').clear().type('Test field');
     cy.clickToolbarButton('Save & Close');
 

--- a/tests/System/integration/administrator/components/com_fields/Fields.cy.js
+++ b/tests/System/integration/administrator/components/com_fields/Fields.cy.js
@@ -1,7 +1,7 @@
 describe('Test in backend that the custom fields list', () => {
   beforeEach(() => {
     cy.doAdministratorLogin();
-    cy.visit('administrator/index.php?option=com_fields&view=fields&context=com_content.article&filter=');
+    cy.visit('/administrator/index.php?option=com_fields&view=fields&context=com_content.article&filter=');
   });
 
   it('has a title', () => {

--- a/tests/System/integration/administrator/components/com_menu/Menu.cy.js
+++ b/tests/System/integration/administrator/components/com_menu/Menu.cy.js
@@ -3,7 +3,7 @@ describe('Test in backend that the user form', () => {
   afterEach(() => cy.task('queryDB', "DELETE FROM #__menu_types WHERE menutype = 'test'"));
 
   it('can create a new menu', () => {
-    cy.visit('administrator/index.php?option=com_menus&task=menu.add');
+    cy.visit('/administrator/index.php?option=com_menus&task=menu.add');
 
     cy.get('#jform_title').clear().type('test menu');
     cy.get('#jform_menutype').clear().type('test');

--- a/tests/System/integration/administrator/components/com_menu/MenuItem.cy.js
+++ b/tests/System/integration/administrator/components/com_menu/MenuItem.cy.js
@@ -1,7 +1,7 @@
 describe('Test in backend that the menu list', () => {
   beforeEach(() => {
     cy.doAdministratorLogin();
-    cy.visit('administrator/index.php?option=com_menus&view=items&menutype=mainmenu');
+    cy.visit('/administrator/index.php?option=com_menus&view=items&menutype=mainmenu');
   });
 
   it('has a title', () => cy.get('h1.page-title').should('contain.text', 'Menus: Items'));

--- a/tests/System/integration/administrator/components/com_menu/Menus.cy.js
+++ b/tests/System/integration/administrator/components/com_menu/Menus.cy.js
@@ -1,7 +1,7 @@
 describe('Test in backend that the menu list', () => {
   beforeEach(() => {
     cy.doAdministratorLogin();
-    cy.visit('administrator/index.php?option=com_menus&view=menus&filter=');
+    cy.visit('/administrator/index.php?option=com_menus&view=menus&filter=');
   });
 
   it('has a title', () => cy.get('h1.page-title').should('contain.text', 'Menus'));

--- a/tests/System/integration/administrator/components/com_users/User.cy.js
+++ b/tests/System/integration/administrator/components/com_users/User.cy.js
@@ -3,7 +3,7 @@ describe('Test in backend that the user form', () => {
   afterEach(() => cy.task('queryDB', "DELETE FROM #__users WHERE username = 'test'"));
 
   it('can create a new user', () => {
-    cy.visit('administrator/index.php?option=com_users&task=user.add');
+    cy.visit('/administrator/index.php?option=com_users&task=user.add');
 
     cy.get('#jform_name').clear().type('test user');
     cy.get('#jform_username').clear().type('test');

--- a/tests/System/integration/administrator/components/com_users/Users.cy.js
+++ b/tests/System/integration/administrator/components/com_users/Users.cy.js
@@ -1,7 +1,7 @@
 describe('Test in backend that the user list', () => {
   beforeEach(() => {
     cy.doAdministratorLogin();
-    cy.visit('administrator/index.php?option=com_users&view=users&filter=');
+    cy.visit('/administrator/index.php?option=com_users&view=users&filter=');
   });
 
   it('has a title', () => {

--- a/tests/System/integration/site/components/com_contact/Categories.cy.js
+++ b/tests/System/integration/site/components/com_contact/Categories.cy.js
@@ -8,7 +8,7 @@ describe('Test in frontend that the contact categories view', () => {
         await cy.db_createContact({ name: 'automated test contact 3', catid: id });
       })
       .then(() => {
-        cy.visit('index.php?option=com_contact&view=categories');
+        cy.visit('/index.php?option=com_contact&view=categories');
 
         cy.contains('automated test category 1');
         cy.contains('automated test category 2');

--- a/tests/System/integration/site/components/com_contact/Form.cy.js
+++ b/tests/System/integration/site/components/com_contact/Form.cy.js
@@ -3,10 +3,10 @@ describe('Test in frontend that the contact form view', () => {
 
   it('can create a contact through a form', () => {
     cy.doFrontendLogin();
-    cy.visit('index.php?option=com_contact&view=form&layout=edit');
+    cy.visit('/index.php?option=com_contact&view=form&layout=edit');
     cy.get('#jform_name').type('test contact 1');
     cy.get('.mb-2 > .btn-primary').click();
-    cy.visit('index.php?option=com_contact&view=category&id=4');
+    cy.visit('/index.php?option=com_contact&view=category&id=4');
 
     cy.contains('test contact 1').should('exist');
   });

--- a/tests/System/integration/site/components/com_newsfeed/Categories.cy.js
+++ b/tests/System/integration/site/components/com_newsfeed/Categories.cy.js
@@ -8,7 +8,7 @@ describe('Test in frontend that the newsfeeds categories view', () => {
         await cy.db_createNewsFeed({ name: 'automated test feed 3', catid: id });
       })
       .then(() => {
-        cy.visit('index.php?option=com_newsfeeds&view=categories');
+        cy.visit('/index.php?option=com_newsfeeds&view=categories');
 
         cy.contains('automated test category 1');
         cy.contains('automated test category 2');

--- a/tests/System/integration/site/components/com_newsfeed/Category.cy.js
+++ b/tests/System/integration/site/components/com_newsfeed/Category.cy.js
@@ -22,7 +22,7 @@ describe('Test in frontend that the newsfeeds category view', () => {
       .then(() => cy.db_createNewsFeed({ name: 'automated test feed 3' }))
       .then(() => cy.db_createNewsFeed({ name: 'automated test feed 4' }))
       .then(() => {
-        cy.visit('index.php?option=com_newsfeeds&view=category&id=5');
+        cy.visit('/index.php?option=com_newsfeeds&view=category&id=5');
 
         cy.contains('automated test feed 1');
         cy.contains('automated test feed 2');

--- a/tests/System/integration/site/components/com_tag/Tag.cy.js
+++ b/tests/System/integration/site/components/com_tag/Tag.cy.js
@@ -22,7 +22,7 @@ describe('Test in frontend that the tags tag view', () => {
       .then(() => cy.db_createTag({ title: 'automated test tag 3' }))
       .then(() => cy.db_createTag({ title: 'automated test tag 4' }))
       .then(() => {
-        cy.visit('index.php?option=com_tags&view=tags');
+        cy.visit('/index.php?option=com_tags&view=tags');
 
         cy.contains('automated test tag 1');
         cy.contains('automated test tag 2');

--- a/tests/System/integration/site/components/com_users/Login.cy.js
+++ b/tests/System/integration/site/components/com_users/Login.cy.js
@@ -2,7 +2,7 @@ describe('Test in frontend that the users login view', () => {
   it('can log in a test user without a menu item', () => {
     cy.db_createUser({ username: 'test', password: '098f6bcd4621d373cade4e832627b4f6' })
       .then(() => {
-        cy.visit('index.php?option=com_users&view=login');
+        cy.visit('/index.php?option=com_users&view=login');
         cy.get('#username').type('test');
         cy.get('#password').type('test');
         cy.get('#remember').check();

--- a/tests/System/integration/site/components/com_users/Profile.cy.js
+++ b/tests/System/integration/site/components/com_users/Profile.cy.js
@@ -4,7 +4,7 @@ describe('Test in frontend that the users profile view', () => {
       name: 'automated test user', username: 'automatedtestuser', password: '098f6bcd4621d373cade4e832627b4f6', registerDate: '2023-03-01 20:00:00',
     })
       .then(() => {
-        cy.visit('index.php?option=com_users&view=profile');
+        cy.visit('/index.php?option=com_users&view=profile');
         cy.get('#username').type('automatedtestuser');
         cy.get('#password').type('test');
         cy.get('#remember').check();

--- a/tests/System/integration/site/components/com_users/Profile_Edit.cy.js
+++ b/tests/System/integration/site/components/com_users/Profile_Edit.cy.js
@@ -1,7 +1,7 @@
 describe('Test in frontend that the users profile view', () => {
   it('can display a user form without a menu item', () => {
     cy.doFrontendLogin();
-    cy.visit('index.php?option=com_users&view=profile&layout=edit');
+    cy.visit('/index.php?option=com_users&view=profile&layout=edit');
 
     cy.get('#member-profile > :nth-child(1) > legend').should('contain.text', 'Edit Your Profile');
   });
@@ -23,7 +23,7 @@ describe('Test in frontend that the users profile view', () => {
     })
       .then(() => {
         cy.doFrontendLogin('automatedtestuser2', 'test', false);
-        cy.visit('index.php?option=com_users&view=profile&layout=edit');
+        cy.visit('/index.php?option=com_users&view=profile&layout=edit');
 
         cy.get('#jform_name').clear().type('automated test user edited');
         cy.get('#jform_email1').clear().type('testedited@example.com');

--- a/tests/System/integration/site/components/com_users/Registration.cy.js
+++ b/tests/System/integration/site/components/com_users/Registration.cy.js
@@ -2,7 +2,7 @@ describe('Test in frontend that the users registration view', () => {
   it('can display a registration form for a test user without a menu item', () => {
     cy.db_createUser({ username: 'test', password: '098f6bcd4621d373cade4e832627b4f6' })
       .then(() => {
-        cy.visit('index.php?option=com_users&view=registration');
+        cy.visit('/index.php?option=com_users&view=registration');
         cy.get('#username').type('test');
         cy.get('#password').type('test');
         cy.get('#remember').check();

--- a/tests/System/integration/site/components/com_users/Remind.cy.js
+++ b/tests/System/integration/site/components/com_users/Remind.cy.js
@@ -15,7 +15,7 @@ describe('Test in frontend that the users remind view', () => {
   it('can send a reminder email for a test user without a menu item', () => {
     cy.db_createUser({ name: 'test user', email: 'test@example.com' })
       .then(() => {
-        cy.visit('index.php?option=com_users&view=remind');
+        cy.visit('/index.php?option=com_users&view=remind');
         cy.get('#jform_email').type('test@example.com');
         cy.get('.controls > .btn').click();
 

--- a/tests/System/integration/site/components/com_users/Reset.cy.js
+++ b/tests/System/integration/site/components/com_users/Reset.cy.js
@@ -2,7 +2,7 @@ describe('Test in frontend that the users reset view', () => {
   it('can send a reset email for a test user without a menu item', () => {
     cy.db_createUser({ email: 'test@example.com' })
       .then(() => {
-        cy.visit('index.php?option=com_users&view=reset');
+        cy.visit('/index.php?option=com_users&view=reset');
         cy.get('#jform_email').type('test@example.com');
         cy.get('.controls > .btn').click();
 


### PR DESCRIPTION
As soon as an query value contains a dot, cypress can't open the url anymore. Was the case in https://github.com/joomla/joomla-cms/pull/40394/files#r1169665990. So this pr adds a slash to all `cy.visit()` calls.