### PR TITLE
Fixing broken Folder::exists()

### DIFF
--- a/libraries/src/Form/Field/ChromestyleField.php
+++ b/libraries/src/Form/Field/ChromestyleField.php
@@ -15,6 +15,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\ParameterType;
 use Joomla\Filesystem\Folder;
+use Joomla\Filesystem\Path;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('JPATH_PLATFORM') or die;
@@ -189,7 +190,7 @@ class ChromestyleField extends GroupedlistField
         foreach ($templates as $template) {
             $chromeLayoutPath = $path . '/templates/' . $template->element . '/html/layouts/chromes';
 
-            if (!Folder::exists($chromeLayoutPath)) {
+            if (!is_dir(Path::clean($chromeLayoutPath))) {
                 continue;
             }
 


### PR DESCRIPTION
Followup Pull Request for pr #40239.

### Summary of Changes
Fixes the error message undefined method Folder::exist, which comes from #40239.

![image](https://user-images.githubusercontent.com/251072/232724223-028f7c18-26b6-4d3e-b9ce-beb61a186e51.png)


### Testing Instructions
Edit a module in the back end.

### Actual result BEFORE applying this Pull Request
Error message.

### Expected result AFTER applying this Pull Request
Module can be edited.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
