### PR TITLE
Use CMS Folder class in ChromestyleField

### DIFF
--- a/libraries/src/Form/Field/ChromestyleField.php
+++ b/libraries/src/Form/Field/ChromestyleField.php
@@ -10,11 +10,11 @@
 namespace Joomla\CMS\Form\Field;
 
 use Joomla\CMS\Application\ApplicationHelper;
+use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\ParameterType;
-use Joomla\Filesystem\Folder;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('JPATH_PLATFORM') or die;


### PR DESCRIPTION
Followup Pull Request for pr #40239 and alternative to #40403.

### Summary of Changes
It reverts the change in the file libraries/src/Form/Field/ChromestyleField.php from #40239. It has introduced the error message undefined method Folder::exist.

![image](https://user-images.githubusercontent.com/251072/232724223-028f7c18-26b6-4d3e-b9ce-beb61a186e51.png)


### Testing Instructions
Edit a module in the back end.

### Actual result BEFORE applying this Pull Request
Error message.

### Expected result AFTER applying this Pull Request
Module can be edited.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
