### PR TITLE
[4.3] Delete autoload_psr4.php when update Joomla using CLI

### DIFF
--- a/libraries/src/Console/UpdateCoreCommand.php
+++ b/libraries/src/Console/UpdateCoreCommand.php
@@ -224,6 +224,13 @@ class UpdateCoreCommand extends AbstractCommand
                 $this->progressBar->advance();
                 $this->progressBar->setMessage("Cleaning up ...");
 
+                // Remove the administrator/cache/autoload_psr4.php file
+                $autoloadFile = JPATH_CACHE . '/autoload_psr4.php';
+
+                if (File::exists($autoloadFile)) {
+                    File::delete($autoloadFile);
+                }
+
                 // Remove the xml
                 if (file_exists(JPATH_BASE . '/joomla.xml')) {
                     File::delete(JPATH_BASE . '/joomla.xml');


### PR DESCRIPTION
Pull Request for Issue #40411

### Summary of Changes
This small PR deletes administrator/cache/autoload_psr4.php to prevent fatal error when Joomla is updated using CLI. See https://github.com/joomla/joomla-cms/issues/40411 to understand more about the issue.

Please note that this can only fix the issue when users update from next Joomla release 4.3.1 to future Joomla releases. If users update from 4.3.0 or earlier to future Joomla version using CLI, the issue will still happen.

### Testing Instructions
1. Use Joomla 4.3
2. Modify libraries/src/Version.php, change **MINOR_VERSION** to **2** and **PATCH_VERSION** to **9** to fake the current installed Joomla version to **4.2.9**
3. Execute `cli/joomla.php core:update`


### Actual result BEFORE applying this Pull Request
The file administrator/cache/autoload_psr4.php is not deleted, thus causes fatal error when there is changes in new Joomla version requires re-generate namespace map, for example, there new plugin added or plugin converted to new structure...


### Expected result AFTER applying this Pull Request
The file administrator/cache/autoload_psr4.php is deleted . It will be re-generated on next page load, thus no fatal error anymore


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
