### PR TITLE
Tags router: unset Itemid for not matching menu, in the end of build

### DIFF
--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -127,6 +127,15 @@ class Router extends RouterBase
             $query['Itemid'] = $active->id;
         }
 
+        // If not found, return language specific home link
+        if (!isset($query['Itemid'])) {
+            $default = $this->menu->getDefault($language);
+
+            if (!empty($default->id)) {
+                $query['Itemid'] = $default->id;
+            }
+        }
+
         return $query;
     }
 
@@ -173,7 +182,7 @@ class Router extends RouterBase
             unset($query['view']);
         } else {
             $segments[] = $query['view'];
-            unset($query['view']);
+            unset($query['view'], $query['Itemid']);
 
             if (isset($query['id']) && is_array($query['id'])) {
                 foreach ($query['id'] as $id) {


### PR DESCRIPTION
Pull Request for Issue #40442 redo of #40448 .

### Summary of Changes

Other way around,
Unset Itemid for not matching menu, in the end of Router::build.

### Testing Instructions

Please follow #40442
Also open Tags list URL /component/tags/tags and check paginations links  (Tag menu should be unpublished or not exists)


### Actual result BEFORE applying this Pull Request
the url contain `Itemid`


### Expected result AFTER applying this Pull Request
the url does not contain `Itemid`


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: 
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: 
- [x] No documentation changes for manual.joomla.org needed
