### PR TITLE
[4.4] Browser becomes temporarily unresponsive when editing a menu item and selecting a menu containing a large number of items

### DIFF
--- a/build/media_source/com_menus/js/admin-item-edit.es6.js
+++ b/build/media_source/com_menus/js/admin-item-edit.es6.js
@@ -63,7 +63,7 @@
         });
 
         if (options.length) {
-          fancySelect.choicesInstance.setChoices([options], 'id', 'innerText', false);
+          fancySelect.choicesInstance.setChoices(options, 'id', 'innerText', false);
         }
 
         fancySelect.choicesInstance.setChoiceByValue('1');

--- a/build/media_source/com_menus/js/admin-item-edit.es6.js
+++ b/build/media_source/com_menus/js/admin-item-edit.es6.js
@@ -53,13 +53,18 @@
         fancySelect.choicesInstance.clearChoices();
         fancySelect.choicesInstance.setChoices([{ id: '1', text: Joomla.Text._('JGLOBAL_ROOT_PARENT') }], 'id', 'text', false);
 
+        const options = [];
+
         data.forEach((value) => {
           const option = {};
           option.innerText = value.title;
           option.id = value.id;
-
-          fancySelect.choicesInstance.setChoices([option], 'id', 'innerText', false);
+          options.push(option);
         });
+
+        if (options.length) {
+          fancySelect.choicesInstance.setChoices([options], 'id', 'innerText', false);
+        }
 
         fancySelect.choicesInstance.setChoiceByValue('1');
 


### PR DESCRIPTION
### Summary of Changes

Updated the onChange handler for the 'Menu' field to pass all options for the 'Parent Item' field to the setChoices function of the Choices instance created by JoomlaFieldFancySelect using a single call, rather than one call per option.

### Testing Instructions

This issue was experienced when a menu containing 1814 published menu items was selected.

- Create a new menu item, or edit an existing one.
- Using the 'Menu' field, select a menu containing a large number of menu items.
  - The issue does not occur if the menu containing a large number of menu items is already selected.

### Environmental Information

Joomla 4.3.0
PHP 8.0.26
Google Chrome 112.0.5615,138

### Actual result BEFORE applying this Pull Request

The browser becomes temporarily unresponsive after selecting a menu containing a large number of items using the 'Menu' field. Continuing to edit the menu item is not possible until the processing of options for the 'Parent Item' field is complete.

### Expected result AFTER applying this Pull Request

Selecting a menu containing a large number of menu items using the 'Menu' field does not effect browser responsiveness. Editing the menu item can continue as normal.

### Link to documentations

No documentation changes for docs.joomla.org needed.
No documentation changes for manual.joomla.org needed.
