### PR TITLE
Tags router: fix Lookup when multilang is enabled

### DIFF
--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -261,9 +261,7 @@ class Router extends RouterBase
         $component = ComponentHelper::getComponent('com_tags');
         $items     = $this->app->getMenu()->getItems(['component_id', 'language'], [$component->id, [$language, '*']]);
 
-        if (!isset($this->lookup[$language])) {
-            $this->lookup[$language] = ['tags' => [], 'tag' => []];
-        }
+        $this->lookup[$language] = ['tags' => [], 'tag' => []];
 
         foreach ($items as $item) {
             if ($item->query['view'] == 'tag') {

--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -269,16 +269,7 @@ class Router extends RouterBase
             if ($item->query['view'] == 'tag') {
                 $id = $item->query['id'];
                 sort($id);
-
-                // Create a lookup for all ids
                 $this->lookup[$language]['tag'][implode(',', $id)] = $item->id;
-
-                // Create a lookup for each id
-                if (count($id) > 1) {
-                    foreach ($id as $idOne) {
-                        $this->lookup[$language]['tag'][$idOne] = $item->id;
-                    }
-                }
             }
 
             if ($item->query['view'] == 'tags') {

--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -115,8 +115,10 @@ class Router extends RouterBase
                 $id = ArrayHelper::toInteger($query['id']);
                 sort($id);
 
-                if (isset($this->lookup[$language]['tag'][implode(',', $id)])) {
-                    $query['Itemid'] = $this->lookup[$language]['tag'][implode(',', $id)];
+                $lookupKey = implode(',', $id);
+
+                if (isset($this->lookup[$language]['tag'][$lookupKey])) {
+                    $query['Itemid'] = $this->lookup[$language]['tag'][$lookupKey];
                 } elseif (isset($this->lookup[$language]['tags'][0])) {
                     $query['Itemid'] = $this->lookup[$language]['tags'][0];
                 }
@@ -267,7 +269,16 @@ class Router extends RouterBase
             if ($item->query['view'] == 'tag') {
                 $id = $item->query['id'];
                 sort($id);
+
+                // Create a lookup for all ids
                 $this->lookup[$language]['tag'][implode(',', $id)] = $item->id;
+
+                // Create a lookup for each id
+                if (count($id) > 1) {
+                    foreach ($id as $idOne) {
+                        $this->lookup[$language]['tag'][$idOne] = $item->id;
+                    }
+                }
             }
 
             if ($item->query['view'] == 'tags') {


### PR DESCRIPTION
Pull Request for Issue #40454 .

### Summary of Changes

Adjust buildLookup to handle multilanguage correctly. 
To behavior similar to `MenuRules`


### Testing Instructions
Please follow #40454,
Or, on test installation, enable multilanguage, and check links for tags at home page


### Actual result BEFORE applying this Pull Request
The links starts with /component/....


### Expected result AFTER applying this Pull Request
The links linked to existing tag menu


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: 
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org:
- [x] No documentation changes for manual.joomla.org needed
