### PR TITLE
[4.3] Fix sort by menu in com_associations

### DIFF
--- a/administrator/components/com_associations/src/Model/AssociationsModel.php
+++ b/administrator/components/com_associations/src/Model/AssociationsModel.php
@@ -64,6 +64,29 @@ class AssociationsModel extends ListModel
     }
 
     /**
+     * Get the filter form
+     *
+     * @param   array    $data      data
+     * @param   boolean  $loadData  load current data
+     *
+     * @return  Form|null  The \JForm object or null if the form can't be found
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getFilterForm($data = [], $loadData = true)
+    {
+        $form = parent::getFilterForm($data, $loadData);
+
+        if ($form && $this->state->get('itemtype') === 'com_menus.item') {
+            $field = $form->getField('fullordering', 'list');
+            $field->addOption(Text::_('COM_ASSOCIATIONS_HEADING_MENUTYPE_ASC'), ['value' => 'menutype_title ASC']);
+            $field->addOption(Text::_('COM_ASSOCIATIONS_HEADING_MENUTYPE_DESC'), ['value' => 'menutype_title DESC']);
+        }
+
+        return $form;
+    }
+
+    /**
      * Method to auto-populate the model state.
      *
      * Note. Calling getState in this method will result in recursion.


### PR DESCRIPTION
### Summary of Changes
Completes the functionality of the sort by menuitem 


### Testing Instructions
On a multilingual site with sample data go to the associations component
Select menu items and a language
![image](https://user-images.githubusercontent.com/1296369/234071965-639eee85-aa49-44d3-89ab-15e5ac38cfab.png)

Observe that there is no Sort by Menu in the dropdown 
![image](https://user-images.githubusercontent.com/1296369/234072632-e2fd0e96-beee-4897-a6b9-57535d4aff64.png)

but you can sort by clicking on the Menu column header
![image](https://user-images.githubusercontent.com/1296369/234072866-4eb8cad8-8a21-4d05-9fe1-4a134a8ab125.png)

### Actual result BEFORE applying this Pull Request
You can only sort by clicking on the Menu column header
Clicking on the column header does not show the correct information in the dropdown

### Expected result AFTER applying this Pull Request
You can sort by clicking on the Menu column header 
Or by clicking on the option in the dropdown
AND the collapsed option will show the correct value
AND that these  menu sort options are only available for a _menu items_ item type 

### Additional comment
The extra sort option is appended to the end of the options and not in column order. This _bug_ is the same as observed with the workflows component

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
