### PR TITLE
[4.4] Improve system cypress test descriptions for frontend modules

### DIFF
--- a/tests/System/integration/site/modules/mod_articles_archive/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_articles_archive/Default.cy.js
@@ -1,5 +1,5 @@
-describe('Test the articles archive module', () => {
-  it('can load in frontend and showing a list of months with archived articles', () => {
+describe('Test in frondend that the articles archive module', () => {
+  it('can display a list of months with archived articles', () => {
     cy.db_createArticle({ state: 2, created: '2022-09-09 20:00:00', modified: '2022-09-09 20:00:00' })
       .then(() => cy.db_createModule({ module: 'mod_articles_archive' }))
       .then(() => {

--- a/tests/System/integration/site/modules/mod_articles_archive/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_articles_archive/Default.cy.js
@@ -1,4 +1,4 @@
-describe('Test in frondend that the articles archive module', () => {
+describe('Test in frontend that the articles archive module', () => {
   it('can display a list of months with archived articles', () => {
     cy.db_createArticle({ state: 2, created: '2022-09-09 20:00:00', modified: '2022-09-09 20:00:00' })
       .then(() => cy.db_createModule({ module: 'mod_articles_archive' }))

--- a/tests/System/integration/site/modules/mod_articles_categories/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_articles_categories/Default.cy.js
@@ -1,5 +1,5 @@
-describe('Test the articles categories module', () => {
-  it('can load in frontend and showing the title of the categories', () => {
+describe('Test in frontend that the articles categories module', () => {
+  it('can display the title of the categories', () => {
     cy.db_createCategory({ title: 'automated test category' })
       .then(() => cy.db_createModule({ module: 'mod_articles_categories' }))
       .then(() => {

--- a/tests/System/integration/site/modules/mod_articles_category/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_articles_category/Default.cy.js
@@ -1,5 +1,5 @@
-describe('Test the articles category module', () => {
-  it('can load in frontend and showing the title of the articles', () => {
+describe('Test in frontend that the articles category module', () => {
+  it('can display the title of the articles', () => {
     cy.db_createCategory({ extension: 'com_content' })
       .then(async (categoryId) => {
         await cy.db_createArticle({ title: 'automated test article', catid: categoryId });

--- a/tests/System/integration/site/modules/mod_articles_latest/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_articles_latest/Default.cy.js
@@ -1,5 +1,5 @@
-describe('Test that the latest articles module', () => {
-  it('can load in frontend without ordering parameter', () => {
+describe('Test in frontend that the latest articles module', () => {
+  it('can load without ordering parameter', () => {
     cy.db_createArticle({ title: 'automated test article' })
       .then(() => cy.db_createModule({ module: 'mod_articles_latest' }))
       .then(() => {

--- a/tests/System/integration/site/modules/mod_articles_news/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_articles_news/Default.cy.js
@@ -1,5 +1,5 @@
-describe('Test that the news module', () => {
-  it('can load in frontend and showing the title of the articles', () => {
+describe('Test in frontend that the news module', () => {
+  it('can display the title of the articles', () => {
     cy.db_createArticle({ title: 'automated test article' })
       .then(() => cy.db_createModule({ module: 'mod_articles_news', params: JSON.stringify({ item_title: 1, item_heading: 'h3' }) }))
       .then(() => {

--- a/tests/System/integration/site/modules/mod_articles_popular/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_articles_popular/Default.cy.js
@@ -1,5 +1,5 @@
-describe('Test that the popular articles module', () => {
-  it('can load in frontend and shows the title of the test article ', () => {
+describe('Test in frontend that the popular articles module', () => {
+  it('can display the title of the test article', () => {
     cy.db_createCategory({ extension: 'com_content' })
       .then(async (categoryId) => {
         await cy.db_createArticle({ title: 'automated test article', catid: categoryId });

--- a/tests/System/integration/site/modules/mod_banners/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_banners/Default.cy.js
@@ -1,4 +1,4 @@
-describe('Test that the banner module', () => {
+describe('Test in frontend that the banner module', () => {
   it('can display banners', () => {
     cy.db_createBanner({ custombannercode: 'automated test banner 1' })
       .then(() => cy.db_createBanner({ custombannercode: 'automated test banner 2' }))

--- a/tests/System/integration/site/modules/mod_custom/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_custom/Default.cy.js
@@ -1,5 +1,5 @@
-describe('Test that the custom module', () => {
-  it('can load in frontend and shows the custom text', () => {
+describe('Test in frontend that the custom module', () => {
+  it('can display the custom text', () => {
     cy.db_createModule({ module: 'mod_custom', content: '<p>Automated test text</p>' }).then(() => {
       cy.visit('/');
 

--- a/tests/System/integration/site/modules/mod_footer/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_footer/Default.cy.js
@@ -1,5 +1,5 @@
-describe('Test that the footer module', () => {
-  it('can load in frontend and shows the copyright message from Joomla', () => {
+describe('Test in frontend that the footer module', () => {
+  it('can display the copyright message from Joomla', () => {
     cy.db_createModule({ module: 'mod_footer' }).then(() => {
       cy.visit('/');
 

--- a/tests/System/integration/site/modules/mod_login/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_login/Default.cy.js
@@ -1,5 +1,5 @@
-describe('Test that the login module', () => {
-  it('can log in and log out in frontend with the default credentials', () => {
+describe('Test in frontend that the login module', () => {
+  it('can log in and out with the default credentials', () => {
     cy.doFrontendLogin(null, null, false);
     cy.doFrontendLogout();
   });

--- a/tests/System/integration/site/modules/mod_related_items/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_related_items/Default.cy.js
@@ -1,5 +1,5 @@
-describe('Test the related items module', () => {
-  it('can load in frontend showing a list of related articles based on the metakey field', () => {
+describe('Test in frontend that the related items module', () => {
+  it('can display a list of related articles based on the metakey field', () => {
     cy.db_createArticle({ title: 'Main Article', metakey: 'joomla', featured: 1 })
       .then(() => cy.db_createArticle({ title: 'article with joomla keyword', metakey: 'joomla' }))
       .then(() => cy.db_createModule({ module: 'mod_related_items' }))

--- a/tests/System/integration/site/modules/mod_users_latest/Default.cy.js
+++ b/tests/System/integration/site/modules/mod_users_latest/Default.cy.js
@@ -1,5 +1,5 @@
-describe('Test that the users latest module', () => {
-  it('can load in frontend and displays the latest registered users', () => {
+describe('Test in frontend that the users latest module', () => {
+  it('can display the latest registered users', () => {
     cy.db_createUser({ username: 'automatedtestuser' })
       .then(() => cy.db_createModule({ module: 'mod_users_latest' }))
       .then(() => {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes



### Testing Instructions

Unifies the test descriptions. The describe text should always be:

`Test in frontend that the {module name} {view name} view`

While the description of the test itself should be a continuation of the description text like:

`can {the tests which are performed}`

Like:

![Schermafbeelding 2023-04-26 121748](https://user-images.githubusercontent.com/9271775/234546335-c7ff36d9-b7da-40eb-95d3-2bd0a521f38a.png)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed


Ping @laoneo - related #40386