### PR TITLE
Update FormField.php

### DIFF
--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1015,7 +1015,7 @@ abstract class FormField implements DatabaseAwareInterface
             }
         }
 
-        $options['inlineHelp'] = isset($this->form->getXml()->config->inlinehelp['button'])
+        $options['inlineHelp'] = isset($this->form, $this->form->getXml()->config->inlinehelp['button'])
             ? ((string) $this->form->getXml()->config->inlinehelp['button'] == 'show' ?: false)
             : false;
 


### PR DESCRIPTION
Proper checking of isset conditions, roborating the code. Otherwise, in case there is no form set, code will crash ( with error : "Call to a member function getXml() on null" ). Please Update the code accordingly.

Pull Request for Issue # .

### Summary of Changes

Addes isset check to prevent crash of code, when improperly assumed condition ( ->form exists ) is not met. Roborates the Code.


### Testing Instructions

Not necessary, it's selfexplaining in this case.

### Actual result BEFORE applying this Pull Request

crash with error : "Call to a member function getXml() on null" if the field has no form set


### Expected result AFTER applying this Pull Request

just works even when there is no form present /set.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
