### PR TITLE
[4.4] Can't call File::write() with string-literal

### DIFF
--- a/installation/src/Helper/DatabaseHelper.php
+++ b/installation/src/Helper/DatabaseHelper.php
@@ -365,9 +365,10 @@ abstract class DatabaseHelper
 
                     // Get the path
                     $remoteDbPath = JPATH_INSTALLATION . '/' . $remoteDbFile;
+                    $emptyString  = '';
 
                     // When the path is not writable the user needs to create the file manually
-                    if (!File::write($remoteDbPath, '')) {
+                    if (!File::write($remoteDbPath, $emptyString)) {
                         // Request to create the file manually
                         Factory::getApplication()->enqueueMessage(
                             Text::sprintf(


### PR DESCRIPTION
Pull Request for Issue #40503 .

### Summary of Changes
This is the PR to fix this in 4.4-dev. When installing Joomla on a different database server than localhost, a check is done to ensure that you are really the person having control over the server. This check writes a file to the filesystem and the content is empty. The code called `File::write()` with the string-literal, which is not valid, since you can't hand over a string-literal by reference. This PR first creates a variable, which then is handed over as the content for `File::write()`.


### Testing Instructions
Install Joomla 4.4-dev on a system and don't use localhost as your database server. Alternatively modify `installation/src/Helper/DatabaseHelper.php` in `checkRemoteDbHost()` to execute the check even though you are installing to localhost.


### Actual result BEFORE applying this Pull Request
You get a red warning in the browser.


### Expected result AFTER applying this Pull Request
Installation passes without error messages.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
