### PR TITLE
[4.4] remove deprecation from used string

### DIFF
--- a/administrator/language/en-GB/com_newsfeeds.ini
+++ b/administrator/language/en-GB/com_newsfeeds.ini
@@ -88,7 +88,6 @@ COM_NEWSFEEDS_NUM_ARTICLES_HEADING="# Articles"
 COM_NEWSFEEDS_NUM_ARTICLES_HEADING_ASC="# Articles ascending"
 COM_NEWSFEEDS_NUM_ARTICLES_HEADING_DESC="# Articles descending"
 COM_NEWSFEEDS_RIGHT="Right"
-; Deprecated, will be removed with 5.0
 COM_NEWSFEEDS_SAVE_SUCCESS="News feed saved."
 ; Deprecated, will be removed with 5.0
 COM_NEWSFEEDS_SEARCH_IN_TITLE="Search"


### PR DESCRIPTION
### Summary of Changes

remove deprecation from used string (added with #40493)

### Testing Instructions

save a news feed

### Actual result BEFORE applying this Pull Request

if `COM_NEWSFEEDS_SAVE_SUCCESS` is removed
![image](https://user-images.githubusercontent.com/66922325/235994945-568d6a36-ad09-4902-a97b-80bb02362d29.png)

### Expected result AFTER applying this Pull Request

if `COM_NEWSFEEDS_SAVE_SUCCESS` still present
![image](https://user-images.githubusercontent.com/66922325/235995100-7565a1b5-7cb1-4e16-9639-1e873ff92f14.png)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
