### PR TITLE
Revert "Use icon exit  for close buttons"

### DIFF
--- a/libraries/src/Toolbar/CoreButtonsTrait.php
+++ b/libraries/src/Toolbar/CoreButtonsTrait.php
@@ -469,7 +469,7 @@ trait CoreButtonsTrait
      */
     public function cancel(string $task, string $text = 'JTOOLBAR_CLOSE'): StandardButton
     {
-        return $this->standardButton('exit', $text, $task);
+        return $this->standardButton('cancel', $text, $task);
     }
 
     /**


### PR DESCRIPTION
Reverts joomla/joomla-cms#40167

Should be something that would be handled in 5.0 rather than in a bug fix release.