### PR TITLE
[4.4] Deleted the unused `HelperFactory` use statement + minor changes custom module

### DIFF
--- a/modules/mod_custom/services/provider.php
+++ b/modules/mod_custom/services/provider.php
@@ -8,13 +8,12 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-use Joomla\CMS\Extension\Service\Provider\HelperFactory;
+defined('_JEXEC') or die;
+
 use Joomla\CMS\Extension\Service\Provider\Module;
 use Joomla\CMS\Extension\Service\Provider\ModuleDispatcherFactory;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
-
-defined('_JEXEC') or die;
 
 /**
  * The module Custom HTML service provider.
@@ -31,7 +30,7 @@ return new class () implements ServiceProviderInterface {
      *
      * @since   __DEPLOY_VERSION__
      */
-    public function register(Container $container)
+    public function register(Container $container): void
     {
         $container->registerServiceProvider(new ModuleDispatcherFactory('\\Joomla\\Module\\Custom'));
         $container->registerServiceProvider(new Module());


### PR DESCRIPTION
Delete HelperFactory use statement+ minor changes to make code consistent with other modules

Pull Request for Issue # .

### Summary of Changes

- Deleted the unused `HelperFactory` use statement
- Moved to above `defined('_JEXEC') or die;`
- Added a `void` return statement 

### Testing Instructions

- Code review
- Works

### Actual result BEFORE applying this Pull Request

Works

### Expected result AFTER applying this Pull Request

Works

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
