### PR TITLE
[4.4] Fix a11y issue in accordion

### DIFF
--- a/libraries/src/HTML/Helpers/Bootstrap.php
+++ b/libraries/src/HTML/Helpers/Bootstrap.php
@@ -676,7 +676,7 @@ abstract class Bootstrap
 
         static::$loaded[__METHOD__][$selector] = $opt;
 
-        return '<div id="' . $selector . '" class="accordion" role="tablist">';
+        return '<div id="' . $selector . '" class="accordion">';
     }
 
     /**
@@ -715,11 +715,11 @@ abstract class Bootstrap
         return <<<HTMLSTR
 <div class="accordion-item $class">
   <h2 class="accordion-header" id="$id-heading">
-    <button class="accordion-button $collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#$id" aria-expanded="$ariaExpanded" aria-controls="$id" role="tab">
+    <button class="accordion-button $collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#$id" aria-expanded="$ariaExpanded" aria-controls="$id">
 		$text
     </button>
   </h2>
-  <div id="$id" class="accordion-collapse collapse $in" aria-labelledby="$id-heading" $parent role="tabpanel">
+  <div id="$id" class="accordion-collapse collapse $in" aria-labelledby="$id-heading" $parent>
     <div class="accordion-body">
 HTMLSTR;
     }


### PR DESCRIPTION
Pull Request for Issue # .
The issue was mentioned in JAT channel by @rytechsites. Thanks for reporting.

### Summary of Changes
This PR removes the role attribute from bootstrap accordion. Thanks @drmenzelit.

### Testing Instructions
Add a few page breaks into an article, set the layout in the page break plugin to "slider". 
Check the result with an a11y tool.

Similar for menu item types modal or other occurrences of accordions

### Actual result BEFORE applying this Pull Request
You will get a11y issues for the role attribute.


### Expected result AFTER applying this Pull Request
No a11y issues. 


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
