### PR TITLE
change "navbar navbar-expand-md" to "navbar navbar-expand-lg"

### DIFF
--- a/templates/cassiopeia/html/mod_menu/collapse-metismenu.php
+++ b/templates/cassiopeia/html/mod_menu/collapse-metismenu.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 HTMLHelper::_('bootstrap.collapse');
 ?>
 
-<nav class="navbar navbar-expand-md" aria-label="<?php echo htmlspecialchars($module->title, ENT_QUOTES, 'UTF-8'); ?>">
+<nav class="navbar navbar-expand-lg" aria-label="<?php echo htmlspecialchars($module->title, ENT_QUOTES, 'UTF-8'); ?>">
     <button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbar<?php echo $module->id; ?>" aria-controls="navbar<?php echo $module->id; ?>" aria-expanded="false" aria-label="<?php echo Text::_('MOD_MENU_TOGGLE'); ?>">
         <span class="icon-menu" aria-hidden="true"></span>
     </button>


### PR DESCRIPTION
Pull Request for Issue #37926

### Summary of Changes

This PR will change "navbar navbar-expand-mg" into "navbar navbar-expand-lg"

### Testing Instructions

- Reduce screen width and notice that the horizontal menu will change to vertical at 992px
- Reduce even more and notice that the vertical menu will be replaced by a hamburger at 768px

After applying the patch the horizontal menu will be replaced by a hamburger at 992px.

Testing instructions are mentioned in the issue https://github.com/joomla/joomla-cms/issues/37926#issue-1252563816

### Actual result BEFORE applying this Pull Request

- Until viewport < 768px the hamburger is present.
- From 768px (`md`) the hamburger is gone... leaving a vertical menu
- From 992px (`lg`) the menu is horizontal

### Expected result AFTER applying this Pull Request

Hamburger menu will stay until 992px (`lg`)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
