### PR TITLE
Fix calendar field min/max year

### DIFF
--- a/build/media_source/system/js/fields/calendar.es5.js
+++ b/build/media_source/system/js/fields/calendar.es5.js
@@ -126,11 +126,11 @@
 
 		// Evaluate the min year
 		if (btn.dataset.minYear) {
-			self.params.minYear = parseInt(btn.dataset.minYear, 10);
+			self.params.minYear = getBoundary(parseInt(btn.dataset.minYear, 10), self.params.dateType);
 		}
 		// Evaluate the max year
 		if (btn.dataset.maxYear) {
-			self.params.maxYear = parseInt(btn.dataset.maxYear, 10);
+			self.params.maxYear = getBoundary(parseInt(btn.dataset.maxYear, 10), self.params.dateType);
 		}
 		// Evaluate the weekend days
 		if (btn.dataset.weekend) {


### PR DESCRIPTION
Pull Request for Issue #40481 .

### Summary of Changes

Restoring feature, that was broken in 4.x (#34870)
https://docs.joomla.org/Calendar_form_field_type
min/max year is relative numbers.


### Testing Instructions
Apply patch, run `npm install`
Please follow #40481
Or create a custom calendar field, somewhere in XML:

```xml
<field type="calendar" name="cal1" label="Calendar test" minyear="-1" maxyear="1"/>
```
And check which year is available to select.


### Actual result BEFORE applying this Pull Request
It display year 1


### Expected result AFTER applying this Pull Request
It allows to select years:  2022, 2023, 2024


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: 
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: 
- [x] No documentation changes for manual.joomla.org needed
