### PR TITLE
[4.3] Fix module Ajax broken behaviour

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -57,7 +57,7 @@ if (!$format) {
      */
     $module   = $input->get('module');
     $table    = Table::getInstance('extension');
-    $moduleId = $table->find(['type' => 'module', 'element' => 'mod_' . $module]);
+    $moduleId = $table->find(['type' => 'module', 'element' => 'mod_' . strtolower($module)]);
 
     if ($moduleId && $table->load($moduleId) && $table->enabled) {
         $helperFile = JPATH_BASE . '/modules/mod_' . $module . '/helper.php';


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

There's an inconsistency in the com_ajax logic that prevents modules resolving correctly the Helper file (read the testing instructions below). The proposed fix is to use a `strtolower` for the db name of the module and let the other parts intact...


### Testing Instructions

To experience the bug you need to edit the file `administrator/modules/mod_guidedtours/src/Helper/GuidedToursHelper.php` and add on function named `toursAjax` ie: 

```php
    public function toursAjax()
    {
        return ["success" => true, "message" => "in a bottle"];
    }
```
Then in the cpanel open the browser console and run

```js

await fetch(new URL(`${Joomla.getOptions('system.paths').baseFull}index.php?option=com_ajax&module=guidedtours&method=tours&format=json`), { headers: { 'X-CSRF-Token': Joomla.getOptions('csrf.token') } }).then(x => x.json())

```

Note: the part `module=guidedtours` (prefixed with `mod_`) reflects the column `element` in the `#__extensions` table.

![Screenshot 2023-05-14 at 12 05 57](https://github.com/joomla/joomla-cms/assets/3889375/dc82e7ef-cdec-4d94-8011-f0d047bf5dbc)

The result is that the com_ajax will Look for a `GuidedtoursHelper` class, which will fail on any case sensitive filesystem:
![Screenshot 2023-05-14 at 11 37 58](https://github.com/joomla/joomla-cms/assets/3889375/27e68b4a-e8a5-43ad-a914-df9ef9624131)

Apply the PR and run in the console the following (observe that the module now is defined as `GuidedTours`)

```js
await fetch(new URL(`${Joomla.getOptions('system.paths').baseFull}index.php?option=com_ajax&module=GuidedTours&method=tours&format=json`), { headers: { 'X-CSRF-Token': Joomla.getOptions('csrf.token') } }).then(x => x.json())
```

The class is correctly identified as `GuidedToursHelper`
![Screenshot 2023-05-14 at 12 16 12](https://github.com/joomla/joomla-cms/assets/3889375/e2caa1dc-1937-49f6-a2a6-a5e2506f33e6)


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed


@laoneo 