### PR TITLE
Replace img by HTMLHelper image

### DIFF
--- a/modules/mod_banners/tmpl/default.php
+++ b/modules/mod_banners/tmpl/default.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
@@ -17,103 +18,111 @@ use Joomla\Component\Banners\Site\Helper\BannerHelper;
 
 ?>
 <div class="mod-banners bannergroup">
-<?php if ($headerText) : ?>
-    <div class="bannerheader">
-        <?php echo $headerText; ?>
-    </div>
-<?php endif; ?>
+    <?php if ($headerText) : ?>
+        <div class="bannerheader">
+            <?php echo $headerText; ?>
+        </div>
+    <?php endif; ?>
 
-<?php foreach ($list as $item) : ?>
-    <div class="mod-banners__item banneritem">
-        <?php $link = Route::_('index.php?option=com_banners&task=click&id=' . $item->id); ?>
-        <?php if ($item->type == 1) : ?>
-            <?php // Text based banners ?>
-            <?php echo str_replace(['{CLICKURL}', '{NAME}'], [$link, $item->name], $item->custombannercode); ?>
-        <?php else : ?>
-            <?php $imageurl = $item->params->get('imageurl'); ?>
-            <?php $width = $item->params->get('width'); ?>
-            <?php $height = $item->params->get('height'); ?>
-            <?php if (BannerHelper::isImage($imageurl)) : ?>
-                <?php // Image based banner ?>
-                <?php $baseurl = strpos($imageurl, 'http') === 0 ? '' : Uri::base(); ?>
-                <?php $alt = $item->params->get('alt'); ?>
-                <?php $alt = $alt ?: $item->name; ?>
-                <?php $alt = $alt ?: Text::_('MOD_BANNERS_BANNER'); ?>
-                <?php if ($item->clickurl) : ?>
-                    <?php // Wrap the banner in a link ?>
-                    <?php $target = $params->get('target', 1); ?>
-                    <?php if ($target == 1) : ?>
-                        <?php // Open in a new window ?>
-                        <a
-                            href="<?php echo $link; ?>" target="_blank" rel="noopener noreferrer"
-                            title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
-                            <img
-                                src="<?php echo $baseurl . $imageurl; ?>"
-                                alt="<?php echo htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'); ?>"
+    <?php foreach ($list as $item) : ?>
+        <div class="mod-banners__item banneritem">
+            <?php $link = Route::_('index.php?option=com_banners&task=click&id=' . $item->id); ?>
+            <?php if ($item->type == 1) : ?>
+                <?php // Text based banners ?>
+                <?php echo str_replace(['{CLICKURL}', '{NAME}'], [$link, $item->name], $item->custombannercode); ?>
+            <?php else : ?>
+                <?php $imageurl = $item->params->get('imageurl'); ?>
+                <?php $width = $item->params->get('width'); ?>
+                <?php $height = $item->params->get('height'); ?>
+                <?php if (BannerHelper::isImage($imageurl)) : ?>
+                    <?php // Image based banner ?>
+                    <?php $baseurl = strpos($imageurl, 'http') === 0 ? '' : Uri::base(); ?>
+                    <?php $alt = $item->params->get('alt'); ?>
+                    <?php $alt = $alt ?: $item->name; ?>
+                    <?php $alt = $alt ?: Text::_('MOD_BANNERS_BANNER'); ?>
+                    <?php if ($item->clickurl) : ?>
+                        <?php // Wrap the banner in a link ?>
+                        <?php $target = $params->get('target', 1); ?>
+                        <?php if ($target == 1) : ?>
+                            <?php // Open in a new window ?>
+                            <a
+                                href="<?php echo $link; ?>" target="_blank" rel="noopener noreferrer"
+                                title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
+                                <?php $imgAttr = []; ?>
                                 <?php if (!empty($width)) {
-                                    echo 'width="' . $width . '"';
+                                    $imgAttr['width'] = $width;
                                 } ?>
                                 <?php if (!empty($height)) {
-                                    echo 'height="' . $height . '"';
+                                    $imgAttr['height'] = $height;
                                 } ?>
-                            >
-                        </a>
-                    <?php elseif ($target == 2) : ?>
-                        <?php // Open in a popup window ?>
-                        <a
-                            href="<?php echo $link; ?>" onclick="window.open(this.href, '',
+                                <?php echo HTMLHelper::_('image',
+                                    $baseurl . $imageurl,
+                                    htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
+                                    $imgAttr
+                                ); ?>
+                            </a>
+                        <?php elseif ($target == 2) : ?>
+                            <?php // Open in a popup window ?>
+                            <a
+                                href="<?php echo $link; ?>" onclick="window.open(this.href, '',
                                 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=780,height=550');
                                 return false"
-                            title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
-                            <img
-                                src="<?php echo $baseurl . $imageurl; ?>"
-                                alt="<?php echo htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'); ?>"
+                                title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
+                                <?php $imgAttr = []; ?>
                                 <?php if (!empty($width)) {
-                                    echo 'width="' . $width . '"';
+                                    $imgAttr['width'] = $width;
                                 } ?>
                                 <?php if (!empty($height)) {
-                                    echo 'height="' . $height . '"';
+                                    $imgAttr['height'] = $height;
                                 } ?>
-                            >
-                        </a>
+                                <?php echo HTMLHelper::_('image',
+                                    $baseurl . $imageurl,
+                                    htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
+                                    $imgAttr
+                                ); ?>
+                            </a>
+                        <?php else : ?>
+                            <?php // Open in parent window ?>
+                            <a
+                                href="<?php echo $link; ?>"
+                                title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
+                                <?php $imgAttr = []; ?>
+                                <?php if (!empty($width)) {
+                                    $imgAttr['width'] = $width;
+                                } ?>
+                                <?php if (!empty($height)) {
+                                    $imgAttr['height'] = $height;
+                                } ?>
+                                <?php echo HTMLHelper::_('image',
+                                    $baseurl . $imageurl,
+                                    htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
+                                    $imgAttr
+                                ); ?>
+                            </a>
+                        <?php endif; ?>
                     <?php else : ?>
-                        <?php // Open in parent window ?>
-                        <a
-                            href="<?php echo $link; ?>"
-                            title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
-                            <img
-                                src="<?php echo $baseurl . $imageurl; ?>"
-                                alt="<?php echo htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'); ?>"
-                                <?php if (!empty($width)) {
-                                    echo 'width="' . $width . '"';
-                                } ?>
-                                <?php if (!empty($height)) {
-                                    echo 'height="' . $height . '"';
-                                } ?>
-                            >
-                        </a>
-                    <?php endif; ?>
-                <?php else : ?>
-                    <?php // Just display the image if no link specified ?>
-                    <img
-                        src="<?php echo $baseurl . $imageurl; ?>"
-                        alt="<?php echo htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'); ?>"
+                        <?php // Just display the image if no link specified ?>
+                        <?php $imgAttr = []; ?>
                         <?php if (!empty($width)) {
-                            echo 'width="' . $width . '"';
+                            $imgAttr['width'] = $width;
                         } ?>
                         <?php if (!empty($height)) {
-                            echo 'height="' . $height . '"';
+                            $imgAttr['height'] = $height;
                         } ?>
-                    >
+                        <?php echo HTMLHelper::_('image',
+                            $baseurl . $imageurl,
+                            htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
+                            $imgAttr
+                        ); ?>
+                    <?php endif; ?>
                 <?php endif; ?>
             <?php endif; ?>
-        <?php endif; ?>
-    </div>
-<?php endforeach; ?>
+        </div>
+    <?php endforeach; ?>
 
-<?php if ($footerText) : ?>
-    <div class="mod-banners__footer bannerfooter">
-        <?php echo $footerText; ?>
-    </div>
-<?php endif; ?>
+    <?php if ($footerText) : ?>
+        <div class="mod-banners__footer bannerfooter">
+            <?php echo $footerText; ?>
+        </div>
+    <?php endif; ?>
 </div>

--- a/modules/mod_banners/tmpl/default.php
+++ b/modules/mod_banners/tmpl/default.php
@@ -18,111 +18,111 @@ use Joomla\Component\Banners\Site\Helper\BannerHelper;
 
 ?>
 <div class="mod-banners bannergroup">
-    <?php if ($headerText) : ?>
-        <div class="bannerheader">
-            <?php echo $headerText; ?>
-        </div>
-    <?php endif; ?>
+<?php if ($headerText) : ?>
+    <div class="bannerheader">
+        <?php echo $headerText; ?>
+    </div>
+<?php endif; ?>
 
-    <?php foreach ($list as $item) : ?>
-        <div class="mod-banners__item banneritem">
-            <?php $link = Route::_('index.php?option=com_banners&task=click&id=' . $item->id); ?>
-            <?php if ($item->type == 1) : ?>
-                <?php // Text based banners ?>
-                <?php echo str_replace(['{CLICKURL}', '{NAME}'], [$link, $item->name], $item->custombannercode); ?>
-            <?php else : ?>
-                <?php $imageurl = $item->params->get('imageurl'); ?>
-                <?php $width = $item->params->get('width'); ?>
-                <?php $height = $item->params->get('height'); ?>
-                <?php if (BannerHelper::isImage($imageurl)) : ?>
-                    <?php // Image based banner ?>
-                    <?php $baseurl = strpos($imageurl, 'http') === 0 ? '' : Uri::base(); ?>
-                    <?php $alt = $item->params->get('alt'); ?>
-                    <?php $alt = $alt ?: $item->name; ?>
-                    <?php $alt = $alt ?: Text::_('MOD_BANNERS_BANNER'); ?>
-                    <?php if ($item->clickurl) : ?>
-                        <?php // Wrap the banner in a link ?>
-                        <?php $target = $params->get('target', 1); ?>
-                        <?php if ($target == 1) : ?>
-                            <?php // Open in a new window ?>
-                            <a
-                                href="<?php echo $link; ?>" target="_blank" rel="noopener noreferrer"
-                                title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
-                                <?php $imgAttr = []; ?>
-                                <?php if (!empty($width)) {
-                                    $imgAttr['width'] = $width;
-                                } ?>
-                                <?php if (!empty($height)) {
-                                    $imgAttr['height'] = $height;
-                                } ?>
-                                <?php echo HTMLHelper::_('image',
-                                    $baseurl . $imageurl,
-                                    htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
-                                    $imgAttr
-                                ); ?>
-                            </a>
-                        <?php elseif ($target == 2) : ?>
-                            <?php // Open in a popup window ?>
-                            <a
-                                href="<?php echo $link; ?>" onclick="window.open(this.href, '',
+<?php foreach ($list as $item) : ?>
+    <div class="mod-banners__item banneritem">
+        <?php $link = Route::_('index.php?option=com_banners&task=click&id=' . $item->id); ?>
+        <?php if ($item->type == 1) : ?>
+            <?php // Text based banners ?>
+            <?php echo str_replace(['{CLICKURL}', '{NAME}'], [$link, $item->name], $item->custombannercode); ?>
+        <?php else : ?>
+            <?php $imageurl = $item->params->get('imageurl'); ?>
+            <?php $width = $item->params->get('width'); ?>
+            <?php $height = $item->params->get('height'); ?>
+            <?php if (BannerHelper::isImage($imageurl)) : ?>
+                <?php // Image based banner ?>
+                <?php $baseurl = strpos($imageurl, 'http') === 0 ? '' : Uri::base(); ?>
+                <?php $alt = $item->params->get('alt'); ?>
+                <?php $alt = $alt ?: $item->name; ?>
+                <?php $alt = $alt ?: Text::_('MOD_BANNERS_BANNER'); ?>
+                <?php if ($item->clickurl) : ?>
+                    <?php // Wrap the banner in a link ?>
+                    <?php $target = $params->get('target', 1); ?>
+                    <?php if ($target == 1) : ?>
+                        <?php // Open in a new window ?>
+                        <a
+                            href="<?php echo $link; ?>" target="_blank" rel="noopener noreferrer"
+                            title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
+                            <?php $imgAttr = []; ?>
+                            <?php if (!empty($width)) {
+                                $imgAttr['width'] = $width;
+                            } ?>
+                            <?php if (!empty($height)) {
+                                $imgAttr['height'] = $height;
+                            } ?>
+                            <?php echo HTMLHelper::_('image',
+                                $baseurl . $imageurl,
+                                htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
+                                $imgAttr
+                            ); ?>
+                        </a>
+                    <?php elseif ($target == 2) : ?>
+                        <?php // Open in a popup window ?>
+                        <a
+                            href="<?php echo $link; ?>" onclick="window.open(this.href, '',
                                 'toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=yes,width=780,height=550');
                                 return false"
-                                title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
-                                <?php $imgAttr = []; ?>
-                                <?php if (!empty($width)) {
-                                    $imgAttr['width'] = $width;
-                                } ?>
-                                <?php if (!empty($height)) {
-                                    $imgAttr['height'] = $height;
-                                } ?>
-                                <?php echo HTMLHelper::_('image',
-                                    $baseurl . $imageurl,
-                                    htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
-                                    $imgAttr
-                                ); ?>
-                            </a>
-                        <?php else : ?>
-                            <?php // Open in parent window ?>
-                            <a
-                                href="<?php echo $link; ?>"
-                                title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
-                                <?php $imgAttr = []; ?>
-                                <?php if (!empty($width)) {
-                                    $imgAttr['width'] = $width;
-                                } ?>
-                                <?php if (!empty($height)) {
-                                    $imgAttr['height'] = $height;
-                                } ?>
-                                <?php echo HTMLHelper::_('image',
-                                    $baseurl . $imageurl,
-                                    htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
-                                    $imgAttr
-                                ); ?>
-                            </a>
-                        <?php endif; ?>
+                            title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
+                            <?php $imgAttr = []; ?>
+                            <?php if (!empty($width)) {
+                                $imgAttr['width'] = $width;
+                            } ?>
+                            <?php if (!empty($height)) {
+                                $imgAttr['height'] = $height;
+                            } ?>
+                            <?php echo HTMLHelper::_('image',
+                                $baseurl . $imageurl,
+                                htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
+                                $imgAttr
+                            ); ?>
+                        </a>
                     <?php else : ?>
-                        <?php // Just display the image if no link specified ?>
-                        <?php $imgAttr = []; ?>
-                        <?php if (!empty($width)) {
-                            $imgAttr['width'] = $width;
-                        } ?>
-                        <?php if (!empty($height)) {
-                            $imgAttr['height'] = $height;
-                        } ?>
-                        <?php echo HTMLHelper::_('image',
-                            $baseurl . $imageurl,
-                            htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
-                            $imgAttr
-                        ); ?>
+                        <?php // Open in parent window ?>
+                        <a
+                            href="<?php echo $link; ?>"
+                            title="<?php echo htmlspecialchars($item->name, ENT_QUOTES, 'UTF-8'); ?>">
+                            <?php $imgAttr = []; ?>
+                            <?php if (!empty($width)) {
+                                $imgAttr['width'] = $width;
+                            } ?>
+                            <?php if (!empty($height)) {
+                                $imgAttr['height'] = $height;
+                            } ?>
+                            <?php echo HTMLHelper::_('image',
+                                $baseurl . $imageurl,
+                                htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
+                                $imgAttr
+                            ); ?>
+                        </a>
                     <?php endif; ?>
+                <?php else : ?>
+                    <?php // Just display the image if no link specified ?>
+                    <?php $imgAttr = []; ?>
+                    <?php if (!empty($width)) {
+                        $imgAttr['width'] = $width;
+                    } ?>
+                    <?php if (!empty($height)) {
+                        $imgAttr['height'] = $height;
+                    } ?>
+                    <?php echo HTMLHelper::_('image',
+                        $baseurl . $imageurl,
+                        htmlspecialchars($alt, ENT_QUOTES, 'UTF-8'),
+                        $imgAttr
+                    ); ?>
                 <?php endif; ?>
             <?php endif; ?>
-        </div>
-    <?php endforeach; ?>
+        <?php endif; ?>
+    </div>
+<?php endforeach; ?>
 
-    <?php if ($footerText) : ?>
-        <div class="mod-banners__footer bannerfooter">
-            <?php echo $footerText; ?>
-        </div>
-    <?php endif; ?>
+<?php if ($footerText) : ?>
+    <div class="mod-banners__footer bannerfooter">
+        <?php echo $footerText; ?>
+    </div>
+<?php endif; ?>
 </div>


### PR DESCRIPTION
Pull Request for no issue

### Summary of Changes
This PR will replace the hard coded `<img src="" alt=""/>` by `HTMLHelper::_('image',$src,$alt,$data)` for the default output of module mod_bannsers

The `HTMLHelper::_('image'`will render the JLayout `joomla.html.image`
https://github.com/joomla/joomla-cms/blob/c20185413b05ad94f46ec8fe6d803f5d6d2e8e81/libraries/src/HTML/HTMLHelper.php#L731

In cases a Frontend Developer created a template override of this JLayout, the changed can profit too. 
( in my case... I've created a template override to be able to use imagekit.io for image rendering... others might create an override to use Cloudinary)

### Testing Instructions

- Joomla with sample data
- Make sure the mod_banners is assigned to a menu item and set to show images. Change module config if it does not. 
- Apply the patch and refresh the page where mod_banners is used

Before and after should look the same... only the way the code is generated changed. 

### Actual result BEFORE applying this Pull Request

- images are shown

### Expected result AFTER applying this Pull Request

- images are shown the same way as before


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
