### PR TITLE
[4.3] Mobile pagination Cassiopeia

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/vendor/bootstrap/_pagination.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/vendor/bootstrap/_pagination.scss
@@ -3,3 +3,27 @@
 .pagination {
   margin: 1rem;
 }
+
+@include media-breakpoint-down(md) {
+  .page-item {
+    display: none;
+
+    &:nth-of-type(4) {
+      position: relative;
+      padding-right: 45px;
+
+      &::after {
+        content: '\2026';
+        position: absolute;
+        font-size: 24px;
+        top: 0;
+        left: 45px;
+      }
+    }
+
+    &:nth-child(-n+4),
+    &:nth-last-child(-n+4) {
+      display: block;
+    }
+  }
+}


### PR DESCRIPTION
Pull Request for Issue #32674 #37711 and many more reports

### Summary of Changes
Prevent the pagination going "off-screen" on small devices


### Testing Instructions
This PR is an scss change so either apply the PR and then `npm run build:css` or install a prebuilt package
Then create a menu item to a list of all articles in a category making sure that you have a lot of articles to force the pagination. _Hint if you set the list limit to 5 you need less articles_


### Actual result BEFORE applying this Pull Request
The pagination forces the screen to be much wider than the device
![image](https://github.com/joomla/joomla-cms/assets/1296369/86ad2bbd-e9b0-46d1-9ef3-4d6bc1b74b7c)



### Expected result AFTER applying this Pull Request
The navigation bar is truncated as shown in the screenshot
![image](https://github.com/joomla/joomla-cms/assets/1296369/fb7cae17-751c-48f0-b1c2-7dec5f4d0949)


If accepted I will make the same change for the same problem in atum

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
