### PR TITLE
[5.0][a11y] change ordered lists in com_content links to unordered lists

### DIFF
--- a/components/com_content/tmpl/category/blog_links.php
+++ b/components/com_content/tmpl/category/blog_links.php
@@ -15,11 +15,11 @@ use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 ?>
 
-<ol class="com-content-blog__links">
+<ul class="com-content-blog__links">
     <?php foreach ($this->link_items as $item) : ?>
         <li class="com-content-blog__link">
             <a href="<?php echo Route::_(RouteHelper::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
                 <?php echo $item->title; ?></a>
         </li>
     <?php endforeach; ?>
-</ol>
+</ul>

--- a/components/com_content/tmpl/featured/default_links.php
+++ b/components/com_content/tmpl/featured/default_links.php
@@ -14,11 +14,11 @@ use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 ?>
-<ol class="com-content-blog__links">
+<ul class="com-content-blog__links">
     <?php foreach ($this->link_items as $item) : ?>
         <li class="com-content-blog__link">
             <a href="<?php echo Route::_(RouteHelper::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
                 <?php echo $item->title; ?></a>
         </li>
     <?php endforeach; ?>
-</ol>
+</ul>


### PR DESCRIPTION
change ordered list in blog-links to unordered list

Pull Request for PR #40600 that was merged then reverted in 4.3.

### Summary of Changes

This PR changes the unordered list of 
com_content > category > blog-links.php 
com_content > featured > default-links.php 
into an unordered list.

The list is no sequential information but a list of items where the order is not relevant. 
Therefor an unordered list should be used. 

`<ul></ul>` instead of `<ol></ol>`

### Testing Instructions

Check PR #40600 for testing instructions

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: [#120](https://github.com/joomla/Manual/pull/120)
- [ ] No documentation changes for manual.joomla.org needed
