### PR TITLE
[a11y] change ordered list in blog-links to unordered list

### DIFF
--- a/components/com_content/tmpl/category/blog_links.php
+++ b/components/com_content/tmpl/category/blog_links.php
@@ -15,11 +15,11 @@ use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 ?>
 
-<ol class="com-content-blog__links">
+<ul class="com-content-blog__links">
     <?php foreach ($this->link_items as $item) : ?>
         <li class="com-content-blog__link">
             <a href="<?php echo Route::_(RouteHelper::getArticleRoute($item->slug, $item->catid, $item->language)); ?>">
                 <?php echo $item->title; ?></a>
         </li>
     <?php endforeach; ?>
-</ol>
+</ul>


### PR DESCRIPTION
Pull Request for Issue this issue .

didn't make it in 4.3, so retry for 5.0

### Summary of Changes
This PR will change the unordered list of com_content > category > blog-links.php into an unordered list.
The list is no sequential information but a list of items where the order is not relevant. 
Therefor an unordered list should be used. 

`<ul></ul>` instead of `<ol></ol>`


### Testing Instructions

- Joomla test environment with demo sample data. 
- Go to Sample Layouts > Blog
- Scroll to the pagination and notice a single link with title = _Welcome to your blog_

### Actual result BEFORE applying this Pull Request

![Scherm­afbeelding 2023-05-15 om 16 05 18](https://github.com/joomla/joomla-cms/assets/639822/14a6f69a-4495-43f7-8341-cbc811f063f4)

### Expected result AFTER applying this Pull Request

![Scherm­afbeelding 2023-05-15 om 16 05 37](https://github.com/joomla/joomla-cms/assets/639822/7b6774f7-12e4-47b4-910e-165b411f2a42)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
