### PR TITLE
[5.0] ordered/unordered lists

### DIFF
--- a/components/com_finder/tmpl/search/default_results.php
+++ b/components/com_finder/tmpl/search/default_results.php
@@ -66,7 +66,7 @@ use Joomla\CMS\Uri\Uri;
     ?>
 <?php endif; ?>
 <?php // Display a list of results ?>
-<ol id="search-result-list" class="js-highlight com-finder__results-list" start="<?php echo (int) $this->pagination->limitstart + 1; ?>">
+<ul id="search-result-list" class="js-highlight com-finder__results-list" start="<?php echo (int) $this->pagination->limitstart + 1; ?>">
     <?php $this->baseUrl = Uri::getInstance()->toString(['scheme', 'host', 'port']); ?>
     <?php foreach ($this->results as $i => $result) : ?>
         <?php $this->result = &$result; ?>
@@ -74,7 +74,7 @@ use Joomla\CMS\Uri\Uri;
         <?php $layout = $this->getLayoutFile($this->result->layout); ?>
         <?php echo $this->loadTemplate($layout); ?>
     <?php endforeach; ?>
-</ol>
+</ul>
 <?php // Display the pagination ?>
 <div class="com-finder__navigation search-pagination">
     <?php if ($this->params->get('show_pagination', 1) > 0) : ?>

--- a/components/com_newsfeeds/tmpl/newsfeed/default.php
+++ b/components/com_newsfeeds/tmpl/newsfeed/default.php
@@ -121,7 +121,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 
         <!-- Show items -->
         <?php if (!empty($this->rssDoc[0])) : ?>
-            <ol class="com-newsfeeds-newsfeed__items">
+            <ul class="com-newsfeeds-newsfeed__items">
                 <?php for ($i = 0; $i < $this->item->numarticles; $i++) : ?>
                     <?php if (empty($this->rssDoc[$i])) : ?>
                         <?php break; ?>
@@ -151,7 +151,7 @@ use Joomla\CMS\Layout\LayoutHelper;
                         <?php endif; ?>
                     </li>
                 <?php endfor; ?>
-            </ol>
+            </ul>
         <?php endif; ?>
     </div>
 <?php endif; ?>

--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -45,14 +45,14 @@ $this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error-
             <div id="errorboxheader"><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></div>
             <div id="errorboxbody">
             <p><strong><?php echo Text::_('JERROR_LAYOUT_NOT_ABLE_TO_VISIT'); ?></strong></p>
-            <ol>
+            <ul>
                 <li><?php echo Text::_('JERROR_LAYOUT_AN_OUT_OF_DATE_BOOKMARK_FAVOURITE'); ?></li>
                 <li><?php echo Text::_('JERROR_LAYOUT_SEARCH_ENGINE_OUT_OF_DATE_LISTING'); ?></li>
                 <li><?php echo Text::_('JERROR_LAYOUT_MIS_TYPED_ADDRESS'); ?></li>
                 <li><?php echo Text::_('JERROR_LAYOUT_YOU_HAVE_NO_ACCESS_TO_THIS_PAGE'); ?></li>
                 <li><?php echo Text::_('JERROR_LAYOUT_REQUESTED_RESOURCE_WAS_NOT_FOUND'); ?></li>
                 <li><?php echo Text::_('JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST'); ?></li>
-            </ol>
+            </ul>
             <p><strong><?php echo Text::_('JERROR_LAYOUT_PLEASE_TRY_ONE_OF_THE_FOLLOWING_PAGES'); ?></strong></p>
             <ul>
                 <li><a href="<?php echo Uri::root(true); ?>/index.php"><?php echo Text::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></li>


### PR DESCRIPTION
Following the determination by the JAT that ordered lists should only be used when the list should be considered as a stepped progression and the subsequent (merged) #40629 pr to adjust the lists in com_content this PR does the same for
- Newsfeed Items
- Search results
- error.php

With the default cassiopeia template there is no visual change
