### PR TITLE
[5.0] Unify the com_ajax functionality

### DIFF
--- a/build/media_source/plg_system_stats/js/stats-message.es6.js
+++ b/build/media_source/plg_system_stats/js/stats-message.es6.js
@@ -43,7 +43,7 @@ Joomla = window.Joomla || {};
         // Remove message
         joomlaAlert.close();
 
-        callback({ plugin: 'sendAlways' });
+        callback({ method: 'sendAlways' });
       }
     });
 
@@ -55,13 +55,13 @@ Joomla = window.Joomla || {};
         // Remove message
         joomlaAlert.close();
 
-        callback({ plugin: 'sendNever' });
+        callback({ method: 'sendNever' });
       }
     });
   };
 
-  const getJson = ({ plugin = 'sendStats' } = {}) => {
-    const url = `index.php?option=com_ajax&group=system&plugin=${plugin}&format=raw`;
+  const getJson = ({ plugin = 'stats', method = 'sendStats' } = {}) => {
+    const url = `index.php?option=com_ajax&group=system&plugin=${plugin}&method=${method}&format=raw`;
     const messageContainer = document.getElementById('system-message-container');
     Joomla.request({
       url,

--- a/build/media_source/plg_system_stats/js/stats-message.es6.js
+++ b/build/media_source/plg_system_stats/js/stats-message.es6.js
@@ -61,7 +61,7 @@ Joomla = window.Joomla || {};
   };
 
   const getJson = ({ plugin = 'stats', method = 'sendStats' } = {}) => {
-    const url = `index.php?option=com_ajax&group=system&plugin=${plugin}&method=${method}&format=raw`;
+    const url = `index.php?option=com_ajax&group=system&plugin=${plugin}&pluginMethod=${method}&format=raw`;
     const messageContainer = document.getElementById('system-message-container');
     Joomla.request({
       url,

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -124,7 +124,7 @@ if (!$format) {
      * where 'foo' is the value of the 'plugin' variable passed via the URL
      * (i.e. index.php?option=com_ajax&plugin=foo)
      * If a method is specified (i.e. index.php?option=com_ajax&plugin=foo&group=system&method=bar)
-     * then the method is directly called (i.e. plgSystemFooInstance->bar())
+     * then the method will be called directly (i.e. plgSystemFooInstance->bar())
      */
     $group      = $input->get('group', 'ajax');
     $plugin     = ucfirst($input->get('plugin'));

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -120,17 +120,25 @@ if (!$format) {
      * Plugin support by default is based on the "Ajax" plugin group.
      * An optional 'group' variable can be passed via the URL.
      *
-     * The plugin event triggered is onAjaxFoo, where 'foo' is
-     * the value of the 'plugin' variable passed via the URL
+     * If a method is NOT specified, the plugin event triggered is onAjaxFoo,
+     * where 'foo' is the value of the 'plugin' variable passed via the URL
      * (i.e. index.php?option=com_ajax&plugin=foo)
-     *
+     * If a method is specified (i.e. index.php?option=com_ajax&plugin=foo&group=system&method=bar)
+     * then the method is directly called (i.e. plgSystemFooInstance->bar())
      */
     $group      = $input->get('group', 'ajax');
-    PluginHelper::importPlugin($group);
     $plugin     = ucfirst($input->get('plugin'));
+    $method     = $input->get('method') ?: '';
+
+    PluginHelper::importPlugin($group);
 
     try {
-        $results = Factory::getApplication()->triggerEvent('onAjax' . $plugin);
+        if ($method === '') {
+            $results = Factory::getApplication()->triggerEvent('onAjax' . $plugin);
+        } elseif ($group !== 'ajax') {
+            $pluginInstance = $app->bootPlugin($plugin, $group);
+            $results        = method_exists($pluginInstance, $method . 'Ajax') ? $pluginInstance->{$method . 'Ajax'}() : null;
+        }
     } catch (Exception $e) {
         $results = $e;
     }

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -128,7 +128,7 @@ if (!$format) {
      */
     $group      = $input->get('group', 'ajax');
     $plugin     = ucfirst($input->get('plugin'));
-    $method     = $input->get('method') ?: '';
+    $method     = $input->get('pluginMethod') ?: '';
 
     PluginHelper::importPlugin($group);
 

--- a/plugins/system/stats/src/Extension/Stats.php
+++ b/plugins/system/stats/src/Extension/Stats.php
@@ -146,7 +146,7 @@ final class Stats extends CMSPlugin
      * @throws  Exception         If user is not allowed.
      * @throws  RuntimeException  If there is an error saving the params or sending the data.
      */
-    public function onAjaxSendAlways()
+    public function sendAlwaysAjax()
     {
         if (!$this->isAllowedUser() || !$this->isAjaxRequest()) {
             throw new Exception($this->getApplication()->getLanguage()->_('JGLOBAL_AUTH_ACCESS_DENIED'), 403);
@@ -171,7 +171,7 @@ final class Stats extends CMSPlugin
      * @throws  Exception         If user is not allowed.
      * @throws  RuntimeException  If there is an error saving the params.
      */
-    public function onAjaxSendNever()
+    public function sendNeverAjax()
     {
         if (!$this->isAllowedUser() || !$this->isAjaxRequest()) {
             throw new Exception($this->getApplication()->getLanguage()->_('JGLOBAL_AUTH_ACCESS_DENIED'), 403);
@@ -201,7 +201,7 @@ final class Stats extends CMSPlugin
      * @throws  Exception         If user is not allowed.
      * @throws  RuntimeException  If there is an error saving the params, disabling the plugin or sending the data.
      */
-    public function onAjaxSendStats()
+    public function sendStatsAjax()
     {
         if (!$this->isAllowedUser() || !$this->isAjaxRequest()) {
             throw new Exception($this->getApplication()->getLanguage()->_('JGLOBAL_AUTH_ACCESS_DENIED'), 403);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- Add the missing method as `pluginMethod` part for the plugins
- Add a conditional so the changes would be 100% B/C 

### Testing Instructions

- Install Joomla from the GH PR.
- Check that the send statistics still works
- Check that Sample data still works

### Actual result BEFORE applying this Pull Request

Plugins where only supporting one method `onAjaxPluginName`

### Expected result AFTER applying this Pull Request

Plugins support also a custom `method` name as modules and templates

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed

@HLeithner @laoneo 