### PR TITLE
[5.0] Do not boot whole plugin when it will not be used

### DIFF
--- a/libraries/src/Extension/DummyPlugin.php
+++ b/libraries/src/Extension/DummyPlugin.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Plugin\CMSPlugin;
 
 /**
  * Placeholder plugin. The Plugin does not provide any events.
+ * The class to be used as placeholder for cases when need to avoid from booting a real plugin, or it is not possible to boot one (fallback).
  *
  * @since  4.0.0
  */

--- a/libraries/src/Extension/DummyPlugin.php
+++ b/libraries/src/Extension/DummyPlugin.php
@@ -16,10 +16,29 @@ use Joomla\CMS\Plugin\CMSPlugin;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * Placeholder plugin.
+ * Placeholder plugin. The Plugin does not provide any events.
  *
  * @since  4.0.0
  */
 class DummyPlugin extends CMSPlugin
 {
+    /**
+     * Override parent constructor, to keep it clean.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function __construct()
+    {
+        // The plugin does not provide any events
+    }
+
+    /**
+     * Override parent registerListeners, to keep it clean.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function registerListeners()
+    {
+        // The plugin does not provide any events
+    }
 }

--- a/libraries/src/Extension/ExtensionManagerTrait.php
+++ b/libraries/src/Extension/ExtensionManagerTrait.php
@@ -210,7 +210,7 @@ trait ExtensionManagerTrait
 
         // Return an empty class when the file doesn't exist
         if (!is_file($path)) {
-            return new DummyPlugin($dispatcher);
+            return new DummyPlugin();
         }
 
         // Include the file of the plugin
@@ -235,7 +235,7 @@ trait ExtensionManagerTrait
 
         // Return an empty class when the class doesn't exist
         if (!class_exists($className)) {
-            return new DummyPlugin($dispatcher);
+            return new DummyPlugin();
         }
 
         // Instantiate the plugin

--- a/plugins/system/guidedtours/services/provider.php
+++ b/plugins/system/guidedtours/services/provider.php
@@ -10,7 +10,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\Application\ApplicationInterface;
+use Joomla\CMS\Extension\DummyPlugin;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -35,10 +35,15 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
-                $dispatcher = $container->get(DispatcherInterface::class);
-                $app        = Factory::getApplication();
+                $app = Factory::getApplication();
 
-                $plugin = new GuidedTours(
+                if (!$app->isClient('administrator')) {
+                    // Return an empty class when we in wrong App
+                    return new DummyPlugin();
+                }
+
+                $dispatcher = $container->get(DispatcherInterface::class);
+                $plugin     = new GuidedTours(
                     $dispatcher,
                     (array) PluginHelper::getPlugin('system', 'guidedtours'),
                     $app->isClient('administrator')

--- a/plugins/system/guidedtours/src/Extension/GuidedTours.php
+++ b/plugins/system/guidedtours/src/Extension/GuidedTours.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
 use Joomla\Component\Guidedtours\Administrator\Extension\GuidedtoursComponent;
-use Joomla\Event\DispatcherInterface;
 use Joomla\Event\Event;
 use Joomla\Event\SubscriberInterface;
 
@@ -55,32 +54,6 @@ final class GuidedTours extends CMSPlugin implements SubscriberInterface
     ];
 
     /**
-     * An internal flag whether plugin should listen any event.
-     *
-     * @var bool
-     *
-     * @since   4.3.0
-     */
-    protected static $enabled = false;
-
-    /**
-     * Constructor
-     *
-     * @param   DispatcherInterface  $subject  The object to observe
-     * @param   array                $config   An optional associative array of configuration settings.
-     * @param   boolean              $enabled  An internal flag whether plugin should listen any event.
-     *
-     * @since   4.3.0
-     */
-    public function __construct($subject, array $config = [], bool $enabled = false)
-    {
-        $this->autoloadLanguage = $enabled;
-        self::$enabled          = $enabled;
-
-        parent::__construct($subject, $config);
-    }
-
-    /**
      * function for getSubscribedEvents : new Joomla 4 feature
      *
      * @return array
@@ -89,10 +62,10 @@ final class GuidedTours extends CMSPlugin implements SubscriberInterface
      */
     public static function getSubscribedEvents(): array
     {
-        return self::$enabled ? [
+        return [
             'onAjaxGuidedtours'   => 'startTour',
             'onBeforeCompileHead' => 'onBeforeCompileHead',
-        ] : [];
+        ];
     }
 
     /**

--- a/plugins/system/highlight/services/provider.php
+++ b/plugins/system/highlight/services/provider.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Extension\DummyPlugin;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -33,12 +34,19 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                $app = Factory::getApplication();
+
+                if (!$app->isClient('site')) {
+                    // Return an empty class when we in wrong App
+                    return new DummyPlugin();
+                }
+
                 $dispatcher = $container->get(DispatcherInterface::class);
                 $plugin     = new Highlight(
                     $dispatcher,
                     (array) PluginHelper::getPlugin('system', 'highlight')
                 );
-                $plugin->setApplication(Factory::getApplication());
+                $plugin->setApplication($app);
 
                 return $plugin;
             }

--- a/plugins/system/highlight/src/Extension/Highlight.php
+++ b/plugins/system/highlight/src/Extension/Highlight.php
@@ -39,11 +39,6 @@ final class Highlight extends CMSPlugin
      */
     public function onAfterDispatch()
     {
-        // Check that we are in the site application.
-        if (!$this->getApplication()->isClient('site')) {
-            return;
-        }
-
         // Set the variables.
         $input     = $this->getApplication()->getInput();
         $extension = $input->get('option', '', 'cmd');

--- a/plugins/system/jooa11y/services/provider.php
+++ b/plugins/system/jooa11y/services/provider.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Extension\DummyPlugin;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -33,12 +34,19 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                $app = Factory::getApplication();
+
+                if (!$app->isClient('site')) {
+                    // Return an empty class when we in wrong App
+                    return new DummyPlugin();
+                }
+
                 $dispatcher = $container->get(DispatcherInterface::class);
                 $plugin     = new Jooa11y(
                     $dispatcher,
                     (array) PluginHelper::getPlugin('system', 'jooa11y')
                 );
-                $plugin->setApplication(Factory::getApplication());
+                $plugin->setApplication($app);
 
                 return $plugin;
             }

--- a/plugins/system/jooa11y/src/Extension/Jooa11y.php
+++ b/plugins/system/jooa11y/src/Extension/Jooa11y.php
@@ -89,10 +89,6 @@ final class Jooa11y extends CMSPlugin implements SubscriberInterface
      */
     public function initJooa11y()
     {
-        if (!$this->getApplication()->isClient('site')) {
-            return;
-        }
-
         // Check if we are in a preview modal or the plugin has enforced loading
         $showJooa11y = $this->getApplication()->getInput()->get('jooa11y', $this->params->get('showAlways', 0));
 

--- a/plugins/system/logout/services/provider.php
+++ b/plugins/system/logout/services/provider.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Extension\DummyPlugin;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -33,10 +34,17 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                $app = Factory::getApplication();
+
+                if (!$app->isClient('site')) {
+                    // Return an empty class when we in wrong App
+                    return new DummyPlugin();
+                }
+
                 return new Logout(
                     $container->get(DispatcherInterface::class),
                     (array) PluginHelper::getPlugin('system', 'logout'),
-                    Factory::getApplication()
+                    $app
                 );
             }
         );

--- a/plugins/system/logout/src/Extension/Logout.php
+++ b/plugins/system/logout/src/Extension/Logout.php
@@ -48,11 +48,6 @@ final class Logout extends CMSPlugin
 
         $this->setApplication($app);
 
-        // If we are on admin don't process.
-        if (!$this->getApplication()->isClient('site')) {
-            return;
-        }
-
         $hash  = ApplicationHelper::getHash('PlgSystemLogout');
 
         if ($this->getApplication()->getInput()->cookie->getString($hash)) {
@@ -79,18 +74,16 @@ final class Logout extends CMSPlugin
      */
     public function onUserLogout($user, $options = [])
     {
-        if ($this->getApplication()->isClient('site')) {
-            // Create the cookie.
-            $this->getApplication()->getInput()->cookie->set(
-                ApplicationHelper::getHash('PlgSystemLogout'),
-                true,
-                time() + 86400,
-                $this->getApplication()->get('cookie_path', '/'),
-                $this->getApplication()->get('cookie_domain', ''),
-                $this->getApplication()->isHttpsForced(),
-                true
-            );
-        }
+        // Create the cookie.
+        $this->getApplication()->getInput()->cookie->set(
+            ApplicationHelper::getHash('PlgSystemLogout'),
+            true,
+            time() + 86400,
+            $this->getApplication()->get('cookie_path', '/'),
+            $this->getApplication()->get('cookie_domain', ''),
+            $this->getApplication()->isHttpsForced(),
+            true
+        );
 
         return true;
     }

--- a/plugins/system/redirect/services/provider.php
+++ b/plugins/system/redirect/services/provider.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Extension\DummyPlugin;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -34,12 +35,19 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                $app = Factory::getApplication();
+
+                if (!$app->isClient('site')) {
+                    // Return an empty class when we in wrong App
+                    return new DummyPlugin();
+                }
+
                 $dispatcher = $container->get(DispatcherInterface::class);
                 $plugin     = new Redirect(
                     $dispatcher,
                     (array) PluginHelper::getPlugin('system', 'redirect')
                 );
-                $plugin->setApplication(Factory::getApplication());
+                $plugin->setApplication($app);
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
 
                 return $plugin;

--- a/plugins/system/redirect/src/Extension/Redirect.php
+++ b/plugins/system/redirect/src/Extension/Redirect.php
@@ -70,7 +70,7 @@ final class Redirect extends CMSPlugin implements SubscriberInterface
         /** @var \Joomla\CMS\Application\CMSApplication $app */
         $app = $event->getApplication();
 
-        if ($app->isClient('administrator') || ((int) $event->getError()->getCode() !== 404)) {
+        if ((int) $event->getError()->getCode() !== 404) {
             return;
         }
 

--- a/plugins/system/sef/services/provider.php
+++ b/plugins/system/sef/services/provider.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Extension\DummyPlugin;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -33,12 +34,19 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                $app = Factory::getApplication();
+
+                if (!$app->isClient('site')) {
+                    // Return an empty class when we in wrong App
+                    return new DummyPlugin();
+                }
+
                 $dispatcher = $container->get(DispatcherInterface::class);
                 $plugin     = new Sef(
                     $dispatcher,
                     (array) PluginHelper::getPlugin('system', 'sef')
                 );
-                $plugin->setApplication(Factory::getApplication());
+                $plugin->setApplication($app);
 
                 return $plugin;
             }

--- a/plugins/system/sef/src/Extension/Sef.php
+++ b/plugins/system/sef/src/Extension/Sef.php
@@ -37,7 +37,7 @@ final class Sef extends CMSPlugin
     {
         $doc = $this->getApplication()->getDocument();
 
-        if (!$this->getApplication()->isClient('site') || $doc->getType() !== 'html') {
+        if ($doc->getType() !== 'html') {
             return;
         }
 
@@ -81,10 +81,6 @@ final class Sef extends CMSPlugin
      */
     public function onAfterRender()
     {
-        if (!$this->getApplication()->isClient('site')) {
-            return;
-        }
-
         // Replace src links.
         $base   = Uri::base(true) . '/';
         $buffer = $this->getApplication()->getBody();

--- a/plugins/system/shortcut/services/provider.php
+++ b/plugins/system/shortcut/services/provider.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Extension\DummyPlugin;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -33,12 +34,19 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                $app = Factory::getApplication();
+
+                if (!$app->isClient('administrator')) {
+                    // Return an empty class when we in wrong App
+                    return new DummyPlugin();
+                }
+
                 $dispatcher = $container->get(DispatcherInterface::class);
                 $plugin     = new Shortcut(
                     $dispatcher,
                     (array) PluginHelper::getPlugin('system', 'shortcut')
                 );
-                $plugin->setApplication(Factory::getApplication());
+                $plugin->setApplication($app);
 
                 return $plugin;
             }

--- a/plugins/system/shortcut/src/Extension/Shortcut.php
+++ b/plugins/system/shortcut/src/Extension/Shortcut.php
@@ -71,10 +71,6 @@ final class Shortcut extends CMSPlugin implements SubscriberInterface
      */
     public function initialize()
     {
-        if (!$this->getApplication()->isClient('administrator')) {
-            return;
-        }
-
         $context = $this->getApplication()->getInput()->get('option') . '.' . $this->getApplication()->getInput()->get('view');
 
         $shortcuts = [];

--- a/plugins/system/stats/services/provider.php
+++ b/plugins/system/stats/services/provider.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Extension\DummyPlugin;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -34,12 +35,19 @@ return new class () implements ServiceProviderInterface {
         $container->set(
             PluginInterface::class,
             function (Container $container) {
+                $app = Factory::getApplication();
+
+                if (!$app->isClient('administrator')) {
+                    // Return an empty class when we in wrong App
+                    return new DummyPlugin();
+                }
+
                 $dispatcher = $container->get(DispatcherInterface::class);
                 $plugin     = new Stats(
                     $dispatcher,
                     (array) PluginHelper::getPlugin('system', 'stats')
                 );
-                $plugin->setApplication(Factory::getApplication());
+                $plugin->setApplication($app);
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
 
                 return $plugin;

--- a/plugins/system/stats/src/Extension/Stats.php
+++ b/plugins/system/stats/src/Extension/Stats.php
@@ -83,7 +83,7 @@ final class Stats extends CMSPlugin
      */
     public function onAfterInitialise()
     {
-        if (!$this->getApplication()->isClient('administrator') || !$this->isAllowedUser()) {
+        if (!$this->isAllowedUser()) {
             return;
         }
 
@@ -112,7 +112,7 @@ final class Stats extends CMSPlugin
      */
     public function onAfterDispatch()
     {
-        if (!$this->getApplication()->isClient('administrator') || !$this->isAllowedUser()) {
+        if (!$this->isAllowedUser()) {
             return;
         }
 


### PR DESCRIPTION
### Summary of Changes

This is an idea about what we can do to prevent plugin from booting, when it will not be in use.
Example, when plugin designed to work only for Site or only for Administrator.

When the plugin should not be loaded, the service/provider should return a plugin placeholder.
We already have a class for it called DummyPlugin, so it is not a new feature.

What do you think about it?

### Testing Instructions

Apply patch, and check the modified plugins, they should work as before.
For advanced users: dump $dispatcher, to make sure the plugin not loaded when they should not.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: IDK
- [ ] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: IDK
- [ ] No documentation changes for manual.joomla.org needed
