### PR TITLE
[5.0] Module menu improvement

### DIFF
--- a/modules/mod_menu/src/Helper/MenuHelper.php
+++ b/modules/mod_menu/src/Helper/MenuHelper.php
@@ -242,7 +242,11 @@ class MenuHelper
             $linktype = HTMLHelper::_('image', $item->menu_image, '', $image_attributes);
 
             if ($itemParams->get('menu_text', 1)) {
-                $linktype .= '<span class="image-title">' .  '" alt="' . $item->title . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
+                $linktype .= $item->title;
+
+            } else {
+                // If the icon itself is the link, it needs a visually hidden text
+                $linktype .= '<span class="visually-hidden">' . $item->title . '</span>';
             }
         }
 

--- a/modules/mod_menu/src/Helper/MenuHelper.php
+++ b/modules/mod_menu/src/Helper/MenuHelper.php
@@ -13,8 +13,10 @@ namespace Joomla\Module\Menu\Site\Helper;
 use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Cache\Controller\OutputController;
 use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Router\Route;
+
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -165,6 +167,7 @@ class MenuHelper
                     $item->anchor_rel     = htmlspecialchars($itemParams->get('menu-anchor_rel', ''), ENT_COMPAT, 'UTF-8', false);
                     $item->menu_image     = htmlspecialchars($itemParams->get('menu_image', ''), ENT_COMPAT, 'UTF-8', false);
                     $item->menu_image_css = htmlspecialchars($itemParams->get('menu_image_css', ''), ENT_COMPAT, 'UTF-8', false);
+                    $item->menu_linktype  = self::getLinktype($item, $itemParams);
                 }
 
                 if (isset($items[$lastitem])) {
@@ -204,6 +207,46 @@ class MenuHelper
         }
 
         return $base;
+    }
+
+    /**
+     * Get the html code for the linktype.
+     *
+     * @param   \Joomla\Registry\Registry  &$params  The module options.
+     *
+     * @return  string
+     *
+     * @since    __DEPLOY_VERSION__
+     */
+    public static function getLinktype($item, $itemParams)
+    {
+        $linktype = $item->title;
+
+        if ($item->menu_icon) {
+            // The link is an icon
+            if ($itemParams->get('menu_text', 1)) {
+                // If the link text is to be displayed, the icon is added with aria-hidden
+                $linktype = '<span class="p-2 ' . $item->menu_icon . '" alt="" aria-hidden="true"></span>' . $item->title;
+            } else {
+                // If the icon itself is the link, it needs a visually hidden text
+                $linktype = '<span class="p-2 ' . $item->menu_icon . '" alt="' . $item->title . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
+            }
+        } elseif ($item->menu_image) {
+            // The link is an image, maybe with an own class
+            $image_attributes = [];
+
+            if ($item->menu_image_css) {
+                $image_attributes['class'] = $item->menu_image_css;
+            }
+
+            $linktype = HTMLHelper::_('image', $item->menu_image, '', $image_attributes);
+
+            if ($itemParams->get('menu_text', 1)) {
+                $linktype .= '<span class="image-title">' .  '" alt="' . $item->title . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
+            }
+        }
+
+        return $linktype;
     }
 
     /**

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Helper\ModuleHelper;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
@@ -60,6 +61,35 @@ if ($tagId = $params->get('tag_id', '')) {
 
     if ($item->parent) {
         $class .= ' parent';
+    }
+
+    $linktype = $item->title;
+
+    if ($item->menu_icon) {
+        // The link is an icon
+        if ($itemParams->get('menu_text', 1)) {
+            // If the link text is to be displayed, the icon is added with aria-hidden
+            $linktype = '<span class="p-2 ' . $item->menu_icon . '" alt="" aria-hidden="true"></span>' . $item->title;
+        } else {
+            // If the icon itself is the link, it needs a visually hidden text
+            $linktype = '<span class="p-2 ' . $item->menu_icon . '" alt="' . $item->title . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
+        }
+    } elseif ($item->menu_image) {
+        // The link is an image, maybe with an own class
+        $image_attributes = [];
+
+        // Alt text is empty if the menuitem title is displayed
+        $alt = $itemParams->get('menu_text', 1) ? '' : $item->title;
+
+        if ($item->menu_image_css) {
+            $image_attributes['class'] = $item->menu_image_css;
+        }
+
+        $linktype = HTMLHelper::_('image', $item->menu_image, $alt, $image_attributes);
+
+        if ($itemParams->get('menu_text', 1)) {
+            $linktype .= '<span class="image-title">' . $item->title . '</span>';
+        }
     }
 
     echo '<li class="' . $class . '">';

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -63,35 +63,6 @@ if ($tagId = $params->get('tag_id', '')) {
         $class .= ' parent';
     }
 
-    $linktype = $item->title;
-
-    if ($item->menu_icon) {
-        // The link is an icon
-        if ($itemParams->get('menu_text', 1)) {
-            // If the link text is to be displayed, the icon is added with aria-hidden
-            $linktype = '<span class="p-2 ' . $item->menu_icon . '" alt="" aria-hidden="true"></span>' . $item->title;
-        } else {
-            // If the icon itself is the link, it needs a visually hidden text
-            $linktype = '<span class="p-2 ' . $item->menu_icon . '" alt="' . $item->title . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
-        }
-    } elseif ($item->menu_image) {
-        // The link is an image, maybe with an own class
-        $image_attributes = [];
-
-        // Alt text is empty if the menuitem title is displayed
-        $alt = $itemParams->get('menu_text', 1) ? '' : $item->title;
-
-        if ($item->menu_image_css) {
-            $image_attributes['class'] = $item->menu_image_css;
-        }
-
-        $linktype = HTMLHelper::_('image', $item->menu_image, $alt, $image_attributes);
-
-        if ($itemParams->get('menu_text', 1)) {
-            $linktype .= '<span class="image-title">' . $item->title . '</span>';
-        }
-    }
-
     echo '<li class="' . $class . '">';
 
     switch ($item->type) :

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Helper\ModuleHelper;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */

--- a/modules/mod_menu/tmpl/default_component.php
+++ b/modules/mod_menu/tmpl/default_component.php
@@ -35,32 +35,6 @@ if ($item->id == $active_id) {
     }
 }
 
-$linktype = $item->title;
-
-if ($item->menu_icon) {
-    // The link is an icon
-    if ($itemParams->get('menu_text', 1)) {
-        // If the link text is to be displayed, the icon is added with aria-hidden
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span>' . $item->title;
-    } else {
-        // If the icon itself is the link, it needs a visually hidden text
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
-    }
-} elseif ($item->menu_image) {
-    // The link is an image, maybe with its own class
-    $image_attributes = [];
-
-    if ($item->menu_image_css) {
-        $image_attributes['class'] = $item->menu_image_css;
-    }
-
-    $linktype = HTMLHelper::_('image', $item->menu_image, $item->title, $image_attributes);
-
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
-}
-
 if ($item->browserNav == 1) {
     $attributes['target'] = '_blank';
 } elseif ($item->browserNav == 2) {

--- a/modules/mod_menu/tmpl/default_component.php
+++ b/modules/mod_menu/tmpl/default_component.php
@@ -43,4 +43,4 @@ if ($item->browserNav == 1) {
     $attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
 }
 
-echo HTMLHelper::_('link', OutputFilter::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $linktype, $attributes);
+echo HTMLHelper::_('link', OutputFilter::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $item->menu_linktype, $attributes);

--- a/modules/mod_menu/tmpl/default_heading.php
+++ b/modules/mod_menu/tmpl/default_heading.php
@@ -15,4 +15,4 @@ use Joomla\CMS\HTML\HTMLHelper;
 $title      = $item->anchor_title ? ' title="' . $item->anchor_title . '"' : '';
 $anchor_css = $item->anchor_css ?: '';
 ?>
-<span class="mod-menu__heading nav-header <?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>
+<span class="mod-menu__heading nav-header <?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $item->menu_linktype; ?></span>

--- a/modules/mod_menu/tmpl/default_heading.php
+++ b/modules/mod_menu/tmpl/default_heading.php
@@ -14,31 +14,5 @@ use Joomla\CMS\HTML\HTMLHelper;
 
 $title      = $item->anchor_title ? ' title="' . $item->anchor_title . '"' : '';
 $anchor_css = $item->anchor_css ?: '';
-$linktype   = $item->title;
-
-if ($item->menu_icon) {
-    // The link is an icon
-    if ($itemParams->get('menu_text', 1)) {
-        // If the link text is to be displayed, the icon is added with aria-hidden
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span>' . $item->title;
-    } else {
-        // If the icon itself is the link, it needs a visually hidden text
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
-    }
-} elseif ($item->menu_image) {
-    // The link is an image, maybe with its own class
-    $image_attributes = [];
-
-    if ($item->menu_image_css) {
-        $image_attributes['class'] = $item->menu_image_css;
-    }
-
-    $linktype = HTMLHelper::_('image', $item->menu_image, $item->title, $image_attributes);
-
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
-}
-
 ?>
 <span class="mod-menu__heading nav-header <?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>

--- a/modules/mod_menu/tmpl/default_separator.php
+++ b/modules/mod_menu/tmpl/default_separator.php
@@ -14,31 +14,6 @@ use Joomla\CMS\HTML\HTMLHelper;
 
 $title      = $item->anchor_title ? ' title="' . $item->anchor_title . '"' : '';
 $anchor_css = $item->anchor_css ?: '';
-$linktype   = $item->title;
-
-if ($item->menu_icon) {
-    // The link is an icon
-    if ($itemParams->get('menu_text', 1)) {
-        // If the link text is to be displayed, the icon is added with aria-hidden
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span>' . $item->title;
-    } else {
-        // If the icon itself is the link, it needs a visually hidden text
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
-    }
-} elseif ($item->menu_image) {
-    // The link is an image, maybe with its own class
-    $image_attributes = [];
-
-    if ($item->menu_image_css) {
-        $image_attributes['class'] = $item->menu_image_css;
-    }
-
-    $linktype = HTMLHelper::_('image', $item->menu_image, $item->title, $image_attributes);
-
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
-}
 
 ?>
 <span class="mod-menu__separator separator <?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>

--- a/modules/mod_menu/tmpl/default_separator.php
+++ b/modules/mod_menu/tmpl/default_separator.php
@@ -16,4 +16,4 @@ $title      = $item->anchor_title ? ' title="' . $item->anchor_title . '"' : '';
 $anchor_css = $item->anchor_css ?: '';
 
 ?>
-<span class="mod-menu__separator separator <?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $linktype; ?></span>
+<span class="mod-menu__separator separator <?php echo $anchor_css; ?>"<?php echo $title; ?>><?php echo $item->menu_linktype; ?></span>

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -40,4 +40,4 @@ if ($item->browserNav == 1) {
     $attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
 }
 
-echo HTMLHelper::_('link', OutputFilter::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $linktype, $attributes);
+echo HTMLHelper::_('link', OutputFilter::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $item->menu_linktype, $attributes);

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -27,32 +27,6 @@ if ($item->anchor_rel) {
     $attributes['rel'] = $item->anchor_rel;
 }
 
-$linktype = $item->title;
-
-if ($item->menu_icon) {
-    // The link is an icon
-    if ($itemParams->get('menu_text', 1)) {
-        // If the link text is to be displayed, the icon is added with aria-hidden
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span>' . $item->title;
-    } else {
-        // If the icon itself is the link, it needs a visually hidden text
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
-    }
-} elseif ($item->menu_image) {
-    // The link is an image, maybe with an own class
-    $image_attributes = [];
-
-    if ($item->menu_image_css) {
-        $image_attributes['class'] = $item->menu_image_css;
-    }
-
-    $linktype = HTMLHelper::_('image', $item->menu_image, $item->title, $image_attributes);
-
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
-}
-
 if ($item->browserNav == 1) {
     $attributes['target'] = '_blank';
     $attributes['rel'] = 'noopener noreferrer';

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_component.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_component.php
@@ -35,31 +35,6 @@ if ($item->id == $active_id) {
     }
 }
 
-$linktype = $item->title;
-
-if ($item->menu_icon) {
-    // The link is an icon
-    if ($itemParams->get('menu_text', 1)) {
-        // If the link text is to be displayed, the icon is added with aria-hidden
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span>' . $item->title;
-    } else {
-        // If the icon itself is the link, it needs a visually hidden text
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
-    }
-} elseif ($item->menu_image) {
-    // The link is an image, maybe with an own class
-    $image_attributes = [];
-
-    if ($item->menu_image_css) {
-        $image_attributes['class'] = $item->menu_image_css;
-    }
-
-    $linktype = HTMLHelper::_('image', $item->menu_image, $item->title, $image_attributes);
-
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
-}
 
 if ($item->browserNav == 1) {
     $attributes['target'] = '_blank';
@@ -69,7 +44,7 @@ if ($item->browserNav == 1) {
     $attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
 }
 
-echo HTMLHelper::link(OutputFilter::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $linktype, $attributes);
+echo HTMLHelper::link(OutputFilter::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $item->menu_linktype, $attributes);
 
 if ($showAll && $item->deeper) {
     echo '<button class="mm-collapsed mm-toggler mm-toggler-link" aria-haspopup="true" aria-expanded="false" aria-label="' . $item->title . '"></button>';

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_heading.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_heading.php
@@ -22,37 +22,11 @@ if ($item->anchor_title) {
 $attributes['class'] = 'mod-menu__heading nav-header';
 $attributes['class'] .= $item->anchor_css ? ' ' . $item->anchor_css : null;
 
-$linktype = $item->title;
-
-if ($item->menu_icon) {
-    // The link is an icon
-    if ($itemParams->get('menu_text', 1)) {
-        // If the link text is to be displayed, the icon is added with aria-hidden
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span>' . $item->title;
-    } else {
-        // If the icon itself is the link, it needs a visually hidden text
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
-    }
-} elseif ($item->menu_image) {
-    // The link is an image, maybe with an own class
-    $image_attributes = [];
-
-    if ($item->menu_image_css) {
-        $image_attributes['class'] = $item->menu_image_css;
-    }
-
-    $linktype = HTMLHelper::_('image', $item->menu_image, $item->title, $image_attributes);
-
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
-}
-
 if ($showAll && $item->deeper) {
     $attributes['class'] .= ' mm-collapsed mm-toggler mm-toggler-nolink';
     $attributes['aria-haspopup'] = 'true';
     $attributes['aria-expanded'] = 'false';
-    echo '<button ' . ArrayHelper::toString($attributes) . '>' . $linktype . '</button>';
+    echo '<button ' . ArrayHelper::toString($attributes) . '>' . $item->menu_linktype . '</button>';
 } else {
-    echo '<span ' . ArrayHelper::toString($attributes) . '>' . $linktype . '</span>';
+    echo '<span ' . ArrayHelper::toString($attributes) . '>' . $item->menu_linktype . '</span>';
 }

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_separator.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_separator.php
@@ -22,37 +22,11 @@ if ($item->anchor_title) {
 $attributes['class'] = 'mod-menu__separator separator';
 $attributes['class'] .= $item->anchor_css ? ' ' . $item->anchor_css : null;
 
-$linktype = $item->title;
-
-if ($item->menu_icon) {
-    // The link is an icon
-    if ($itemParams->get('menu_text', 1)) {
-        // If the link text is to be displayed, the icon is added with aria-hidden
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span>' . $item->title;
-    } else {
-        // If the icon itself is the link, it needs a visually hidden text
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
-    }
-} elseif ($item->menu_image) {
-    // The link is an image, maybe with an own class
-    $image_attributes = [];
-
-    if ($item->menu_image_css) {
-        $image_attributes['class'] = $item->menu_image_css;
-    }
-
-    $linktype = HTMLHelper::_('image', $item->menu_image, $item->title, $image_attributes);
-
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
-}
-
 if ($showAll && $item->deeper) {
     $attributes['class'] .= ' mm-collapsed mm-toggler mm-toggler-nolink';
     $attributes['aria-haspopup'] = 'true';
     $attributes['aria-expanded'] = 'false';
-    echo '<button ' . ArrayHelper::toString($attributes) . '>' . $linktype . '</button>';
+    echo '<button ' . ArrayHelper::toString($attributes) . '>' . $item->menu_linktype . '</button>';
 } else {
-    echo '<span ' . ArrayHelper::toString($attributes) . '>' . $linktype . '</span>';
+    echo '<span ' . ArrayHelper::toString($attributes) . '>' . $item->menu_linktype . '</span>';
 }

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_url.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_url.php
@@ -27,32 +27,6 @@ if ($item->anchor_rel) {
     $attributes['rel'] = $item->anchor_rel;
 }
 
-$linktype = $item->title;
-
-if ($item->menu_icon) {
-    // The link is an icon
-    if ($itemParams->get('menu_text', 1)) {
-        // If the link text is to be displayed, the icon is added with aria-hidden
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span>' . $item->title;
-    } else {
-        // If the icon itself is the link, it needs a visually hidden text
-        $linktype = '<span class="p-2 ' . $item->menu_icon . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
-    }
-} elseif ($item->menu_image) {
-    // The link is an image, maybe with an own class
-    $image_attributes = [];
-
-    if ($item->menu_image_css) {
-        $image_attributes['class'] = $item->menu_image_css;
-    }
-
-    $linktype = HTMLHelper::_('image', $item->menu_image, $item->title, $image_attributes);
-
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
-}
-
 if ($item->browserNav == 1) {
     $attributes['target'] = '_blank';
     $attributes['rel']    = 'noopener noreferrer';
@@ -66,7 +40,7 @@ if ($item->browserNav == 1) {
     $attributes['onclick'] = "window.open(this.href, 'targetWindow', '" . $options . "'); return false;";
 }
 
-echo HTMLHelper::link(OutputFilter::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $linktype, $attributes);
+echo HTMLHelper::link(OutputFilter::ampReplace(htmlspecialchars($item->flink, ENT_COMPAT, 'UTF-8', false)), $item->menu_linktype, $attributes);
 
 if ($showAll && $item->deeper) {
     echo '<button class="mm-collapsed mm-toggler mm-toggler-link" aria-haspopup="true" aria-expanded="false" aria-label="' . $item->title . '"></button>';


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Over the time, images and icons were added.
The code for images and icons was copied - the contrary of the DRY principle.
It works, but a new accessibility tool brings up a11y issues with alt texts in images and icons:
- In one case the alt attribute is missing completely,
- in an other case the alt attribute is the same as the menu title which not correct.

I would like to fix both issues in one step - the alt attribute and the multiple used code. 

This PR did two things: 
The whole block for generating the item menu is removed from the 8 sub templates and added to the MenuHelper, where all the other attributes are est. 

### Testing Instructions
We have 4 menu types
url, separator, component, heading 
in "normal" menus and in metismneu overrides. 

Inspect HTML-code of your menu Items before and after Patch.  
Make sure that all your menuItems don't change their apparance and behaviour. 

### Actual result BEFORE applying this Pull Request
Alt text for images and icons is missing 
If the is  displayed for sighted users the alt text is the same as the title


### Expected result AFTER applying this Pull Request
Alt text  is always empty alt-text. 
If the title is not displayed for sighted users, it is displayed as visually-hidden text.

### Link to documentations
This is no b/c break. Users who have own overrides for menu modules will get a warning that overrides are not up-to-date. 
A docmentation should explain the a11y issue.

Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
