### PR TITLE
Move HTML from MenuHelper to a JLayout

### DIFF
--- a/layouts/joomla/menu/linktype.php
+++ b/layouts/joomla/menu/linktype.php
@@ -4,7 +4,7 @@
  * @package     Joomla.Site
  * @subpackage  Layout
  *
- * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 

--- a/layouts/joomla/menu/linktype.php
+++ b/layouts/joomla/menu/linktype.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   (C) 2021 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+// Display Icon if set
+echo $displayData['icon'] ?? null;
+
+// Display Image if set
+echo $displayData['image'] ?? null;
+
+// Display / Hide Menu Item Title
+if ($displayData['menu_text'])
+{
+    echo $displayData['title'];
+} else {
+    echo '<span class="visually-hidden">' . $displayData['title'] . '</span>';
+}

--- a/modules/mod_menu/src/Helper/MenuHelper.php
+++ b/modules/mod_menu/src/Helper/MenuHelper.php
@@ -229,7 +229,7 @@ class MenuHelper
         {
             $icon_attributes = [
                 'icon'   => $item->menu_icon,
-                'suffix' => 'p-2'
+                'suffix' => 'p-2',
             ];
 
             $attributes['icon'] = LayoutHelper::render('joomla.icon.iconclass', $icon_attributes);

--- a/modules/mod_menu/src/Helper/MenuHelper.php
+++ b/modules/mod_menu/src/Helper/MenuHelper.php
@@ -238,7 +238,7 @@ class MenuHelper
         {
             $image_attributes = [
                 'src' => $item->menu_image,
-                'alt' => ''
+                'alt' => '',
             ];
 
             if ($item->menu_image_css)

--- a/modules/mod_menu/src/Helper/MenuHelper.php
+++ b/modules/mod_menu/src/Helper/MenuHelper.php
@@ -222,7 +222,7 @@ class MenuHelper
     {
         $attributes = [
             'title'     => $item->title,
-            'menu_text' => $itemParams->get('menu_text', 1)
+            'menu_text' => $itemParams->get('menu_text', 1),
         ];
 
         if ($item->menu_icon)

--- a/modules/mod_menu/src/Helper/MenuHelper.php
+++ b/modules/mod_menu/src/Helper/MenuHelper.php
@@ -13,8 +13,8 @@ namespace Joomla\Module\Menu\Site\Helper;
 use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Cache\Controller\OutputController;
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Multilanguage;
+use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
 
@@ -220,37 +220,36 @@ class MenuHelper
      */
     public static function getLinktype($item, $itemParams)
     {
-        $linktype = $item->title;
+        $attributes = [
+            'title'     => $item->title,
+            'menu_text' => $itemParams->get('menu_text', 1)
+        ];
 
-        if ($item->menu_icon) {
-            // The link is an icon
-            if ($itemParams->get('menu_text', 1)) {
-                // If the link text is to be displayed, the icon is added with aria-hidden
-                $linktype = '<span class="p-2 ' . $item->menu_icon . '" alt="" aria-hidden="true"></span>' . $item->title;
-            } else {
-                // If the icon itself is the link, it needs a visually hidden text
-                $linktype = '<span class="p-2 ' . $item->menu_icon . '" alt="' . $item->title . '" aria-hidden="true"></span><span class="visually-hidden">' . $item->title . '</span>';
-            }
-        } elseif ($item->menu_image) {
-            // The link is an image, maybe with an own class
-            $image_attributes = [];
+        if ($item->menu_icon)
+        {
+            $icon_attributes = [
+                'icon'   => $item->menu_icon,
+                'suffix' => 'p-2'
+            ];
 
-            if ($item->menu_image_css) {
+            $attributes['icon'] = LayoutHelper::render('joomla.icon.iconclass', $icon_attributes);
+        }
+        elseif ($item->menu_image)
+        {
+            $image_attributes = [
+                'src' => $item->menu_image,
+                'alt' => ''
+            ];
+
+            if ($item->menu_image_css)
+            {
                 $image_attributes['class'] = $item->menu_image_css;
             }
 
-            $linktype = HTMLHelper::_('image', $item->menu_image, '', $image_attributes);
-
-            if ($itemParams->get('menu_text', 1)) {
-                $linktype .= $item->title;
-
-            } else {
-                // If the icon itself is the link, it needs a visually hidden text
-                $linktype .= '<span class="visually-hidden">' . $item->title . '</span>';
-            }
+            $attributes['image'] = LayoutHelper::render('joomla.html.image', $image_attributes);
         }
 
-        return $linktype;
+        return LayoutHelper::render('joomla.menu.linktype', $attributes);
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #40656 .

### Summary of Changes

This PR on Draft PR will move the HTML inside MenuHelper to it's own JLayout joomla.menu.linktype

### Testing Instructions

apply PR and test output


### Actual result BEFORE applying this Pull Request

Before and after should be the same.

### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
