### PR TITLE
[5.0] Fix PHP warnings e.g. when installing Blog Sample Data

### DIFF
--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -115,10 +115,10 @@ class FieldModel extends AdminModel
             $field = $this->getItem($data['id']);
         }
 
-        if (
-            (is_null($field) && $data['params']['searchindex'] > 0)
-            || ($field->params['searchindex'] != $data['params']['searchindex'])
-            || ($data['params']['searchindex'] > 0 && ($field->state != $data['state'] || $field->access != $data['access']))
+        if (isset($data['params']['searchindex'])
+            && ((is_null($field) && $data['params']['searchindex'] > 0)
+                || ($field->params['searchindex'] != $data['params']['searchindex'])
+                || ($data['params']['searchindex'] > 0 && ($field->state != $data['state'] || $field->access != $data['access'])))
         ) {
             Factory::getApplication()->enqueueMessage(Text::_('COM_FIELDS_SEARCHINDEX_MIGHT_REQUIRE_REINDEXING'), 'notice');
         }

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -884,7 +884,7 @@ class FieldModel extends AdminModel
         foreach ($pks as $pk) {
             $item = $this->getItem($pk);
 
-            if ($item->params['searchindex'] > 0) {
+            if (isset($item->params['searchindex']) && $item->params['searchindex'] > 0) {
                 Factory::getApplication()->enqueueMessage(Text::_('COM_FIELDS_SEARCHINDEX_MIGHT_REQUIRE_REINDEXING'), 'notice');
 
                 break;

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -115,7 +115,8 @@ class FieldModel extends AdminModel
             $field = $this->getItem($data['id']);
         }
 
-        if (isset($data['params']['searchindex'])
+        if (
+            isset($data['params']['searchindex'])
             && ((is_null($field) && $data['params']['searchindex'] > 0)
                 || ($field->params['searchindex'] != $data['params']['searchindex'])
                 || ($data['params']['searchindex'] > 0 && ($field->state != $data['state'] || $field->access != $data['access'])))


### PR DESCRIPTION
Pull Request for Issue #40680 .

### Summary of Changes

This pull request (PR) fixes the PHP warnings reported in the linked issue when installing Blog Sample Data by adding an `isset` check.

In addition it fixes `PHP Warning:  Undefined array key "searchindex" in /administrator/components/com_fields/src/Model/FieldModel.php on line 886` happening when publishing or unpublishing a field which doesn't have the "searchindex" parameter set, e.g. when having updated from 4.4 and not saved the field again, or when having installed Blog Sample Data without that parameter.

This is one possible way to fix the issue, but it might be not the best way.

@Hackwar Please check. I have tested and it works, but as said, it might be the wrong way to fix it. But keep in mind that when updating from 4.4 and not having a migration for the fields parameters, we always might run into the new parameter not being set.

### Testing Instructions

On a clean, current 5.0-dev branch where PR #38650 has been merged, make a new installation.

Then login to backend.

Then either set error reporting to maximum or make sure that PHP warnings are logged into a log file.

### Actual result BEFORE applying this Pull Request

PHP warnings:

```
PHP Warning:  Undefined array key "searchindex" in /administrator/components/com_fields/src/Model/FieldModel.php on line 119
PHP Warning:  Attempt to read property "params" on null in /administrator/components/com_fields/src/Model/FieldModel.php on line 120
PHP Warning:  Trying to access array offset on value of type null in /administrator/components/com_fields/src/Model/FieldModel.php on line 120
PHP Warning:  Undefined array key "searchindex" in/administrator/components/com_fields/src/Model/FieldModel.php on line 120
PHP Warning:  Undefined array key "searchindex" in /administrator/components/com_fields/src/Model/FieldModel.php on line 121
```

When error reporting is set to maximum, the Blog Sampe Data installation fails.

### Expected result AFTER applying this Pull Request

No PHP warnings, installation of Blog Sample Data succeeds in any case.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
