### PR TITLE
[4.3] Media Manager Regression

### DIFF
--- a/administrator/components/com_media/resources/scripts/app/Api.es6.js
+++ b/administrator/components/com_media/resources/scripts/app/Api.es6.js
@@ -152,12 +152,11 @@ class Api {
     url.searchParams.append('content', true);
 
     return fetch(url, {
-        method: 'GET',
-        data: JSON.stringify({ [this.csrfToken]: '1'}),
-        headers: {
-          'X-CSRF-Token': Joomla.getOptions('csrf.token'),
-          'Content-Type': 'application/json'
-        },
+      method: 'GET',
+      headers: {
+        'X-CSRF-Token': Joomla.getOptions('csrf.token'),
+        'Content-Type': 'application/json',
+      },
     }).then((response) => response.ok);
   }
 

--- a/administrator/components/com_media/resources/scripts/app/Api.es6.js
+++ b/administrator/components/com_media/resources/scripts/app/Api.es6.js
@@ -140,6 +140,28 @@ class Api {
   }
 
   /**
+   * Check if the path exists
+   *
+   * @param {string} dir
+   *
+   * @returns {boolean}
+   */
+  async checkPath(dir) {
+    const url = new URL(`${this.baseUrl}&task=api.files&path=${encodeURIComponent(dir)}`);
+    url.searchParams.append('url', true);
+    url.searchParams.append('content', true);
+
+    return fetch(url, {
+        method: 'GET',
+        data: JSON.stringify({ [this.csrfToken]: '1'}),
+        headers: {
+          'X-CSRF-Token': Joomla.getOptions('csrf.token'),
+          'Content-Type': 'application/json'
+        },
+    }).then((response) => response.ok);
+  }
+
+  /**
      * Create a directory
      * @param name
      * @param parent

--- a/administrator/components/com_media/resources/scripts/mediamanager.es6.js
+++ b/administrator/components/com_media/resources/scripts/mediamanager.es6.js
@@ -9,5 +9,9 @@ window.MediaManager = window.MediaManager || {};
 // Register the media manager event bus
 window.MediaManager.Event = new Event();
 
-// Create the Vue app instance
-createApp(App).use(store).use(translate).mount('#com-media');
+(async () => {
+  const newStore = await store();
+
+  // Create the Vue app instance
+  createApp(App).use(newStore).use(translate).mount('#com-media');
+})();

--- a/administrator/components/com_media/resources/scripts/store/state.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/state.es6.js
@@ -86,6 +86,8 @@ async function getCurrentPath() {
 }
 
 async function getState() {
+  const selectedPath = await getCurrentPath();
+
   return {
     // The general loading state
     isLoading: false,
@@ -103,7 +105,7 @@ async function getState() {
     files: [],
     // The selected disk. Providers are ordered by plugin ordering, so we set the first provider
     // in the list as the default provider and load first drive on it as default
-    selectedDirectory: await getCurrentPath(),
+    selectedDirectory: selectedPath,
     // The currently selected items
     selectedItems: [],
     // The state of the infobar

--- a/administrator/components/com_media/resources/scripts/store/state.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/state.es6.js
@@ -85,49 +85,53 @@ async function getCurrentPath() {
   return defaultDisk.drives[0].root;
 }
 
-// The initial state
-export default {
-  // The general loading state
-  isLoading: false,
-  // Will hold the activated filesystem disks
-  disks: loadedDisks,
-  // The loaded directories
-  directories: loadedDisks.map(() => ({
-    path: defaultDisk.drives[0].root,
-    name: defaultDisk.displayName,
-    directories: [],
+async function getState() {
+  return {
+    // The general loading state
+    isLoading: false,
+    // Will hold the activated filesystem disks
+    disks: loadedDisks,
+    // The loaded directories
+    directories: loadedDisks.map(() => ({
+      path: defaultDisk.drives[0].root,
+      name: defaultDisk.displayName,
+      directories: [],
+      files: [],
+      directory: null,
+    })),
+    // The loaded files
     files: [],
-    directory: null,
-  })),
-  // The loaded files
-  files: [],
-  // The selected disk. Providers are ordered by plugin ordering, so we set the first provider
-  // in the list as the default provider and load first drive on it as default
-  selectedDirectory: await getCurrentPath(),
-  // The currently selected items
-  selectedItems: [],
-  // The state of the infobar
-  showInfoBar: false,
-  // List view
-  listView: 'grid',
-  // The size of the grid items
-  gridSize: 'md',
-  // The state of confirm delete model
-  showConfirmDeleteModal: false,
-  // The state of create folder model
-  showCreateFolderModal: false,
-  // The state of preview model
-  showPreviewModal: false,
-  // The state of share model
-  showShareModal: false,
-  // The state of  model
-  showRenameModal: false,
-  // The preview item
-  previewItem: null,
-  // The Search Query
-  search: '',
-  // The sorting by
-  sortBy: storedState && storedState.sortBy ? storedState.sortBy : 'name',
-  // The sorting direction
-  sortDirection: storedState && storedState.sortDirection ? storedState.sortDirection : 'asc',
-};
+    // The selected disk. Providers are ordered by plugin ordering, so we set the first provider
+    // in the list as the default provider and load first drive on it as default
+    selectedDirectory: await getCurrentPath(),
+    // The currently selected items
+    selectedItems: [],
+    // The state of the infobar
+    showInfoBar: false,
+    // List view
+    listView: 'grid',
+    // The size of the grid items
+    gridSize: 'md',
+    // The state of confirm delete model
+    showConfirmDeleteModal: false,
+    // The state of create folder model
+    showCreateFolderModal: false,
+    // The state of preview model
+    showPreviewModal: false,
+    // The state of share model
+    showShareModal: false,
+    // The state of  model
+    showRenameModal: false,
+    // The preview item
+    previewItem: null,
+    // The Search Query
+    search: '',
+    // The sorting by
+    sortBy: storedState && storedState.sortBy ? storedState.sortBy : 'name',
+    // The sorting direction
+    sortDirection: storedState && storedState.sortDirection ? storedState.sortDirection : 'asc',
+  };
+}
+
+// The initial state
+export default getState;

--- a/administrator/components/com_media/resources/scripts/store/store.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/store.es6.js
@@ -6,11 +6,15 @@ import * as actions from './actions.es6';
 import mutations from './mutations.es6';
 import persistedStateOptions from './plugins/persisted-state.es6.js';
 // A Vuex instance is created by combining the state, mutations, actions, and getters.
-export default createStore({
-  state,
-  getters,
-  actions,
-  mutations,
-  plugins: [new VuexPersistence(persistedStateOptions).plugin],
-  strict: (process.env.NODE_ENV !== 'production'),
-});
+
+async function newStore() {
+  return createStore({
+    state: await state(),
+    getters,
+    actions,
+    mutations,
+    plugins: [new VuexPersistence(persistedStateOptions).plugin],
+    strict: (process.env.NODE_ENV !== 'production'),
+  });
+}
+export default newStore;

--- a/administrator/components/com_media/resources/scripts/store/store.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/store.es6.js
@@ -8,8 +8,10 @@ import persistedStateOptions from './plugins/persisted-state.es6.js';
 // A Vuex instance is created by combining the state, mutations, actions, and getters.
 
 async function newStore() {
+  const stateResolved = await state();
+
   return createStore({
-    state: await state(),
+    state: stateResolved,
     getters,
     actions,
     mutations,
@@ -17,4 +19,5 @@ async function newStore() {
     strict: (process.env.NODE_ENV !== 'production'),
   });
 }
+
 export default newStore;


### PR DESCRIPTION
Pull Request for Issue #40690 .

### Summary of Changes

- The url/session path is not respected

### Testing Instructions

- test a url like (existing path) `/administrator/index.php?option=com_media&path=local-images:/banners`
- test a url like (not existing path) `/administrator/index.php?option=com_media&path=local-none:/banners`
- test a url like (not existing path) `/administrator/index.php?option=com_media&path=local-none:/noooooo`
- test a url like (not existing path) `/administrator/index.php?option=com_media`
- Open the browser console and edit the session value from something like: `{"selectedDirectory":"local-images:/banners","showInfoBar":false,"listView":"grid","gridSize":"md","search":"","sortBy":"name","sortDirection":"asc"}` to values matching the changes on the previous steps (eg `"selectedDirectory":"local-none:/banners"`, "selectedDirectory":"local-none:/noooooo") and check if the media manager loads without an error
- Apply all possible combos between the url and the session storage

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed


@laoneo please check all possible combinations between stored session/given url