### PR TITLE
[4.3] change icon for failed checks

### DIFF
--- a/build/media_source/com_cpanel/js/admin-system-loader.es6.js
+++ b/build/media_source/com_cpanel/js/admin-system-loader.es6.js
@@ -34,7 +34,7 @@
               element.classList.remove('icon-spin');
               element.classList.remove('icon-spinner');
               element.classList.add('text-danger');
-              element.classList.add('icon-remove');
+              element.classList.add('icon-help');
             } else if (response.data) {
               const elem = document.createElement('span');
 
@@ -54,7 +54,7 @@
             element.classList.remove('icon-spin');
             element.classList.remove('icon-spinner');
             element.classList.add('text-danger');
-            element.classList.add('icon-remove');
+            element.classList.add('icon-help');
           });
         }
       });


### PR DESCRIPTION
On the system cpanel there is a json check for various things such as available updates. This will normally show either a ✔️ or a count. BUT in some circumstances the check fails and in this case a ❌ is displayed.

### Summary of Changes
As we normally use the ❌to indicate that something can be removed or deleted this is confusing andb doesnt indicate that there was any problem in getting the data. This PR changes the icon to ❓


### Testing Instructions
This is a js change so you will need to either code review, use a pre-built install or run `npm run build:js`

The harder part is to force the json error so that the icon is displayed. If you are on a localhost then you might try to disable the internet and then go to the system cpanel.


### Actual result BEFORE applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/1296369/ec6d2a55-eb74-458f-834f-fd4e9c9d0899)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/8f4fca19-bd81-4658-af37-40e2f982ee02)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
