### PR TITLE
[5.0] Adapt EOS quickicon plugin to Joomla 5

### DIFF
--- a/plugins/quickicon/eos/eos.xml
+++ b/plugins/quickicon/eos/eos.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>4.4.0</version>
+	<version>5.0.0</version>
 	<description>PLG_QUICKICON_EOS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\Quickicon\Eos</namespace>
 	<files>

--- a/plugins/quickicon/eos/eos.xml
+++ b/plugins/quickicon/eos/eos.xml
@@ -7,7 +7,7 @@
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>
-	<version>5.0.0</version>
+	<version>4.4.0</version>
 	<description>PLG_QUICKICON_EOS_XML_DESCRIPTION</description>
 	<namespace path="src">Joomla\Plugin\Quickicon\Eos</namespace>
 	<files>

--- a/plugins/quickicon/eos/src/Extension/Eos.php
+++ b/plugins/quickicon/eos/src/Extension/Eos.php
@@ -34,7 +34,7 @@ final class Eos extends CMSPlugin implements SubscriberInterface
     use DatabaseAwareTrait;
 
     /**
-     * The EOS date for 5.x.
+     * The EOS date for the current major version.
      *
      * @var    string
      * @since 4.4.0

--- a/plugins/quickicon/eos/src/Extension/Eos.php
+++ b/plugins/quickicon/eos/src/Extension/Eos.php
@@ -39,7 +39,7 @@ final class Eos extends CMSPlugin implements SubscriberInterface
      * @var    string
      * @since 4.4.0
      */
-    private const EOS_DATE = '2027-11-17';
+    private const EOS_DATE = '2027-10-19';
 
     /**
      * Load the language file on instantiation.

--- a/plugins/quickicon/eos/src/Extension/Eos.php
+++ b/plugins/quickicon/eos/src/Extension/Eos.php
@@ -34,12 +34,12 @@ final class Eos extends CMSPlugin implements SubscriberInterface
     use DatabaseAwareTrait;
 
     /**
-     * The EOS date for 4.4.
+     * The EOS date for 5.x.
      *
      * @var    string
      * @since 4.4.0
      */
-    private const EOS_DATE = '2025-10-17';
+    private const EOS_DATE = '2027-11-17';
 
     /**
      * Load the language file on instantiation.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

To make the EOS quickicon plugin work for 5.x in the right way, it needs to be adapted. This has to be done with every new major version. This pull request (PR) here does that for version 5.

In detail following is changed:
- Adapt the `EOS_DATE` constant to the right end of support date.
- Adapt the doc block comment of that constant to the right major version.
- Update the version number in the plugin's manifest XML to show it was changed.

For Joomla 5 the end of support is November 17, 2027, as stated in the [project road map](https://developer.joomla.org/roadmap.html). 

As it is not decided with minor version will be the last Joomla 5 version, the doc block comment is changed to `The EOS date for 5.x.`, which fits to what the road map says ("End of Support for 5.x").

### To be done with a future PR when documentation is available

The message links have to be adjusted, too, because they have URLs specific to the next major version, which would be 6, but that would lead to 404 links if we would do that now as long as the linked documentation doesn't exist for Joomla 6.

These are the four `'messageLink'`s here:
- https://github.com/joomla/joomla-cms/blob/5.0-dev/plugins/quickicon/eos/src/Extension/Eos.php#L217
- https://github.com/joomla/joomla-cms/blob/5.0-dev/plugins/quickicon/eos/src/Extension/Eos.php#L231
- https://github.com/joomla/joomla-cms/blob/5.0-dev/plugins/quickicon/eos/src/Extension/Eos.php#L245
- https://github.com/joomla/joomla-cms/blob/5.0-dev/plugins/quickicon/eos/src/Extension/Eos.php#L273

They point to following two URLs for which it needs to create the Joomla 6 equivalents:
- https://docs.joomla.org/Special:MyLanguage/Planning_for_Mini-Migration_-_Joomla_3.10.x_to_4.x
It needs to be something like "Planning_for_Mini-Migration_-_Joomla_5.?.x_to_6.x", with "?" being the last 5.x minor, which is not clear yet.
- https://www.joomla.org/4/#features
Needs to be for Joomla 6.

One link points to https://docs.joomla.org/Special:MyLanguage/Pre-Update_Check which seems not to depend on the major version:
- https://github.com/joomla/joomla-cms/blob/5.0-dev/plugins/quickicon/eos/src/Extension/Eos.php#L259

It seems it needs similar adjustments also on the 4.4-dev branch for having the right links to documentation for migrating from 4.4 to 5.

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

EOS plugin uses comment and EOS date for Joomla 4.4.

### Expected result AFTER applying this Pull Request

EOS plugin uses comment and EOS date for Joomla 5.x.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
