### PR TITLE
[5.0] Remove obsolete uninstallEosPlugin method from script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -90,9 +90,6 @@ class JoomlaInstallerScript
             // Informational log only
         }
 
-        // Uninstall plugins before removing their files and folders
-        $this->uninstallEosPlugin();
-
         // This needs to stay for 2.5 update compatibility
         $this->deleteUnexistingFiles();
         $this->updateManifestCaches();
@@ -201,53 +198,6 @@ class JoomlaInstallerScript
             }
 
             break;
-        }
-    }
-
-    /**
-     * Uninstall the 3.10 EOS plugin
-     *
-     * @return  void
-     *
-     * @since   4.0.0
-     */
-    protected function uninstallEosPlugin()
-    {
-        $db = Factory::getDbo();
-
-        // Check if the plg_quickicon_eos310 plugin is present
-        $extensionId = $db->setQuery(
-            $db->getQuery(true)
-                ->select('extension_id')
-                ->from('#__extensions')
-                ->where('name = ' . $db->quote('plg_quickicon_eos310'))
-        )->loadResult();
-
-        // Skip uninstalling if it doesn't exist
-        if (!$extensionId) {
-            return;
-        }
-
-        try {
-            $db->transactionStart();
-
-            // Unprotect the plugin so we can uninstall it
-            $db->setQuery(
-                $db->getQuery(true)
-                    ->update('#__extensions')
-                    ->set('protected = 0')
-                    ->where($db->quoteName('extension_id') . ' = ' . $extensionId)
-            )->execute();
-
-            // Uninstall the plugin
-            $installer = new Installer();
-            $installer->setDatabase($db);
-            $installer->uninstall('plugin', $extensionId);
-
-            $db->transactionCommit();
-        } catch (\Exception $e) {
-            $db->transactionRollback();
-            throw $e;
         }
     }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) removes the "uninstallEosPlugin" function from script.php and the one call to in the "update" function of the same file.

The function is obsolete in the 5.0 core because it handles uninstallation of the 3.10 EOS plugin, which is already uninstalled when updating from 3.10 to 4.x, and beginning with 4.4 and 5.0 there is a permanently installed EOS plugin which has been introduced with PR #40565 so it doesn't need to keep that function.

### Possible B/C break to be approved by release managers

In opposite to previously removed, obsolete code in script.php for 5.0, this time the removed function is not private but protected.

That means that theoretically the method could be overridden in the installation scripts of 3rd party extension developers with code for doing own stuff when their scripts is based on the "JoomlaInstallerScript" class of our script.php.

But the name of that method is so specific to the core that I don't really think anybody has ever done that.

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

File "administrator/components/com_admin/script.php" contains the obsolete function "uninstallEosPlugin" which is called only at one place in the public function "Update" of the same file.

### Expected result AFTER applying this Pull Request

File "administrator/components/com_admin/script.php" doesn't contain anymore the obsolete function "uninstallEosPlugin" and any call to it.

### Link to documentations

Not sure if it needs to be documented somewhere for the "JoomlaInstallerScript" class on manual.joomla.org that this method has been removed.

Please select:
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
