### PR TITLE
Update TemplateModel.php

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1812,7 +1812,7 @@ class TemplateModel extends FormModel
 
         if (!is_dir($path)) {
             // Just in case an admin has removed the template media folder
-            /// or the template did not include any media in the first place (is media mandatory - should the installation have failed?).
+            // or the template did not include any media in the first place (is media mandatory - should the installation have failed?).
             Folder::create($path);
         }
 

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1810,14 +1810,23 @@ class TemplateModel extends FormModel
         $path               = Path::clean(JPATH_ROOT . '/media/templates/' . ($template->client_id === 0 ? 'site' : 'administrator') . '/' . $template->element . '/');
         $this->mediaElement = $path;
 
+        if (!is_dir($path)) {
+            // Just in case an admin has removed the template media folder
+            /// or the template did not include any media in the first place (is media mandatory - should the installation have failed?).
+            Folder::create($path);
+        }
+
         if (!is_writable($path)) {
             $app->enqueueMessage(Text::_('COM_TEMPLATES_DIRECTORY_NOT_WRITABLE'), 'error');
         }
 
-        if (is_dir($path)) {
-            $result = $this->getDirectoryTree($path);
-        }
+        $result = $this->getDirectoryTree($path);
 
+        if (empty($result)) {
+            // Make sure empty folder appears in 'Templates: Customise' page.
+            $result = ['.'];
+        }
+        
         return $result;
     }
 


### PR DESCRIPTION
Allows admin to add files to an empty template media folder.

Pull Request for Issue #40666 .

### Summary of Changes

Allow admin to add files / folders to empty template media folder.
The admin might have deleted (accidently or intentionally) all template media content.
See admin Templates: Customise page.

Similarly admin can add media to a template which did not have any in the first place.
Should installation of templates without media be disallowed? Not addressed by this PR.

### Testing Instructions

Install a template and use the admin Templates: Customise page to delete all the files / folders for that template.
Check that on the adminTemplates: Customise page the media folder is still accessible and more media files / folders can be added.

Similarly add a template without a media section and check that media files / folders can be added by the admin.
[tpl_cassiopeia_test1.zip](https://github.com/joomla/joomla-cms/files/11643507/tpl_cassiopeia_test1.zip)

### Actual result BEFORE applying this Pull Request

Cannot add media files / folders to a template when the template media folder is empty.
When the template media folder is empty there is a misleading message about the media template folder not being writtable ... it is writtable but empty!

### Expected result AFTER applying this Pull Request

Use the admin Templates: Customise page to delete template media files / folders and when all have been deleted be able to add media files / folders. Similarly add such if the template did not contain any media files in the first place.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
