### PR TITLE
[4.3] Same width for Quickicons

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
@@ -5,7 +5,7 @@
 
   .nav {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(190px, 1fr));
     grid-gap: 1rem;
   }
 


### PR DESCRIPTION
Pull Request for Issue # . 40701

### Summary of Changes
Changes background for modules to be fixed width


### Testing Instructions

see #40701 

### Actual result BEFORE applying this Pull Request
icon background are various widths


### Expected result AFTER applying this Pull Request
icon backgrounds are fixed width


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x ] No documentation changes for manual.joomla.org needed
