### PR TITLE
[4.4] Deprecating com_search methods in Joomla\CMS\Language\Language

### DIFF
--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -148,6 +148,8 @@ class Language
      *
      * @var    callable
      * @since  1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     protected $ignoredSearchWordsCallback = null;
 
@@ -156,6 +158,8 @@ class Language
      *
      * @var    callable
      * @since  1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     protected $lowerLimitSearchWordCallback = null;
 
@@ -164,6 +168,8 @@ class Language
      *
      * @var    callable
      * @since  1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     protected $upperLimitSearchWordCallback = null;
 
@@ -172,6 +178,8 @@ class Language
      *
      * @var    callable
      * @since  1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     protected $searchDisplayedCharactersNumberCallback = null;
 
@@ -484,6 +492,8 @@ class Language
      * @return  array  The array of ignored search words.
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function getIgnoredSearchWords()
     {
@@ -500,6 +510,8 @@ class Language
      * @return  callable  Function name or the actual function.
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function getIgnoredSearchWordsCallback()
     {
@@ -514,6 +526,8 @@ class Language
      * @return  callable  The previous function.
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function setIgnoredSearchWordsCallback(callable $function)
     {
@@ -529,6 +543,8 @@ class Language
      * @return  integer  The lower limit integer for length of search words (3 if no value was set for a specific language).
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function getLowerLimitSearchWord()
     {
@@ -545,6 +561,8 @@ class Language
      * @return  callable  Function name or the actual function.
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function getLowerLimitSearchWordCallback()
     {
@@ -559,6 +577,8 @@ class Language
      * @return  callable  The previous function.
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function setLowerLimitSearchWordCallback(callable $function)
     {
@@ -574,6 +594,8 @@ class Language
      * @return  integer  The upper limit integer for length of search words (200 if no value was set or if default value is < 200).
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function getUpperLimitSearchWord()
     {
@@ -590,6 +612,8 @@ class Language
      * @return  callable  Function name or the actual function.
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function getUpperLimitSearchWordCallback()
     {
@@ -604,6 +628,8 @@ class Language
      * @return  callable  The previous function.
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function setUpperLimitSearchWordCallback(callable $function)
     {
@@ -619,6 +645,8 @@ class Language
      * @return  integer  The number of characters displayed (200 if no value was set for a specific language).
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function getSearchDisplayedCharactersNumber()
     {
@@ -635,6 +663,8 @@ class Language
      * @return  callable  Function name or the actual function.
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function getSearchDisplayedCharactersNumberCallback()
     {
@@ -649,6 +679,8 @@ class Language
      * @return  callable  The previous function.
      *
      * @since   1.7.0
+     *
+     * @deprecated  4.4 will be removed in 6.0 without replacement
      */
     public function setSearchDisplayedCharactersNumberCallback(callable $function)
     {


### PR DESCRIPTION
### Summary of Changes
com_search has been removed from the core and will not be supported in Joomla 6.0 anymore. Thus we should deprecate these methods.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [X] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/123
- [ ] No documentation changes for manual.joomla.org needed
