### PR TITLE
Use the injected user factory in MVC and plugins

### DIFF
--- a/administrator/components/com_messages/src/Model/MessageModel.php
+++ b/administrator/components/com_messages/src/Model/MessageModel.php
@@ -24,6 +24,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Table\Asset;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Database\ParameterType;
 use PHPMailer\PHPMailer\Exception as phpMailerException;
 
@@ -36,8 +38,10 @@ use PHPMailer\PHPMailer\Exception as phpMailerException;
  *
  * @since  1.6
  */
-class MessageModel extends AdminModel
+class MessageModel extends AdminModel implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * Message
      *
@@ -311,7 +315,7 @@ class MessageModel extends AdminModel
         }
 
         // Load the user details (already valid from table check).
-        $toUser = User::getInstance($table->user_id_to);
+        $toUser = $this->getUserFactory()->loadUserById($table->user_id_to);
 
         // Check if recipient can access com_messages.
         if (!$toUser->authorise('core.login.admin') || !$toUser->authorise('core.manage', 'com_messages')) {
@@ -352,7 +356,7 @@ class MessageModel extends AdminModel
         }
 
         if ($config->get('mail_on_new', true)) {
-            $fromUser         = User::getInstance($table->user_id_from);
+            $fromUser         = $this->getUserFactory()->loadUserById($table->user_id_from);
             $debug            = Factory::getApplication()->get('debug_lang');
             $default_language = ComponentHelper::getParams('com_languages')->get('administrator');
             $lang             = Language::getInstance($toUser->getParam('admin_language', $default_language), $debug);

--- a/administrator/components/com_messages/src/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Message/HtmlView.php
@@ -16,7 +16,8 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -27,8 +28,10 @@ use Joomla\CMS\User\User;
  *
  * @since  1.6
  */
-class HtmlView extends BaseHtmlView
+class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * The Form object
      *
@@ -98,7 +101,7 @@ class HtmlView extends BaseHtmlView
             $toolbar->help('Private_Messages:_Write');
         } else {
             ToolbarHelper::title(Text::_('COM_MESSAGES_VIEW_PRIVATE_MESSAGE'), 'envelope inbox');
-            $sender = User::getInstance($this->item->user_id_from);
+            $sender = $this->getUserFactory()->loadUserById($this->item->user_id_from);
 
             if (
                 $sender->id !== $app->getIdentity()->get('id') && ($sender->authorise('core.admin')

--- a/administrator/components/com_privacy/src/Model/ExportModel.php
+++ b/administrator/components/com_privacy/src/Model/ExportModel.php
@@ -19,7 +19,8 @@ use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Component\Actionlogs\Administrator\Model\ActionlogModel;
 use Joomla\Component\Privacy\Administrator\Export\Domain;
 use Joomla\Component\Privacy\Administrator\Helper\PrivacyHelper;
@@ -35,8 +36,10 @@ use PHPMailer\PHPMailer\Exception as phpmailerException;
  *
  * @since  3.9.0
  */
-class ExportModel extends BaseDatabaseModel
+class ExportModel extends BaseDatabaseModel implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * Create the export document for an information request.
      *
@@ -89,7 +92,7 @@ class ExportModel extends BaseDatabaseModel
                 ->setLimit(1)
         )->loadResult();
 
-        $user = $userId ? User::getInstance($userId) : null;
+        $user = $userId ? $this->getUserFactory()->loadUserById($userId) : null;
 
         // Log the export
         $this->logExport($table);
@@ -180,7 +183,7 @@ class ExportModel extends BaseDatabaseModel
         )->loadResult();
 
         if ($userId) {
-            $receiver = User::getInstance($userId);
+            $receiver = $this->getUserFactory()->loadUserById($userId);
 
             /*
              * We don't know if the user has admin access, so we will check if they have an admin language in their parameters,

--- a/administrator/components/com_privacy/src/Model/RemoveModel.php
+++ b/administrator/components/com_privacy/src/Model/RemoveModel.php
@@ -16,7 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
-use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Component\Actionlogs\Administrator\Model\ActionlogModel;
 use Joomla\Component\Privacy\Administrator\Removal\Status;
 use Joomla\Component\Privacy\Administrator\Table\RequestTable;
@@ -30,8 +31,10 @@ use Joomla\Component\Privacy\Administrator\Table\RequestTable;
  *
  * @since  3.9.0
  */
-class RemoveModel extends BaseDatabaseModel
+class RemoveModel extends BaseDatabaseModel implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * Remove the user data.
      *
@@ -84,7 +87,7 @@ class RemoveModel extends BaseDatabaseModel
                 ->setLimit(1)
         )->loadResult();
 
-        $user = $userId ? User::getInstance($userId) : null;
+        $user = $userId ? $this->getUserFactory()->loadUserById($userId) : null;
 
         $canRemove = true;
 

--- a/administrator/components/com_privacy/src/Model/RequestModel.php
+++ b/administrator/components/com_privacy/src/Model/RequestModel.php
@@ -21,7 +21,8 @@ use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Component\Actionlogs\Administrator\Model\ActionlogModel;
 use Joomla\Component\Privacy\Administrator\Table\RequestTable;
@@ -37,8 +38,10 @@ use PHPMailer\PHPMailer\Exception as phpmailerException;
  *
  * @since  3.9.0
  */
-class RequestModel extends AdminModel
+class RequestModel extends AdminModel implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * Clean the cache
      *
@@ -270,7 +273,7 @@ class RequestModel extends AdminModel
         )->loadResult();
 
         if ($userId) {
-            $receiver = User::getInstance($userId);
+            $receiver = $this->getUserFactory()->loadUserById($userId);
 
             /*
              * We don't know if the user has admin access, so we will check if they have an admin language in their parameters,

--- a/administrator/components/com_users/src/Model/DebuguserModel.php
+++ b/administrator/components/com_users/src/Model/DebuguserModel.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Component\Users\Administrator\Helper\DebugHelper;
 use Joomla\Database\DatabaseQuery;
 use Joomla\Database\ParameterType;
@@ -28,8 +30,10 @@ use Joomla\Database\ParameterType;
  *
  * @since  1.6
  */
-class DebuguserModel extends ListModel
+class DebuguserModel extends ListModel implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * Constructor.
      *
@@ -78,7 +82,7 @@ class DebuguserModel extends ListModel
     public function getItems()
     {
         $userId = $this->getState('user_id');
-        $user   = Factory::getUser($userId);
+        $user   = $this->getUserFactory()->loadUserById($userId);
 
         if (($assets = parent::getItems()) && $userId) {
             $actions = $this->getDebugActions();
@@ -179,7 +183,7 @@ class DebuguserModel extends ListModel
     {
         $userId = $this->getState('user_id');
 
-        return Factory::getUser($userId);
+        return $this->getUserFactory()->loadUserById($userId);
     }
 
     /**

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -20,7 +20,6 @@ use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
-use Joomla\CMS\User\User;
 use Joomla\CMS\User\UserFactoryAwareInterface;
 use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\User\UserHelper;
@@ -226,7 +225,7 @@ class UserModel extends AdminModel implements UserFactoryAwareInterface
     public function save($data)
     {
         $pk   = (!empty($data['id'])) ? $data['id'] : (int) $this->getState('user.id');
-        $user = User::getInstance($pk);
+        $user = $this->getUserFactory()->loadUserById($pk);
 
         $my            = $this->getCurrentUser();
         $iAmSuperAdmin = $my->authorise('core.admin');

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -21,6 +21,8 @@ use Joomla\CMS\MVC\Model\AdminModel;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
@@ -34,8 +36,10 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  1.6
  */
-class UserModel extends AdminModel
+class UserModel extends AdminModel implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * An item.
      *
@@ -327,7 +331,7 @@ class UserModel extends AdminModel
 
                 if ($allow) {
                     // Get users data for the users to delete.
-                    $user_to_delete = Factory::getUser($pk);
+                    $user_to_delete = $this->getUserFactory()->loadUserById($pk);
 
                     // Fire the before delete event.
                     Factory::getApplication()->triggerEvent($this->event_before_delete, [$table->getProperties()]);

--- a/api/components/com_contact/src/Controller/ContactController.php
+++ b/api/components/com_contact/src/Controller/ContactController.php
@@ -23,7 +23,8 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Exception\RouteNotFoundException;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 use Joomla\Registry\Registry;
 use Joomla\String\Inflector;
@@ -39,8 +40,10 @@ use Tobscure\JsonApi\Exception\InvalidParameterException;
  *
  * @since  4.0.0
  */
-class ContactController extends ApiController
+class ContactController extends ApiController implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * The content type of the item.
      *
@@ -191,7 +194,7 @@ class ContactController extends ApiController
         Factory::getLanguage()->load('com_contact', JPATH_SITE, $app->getLanguage()->getTag(), true);
 
         if ($contact->email_to == '' && $contact->user_id != 0) {
-            $contact_user      = User::getInstance($contact->user_id);
+            $contact_user      = $this->getUserFactory()->loadUserById($contact->user_id);
             $contact->email_to = $contact_user->get('email');
         }
 

--- a/components/com_contact/src/Controller/ContactController.php
+++ b/components/com_contact/src/Controller/ContactController.php
@@ -20,7 +20,8 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\Versioning\VersionableControllerTrait;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 use Joomla\Utilities\ArrayHelper;
@@ -35,8 +36,9 @@ use PHPMailer\PHPMailer\Exception as phpMailerException;
  *
  * @since  1.5.19
  */
-class ContactController extends FormController
+class ContactController extends FormController implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
     use VersionableControllerTrait;
 
     /**
@@ -223,7 +225,7 @@ class ContactController extends FormController
         $app = $this->app;
 
         if ($contact->email_to == '' && $contact->user_id != 0) {
-            $contact_user      = User::getInstance($contact->user_id);
+            $contact_user      = $this->getUserFactory()->loadUserById($contact->user_id);
             $contact->email_to = $contact_user->get('email');
         }
 

--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -18,6 +18,8 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -29,8 +31,10 @@ use Joomla\Component\Contact\Site\Helper\RouteHelper;
  *
  * @since  1.5
  */
-class HtmlView extends BaseHtmlView
+class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * The item model state
      *
@@ -348,7 +352,7 @@ class HtmlView extends BaseHtmlView
 
         $contactUser = null;
 
-        if ($item->params->get('show_user_custom_fields') && $item->user_id && $contactUser = Factory::getUser($item->user_id)) {
+        if ($item->params->get('show_user_custom_fields') && $item->user_id && $contactUser = $this->getUserFactory()->loadUserById($item->user_id)) {
             $contactUser->text = '';
             $app->triggerEvent('onContentPrepare', ['com_users.user', &$contactUser, &$item->params, 0]);
 

--- a/components/com_users/src/Controller/RegistrationController.php
+++ b/components/com_users/src/Controller/RegistrationController.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Router\Route;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -25,8 +27,10 @@ use Joomla\CMS\Router\Route;
  *
  * @since  1.6
  */
-class RegistrationController extends BaseController
+class RegistrationController extends BaseController implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * Method to activate a user.
      *
@@ -73,7 +77,7 @@ class RegistrationController extends BaseController
         }
 
         // Get the user we want to activate
-        $userToActivate = Factory::getUser($userIdToActivate);
+        $userToActivate = $this->getUserFactory()->loadUserById($userIdToActivate);
 
         // Admin activation is on and admin is activating the account
         if (($uParams->get('useractivation') == 2) && $userToActivate->getParam('activate', 0)) {

--- a/components/com_users/src/Model/RegistrationModel.php
+++ b/components/com_users/src/Model/RegistrationModel.php
@@ -27,6 +27,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Database\ParameterType;
 
@@ -39,8 +41,10 @@ use Joomla\Database\ParameterType;
  *
  * @since  1.6
  */
-class RegistrationModel extends FormModel
+class RegistrationModel extends FormModel implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * @var    object  The user registration data.
      * @since  1.6
@@ -127,7 +131,7 @@ class RegistrationModel extends FormModel
         PluginHelper::importPlugin('user');
 
         // Activate the user.
-        $user = Factory::getUser($userId);
+        $user = $this->getUserFactory()->loadUserById($userId);
 
         // Admin activation is on and user is verifying their email
         if (($userParams->get('useractivation') == 2) && !$user->getParam('activate', 0)) {
@@ -171,7 +175,7 @@ class RegistrationModel extends FormModel
 
             // Send mail to all users with users creating permissions and receiving system emails
             foreach ($rows as $row) {
-                $usercreator = Factory::getUser($row->id);
+                $usercreator = $this->getUserFactory()->loadUserById($row->id);
 
                 if ($usercreator->authorise('core.create', 'com_users') && $usercreator->authorise('core.manage', 'com_users')) {
                     try {
@@ -544,7 +548,7 @@ class RegistrationModel extends FormModel
 
             // Send mail to all superadministrators id
             foreach ($rows as $row) {
-                $usercreator = Factory::getUser($row->id);
+                $usercreator = $this->getUserFactory()->loadUserById($row->id);
 
                 if (!$usercreator->authorise('core.create', 'com_users') || !$usercreator->authorise('core.manage', 'com_users')) {
                     continue;

--- a/components/com_users/src/Model/ResetModel.php
+++ b/components/com_users/src/Model/ResetModel.php
@@ -21,6 +21,8 @@ use Joomla\CMS\MVC\Model\FormModel;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\User\UserHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -32,8 +34,10 @@ use Joomla\CMS\User\UserHelper;
  *
  * @since  1.5
  */
-class ResetModel extends FormModel
+class ResetModel extends FormModel implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * Method to get the password reset request form.
      *
@@ -193,7 +197,7 @@ class ResetModel extends FormModel
         }
 
         // Get the user object.
-        $user = User::getInstance($userId);
+        $user = $this->getUserFactory()->loadUserById($userId);
 
         $event = AbstractEvent::create(
             'onUserBeforeResetComplete',
@@ -417,7 +421,7 @@ class ResetModel extends FormModel
         }
 
         // Get the user object.
-        $user = User::getInstance($userId);
+        $user = $this->getUserFactory()->loadUserById($userId);
 
         // Make sure the user isn't blocked.
         if ($user->block) {

--- a/plugins/actionlog/joomla/services/provider.php
+++ b/plugins/actionlog/joomla/services/provider.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
@@ -40,6 +41,7 @@ return new class () implements ServiceProviderInterface {
                 );
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
+                $plugin->setUserFactory($container->get(UserFactoryInterface::class));
 
                 return $plugin;
             }

--- a/plugins/actionlog/joomla/src/Extension/Joomla.php
+++ b/plugins/actionlog/joomla/src/Extension/Joomla.php
@@ -11,11 +11,10 @@
 namespace Joomla\Plugin\Actionlog\Joomla\Extension;
 
 use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\MVC\Factory\MVCFactoryServiceInterface;
 use Joomla\CMS\Table\Table;
-use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Component\Actionlogs\Administrator\Helper\ActionlogsHelper;
 use Joomla\Component\Actionlogs\Administrator\Plugin\ActionLogPlugin;
 use Joomla\Database\DatabaseAwareTrait;
@@ -37,6 +36,7 @@ use stdClass;
 final class Joomla extends ActionLogPlugin
 {
     use DatabaseAwareTrait;
+    use UserFactoryAwareTrait;
 
     /**
      * Array of loggable extensions.
@@ -835,7 +835,7 @@ final class Joomla extends ActionLogPlugin
             return;
         }
 
-        $loggedOutUser = User::getInstance($user['id']);
+        $loggedOutUser = $this->getUserFactory()->loadUserById($user['id']);
 
         if ($loggedOutUser->block) {
             return;

--- a/plugins/authentication/cookie/services/provider.php
+++ b/plugins/authentication/cookie/services/provider.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
@@ -42,6 +43,7 @@ return new class () implements ServiceProviderInterface {
                 );
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
+                $plugin->setUserFactory($container->get(UserFactoryInterface::class));
 
                 return $plugin;
             }

--- a/plugins/authentication/cookie/src/Extension/Cookie.php
+++ b/plugins/authentication/cookie/src/Extension/Cookie.php
@@ -15,7 +15,7 @@ use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\CMSPlugin;
-use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Database\DatabaseAwareTrait;
 use RuntimeException;
@@ -34,6 +34,7 @@ use RuntimeException;
 final class Cookie extends CMSPlugin
 {
     use DatabaseAwareTrait;
+    use UserFactoryAwareTrait;
 
     /**
      * Reports the privacy related capabilities for this plugin to site administrators.
@@ -195,7 +196,7 @@ final class Cookie extends CMSPlugin
 
         if ($result) {
             // Bring this in line with the rest of the system
-            $user = User::getInstance($result->id);
+            $user = $this->getUserFactory()->loadUserById($result->id);
 
             // Set response data.
             $response->username = $result->username;

--- a/plugins/authentication/joomla/services/provider.php
+++ b/plugins/authentication/joomla/services/provider.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
@@ -42,6 +43,7 @@ return new class () implements ServiceProviderInterface {
                 );
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
+                $plugin->setUserFactory($container->get(UserFactoryInterface::class));
 
                 return $plugin;
             }

--- a/plugins/authentication/joomla/src/Extension/Joomla.php
+++ b/plugins/authentication/joomla/src/Extension/Joomla.php
@@ -12,7 +12,7 @@ namespace Joomla\Plugin\Authentication\Joomla\Extension;
 
 use Joomla\CMS\Authentication\Authentication;
 use Joomla\CMS\Plugin\CMSPlugin;
-use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Database\DatabaseAwareTrait;
 
@@ -28,6 +28,7 @@ use Joomla\Database\DatabaseAwareTrait;
 final class Joomla extends CMSPlugin
 {
     use DatabaseAwareTrait;
+    use UserFactoryAwareTrait;
 
     /**
      * This method should handle any authentication and report back to the subject
@@ -67,7 +68,7 @@ final class Joomla extends CMSPlugin
 
             if ($match === true) {
                 // Bring this in line with the rest of the system
-                $user               = User::getInstance($result->id);
+                $user               = $this->getUserFactory()->loadUserById($result->id);
                 $response->email    = $user->email;
                 $response->fullname = $user->name;
 

--- a/plugins/fields/user/services/provider.php
+++ b/plugins/fields/user/services/provider.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
@@ -39,6 +40,7 @@ return new class () implements ServiceProviderInterface {
                     (array) PluginHelper::getPlugin('fields', 'user')
                 );
                 $plugin->setApplication(Factory::getApplication());
+                $plugin->setUserFactory($container->get(UserFactoryInterface::class));
 
                 return $plugin;
             }

--- a/plugins/fields/user/src/Extension/User.php
+++ b/plugins/fields/user/src/Extension/User.php
@@ -12,7 +12,6 @@ namespace Joomla\Plugin\Fields\User\Extension;
 
 use DOMElement;
 use Joomla\CMS\Form\Form;
-use Joomla\CMS\User\UserFactoryAwareInterface;
 use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin;
 
@@ -25,7 +24,7 @@ use Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin;
  *
  * @since  3.7.0
  */
-final class User extends FieldsPlugin implements UserFactoryAwareInterface
+final class User extends FieldsPlugin
 {
     use UserFactoryAwareTrait;
 

--- a/plugins/fields/user/src/Extension/User.php
+++ b/plugins/fields/user/src/Extension/User.php
@@ -12,6 +12,8 @@ namespace Joomla\Plugin\Fields\User\Extension;
 
 use DOMElement;
 use Joomla\CMS\Form\Form;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -23,8 +25,10 @@ use Joomla\Component\Fields\Administrator\Plugin\FieldsPlugin;
  *
  * @since  3.7.0
  */
-final class User extends FieldsPlugin
+final class User extends FieldsPlugin implements UserFactoryAwareInterface
 {
+    use UserFactoryAwareTrait;
+
     /**
      * Transforms the field into a DOM XML element and appends it as a child on the given parent.
      *

--- a/plugins/fields/user/tmpl/user.php
+++ b/plugins/fields/user/tmpl/user.php
@@ -10,8 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
-
 $value = $field->value;
 
 if ($value == '') {
@@ -26,7 +24,7 @@ foreach ($value as $userId) {
         continue;
     }
 
-    $user = Factory::getUser($userId);
+    $user = $this->getUserFactory()->loadUserById($userId);
 
     if ($user) {
         // Use the Username

--- a/plugins/system/privacyconsent/services/provider.php
+++ b/plugins/system/privacyconsent/services/provider.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
@@ -41,6 +42,7 @@ return new class () implements ServiceProviderInterface {
                 );
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
+                $plugin->setUserFactory($container->get(UserFactoryInterface::class));
 
                 return $plugin;
             }

--- a/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
+++ b/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
@@ -24,7 +24,6 @@ use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
-use Joomla\CMS\User\UserFactoryAwareInterface;
 use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Component\Actionlogs\Administrator\Model\ActionlogModel;
@@ -45,7 +44,7 @@ use RuntimeException;
  *
  * @since  3.9.0
  */
-final class PrivacyConsent extends CMSPlugin implements UserFactoryAwareInterface
+final class PrivacyConsent extends CMSPlugin
 {
     use DatabaseAwareTrait;
     use UserFactoryAwareTrait;

--- a/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
+++ b/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
@@ -24,6 +24,8 @@ use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Component\Actionlogs\Administrator\Model\ActionlogModel;
 use Joomla\Component\Messages\Administrator\Model\MessageModel;
@@ -43,9 +45,10 @@ use RuntimeException;
  *
  * @since  3.9.0
  */
-final class PrivacyConsent extends CMSPlugin
+final class PrivacyConsent extends CMSPlugin implements UserFactoryAwareInterface
 {
     use DatabaseAwareTrait;
+    use UserFactoryAwareTrait;
 
     /**
      * Load the language file on instantiation.
@@ -660,7 +663,7 @@ final class PrivacyConsent extends CMSPlugin
 
             $messageModel->notifySuperUsers(
                 $this->getApplication()->getLanguage()->_('PLG_SYSTEM_PRIVACYCONSENT_NOTIFICATION_USER_PRIVACY_EXPIRED_SUBJECT'),
-                Text::sprintf('PLG_SYSTEM_PRIVACYCONSENT_NOTIFICATION_USER_PRIVACY_EXPIRED_MESSAGE', Factory::getUser($user->user_id)->username)
+                Text::sprintf('PLG_SYSTEM_PRIVACYCONSENT_NOTIFICATION_USER_PRIVACY_EXPIRED_MESSAGE', $this->getUserFactory()->loadUserById($user->user_id)->username)
             );
         }
 

--- a/plugins/user/joomla/services/provider.php
+++ b/plugins/user/joomla/services/provider.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
@@ -41,6 +42,7 @@ return new class () implements ServiceProviderInterface {
                 );
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
+                $plugin->setUserFactory($container->get(UserFactoryInterface::class));
 
                 return $plugin;
             }

--- a/plugins/user/joomla/src/Extension/Joomla.php
+++ b/plugins/user/joomla/src/Extension/Joomla.php
@@ -472,7 +472,6 @@ final class Joomla extends CMSPlugin
         $instance = $this->getUserFactory()->loadUserByUsername($user['username']);
 
         if ($instance && $instance->id) {
-
             return $instance;
         }
 

--- a/plugins/user/joomla/src/Extension/Joomla.php
+++ b/plugins/user/joomla/src/Extension/Joomla.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\User\User;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\CMS\User\UserHelper;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\Exception\ExecutionFailureException;
@@ -38,6 +39,7 @@ use RuntimeException;
 final class Joomla extends CMSPlugin
 {
     use DatabaseAwareTrait;
+    use UserFactoryAwareTrait;
 
     /**
      * Set as required the passwords fields when mail to user is set to No
@@ -467,14 +469,14 @@ final class Joomla extends CMSPlugin
      */
     private function getUser($user, $options = [])
     {
-        $instance = User::getInstance();
-        $id       = (int) UserHelper::getUserId($user['username']);
+        $instance = $this->getUserFactory()->loadUserByUsername($user['username']);
 
-        if ($id) {
-            $instance->load($id);
+        if ($instance && $instance->id) {
 
             return $instance;
         }
+
+        $instance = $this->getUserFactory()->loadUserById(0);
 
         // @todo : move this out of the plugin
         $params = ComponentHelper::getParams('com_users');

--- a/plugins/user/token/services/provider.php
+++ b/plugins/user/token/services/provider.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\User\UserFactoryInterface;
 use Joomla\Database\DatabaseInterface;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
@@ -41,6 +42,7 @@ return new class () implements ServiceProviderInterface {
                 );
                 $plugin->setApplication(Factory::getApplication());
                 $plugin->setDatabase($container->get(DatabaseInterface::class));
+                $plugin->setUserFactory($container->get(UserFactoryInterface::class));
 
                 return $plugin;
             }

--- a/plugins/user/token/src/Extension/Token.php
+++ b/plugins/user/token/src/Extension/Token.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Crypt\Crypt;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\CMS\User\UserFactoryAwareInterface;
 use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\ParameterType;
@@ -30,7 +29,7 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  3.9.0
  */
-final class Token extends CMSPlugin implements UserFactoryAwareInterface
+final class Token extends CMSPlugin
 {
     use DatabaseAwareTrait;
     use UserFactoryAwareTrait;

--- a/plugins/user/token/src/Extension/Token.php
+++ b/plugins/user/token/src/Extension/Token.php
@@ -12,10 +12,11 @@ namespace Joomla\Plugin\User\Token\Extension;
 
 use Exception;
 use Joomla\CMS\Crypt\Crypt;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\User\UserFactoryAwareInterface;
+use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
@@ -29,9 +30,10 @@ use Joomla\Utilities\ArrayHelper;
  *
  * @since  3.9.0
  */
-final class Token extends CMSPlugin
+final class Token extends CMSPlugin implements UserFactoryAwareInterface
 {
     use DatabaseAwareTrait;
+    use UserFactoryAwareTrait;
 
     /**
      * Load the language file on instantiation.
@@ -489,7 +491,7 @@ final class Token extends CMSPlugin
     {
         $allowedUserGroups = $this->getAllowedUserGroups();
 
-        $user = Factory::getUser($userId);
+        $user = $this->getUserFactory()->loadUserById($userId);
 
         if ($user->id != $userId) {
             return false;


### PR DESCRIPTION
### Summary of Changes
Injects the user factory into the MVC classes whenever requested. Additionally it injects the user factory into plugins when they need it.

This pr reduces the usage of deprecated calls `User::getInstance` and `Factory::getUser`.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
