### PR TITLE
Use the current user in local media adapter

### DIFF
--- a/plugins/filesystem/local/src/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/src/Adapter/LocalAdapter.php
@@ -22,6 +22,7 @@ use Joomla\CMS\Image\Image;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
+use Joomla\CMS\User\CurrentUserTrait;
 use Joomla\Component\Media\Administrator\Adapter\AdapterInterface;
 use Joomla\Component\Media\Administrator\Exception\FileNotFoundException;
 use Joomla\Component\Media\Administrator\Exception\InvalidPathException;
@@ -37,6 +38,8 @@ use Joomla\Component\Media\Administrator\Exception\InvalidPathException;
  */
 class LocalAdapter implements AdapterInterface
 {
+    use CurrentUserTrait;
+
     /**
      * The root path to gather file information from.
      *
@@ -430,7 +433,7 @@ class LocalAdapter implements AdapterInterface
         $dateObj = Factory::getDate($date);
 
         $timezone = Factory::getApplication()->get('offset');
-        $user     = Factory::getUser();
+        $user     = $this->getCurrentUser();
 
         if ($user->id) {
             $userTimezone = $user->getParam('timezone');

--- a/plugins/filesystem/local/src/Extension/Local.php
+++ b/plugins/filesystem/local/src/Extension/Local.php
@@ -133,6 +133,7 @@ final class Local extends CMSPlugin implements ProviderInterface
                 $directoryEntity->thumbs,
                 [200, 200]
             );
+            $adapter->setCurrentUser($this->getApplication()->getIdentity());
 
             $adapters[$adapter->getAdapterName()] = $adapter;
         }

--- a/tests/Unit/Plugin/Filesystem/Local/Extension/LocalPluginTest.php
+++ b/tests/Unit/Plugin/Filesystem/Local/Extension/LocalPluginTest.php
@@ -13,6 +13,7 @@ namespace Joomla\Tests\Unit\Plugin\Filesystem\Local\Extension;
 use InvalidArgumentException;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Language\Language;
+use Joomla\CMS\User\User;
 use Joomla\Component\Media\Administrator\Event\MediaProviderEvent;
 use Joomla\Component\Media\Administrator\Provider\ProviderManager;
 use Joomla\Event\Dispatcher;
@@ -104,7 +105,11 @@ class LocalPluginTest extends UnitTestCase
     {
         $dispatcher = new Dispatcher();
 
+        $app = $this->createStub(CMSApplicationInterface::class);
+        $app->method('getIdentity')->willReturn(new User());
+
         $plugin   = new Local($dispatcher, ['params' => ['directories' => '[{"directory": "tests"}]']], JPATH_ROOT);
+        $plugin->setApplication($app);
         $adapters = $plugin->getAdapters();
 
         $this->assertCount(1, $adapters);


### PR DESCRIPTION
### Summary of Changes
The local media adapter is loading the current user through the interface.

### Testing Instructions
Open the media manager.

### Actual result BEFORE applying this Pull Request
Media data is loaded.

### Expected result AFTER applying this Pull Request
Media data is loaded.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
