### PR TITLE
[5.0] Add extensions uninstallation with optional parameter migration on update from 4.4

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -264,7 +264,8 @@ class JoomlaInstallerScript
                     $db->getQuery(true)
                         ->update($db->quoteName('#__extensions'))
                         ->set($db->quoteName('protected') . ' = 0')
-                        ->where($db->quoteName('extension_id') . ' = ' . $row->extension_id)
+                        ->where($db->quoteName('extension_id') . ' = :extension_id')
+                        ->bind(':extension_id', $row->extension_id, ParameterType::INTEGER)
                 )->execute();
 
                 // Uninstall the plugin

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -206,7 +206,7 @@ class JoomlaInstallerScript
 
     /**
      * Uninstall extensions and optionally migrate their parameters when
-     * updating from the previous major version.
+     * updating from a version older than 5.0.1.
      *
      * @return  void
      *
@@ -214,8 +214,8 @@ class JoomlaInstallerScript
      */
     protected function uninstallExtensions()
     {
-        // Don't uninstall extensions when not updating from the previous major version
-        if (empty($this->fromVersion) || version_compare($this->fromVersion, '5.0.0', 'ge')) {
+        // Don't uninstall extensions when not updating from a version older than 5.0.1
+        if (empty($this->fromVersion) || version_compare($this->fromVersion, '5.0.1', 'ge')) {
             return true;
         }
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -253,7 +253,7 @@ class JoomlaInstallerScript
 
             // If there is a function for migration to be called before uninstalling, call it
             if ($extension['pre_function'] && method_exists($this, $extension['pre_function'])) {
-                $this->{$extension['pre_function']}($row->extension_id, $row->params);
+                $this->{$extension['pre_function']}($row);
             }
 
             try {

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -259,10 +259,11 @@ class JoomlaInstallerScript
             try {
                 $db->transactionStart();
 
-                // Unprotect the plugin so we can uninstall it
+                // Unlock and unprotect the plugin so we can uninstall it
                 $db->setQuery(
                     $db->getQuery(true)
                         ->update($db->quoteName('#__extensions'))
+                        ->set($db->quoteName('locked') . ' = 0')
                         ->set($db->quoteName('protected') . ' = 0')
                         ->where($db->quoteName('extension_id') . ' = :extension_id')
                         ->bind(':extension_id', $row->extension_id, ParameterType::INTEGER)

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -90,6 +90,9 @@ class JoomlaInstallerScript
             // Informational log only
         }
 
+        // Uninstall extensions before removing their files and folders
+        $this->uninstallExtensions();
+
         // This needs to stay for 2.5 update compatibility
         $this->deleteUnexistingFiles();
         $this->updateManifestCaches();
@@ -198,6 +201,83 @@ class JoomlaInstallerScript
             }
 
             break;
+        }
+    }
+
+    /**
+     * Uninstall extensions and optionally migrate their parameters when
+     * updating from the previous major version.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function uninstallExtensions()
+    {
+        // Don't uninstall extensions when not updating from the previous major version
+        if (empty($this->fromVersion) || version_compare($this->fromVersion, '5.0.0', 'ge')) {
+            return true;
+        }
+
+        $extensions = [
+            /**
+             * Define here the extensions to be uninstalled and optionally migrated on update.
+             * For each extension, specify an associative array with following elements (key => value):
+             * 'type'         => Field `type` in the `#__extensions` table
+             * 'element'      => Field `element` in the `#__extensions` table
+             * 'folder'       => Field `folder` in the `#__extensions` table
+             * 'client_id'    => Field `client_id` in the `#__extensions` table
+             * 'pre_function' => Name of an optional migration function to be called before
+             *                   uninstalling, `null` if not used.
+             */
+        ];
+
+        $db = Factory::getDbo();
+
+        foreach ($extensions as $extension) {
+            $row = $db->setQuery(
+                $db->getQuery(true)
+                    ->select($db->quoteName('extension_id'))
+                    ->select($db->quoteName('params'))
+                    ->from($db->quoteName('#__extensions'))
+                    ->where($db->quoteName('type') . ' = ' . $db->quote($extension['type']))
+                    ->where($db->quoteName('element') . ' = ' . $db->quote($extension['element']))
+                    ->where($db->quoteName('folder') . ' = ' . $db->quote($extension['folder']))
+                    ->where($db->quoteName('client_id') . ' = ' . $db->quote($extension['client_id']))
+            )->loadObject();
+
+            // Skip migrating and uninstalling if the extension doesn't exist
+            if (!$row) {
+                continue;
+            }
+
+            // If there is a function for migration to be called before uninstalling, call it
+            if ($extension['pre_function'] && method_exists($this, $extension['pre_function'])) {
+                $this->{$extension['pre_function']}($row->extension_id, $row->params);
+            }
+
+            try {
+                $db->transactionStart();
+
+                // Unprotect the plugin so we can uninstall it
+                $db->setQuery(
+                    $db->getQuery(true)
+                        ->update($db->quoteName('#__extensions'))
+                        ->set($db->quoteName('protected') . ' = 0')
+                        ->where($db->quoteName('extension_id') . ' = ' . $row->extension_id)
+                )->execute();
+
+                // Uninstall the plugin
+                $installer = new Installer();
+                $installer->setDatabase($db);
+                $installer->uninstall($extension['type'], $row->extension_id);
+
+                $db->transactionCommit();
+            } catch (\Exception $e) {
+                $db->transactionRollback();
+                echo Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()) . '<br>';
+                throw $e;
+            }
         }
     }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) adds the capability to uninstall core extensions and optionally migrate their parameters to other core extensions when updating from the previous major version, i.e. here from 4.4.

Therefore a new function "uninstallExtensions" is added to script.php and called in the "update" function of the same file.

The call happens at the same place where the "uninstallEosPlugin" was called before it has been removed in 5.0-dev with my PR #40711 , and the new function basically works in the same way as the removed "uninstallEosPlugin" function, except that it is not limited to one plugin but goes through a list of extensions of any type and that it optionally calls a function e.g. to migrate parameters or save data before the extension is uninstalled.

The new function can be used to properly uninstall the demo task plugin as proposed with PR #40147 instead of doing that in an update SQL script, and it can be used for migrating the "System - Log Rotation" plugin to a scheduler task plugin as proposed with PR #40519 .

What this PR here does not do it to implement any parameter migration for extensions which are not uninstalled on update. This shall be done in the "postflight" method like it has been implemented for the migration of the TinyMCE plugin's paremeter with PR #40626 with function "migrateTinymceConfiguration".

### Testing Instructions

For testing I have prepared code and packages which use the scheduler task demo plugin as example.

This will work as long as PR #40147 has not been merged, or when it has been merged without the update SQL scripts to delete the obsolete plugin.

#### Test 1: Uninstall extension without calling a migration function

1. Modify script.php of this PR for uninstalling an extension as shown here https://github.com/richard67/joomla-cms/pull/37/files and build a package from that.
Or download the following package which already contains these modifications: https://test5.richard-fath.de/Joomla_5.0.0-alpha2-dev-Development-Update_Package_pr40768-test-1.zip
2. On a current 4.4-dev nightly build installation, switch on "Debug System" and set "Error Reporting" to "Maximum".
3. Update the 4.4-dev to the modified package.
4. Check that the extension which shall be uninstalled has properly been uninstalled and that no errors appeared during the update which could be related to the changes from this PR here.

#### Test 2: Uninstall extension with calling a migration function

1. Modify script.php of this PR for uninstalling an extension with calling a migration function as shown here https://github.com/richard67/joomla-cms/pull/38/files and build a package from that.
Or download the following package which already contains these modifications: https://test5.richard-fath.de/Joomla_5.0.0-alpha2-dev-Development-Update_Package_pr40768-test-2.zip
2. On a current 4.4-dev nightly build installation, switch on "Debug System" and set "Error Reporting" to "Maximum".
3. Make sure that PHP errors are logged into a log file, e.g. by using "log_errors = On" and "error_log = ..." in your php.ini file.
4. Update the 4.4-dev to the modified package.
5. Check that the extension which shall be uninstalled has properly been uninstalled and that no errors appeared during the update which could be related to the changes from this PR here.
6. Check the PHP error log file if it shows the log from the testing migration function added in step 1.

### Actual result BEFORE applying this Pull Request

#### Test 1: Uninstall extension without calling a migration function

Currently this is possible to delete the extension with an update SQL script, but this would not remove any assets or other things which would be removed on a regular uninstallation.

#### Test 2: Uninstall extension with calling a migration function

Currently this is not possible within update SQL scripts.

### Expected result AFTER applying this Pull Request

#### Test 1: Uninstall extension without calling a migration function

The extension has been uninstalled after the update from 4.4-dev.

#### Test 2: Uninstall extension with calling a migration function

The extension has been uninstalled after the update from 4.4-dev, and the migration function has been called before uninstalling.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
