### PR TITLE
[5.0] Select all columns in extensions uninstallation on update

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -238,6 +238,7 @@ class JoomlaInstallerScript
             $row = $db->setQuery(
                 $db->getQuery(true)
                     ->select($db->quoteName('extension_id'))
+                    ->select($db->quoteName('enabled'))
                     ->select($db->quoteName('params'))
                     ->from($db->quoteName('#__extensions'))
                     ->where($db->quoteName('type') . ' = ' . $db->quote($extension['type']))

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -236,9 +236,7 @@ class JoomlaInstallerScript
         foreach ($extensions as $extension) {
             $row = $db->setQuery(
                 $db->getQuery(true)
-                    ->select($db->quoteName('extension_id'))
-                    ->select($db->quoteName('enabled'))
-                    ->select($db->quoteName('params'))
+                    ->select('*')
                     ->from($db->quoteName('#__extensions'))
                     ->where($db->quoteName('type') . ' = ' . $db->quote($extension['type']))
                     ->where($db->quoteName('element') . ' = ' . $db->quote($extension['element']))


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/40768#issuecomment-1592897656 .

### Summary of Changes

With my just merged PR #40768 , extensions uninstallation with optional parameter migration on update was implemented in 5.0-dev.

But the `enabled` status of the extension is not passed to the migration function, so that function can not work differently depending on that status. There might also be other columns in the extensions table which might be of interest of a migration function.

This PR here fixes that by selecting all columns with the database query, so the `$row` object passed to the migration function contains them all. 

### Testing Instructions

Code review should be enough.

### Actual result BEFORE applying this Pull Request

The extensions uninstallation with parameter migration on update passes only the `extension_id` and the `params` properties of the extension to the migration function.

### Expected result AFTER applying this Pull Request

The extensions uninstallation with parameter migration on update passes all properties of the extension to the migration function.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
