### PR TITLE
Do deep search in system tests instead of hardcoded sorting

### DIFF
--- a/tests/System/integration/api/com_banners/Categories.cy.js
+++ b/tests/System/integration/api/com_banners/Categories.cy.js
@@ -3,7 +3,6 @@ describe('Test that content categories API endpoint', () => {
     cy.db_createCategory({ title: 'automated test category', extension: 'com_banners' })
       .then((id) => cy.db_createBanner({ name: 'automated test banner', catid: id }))
       .then(() => cy.api_get('/banners/categories'))
-      .then((response) => cy.wrap(response.body.data.map((category) => ({ title: category.attributes.title })))
-        .should('deep.include', { title: 'automated test category' }));
+      .then((response) => cy.api_responseContains(response, 'title', 'automated test category'));
   });
 });

--- a/tests/System/integration/api/com_contact/Categories.cy.js
+++ b/tests/System/integration/api/com_contact/Categories.cy.js
@@ -3,7 +3,6 @@ describe('Test that content categories API endpoint', () => {
     cy.db_createCategory({ title: 'automated test category', extension: 'com_contact' })
       .then((id) => cy.db_createContact({ name: 'automated test contact', catid: id }))
       .then(() => cy.api_get('/contacts/categories'))
-      .then((response) => cy.wrap(response.body.data.map((category) => ({ title: category.attributes.title })))
-        .should('deep.include', { title: 'automated test category' }));
+      .then((response) => cy.api_responseContains(response, 'title', 'automated test category'));
   });
 });

--- a/tests/System/integration/api/com_content/Categories.cy.js
+++ b/tests/System/integration/api/com_content/Categories.cy.js
@@ -3,7 +3,6 @@ describe('Test that content categories API endpoint', () => {
     cy.db_createCategory({ title: 'automated test category', extension: 'com_content' })
       .then((id) => cy.db_createArticle({ title: 'automated test article', catid: id }))
       .then(() => cy.api_get('/content/categories'))
-      .then((response) => cy.wrap(response.body.data.map((category) => ({ title: category.attributes.title })))
-        .should('deep.include', { title: 'automated test category' }));
+      .then((response) => cy.api_responseContains(response, 'title', 'automated test category'));
   });
 });

--- a/tests/System/integration/api/com_media/Files.cy.js
+++ b/tests/System/integration/api/com_media/Files.cy.js
@@ -6,35 +6,25 @@ describe('Test that media files API endpoint', () => {
   it('can deliver a list of files', () => {
     cy.api_get('/media/files')
       .then((response) => {
-        cy.wrap(response).its('body').its('data.0').its('attributes')
-          .its('name')
-          .should('include', 'banners');
-        cy.wrap(response).its('body').its('data.4').its('attributes')
-          .its('name')
-          .should('include', 'joomla_black.png');
+        cy.api_responseContains(response, 'name', 'banners');
+        cy.api_responseContains(response, 'name', 'joomla_black.png');
       });
   });
 
   it('can deliver a list of files in a subfolder', () => {
     cy.api_get('/media/files/sampledata/cassiopeia/')
-      .then((response) => cy.wrap(response).its('body').its('data.0').its('attributes')
-        .its('name')
-        .should('include', 'nasa1-1200.jpg'));
+      .then((response) => cy.api_responseContains(response, 'name', 'nasa1-1200.jpg'));
   });
 
   it('can deliver a list of files with an adapter', () => {
     cy.api_get('/media/files/local-images:/sampledata/cassiopeia/')
-      .then((response) => cy.wrap(response).its('body').its('data.0').its('attributes')
-        .its('name')
-        .should('include', 'nasa1-1200.jpg'));
+      .then((response) => cy.api_responseContains(response, 'name', 'nasa1-1200.jpg'));
   });
 
   it('can search in filenames', () => {
     cy.api_get('/media/files?filter[search]=joomla')
       .then((response) => {
-        cy.wrap(response).its('body').its('data.0').its('attributes')
-          .its('name')
-          .should('include', 'joomla_black.png');
+        cy.api_responseContains(response, 'name', 'joomla_black.png');
         cy.wrap(response).its('body').its('data').should('have.length', 1);
       });
   });

--- a/tests/System/integration/api/com_newsfeed/Categories.cy.js
+++ b/tests/System/integration/api/com_newsfeed/Categories.cy.js
@@ -3,8 +3,6 @@ describe('Test that newsfeed categories API endpoint', () => {
     cy.db_createCategory({ title: 'automated test category', extension: 'com_newsfeeds' })
       .then((id) => cy.db_createNewsFeed({ name: 'automated test feed', catid: id }))
       .then(() => cy.api_get('/newsfeeds/categories'))
-      .then((response) => cy.wrap(response).its('body').its('data[0]').its('attributes')
-        .its('title')
-        .should('include', 'automated test category'));
+      .then((response) => cy.api_responseContains(response, 'name', 'automated test category'));
   });
 });

--- a/tests/System/integration/api/com_newsfeed/Categories.cy.js
+++ b/tests/System/integration/api/com_newsfeed/Categories.cy.js
@@ -3,6 +3,6 @@ describe('Test that newsfeed categories API endpoint', () => {
     cy.db_createCategory({ title: 'automated test category', extension: 'com_newsfeeds' })
       .then((id) => cy.db_createNewsFeed({ name: 'automated test feed', catid: id }))
       .then(() => cy.api_get('/newsfeeds/categories'))
-      .then((response) => cy.api_responseContains(response, 'name', 'automated test category'));
+      .then((response) => cy.api_responseContains(response, 'title', 'automated test category'));
   });
 });

--- a/tests/System/support/commands/api.js
+++ b/tests/System/support/commands/api.js
@@ -1,3 +1,8 @@
+Cypress.Commands.add('api_responseContains', (response, attribute, value) => {
+  const items = response.body.data.map((item) => ({ attribute: item.attributes[attribute] }));
+  cy.wrap(items).should('deep.include', { attribute: value });
+});
+
 Cypress.Commands.add('api_get', (path) => cy.api_getBearerToken().then((token) => cy.request({ method: 'GET', url: `/api/index.php/v1${path}`, headers: { Authorization: `Bearer ${token}` } })));
 
 Cypress.Commands.add('api_post', (path, body) => cy.api_getBearerToken().then((token) => cy.request({


### PR DESCRIPTION
Makes the tests more stable when we don't care about the sorting when testing API responses.