### PR TITLE
[5.0] Remove obsolete use statement from script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -18,7 +18,6 @@ use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Table;
-use Joomla\Component\Fields\Administrator\Model\FieldModel;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) removes the `use Joomla\Component\Fields\Administrator\Model\FieldModel;` statement from file `administrator/components/com_admin/script.php` which I have forgotten to remove with my PR #40249 .

### Testing Instructions

Code review: Check in file `administrator/components/com_admin/script.php` on a current 5.0-dev branch if there is any use of  the `FieldModel` class.

### Actual result BEFORE applying this Pull Request

Class `FieldModel` is not used, but there is still the `use` statement for it.

### Expected result AFTER applying this Pull Request

Class `FieldModel` is not used, and there is no `use` statement for it.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
