### PR TITLE
[5.0] [RFC] Adapt minimum database server versions to Joomla 5

### DIFF
--- a/installation/src/Helper/DatabaseHelper.php
+++ b/installation/src/Helper/DatabaseHelper.php
@@ -45,7 +45,7 @@ abstract class DatabaseHelper
      * @var    string
      * @since  4.0.0
      */
-    protected static $dbMinimumMySql = '8.0.11';
+    protected static $dbMinimumMySql = '8.0.13';
 
     /**
      * The minimum database server version for PostgreSQL databases as required by the CMS.

--- a/installation/src/Helper/DatabaseHelper.php
+++ b/installation/src/Helper/DatabaseHelper.php
@@ -36,7 +36,7 @@ abstract class DatabaseHelper
      * @var    string
      * @since  4.0.0
      */
-    protected static $dbMinimumMariaDb = '10.1';
+    protected static $dbMinimumMariaDb = '10.4';
 
     /**
      * The minimum database server version for MySQL databases as required by the CMS.
@@ -45,7 +45,7 @@ abstract class DatabaseHelper
      * @var    string
      * @since  4.0.0
      */
-    protected static $dbMinimumMySql = '5.6';
+    protected static $dbMinimumMySql = '8.0.11';
 
     /**
      * The minimum database server version for PostgreSQL databases as required by the CMS.
@@ -54,7 +54,7 @@ abstract class DatabaseHelper
      * @var    string
      * @since  4.0.0
      */
-    protected static $dbMinimumPostgreSql = '11.0';
+    protected static $dbMinimumPostgreSql = '12.0';
 
     /**
      * Method to get a database driver.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) adapts the minimum database server version required by the CMS on installation to the versions listed here https://www.joomla.org/announcements/release-news/5868-joomla-5-panta-rhei-the-follow-up.html :
> Joomla 5 will support MySQL 8.0.11+, MariaDB 10.4+ and PostgreSQL 12+.

### Request for Comments (RFC)

1. Are the version numbers mentioned above still up to date, or has there meanwhile made a change in the requirements?

2. Shall we also adapt the minimum version requirements of the database drivers in the 3.0-dev branch of the [joomla-framework/database repo](https://github.com/joomla-framework/database) and if yes, to which versions, same as CMS requirements or lower?
- https://github.com/joomla-framework/database/blob/3.x-dev/src/Mysqli/MysqliDriver.php#L81-L95
- https://github.com/joomla-framework/database/blob/3.x-dev/src/Pgsql/PgsqlDriver.php#L49-L55

3. Which documentation needs to be created or changed where?
Currently https://downloads.joomla.org/technical-requirements is not prepared yet for Joomla 4.
The "Joomla! 5x section" on https://developer.joomla.org/roadmap.html doesn't mention the increased technical requirements, and there is no "Joomla! Framework 3.x" section.

4. Shall we increase the minimum version for MySQL to 8.0.13?

The reason for question 4 is as follows:

Since Joomla 4 the database schema checker and fixer not only handles the CMS core but also 3rd party extensions.

We have some issues reported by extension developers that they want to use CURRENT_TIMESTAMP as default value for datetime columns, but the database checker currently doesn't support that. See e.g. #40765 and https://github.com/joomla-framework/database/issues/267 .

There might be other kinds of expressions which extension developers want to use as default values for their database columns.

While MariaDB supports expressions since version 10.2.1 and PostgreSQL  at least since 11, if not longer, MySQL is different:
- Prior to version 8.0.13, MySQL supports expressions for default values of table columns only for datetime or timestamp columns using NOW or CURRENT_DATE or CURRENT_TIMESTAMP.
- Since version 8.0.13, MySQL supports expressions without these limitations similar to MariaDB and MariaDB.

See https://dev.mysql.com/doc/refman/8.0/en/data-type-defaults.html , https://mariadb.com/kb/en/create-table/#default-column-option and https://www.postgresql.org/docs/12/ddl-default.html .

When we want to improve the database schema checker / fixer to be able to handle expressions as default values, which is one thing I plan to work on hopefully soon enough, we can either limit that for MySQL to the functionality of 8.0.11, or we can raise the version requirement to 8.0.13 and implement it without these limitations in a similar way as for the other databases.

@HLeithner @bembelimen Please check the above 4 questions and if necessary discuss in the production department. Thanks in advance.

### Testing Instructions

Code review, or try to make a new installation of a curent 5.0-dev branch or 5.0-dev nightly build with a database server which doesn't fulfil the minimum version requirements of Joomla 5, and then try the same with the installation package created by Drone for this PR.

### Actual result BEFORE applying this Pull Request

Joomla 5 can be installed using a database server which doesn't fulfil the minimum version requirements of Joomla 5.

### Expected result AFTER applying this Pull Request

Joomla 5 cannot be installed using a database server which doesn't fulfil the minimum version requirements of Joomla 5.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
