### PR TITLE
Remove hardcoded catid's in tests

### DIFF
--- a/tests/System/integration/administrator/components/com_banners/Banner.cy.js
+++ b/tests/System/integration/administrator/components/com_banners/Banner.cy.js
@@ -1,5 +1,9 @@
 describe('Test in backend that the banners form', () => {
-  beforeEach(() => cy.doAdministratorLogin());
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    // Clear the filter
+    cy.visit('/administrator/index.php?option=com_banners&filter=');
+  });
   afterEach(() => cy.task('queryDB', "DELETE FROM #__banners WHERE name = 'Test banner'"));
 
   it('can create a banner', () => {
@@ -12,7 +16,7 @@ describe('Test in backend that the banners form', () => {
   });
 
   it('check redirection to list view', () => {
-    cy.visit('administrator/index.php?option=com_banners&task=banner.add');
+    cy.visit('/administrator/index.php?option=com_banners&task=banner.add');
     cy.intercept('index.php?option=com_banners&view=banners').as('listview');
     cy.clickToolbarButton('Cancel');
 
@@ -20,8 +24,8 @@ describe('Test in backend that the banners form', () => {
   });
 
   it('can edit a banner', () => {
-    cy.db_createBanner({ name: 'Test Banner' }).then((id) => {
-      cy.visit(`administrator/index.php?option=com_banners&task=banner.edit&id=${id}`);
+    cy.db_createBanner({ name: 'Test Banner' }).then((banner) => {
+      cy.visit(`administrator/index.php?option=com_banners&task=banner.edit&id=${banner.id}`);
       cy.get('#jform_name').clear().type('Test banner edited');
       cy.clickToolbarButton('Save & Close');
 

--- a/tests/System/integration/administrator/components/com_banners/Banner.cy.js
+++ b/tests/System/integration/administrator/components/com_banners/Banner.cy.js
@@ -25,7 +25,7 @@ describe('Test in backend that the banners form', () => {
 
   it('can edit a banner', () => {
     cy.db_createBanner({ name: 'Test Banner' }).then((banner) => {
-      cy.visit(`administrator/index.php?option=com_banners&task=banner.edit&id=${banner.id}`);
+      cy.visit(`/administrator/index.php?option=com_banners&task=banner.edit&id=${banner.id}`);
       cy.get('#jform_name').clear().type('Test banner edited');
       cy.clickToolbarButton('Save & Close');
 

--- a/tests/System/integration/administrator/components/com_categories/Category.cy.js
+++ b/tests/System/integration/administrator/components/com_categories/Category.cy.js
@@ -1,5 +1,9 @@
 describe('Test in backend that the category form', () => {
-  beforeEach(() => cy.doAdministratorLogin());
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    // Clear the filter
+    cy.visit('/administrator/index.php?option=com_categories&extension=com_content&filter=');
+  });
   afterEach(() => cy.task('queryDB', "DELETE FROM #__categories WHERE title = 'Test category'"));
 
   it('can create a category', () => {
@@ -13,7 +17,7 @@ describe('Test in backend that the category form', () => {
 
   it('can change access level of a test category', () => {
     cy.db_createCategory({ title: 'Test category' }).then((id) => {
-      cy.visit(`administrator/index.php?option=com_categories&task=category.edit&id=${id}&extension=com_content`);
+      cy.visit(`/administrator/index.php?option=com_categories&task=category.edit&id=${id}&extension=com_content`);
       cy.get('#jform_access').select('Special');
       cy.clickToolbarButton('Save & Close');
 
@@ -22,7 +26,7 @@ describe('Test in backend that the category form', () => {
   });
 
   it('check redirection to list view', () => {
-    cy.visit('administrator/index.php?option=com_categories&task=category.add&extension=com_content');
+    cy.visit('/administrator/index.php?option=com_categories&task=category.add&extension=com_content&filter[published]=');
     cy.intercept('index.php?option=com_categories&view=categories&extension=com_content').as('listview');
     cy.clickToolbarButton('Cancel');
 

--- a/tests/System/integration/administrator/components/com_contact/Contact.cy.js
+++ b/tests/System/integration/administrator/components/com_contact/Contact.cy.js
@@ -17,7 +17,7 @@ describe('Test in backend that the contact form', () => {
 
   it('can change access level of a test contact', () => {
     cy.db_createContact({ name: 'Test contact' }).then((contact) => {
-      cy.visit(`administrator/index.php?option=com_contact&task=contact.edit&id=${contact.id}`);
+      cy.visit(`/administrator/index.php?option=com_contact&task=contact.edit&id=${contact.id}`);
       cy.get('#jform_access').select('Special');
       cy.clickToolbarButton('Save & Close');
 

--- a/tests/System/integration/administrator/components/com_contact/Contact.cy.js
+++ b/tests/System/integration/administrator/components/com_contact/Contact.cy.js
@@ -1,5 +1,9 @@
 describe('Test in backend that the contact form', () => {
-  beforeEach(() => cy.doAdministratorLogin());
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    // Clear the filter
+    cy.visit('/administrator/index.php?option=com_contact&filter=');
+  });
   afterEach(() => cy.task('queryDB', "DELETE FROM #__contact_details WHERE name = 'Test contact'"));
 
   it('can create a contact', () => {
@@ -12,8 +16,8 @@ describe('Test in backend that the contact form', () => {
   });
 
   it('can change access level of a test contact', () => {
-    cy.db_createContact({ name: 'Test contact' }).then((id) => {
-      cy.visit(`administrator/index.php?option=com_contact&task=contact.edit&id=${id}`);
+    cy.db_createContact({ name: 'Test contact' }).then((contact) => {
+      cy.visit(`administrator/index.php?option=com_contact&task=contact.edit&id=${contact.id}`);
       cy.get('#jform_access').select('Special');
       cy.clickToolbarButton('Save & Close');
 
@@ -22,7 +26,7 @@ describe('Test in backend that the contact form', () => {
   });
 
   it('check redirection to list view', () => {
-    cy.visit('administrator/index.php?option=com_contact&task=contact.add');
+    cy.visit('/administrator/index.php?option=com_contact&task=contact.add');
     cy.intercept('index.php?option=com_contact&view=contacts').as('listview');
     cy.clickToolbarButton('Cancel');
 

--- a/tests/System/integration/administrator/components/com_content/Article.cy.js
+++ b/tests/System/integration/administrator/components/com_content/Article.cy.js
@@ -17,7 +17,7 @@ describe('Test in backend that the article form', () => {
 
   it('can change access level of a test article', () => {
     cy.db_createArticle({ title: 'Test article' }).then((article) => {
-      cy.visit(`administrator/index.php?option=com_content&task=article.edit&id=${article.id}`);
+      cy.visit(`/administrator/index.php?option=com_content&task=article.edit&id=${article.id}`);
       cy.get('#jform_access').select('Special');
       cy.clickToolbarButton('Save & Close');
 

--- a/tests/System/integration/administrator/components/com_content/Article.cy.js
+++ b/tests/System/integration/administrator/components/com_content/Article.cy.js
@@ -1,5 +1,9 @@
 describe('Test in backend that the article form', () => {
-  beforeEach(() => cy.doAdministratorLogin());
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    // Clear the filter
+    cy.visit('/administrator/index.php?option=com_content&filter=');
+  });
   afterEach(() => cy.task('queryDB', "DELETE FROM #__content WHERE title = 'Test article'"));
 
   it('can create an article', () => {
@@ -12,8 +16,8 @@ describe('Test in backend that the article form', () => {
   });
 
   it('can change access level of a test article', () => {
-    cy.db_createArticle({ title: 'Test article' }).then((id) => {
-      cy.visit(`administrator/index.php?option=com_content&task=article.edit&id=${id}`);
+    cy.db_createArticle({ title: 'Test article' }).then((article) => {
+      cy.visit(`administrator/index.php?option=com_content&task=article.edit&id=${article.id}`);
       cy.get('#jform_access').select('Special');
       cy.clickToolbarButton('Save & Close');
 
@@ -22,7 +26,7 @@ describe('Test in backend that the article form', () => {
   });
 
   it('check redirection to list view', () => {
-    cy.visit('administrator/index.php?option=com_content&task=article.add');
+    cy.visit('/administrator/index.php?option=com_content&task=article.add');
     cy.intercept('index.php?option=com_content&view=articles').as('listview');
     cy.clickToolbarButton('Cancel');
 

--- a/tests/System/integration/administrator/components/com_fields/Field.cy.js
+++ b/tests/System/integration/administrator/components/com_fields/Field.cy.js
@@ -1,5 +1,9 @@
 describe('Test in backend that the field form', () => {
-  beforeEach(() => cy.doAdministratorLogin());
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    // Clear the filter
+    cy.visit('/administrator/index.php?option=com_fields&filter=');
+  });
   afterEach(() => cy.task('queryDB', "DELETE FROM #__fields WHERE title = 'Test field'"));
 
   it('can create a field', () => {
@@ -12,7 +16,7 @@ describe('Test in backend that the field form', () => {
   });
 
   it('check redirection to list view', () => {
-    cy.visit('administrator/index.php?option=com_fields&task=field.add&context=com_content.article');
+    cy.visit('/administrator/index.php?option=com_fields&task=field.add&context=com_content.article');
     cy.intercept('index.php?option=com_fields&view=fields&context=com_content.article').as('listview');
     cy.clickToolbarButton('Cancel');
 

--- a/tests/System/integration/administrator/components/com_fields/Field.cy.js
+++ b/tests/System/integration/administrator/components/com_fields/Field.cy.js
@@ -25,7 +25,7 @@ describe('Test in backend that the field form', () => {
 
   it('can edit a field', () => {
     cy.db_createField({ title: 'Test field' }).then((id) => {
-      cy.visit(`administrator/index.php?option=com_fields&task=field.edit&id=${id}&context=com_content.article`);
+      cy.visit(`/administrator/index.php?option=com_fields&task=field.edit&id=${id}&context=com_content.article`);
       cy.get('#jform_title').clear().type('Test field edited');
       cy.clickToolbarButton('Save & Close');
 

--- a/tests/System/integration/administrator/components/com_modules/Module.cy.js
+++ b/tests/System/integration/administrator/components/com_modules/Module.cy.js
@@ -1,5 +1,9 @@
 describe('Test in backend that the module form', () => {
-  beforeEach(() => cy.doAdministratorLogin());
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    // Clear the filter
+    cy.visit('/administrator/index.php?option=com_modules&filter=');
+  });
   afterEach(() => cy.task('queryDB', "DELETE FROM #__modules WHERE title = 'Test module'"));
 
   it('can create a module', () => {
@@ -16,10 +20,6 @@ describe('Test in backend that the module form', () => {
       cy.visit(`/administrator/index.php?option=com_modules&task=module.edit&id=${id}`);
       cy.get('#jform_title').clear().type('Test module edited');
       cy.clickToolbarButton('Save & Close');
-
-      // This is needed as it can be that the backend list still has a filter active
-      cy.visit('/administrator/index.php?option=com_modules&view=modules&filter=');
-      cy.reload();
 
       cy.contains('Test module edited');
     });

--- a/tests/System/integration/administrator/components/com_newsfeeds/Newsfeed.cy.js
+++ b/tests/System/integration/administrator/components/com_newsfeeds/Newsfeed.cy.js
@@ -14,7 +14,7 @@ describe('Test in backend that the newsfeed form', () => {
 
   it('can change access level of a test newsfeed', () => {
     cy.db_createNewsFeed({ name: 'Test newsfeed', link: 'https://newsfeedtesturl' }).then((feed) => {
-      cy.visit(`administrator/index.php?option=com_newsfeeds&task=newsfeed.edit&id=${feed.id}`);
+      cy.visit(`/administrator/index.php?option=com_newsfeeds&task=newsfeed.edit&id=${feed.id}`);
       cy.get('#jform_access').select('Special');
       cy.clickToolbarButton('Save & Close');
 

--- a/tests/System/integration/administrator/components/com_newsfeeds/Newsfeed.cy.js
+++ b/tests/System/integration/administrator/components/com_newsfeeds/Newsfeed.cy.js
@@ -13,8 +13,8 @@ describe('Test in backend that the newsfeed form', () => {
   });
 
   it('can change access level of a test newsfeed', () => {
-    cy.db_createNewsFeed({ name: 'Test newsfeed', link: 'https://newsfeedtesturl' }).then((id) => {
-      cy.visit(`administrator/index.php?option=com_newsfeeds&task=newsfeed.edit&id=${id}`);
+    cy.db_createNewsFeed({ name: 'Test newsfeed', link: 'https://newsfeedtesturl' }).then((feed) => {
+      cy.visit(`administrator/index.php?option=com_newsfeeds&task=newsfeed.edit&id=${feed.id}`);
       cy.get('#jform_access').select('Special');
       cy.clickToolbarButton('Save & Close');
 

--- a/tests/System/integration/administrator/components/com_tags/Tag.cy.js
+++ b/tests/System/integration/administrator/components/com_tags/Tag.cy.js
@@ -1,5 +1,9 @@
 describe('Test in backend that the tag form', () => {
-  beforeEach(() => cy.doAdministratorLogin());
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    // Clear the filter
+    cy.visit('/administrator/index.php?option=com_tags&filter=');
+  });
   afterEach(() => cy.task('queryDB', "DELETE FROM #__tags WHERE title = 'Test tag'"));
 
   it('can create a tag', () => {
@@ -22,7 +26,7 @@ describe('Test in backend that the tag form', () => {
   });
 
   it('check redirection to list view', () => {
-    cy.visit('administrator/index.php?option=com_tags&task=tag.add');
+    cy.visit('/administrator/index.php?option=com_tags&task=tag.add');
     cy.intercept('index.php?option=com_tags&view=tags').as('listview');
     cy.clickToolbarButton('Cancel');
 

--- a/tests/System/integration/administrator/components/com_tags/Tag.cy.js
+++ b/tests/System/integration/administrator/components/com_tags/Tag.cy.js
@@ -17,7 +17,7 @@ describe('Test in backend that the tag form', () => {
 
   it('can edit a tag', () => {
     cy.db_createTag({ title: 'Test tag' }).then((id) => {
-      cy.visit(`administrator/index.php?option=com_tags&task=tag.edit&id=${id}`);
+      cy.visit(`/administrator/index.php?option=com_tags&task=tag.edit&id=${id}`);
       cy.get('#jform_title').clear().type('Test tag edited');
       cy.clickToolbarButton('Save & Close');
 

--- a/tests/System/integration/administrator/components/com_users/User.cy.js
+++ b/tests/System/integration/administrator/components/com_users/User.cy.js
@@ -18,7 +18,7 @@ describe('Test in backend that the user form', () => {
 
   it('can edit a user', () => {
     cy.db_createUser().then((id) => {
-      cy.visit(`administrator/index.php?option=com_users&task=user.edit&id=${id}`);
+      cy.visit(`/administrator/index.php?option=com_users&task=user.edit&id=${id}`);
 
       cy.get('#jform_name').clear().type('test edited');
       cy.get('#jform_username').clear().type('testedited');

--- a/tests/System/integration/api/com_banners/Banners.cy.js
+++ b/tests/System/integration/api/com_banners/Banners.cy.js
@@ -30,7 +30,7 @@ describe('Test that banners API endpoint', () => {
 
   it('can update a banner', () => {
     cy.db_createBanner({ name: 'automated test banner' })
-      .then((id) => cy.api_patch(`/banners/${id}`, { name: 'updated automated test banner' }))
+      .then((banner) => cy.api_patch(`/banners/${banner.id}`, { name: 'updated automated test banner' }))
       .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
         .its('name')
         .should('include', 'updated automated test banner'));
@@ -38,6 +38,6 @@ describe('Test that banners API endpoint', () => {
 
   it('can delete a banner', () => {
     cy.db_createBanner({ name: 'automated test banner', state: -2 })
-      .then((id) => cy.api_delete(`/banners/${id}`));
+      .then((banner) => cy.api_delete(`/banners/${banner.id}`));
   });
 });

--- a/tests/System/integration/api/com_contact/Contacts.cy.js
+++ b/tests/System/integration/api/com_contact/Contacts.cy.js
@@ -25,7 +25,7 @@ describe('Test that contacts API endpoint', () => {
 
   it('can update a contact', () => {
     cy.db_createContact({ name: 'automated test contact', access: 1 })
-      .then((id) => cy.api_patch(`/contacts/${id}`, { name: 'updated automated test contact' }))
+      .then((contact) => cy.api_patch(`/contacts/${contact.id}`, { name: 'updated automated test contact' }))
       .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
         .its('name')
         .should('include', 'updated automated test contact'));
@@ -33,6 +33,6 @@ describe('Test that contacts API endpoint', () => {
 
   it('can delete a contact', () => {
     cy.db_createContact({ name: 'automated test contact', published: -2 })
-      .then((id) => cy.api_delete(`/contacts/${id}`));
+      .then((contact) => cy.api_delete(`/contacts/${contact.id}`));
   });
 });

--- a/tests/System/integration/api/com_content/Articles.cy.js
+++ b/tests/System/integration/api/com_content/Articles.cy.js
@@ -35,13 +35,14 @@ describe('Test that content API endpoint', () => {
 
   it('can update an article', () => {
     cy.db_createArticle({ title: 'automated test article' })
-      .then((id) => cy.api_patch(`/content/articles/${id}`, { title: 'updated automated test article' }))
+      .then((article) => cy.api_patch(`/content/articles/${article.id}`, { title: 'updated automated test article' }))
       .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
         .its('title')
         .should('include', 'updated automated test article'));
   });
 
   it('can delete an article', () => {
-    cy.db_createArticle({ title: 'automated test article', state: -2 }).then((id) => cy.api_delete(`/content/articles/${id}`));
+    cy.db_createArticle({ title: 'automated test article', state: -2 })
+      .then((article) => cy.api_delete(`/content/articles/${article.id}`));
   });
 });

--- a/tests/System/integration/api/com_newsfeed/NewsFeed.cy.js
+++ b/tests/System/integration/api/com_newsfeed/NewsFeed.cy.js
@@ -55,7 +55,7 @@ describe('Test that newsfeed API endpoint', () => {
 
     it('can update a feed', () => {
       cy.db_createNewsFeed({ name: 'automated test contact', access: 1, link: `${Cypress.config('baseUrl')}/tests/System/data/com_newsfeeds/${file}.xml` })
-        .then((id) => cy.api_patch(`/newsfeeds/feeds/${id}`, { name: 'updated automated test feed' }))
+        .then((feed) => cy.api_patch(`/newsfeeds/feeds/${feed.id}`, { name: 'updated automated test feed' }))
         .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
           .its('name')
           .should('include', 'updated automated test feed'));
@@ -65,7 +65,7 @@ describe('Test that newsfeed API endpoint', () => {
       cy.db_createNewsFeed({
         name: 'automated test contact', access: 1, link: `${Cypress.config('baseUrl')}/tests/System/data/com_newsfeeds/${file}.xml`, published: -2,
       })
-        .then((id) => cy.api_delete(`/newsfeeds/feeds/${id}`));
+        .then((feed) => cy.api_delete(`/newsfeeds/feeds/${feed.id}`));
     });
   });
 });

--- a/tests/System/integration/site/components/com_contact/Category.cy.js
+++ b/tests/System/integration/site/components/com_contact/Category.cy.js
@@ -18,11 +18,11 @@ describe('Test in frontend that the contact category view', () => {
 
   it('can display a list of contacts without a menu item', () => {
     cy.db_createContact({ name: 'automated test contact 1' })
-      .then(() => cy.db_createContact({ name: 'automated test contact 2' }))
-      .then(() => cy.db_createContact({ name: 'automated test contact 3' }))
-      .then(() => cy.db_createContact({ name: 'automated test contact 4' }))
-      .then(() => {
-        cy.visit('/index.php?option=com_contact&view=category&id=4');
+      .then((contact) => cy.db_createContact({ name: 'automated test contact 2', featured: 1, catid: contact.catid }))
+      .then((contact) => cy.db_createContact({ name: 'automated test contact 3', featured: 1, catid: contact.catid }))
+      .then((contact) => cy.db_createContact({ name: 'automated test contact 4', featured: 1, catid: contact.catid }))
+      .then((contact) => {
+        cy.visit(`/index.php?option=com_contact&view=category&id=${contact.catid}`);
 
         cy.contains('automated test contact 1');
         cy.contains('automated test contact 2');
@@ -33,7 +33,7 @@ describe('Test in frontend that the contact category view', () => {
 
   it('can open the contact form in the default layout', () => {
     cy.db_createContact({ name: 'contact 1' })
-      .then(() => cy.db_createMenuItem({ title: 'automated test', link: 'index.php?option=com_contact&view=category&id=4' }))
+      .then((contact) => cy.db_createMenuItem({ title: 'automated test', link: `index.php?option=com_contact&view=category&id=${contact.catid}` }))
       .then(() => {
         cy.doFrontendLogin();
         cy.visit('/');

--- a/tests/System/integration/site/components/com_contact/Contact.cy.js
+++ b/tests/System/integration/site/components/com_contact/Contact.cy.js
@@ -2,7 +2,7 @@ describe('Test in frontend that the contact details view', () => {
   it('can display a form', () => {
     cy.db_getUserId().then((id) => cy.db_createContact({ name: 'contact 1', user_id: id }))
       .then((contact) => {
-        cy.visit(`index.php?option=com_contact&view=contact&id='${contact.id}'`);
+        cy.visit(`/index.php?option=com_contact&view=contact&id='${contact.id}'`);
 
         cy.contains('Contact Form');
         cy.get('.m-0').should('exist');
@@ -17,7 +17,7 @@ describe('Test in frontend that the contact details view', () => {
       .then(() => cy.db_getUserId())
       .then((userId) => cy.db_createContact({ name: 'automated test contact 1', user_id: userId }))
       .then((contact) => {
-        cy.visit(`index.php?option=com_contact&view=contact&id='${contact.id}'`);
+        cy.visit(`/index.php?option=com_contact&view=contact&id='${contact.id}'`);
 
         cy.contains('automated test_field group').should('exist');
         cy.contains('test field').should('exist');

--- a/tests/System/integration/site/components/com_contact/Contact.cy.js
+++ b/tests/System/integration/site/components/com_contact/Contact.cy.js
@@ -1,8 +1,8 @@
 describe('Test in frontend that the contact details view', () => {
   it('can display a form', () => {
     cy.db_getUserId().then((id) => cy.db_createContact({ name: 'contact 1', user_id: id }))
-      .then((contactId) => {
-        cy.visit(`index.php?option=com_contact&view=contact&id='${contactId}'`);
+      .then((contact) => {
+        cy.visit(`index.php?option=com_contact&view=contact&id='${contact.id}'`);
 
         cy.contains('Contact Form');
         cy.get('.m-0').should('exist');
@@ -16,8 +16,8 @@ describe('Test in frontend that the contact details view', () => {
       }))
       .then(() => cy.db_getUserId())
       .then((userId) => cy.db_createContact({ name: 'automated test contact 1', user_id: userId }))
-      .then((contactId) => {
-        cy.visit(`index.php?option=com_contact&view=contact&id='${contactId}'`);
+      .then((contact) => {
+        cy.visit(`index.php?option=com_contact&view=contact&id='${contact.id}'`);
 
         cy.contains('automated test_field group').should('exist');
         cy.contains('test field').should('exist');

--- a/tests/System/integration/site/components/com_contact/Form.cy.js
+++ b/tests/System/integration/site/components/com_contact/Form.cy.js
@@ -6,8 +6,11 @@ describe('Test in frontend that the contact form view', () => {
     cy.visit('/index.php?option=com_contact&view=form&layout=edit');
     cy.get('#jform_name').type('test contact 1');
     cy.get('.mb-2 > .btn-primary').click();
-    cy.visit('/index.php?option=com_contact&view=category&id=4');
 
-    cy.contains('test contact 1').should('exist');
+    cy.task('queryDB', 'SELECT catid FROM #__contact_details WHERE name = \'test contact 1\'').then((id) => {
+      cy.visit(`/index.php?option=com_contact&view=category&id=${id[0].catid}`);
+
+      cy.contains('test contact 1').should('exist');
+    });
   });
 });

--- a/tests/System/integration/site/components/com_content/Article.cy.js
+++ b/tests/System/integration/site/components/com_content/Article.cy.js
@@ -17,7 +17,7 @@ describe('Test in frontend that the content article form', () => {
 
   it('can edit an article without menu item', () => {
     cy.doFrontendLogin();
-    cy.visit('index.php?option=com_content&view=form&layout=edit');
+    cy.visit('/index.php?option=com_content&view=form&layout=edit');
 
     cy.get('#jform_title').type('test article');
     cy.get('[data-submit-task="article.save"]').click();

--- a/tests/System/integration/site/components/com_content/Categories.cy.js
+++ b/tests/System/integration/site/components/com_content/Categories.cy.js
@@ -8,7 +8,7 @@ describe('Test in frontend that the content categories view', () => {
         await cy.db_createArticle({ title: 'automated test article 3', catid: id });
       })
       .then(() => {
-        cy.visit('index.php?option=com_content&view=categories');
+        cy.visit('/index.php?option=com_content&view=categories');
 
         cy.contains('automated test category 1');
         cy.get(':nth-child(1) > .com-content-categories__item-title-wrapper > .com-content-categories__item-title > .badge').contains('Article Count: 1');

--- a/tests/System/integration/site/components/com_content/Category.cy.js
+++ b/tests/System/integration/site/components/com_content/Category.cy.js
@@ -2,13 +2,13 @@ describe('Test in frontend that the content category view', () => {
   ['default', 'blog'].forEach((layout) => {
     it(`can display a list of articles in the ${layout} layout in a menu item`, () => {
       cy.db_createArticle({ title: 'article 1' })
-        .then(() => cy.db_createArticle({ title: 'article 2' }))
-        .then(() => cy.db_createArticle({ title: 'article 3' }))
-        .then(() => cy.db_createArticle({ title: 'article 4' }))
-        .then(() => cy.db_createMenuItem({
+        .then((article) => cy.db_createArticle({ title: 'article 2', catid: article.catid }))
+        .then((article) => cy.db_createArticle({ title: 'article 3', catid: article.catid }))
+        .then((article) => cy.db_createArticle({ title: 'article 4', catid: article.catid }))
+        .then((article) => cy.db_createMenuItem({
           title: 'automated test',
           alias: 'automated-test',
-          link: `index.php?option=com_content&view=category&id=2&layout=${layout}`,
+          link: `index.php?option=com_content&view=category&id=${article.catid}&layout=${layout}`,
           path: 'automated-test/root',
         }))
         .then(() => {
@@ -23,12 +23,12 @@ describe('Test in frontend that the content category view', () => {
     });
 
     it(`can display a list of articles in the ${layout} layout without a menu item`, () => {
-      cy.db_createArticle({ title: 'article 1' })
-        .then(() => cy.db_createArticle({ title: 'article 2' }))
-        .then(() => cy.db_createArticle({ title: 'article 3' }))
-        .then(() => cy.db_createArticle({ title: 'article 4' }))
-        .then(() => {
-          cy.visit(`/index.php?option=com_content&view=category&id=2&layout=${layout}`);
+      cy.db_createArticle({ title: 'article 1'})
+        .then((article) => cy.db_createArticle({ title: 'article 2', catid: article.catid }))
+        .then((article) => cy.db_createArticle({ title: 'article 3', catid: article.catid }))
+        .then((article) => cy.db_createArticle({ title: 'article 4', catid: article.catid }))
+        .then((article) => {
+          cy.visit(`/index.php?option=com_content&view=category&id=${article.catid}&layout=${layout}`);
 
           cy.contains('article 1');
           cy.contains('article 2');
@@ -40,10 +40,10 @@ describe('Test in frontend that the content category view', () => {
 
   it('can open the article form in the default layout', () => {
     cy.db_createArticle({ title: 'article 1' })
-      .then(() => cy.db_createMenuItem({
+      .then((article) => cy.db_createMenuItem({
         title: 'automated test',
         alias: 'automated-test',
-        link: 'index.php?option=com_content&view=category&id=2&layout=default',
+        link: `index.php?option=com_content&view=category&id=${article.catid}&layout=default`,
         path: 'automated-test/root',
       }))
       .then(() => {

--- a/tests/System/integration/site/components/com_content/Category.cy.js
+++ b/tests/System/integration/site/components/com_content/Category.cy.js
@@ -23,7 +23,7 @@ describe('Test in frontend that the content category view', () => {
     });
 
     it(`can display a list of articles in the ${layout} layout without a menu item`, () => {
-      cy.db_createArticle({ title: 'article 1'})
+      cy.db_createArticle({ title: 'article 1' })
         .then((article) => cy.db_createArticle({ title: 'article 2', catid: article.catid }))
         .then((article) => cy.db_createArticle({ title: 'article 3', catid: article.catid }))
         .then((article) => cy.db_createArticle({ title: 'article 4', catid: article.catid }))

--- a/tests/System/integration/site/components/com_newsfeed/Category.cy.js
+++ b/tests/System/integration/site/components/com_newsfeed/Category.cy.js
@@ -1,9 +1,9 @@
 describe('Test in frontend that the newsfeeds category view', () => {
   it('can display a list of feeds in a menu item', () => {
     cy.db_createNewsFeed({ name: 'automated test feed 1' })
-      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 2', catid:feed.catid }))
-      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 3', catid:feed.catid }))
-      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 4', catid:feed.catid }))
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 2', catid: feed.catid }))
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 3', catid: feed.catid }))
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 4', catid: feed.catid }))
       .then((feed) => cy.db_createMenuItem({ title: 'automated test feeds', link: `index.php?option=com_newsfeeds&view=category&id=${feed.catid}` }))
       .then(() => {
         cy.visit('/');
@@ -18,11 +18,11 @@ describe('Test in frontend that the newsfeeds category view', () => {
 
   it('can display a list of feeds without a menu item', () => {
     cy.db_createNewsFeed({ name: 'automated test feed 1' })
-      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 2', catid:feed.catid }))
-      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 3', catid:feed.catid }))
-      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 4', catid:feed.catid }))
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 2', catid: feed.catid }))
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 3', catid: feed.catid }))
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 4', catid: feed.catid }))
       .then((feed) => {
-        cy.visit(`/index.php?option=com_newsfeeds&view=category&id=${feed.catid}` );
+        cy.visit(`/index.php?option=com_newsfeeds&view=category&id=${feed.catid}`);
 
         cy.contains('automated test feed 1');
         cy.contains('automated test feed 2');

--- a/tests/System/integration/site/components/com_newsfeed/Category.cy.js
+++ b/tests/System/integration/site/components/com_newsfeed/Category.cy.js
@@ -1,10 +1,10 @@
 describe('Test in frontend that the newsfeeds category view', () => {
   it('can display a list of feeds in a menu item', () => {
     cy.db_createNewsFeed({ name: 'automated test feed 1' })
-      .then(() => cy.db_createNewsFeed({ name: 'automated test feed 2' }))
-      .then(() => cy.db_createNewsFeed({ name: 'automated test feed 3' }))
-      .then(() => cy.db_createNewsFeed({ name: 'automated test feed 4' }))
-      .then(() => cy.db_createMenuItem({ title: 'automated test feeds', link: 'index.php?option=com_newsfeeds&view=category&id=5' }))
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 2', catid:feed.catid }))
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 3', catid:feed.catid }))
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 4', catid:feed.catid }))
+      .then((feed) => cy.db_createMenuItem({ title: 'automated test feeds', link: `index.php?option=com_newsfeeds&view=category&id=${feed.catid}` }))
       .then(() => {
         cy.visit('/');
         cy.get('a:contains(automated test feeds)').click();
@@ -18,11 +18,11 @@ describe('Test in frontend that the newsfeeds category view', () => {
 
   it('can display a list of feeds without a menu item', () => {
     cy.db_createNewsFeed({ name: 'automated test feed 1' })
-      .then(() => cy.db_createNewsFeed({ name: 'automated test feed 2' }))
-      .then(() => cy.db_createNewsFeed({ name: 'automated test feed 3' }))
-      .then(() => cy.db_createNewsFeed({ name: 'automated test feed 4' }))
-      .then(() => {
-        cy.visit('/index.php?option=com_newsfeeds&view=category&id=5');
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 2', catid:feed.catid }))
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 3', catid:feed.catid }))
+      .then((feed) => cy.db_createNewsFeed({ name: 'automated test feed 4', catid:feed.catid }))
+      .then((feed) => {
+        cy.visit(`/index.php?option=com_newsfeeds&view=category&id=${feed.catid}` );
 
         cy.contains('automated test feed 1');
         cy.contains('automated test feed 2');

--- a/tests/System/integration/site/components/com_newsfeed/NewsFeed.cy.js
+++ b/tests/System/integration/site/components/com_newsfeed/NewsFeed.cy.js
@@ -2,7 +2,7 @@ describe('Test in frontend that the newsfeeds details view', () => {
   ['joomla.org'].forEach((file) => {
     it(`can display a feed in a menu item from ${file}`, () => {
       cy.db_createNewsFeed({ name: 'automated test feed 1', link: `${Cypress.config('baseUrl')}/tests/System/data/com_newsfeeds/${file}.xml` })
-        .then((id) => cy.db_createMenuItem({ title: 'automated test feeds', link: `index.php?option=com_newsfeeds&view=newsfeed&id=${id}` }))
+        .then((feed) => cy.db_createMenuItem({ title: 'automated test feeds', link: `index.php?option=com_newsfeeds&view=newsfeed&id=${feed.id}` }))
         .then(() => {
           cy.visit('/');
           cy.get('a:contains(automated test feed)').click();
@@ -15,8 +15,8 @@ describe('Test in frontend that the newsfeeds details view', () => {
 
     it(`can display a feed without a menu item from ${file}`, () => {
       cy.db_createNewsFeed({ name: 'automated test feed 1', link: `${Cypress.config('baseUrl')}/tests/System/data/com_newsfeeds/${file}.xml` })
-        .then((id) => {
-          cy.visit(`index.php?option=com_newsfeeds&view=newsfeed&id=${id}`);
+        .then((feed) => {
+          cy.visit(`index.php?option=com_newsfeeds&view=newsfeed&id=${feed.id}`);
 
           cy.contains('automated test feed 1');
           cy.get('.com-newsfeeds-newsfeed__items').should('exist');

--- a/tests/System/integration/site/components/com_newsfeed/NewsFeed.cy.js
+++ b/tests/System/integration/site/components/com_newsfeed/NewsFeed.cy.js
@@ -16,7 +16,7 @@ describe('Test in frontend that the newsfeeds details view', () => {
     it(`can display a feed without a menu item from ${file}`, () => {
       cy.db_createNewsFeed({ name: 'automated test feed 1', link: `${Cypress.config('baseUrl')}/tests/System/data/com_newsfeeds/${file}.xml` })
         .then((feed) => {
-          cy.visit(`index.php?option=com_newsfeeds&view=newsfeed&id=${feed.id}`);
+          cy.visit(`/index.php?option=com_newsfeeds&view=newsfeed&id=${feed.id}`);
 
           cy.contains('automated test feed 1');
           cy.get('.com-newsfeeds-newsfeed__items').should('exist');

--- a/tests/System/support/commands/db.js
+++ b/tests/System/support/commands/db.js
@@ -1,26 +1,15 @@
 /**
- * Returns an insert query for the given database and fields.
+ * Creates an article in the database with the given data. The article contains some default values when
+ * not all required fields are passed in the given data. The id of the inserted article is returned.
  *
- * @param {string} table The DB table name
- * @param {Object} values The values to insert
+ * @param {Object} articleData The article data to insert
  *
- * @returns string
+ * @returns Object
  */
-function createInsertQuery(table, values) {
-  let query = `INSERT INTO #__${table} (\`${Object.keys(values).join('\`, \`')}\`) VALUES (:${Object.keys(values).join(',:')})`;
-
-  Object.keys(values).forEach((variable) => {
-    query = query.replace(`:${variable}`, `'${values[variable]}'`);
-  });
-
-  return query;
-}
-
 Cypress.Commands.add('db_createArticle', (articleData) => {
   const defaultArticleOptions = {
     title: 'test article',
     alias: 'test-article',
-    catid: 2,
     introtext: '',
     fulltext: '',
     featured: 0,
@@ -38,22 +27,37 @@ Cypress.Commands.add('db_createArticle', (articleData) => {
 
   const article = { ...defaultArticleOptions, ...articleData };
 
-  return cy.task('queryDB', createInsertQuery('content', article))
-    .then(async (info) => {
-      if (article.featured === 1) {
-        await cy.task('queryDB', `INSERT INTO #__content_frontpage (content_id, ordering) VALUES ('${info.insertId}', '1')`);
+  return getDefaultCategoryId('com_content')
+    .then((id) => {
+      if (article.catid === undefined) {
+        article.catid = id;
       }
-      await cy.task('queryDB', `INSERT INTO #__workflow_associations (item_id, stage_id, extension) VALUES (${info.insertId}, 1, 'com_content.article')`);
 
-      return info.insertId;
+      return cy.task('queryDB', createInsertQuery('content', article));
+    }).then(async (info) => {
+      article.id = info.insertId;
+
+      if (article.featured === 1) {
+        await cy.task('queryDB', `INSERT INTO #__content_frontpage (content_id, ordering) VALUES ('${article.id}', '1')`);
+      }
+      await cy.task('queryDB', `INSERT INTO #__workflow_associations (item_id, stage_id, extension) VALUES (${article.id}, 1, 'com_content.article')`);
+
+      return article;
     });
 });
 
-Cypress.Commands.add('db_createContact', (contact) => {
+/**
+ * Creates a contact in the database with the given data. The contact contains some default values when
+ * not all required fields are passed in the given data. The id of the inserted contact is returned.
+ *
+ * @param {Object} contactData The contact data to insert
+ *
+ * @returns Object
+ */
+Cypress.Commands.add('db_createContact', (contactData) => {
   const defaultContactOptions = {
     name: 'test contact',
     alias: 'test-contact',
-    catid: 4,
     published: 1,
     access: 1,
     language: '*',
@@ -64,15 +68,35 @@ Cypress.Commands.add('db_createContact', (contact) => {
     params: '',
   };
 
-  return cy.task('queryDB', createInsertQuery('contact_details', { ...defaultContactOptions, ...contact }))
-    .then(async (info) => info.insertId);
+  const contact = { ...defaultContactOptions, ...contactData };
+
+  return getDefaultCategoryId('com_contact')
+    .then((id) => {
+      if (contact.catid === undefined) {
+        contact.catid = id;
+      }
+
+      return cy.task('queryDB', createInsertQuery('contact_details', contact));
+    })
+    .then(async (info) => {
+      contact.id = info.insertId;
+
+      return contact;
+    });
 });
 
-Cypress.Commands.add('db_createBanner', (banner) => {
+/**
+ * Creates a banner in the database with the given data. The banner contains some default values when
+ * not all required fields are passed in the given data. The id of the inserted banner is returned.
+ *
+ * @param {Object} bannerData The banner data to insert
+ *
+ * @returns Object
+ */
+Cypress.Commands.add('db_createBanner', (bannerData) => {
   const defaultBannerOptions = {
     name: 'test banner',
     alias: 'test-banner',
-    catid: 3,
     state: 1,
     type: 1,
     language: '*',
@@ -83,9 +107,200 @@ Cypress.Commands.add('db_createBanner', (banner) => {
     params: '',
   };
 
-  return cy.task('queryDB', createInsertQuery('banners', { ...defaultBannerOptions, ...banner })).then(async (info) => info.insertId);
+  const banner = { ...defaultBannerOptions, ...bannerData };
+
+  return getDefaultCategoryId('com_banners')
+    .then((id) => {
+      if (banner.catid === undefined) {
+        banner.catid = id;
+      }
+
+      return cy.task('queryDB', createInsertQuery('banners', banner));
+    })
+    .then(async (info) => {
+      banner.id = info.insertId;
+
+      return banner;
+    });
 });
 
+/**
+ * Creates a newsfeed in the database with the given data. The newsfeed contains some default values when
+ * not all required fields are passed in the given data. The id of the inserted newsfeed is returned.
+ *
+ * @param {Object} newsFeedData The newsfeed data to insert
+ *
+ * @returns Object
+ */
+Cypress.Commands.add('db_createNewsFeed', (newsFeedData) => {
+  const defaultNewsfeedOptions = {
+    name: 'test feed',
+    alias: 'test-feed',
+    link: '',
+    published: 1,
+    numarticles: 5,
+    checked_out: 0,
+    checked_out_time: '2023-01-01 20:00:00',
+    rtl: 0,
+    access: 1,
+    language: '*',
+    created: '2023-01-01 20:00:00',
+    modified: '2023-01-01 20:00:00',
+    metakey: '',
+    metadata: '',
+    metadesc: '',
+    description: '',
+    params: '',
+    images: '',
+  };
+
+  const newsFeed = { ...defaultNewsfeedOptions, ...newsFeedData };
+
+  return getDefaultCategoryId('com_newsfeeds')
+    .then((id) => {
+      if (newsFeed.catid === undefined) {
+        newsFeed.catid = id;
+      }
+
+      return cy.task('queryDB', createInsertQuery('newsfeeds', newsFeed));
+    })
+    .then(async (info) => {
+      newsFeed.id = info.insertId;
+
+      return newsFeed;
+    });
+});
+
+/**
+ * Creates a category in the database with the given data. The category contains some default values when
+ * not all required fields are passed in the given data. The id of the inserted category is returned.
+ *
+ * @param {Object} categoryData The category data to insert
+ *
+ * @returns integer
+ */
+Cypress.Commands.add('db_createCategory', (category) => {
+  const defaultCategoryOptions = {
+    title: 'test category',
+    alias: 'test-category',
+    path: 'test-category',
+    extension: 'com_content',
+    published: 1,
+    access: 1,
+    params: '',
+    parent_id: 1,
+    level: 1,
+    lft: 1,
+    metadata: '',
+    metadesc: '',
+    created_time: '2023-01-01 20:00:00',
+    modified_time: '2023-01-01 20:00:00',
+  };
+
+  return cy.task('queryDB', createInsertQuery('categories', { ...defaultCategoryOptions, ...category })).then(async (info) => info.insertId);
+});
+
+/**
+ * Creates a field in the database with the given data. The field contains some default values when
+ * not all required fields are passed in the given data. The id of the inserted field is returned.
+ *
+ * @param {Object} field The field data to insert
+ *
+ * @returns integer
+ */
+Cypress.Commands.add('db_createField', (field) => {
+  const defaultFieldOptions = {
+    title: 'test field',
+    name: 'test-field',
+    label: 'test field',
+    default_value: '',
+    note: '',
+    description: '',
+    group_id: 0,
+    type: 'text',
+    required: 1,
+    state: 1,
+    context: 'com_content.article',
+    access: 1,
+    language: '*',
+    created_time: '2023-01-01 20:00:00',
+    modified_time: '2023-01-01 20:00:00',
+    params: '',
+    fieldparams: '',
+  };
+
+  return cy.task('queryDB', createInsertQuery('fields', { ...defaultFieldOptions, ...field })).then(async (info) => info.insertId);
+});
+
+/**
+ * Creates a field group in the database with the given data. The field group contains some default values when
+ * not all required fields are passed in the given data. The id of the inserted field group is returned.
+ *
+ * @param {Object} fieldGroup The field group data to insert
+ *
+ * @returns integer
+ */
+Cypress.Commands.add('db_createFieldGroup', (fieldGroup) => {
+  const defaultFieldGroupOptions = {
+    title: 'test field group',
+    state: 1,
+    language: '*',
+    context: '',
+    note: '',
+    description: '',
+    access: 1,
+    created: '2023-01-01 20:00:00',
+    modified: '2023-01-01 20:00:00',
+    params: '',
+  };
+
+  return cy.task('queryDB', createInsertQuery('fields_groups', { ...defaultFieldGroupOptions, ...fieldGroup })).then(async (info) => info.insertId);
+});
+
+/**
+ * Creates a tag in the database with the given data. The tag contains some default values when
+ * not all required fields are passed in the given data. The id of the inserted tag is returned.
+ *
+ * @param {Object} tag The tag data to insert
+ *
+ * @returns integer
+ */
+Cypress.Commands.add('db_createTag', (tag) => {
+  const defaultTagOptions = {
+    title: 'test tag',
+    alias: 'test-tag',
+    note: '',
+    description: '',
+    published: 1,
+    parent_id: 1,
+    level: 1,
+    path: 'test-tag',
+    access: 1,
+    lft: 1,
+    metadata: '',
+    metadesc: '',
+    checked_out: 0,
+    checked_out_time: '2023-01-01 20:00:00',
+    metakey: '',
+    urls: '',
+    created_time: '2023-01-01 20:00:00',
+    modified_time: '2023-01-01 20:00:00',
+    language: '*',
+    params: '',
+    images: '',
+  };
+
+  return cy.task('queryDB', createInsertQuery('tags', { ...defaultTagOptions, ...tag })).then(async (info) => info.insertId);
+});
+
+/**
+ * Creates an menu item in the database with the given data. The menu item contains some default values when
+ * not all required fields are passed in the given data. The id of the inserted menu item is returned.
+ *
+ * @param {Object} menuItemData The menu item data to insert
+ *
+ * @returns integerd
+ */
 Cypress.Commands.add('db_createMenuItem', (menuItemData) => {
   const defaultMenuItemOptions = {
     title: 'test menu item',
@@ -120,6 +335,14 @@ Cypress.Commands.add('db_createMenuItem', (menuItemData) => {
   });
 });
 
+/**
+ * Creates a module in the database with the given data. The module contains some default values when
+ * not all required fields are passed in the given data. The id of the inserted module is returned.
+ *
+ * @param {Object} moduleData The module data to insert
+ *
+ * @returns integer
+ */
 Cypress.Commands.add('db_createModule', (module) => {
   const defaultModuleOptions = {
     title: 'test module',
@@ -140,6 +363,14 @@ Cypress.Commands.add('db_createModule', (module) => {
     });
 });
 
+/**
+ * Creates a user in the database with the given data. The user contains some default values when
+ * not all required fields are passed in the given data. The id of the inserted user is returned.
+ *
+ * @param {Object} userData The user data to insert
+ *
+ * @returns integer
+ */
 Cypress.Commands.add('db_createUser', (userData) => {
   const defaultUserOptions = {
     name: 'test user',
@@ -162,128 +393,24 @@ Cypress.Commands.add('db_createUser', (userData) => {
   });
 });
 
-Cypress.Commands.add('db_createCategory', (category) => {
-  const defaultCategoryOptions = {
-    title: 'test category',
-    alias: 'test-category',
-    path: 'test-category',
-    extension: 'com_content',
-    published: 1,
-    access: 1,
-    params: '',
-    parent_id: 1,
-    level: 1,
-    lft: 1,
-    metadata: '',
-    metadesc: '',
-    created_time: '2023-01-01 20:00:00',
-    modified_time: '2023-01-01 20:00:00',
-  };
-
-  return cy.task('queryDB', createInsertQuery('categories', { ...defaultCategoryOptions, ...category })).then(async (info) => info.insertId);
-});
-
-Cypress.Commands.add('db_createFieldGroup', (fieldGroup) => {
-  const defaultFieldGroupOptions = {
-    title: 'test field group',
-    state: 1,
-    language: '*',
-    context: '',
-    note: '',
-    description: '',
-    access: 1,
-    created: '2023-01-01 20:00:00',
-    modified: '2023-01-01 20:00:00',
-    params: '',
-  };
-
-  return cy.task('queryDB', createInsertQuery('fields_groups', { ...defaultFieldGroupOptions, ...fieldGroup })).then(async (info) => info.insertId);
-});
-
-Cypress.Commands.add('db_createField', (field) => {
-  const defaultFieldOptions = {
-    title: 'test field',
-    name: 'test-field',
-    label: 'test field',
-    default_value: '',
-    note: '',
-    description: '',
-    group_id: 0,
-    type: 'text',
-    required: 1,
-    state: 1,
-    context: 'com_content.article',
-    access: 1,
-    language: '*',
-    created_time: '2023-01-01 20:00:00',
-    modified_time: '2023-01-01 20:00:00',
-    params: '',
-    fieldparams: '',
-  };
-
-  return cy.task('queryDB', createInsertQuery('fields', { ...defaultFieldOptions, ...field })).then(async (info) => info.insertId);
-});
-
-Cypress.Commands.add('db_createTag', (tag) => {
-  const defaultTagOptions = {
-    title: 'test tag',
-    alias: 'test-tag',
-    note: '',
-    description: '',
-    published: 1,
-    parent_id: 1,
-    level: 1,
-    path: 'test-tag',
-    access: 1,
-    lft: 1,
-    metadata: '',
-    metadesc: '',
-    checked_out: 0,
-    checked_out_time: '2023-01-01 20:00:00',
-    metakey: '',
-    urls: '',
-    created_time: '2023-01-01 20:00:00',
-    modified_time: '2023-01-01 20:00:00',
-    language: '*',
-    params: '',
-    images: '',
-  };
-
-  return cy.task('queryDB', createInsertQuery('tags', { ...defaultTagOptions, ...tag })).then(async (info) => info.insertId);
-});
-
-Cypress.Commands.add('db_createNewsFeed', (feed) => {
-  const defaultNewsfeedOptions = {
-    name: 'test feed',
-    alias: 'test-feed',
-    catid: 5,
-    link: '',
-    published: 1,
-    numarticles: 5,
-    checked_out: 0,
-    checked_out_time: '2023-01-01 20:00:00',
-    rtl: 0,
-    access: 1,
-    language: '*',
-    created: '2023-01-01 20:00:00',
-    modified: '2023-01-01 20:00:00',
-    metakey: '',
-    metadata: '',
-    metadesc: '',
-    description: '',
-    params: '',
-    images: '',
-  };
-
-  return cy.task('queryDB', createInsertQuery('newsfeeds', { ...defaultNewsfeedOptions, ...feed })).then(async (info) => info.insertId);
-});
-
+/**
+ * Sets the parameter for the given extension.
+ *
+ * @param {string} key The key
+ * @param {string} value The value
+ * @param {string} extension The extension
+ */
 Cypress.Commands.add('db_updateExtensionParameter', (key, value, extension) => cy.task('queryDB', `SELECT params FROM #__extensions WHERE name = '${extension}'`).then((paramsString) => {
   const params = JSON.parse(paramsString[0].params);
   params[key] = value;
   return cy.task('queryDB', `UPDATE #__extensions SET params = '${JSON.stringify(params)}' WHERE name = '${extension}'`);
 }));
 
+/**
+ * Returns the id of the currently logged in user.
+ *
+ * @returns integer
+ */
 Cypress.Commands.add('db_getUserId', () => {
   cy.task('queryDB', `SELECT id FROM #__users WHERE username = '${Cypress.env('username')}'`)
     .then((id) => {
@@ -294,3 +421,48 @@ Cypress.Commands.add('db_getUserId', () => {
       return id[0].id;
     });
 });
+
+/**
+ * The global cached default categories
+ */
+globalThis.joomlaCategories = [];
+
+/**
+ * Does return the default category id for the given extension with the name 'Uncategorized' from the default installation.
+ *
+ * The data is cached for performance reasons in the globalThis object
+ *
+ * @param {string} extension The extension
+ *
+ * @returns integer
+ */
+function getDefaultCategoryId(extension) {
+  if (globalThis.joomlaCategories[extension] !== undefined) {
+    return cy.wrap(globalThis.joomlaCategories[extension]);
+  }
+
+  return cy.task('queryDB', `SELECT id FROM #__categories where extension = '${extension}' AND title = 'Uncategorised' ORDER BY id ASC LIMIT 1`)
+    .then(async (data) => {
+      // Cache
+      globalThis.joomlaCategories[extension] = data[0].id;
+      return data[0].id;
+    });
+}
+
+/**
+ * Returns an insert query for the given database and fields.
+ *
+ * @param {string} table The DB table name
+ * @param {Object} values The values to insert
+ *
+ * @returns string
+ */
+function createInsertQuery(table, values) {
+  let query = `INSERT INTO #__${table} (\`${Object.keys(values).join('\`, \`')}\`) VALUES (:${Object.keys(values).join(',:')})`;
+
+  Object.keys(values).forEach((variable) => {
+    query = query.replace(`:${variable}`, `'${values[variable]}'`);
+  });
+
+  return query;
+}


### PR DESCRIPTION
### Summary of Changes
Does remove the hardcoded categories in the system tests. Additionally it does some restructure in the db tasks file to be more logic.

Is a preparation pr for #40733.