### PR TITLE
Replace the CMSObject state docs in views with Registry

### DIFF
--- a/administrator/components/com_associations/src/View/Association/HtmlView.php
+++ b/administrator/components/com_associations/src/View/Association/HtmlView.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Toolbar;
@@ -59,7 +58,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      *
      * @since  3.7.0
      */

--- a/administrator/components/com_banners/src/View/Client/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Client/HtmlView.php
@@ -53,7 +53,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  1.5
      */
     protected $state;

--- a/administrator/components/com_banners/src/View/Clients/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Clients/HtmlView.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -68,7 +67,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  1.6
      */
     protected $state;

--- a/administrator/components/com_banners/src/View/Tracks/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Tracks/HtmlView.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Toolbar;
@@ -69,7 +68,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  1.6
      */
     protected $state;

--- a/administrator/components/com_cache/src/View/Cache/HtmlView.php
+++ b/administrator/components/com_cache/src/View/Cache/HtmlView.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -74,7 +73,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  1.6
      */
     protected $state;

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -22,6 +22,7 @@ use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Associations\Administrator\Helper\AssociationsHelper;
+use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -51,7 +52,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_checkin/src/View/Checkin/HtmlView.php
+++ b/administrator/components/com_checkin/src/View/Checkin/HtmlView.php
@@ -45,7 +45,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_config/src/View/Application/HtmlView.php
+++ b/administrator/components/com_config/src/View/Application/HtmlView.php
@@ -32,7 +32,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      * @since  3.2
      */
     public $state;

--- a/administrator/components/com_config/src/View/Component/HtmlView.php
+++ b/administrator/components/com_config/src/View/Component/HtmlView.php
@@ -31,7 +31,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      * @since  3.2
      */
     public $state;

--- a/administrator/components/com_contact/src/View/Contact/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contact/HtmlView.php
@@ -48,7 +48,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_contact/src/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contacts/HtmlView.php
@@ -48,7 +48,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -58,7 +58,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The actions the user is authorised to perform
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $canDo;
 

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -51,7 +51,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var   \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_content/src/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/src/View/Featured/HtmlView.php
@@ -51,7 +51,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_contenthistory/src/View/Compare/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/Compare/HtmlView.php
@@ -34,7 +34,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_contenthistory/src/View/History/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/History/HtmlView.php
@@ -48,7 +48,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_contenthistory/src/View/Preview/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/Preview/HtmlView.php
@@ -35,7 +35,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_fields/src/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Fields/HtmlView.php
@@ -64,7 +64,7 @@ class HtmlView extends BaseHtmlView
     protected $pagination;
 
     /**
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      *
      * @since  3.7.0
      */

--- a/administrator/components/com_fields/src/View/Group/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Group/HtmlView.php
@@ -47,7 +47,7 @@ class HtmlView extends BaseHtmlView
     protected $item;
 
     /**
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      *
      * @since  3.7.0
      */

--- a/administrator/components/com_fields/src/View/Groups/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Groups/HtmlView.php
@@ -64,7 +64,7 @@ class HtmlView extends BaseHtmlView
     protected $pagination;
 
     /**
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      *
      * @since  3.7.0
      */

--- a/administrator/components/com_finder/src/View/Filter/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Filter/HtmlView.php
@@ -60,7 +60,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      *
      * @since  3.6.2
      */

--- a/administrator/components/com_finder/src/View/Filters/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Filters/HtmlView.php
@@ -50,7 +50,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      *
      * @since  3.6.1
      */

--- a/administrator/components/com_finder/src/View/Maps/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Maps/HtmlView.php
@@ -51,7 +51,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      *
      * @since  3.6.1
      */

--- a/administrator/components/com_finder/src/View/Searches/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Searches/HtmlView.php
@@ -56,7 +56,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_guidedtours/src/View/Steps/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Steps/HtmlView.php
@@ -47,7 +47,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var \Joomla\CMS\Object\CMSObject
+     * @var \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_guidedtours/src/View/Tours/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Tours/HtmlView.php
@@ -47,7 +47,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var \Joomla\CMS\Object\CMSObject
+     * @var \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_installer/src/View/Installer/HtmlView.php
+++ b/administrator/components/com_installer/src/View/Installer/HtmlView.php
@@ -31,7 +31,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      *
      * @since  4.0.0
      */

--- a/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
@@ -67,7 +67,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      *
      * @since  4.0.0
      */

--- a/administrator/components/com_languages/src/View/Installed/HtmlView.php
+++ b/administrator/components/com_languages/src/View/Installed/HtmlView.php
@@ -52,7 +52,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      *
      * @since  4.0.0
      */

--- a/administrator/components/com_languages/src/View/Language/HtmlView.php
+++ b/administrator/components/com_languages/src/View/Language/HtmlView.php
@@ -47,7 +47,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     public $state;
 

--- a/administrator/components/com_languages/src/View/Languages/HtmlView.php
+++ b/administrator/components/com_languages/src/View/Languages/HtmlView.php
@@ -46,7 +46,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      *
      * @since  4.0.0
      */

--- a/administrator/components/com_mails/src/View/Templates/HtmlView.php
+++ b/administrator/components/com_mails/src/View/Templates/HtmlView.php
@@ -63,7 +63,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_menus/src/View/Item/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Item/HtmlView.php
@@ -54,7 +54,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var   CMSObject
+     * @var   \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_menus/src/View/Items/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Items/HtmlView.php
@@ -56,7 +56,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_menus/src/View/Menu/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menu/HtmlView.php
@@ -47,7 +47,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_menus/src/View/Menu/XmlView.php
+++ b/administrator/components/com_menus/src/View/Menu/XmlView.php
@@ -36,7 +36,7 @@ class XmlView extends BaseHtmlView
     protected $items;
 
     /**
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      *
      * @since  3.8.0
      */

--- a/administrator/components/com_menus/src/View/Menus/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menus/HtmlView.php
@@ -52,7 +52,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_messages/src/View/Config/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Config/HtmlView.php
@@ -45,7 +45,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_messages/src/View/Message/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Message/HtmlView.php
@@ -46,7 +46,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_messages/src/View/Messages/HtmlView.php
+++ b/administrator/components/com_messages/src/View/Messages/HtmlView.php
@@ -46,7 +46,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_modules/src/View/Module/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Module/HtmlView.php
@@ -46,7 +46,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_modules/src/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Modules/HtmlView.php
@@ -49,7 +49,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_modules/src/View/Select/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Select/HtmlView.php
@@ -31,7 +31,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -52,7 +52,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state of the newsfeed
      *
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      *
      * @since  1.6
      */

--- a/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeeds/HtmlView.php
@@ -53,7 +53,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      *
      * @since  1.6
      */

--- a/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
@@ -47,7 +47,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state of the newsfeed
      *
-     * @var   CMSObject
+     * @var   \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_plugins/src/View/Plugins/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugins/HtmlView.php
@@ -45,7 +45,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var   \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_privacy/src/View/Capabilities/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Capabilities/HtmlView.php
@@ -13,7 +13,6 @@ namespace Joomla\Component\Privacy\Administrator\View\Capabilities;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
@@ -39,7 +38,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The state information
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  3.9.0
      */
     protected $state;

--- a/administrator/components/com_privacy/src/View/Consents/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Consents/HtmlView.php
@@ -68,7 +68,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The state information
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  3.9.0
      */
     protected $state;

--- a/administrator/components/com_privacy/src/View/Request/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Request/HtmlView.php
@@ -60,7 +60,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The state information
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  3.9.0
      */
     protected $state;

--- a/administrator/components/com_privacy/src/View/Requests/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Requests/HtmlView.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -78,7 +77,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The state information
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  3.9.0
      */
     protected $state;

--- a/administrator/components/com_redirect/src/View/Link/HtmlView.php
+++ b/administrator/components/com_redirect/src/View/Link/HtmlView.php
@@ -46,7 +46,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var   \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_redirect/src/View/Links/HtmlView.php
+++ b/administrator/components/com_redirect/src/View/Links/HtmlView.php
@@ -71,7 +71,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_scheduler/src/View/Select/HtmlView.php
+++ b/administrator/components/com_scheduler/src/View/Select/HtmlView.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Scheduler\Administrator\Task\TaskOption;
@@ -41,7 +40,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      * @since  4.1.0
      */
     protected $state;

--- a/administrator/components/com_scheduler/src/View/Task/HtmlView.php
+++ b/administrator/components/com_scheduler/src/View/Task/HtmlView.php
@@ -56,7 +56,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var CMSObject
+     * @var \Joomla\Registry\Registry
      * @since  4.1.0
      */
     protected $state;

--- a/administrator/components/com_scheduler/src/View/Tasks/HtmlView.php
+++ b/administrator/components/com_scheduler/src/View/Tasks/HtmlView.php
@@ -53,7 +53,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state.
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  4.1.0
      */
     protected $state;

--- a/administrator/components/com_tags/src/View/Tag/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tag/HtmlView.php
@@ -48,7 +48,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_tags/src/View/Tags/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tags/HtmlView.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -49,7 +48,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var   CMSObject
+     * @var   \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_templates/src/View/Style/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Style/HtmlView.php
@@ -47,7 +47,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_templates/src/View/Style/JsonView.php
+++ b/administrator/components/com_templates/src/View/Style/JsonView.php
@@ -42,7 +42,7 @@ class JsonView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var   CMSObject
+     * @var   \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_templates/src/View/Styles/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Styles/HtmlView.php
@@ -46,7 +46,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\Toolbar;
@@ -37,7 +36,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The Model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_users/src/View/Debuggroup/HtmlView.php
+++ b/administrator/components/com_users/src/View/Debuggroup/HtmlView.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
@@ -56,7 +55,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state.
      *
-     * @var   CMSObject
+     * @var   \Joomla\Registry\Registry
      * @since 1.6
      */
     protected $state;

--- a/administrator/components/com_users/src/View/Debuguser/HtmlView.php
+++ b/administrator/components/com_users/src/View/Debuguser/HtmlView.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\CMS\User\User;
@@ -57,7 +56,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state.
      *
-     * @var   CMSObject
+     * @var   \Joomla\Registry\Registry
      * @since 1.6
      */
     protected $state;

--- a/administrator/components/com_users/src/View/Group/HtmlView.php
+++ b/administrator/components/com_users/src/View/Group/HtmlView.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
@@ -48,7 +47,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state.
      *
-     * @var   CMSObject
+     * @var   \Joomla\Registry\Registry
      * @since 1.6
      */
     protected $state;

--- a/administrator/components/com_users/src/View/Groups/HtmlView.php
+++ b/administrator/components/com_users/src/View/Groups/HtmlView.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
@@ -48,7 +47,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state.
      *
-     * @var   CMSObject
+     * @var   \Joomla\Registry\Registry
      * @since 1.6
      */
     protected $state;

--- a/administrator/components/com_users/src/View/Level/HtmlView.php
+++ b/administrator/components/com_users/src/View/Level/HtmlView.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
@@ -48,7 +47,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state.
      *
-     * @var   CMSObject
+     * @var   \Joomla\Registry\Registry
      * @since 1.6
      */
     protected $state;

--- a/administrator/components/com_users/src/View/Levels/HtmlView.php
+++ b/administrator/components/com_users/src/View/Levels/HtmlView.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
@@ -48,7 +47,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state.
      *
-     * @var   CMSObject
+     * @var   \Joomla\Registry\Registry
      * @since 1.6
      */
     protected $state;

--- a/administrator/components/com_users/src/View/Note/HtmlView.php
+++ b/administrator/components/com_users/src/View/Note/HtmlView.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
@@ -51,7 +50,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state.
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  2.5
      */
     protected $state;

--- a/administrator/components/com_users/src/View/Notes/HtmlView.php
+++ b/administrator/components/com_users/src/View/Notes/HtmlView.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
@@ -51,7 +50,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state.
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  2.5
      */
     protected $state;

--- a/administrator/components/com_users/src/View/User/HtmlView.php
+++ b/administrator/components/com_users/src/View/User/HtmlView.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\CMS\User\UserFactoryAwareInterface;
@@ -67,7 +66,7 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/administrator/components/com_users/src/View/Users/HtmlView.php
+++ b/administrator/components/com_users/src/View/Users/HtmlView.php
@@ -51,7 +51,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state.
      *
-     * @var   CMSObject
+     * @var   \Joomla\Registry\Registry
      * @since 1.6
      */
     protected $state;

--- a/components/com_content/src/View/Archive/HtmlView.php
+++ b/components/com_content/src/View/Archive/HtmlView.php
@@ -31,7 +31,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var   \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      */
     protected $state = null;
 

--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -62,7 +62,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var   \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -31,7 +31,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state = null;
 

--- a/components/com_content/src/View/Form/HtmlView.php
+++ b/components/com_content/src/View/Form/HtmlView.php
@@ -53,7 +53,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -58,7 +58,7 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
     /**
      * The model state
      *
-     * @var  \Joomla\CMS\Object\CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/components/com_privacy/src/View/Confirm/HtmlView.php
+++ b/components/com_privacy/src/View/Confirm/HtmlView.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -56,7 +55,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The state information
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  3.9.0
      */
     protected $state;

--- a/components/com_privacy/src/View/Remind/HtmlView.php
+++ b/components/com_privacy/src/View/Remind/HtmlView.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -56,7 +55,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The state information
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  3.9.0
      */
     protected $state;

--- a/components/com_privacy/src/View/Request/HtmlView.php
+++ b/components/com_privacy/src/View/Request/HtmlView.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -64,7 +63,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The state information
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      * @since  3.9.0
      */
     protected $state;

--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -34,7 +34,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    CMSObject
+     * @var    \Joomla\Registry\Registry
      *
      * @since  3.1
      */

--- a/components/com_tags/src/View/Tags/HtmlView.php
+++ b/components/com_tags/src/View/Tags/HtmlView.php
@@ -31,7 +31,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var    \Joomla\CMS\Object\CMSObject
+     * @var   \Joomla\Registry\Registry
      *
      * @since  3.1
      */

--- a/components/com_users/src/View/Login/HtmlView.php
+++ b/components/com_users/src/View/Login/HtmlView.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Helper\AuthenticationHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\User\User;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -46,7 +45,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -56,7 +56,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/components/com_users/src/View/Registration/HtmlView.php
+++ b/components/com_users/src/View/Registration/HtmlView.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -53,7 +52,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/components/com_users/src/View/Remind/HtmlView.php
+++ b/components/com_users/src/View/Remind/HtmlView.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -44,7 +43,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/components/com_users/src/View/Reset/HtmlView.php
+++ b/components/com_users/src/View/Reset/HtmlView.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -44,7 +43,7 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 

--- a/libraries/src/MVC/Controller/ApiController.php
+++ b/libraries/src/MVC/Controller/ApiController.php
@@ -78,7 +78,7 @@ class ApiController extends BaseController
     /**
      * The model state to inject
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $modelState;
 

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -46,7 +46,7 @@ class ListView extends HtmlView
     /**
      * The model state
      *
-     * @var  CMSObject
+     * @var  \Joomla\Registry\Registry
      */
     protected $state;
 


### PR DESCRIPTION
### Summary of Changes
Followup pr from #39663 which replaces the docs of the state variable in views to `Registry`.