### PR TITLE
[4.4] Update deleted files list in script.php for 4.4.0-alpha2

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6624,6 +6624,10 @@ class JoomlaInstallerScript
             '/plugins/workflow/featuring/featuring.php',
             '/plugins/workflow/notification/notification.php',
             '/plugins/workflow/publishing/publishing.php',
+            // From 4.4.0-alpha1 to 4.4.0-alpha2
+            '/libraries/vendor/jfcherng/php-diff/src/languages/readme.txt',
+            '/plugins/editors-xtd/pagebreak/pagebreak.php',
+
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in file "administrator/components/com_admin/script.php" to recent changes in the 4.4-dev branch in preparation for the first 4.4.0-alpha2 release.

In detail deleted files from following PR's are added:

- PR #40743 file
'/plugins/editors-xtd/pagebreak/pagebreak.php',
- PR #40783 file
'/libraries/vendor/jfcherng/php-diff/src/languages/readme.txt',

### Testing Instructions

Code review.

Or if you want to make a real test, update a 4.3.2 or recent 4.3 nightly build or 4.4.0-alpha1 to the last 4.4 nightly build to get the actual result, and update a 4.3.2 or recent 4.3 nightly build or 4.4.0-alpha1 to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

The files mentioned above are still present after updating from a 4.3.2 or recent 4.3 nightly build or 4.4.0-alpha1.

### Expected result AFTER applying this Pull Request

The files mentioned above have been deleted after updating from a 4.3.2 or recent 4.3 nightly build or 4.4.0-alpha1.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
