### PR TITLE
[5.0] Fix tinymce highlight plugin after removing es5

### DIFF
--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -318,7 +318,7 @@ trait DisplayTrait
 
         // Use CodeMirror in the code view instead of plain text to provide syntax highlighting
         if ($levelParams->get('sourcecode', 1)) {
-            $externalPlugins['highlightPlus'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/highlighter/plugin-es5.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
+            $externalPlugins['highlightPlus'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/highlighter/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
         }
 
         $dragdrop = $levelParams->get('drag_drop', 1);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix tinymce highlight plugin after removing es5


### Testing Instructions

Run npm install, check tinymce editor


### Actual result BEFORE applying this Pull Request
Broken


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed

ref #39618