### PR TITLE
[5.0] Remove obsolete use of es5 script from quickicon admin module

### DIFF
--- a/administrator/modules/mod_quickicon/tmpl/default.php
+++ b/administrator/modules/mod_quickicon/tmpl/default.php
@@ -18,7 +18,6 @@ $wa = $app->getDocument()->getWebAssetManager();
 $wa->useScript('core')
     ->useScript('bootstrap.dropdown');
 $wa->registerAndUseScript('mod_quickicon', 'mod_quickicon/quickicon.min.js', ['relative' => true, 'version' => 'auto'], ['type' => 'module']);
-$wa->registerAndUseScript('mod_quickicon-es5', 'mod_quickicon/quickicon-es5.min.js', ['relative' => true, 'version' => 'auto'], ['nomodule' => true, 'defer' => true]);
 
 $html = HTMLHelper::_('icons.buttons', $buttons);
 ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) removes the `$wa->registerAndUseScript` call in the quickicon admin module's default template for loading the "quickicon-es5.min.js" script, since that script doesn't exist anymore since PR #39618 has been merged.

### Testing Instructions

Code review, and check that the quickicons module still works with option "Show items with count" switched on.

### Actual result BEFORE applying this Pull Request

The quickicon admin module's default template contains an obsolete call to `$wa->registerAndUseScript` for loading the "quickicon-es5.min.js" script.

### Expected result AFTER applying this Pull Request

The quickicon admin module's default template doesn't contain an obsolete call to `$wa->registerAndUseScript` for loading the "quickicon-es5.min.js" script.

The module still works as well as before.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
