### PR TITLE
[5.0] Remove annoying "user not found" message

### DIFF
--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -856,8 +856,6 @@ class User
             // Reset to guest user
             $this->guest = 1;
 
-            Log::add(Text::sprintf('JLIB_USER_ERROR_UNABLE_TO_LOAD_USER', $id), Log::WARNING, 'jerror');
-
             return false;
         }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Remove annoying "user not found" message. That show up every time when open list of content that created by removed user.


### Testing Instructions
Apply patch.
Create testing user.
Create an article with this user.
Delete testing user.
Open just created article to edit.


### Actual result BEFORE applying this Pull Request
Message, kind of "cannot load X user"


### Expected result AFTER applying this Pull Request
No message


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
