### PR TITLE
[5.0] Custom system error page

### DIFF
--- a/templates/system/error.php
+++ b/templates/system/error.php
@@ -30,6 +30,8 @@ if ($this->direction === 'rtl') {
 // Set page title
 $this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'));
 
+// Get the error code
+$errorCode = $this->error->getCode();
 ?>
 <!DOCTYPE html>
 <html lang="<?php echo $this->language; ?>" dir="<?php echo $this->direction; ?>">
@@ -42,6 +44,9 @@ $this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error-
     <div class="error">
         <div id="outline">
         <div id="errorboxoutline">
+            <?php if ($this->countModules('error-' . $errorCode)): ?>
+                    <jdoc:include type="modules" name="error-<?php echo $errorCode; ?>" style="none" />
+            <?php else: ?>
             <div id="errorboxheader"><?php echo $this->error->getCode(); ?> - <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?></div>
             <div id="errorboxbody">
             <p><strong><?php echo Text::_('JERROR_LAYOUT_NOT_ABLE_TO_VISIT'); ?></strong></p>
@@ -58,6 +63,7 @@ $this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error-
                 <li><a href="<?php echo Uri::root(true); ?>/index.php"><?php echo Text::_('JERROR_LAYOUT_HOME_PAGE'); ?></a></li>
             </ul>
             <p><?php echo Text::_('JERROR_LAYOUT_PLEASE_CONTACT_THE_SYSTEM_ADMINISTRATOR'); ?></p>
+            <?php endif; ?>
             <div id="techinfo">
             <p>
                 <?php echo htmlspecialchars($this->error->getMessage(), ENT_QUOTES, 'UTF-8'); ?>
@@ -93,7 +99,6 @@ $this->setTitle($this->error->getCode() . ' - ' . htmlspecialchars($this->error-
         </div>
         </div>
     </div>
-
     <jdoc:include type="modules" name="debug" style="none" />
 </body>
 </html>


### PR DESCRIPTION
### Summary of Changes
Adds a module position to the error.php page of system template so that you can customise the 404 page without having to change language strings or asking the user to modify the error.php (which they will lose on update)

This is fully backwards compatible as the existing error page text is displayed if there is no module. If debug is enabled then the debug information is still displayed

In theory the error.php is used by joomla for all error codes so this PR is able to display a specific module for each error code.

This system error.php is only displayed if the site template does not have its own error.php

### Testing Instructions
Apply the PR
Create a new module (custom html is probably the most useful) and publish in the new position error-404
Rename/delete the cassiopeia error.php file so that this system file will be used
Go to a fake page on your site and you will see the 404 page with your new module
Unpublish the module and repeat and you will see the original 404 page with the language strings

