### PR TITLE
[5.0] Return a registry in button plugins

### DIFF
--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -244,7 +244,7 @@ class Editor implements DispatcherAwareInterface
                 continue;
             }
 
-            $button->editor = $editor;
+            $button->set('editor', $editor);
 
             $result[] = $button;
         }

--- a/plugins/editors-xtd/article/src/Extension/Article.php
+++ b/plugins/editors-xtd/article/src/Extension/Article.php
@@ -11,9 +11,10 @@
 namespace Joomla\Plugin\EditorsXtd\Article\Extension;
 
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
+use Joomla\Registry\Registry;
+use stdClass;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -39,7 +40,7 @@ final class Article extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  CMSObject|void  The button options as CMSObject, void if ACL check fails.
+     * @return  stdClass|void  The button options as stdClass, void if ACL check fails.
      *
      * @since   1.5
      */
@@ -64,7 +65,7 @@ final class Article extends CMSPlugin
         $link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;'
             . Session::getFormToken() . '=1&amp;editor=' . $name;
 
-        $button          = new CMSObject();
+        $button          = new stdClass();
         $button->modal   = true;
         $button->link    = $link;
         $button->text    = Text::_('PLG_ARTICLE_BUTTON_ARTICLE');
@@ -79,6 +80,6 @@ final class Article extends CMSPlugin
             'modalWidth' => '80',
         ];
 
-        return $button;
+        return new Registry($button);
     }
 }

--- a/plugins/editors-xtd/article/src/Extension/Article.php
+++ b/plugins/editors-xtd/article/src/Extension/Article.php
@@ -40,7 +40,7 @@ final class Article extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  stdClass|void  The button options as stdClass, void if ACL check fails.
+     * @return  Registry|void  The button options as stdClass, void if ACL check fails.
      *
      * @since   1.5
      */

--- a/plugins/editors-xtd/article/src/Extension/Article.php
+++ b/plugins/editors-xtd/article/src/Extension/Article.php
@@ -40,7 +40,7 @@ final class Article extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  Registry|void  The button options as stdClass, void if ACL check fails.
+     * @return  Registry|void  The button options as Registry, void if ACL check fails.
      *
      * @since   1.5
      */

--- a/plugins/editors-xtd/contact/src/Extension/Contact.php
+++ b/plugins/editors-xtd/contact/src/Extension/Contact.php
@@ -11,9 +11,10 @@
 namespace Joomla\Plugin\EditorsXtd\Contact\Extension;
 
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
+use Joomla\Registry\Registry;
+use stdClass;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -39,7 +40,7 @@ final class Contact extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  CMSObject|void  The button options as CMSObject
+     * @return  stdClass|void  The button options as stdClass
      *
      * @since   3.7.0
      */
@@ -56,7 +57,7 @@ final class Contact extends CMSPlugin
             $link = 'index.php?option=com_contact&amp;view=contacts&amp;layout=modal&amp;tmpl=component&amp;'
                 . Session::getFormToken() . '=1&amp;editor=' . $name;
 
-            $button          = new CMSObject();
+            $button          = new stdClass();
             $button->modal   = true;
             $button->link    = $link;
             $button->text    = Text::_('PLG_EDITORS-XTD_CONTACT_BUTTON_CONTACT');
@@ -70,13 +71,13 @@ final class Contact extends CMSPlugin
                             . '</path></svg>';
 
             $button->options = [
-            'height'     => '300px',
-            'width'      => '800px',
-            'bodyHeight' => '70',
-            'modalWidth' => '80',
+                'height'     => '300px',
+                'width'      => '800px',
+                'bodyHeight' => '70',
+                'modalWidth' => '80',
             ];
 
-            return $button;
+            return new Registry($button);
         }
     }
 }

--- a/plugins/editors-xtd/contact/src/Extension/Contact.php
+++ b/plugins/editors-xtd/contact/src/Extension/Contact.php
@@ -40,7 +40,7 @@ final class Contact extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  stdClass|void  The button options as stdClass
+     * @return  Registry|void  The button options as Registry
      *
      * @since   3.7.0
      */

--- a/plugins/editors-xtd/fields/src/Extension/Fields.php
+++ b/plugins/editors-xtd/fields/src/Extension/Fields.php
@@ -41,7 +41,7 @@ final class Fields extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  stdClass|void  The button options as stdClass
+     * @return  Registry|void  The button options as Registry
      *
      * @since  3.7.0
      */

--- a/plugins/editors-xtd/fields/src/Extension/Fields.php
+++ b/plugins/editors-xtd/fields/src/Extension/Fields.php
@@ -12,9 +12,10 @@ namespace Joomla\Plugin\EditorsXtd\Fields\Extension;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
+use Joomla\Registry\Registry;
+use stdClass;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -40,7 +41,7 @@ final class Fields extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  CMSObject|void  The button options as CMSObject
+     * @return  stdClass|void  The button options as stdClass
      *
      * @since  3.7.0
      */
@@ -63,7 +64,7 @@ final class Fields extends CMSPlugin
         $link = 'index.php?option=com_fields&amp;view=fields&amp;layout=modal&amp;tmpl=component&amp;context='
             . $context . '&amp;editor=' . $name . '&amp;' . Session::getFormToken() . '=1';
 
-        $button          = new CMSObject();
+        $button          = new stdClass();
         $button->modal   = true;
         $button->link    = $link;
         $button->text    = Text::_('PLG_EDITORS-XTD_FIELDS_BUTTON_FIELD');
@@ -83,6 +84,6 @@ final class Fields extends CMSPlugin
             'modalWidth' => '80',
         ];
 
-        return $button;
+        return new Registry($button);
     }
 }

--- a/plugins/editors-xtd/image/src/Extension/Image.php
+++ b/plugins/editors-xtd/image/src/Extension/Image.php
@@ -12,9 +12,10 @@ namespace Joomla\Plugin\EditorsXtd\Image\Extension;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Registry\Registry;
+use stdClass;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -42,7 +43,7 @@ final class Image extends CMSPlugin
      * @param   string   $asset   The name of the asset being edited.
      * @param   integer  $author  The id of the author owning the asset being edited.
      *
-     * @return  CMSObject|false
+     * @return  stdClass|false
      *
      * @since   1.5
      */
@@ -147,7 +148,7 @@ final class Image extends CMSPlugin
 
             $link = 'index.php?option=com_media&view=media&tmpl=component&e_name=' . $name . '&asset=' . $asset . '&mediatypes=0,1,2,3' . '&author=' . $author;
 
-            $button          = new CMSObject();
+            $button          = new stdClass();
             $button->modal   = true;
             $button->link    = $link;
             $button->text    = Text::_('PLG_IMAGE_BUTTON_IMAGE');
@@ -168,7 +169,7 @@ final class Image extends CMSPlugin
                 'confirmText'     => Text::_('PLG_IMAGE_BUTTON_INSERT'),
             ];
 
-            return $button;
+            return new Registry($button);
         }
 
         return false;

--- a/plugins/editors-xtd/image/src/Extension/Image.php
+++ b/plugins/editors-xtd/image/src/Extension/Image.php
@@ -43,7 +43,7 @@ final class Image extends CMSPlugin
      * @param   string   $asset   The name of the asset being edited.
      * @param   integer  $author  The id of the author owning the asset being edited.
      *
-     * @return  stdClass|false
+     * @return  Registry|false
      *
      * @since   1.5
      */

--- a/plugins/editors-xtd/menu/src/Extension/Menu.php
+++ b/plugins/editors-xtd/menu/src/Extension/Menu.php
@@ -11,9 +11,10 @@
 namespace Joomla\Plugin\EditorsXtd\Menu\Extension;
 
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
+use Joomla\Registry\Registry;
+use stdClass;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -40,7 +41,7 @@ final class Menu extends CMSPlugin
      * @param   string  $name  The name of the button to add
      *
      * @since  3.7.0
-     * @return CMSObject
+     * @return stdClass
      */
     public function onDisplay($name)
     {
@@ -57,7 +58,7 @@ final class Menu extends CMSPlugin
             $link = 'index.php?option=com_menus&amp;view=items&amp;layout=modal&amp;tmpl=component&amp;'
             . Session::getFormToken() . '=1&amp;editor=' . $name;
 
-            $button          = new CMSObject();
+            $button          = new stdClass();
             $button->modal   = true;
             $button->link    = $link;
             $button->text    = Text::_('PLG_EDITORS-XTD_MENU_BUTTON_MENU');
@@ -77,7 +78,7 @@ final class Menu extends CMSPlugin
             'modalWidth' => '80',
             ];
 
-            return $button;
+            return new Registry($button);
         }
     }
 }

--- a/plugins/editors-xtd/menu/src/Extension/Menu.php
+++ b/plugins/editors-xtd/menu/src/Extension/Menu.php
@@ -41,7 +41,7 @@ final class Menu extends CMSPlugin
      * @param   string  $name  The name of the button to add
      *
      * @since  3.7.0
-     * @return stdClass
+     * @return Registry
      */
     public function onDisplay($name)
     {

--- a/plugins/editors-xtd/module/src/Extension/Module.php
+++ b/plugins/editors-xtd/module/src/Extension/Module.php
@@ -11,9 +11,10 @@
 namespace Joomla\Plugin\EditorsXtd\Module\Extension;
 
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
+use Joomla\Registry\Registry;
+use stdClass;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -39,7 +40,7 @@ final class Module extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  CMSObject|void  The button options as CMSObject
+     * @return  stdClass|void  The button options as stdClass
      *
      * @since   3.5
      */
@@ -58,7 +59,7 @@ final class Module extends CMSPlugin
         ) {
             $link = 'index.php?option=com_modules&amp;view=modules&amp;layout=modal&amp;tmpl=component&amp;editor='
                     . $name . '&amp;' . Session::getFormToken() . '=1';
-            $button          = new CMSObject();
+            $button          = new stdClass();
             $button->modal   = true;
             $button->link    = $link;
             $button->text    = Text::_('PLG_MODULE_BUTTON_MODULE');
@@ -75,7 +76,7 @@ final class Module extends CMSPlugin
                 'modalWidth' => '80',
             ];
 
-            return $button;
+            return new Registry($button);
         }
     }
 }

--- a/plugins/editors-xtd/module/src/Extension/Module.php
+++ b/plugins/editors-xtd/module/src/Extension/Module.php
@@ -40,7 +40,7 @@ final class Module extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  stdClass|void  The button options as stdClass
+     * @return  Registry|void  The button options as Registry
      *
      * @since   3.5
      */

--- a/plugins/editors-xtd/pagebreak/src/Extension/PageBreak.php
+++ b/plugins/editors-xtd/pagebreak/src/Extension/PageBreak.php
@@ -39,7 +39,7 @@ final class PageBreak extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  stdClass|void  The button options as stdClass
+     * @return  Registry|void  The button options as Registry
      *
      * @since   1.5
      */

--- a/plugins/editors-xtd/pagebreak/src/Extension/PageBreak.php
+++ b/plugins/editors-xtd/pagebreak/src/Extension/PageBreak.php
@@ -11,8 +11,9 @@
 namespace Joomla\Plugin\EditorsXtd\PageBreak\Extension;
 
 use Joomla\CMS\Application\CMSWebApplicationInterface;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Registry\Registry;
+use stdClass;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -38,7 +39,7 @@ final class PageBreak extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  CMSObject|void  The button options as CMSObject
+     * @return  stdClass|void  The button options as stdClass
      *
      * @since   1.5
      */
@@ -69,7 +70,7 @@ final class PageBreak extends CMSPlugin
         $app->getDocument()->addScriptOptions('xtd-pagebreak', ['editor' => $name]);
         $link = 'index.php?option=com_content&amp;view=article&amp;layout=pagebreak&amp;tmpl=component&amp;e_name=' . $name;
 
-        $button          = new CMSObject();
+        $button          = new stdClass();
         $button->modal   = true;
         $button->link    = $link;
         $button->text    = $app->getLanguage()->_('PLG_EDITORSXTD_PAGEBREAK_BUTTON_PAGEBREAK');
@@ -85,6 +86,6 @@ final class PageBreak extends CMSPlugin
             'modalWidth' => '80',
         ];
 
-        return $button;
+        return new Registry($button);
     }
 }

--- a/plugins/editors-xtd/readmore/src/Extension/ReadMore.php
+++ b/plugins/editors-xtd/readmore/src/Extension/ReadMore.php
@@ -11,8 +11,9 @@
 namespace Joomla\Plugin\EditorsXtd\ReadMore\Extension;
 
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\Registry\Registry;
+use stdClass;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -38,7 +39,7 @@ final class ReadMore extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  CMSObject  $button  A two element array of (imageName, textToInsert)
+     * @return  stdClass  $button  A two element array of (imageName, textToInsert)
      *
      * @since   1.5
      */
@@ -56,7 +57,7 @@ final class ReadMore extends CMSPlugin
             ]
         );
 
-        $button          = new CMSObject();
+        $button          = new stdClass();
         $button->modal   = false;
         $button->onclick = 'insertReadmore(\'' . $name . '\');return false;';
         $button->text    = Text::_('PLG_READMORE_BUTTON_READMORE');
@@ -65,6 +66,6 @@ final class ReadMore extends CMSPlugin
         $button->iconSVG = '<svg viewBox="0 0 32 32" width="24" height="24"><path d="M32 12l-6-6-10 10-10-10-6 6 16 16z"></path></svg>';
         $button->link    = '#';
 
-        return $button;
+        return new Registry($button);
     }
 }

--- a/plugins/editors-xtd/readmore/src/Extension/ReadMore.php
+++ b/plugins/editors-xtd/readmore/src/Extension/ReadMore.php
@@ -39,7 +39,7 @@ final class ReadMore extends CMSPlugin
      *
      * @param   string  $name  The name of the button to add
      *
-     * @return  stdClass  $button  A two element array of (imageName, textToInsert)
+     * @return  Registry  $button  A two element array of (imageName, textToInsert)
      *
      * @since   1.5
      */

--- a/plugins/editors/tinymce/src/PluginTraits/XTDButtons.php
+++ b/plugins/editors/tinymce/src/PluginTraits/XTDButtons.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Event\Event;
-use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;

--- a/plugins/editors/tinymce/src/PluginTraits/XTDButtons.php
+++ b/plugins/editors/tinymce/src/PluginTraits/XTDButtons.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Event\Event;
+use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -58,7 +59,7 @@ trait XTDButtons
 
             // Build the script
             foreach ($buttons as $i => $button) {
-                $button->id = $name . '_' . $button->name . '_modal';
+                $button->set('id', $name . '_' . $button->get('name') . '_modal');
 
                 echo LayoutHelper::render('joomla.editors.buttons.modal', $button);
 
@@ -66,7 +67,7 @@ trait XTDButtons
                     $coreButton            = [];
                     $coreButton['name']    = $button->get('text');
                     $coreButton['href']    = $button->get('link') !== '#' ? Uri::base() . $button->get('link') : null;
-                    $coreButton['id']      = $name . '_' . $button->name;
+                    $coreButton['id']      = $name . '_' . $button->get('name');
                     $coreButton['icon']    = $button->get('icon');
                     $coreButton['click']   = $button->get('onclick') ?: null;
                     $coreButton['iconSVG'] = $button->get('iconSVG');

--- a/tests/Unit/Plugin/EditorsXtd/PageBreak/Extension/PageBreakTest.php
+++ b/tests/Unit/Plugin/EditorsXtd/PageBreak/Extension/PageBreakTest.php
@@ -55,9 +55,9 @@ class PageBreakTest extends UnitTestCase
         $button = $plugin->onDisplay('test');
 
         $this->assertNotNull($button);
-        $this->assertNotEmpty($button->name);
-        $this->assertNotEmpty($button->link);
-        $this->assertNotEmpty($button->options);
+        $this->assertNotEmpty($button->get('name'));
+        $this->assertNotEmpty($button->get('link'));
+        $this->assertNotEmpty($button->get('options'));
     }
 
     /**


### PR DESCRIPTION
### Summary of Changes
Editor buttons should return a `Registry` object instead of `CMSObject`. `CMSObject` buttons are still supported.

### Testing Instructions
Open the article form and add some images though the  editor buttons or a readmore divider.

### Actual result BEFORE applying this Pull Request
All works.

### Expected result AFTER applying this Pull Request
All works.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
