### PR TITLE
[5.0] Fix uninstalling the demo tasks plugin on update

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -756,8 +756,6 @@ class JoomlaInstallerScript
             '/plugins/system/webauthn/src/Hotfix/FidoU2FAttestationStatementSupport.php',
             '/plugins/system/webauthn/src/Hotfix/Server.php',
             // From 5.0.0-alpha1 to 5.0.0-alpha2
-            '/administrator/language/en-GB/plg_task_demotasks.ini',
-            '/administrator/language/en-GB/plg_task_demotasks.sys.ini',
             '/libraries/vendor/jfcherng/php-diff/src/languages/readme.txt',
             '/media/com_actionlogs/js/admin-actionlogs-default-es5.js',
             '/media/com_actionlogs/js/admin-actionlogs-default-es5.min.js',

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1215,10 +1215,6 @@ class JoomlaInstallerScript
             '/media/vendor/mediaelement/js/mediaelement-flash-video-mdash.swf',
             '/media/vendor/mediaelement/js/mediaelement-flash-video.swf',
             '/plugins/editors-xtd/pagebreak/pagebreak.php',
-            '/plugins/task/demotasks/demotasks.xml',
-            '/plugins/task/demotasks/forms/testTaskForm.xml',
-            '/plugins/task/demotasks/services/provider.php',
-            '/plugins/task/demotasks/src/Extension/DemoTasks.php',
         ];
 
         $folders = [
@@ -1289,12 +1285,6 @@ class JoomlaInstallerScript
             '/libraries/vendor/beberlei',
             '/administrator/components/com_admin/sql/others/mysql',
             '/administrator/components/com_admin/sql/others',
-            // From 5.0.0-alpha1 to 5.0.0-alpha2
-            '/plugins/task/demotasks/src/Extension',
-            '/plugins/task/demotasks/src',
-            '/plugins/task/demotasks/services',
-            '/plugins/task/demotasks/forms',
-            '/plugins/task/demotasks',
         ];
 
         $status['files_checked']   = $files;

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -59,9 +59,11 @@ if (empty($options['to'])) {
     exit(1);
 }
 
-// Directories to skip for the check (needs to include anything from J3 we want to keep)
+// Directories and files to skip for the check (needs to include anything from J3 we want to keep)
 $previousReleaseExclude = [
     $options['from'] . '/administrator/components/com_search',
+    $options['from'] . '/administrator/language/en-GB/plg_task_demotasks.ini',
+    $options['from'] . '/administrator/language/en-GB/plg_task_demotasks.sys.ini',
     $options['from'] . '/components/com_search',
     $options['from'] . '/images/sampledata',
     $options['from'] . '/installation',

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -71,6 +71,7 @@ $previousReleaseExclude = [
     $options['from'] . '/plugins/fields/repeatable',
     $options['from'] . '/plugins/quickicon/eos310',
     $options['from'] . '/plugins/search',
+    $options['from'] . '/plugins/task/demotasks',
 ];
 
 /**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With pull request (PR) #40768 , a function for uninstalling and optionally migrating extensions on update has been added to script.php, and with PR #40147 that function is used to uninstall the demo tasks plugin.

However, this results in an alert about an error when trying to delete the plugin's folder and in PHP notices at the end of the update.

The reason is that the "deleteUnexistingFiles" method is not only called from function "update" in script.php but also from the "finalisation.php" file of the update component.

That means the plugin's files and folders are deleted before the function to uninstall the plugin is executed.

We once had similar problems in 4.x when uninstalling the eos310 plugin on update, and the solution was to not include the files and folders of the plugin in the lists of deleted files and folders. See https://github.com/joomla/joomla-cms/pull/34898 .

This PR here solves it in the same way by removing the files and folders from the deleted files and folders lists and add them as exceptions to the "deleted_file_check.php" file so they will not be added again to the lists later due to that script reporting them as to be deleted.

### Testing Instructions

On a current 4.4-dev or 4.4 nightly build or 5.0.0-alpha1, set error reporting to maximum and make sure that PHP errors are logged into a file.

Update to the latest 5.0 nightly build to get the actual result, and update with the same starting conditions to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

![2023-06-27_j5-error-on-update](https://github.com/joomla/joomla-cms/assets/7413183/58422fe8-86c3-4951-b90b-189462812f96)

In the PHP error log file:

```
Warning:  Attempt to read property "files" on null in /home/richard/lamp/public_html/test-1/libraries/src/Installer/Adapter/PluginAdapter.php on line 291
```
(and others of this kind)

However, the update succeeds despite of these issues.

### Expected result AFTER applying this Pull Request

Update succeeds without PHP notices and without the alert about deleting the folder.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
