### PR TITLE
[5.0] Remove obsolete assets for com_users.admin-users-mail to fix broken versioning on build

### DIFF
--- a/build/media_source/com_users/joomla.asset.json
+++ b/build/media_source/com_users/joomla.asset.json
@@ -30,30 +30,6 @@
       }
     },
     {
-      "name": "com_users.admin-users-mail.es5",
-      "type": "script",
-      "deprecated": true,
-      "uri": "",
-      "dependencies": [
-        "core"
-      ],
-      "attributes": {
-        "nomodule": true,
-        "defer": true
-      }
-    },
-    {
-      "name": "com_users.admin-users-mail",
-      "type": "script",
-      "uri": "com_users/admin-users-mail.min.js",
-      "dependencies": [
-        "core"
-      ],
-      "attributes": {
-        "type": "module"
-      }
-    },
-    {
       "name": "com_users.two-factor-focus.es5",
       "type": "script",
       "deprecated": true,


### PR DESCRIPTION
Pull Request for Issue #41066 .

### Summary of Changes

This pull request (PR) removes the obsolete assets `com_users.admin-users-mail.es5` and `com_users.admin-users-mail` from file `build/media_source/com_users/joomla.asset.json`.

They should have been removed with #40302 , but that was overlooked since the original PR #39374 also had forgotten to remove them, so they were not added back later with PR #39431 and then were not marked as deprecated with PR #40385 .

### Testing Instructions

On a clean, current 5.0-dev branch, run `php ./build/build.php --remote=HEAD --exclude-gzip --exclude-bzip2` to get the actual result, and do the same on the branch of this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

```
> joomla@5.0.0 versioning
> node build/build.js --versioning

[Error: ENOENT: no such file or directory, lstat '/home/richard/lamp/public_html/joomla-cms-5.0-dev/build/tmp/1687872657/media/com_users/js/admin-users-mail.min.js'] {
  errno: -2,
  code: 'ENOENT',
  syscall: 'lstat',
  path: '/home/richard/lamp/public_html/joomla-cms-5.0-dev/build/tmp/1687872657/media/com_users/js/admin-users-mail.min.js'
}
`npm run versioning` did not complete as expected.
```

### Expected result AFTER applying this Pull Request

Build suceeds.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/98
