### PR TITLE
[5.0] Fix MFA with WebAuthn failing due to Factory class not found.

### DIFF
--- a/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
+++ b/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
@@ -342,9 +342,7 @@ class Webauthn extends CMSPlugin implements SubscriberInterface
         $wam->getRegistry()->addExtensionRegistryFile('plg_multifactorauth_webauthn');
 
         try {
-            /** @var CMSApplication $app */
-            $app = Factory::getApplication();
-            $app->getDocument()->addScriptOptions('com_users.authData', base64_encode($pkRequest), false);
+            $document->addScriptOptions('com_users.authData', base64_encode($pkRequest), false);
             $layoutPath = PluginHelper::getLayoutPath('multifactorauth', 'webauthn');
             ob_start();
             include $layoutPath;


### PR DESCRIPTION
Pull Request for Issue #41072 .

### Summary of Changes

Use the `$document` variable from line 340 instead of using the Factory application for calling `getDocument()` again.

### Testing Instructions

Use a current 5.0-dev branch or a 5.0.0-alpha2.

1. set up Multi Factor Authentication with Web Authentication as default method for a user.
2. Log out from backend.
3. Try to log-in again with this user and click on button "Validate with your Authenticator".

### Actual result BEFORE applying this Pull Request

See issue #41072 .

### Expected result AFTER applying this Pull Request

The user gets logged in after entering their PIN.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
