### PR TITLE
Change generic _ name to text in views

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -78,15 +78,15 @@ $assoc = Associations::isEnabled();
                 ?>
                 <?php if (empty($this->items)) : ?>
                     <div class="alert alert-info">
-                        <span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo $this->_('INFO'); ?></span>
-                        <?php echo $this->_('JGLOBAL_NO_MATCHING_RESULTS'); ?>
+                        <span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo $this->text('INFO'); ?></span>
+                        <?php echo $this->text('JGLOBAL_NO_MATCHING_RESULTS'); ?>
                     </div>
                 <?php else : ?>
                     <table class="table itemList" id="articleList">
                         <caption class="visually-hidden">
-                            <?php echo $this->_('COM_CONTENT_ARTICLES_TABLE_CAPTION'); ?>,
-                            <span id="orderedBy"><?php echo $this->_('JGLOBAL_SORTED_BY'); ?> </span>,
-                            <span id="filteredBy"><?php echo $this->_('JGLOBAL_FILTERED_BY'); ?></span>
+                            <?php echo $this->text('COM_CONTENT_ARTICLES_TABLE_CAPTION'); ?>,
+                            <span id="orderedBy"><?php echo $this->text('JGLOBAL_SORTED_BY'); ?> </span>,
+                            <span id="filteredBy"><?php echo $this->text('JGLOBAL_FILTERED_BY'); ?></span>
                         </caption>
                         <thead>
                             <tr>
@@ -179,7 +179,7 @@ $assoc = Associations::isEnabled();
                                     if (!$canChange) {
                                         $iconClass = ' inactive';
                                     } elseif (!$saveOrder) {
-                                        $iconClass = ' inactive" title="' . $this->_('JORDERINGDISABLED');
+                                        $iconClass = ' inactive" title="' . $this->text('JORDERINGDISABLED');
                                     }
                                     ?>
                                     <span class="sortable-handler<?php echo $iconClass ?>">
@@ -194,8 +194,8 @@ $assoc = Associations::isEnabled();
                                     <?php
                                     $options = [
                                     'transitions' => $transitions,
-                                    'title' => $this->_($item->stage_title),
-                                    'tip_content' => Text::sprintf('JWORKFLOW', $this->_($item->workflow_title)),
+                                    'title' => $this->text($item->stage_title),
+                                    'tip_content' => Text::sprintf('JWORKFLOW', $this->text($item->workflow_title)),
                                     'id' => 'workflow-' . $item->id,
                                     'task' => 'articles.runTransition'
                                     ];
@@ -204,7 +204,7 @@ $assoc = Associations::isEnabled();
                                     ->render(0, $i);
                                     ?>
                                     <div class="small">
-                                        <?php echo $this->_($item->stage_title); ?>
+                                        <?php echo $this->text($item->stage_title); ?>
                                     </div>
                                 </td>
                                 <?php endif; ?>
@@ -238,7 +238,7 @@ $assoc = Associations::isEnabled();
                                             <?php echo HTMLHelper::_('jgrid.checkedout', $i, $item->editor, $item->checked_out_time, 'articles.', $canCheckin); ?>
                                         <?php endif; ?>
                                         <?php if ($canEdit || $canEditOwn) : ?>
-                                            <a href="<?php echo Route::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" title="<?php echo $this->_('JACTION_EDIT'); ?> <?php echo $this->escape($item->title); ?>">
+                                            <a href="<?php echo Route::_('index.php?option=com_content&task=article.edit&id=' . $item->id); ?>" title="<?php echo $this->text('JACTION_EDIT'); ?> <?php echo $this->escape($item->title); ?>">
                                                 <?php echo $this->escape($item->title); ?></a>
                                         <?php else : ?>
                                             <span title="<?php echo Text::sprintf('JFIELD_ALIAS_LABEL', $this->escape($item->alias)); ?>"><?php echo $this->escape($item->title); ?></span>
@@ -254,8 +254,8 @@ $assoc = Associations::isEnabled();
                                             <?php
                                             $ParentCatUrl = Route::_('index.php?option=com_categories&task=category.edit&id=' . $item->parent_category_id . '&extension=com_content');
                                             $CurrentCatUrl = Route::_('index.php?option=com_categories&task=category.edit&id=' . $item->catid . '&extension=com_content');
-                                            $EditCatTxt = $this->_('COM_CONTENT_EDIT_CATEGORY');
-                                            echo $this->_('JCATEGORY') . ': ';
+                                            $EditCatTxt = $this->text('COM_CONTENT_EDIT_CATEGORY');
+                                            echo $this->text('JCATEGORY') . ': ';
                                             if ($item->category_level != '1') :
                                                 if ($item->parent_category_level != '1') :
                                                     echo ' &#187; ';
@@ -299,7 +299,7 @@ $assoc = Associations::isEnabled();
                                                 endif;
                                             }
                                             if ($item->category_published < '1') :
-                                                echo $item->category_published == '0' ? ' (' . $this->_('JUNPUBLISHED') . ')' : ' (' . $this->_('JTRASHED') . ')';
+                                                echo $item->category_published == '0' ? ' (' . $this->text('JUNPUBLISHED') . ')' : ' (' . $this->text('JTRASHED') . ')';
                                             endif;
                                             ?>
                                         </div>
@@ -314,7 +314,7 @@ $assoc = Associations::isEnabled();
                                             <?php echo $this->escape($item->author_name); ?>
                                         </a>
                                     <?php else : ?>
-                                        <?php echo $this->_('JNONE'); ?>
+                                        <?php echo $this->text('JNONE'); ?>
                                     <?php endif; ?>
                                     <?php if ($item->created_by_alias) : ?>
                                         <div class="smallsub"><?php echo Text::sprintf('JGLOBAL_LIST_ALIAS', $this->escape($item->created_by_alias)); ?></div>
@@ -335,7 +335,7 @@ $assoc = Associations::isEnabled();
                                 <td class="small d-none d-md-table-cell text-center">
                                     <?php
                                     $date = $item->{$orderingColumn};
-                                    echo $date > 0 ? HTMLHelper::_('date', $date, $this->_('DATE_FORMAT_LC4')) : '-';
+                                    echo $date > 0 ? HTMLHelper::_('date', $date, $this->text('DATE_FORMAT_LC4')) : '-';
                                     ?>
                                 </td>
                                 <?php if ($this->hits) : ?>
@@ -379,7 +379,7 @@ $assoc = Associations::isEnabled();
                             'bootstrap.renderModal',
                             'collapseModal',
                             [
-                                'title'  => $this->_('COM_CONTENT_BATCH_OPTIONS'),
+                                'title'  => $this->text('COM_CONTENT_BATCH_OPTIONS'),
                                 'footer' => $this->loadTemplate('batch_footer'),
                             ],
                             $this->loadTemplate('batch_body')

--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -233,7 +233,7 @@ abstract class AbstractView extends CMSObject implements ViewInterface, Dispatch
             }
 
             if (empty($this->_name)) {
-                throw new \Exception(sprintf($this->_('JLIB_APPLICATION_ERROR_GET_NAME'), __METHOD__), 500);
+                throw new \Exception(sprintf($this->text('JLIB_APPLICATION_ERROR_GET_NAME'), __METHOD__), 500);
             }
         }
 
@@ -298,7 +298,7 @@ abstract class AbstractView extends CMSObject implements ViewInterface, Dispatch
      *
      * @since   4.4.0
      */
-    protected function _(string $key): string
+    protected function text(string $key): string
     {
         try {
             return $this->getLanguage()->_($key);

--- a/tests/Unit/Libraries/Cms/MVC/View/AbstractViewTest.php
+++ b/tests/Unit/Libraries/Cms/MVC/View/AbstractViewTest.php
@@ -268,7 +268,7 @@ class AbstractViewTest extends UnitTestCase
         $view = new class () extends AbstractView {
             public function translate(string $key)
             {
-                return $this->_($key);
+                return $this->text($key);
             }
 
             public function display($tpl = null)


### PR DESCRIPTION
### Summary of Changes
According to the discussion in #41063 the `_` function in the view class should be renamed to `text` to be more meaningful.