### PR TITLE
[5.0] Smart Search: Fix index button in emptystate

### DIFF
--- a/administrator/components/com_finder/tmpl/index/emptystate.php
+++ b/administrator/components/com_finder/tmpl/index/emptystate.php
@@ -22,7 +22,7 @@ $displayData = [
     'icon'       => 'icon-search-plus finder',
     'content'    => Text::_('COM_FINDER_INDEX_NO_DATA') . '<br>' . Text::_('COM_FINDER_INDEX_TIP'),
     'title'      => Text::_('COM_FINDER_HEADING_INDEXER'),
-    'createURL'  => "javascript:document.getElementsByClassName('button-archive')[0].click();",
+    'createURL'  => "javascript:document.getElementsByClassName('button-index')[0].click();",
 ];
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);


### PR DESCRIPTION
Pull Request for Issue #41089.

### Summary of Changes
When in Joomla 5.0 the index is empty, the button in the emptystate layout references the wrong toolbar button to start the indexing process.


### Testing Instructions
1. Clear your index.
2. Click on the button "Start the Indexer"


### Actual result BEFORE applying this Pull Request
Nothing happens except for an error in the JS console.


### Expected result AFTER applying this Pull Request
The modal of the indexer pops up and content is indexed, similar to clicking the toolbar button "index" at the top.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
