### PR TITLE
[5.0] Joomla Update: Improve progress bar display

### DIFF
--- a/administrator/components/com_joomlaupdate/extract.php
+++ b/administrator/components/com_joomlaupdate/extract.php
@@ -1907,7 +1907,7 @@ if ($enabled) {
                 $retArray['files']    = $engine->filesProcessed;
                 $retArray['bytesIn']  = $engine->compressedTotal;
                 $retArray['bytesOut'] = $engine->uncompressedTotal;
-                $retArray['percent']  = 100;
+                $retArray['percent']  = 80;
                 $retArray['status']   = true;
                 $retArray['done']     = true;
 
@@ -1916,7 +1916,7 @@ if ($enabled) {
                 $retArray['files']    = $engine->filesProcessed;
                 $retArray['bytesIn']  = $engine->compressedTotal;
                 $retArray['bytesOut'] = $engine->uncompressedTotal;
-                $retArray['percent']  = ($engine->totalSize > 0) ? (100 * $engine->compressedTotal / $engine->totalSize) : 0;
+                $retArray['percent']  = ($engine->totalSize > 0) ? (80 * $engine->compressedTotal / $engine->totalSize) : 0;
                 $retArray['status']   = true;
                 $retArray['done']     = false;
                 $retArray['instance'] = ZIPExtraction::getSerialised();

--- a/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
@@ -180,7 +180,7 @@ Joomla.Update = window.Joomla.Update || {
         progressDiv.style.width = '100%';
         progressDiv.innerText = '100%';
         progressDiv.setAttribute('aria-valuenow', 100);
-        titleDiv.innerHTML = Joomla.Text._('COM_JOOMLAUPDATE_UPDATING_COMPLETE');
+        titleDiv.innerText = Joomla.Text._('COM_JOOMLAUPDATE_UPDATING_COMPLETE');
 
         // Allow people to see the completion message
         window.setTimeout(() => {

--- a/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
@@ -95,26 +95,24 @@ Joomla.Update = window.Joomla.Update || {
     }
 
     const progressDiv = document.getElementById('progress-bar');
-    const titleDiv = document.getElementById('update-title');
 
     // Add data to variables
     Joomla.Update.stat_inbytes = data.bytesIn;
     Joomla.Update.stat_percent = data.percent;
     Joomla.Update.stat_percent = Joomla.Update.stat_percent
-      || (100 * (Joomla.Update.stat_inbytes / Joomla.Update.totalsize));
+      || (80 * (Joomla.Update.stat_inbytes / Joomla.Update.totalsize));
 
     // Update GUI
     Joomla.Update.stat_outbytes = data.bytesOut;
     Joomla.Update.stat_files = data.files;
 
-    if (Joomla.Update.stat_percent < 100) {
+    if (Joomla.Update.stat_percent < 80) {
       progressDiv.classList.remove('bg-success');
       progressDiv.style.width = `${Joomla.Update.stat_percent}%`;
       progressDiv.setAttribute('aria-valuenow', Joomla.Update.stat_percent);
-    } else if (Joomla.Update.stat_percent >= 100) {
-      progressDiv.classList.add('bg-success');
-      progressDiv.style.width = '100%';
-      progressDiv.setAttribute('aria-valuenow', 100);
+    } else if (Joomla.Update.stat_percent >= 80) {
+      progressDiv.style.width = '80%';
+      progressDiv.setAttribute('aria-valuenow', 80);
     }
 
     progressDiv.innerText = `${Joomla.Update.stat_percent.toFixed(1)}%`;
@@ -125,10 +123,8 @@ Joomla.Update = window.Joomla.Update || {
 
     // Are we done extracting?
     if (data.done) {
-      progressDiv.classList.add('bg-success');
-      progressDiv.style.width = '100%';
-      progressDiv.setAttribute('aria-valuenow', 100);
-      titleDiv.innerHTML = Joomla.Text._('COM_JOOMLAUPDATE_UPDATING_COMPLETE');
+      progressDiv.style.width = '80%';
+      progressDiv.setAttribute('aria-valuenow', 80);
 
       Joomla.Update.finalizeUpdate();
 
@@ -177,7 +173,19 @@ Joomla.Update = window.Joomla.Update || {
       method: 'POST',
       perform: true,
       onSuccess: () => {
-        window.location = Joomla.Update.return_url;
+        const progressDiv = document.getElementById('progress-bar');
+        const titleDiv = document.getElementById('update-title');
+
+        progressDiv.classList.add('bg-success');
+        progressDiv.style.width = '100%';
+        progressDiv.setAttribute('aria-valuenow', 100);
+        titleDiv.innerHTML = Joomla.Text._('COM_JOOMLAUPDATE_UPDATING_COMPLETE');
+
+        // Allow people to see the completion message
+        window.setTimeout(() => {
+          window.location = Joomla.Update.return_url;
+        }, 1000);
+
       },
       onError: Joomla.Update.handleErrorResponse,
     });

--- a/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
@@ -178,6 +178,7 @@ Joomla.Update = window.Joomla.Update || {
 
         progressDiv.classList.add('bg-success');
         progressDiv.style.width = '100%';
+        progressDiv.innerText = '100%';
         progressDiv.setAttribute('aria-valuenow', 100);
         titleDiv.innerHTML = Joomla.Text._('COM_JOOMLAUPDATE_UPDATING_COMPLETE');
 

--- a/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/admin-update-default.es6.js
@@ -186,7 +186,6 @@ Joomla.Update = window.Joomla.Update || {
         window.setTimeout(() => {
           window.location = Joomla.Update.return_url;
         }, 1000);
-
       },
       onError: Joomla.Update.handleErrorResponse,
     });


### PR DESCRIPTION
Set progress to 80% for extraction and 100% after finalisation

Pull Request for Issue # .

### Summary of Changes
It seems as if several people have issues with the update process because the progressbar shows 100% at the end of extracting the files and only then does the finalisation step, which can take several seconds. Users don't know that something is happening in the background and then navigate away from the page, cancelling the request and thus the finalisation step. This PR tries to get around that by pinning the progressbar to 80% at the end of the extraction process and then only update the progressbar to 100% when the finalisation step is done, waiting one second to display that to people and only then to redirect away from the page.


### Testing Instructions
Update Joomla and see the changed behavior of the progressbar.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
