### PR TITLE
[4.4] Unification of the spelling in plg_quickicon_eos.sys.ini

### DIFF
--- a/administrator/language/en-GB/plg_quickicon_eos.ini
+++ b/administrator/language/en-GB/plg_quickicon_eos.ini
@@ -3,11 +3,11 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_QUICKICON_EOS="Quick Icon - Joomla 4.4 End Of Support Notification"
-PLG_QUICKICON_EOS_MESSAGE_ERROR_SUPPORT_ENDED="<p>Support has ended for your version of Joomla 4.4. <a href=\"%2$s\" target=\"_blank\" rel=\"noopener noreferrer\">Upgrade to Joomla 5</a> as soon as possible.</p>"
+PLG_QUICKICON_EOS="Quick Icon - Joomla 4 End Of Support Notification"
+PLG_QUICKICON_EOS_MESSAGE_ERROR_SUPPORT_ENDED="<p>Support has ended for your version of Joomla 4. <a href=\"%2$s\" target=\"_blank\" rel=\"noopener noreferrer\">Upgrade to Joomla 5</a> as soon as possible.</p>"
 PLG_QUICKICON_EOS_MESSAGE_INFO_01="<p>Joomla 5 has arrived! Find out all that Joomla 5 has to offer you. Check the landing page for <a href=\"%2$s\" target=\"_blank\" rel=\"noopener noreferrer\">Joomla 5 features</a> and improvements.</p>"
 PLG_QUICKICON_EOS_MESSAGE_INFO_02="<p>When is the time to upgrade to Joomla 5? Once the extensions your site needs are compatible. Learn <a href=\"%2$s\" target=\"_blank\" rel=\"noopener noreferrer\"> how to use the Pre-Update Checker</a>.</p>"
-PLG_QUICKICON_EOS_MESSAGE_WARNING_SECURITY_ONLY="<p>Joomla 4.4 has entered security only mode. Support ends %1$s. Start <a href=\"%2$s\" target=\"_blank\" rel=\"noopener noreferrer\">planning to upgrade</a> to Joomla 5 today.</p>"
-PLG_QUICKICON_EOS_MESSAGE_WARNING_SUPPORT_ENDING="<p>Support ends on %1$s for Joomla 4.4 <a href=\"%2$s\" target=\"_blank\" rel=\"noopener noreferrer\">Upgrade to Joomla 5</a> as soon as possible.</p>"
+PLG_QUICKICON_EOS_MESSAGE_WARNING_SECURITY_ONLY="<p>Joomla 4 has entered security only mode. Support ends %1$s. Start <a href=\"%2$s\" target=\"_blank\" rel=\"noopener noreferrer\">planning to upgrade</a> to Joomla 5 today.</p>"
+PLG_QUICKICON_EOS_MESSAGE_WARNING_SUPPORT_ENDING="<p>Support ends on %1$s for Joomla 4 <a href=\"%2$s\" target=\"_blank\" rel=\"noopener noreferrer\">Upgrade to Joomla 5</a> as soon as possible.</p>"
 PLG_QUICKICON_EOS_SNOOZE_BUTTON="Snooze this message for all users"
-PLG_QUICKICON_EOS_XML_DESCRIPTION="Checks for the end of support status of Joomla 4.4 and notifies you when visiting the Control Panel page."
+PLG_QUICKICON_EOS_XML_DESCRIPTION="Checks for the end of support status of Joomla 4 and notifies you when visiting the Control Panel page."

--- a/administrator/language/en-GB/plg_quickicon_eos.sys.ini
+++ b/administrator/language/en-GB/plg_quickicon_eos.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_QUICKICON_EOS="Quick Icon - Joomla! End Of Support Notification"
-PLG_QUICKICON_EOS_XML_DESCRIPTION="Checks for the end of support status of Joomla and places a notification on the Control Panel page."
+PLG_QUICKICON_EOS="Quick Icon - Joomla 4.4 End Of Support Notification"
+PLG_QUICKICON_EOS_XML_DESCRIPTION="Checks for the end of support status of Joomla 4.4 and notifies you when visiting the Control Panel page."

--- a/administrator/language/en-GB/plg_quickicon_eos.sys.ini
+++ b/administrator/language/en-GB/plg_quickicon_eos.sys.ini
@@ -3,5 +3,5 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_QUICKICON_EOS="Quick Icon - Joomla 4.4 End Of Support Notification"
-PLG_QUICKICON_EOS_XML_DESCRIPTION="Checks for the end of support status of Joomla 4.4 and notifies you when visiting the Control Panel page."
+PLG_QUICKICON_EOS="Quick Icon - Joomla 4 End Of Support Notification"
+PLG_QUICKICON_EOS_XML_DESCRIPTION="Checks for the end of support status of Joomla 4 and notifies you when visiting the Control Panel page."


### PR DESCRIPTION
### Summary of Changes

Unification of the spelling in plg_quickicon_eos.sys.ini and plg_quickicon_eos.ini 
AND shortening the spelling from Joomla 4.4 to Joomla 4.

### Testing Instructions

.

### Actual result BEFORE applying this Pull Request

Joomla 4.4

PLG_QUICKICON_EOS="Quick Icon - Joomla! End Of Support Notification"
PLG_QUICKICON_EOS_XML_DESCRIPTION="Checks for the end of support status of Joomla and places a notification on the Control Panel page."

### Expected result AFTER applying this Pull Request

Joomla 4

PLG_QUICKICON_EOS="Quick Icon - Joomla 4.4 End Of Support Notification"
PLG_QUICKICON_EOS_XML_DESCRIPTION="Checks for the end of support status of Joomla 4.4 and notifies you when visiting the Control Panel page."

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
