### PR TITLE
mod_articles_news: Only prepare content if introtext is shown

### DIFF
--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -134,7 +134,9 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
                 $item->linkText = Text::_('MOD_ARTICLES_NEWS_READMORE_REGISTER');
             }
 
-            $item->introtext = HTMLHelper::_('content.prepare', $item->introtext, '', 'mod_articles_news.content');
+            if ($params->get('show_introtext', 1)) {
+                $item->introtext = HTMLHelper::_('content.prepare', $item->introtext, '', 'mod_articles_news.content');
+            }
 
             // Remove any images belongs to the text
             if (!$params->get('image')) {

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -134,7 +134,7 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
                 $item->linkText = Text::_('MOD_ARTICLES_NEWS_READMORE_REGISTER');
             }
 
-            if ($params->get('show_introtext', 1)) {
+            if ($params->get('show_introtext', 1) && $item->introtext != '') {
                 $item->introtext = HTMLHelper::_('content.prepare', $item->introtext, '', 'mod_articles_news.content');
             }
 


### PR DESCRIPTION
Pull Request for Issue #41086.

### Summary of Changes
`content.prepare` is now only called if the module configuration has "show introtext" set to "Yes". This is similar to mod_articles_category:
https://github.com/joomla/joomla-cms/blob/507922c74e5ea76504e2ba98aac70e3124dbcce8/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php#L274-L277


### Testing Instructions

* Have a site with at least one enabled content plugin that does some sort of content replacement and adds some scripts (i.e. image gallery tools, video embedding...)
* Create an article that contains some content that triggers the content plugin (i.e. adds scripts to the output)
* Add a `mod_articles_news` module to any position
* Select the category of the article created above
* Disable the showing of the intro text in the module options
* Observe the HTML output in the frontend: The intro text is _not_ shown (as expected), but scripts that were added are in the output

### Actual result BEFORE applying this Pull Request
Content is always `content.prepare`d, even if the introtext is not displayed. Anything that is changed by content plugins _besides the content_ (e.g. added scripts and stylesheets) is contained in the frontend HTML code (and might have side effects...)


### Expected result AFTER applying this Pull Request
Content is only `content.prepare`d if it is actually selected to be shown. Anything that is changed by content plugins _besides the content_ (e.g. added scripts and stylesheets) is NOT contained in the frontend HTML code.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
