### PR TITLE
[4.3] check of invalid json 'joomla.asset.json'

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -959,7 +959,7 @@ class TemplateModel extends FormModel
         $data['source'] = str_replace(["\r\n", "\r"], "\n", $data['source']);
 
         // If the asset file for the template ensure we have valid template so we don't instantly destroy it
-        if ($fileName === '/joomla.asset.json' && json_decode($data['source']) === null) {
+        if (str_ends_with($fileName, '/joomla.asset.json') && json_decode($data['source']) === null) {
             $this->setError(Text::_('COM_TEMPLATES_ERROR_ASSET_FILE_INVALID_JSON'));
 
             return false;


### PR DESCRIPTION
### Summary of Changes

Validation of `joomla.asset.json` (JSON) is broken since J4.1 #35998 (child templates)

`str_ends_with` should covered by polyfill:
https://github.com/joomla/joomla-cms/blob/c944137dc9c6461290d4631f2b3242dc107dab93/composer.json#L84

### Testing Instructions

try to edit `joomla.asset.json` and save with an invalid json (eg. double comma)

### Actual result BEFORE applying this Pull Request

file saved
![image](https://github.com/joomla/joomla-cms/assets/66922325/8c4aaf8a-898f-4514-abeb-567264563667)

site broken (here frontend cassiopeia)
![image](https://github.com/joomla/joomla-cms/assets/66922325/15282755-72fa-4496-8cfd-05ef50708c0b)

### Expected result AFTER applying this Pull Request

file not saved
![image](https://github.com/joomla/joomla-cms/assets/66922325/61ecebbf-ef22-4327-8cd8-a89b11b0789f)


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
