### PR TITLE
[4.3] The arrow-up icon of the Back-to-top Link should be visible on hovering.

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_back-to-top.scss
@@ -22,7 +22,7 @@
 
   &:hover,
   &:focus {
-    color: var(--white, $white);
+    color: var(--white, $white) !important;
     background-color: var(--cassiopeia-color-hover);
     border-color: var(--white, $white);
   }


### PR DESCRIPTION

Pull Request for Issue # .

### Summary of Changes

The arrow-up icon of the Back-to-top Link should be visible on hovering.
And in addition, the color of the button must then be blue.

Related to the Button text color issue #40435, that caused this problem.


### Testing Instructions

Build npm ci.

Enable the Back-to-top Link button in Templates: Edit Style.

Hover on the Back-to-top button in the fontend of the site.

Code review


### Actual result BEFORE applying this Pull Request

The arrow-up icon is NOT visible on hovering on the button.

![Schermafbeelding 2023-07-13 115902](https://github.com/joomla/joomla-cms/assets/9271775/5f65e5a5-f278-4212-831c-68bc3283bc2c)

### Expected result AFTER applying this Pull Request

The arrow-up icon is visible on hovering on the button. 


![Schermafbeelding 2023-07-13 120207](https://github.com/joomla/joomla-cms/assets/9271775/9db1c898-5f6b-4a7b-8505-c9daf57d5733)

### Link
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
