### PR TITLE
[4.3] Record currentStepId in sessionStorage when responding to an interaction

### DIFF
--- a/build/media_source/plg_system_guidedtours/js/guidedtours.es6.js
+++ b/build/media_source/plg_system_guidedtours/js/guidedtours.es6.js
@@ -374,7 +374,11 @@ function startTour(obj) {
               break;
 
             case 'button':
-              tour.next();
+              ele.addEventListener('click', () => {
+                // the button may submit a form so record the currentStepId in the session storage
+                sessionStorage.setItem('currentStepId', obj.steps[index].id + 1);
+                tour.next();
+              });
               break;
 
             case 'other':


### PR DESCRIPTION
Please see equivalent PR for Joomla 5 at https://github.com/joomla/joomla-cms/pull/40776

Pull Request for Issue # .

### Summary of Changes

Change handling of 'button' interactive type to respond to the button click rather than immediately executing.  

This execution happens at the start of the tour and not when the step has actually been reached and so the modal setup ends up being called twice.  As a result other steps with interactive actions e.g. checkboxes or text input fields cannot be interacted with.

### Testing Instructions

Create a tour as per following screenshots - a JSON import is attached if you have implemented the tours import/export PR https://github.com/joomla/joomla-cms/pull/40645 

[backdropProblemTour.zip](https://github.com/joomla/joomla-cms/files/11757204/backdropProblemTour.zip)

![Screenshot 2023-06-15 at 13-01-58 Guided Tours Edit Tour - Joomla Tours - Administration](https://github.com/joomla/joomla-cms/assets/839810/e0bfd83b-9041-47b6-af1e-b286f3039695)

![Screenshot 2023-06-15 at 13-02-20 Guided Tours Edit Step - Joomla Tours - Administration](https://github.com/joomla/joomla-cms/assets/839810/96178d4f-1094-498c-97a9-bcd414d56954)

![Screenshot 2023-06-15 at 13-02-29 Guided Tours Edit Step - Joomla Tours - Administration](https://github.com/joomla/joomla-cms/assets/839810/c2a5dc60-0eb3-4a60-9d1f-44d8d61932da)

![Screenshot 2023-06-15 at 13-02-38 Guided Tours Edit Step - Joomla Tours - Administration](https://github.com/joomla/joomla-cms/assets/839810/491ca6b0-12bc-4a4b-bf8c-9c63ab5fe723)

![Screenshot 2023-06-15 at 13-02-46 Guided Tours Edit Step - Joomla Tours - Administration](https://github.com/joomla/joomla-cms/assets/839810/c15de5c9-a349-4e0c-8d1d-0aa521998d82)

![Screenshot 2023-06-15 at 13-02-56 Guided Tours Edit Step - Joomla Tours - Administration](https://github.com/joomla/joomla-cms/assets/839810/e51a6966-4063-4bad-a958-f0677cb04d57)

Unpublish steps 3 and 4 so that you have this as an  overview

![Screenshot 2023-06-15 at 13-11-57 Guided Tour Guided Tours Modal Backdrop Problem - Joomla Tours - Administration](https://github.com/joomla/joomla-cms/assets/839810/c060a379-c82b-47c1-ab98-071fc3c8457f)

Now run the tour

### Actual result BEFORE applying this Pull Request

At step 2 you have a double backdrop and can't interact with the checkbox

![Screenshot 2023-06-15 at 13-12-36 Articles Categories - Joomla Tours - Administration](https://github.com/joomla/joomla-cms/assets/839810/79325224-bb05-4e7a-8b99-177e1b9e3222)

If you enable steps 3 and 4 it behaves even worse

![Screenshot 2023-06-15 at 13-13-54 Articles Categories - Joomla Tours - Administration](https://github.com/joomla/joomla-cms/assets/839810/2cbf6209-36d9-4842-95c9-c46c9497ceca)

and if you proceed with clicking the rebuild button you get stuck in a loop.

### Expected result AFTER applying this Pull Request

![Screenshot 2023-06-15 at 13-14-59 Articles Categories - Joomla Tours - Administration](https://github.com/joomla/joomla-cms/assets/839810/0352f82f-8230-4ee4-8eff-5bbd9dc5c317)

You also don't get a loop on the rebuild button action step

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ x] No documentation changes for manual.joomla.org needed
