### PR TITLE
[5.0] Guided Tours - Eliminate tour blur event errors

### DIFF
--- a/build/media_source/plg_system_guidedtours/js/guidedtours.es6.js
+++ b/build/media_source/plg_system_guidedtours/js/guidedtours.es6.js
@@ -160,6 +160,9 @@ function addStepToTourButton(tour, stepObj, buttons) {
           if (target.tagName.toLowerCase() === 'iframe') {
             // Give blur to the content of the iframe, as iframes don't have blur events
             target.contentWindow.document.body.addEventListener('blur', (event) => {
+              if (!sessionStorage.getItem('tourId')) {
+                return;
+              }
               setTimeout(() => {
                 setFocus(primaryButton, secondaryButton, cancelButton);
               }, 1);
@@ -167,16 +170,25 @@ function addStepToTourButton(tour, stepObj, buttons) {
             });
           } else if (target.tagName.toLowerCase() === 'joomla-field-fancy-select') {
             target.querySelector('.choices input').addEventListener('blur', (event) => {
+              if (!sessionStorage.getItem('tourId')) {
+                return;
+              }
               setFocus(primaryButton, secondaryButton, cancelButton);
               event.preventDefault();
             });
           } else if (target.parentElement.tagName.toLowerCase() === 'joomla-field-fancy-select') {
             target.querySelector('input').addEventListener('blur', (event) => {
+              if (!sessionStorage.getItem('tourId')) {
+                return;
+              }
               setFocus(primaryButton, secondaryButton, cancelButton);
               event.preventDefault();
             });
           } else {
             target.addEventListener('blur', (event) => {
+              if (!sessionStorage.getItem('tourId')) {
+                return;
+              }
               setFocus(primaryButton, secondaryButton, cancelButton);
               event.preventDefault();
             });

--- a/build/media_source/plg_system_guidedtours/js/guidedtours.es6.js
+++ b/build/media_source/plg_system_guidedtours/js/guidedtours.es6.js
@@ -368,6 +368,9 @@ function startTour(obj) {
           switch (obj.steps[index].interactive_type) {
             case 'submit':
               ele.addEventListener('click', () => {
+                if (!sessionStorage.getItem('tourId')) {
+                  return;
+                }
                 sessionStorage.setItem('currentStepId', obj.steps[index].id + 1);
               });
               break;
@@ -376,6 +379,9 @@ function startTour(obj) {
               ele.step_id = index;
               if (ele.hasAttribute('required') && ['email', 'password', 'search', 'tel', 'text', 'url'].includes(ele.type)) {
                 ['input', 'focus'].forEach((eventName) => ele.addEventListener(eventName, (event) => {
+                  if (!sessionStorage.getItem('tourId')) {
+                    return;
+                  }
                   if (event.target.value.trim().length) {
                     enableButton(event);
                   } else {


### PR DESCRIPTION
Recreated as PR for Joomla 4.3 at #41160

When you complete a tour and then interact with a targeted element the blur event listener is still attached and throws a javascript error

Pull Request for Issue # .

### Summary of Changes

Check there is a tour active before attempting to focus on the tour step buttons

### Testing Instructions

Run a tour e.g. How to create a menu item - cancel the tour before completing the title step  (the same problem can exist in a completed tour).

Click in the 'title' field and then move it out (i.e. fire a blur event) the view the javascript console

### Actual result BEFORE applying this Pull Request

![Screenshot from 2023-07-14 10-44-22](https://github.com/joomla/joomla-cms/assets/839810/0564ee51-bef4-4253-860f-634dc1f51ff3)

![Screenshot from 2023-07-14 10-44-31](https://github.com/joomla/joomla-cms/assets/839810/73ae3247-0af5-49fb-bd56-84e8d3d3db41)

![Screenshot from 2023-07-14 10-44-43](https://github.com/joomla/joomla-cms/assets/839810/81018e8c-a209-4c14-8442-31ab07dac4f2)

### Expected result AFTER applying this Pull Request

No error message in the console.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
