### PR TITLE
[5.0] Update filter_plugins.xml

### DIFF
--- a/administrator/components/com_plugins/forms/filter_plugins.xml
+++ b/administrator/components/com_plugins/forms/filter_plugins.xml
@@ -12,7 +12,7 @@
 
 		<field
 			name="enabled"
-			type="plugin_status"
+			type="pluginstatus"
 			label="JSTATUS"
 			class="js-select-submit-on-change"
 			>


### PR DESCRIPTION
### Steps to reproduce the issue
Clean install of j5 alpha
Go to plugin manager and display filters


### Expected result
all filters display


### Actual result
the first filter (status) does not display

### Additional comments
The field type in the xml is "plugin_status" but the actual field is "pluginstatus"

In joomla 4 this is resolved by classmap which creates an alias between the two

In Joomla 5 (on a clean install) this classmap is NOT used by default SO UNLESS the new system-backwardcompatibility plugin is enabled it does not work

**_a clean install of joomla 5 should not require this plugin to be enabled_**


