### PR TITLE
[5.x] CacheController

### DIFF
--- a/libraries/src/Cache/CacheController.php
+++ b/libraries/src/Cache/CacheController.php
@@ -105,7 +105,6 @@ class CacheController
         } catch (\RuntimeException $e) {
             $type  = strtolower(preg_replace('/[^A-Z0-9_\.-]/i', '', $type));
 
-
         /** @var CacheController $class */
         $class = __NAMESPACE__ . '\\Controller\\' . ucfirst($type) . 'Controller';
 

--- a/libraries/src/Cache/CacheController.php
+++ b/libraries/src/Cache/CacheController.php
@@ -104,7 +104,14 @@ class CacheController
             return Factory::getContainer()->get(CacheControllerFactoryInterface::class)->createCacheController($type, $options);
         } catch (\RuntimeException $e) {
             $type  = strtolower(preg_replace('/[^A-Z0-9_\.-]/i', '', $type));
-            $class = 'JCacheController' . ucfirst($type);
+
+
+        /** @var CacheController $class */
+        $class = __NAMESPACE__ . '\\Controller\\' . ucfirst($type) . 'Controller';
+
+            if (!class_exists($class)) {
+                $class = 'JCacheController' . ucfirst($type);
+            }
 
             if (!class_exists($class)) {
                 // Search for the class file in the Cache include paths.

--- a/libraries/src/Cache/CacheController.php
+++ b/libraries/src/Cache/CacheController.php
@@ -105,8 +105,8 @@ class CacheController
         } catch (\RuntimeException $e) {
             $type  = strtolower(preg_replace('/[^A-Z0-9_\.-]/i', '', $type));
 
-        /** @var CacheController $class */
-        $class = __NAMESPACE__ . '\\Controller\\' . ucfirst($type) . 'Controller';
+            /** @var CacheController $class */
+            $class = __NAMESPACE__ . '\\Controller\\' . ucfirst($type) . 'Controller';
 
             if (!class_exists($class)) {
                 $class = 'JCacheController' . ucfirst($type);


### PR DESCRIPTION
### Summary of Changes
This is based on a code review and I am going to have to rely on better coders to confirm my assumption and the proposed fix.

From my reading of the code this change is needed in the CacheController for J5 as without the change it is relying on the classmap which is not enabled by default and core should not require.

The code is cloned from libraries\src\Cache\CacheStorage.php so it should be correct
