### PR TITLE
[5.x] Redirect filter

### DIFF
--- a/administrator/components/com_redirect/forms/filter_links.xml
+++ b/administrator/components/com_redirect/forms/filter_links.xml
@@ -11,7 +11,7 @@
 		/>
 		<field
 			name="state"
-			type="redirect_status"
+			type="redirectstatus"
 			label="JSTATUS"
 			class="js-select-submit-on-change"
 			>

--- a/administrator/components/com_redirect/forms/filter_links.xml
+++ b/administrator/components/com_redirect/forms/filter_links.xml
@@ -11,7 +11,7 @@
 		/>
 		<field
 			name="state"
-			type="redirectstatus"
+			type="RedirectStatus"
 			label="JSTATUS"
 			class="js-select-submit-on-change"
 			>

--- a/libraries/src/Form/Field/RedirectStatusField.php
+++ b/libraries/src/Form/Field/RedirectStatusField.php
@@ -26,7 +26,7 @@ class RedirectStatusField extends PredefinedlistField
      * @var    string
      * @since  3.8.0
      */
-    public $type = 'Redirect_Status';
+    public $type = 'RedirectStatus';
 
     /**
      * Available statuses


### PR DESCRIPTION
### Steps to reproduce the issue
Clean install of j5 alpha
Go to redirect manager, create a redirect and display filters


### Expected result
all filters display


### Actual result
the first filter (status) does not display

### Additional comments
The field type in the xml is "redirect_status" but the actual field is "redirectstatus"

In joomla 4 this is resolved by classmap which creates an alias between the two

In Joomla 5 (on a clean install) this classmap is NOT used by default SO UNLESS the new system-backwardcompatibility plugin is enabled it does not work

**_a clean install of joomla 5 should not require this plugin to be enabled_**


