### PR TITLE
[4.3] Fix workflow filter

### DIFF
--- a/administrator/components/com_content/forms/filter_featured.xml
+++ b/administrator/components/com_content/forms/filter_featured.xml
@@ -16,7 +16,7 @@
 			label="JOPTION_SELECT_STAGE"
 			class="js-select-submit-on-change"
 			activeonly="true"
-			extension="com_content"
+			extension="com_content.article"
 			>
 			<option value="">JOPTION_SELECT_STAGE</option>
 		</field>


### PR DESCRIPTION
### Summary of Changes
The filter for workflow stage in the featured articles was empty as it was missing the context


### Testing Instructions
Enable workflows
Make an article featured and go to the list of featured articles
Expand the search filters


### Actual result BEFORE applying this Pull Request
Stage Filter dropdown has no entries


### Expected result AFTER applying this Pull Request
Stage Filter now works as expected


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
