### PR TITLE
[5.0] Fix SQL syntax error when updating on PotgsreSQL caused by PR #38149

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-07-12.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-07-12.sql
@@ -1,2 +1,2 @@
-ALTER TABLE "#__menu_types" ADD COLUMN "ordering" int NOT NULL DEFAULT 0 AFTER "client_id";
+ALTER TABLE "#__menu_types" ADD COLUMN "ordering" int NOT NULL DEFAULT 0;
 UPDATE "#__menu_types" SET "ordering" = "id" WHERE "client_id" = 0;


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/38149/files#r1265261563 .

### Summary of Changes

PostgreSQL doesn't support "AFTER" in "ALTER TABLE ... ADD COLUMN ..." statements, see https://www.postgresql.org/docs/current/sql-altertable.html .

This pull request (PR) here fixes the wrong SQL statement added with PR #38149 .

### Testing Instructions

Run the SQL statement changed by this PR on a PostgreSQL database with a 5.0-dev Joomla installation which doesn't have PR #38149 applied.

### Actual result BEFORE applying this Pull Request

SQL syntax error.

### Expected result AFTER applying this Pull Request

Column is added.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
