### PR TITLE
[5.0] @link docblock

### DIFF
--- a/administrator/components/com_admin/src/Controller/DisplayController.php
+++ b/administrator/components/com_admin/src/Controller/DisplayController.php
@@ -27,7 +27,8 @@ class DisplayController extends BaseController
      * View method
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  Supports chaining.
      *

--- a/administrator/components/com_admin/src/Controller/DisplayController.php
+++ b/administrator/components/com_admin/src/Controller/DisplayController.php
@@ -28,7 +28,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  Supports chaining.
      *

--- a/administrator/components/com_banners/src/Controller/DisplayController.php
+++ b/administrator/components/com_banners/src/Controller/DisplayController.php
@@ -38,7 +38,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  This object to support chaining.
      *

--- a/administrator/components/com_banners/src/Controller/DisplayController.php
+++ b/administrator/components/com_banners/src/Controller/DisplayController.php
@@ -39,7 +39,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  This object to support chaining.
      *

--- a/administrator/components/com_banners/src/Controller/TracksController.php
+++ b/administrator/components/com_banners/src/Controller/TracksController.php
@@ -92,7 +92,8 @@ class TracksController extends BaseController
      * Display method for the raw track data.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  This object to support chaining.
      *

--- a/administrator/components/com_banners/src/Controller/TracksController.php
+++ b/administrator/components/com_banners/src/Controller/TracksController.php
@@ -93,7 +93,7 @@ class TracksController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  This object to support chaining.
      *

--- a/administrator/components/com_categories/src/Controller/DisplayController.php
+++ b/administrator/components/com_categories/src/Controller/DisplayController.php
@@ -68,7 +68,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean  This object to support chaining.
      *

--- a/administrator/components/com_categories/src/Controller/DisplayController.php
+++ b/administrator/components/com_categories/src/Controller/DisplayController.php
@@ -69,7 +69,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean  This object to support chaining.
      *

--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -365,8 +365,8 @@ class CategoryModel extends AdminModel
      *
      * @return  array|boolean  Array of filtered data if valid, false otherwise.
      *
-     * @see     JFormRule
-     * @see     JFilterInput
+     * @see     \Joomla\CMS\Form\FormRule
+     * @see     \Joomla\CMS\Filter\InputFilter
      * @since   3.9.23
      */
     public function validate($form, $data, $group = null)

--- a/administrator/components/com_checkin/src/Controller/DisplayController.php
+++ b/administrator/components/com_checkin/src/Controller/DisplayController.php
@@ -37,7 +37,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  A \JControllerLegacy object to support chaining.
      */

--- a/administrator/components/com_checkin/src/Controller/DisplayController.php
+++ b/administrator/components/com_checkin/src/Controller/DisplayController.php
@@ -38,7 +38,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  A \JControllerLegacy object to support chaining.
      */

--- a/administrator/components/com_config/src/Controller/DisplayController.php
+++ b/administrator/components/com_config/src/Controller/DisplayController.php
@@ -41,7 +41,8 @@ class DisplayController extends BaseController
      * you will need to override it in your own controllers.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link InputFilter::clean()}.
+     * @param   array    $urlparams  An array of safe url parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  A \JControllerLegacy object to support chaining.
      *

--- a/administrator/components/com_config/src/Controller/DisplayController.php
+++ b/administrator/components/com_config/src/Controller/DisplayController.php
@@ -42,7 +42,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe url parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  A \JControllerLegacy object to support chaining.
      *

--- a/administrator/components/com_contact/src/Controller/DisplayController.php
+++ b/administrator/components/com_contact/src/Controller/DisplayController.php
@@ -38,7 +38,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static |boolean  This object to support chaining. False on failure.
      *

--- a/administrator/components/com_contact/src/Controller/DisplayController.php
+++ b/administrator/components/com_contact/src/Controller/DisplayController.php
@@ -37,7 +37,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static |boolean  This object to support chaining. False on failure.
      *

--- a/administrator/components/com_content/src/Controller/DisplayController.php
+++ b/administrator/components/com_content/src/Controller/DisplayController.php
@@ -38,7 +38,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  This object to support chaining.
      *

--- a/administrator/components/com_content/src/Controller/DisplayController.php
+++ b/administrator/components/com_content/src/Controller/DisplayController.php
@@ -37,7 +37,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  This object to support chaining.
      *

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -619,7 +619,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
      * @return  array|boolean  Array of filtered data if valid, false otherwise.
      *
      * @see     \Joomla\CMS\Form\FormRule
-     * @see     JFilterInput
+     * @see     \Joomla\CMS\Filter\InputFilter
      * @since   3.7.0
      */
     public function validate($form, $data, $group = null)

--- a/administrator/components/com_cpanel/src/Controller/DisplayController.php
+++ b/administrator/components/com_cpanel/src/Controller/DisplayController.php
@@ -40,7 +40,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe url parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  An instance of the current object to support chaining.
      *

--- a/administrator/components/com_cpanel/src/Controller/DisplayController.php
+++ b/administrator/components/com_cpanel/src/Controller/DisplayController.php
@@ -39,7 +39,8 @@ class DisplayController extends BaseController
      * you will need to override it in your own controllers.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe url parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  An instance of the current object to support chaining.
      *

--- a/administrator/components/com_fields/src/Controller/DisplayController.php
+++ b/administrator/components/com_fields/src/Controller/DisplayController.php
@@ -42,7 +42,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean     $cachable   If true, the view output will be cached
      * @param   array|bool  $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                      @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  A Controller object to support chaining.
      *

--- a/administrator/components/com_fields/src/Controller/DisplayController.php
+++ b/administrator/components/com_fields/src/Controller/DisplayController.php
@@ -41,7 +41,8 @@ class DisplayController extends BaseController
      * you will need to override it in your own controllers.
      *
      * @param   boolean     $cachable   If true, the view output will be cached
-     * @param   array|bool  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}
+     * @param   array|bool  $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  A Controller object to support chaining.
      *

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -975,8 +975,8 @@ class FieldModel extends AdminModel
      *
      * @return  array|boolean  Array of filtered data if valid, false otherwise.
      *
-     * @see     JFormRule
-     * @see     JFilterInput
+     * @see     \Joomla\CMS\Form\FormRule
+     * @see     \Joomla\CMS\Filter\InputFilter
      * @since   3.9.23
      */
     public function validate($form, $data, $group = null)

--- a/administrator/components/com_fields/src/Model/GroupModel.php
+++ b/administrator/components/com_fields/src/Model/GroupModel.php
@@ -276,8 +276,8 @@ class GroupModel extends AdminModel
      *
      * @return  array|boolean  Array of filtered data if valid, false otherwise.
      *
-     * @see     JFormRule
-     * @see     JFilterInput
+     * @see     \Joomla\CMS\Form\FormRule
+     * @see     \Joomla\CMS\Filter\InputFilter
      * @since   3.9.23
      */
     public function validate($form, $data, $group = null)

--- a/administrator/components/com_finder/src/Controller/DisplayController.php
+++ b/administrator/components/com_finder/src/Controller/DisplayController.php
@@ -41,7 +41,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   A Controller object to support chaining or false on failure.
      *

--- a/administrator/components/com_finder/src/Controller/DisplayController.php
+++ b/administrator/components/com_finder/src/Controller/DisplayController.php
@@ -40,7 +40,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   A Controller object to support chaining or false on failure.
      *

--- a/administrator/components/com_guidedtours/src/Controller/DisplayController.php
+++ b/administrator/components/com_guidedtours/src/Controller/DisplayController.php
@@ -37,7 +37,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean $cachable  If true, the view output will be cached
-     * @param   array   $urlparams An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array   $urlparams An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static |boolean  This object to support chaining. False on failure.
      *

--- a/administrator/components/com_guidedtours/src/Controller/DisplayController.php
+++ b/administrator/components/com_guidedtours/src/Controller/DisplayController.php
@@ -36,9 +36,9 @@ class DisplayController extends BaseController
     /**
      * Method to display a view.
      *
-     * @param   boolean $cachable  If true, the view output will be cached
-     * @param   array   $urlparams An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     * @param   boolean $cachable   If true, the view output will be cached
+     * @param   array   $urlparams  An array of safe URL parameters and their variable types.
+     *                  @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static |boolean  This object to support chaining. False on failure.
      *

--- a/administrator/components/com_installer/src/Controller/DisplayController.php
+++ b/administrator/components/com_installer/src/Controller/DisplayController.php
@@ -30,7 +30,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static   This object to support chaining.
      *

--- a/administrator/components/com_installer/src/Controller/DisplayController.php
+++ b/administrator/components/com_installer/src/Controller/DisplayController.php
@@ -31,7 +31,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static   This object to support chaining.
      *

--- a/administrator/components/com_joomlaupdate/src/Controller/DisplayController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/DisplayController.php
@@ -31,7 +31,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static   This object to support chaining.
      *

--- a/administrator/components/com_joomlaupdate/src/Controller/DisplayController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/DisplayController.php
@@ -30,7 +30,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static   This object to support chaining.
      *

--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -354,7 +354,7 @@ class UpdateController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  This object to support chaining.
      *

--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -353,7 +353,8 @@ class UpdateController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  This object to support chaining.
      *

--- a/administrator/components/com_languages/src/Controller/DisplayController.php
+++ b/administrator/components/com_languages/src/Controller/DisplayController.php
@@ -36,7 +36,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_languages/src/Controller/DisplayController.php
+++ b/administrator/components/com_languages/src/Controller/DisplayController.php
@@ -35,7 +35,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -30,7 +30,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static   This object to support chaining.
      *

--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -29,7 +29,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static   This object to support chaining.
      *

--- a/administrator/components/com_mails/src/Controller/DisplayController.php
+++ b/administrator/components/com_mails/src/Controller/DisplayController.php
@@ -38,7 +38,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  This object to support chaining.
      *

--- a/administrator/components/com_mails/src/Controller/DisplayController.php
+++ b/administrator/components/com_mails/src/Controller/DisplayController.php
@@ -37,7 +37,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  This object to support chaining.
      *

--- a/administrator/components/com_menus/src/Controller/DisplayController.php
+++ b/administrator/components/com_menus/src/Controller/DisplayController.php
@@ -39,7 +39,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean        $cachable   If true, the view output will be cached
      * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                         @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static    This object to support chaining.
      *

--- a/administrator/components/com_menus/src/Controller/DisplayController.php
+++ b/administrator/components/com_menus/src/Controller/DisplayController.php
@@ -38,7 +38,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean        $cachable   If true, the view output will be cached
-     * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+     * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static    This object to support chaining.
      *

--- a/administrator/components/com_menus/src/Controller/MenuController.php
+++ b/administrator/components/com_menus/src/Controller/MenuController.php
@@ -33,7 +33,7 @@ class MenuController extends FormController
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      *

--- a/administrator/components/com_menus/src/Controller/MenuController.php
+++ b/administrator/components/com_menus/src/Controller/MenuController.php
@@ -32,7 +32,8 @@ class MenuController extends FormController
      * Dummy method to redirect back to standard controller
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      *

--- a/administrator/components/com_menus/src/Controller/MenusController.php
+++ b/administrator/components/com_menus/src/Controller/MenusController.php
@@ -29,7 +29,7 @@ class MenusController extends AdminController
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      *

--- a/administrator/components/com_menus/src/Controller/MenusController.php
+++ b/administrator/components/com_menus/src/Controller/MenusController.php
@@ -28,7 +28,8 @@ class MenusController extends AdminController
      * Display the view
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      *

--- a/administrator/components/com_menus/src/Model/MenuModel.php
+++ b/administrator/components/com_menus/src/Model/MenuModel.php
@@ -210,8 +210,8 @@ class MenuModel extends AdminModel
      *
      * @return  array|boolean  Array of filtered data if valid, false otherwise.
      *
-     * @see     JFormRule
-     * @see     JFilterInput
+     * @see     \Joomla\CMS\Form\FormRule
+     * @see     \Joomla\CMS\Filter\InputFilter
      * @since   3.9.23
      */
     public function validate($form, $data, $group = null)

--- a/administrator/components/com_messages/src/Controller/DisplayController.php
+++ b/administrator/components/com_messages/src/Controller/DisplayController.php
@@ -38,7 +38,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_messages/src/Controller/DisplayController.php
+++ b/administrator/components/com_messages/src/Controller/DisplayController.php
@@ -37,7 +37,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_modules/src/Controller/DisplayController.php
+++ b/administrator/components/com_modules/src/Controller/DisplayController.php
@@ -39,7 +39,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean        $cachable   If true, the view output will be cached
      * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                         @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_modules/src/Controller/DisplayController.php
+++ b/administrator/components/com_modules/src/Controller/DisplayController.php
@@ -38,7 +38,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean        $cachable   If true, the view output will be cached
-     * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}
+     * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_newsfeeds/src/Controller/DisplayController.php
+++ b/administrator/components/com_newsfeeds/src/Controller/DisplayController.php
@@ -38,7 +38,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining.
      *

--- a/administrator/components/com_newsfeeds/src/Controller/DisplayController.php
+++ b/administrator/components/com_newsfeeds/src/Controller/DisplayController.php
@@ -37,7 +37,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining.
      *

--- a/administrator/components/com_plugins/src/Controller/DisplayController.php
+++ b/administrator/components/com_plugins/src/Controller/DisplayController.php
@@ -37,7 +37,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_plugins/src/Controller/DisplayController.php
+++ b/administrator/components/com_plugins/src/Controller/DisplayController.php
@@ -38,7 +38,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_privacy/src/Controller/DisplayController.php
+++ b/administrator/components/com_privacy/src/Controller/DisplayController.php
@@ -41,7 +41,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  $this
      *

--- a/administrator/components/com_privacy/src/Controller/DisplayController.php
+++ b/administrator/components/com_privacy/src/Controller/DisplayController.php
@@ -40,7 +40,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  $this
      *

--- a/administrator/components/com_privacy/src/Model/RequestModel.php
+++ b/administrator/components/com_privacy/src/Model/RequestModel.php
@@ -386,7 +386,7 @@ class RequestModel extends AdminModel implements UserFactoryAwareInterface
      * @return  array|boolean  Array of filtered data if valid, false otherwise.
      *
      * @see     \Joomla\CMS\Form\FormRule
-     * @see     JFilterInput
+     * @see     \Joomla\CMS\Filter\InputFilter
      * @since   3.9.0
      */
     public function validate($form, $data, $group = null)

--- a/administrator/components/com_redirect/src/Controller/DisplayController.php
+++ b/administrator/components/com_redirect/src/Controller/DisplayController.php
@@ -38,7 +38,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
-     * @param   mixed    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   mixed    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_redirect/src/Controller/DisplayController.php
+++ b/administrator/components/com_redirect/src/Controller/DisplayController.php
@@ -39,7 +39,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
      * @param   mixed    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_scheduler/src/Controller/DisplayController.php
+++ b/administrator/components/com_scheduler/src/Controller/DisplayController.php
@@ -33,8 +33,8 @@ class DisplayController extends BaseController
 
     /**
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see
-     *                               {@link InputFilter::clean()}.
+     * @param   array    $urlparams  An array of safe url parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return BaseController|boolean  Returns either a BaseController object to support chaining, or false on failure
      *

--- a/administrator/components/com_scheduler/src/Controller/DisplayController.php
+++ b/administrator/components/com_scheduler/src/Controller/DisplayController.php
@@ -34,7 +34,7 @@ class DisplayController extends BaseController
     /**
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe url parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return BaseController|boolean  Returns either a BaseController object to support chaining, or false on failure
      *

--- a/administrator/components/com_tags/src/Controller/DisplayController.php
+++ b/administrator/components/com_tags/src/Controller/DisplayController.php
@@ -37,7 +37,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_tags/src/Controller/DisplayController.php
+++ b/administrator/components/com_tags/src/Controller/DisplayController.php
@@ -38,7 +38,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_templates/src/Controller/DisplayController.php
+++ b/administrator/components/com_templates/src/Controller/DisplayController.php
@@ -36,7 +36,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   boolean  $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_templates/src/Controller/DisplayController.php
+++ b/administrator/components/com_templates/src/Controller/DisplayController.php
@@ -35,7 +35,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   boolean  $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static|boolean   This object to support chaining or false on failure.
      *

--- a/administrator/components/com_users/src/Controller/CallbackController.php
+++ b/administrator/components/com_users/src/Controller/CallbackController.php
@@ -50,8 +50,8 @@ class CallbackController extends BaseController
      * Implement a callback feature, typically used for OAuth2 authentication
      *
      * @param   bool         $cachable    Can this view be cached
-     * @param   array|bool   $urlparams   An array of safe url parameters and their variable types, for valid values see
-     *                                    {@link JFilterInput::clean()}.
+     * @param   array|bool   $urlparams   An array of safe url parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      * @since 4.2.0

--- a/administrator/components/com_users/src/Controller/CallbackController.php
+++ b/administrator/components/com_users/src/Controller/CallbackController.php
@@ -49,9 +49,9 @@ class CallbackController extends BaseController
     /**
      * Implement a callback feature, typically used for OAuth2 authentication
      *
-     * @param   bool         $cachable    Can this view be cached
-     * @param   array|bool   $urlparams   An array of safe url parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     * @param   bool         $cachable   Can this view be cached
+     * @param   array|bool   $urlparams  An array of safe url parameters and their variable types.
+     *                       @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      * @since 4.2.0

--- a/administrator/components/com_users/src/Controller/DisplayController.php
+++ b/administrator/components/com_users/src/Controller/DisplayController.php
@@ -67,7 +67,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  This object to support chaining or false on failure.
      *

--- a/administrator/components/com_users/src/Controller/DisplayController.php
+++ b/administrator/components/com_users/src/Controller/DisplayController.php
@@ -66,8 +66,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types,
-     *                               for valid values see {@link \Joomla\CMS\Filter\InputFilter::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  This object to support chaining or false on failure.
      *

--- a/administrator/components/com_users/src/Controller/MethodsController.php
+++ b/administrator/components/com_users/src/Controller/MethodsController.php
@@ -58,8 +58,8 @@ class MethodsController extends BaseController implements UserFactoryAwareInterf
      * Disable Multi-factor Authentication for the current user
      *
      * @param   bool   $cachable     Can this view be cached
-     * @param   array  $urlparams    An array of safe url parameters and their variable types, for valid values see
-     *                               {@link JFilterInput::clean()}.
+     * @param   array  $urlparams    An array of safe url parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      * @since   4.2.0
@@ -112,8 +112,8 @@ class MethodsController extends BaseController implements UserFactoryAwareInterf
      * List all available Multi-factor Authentication Methods available and guide the user to setting them up
      *
      * @param   bool   $cachable     Can this view be cached
-     * @param   array  $urlparams    An array of safe url parameters and their variable types, for valid values see
-     *                               {@link JFilterInput::clean()}.
+     * @param   array  $urlparams    An array of safe url parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      * @since   4.2.0
@@ -154,8 +154,8 @@ class MethodsController extends BaseController implements UserFactoryAwareInterf
      * Disable Multi-factor Authentication for the current user
      *
      * @param   bool   $cachable     Can this view be cached
-     * @param   array  $urlparams    An array of safe url parameters and their variable types, for valid values see
-     *                               {@link JFilterInput::clean()}.
+     * @param   array  $urlparams    An array of safe url parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      * @since   4.2.0

--- a/administrator/components/com_users/src/Controller/MethodsController.php
+++ b/administrator/components/com_users/src/Controller/MethodsController.php
@@ -57,9 +57,9 @@ class MethodsController extends BaseController implements UserFactoryAwareInterf
     /**
      * Disable Multi-factor Authentication for the current user
      *
-     * @param   bool   $cachable     Can this view be cached
-     * @param   array  $urlparams    An array of safe url parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     * @param   bool   $cachable   Can this view be cached
+     * @param   array  $urlparams  An array of safe url parameters and their variable types.
+     *                 @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      * @since   4.2.0
@@ -111,9 +111,9 @@ class MethodsController extends BaseController implements UserFactoryAwareInterf
     /**
      * List all available Multi-factor Authentication Methods available and guide the user to setting them up
      *
-     * @param   bool   $cachable     Can this view be cached
-     * @param   array  $urlparams    An array of safe url parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     * @param   bool   $cachable   Can this view be cached
+     * @param   array  $urlparams  An array of safe url parameters and their variable types.
+     *                 @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      * @since   4.2.0
@@ -153,9 +153,9 @@ class MethodsController extends BaseController implements UserFactoryAwareInterf
     /**
      * Disable Multi-factor Authentication for the current user
      *
-     * @param   bool   $cachable     Can this view be cached
-     * @param   array  $urlparams    An array of safe url parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     * @param   bool   $cachable   Can this view be cached
+     * @param   array  $urlparams  An array of safe url parameters and their variable types.
+     *                 @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      * @since   4.2.0

--- a/administrator/components/com_users/src/Model/LevelModel.php
+++ b/administrator/components/com_users/src/Model/LevelModel.php
@@ -252,7 +252,7 @@ class LevelModel extends AdminModel
      * @return  array|boolean  Array of filtered data if valid, false otherwise.
      *
      * @see     \Joomla\CMS\Form\FormRule
-     * @see     \JFilterInput
+     * @see     \Joomla\CMS\Filter\InputFilter
      * @since   3.8.8
      */
     public function validate($form, $data, $group = null)

--- a/administrator/components/com_workflow/src/Controller/DisplayController.php
+++ b/administrator/components/com_workflow/src/Controller/DisplayController.php
@@ -90,7 +90,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  This object to support chaining.
      *

--- a/administrator/components/com_workflow/src/Controller/DisplayController.php
+++ b/administrator/components/com_workflow/src/Controller/DisplayController.php
@@ -91,7 +91,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController|boolean  This object to support chaining.
      *

--- a/components/com_config/src/Model/FormModel.php
+++ b/components/com_config/src/Model/FormModel.php
@@ -236,7 +236,7 @@ abstract class FormModel extends BaseForm
      * @return  mixed  Array of filtered data if valid, false otherwise.
      *
      * @see     \Joomla\CMS\Form\FormRule
-     * @see     JFilterInput
+     * @see     \Joomla\CMS\Filter\InputFilter
      * @since   3.2
      */
     public function validate($form, $data, $group = null)

--- a/components/com_contact/src/Controller/DisplayController.php
+++ b/components/com_contact/src/Controller/DisplayController.php
@@ -53,7 +53,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  DisplayController  This object to support chaining.
      *

--- a/components/com_contact/src/Controller/DisplayController.php
+++ b/components/com_contact/src/Controller/DisplayController.php
@@ -52,7 +52,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  DisplayController  This object to support chaining.
      *

--- a/components/com_content/src/Controller/DisplayController.php
+++ b/components/com_content/src/Controller/DisplayController.php
@@ -56,7 +56,8 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
-     * @param   boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+     * @param   boolean  $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  DisplayController  This object to support chaining.
      *

--- a/components/com_content/src/Controller/DisplayController.php
+++ b/components/com_content/src/Controller/DisplayController.php
@@ -57,7 +57,7 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
      * @param   boolean  $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  DisplayController  This object to support chaining.
      *

--- a/components/com_finder/src/Controller/DisplayController.php
+++ b/components/com_finder/src/Controller/DisplayController.php
@@ -28,8 +28,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached. [optional]
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types,
-     *                               for valid values @see \InputFilter::clean(). [optional]
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types. Optional.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  This object is to support chaining.
      *

--- a/components/com_finder/src/Controller/DisplayController.php
+++ b/components/com_finder/src/Controller/DisplayController.php
@@ -29,7 +29,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached. [optional]
      * @param   array    $urlparams  An array of safe URL parameters and their variable types. Optional.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  This object is to support chaining.
      *

--- a/components/com_finder/src/Controller/DisplayController.php
+++ b/components/com_finder/src/Controller/DisplayController.php
@@ -29,7 +29,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached. [optional]
      * @param   array    $urlparams  An array of safe URL parameters and their variable types,
-     *                               for valid values see {@link \JFilterInput::clean()}. [optional]
+     *                               for valid values @see \InputFilter::clean(). [optional]
      *
      * @return  static  This object is to support chaining.
      *

--- a/components/com_newsfeeds/src/Controller/DisplayController.php
+++ b/components/com_newsfeeds/src/Controller/DisplayController.php
@@ -27,7 +27,8 @@ class DisplayController extends BaseController
      * Method to show a newsfeeds view
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link \JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  This object to support chaining.
      *

--- a/components/com_newsfeeds/src/Controller/DisplayController.php
+++ b/components/com_newsfeeds/src/Controller/DisplayController.php
@@ -28,7 +28,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  This object to support chaining.
      *

--- a/components/com_privacy/src/Controller/DisplayController.php
+++ b/components/com_privacy/src/Controller/DisplayController.php
@@ -29,7 +29,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  $this
      *

--- a/components/com_privacy/src/Controller/DisplayController.php
+++ b/components/com_privacy/src/Controller/DisplayController.php
@@ -28,7 +28,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  $this
      *

--- a/components/com_tags/src/Controller/DisplayController.php
+++ b/components/com_tags/src/Controller/DisplayController.php
@@ -29,7 +29,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean        $cachable   If true, the view output will be cached
      * @param   mixed|boolean  $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                         @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  This object to support chaining.
      *

--- a/components/com_tags/src/Controller/DisplayController.php
+++ b/components/com_tags/src/Controller/DisplayController.php
@@ -28,8 +28,7 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean        $cachable   If true, the view output will be cached
-     * @param   mixed|boolean  $urlparams  An array of safe URL parameters and their
-     *                                     variable types.
+     * @param   mixed|boolean  $urlparams  An array of safe URL parameters and their variable types.
      * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  This object to support chaining.

--- a/components/com_tags/src/Controller/DisplayController.php
+++ b/components/com_tags/src/Controller/DisplayController.php
@@ -29,7 +29,8 @@ class DisplayController extends BaseController
      *
      * @param   boolean        $cachable   If true, the view output will be cached
      * @param   mixed|boolean  $urlparams  An array of safe URL parameters and their
-     *                                     variable types, for valid values see {@link \JFilterInput::clean()}.
+     *                                     variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  This object to support chaining.
      *

--- a/components/com_users/src/Controller/DisplayController.php
+++ b/components/com_users/src/Controller/DisplayController.php
@@ -30,7 +30,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean        $cachable   If true, the view output will be cached
      * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                         @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      *

--- a/components/com_users/src/Controller/DisplayController.php
+++ b/components/com_users/src/Controller/DisplayController.php
@@ -29,8 +29,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean        $cachable   If true, the view output will be cached
-     * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types,
-     *                                     for valid values see {@link \Joomla\CMS\Filter\InputFilter::clean()}.
+     * @param   array|boolean  $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  void
      *

--- a/components/com_wrapper/src/Controller/DisplayController.php
+++ b/components/com_wrapper/src/Controller/DisplayController.php
@@ -27,7 +27,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+     * @param   array    $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController  This object to support chaining.
      *

--- a/components/com_wrapper/src/Controller/DisplayController.php
+++ b/components/com_wrapper/src/Controller/DisplayController.php
@@ -28,7 +28,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  BaseController  This object to support chaining.
      *

--- a/installation/src/Controller/DisplayController.php
+++ b/installation/src/Controller/DisplayController.php
@@ -28,7 +28,8 @@ class DisplayController extends BaseController
      * Method to display a view.
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
-     * @param   boolean  $urlparams  An array of safe URL parameters and their variable types, for valid values see {@link JFilterInput::clean()}.
+     * @param   boolean  $urlparams  An array of safe URL parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  \Joomla\CMS\MVC\Controller\BaseController  This object to support chaining.
      *

--- a/installation/src/Controller/DisplayController.php
+++ b/installation/src/Controller/DisplayController.php
@@ -29,7 +29,7 @@ class DisplayController extends BaseController
      *
      * @param   boolean  $cachable   If true, the view output will be cached.
      * @param   boolean  $urlparams  An array of safe URL parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  \Joomla\CMS\MVC\Controller\BaseController  This object to support chaining.
      *

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -675,7 +675,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      * @param   string  $request  The name of the variable passed in a request.
      * @param   string  $default  The default value for the variable if not found. Optional.
      * @param   string  $type     Filter for the variable. Optional.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                  @see      \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  mixed  The request user state.
      *

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -674,7 +674,8 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      * @param   string  $key      The key of the user state variable.
      * @param   string  $request  The name of the variable passed in a request.
      * @param   string  $default  The default value for the variable if not found. Optional.
-     * @param   string  $type     Filter for the variable, for valid values see {@link InputFilter::clean()}. Optional.
+     * @param   string  $type     Filter for the variable. Optional.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  mixed  The request user state.
      *

--- a/libraries/src/Application/CMSWebApplicationInterface.php
+++ b/libraries/src/Application/CMSWebApplicationInterface.php
@@ -80,7 +80,8 @@ interface CMSWebApplicationInterface extends SessionAwareWebApplicationInterface
      * @param   string  $key      The key of the user state variable.
      * @param   string  $request  The name of the variable passed in a request.
      * @param   string  $default  The default value for the variable if not found. Optional.
-     * @param   string  $type     Filter for the variable, for valid values see {@link InputFilter::clean()}. Optional.
+     * @param   string  $type     Filter for the variable. Optional.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  mixed  The request user state.
      *

--- a/libraries/src/Application/CMSWebApplicationInterface.php
+++ b/libraries/src/Application/CMSWebApplicationInterface.php
@@ -81,7 +81,7 @@ interface CMSWebApplicationInterface extends SessionAwareWebApplicationInterface
      * @param   string  $request  The name of the variable passed in a request.
      * @param   string  $default  The default value for the variable if not found. Optional.
      * @param   string  $type     Filter for the variable. Optional.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                  @see      \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  mixed  The request user state.
      *

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -597,7 +597,8 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
      * you will need to override it in your own controllers.
      *
      * @param   boolean  $cachable   If true, the view output will be cached
-     * @param   array    $urlparams  An array of safe url parameters and their variable types, for valid values see {@link InputFilter::clean()}.
+     * @param   array    $urlparams  An array of safe url parameters and their variable types.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  A \JControllerLegacy object to support chaining.
      *

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -598,7 +598,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
      *
      * @param   boolean  $cachable   If true, the view output will be cached
      * @param   array    $urlparams  An array of safe url parameters and their variable types.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      *
      * @return  static  A \JControllerLegacy object to support chaining.
      *

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -629,7 +629,8 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
      * @param   string   $key        The key of the user state variable.
      * @param   string   $request    The name of the variable passed in a request.
      * @param   string   $default    The default value for the variable if not found. Optional.
-     * @param   string   $type       Filter for the variable, for valid values see {@link InputFilter::clean()}. Optional.
+     * @param   string   $type       Filter for the variable. Optional.
+     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      * @param   boolean  $resetPage  If true, the limitstart in request is set to zero
      *
      * @return  mixed  The request user state.

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -630,7 +630,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
      * @param   string   $request    The name of the variable passed in a request.
      * @param   string   $default    The default value for the variable if not found. Optional.
      * @param   string   $type       Filter for the variable. Optional.
-     * @see     \Joomla\CMS\Filter\InputFilter::clean() for valid values.
+     *                   @see        \Joomla\CMS\Filter\InputFilter::clean() for valid values.
      * @param   boolean  $resetPage  If true, the limitstart in request is set to zero
      *
      * @return  mixed  The request user state.


### PR DESCRIPTION

1. `@link` is to display a hyperlink to a URL and it should be `@see`
2. `JFilterInput` should be `InputFilter`
3.  when there is **no** use statement for this then the fqn must be used or it simply doesnt work which as we now remove unuse use statements might have increased. 
4. afaict `@see` only works when it is on a new line

There is no point in having docs if they are not correct so I propose that these `@link` are updated as above and while it might not always be necessary to use the fqn it would make it more consistent.

Code Review