### PR TITLE
Fix error page rendering with unclosed Output buffers

### DIFF
--- a/libraries/src/Exception/ExceptionHandler.php
+++ b/libraries/src/Exception/ExceptionHandler.php
@@ -94,6 +94,11 @@ class ExceptionHandler
                 $app->redirect('index.php');
             }
 
+            // Clear all opened Output buffers to prevent misrendering
+            for ($i = 0, $l = ob_get_level(); $i < $l; $i++) {
+                ob_end_clean();
+            }
+
             /*
              * Try and determine the format to render the error page in
              *


### PR DESCRIPTION
### Summary of Changes

In some cases the error page is rendered incorrectly, when exception happen while rendering.


### Testing Instructions
Applly patch.
Add an error `throw new \Exception('That an error');` in to `layouts/joomla/content/info_block/hits.php`
On the site open the article detail view.

Also can try to add an error in to the text field layout `layouts/joomla/form/field/text.php`
And try to edit the Article.


### Actual result BEFORE applying this Pull Request
You get broken page:
Half article are rendered,
And then an error is rendered


### Expected result AFTER applying this Pull Request
Only error is rendered


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
