### PR TITLE
[4.4] Disabled Option in Select

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_custom-forms.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_custom-forms.scss
@@ -62,5 +62,9 @@
   option {
     color: var(--template-text-dark);
     background-color: $white;
+
+    &:disabled {
+        background-color: var(--template-bg-dark-5);
+      }
   }
 }

--- a/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_custom-forms.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_custom-forms.scss
@@ -64,7 +64,7 @@
     background-color: $white;
 
     &:disabled {
-        background-color: var(--template-bg-dark-5);
-      }
+      background-color: var(--template-bg-dark-5);
+    }
   }
 }


### PR DESCRIPTION
Pull Request for several closed issues

### Summary of Changes
When an option in a select list is disabled it is not visually displayed any differently to an enabled option. You just can't select/highlight it

Although we dont have any examples (that I am aware of) in the core of this there are many extensions that do. Usually when there are "pro" options that are disabled in a regular version.

This PR just adds a slight background to the disabled option

### Testing Instructions
This is an scss change so you will need to either test with a prebuilt package or run `npm run build:css`

Then edit `administrator\components\com_content\forms\article.xml` and add the following line as an additional option for the Status Field
`			<option value="3" disabled="disabled">Disabled</option>
`

### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/1ea0afa1-6d97-46b0-a40c-5ef98f937b13)



### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/d301f26f-9989-4f04-9708-1c6e36236c4c)



### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ x Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
