### PR TITLE
[5.0] Fix excluded files from PR #41065

### DIFF
--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -59,11 +59,9 @@ if (empty($options['to'])) {
     exit(1);
 }
 
-// Directories and files to skip for the check (needs to include anything from J3 we want to keep)
+// Directories to skip for the check (needs to include anything from J3 we want to keep)
 $previousReleaseExclude = [
     $options['from'] . '/administrator/components/com_search',
-    $options['from'] . '/administrator/language/en-GB/plg_task_demotasks.ini',
-    $options['from'] . '/administrator/language/en-GB/plg_task_demotasks.sys.ini',
     $options['from'] . '/components/com_search',
     $options['from'] . '/images/sampledata',
     $options['from'] . '/installation',
@@ -173,6 +171,8 @@ $filesToKeep = [
     "'/administrator/language/en-GB/en-GB.plg_search_weblinks.sys.ini',",
     "'/administrator/language/en-GB/en-GB.plg_system_weblinks.ini',",
     "'/administrator/language/en-GB/en-GB.plg_system_weblinks.sys.ini',",
+    "'/administrator/language/en-GB/plg_task_demotasks.ini',",
+    "'/administrator/language/en-GB/plg_task_demotasks.sys.ini',",
     "'/language/en-GB/en-GB.com_search.ini',",
     "'/language/en-GB/en-GB.mod_search.ini',",
     "'/language/en-GB/en-GB.mod_search.sys.ini',",


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/41065#issuecomment-1646564168 .

### Summary of Changes

This Pull Request (PR) fixes a mistake in the `build/deleted_file_check.php` script which I've made with my recently merged PR #41065 :

The files `administrator/language/en-GB/plg_task_demotasks.ini` and `administrator/language/en-GB/plg_task_demotasks.sys.ini` should be excluded from the list of deleted files, but that doesn't work because I've added them at the wrong place.

### Testing Instructions

1. On a clean, current 5.0-dev branch (no need for having run composer or npm and no need for a Joomla installation), download the following 2 Joomla 5.0 Alpha 1 and 2 full packages and save them in the `tmp` folder:
- https://github.com/joomla/joomla-cms/releases/download/5.0.0-alpha1/Joomla_5.0.0-alpha1-Alpha-Full_Package.zip
- https://github.com/joomla/joomla-cms/releases/download/5.0.0-alpha2/Joomla_5.0.0-alpha2-Alpha-Full_Package.zip
2. Unzip the packages in the `tmp` folder into 2 separate folders `Joomla_5.0.0-alpha1-Alpha-Full_Package` and `Joomla_5.0.0-alpha2-Alpha-Full_Package`.
3. In a command windows in the directory with your git clone and the branch from step 1, run the following command to check the two folders from the previous step for deleted files and folders (on Windows you have to use backslashes `\` instead of slashes `/` for the paths):
```
php ./build/deleted_file_check.php --from=./tmp/Joomla_5.0.0-alpha1-Alpha-Full_Package --to=./tmp/Joomla_5.0.0-alpha2-Alpha-Full_Package
```
4. Check the 2 created text files `./build/deleted_files.txt` and `./build/deleted_folders.txt`.
Result: See section "Actual result BEFORE applying this Pull Request" below.
5. Save the 2 text files from step 4 for later comparison.
6. Apply the changes from this PR.
7. Repeat steps 3 and 4 and compare the 2 text files with those saved in step 5.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

File `./build/deleted_files.txt` still contains 2 rows `'/administrator/language/en-GB/plg_task_demotasks.ini',` and `'/administrator/language/en-GB/plg_task_demotasks.sys.ini',`.

File `./build/deleted_folders.txt` is empty.

### Expected result AFTER applying this Pull Request

File `./build/deleted_files.txt` doesn't contain `'/administrator/language/en-GB/plg_task_demotasks.ini',` and `'/administrator/language/en-GB/plg_task_demotasks.sys.ini',`.

Besides that, it doesn't differ to the file saved in step 5 without this PR applied.

File `./build/deleted_folders.txt` is empty, same as without this PR.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
