### PR TITLE
Fix calendar field, date filter

### DIFF
--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -393,12 +393,20 @@ class CalendarField extends FormField
             throw new \UnexpectedValueException(sprintf('%s::filter `element` is not an instance of SimpleXMLElement', \get_class($this)));
         }
 
-        if ((int) $value <= 0) {
+        if (!$value) {
             return '';
         }
 
         if ($this->filterFormat) {
-            $value = DateTime::createFromFormat($this->filterFormat, $value)->format('Y-m-d H:i:s');
+            // Create a DateTime object from given value, based on filterFormat
+            $dateTime = DateTime::createFromFormat($this->filterFormat, $value);
+
+            // When value is incorrectly formatted
+            if (!$dateTime) {
+                return '';
+            }
+
+            $value = $dateTime->format('Y-m-d H:i:s');
         }
 
         $app = Factory::getApplication();


### PR DESCRIPTION
Pull Request for Issue #41194 .

### Summary of Changes

Fixing Calendar::filter, to work correctly with non numeric dates.


### Testing Instructions
Apply patch.
Add calendar field somewhere:

```xml
<field type="calendar" name="nextdate"  format="%a %e %b %Y" filterformat="D j M Y" 
  translateformat="false" filter="server_utc"
  showtime="false" label="Next Date" />
```
Try edit  the date with this field.

### Actual result BEFORE applying this Pull Request
Date does not saved


### Expected result AFTER applying this Pull Request
Date saved


### Link to documentations
Please select:
- [ ] Need to add a missing info about `filterformat` to https://docs.joomla.org/Calendar_form_field_type
- [x] No documentation changes for manual.joomla.org needed
