### PR TITLE
[5.x] schemaorg plugins mark as core

### DIFF
--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -279,6 +279,15 @@ class ExtensionHelper
         ['plugin', 'blog', 'sampledata', 0],
         ['plugin', 'multilang', 'sampledata', 0],
 
+        // Core plugin extensions - schemaorg
+        ['plugin', 'blogposting', 'schemaorg', 0],
+        ['plugin', 'book', 'schemaorg', 0],
+        ['plugin', 'event', 'schemaorg', 0],
+        ['plugin', 'jobposting', 'schemaorg', 0],
+        ['plugin', 'organization', 'schemaorg', 0],
+        ['plugin', 'person', 'schemaorg', 0],
+        ['plugin', 'recipe', 'schemaorg', 0],
+
         // Core plugin extensions - system
         ['plugin', 'accessibility', 'system', 0],
         ['plugin', 'actionlogs', 'system', 0],
@@ -299,6 +308,7 @@ class ExtensionHelper
         ['plugin', 'redirect', 'system', 0],
         ['plugin', 'remember', 'system', 0],
         ['plugin', 'schedulerunner', 'system', 0],
+        ['plugin', 'schemaorg', 'system', 0],
         ['plugin', 'sef', 'system', 0],
         ['plugin', 'sessiongc', 'system', 0],
         ['plugin', 'shortcut', 'system', 0],


### PR DESCRIPTION
This PR adds the missing code so that the new system and schemaorg plugins are listed as core extensions in the extension manager

### Testing Instructions
Go to the extensions manager and filter on non-core extensions


### Actual result BEFORE applying this Pull Request
All the newly merged schemaorg plugins are listd as non-core extensions

### Expected result AFTER applying this Pull Request
No extensions listed (except dependent on your install just the testing sample data plugin)
![image](https://github.com/joomla/joomla-cms/assets/1296369/f99ca44f-62eb-4e6c-8843-9a3817278163)



### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
