### PR TITLE
[5.0] Smart Search to show Contact images

### DIFF
--- a/plugins/finder/contacts/src/Extension/Contacts.php
+++ b/plugins/finder/contacts/src/Extension/Contacts.php
@@ -270,6 +270,12 @@ final class Contacts extends Adapter
             $item->title = $title;
         }
 
+        // Add the image.
+        if ($item->image) {
+            $item->imageUrl = $item->image;
+            $item->imageAlt = $item->title ?? '';
+        }
+
         /*
          * Add the metadata processing instructions based on the contact
          * configuration parameters.
@@ -401,7 +407,7 @@ final class Contacts extends Adapter
             ->select('a.publish_up AS publish_start_date, a.publish_down AS publish_end_date')
             ->select('a.suburb AS city, a.state AS region, a.country, a.postcode AS zip')
             ->select('a.telephone, a.fax, a.misc AS summary, a.email_to AS email, a.mobile')
-            ->select('a.webpage, a.access, a.published AS state, a.ordering, a.params, a.catid')
+            ->select('a.image, a.webpage, a.access, a.published AS state, a.ordering, a.params, a.catid')
             ->select('c.title AS category, c.published AS cat_state, c.access AS cat_access');
 
         // Handle the alias CASE WHEN portion of the query


### PR DESCRIPTION
### Summary of Changes
This is a follow up to #35612.
Smart Search now shows images only for the articles in the results .

With this PR images for the contacts (com_contact) can be shown as well.


### Testing Instructions

1. You need to have some contacts created (under Components > Contacts > Contacts).
    Your contacts need to have images.

2. Go to the Smart Search and press the "Index" button.

3. In the menu item for the Smart Search enable the setting _Result Image_ .

4. Now in the front-end use the Smart Search (menu item or module) and search for one of your contacts.

### Actual result BEFORE applying this Pull Request
No image in the contact results.


### Expected result AFTER applying this Pull Request
Contact images.


### Link to documentations
Please select:

- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
