### PR TITLE
[5.0] schemaorg missing namespace

### DIFF
--- a/plugins/schemaorg/blogposting/src/Extension/Blogposting.php
+++ b/plugins/schemaorg/blogposting/src/Extension/Blogposting.php
@@ -1,13 +1,11 @@
 <?php
 
 /**
- * @package        Joomla.Plugin
+ * @package     Joomla.Plugin
  * @subpackage  Schemaorg.blogposting
  *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
 namespace Joomla\Plugin\Schemaorg\Blogposting\Extension;

--- a/plugins/schemaorg/book/src/Extension/Book.php
+++ b/plugins/schemaorg/book/src/Extension/Book.php
@@ -2,12 +2,10 @@
 
 /**
  * @package     Joomla.Plugin
-  * @subpackage  Schemaorg.book
-  *
+ * @subpackage  Schemaorg.book
+ *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
 namespace Joomla\Plugin\Schemaorg\Book\Extension;

--- a/plugins/schemaorg/event/src/Extension/Event.php
+++ b/plugins/schemaorg/event/src/Extension/Event.php
@@ -3,12 +3,9 @@
 /**
  * @package     Joomla.Plugin
  * @subpackage  Schemaorg.event
- * @subpackage  Schemaorg.event
  *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
 namespace Joomla\Plugin\Schemaorg\Event\Extension;

--- a/plugins/schemaorg/jobposting/src/Extension/JobPosting.php
+++ b/plugins/schemaorg/jobposting/src/Extension/JobPosting.php
@@ -3,12 +3,9 @@
 /**
  * @package     Joomla.Plugin
  * @subpackage  Schemaorg.jobposting
- * @subpackage  Schemaorg.jobposting
  *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
 namespace Joomla\Plugin\Schemaorg\JobPosting\Extension;

--- a/plugins/schemaorg/organization/src/Extension/Organization.php
+++ b/plugins/schemaorg/organization/src/Extension/Organization.php
@@ -2,12 +2,10 @@
 
 /**
  * @package     Joomla.Plugin
-* @subpackage Schemaorg.organization
-*
+ * @subpackage  Schemaorg.organization
+ *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
 namespace Joomla\Plugin\Schemaorg\Organization\Extension;

--- a/plugins/schemaorg/person/src/Extension/Person.php
+++ b/plugins/schemaorg/person/src/Extension/Person.php
@@ -6,8 +6,6 @@
  *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
 namespace Joomla\Plugin\Schemaorg\Person\Extension;

--- a/plugins/schemaorg/recipe/src/Extension/Recipe.php
+++ b/plugins/schemaorg/recipe/src/Extension/Recipe.php
@@ -6,8 +6,6 @@
  *
  * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
-
- * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
  */
 
 namespace Joomla\Plugin\Schemaorg\Recipe\Extension;


### PR DESCRIPTION
Removes the code that disables phpcs checking for a missing namespace as it is present.

fixes some codestyle at the same time

codereview and if it passes phpcs checks

First reported https://github.com/joomla/joomla-cms/pull/41151#discussion_r1261756142