### PR TITLE
[5.0] schemaorg replace JPATH_PLATFORM with _JEXEC

### DIFF
--- a/libraries/src/Form/Field/SchemaorgComponentSectionsField.php
+++ b/libraries/src/Form/Field/SchemaorgComponentSectionsField.php
@@ -1,5 +1,12 @@
 <?php
 
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
 namespace Joomla\CMS\Form\Field;
 
 use Joomla\CMS\Factory;

--- a/libraries/src/Form/Field/SchemaorgComponentSectionsField.php
+++ b/libraries/src/Form/Field/SchemaorgComponentSectionsField.php
@@ -8,7 +8,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Schemaorg\SchemaorgServiceInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**

--- a/libraries/src/Schemaorg/SchemaorgServiceInterface.php
+++ b/libraries/src/Schemaorg/SchemaorgServiceInterface.php
@@ -10,7 +10,7 @@
 namespace Joomla\CMS\Schemaorg;
 
 // phpcs:disable PSR1.Files.SideEffects
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**

--- a/libraries/src/Schemaorg/SchemaorgServiceTrait.php
+++ b/libraries/src/Schemaorg/SchemaorgServiceTrait.php
@@ -12,7 +12,7 @@ namespace Joomla\CMS\Schemaorg;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**


### PR DESCRIPTION
### Summary of Changes

- replace deprecated JPATH_PLATFORM with _JEXEC
- add copyright

### Testing Instructions

code review
