### PR TITLE
[5.0] schemaorg fix deploy version

### DIFF
--- a/libraries/src/Schemaorg/SchemaorgServiceInterface.php
+++ b/libraries/src/Schemaorg/SchemaorgServiceInterface.php
@@ -16,7 +16,7 @@ namespace Joomla\CMS\Schemaorg;
 /**
  * The schemaorg service.
  *
- * @since  _DEPLOY_VERSION__
+ * @since  5.0.0
  */
 interface SchemaorgServiceInterface
 {
@@ -25,7 +25,7 @@ interface SchemaorgServiceInterface
      *
      * @return  array
      *
-     * @since   _DEPLOY_VERSION__
+     * @since   5.0.0
      */
     public function getSchemaorgContexts(): array;
 }

--- a/libraries/src/Schemaorg/SchemaorgServiceTrait.php
+++ b/libraries/src/Schemaorg/SchemaorgServiceTrait.php
@@ -18,7 +18,7 @@ use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 /**
  * Trait for component schemaorg service.
  *
- * @since  _DEPLOY_VERSION__
+ * @since  5.0.0
  */
 trait SchemaorgServiceTrait
 {

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -470,7 +470,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
      *
      * @return   boolean
      *
-     * @since   _DEPLOY_VERSION__
+     * @since   5.0.0
      */
     protected function isSupported($context)
     {


### PR DESCRIPTION
### Summary of Changes

replace misspelled `_DEPLOY_VERSION__`

### Testing Instructions

code review
