### PR TITLE
[5.0] schemaorg use injected application from plugin provider

### DIFF
--- a/libraries/src/Schemaorg/SchemaorgPluginTrait.php
+++ b/libraries/src/Schemaorg/SchemaorgPluginTrait.php
@@ -9,7 +9,6 @@
 
 namespace Joomla\CMS\Schemaorg;
 
-use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\ListField;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -22,13 +21,6 @@ use Joomla\Event\EventInterface;
  */
 trait SchemaorgPluginTrait
 {
-    /**
-     * The application object
-     *
-     * @var CMSApplication
-     */
-    protected $app;
-
     /**
      * Define all fields which are media type to clean them
      *
@@ -338,7 +330,7 @@ trait SchemaorgPluginTrait
             return false;
         }
 
-        $component = $this->app->bootComponent($parts[0]);
+        $component = $this->getApplication()->bootComponent($parts[0]);
 
         return $component instanceof SchemaorgServiceInterface;
     }

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -39,7 +39,6 @@ use Joomla\Registry\Registry;
  */
 final class Schemaorg extends CMSPlugin implements SubscriberInterface
 {
-    // use SchemaorgPluginTrait;
     use DatabaseAwareTrait;
 
     /**


### PR DESCRIPTION
### Summary of Changes

remove `app` property from plugin trait and replace with `getApplication()`
https://github.com/joomla/joomla-cms/blob/dd286927b99768eaf4049e1fe936128b9e3f146a/libraries/src/Plugin/CMSPlugin.php#L136

### Testing Instructions

Test if schema.org types still available in dropdown
![image](https://github.com/joomla/joomla-cms/assets/66922325/71f11917-8517-4d21-aa76-825575d7f4f9)

