### PR TITLE
[5.0][RFC] Move Toolbar singleton to HtmlDocument

### DIFF
--- a/administrator/components/com_finder/src/View/Indexer/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Indexer/HtmlView.php
@@ -10,7 +10,6 @@
 
 namespace Joomla\Component\Finder\Administrator\View\Indexer;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
@@ -69,7 +68,7 @@ class HtmlView extends BaseHtmlView
 
         ToolbarHelper::title(Text::_('COM_FINDER_INDEXER_TOOLBAR_TITLE'), 'search-plus finder');
 
-        $toolbar->linkButton('back','JTOOLBAR_BACK')
+        $toolbar->linkButton('back', 'JTOOLBAR_BACK')
             ->icon('icon-arrow-' . ($this->getLanguage()->isRtl() ? 'right' : 'left'))
             ->url(Route::_('index.php?option=com_finder&view=index'));
 

--- a/administrator/components/com_finder/src/View/Indexer/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Indexer/HtmlView.php
@@ -64,17 +64,14 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        $toolbar = Toolbar::getInstance('toolbar');
+        /** @var Toolbar $toolbar */
+        $toolbar = $this->getDocument()->getToolbar();
 
         ToolbarHelper::title(Text::_('COM_FINDER_INDEXER_TOOLBAR_TITLE'), 'search-plus finder');
 
-        $arrow  = Factory::getLanguage()->isRtl() ? 'arrow-right' : 'arrow-left';
-
-        ToolbarHelper::link(
-            Route::_('index.php?option=com_finder&view=index'),
-            'JTOOLBAR_BACK',
-            $arrow
-        );
+        $toolbar->linkButton('back','JTOOLBAR_BACK')
+            ->icon('icon-arrow-' . ($this->getLanguage()->isRtl() ? 'right' : 'left'))
+            ->url(Route::_('index.php?option=com_finder&view=index'));
 
         $toolbar->standardButton('index', 'COM_FINDER_INDEX')
             ->icon('icon-play')

--- a/administrator/components/com_finder/src/View/Item/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Item/HtmlView.php
@@ -84,7 +84,7 @@ class HtmlView extends BaseHtmlView
 
         ToolbarHelper::title(Text::_('COM_FINDER_INDEX_TOOLBAR_TITLE'), 'search-plus finder');
 
-        $toolbar->linkButton('back','JTOOLBAR_BACK')
+        $toolbar->linkButton('back', 'JTOOLBAR_BACK')
             ->icon('icon-arrow-' . ($this->getLanguage()->isRtl() ? 'right' : 'left'))
             ->url(Route::_('index.php?option=com_finder&view=index'));
     }

--- a/administrator/components/com_finder/src/View/Item/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Item/HtmlView.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Finder\Administrator\View\Item;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 

--- a/administrator/components/com_finder/src/View/Item/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Item/HtmlView.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Finder\Administrator\View\Item;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 
 /**
@@ -78,7 +79,13 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
+        /** @var Toolbar $toolbar */
+        $toolbar = $this->getDocument()->getToolbar();
+
         ToolbarHelper::title(Text::_('COM_FINDER_INDEX_TOOLBAR_TITLE'), 'search-plus finder');
-        ToolbarHelper::back('JTOOLBAR_BACK', 'index.php?option=com_finder&view=index');
+
+        $toolbar->linkButton('back','JTOOLBAR_BACK')
+            ->icon('icon-arrow-' . ($this->getLanguage()->isRtl() ? 'right' : 'left'))
+            ->url(Route::_('index.php?option=com_finder&view=index'));
     }
 }

--- a/administrator/language/en-GB/mod_toolbar.ini
+++ b/administrator/language/en-GB/mod_toolbar.ini
@@ -4,4 +4,6 @@
 ; Note : All ini files need to be saved as UTF-8
 
 MOD_TOOLBAR="Toolbar"
+MOD_TOOLBAR_FIELD_TOOLBAR_LABEL="Toolbar Identifier"
+MOD_TOOLBAR_FIELD_TOOLBAR_DESCRIPTION="The default toolbar in the administrator is called 'toolbar', if you have an extension that generate own toolbars you can create an own module with it's toolbar identifier. The default toolbar should never be removed!"
 MOD_TOOLBAR_XML_DESCRIPTION="This module shows the toolbar icons used to control actions throughout the Administrator area."

--- a/administrator/modules/mod_toolbar/mod_toolbar.php
+++ b/administrator/modules/mod_toolbar/mod_toolbar.php
@@ -10,9 +10,11 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
-use Joomla\CMS\Toolbar\Toolbar;
 
-$toolbar = Toolbar::getInstance('toolbar')->render();
+/** @var $params Joomla\Registry\Registry */
+
+$toolbar = Factory::getApplication()->getDocument()->getToolbar($params->get('toolbar', 'toolbar'))->render();
 
 require ModuleHelper::getLayoutPath('mod_toolbar', $params->get('layout', 'default'));

--- a/administrator/modules/mod_toolbar/mod_toolbar.xml
+++ b/administrator/modules/mod_toolbar/mod_toolbar.xml
@@ -20,6 +20,16 @@
 	<help key="Admin_Modules:_Toolbar" />
 	<config>
 		<fields name="params">
+			<fieldset name="basic">
+				<field
+					name="toolbar"
+					type="text"
+					default="toolbar"
+					label="MOD_TOOLBAR_FIELD_TOOLBAR_LABEL"
+					description="MOD_TOOLBAR_FIELD_TOOLBAR_DESCRIPTION"
+				/>
+			</fieldset>
+
 			<fieldset name="advanced">
 				<field
 					name="layout"

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -791,10 +791,14 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
     /**
      * Returns a toolbar object or null
      *
-     * @param $toolbar
-     * @return Toolbar|null
+     * @param   string   $toolbar
+     * @param   boolean  $create
+     *
+     * @return  ?Toolbar
+     *
+     * @since   __DEPLOY_VERSION__
      */
-    public function getToolbar($toolbar = 'toolbar', $create = true): ?Toolbar
+    public function getToolbar(string $toolbar = 'toolbar', bool $create = true): ?Toolbar
     {
         if (empty($this->toolbars[$toolbar])) {
             if (!$create) {

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -126,7 +126,8 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
     /**
      * List of type \Joomla\CMS\Toolbar\Toolbar
      *
-     * @var Toolbar[]
+     * @var    Toolbar[]
+     * @since  __DEPLOY_VERSION__
      */
     private $toolbars = [];
 

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -826,12 +826,14 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
     /**
      * Adds a new or replace an existing toolbar object
      *
-     * @param $name
-     * @param Toolbar $toolbar
+     * @param   string   $name
+     * @param   Toolbar  $toolbar
      *
-     * @return $this
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
      */
-    public function setToolbar($name, Toolbar $toolbar): self
+    public function setToolbar(string $name, Toolbar $toolbar): self
     {
         $this->toolbars[$name] = $toolbar;
 

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -814,7 +814,9 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
     /**
      * Returns the toolbar array
      *
-     * @return array
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
      */
     public function getToolbars(): array
     {

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Factory as CmsFactory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Toolbar\Toolbar;
+use Joomla\CMS\Toolbar\ToolbarFactoryInterface;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Utility\Utility;
 use Joomla\Registry\Registry;
@@ -120,6 +122,13 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
      * @since  4.0.0
      */
     private $html5 = true;
+
+    /**
+     * List of type \Joomla\CMS\Toolbar\Toolbar
+     *
+     * @var Toolbar[]
+     */
+    private $toolbars = [];
 
     /**
      * Class constructor
@@ -774,6 +783,50 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
 
         // Load
         $this->_template = $this->_loadTemplate($baseDir, $file);
+
+        return $this;
+    }
+
+    /**
+     * Returns a toolbar object or null
+     *
+     * @param $toolbar
+     * @return Toolbar|null
+     */
+    public function getToolbar($toolbar = 'toolbar', $create = true): ?Toolbar
+    {
+        if (empty($this->toolbars[$toolbar])) {
+            if (!$create) {
+                return null;
+            }
+
+            $this->toolbars[$toolbar] = CmsFactory::getContainer()->get(ToolbarFactoryInterface::class)->createToolbar($toolbar);
+        }
+
+        return $this->toolbars[$toolbar];
+    }
+
+    /**
+     * Returns the toolbar array
+     *
+     * @return array
+     */
+    public function getToolbars(): array
+    {
+        return $this->toolbars;
+    }
+
+    /**
+     * Adds a new or replace an existing toolbar object
+     *
+     * @param $name
+     * @param Toolbar $toolbar
+     *
+     * @return $this
+     */
+    public function setToolbar($name, Toolbar $toolbar): self
+    {
+        $this->toolbars[$name] = $toolbar;
 
         return $this;
     }

--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -77,6 +77,10 @@ class Toolbar
      *
      * @var    Toolbar[]
      * @since  2.5
+     *
+     * @deprecated  5.0 will be removed in 7.0
+     *              Toolbars instances will be stored in the \Joomla\CMS\Document\HTMLDocument object
+     *              Request the instance from Factory::getApplication()->getDocument()->getToolbar('name');
      */
     protected static $instances = [];
 
@@ -141,11 +145,14 @@ class Toolbar
      */
     public static function getInstance($name = 'toolbar')
     {
+        $toolbar = Factory::getApplication()->getDocument()->getToolbar($name);
+
+        // TODO b/c remove with Joomla 7.0 or removed in 6.0 with this function
         if (empty(self::$instances[$name])) {
-            self::$instances[$name] = Factory::getContainer()->get(ToolbarFactoryInterface::class)->createToolbar($name);
+            self::$instances[$name] = $toolbar;
         }
 
-        return self::$instances[$name];
+        return $toolbar;
     }
 
     /**

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -52,7 +52,7 @@ abstract class ToolbarHelper
             $title .= ' - ' . Text::_('JADMINISTRATION');
         }
 
-        Factory::getDocument()->setTitle($title);
+        $app->getDocument()->setTitle($title);
     }
 
     /**


### PR DESCRIPTION
This removes the usage of instances in the Toolbar Class and moves it to HtmlDocument.

Conceptional feedback would be helpful.

### Summary of Changes
The reason moving is mainly because the HtmlDocument is everywhere where we need the toolbar and the toolbar is only relevant to the HtmlDocument.


### Testing Instructions
For the moment only the smart search indexer has been 
changed to use the new getToolbar function. But all other
toolbars also use the HtmlDocument thru the Toolbar::getInstance() 
method.


### Actual result BEFORE applying this Pull Request
toolbars are working


### Expected result AFTER applying this Pull Request
toolbars still working


### Link to documentations
Please select:
- [X] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [X] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
