### PR TITLE
[5.0] Fix wrong XML in plugins/schemaorg/organization/organization.xml

### DIFF
--- a/plugins/schemaorg/organization/organization.xml
+++ b/plugins/schemaorg/organization/organization.xml
@@ -9,7 +9,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<version>5.0.0</version>
 	<description>PLG_SCHEMAORG_ORGANIZATION_XML_DESCRIPTION</description>
- -	<namespace path="src">Joomla\Plugin\Schemaorg\Organization</namespace>
+	<namespace path="src">Joomla\Plugin\Schemaorg\Organization</namespace>
 	<files>
 		<folder plugin="organization">services</folder>
 		<folder>src</folder>


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/41247/files#r1274858031 .

### Summary of Changes

Fix wrong XML in line 12 of  file `plugins/schemaorg/organization/organization.xml` coming from PR #41247 .

It seems the error came with copying code from a GitHub diff view, and the change indicator was copied, too.

### Testing Instructions

Code review: Check line 12 in file `plugins/schemaorg/organization/organization.xml`.

### Actual result BEFORE applying this Pull Request

Line 12 starts with ` -`.

### Expected result AFTER applying this Pull Request

Line 12 doesn't start with ` -`.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
