### PR TITLE
Allow users without com_config access to do ACL changes

### DIFF
--- a/administrator/components/com_config/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_config/src/Dispatcher/Dispatcher.php
@@ -36,8 +36,8 @@ class Dispatcher extends ComponentDispatcher
      */
     protected function checkAccess(): void
     {
-        // sendtestmail expects json response, so we leave the method to handle the permission and send response itself
-        if ($this->input->getCmd('task') === 'application.sendtestmail') {
+        // sendtestmail and store do their own checks, so leave the method to handle the permission and send response itself
+        if (in_array($this->input->getCmd('task'), ['application.sendtestmail', 'application.store'], true)) {
             return;
         }
 


### PR DESCRIPTION
### Summary of Changes
The dispatcher introduced in #39879 broke the feature that allowed users without generic "core.admin" access to com_config to do ACL changes in other components.


### Testing Instructions
Create an "Administrator"-level user and try to change the ACL permissions of an article in com_content.


### Actual result BEFORE applying this Pull Request
403 error being returned.


### Expected result AFTER applying this Pull Request
Changes are applied.