### PR TITLE
[4.4] bugfix Admin Menu Show New

### DIFF
--- a/administrator/components/com_categories/tmpl/categories/default.xml
+++ b/administrator/components/com_categories/tmpl/categories/default.xml
@@ -18,4 +18,25 @@
 			</field>
 		</fieldset>
 	</fields>
+	<fields name="params">
+		<fieldset name="basic">
+
+			<field
+				name="menu-quicktask"
+				type="radio"
+				label="MOD_MENU_FIELD_SHOWNEW"
+				layout="joomla.form.field.radio.switcher"
+				>
+				<option value="">JHIDE</option>
+				<option value="index.php?option=com_categories&amp;extension=com_content&amp;task=category.add">JSHOW</option>
+			</field>
+
+			<field
+				name="menu-quicktask-title"
+				type="hidden"
+				default="COM_CONTENT_MENUS_NEW_CATEGORY"
+			/>
+
+		</fieldset>
+	</fields>
 </metadata>

--- a/administrator/components/com_messages/tmpl/messages/default.xml
+++ b/administrator/components/com_messages/tmpl/messages/default.xml
@@ -5,4 +5,25 @@
 			<![CDATA[COM_MESSAGES_MESSAGES_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
+	<fields name="params">
+		<fieldset name="basic">
+
+			<field
+				name="menu-quicktask"
+				type="radio"
+				label="MOD_MENU_FIELD_SHOWNEW"
+				layout="joomla.form.field.radio.switcher"
+				>
+				<option value="">JHIDE</option>
+				<option value="index.php?option=com_messages&amp;task=message.add">JSHOW</option>
+			</field>
+
+			<field
+				name="menu-quicktask-title"
+				type="hidden"
+				default="MOD_MENU_MESSAGING_NEW"
+			/>
+
+		</fieldset>
+	</fields>
 </metadata>

--- a/administrator/components/com_modules/tmpl/modules/default.xml
+++ b/administrator/components/com_modules/tmpl/modules/default.xml
@@ -5,4 +5,25 @@
 			<![CDATA[COM_MODULES_MODULES_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
+	<fields name="params">
+		<fieldset name="basic">
+
+			<field
+				name="menu-quicktask"
+				type="radio"
+				label="MOD_MENU_FIELD_SHOWNEW"
+				layout="joomla.form.field.radio.switcher"
+				>
+				<option value="">JHIDE</option>
+				<option value="index.php?option=com_modules&amp;view=select&amp;client_id=0">JSHOW</option>
+			</field>
+
+			<field
+				name="menu-quicktask-title"
+				type="hidden"
+				default="COM_CONTENT_MENUS_NEW_SITE_MODULE"
+			/>
+
+		</fieldset>
+	</fields>
 </metadata>

--- a/administrator/components/com_users/tmpl/users/default.xml
+++ b/administrator/components/com_users/tmpl/users/default.xml
@@ -5,4 +5,25 @@
 			<![CDATA[COM_USERS_USERS_VIEW_DEFAULT_DESC]]>
 		</message>
 	</layout>
+	<fields name="params">
+		<fieldset name="basic">
+
+			<field
+				name="menu-quicktask"
+				type="radio"
+				label="MOD_MENU_FIELD_SHOWNEW"
+				layout="joomla.form.field.radio.switcher"
+				>
+				<option value="">JHIDE</option>
+				<option value="index.php?option=com_users&amp;task=user.add">JSHOW</option>
+			</field>
+
+			<field
+				name="menu-quicktask-title"
+				type="hidden"
+				default="COM_USERS_MENUS_ADD_USER"
+			/>
+
+		</fieldset>
+	</fields>
 </metadata>


### PR DESCRIPTION
PARTIAL Pull Request for Issue #41268 .

### Summary of Changes
When creating custom admin menus you usually start from a preset. Many of the menu items in the preset as the + quicktask link.

However as reported in #41268 the quicktask is lost if you edit and save the menu item. This is because the xml for the component doesnt have the relevant param. That is what this PR is doing. Fixing a bug so that you can create an admin menu item with a quicktask AND edit an existing admin menu item without losing the quicktask.

While testing this it became apparent that there are several existing admin menu items that can not be created individually never mind if they support the quicktask. eg new admin module

For that reason I am amrkin this as a draft until I have time over the weekend hopefully to fix it

### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
