### PR TITLE
[5.0] Add support for namespaced template helper (com_ajax)

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Response\JsonResponse;
 use Joomla\CMS\Table\Table;
-use Microsoft\PhpParser\Node\ElseIfClauseNode;
 
 /*
  * References

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Response\JsonResponse;
 use Joomla\CMS\Table\Table;
+use Microsoft\PhpParser\Node\ElseIfClauseNode;
 
 /*
  * References
@@ -151,25 +152,6 @@ if (!$format) {
         $basePath   = ($table->client_id) ? JPATH_ADMINISTRATOR : JPATH_SITE;
         $baseClient = ($table->client_id) ? 'Administrator' : 'Site';
         $helperFile = $basePath . '/templates/' . $template . '/helper.php';
-
-        if (strpos($template, '_')) {
-            $parts = explode('_', $template);
-        } elseif (strpos($template, '-')) {
-            $parts = explode('-', $template);
-        }
-
-        if ($parts) {
-            $class = 'Tpl';
-
-            foreach ($parts as $part) {
-                $class .= ucfirst($part);
-            }
-
-            $class .= 'Helper';
-        } else {
-            $class = 'Tpl' . ucfirst($template) . 'Helper';
-        }
-
         $method     = $input->get('method') ?: 'get';
         $fileExists = false;
         $xmlData    = simplexml_load_file($basePath . '/templates/' . $template . '/templateDetails.xml');
@@ -180,11 +162,31 @@ if (!$format) {
             && isset($xmlData->ajaxhelper)
             && class_exists((string) $xmlData->namespace . '\\' . $baseClient . '\\Helper\\' . (string) $xmlData->ajaxhelper)
         ) {
-            $class = (string) $xmlData->namespace . '\\' . $baseClient . '\\Helper\\' . (string) $xmlData->ajaxhelper;
+            $class      = (string) $xmlData->namespace . '\\' . $baseClient . '\\Helper\\' . (string) $xmlData->ajaxhelper;
             $fileExists = true;
-        } elseif (is_file($helperFile)) {
-            JLoader::register($class, $helperFile);
-            $fileExists = true;
+        } else {
+            if (strpos($template, '_')) {
+                $parts = explode('_', $template);
+            } elseif (strpos($template, '-')) {
+                $parts = explode('-', $template);
+            }
+
+            if ($parts) {
+                $class = 'Tpl';
+
+                foreach ($parts as $part) {
+                    $class .= ucfirst($part);
+                }
+
+                $class .= 'Helper';
+            } else {
+                $class = 'Tpl' . ucfirst($template) . 'Helper';
+            }
+
+            if (is_file($helperFile)) {
+                JLoader::register($class, $helperFile);
+                $fileExists = true;
+            }
         }
 
         if ($fileExists) {


### PR DESCRIPTION
Pull Request is a redo of #39521 with the introduction of an XML tag for the Helper name.

### Summary of Changes

The PR https://github.com/joomla/joomla-cms/pull/39011 introduced namespace to the templates. This obviously solves the Fields problem but there is one more that needs to be tackled: `com_ajax`.
This PR is using the existing conventions but allows to load the namespaced helper


### Testing Instructions
#### Existing functionality Front end templates
- Add a file named `helper.php` in the `templates\cassiopeia` folder with the following content

```php
<?php

defined('_JEXEC') || die;


class TplCassiopeiaHelper
{
    public static function templateAjax(): array
    {
        return ['is' => true, 'namespaced' => false];
    }
}
```

- point your browser to `/index.php?option=com_ajax&type=template&format=json&template=cassiopeia&method=template` and you should have a message: `{"success":true,"message":null,"messages":null,"data":{"is":true,"namespaced":false}}`

#### Proposed code

- Add `<namespace path="src">Joomla\Template\Cassiopeia</namespace>` to the templateDetails.xml of Cassiopeia
- Add `<ajaxhelper>Ajax</ajaxhelper>` to the templateDetails.xml of Cassiopeia
- Delete the file `administrator/cache/autoload_psr4.php`
- create a file named `templates/cassiopeia/src/Helper/Ajax.php` with the following contents:

```php
<?php

namespace Joomla\Template\Cassiopeia\Site\Helper;

defined('_JEXEC') || die;


class Ajax
{
    public static function getAjax(): array
    {
        return ['is' => true, 'namespaced' => true, 'from' => 'getAjax'];
    }
    public static function testAjax(): array
    {
        return ['is' => true, 'namespaced' => true, 'from' => 'testAjax'];
    }
}
```

- visit again the same URL as before `index.php?option=com_ajax&type=template&format=json&template=cassiopeia` and you should have a message: `{"success":true,"message":null,"messages":null,"data":{"is":true,"namespaced":true,"from":"getAjax"}}`

- visit again the same URL as before `index.php?option=com_ajax&type=template&format=json&template=cassiopeia&method=test` and you should have a message: `{"success":true,"message":null,"messages":null,"data":{"is":true,"namespaced":true,"from":"testAjax"}}`
-
#### Existing functionality Back end templates

- Add a file named `helper.php` in the `administrator/templates/atum` folder
- Add the following content

```php
<?php

defined('_JEXEC') || die;


class TplAtumHelper
{
    public static function templateAjax(): array
    {
        return ['is' => true, 'namespaced' => false];
    }
}
```

- point your browser to `administrator/index.php?option=com_ajax&type=template&method=template&format=json&template=atum` and you should have a message: `{"success":true,"message":null,"messages":null,"data":{"is":true,"namespaced":false}}`

#### Proposed code

- Add `<namespace path="src">Joomla\Template\Atum</namespace>` to the templateDetails.xml of the Atum template
- Add `<ajaxhelper>Ajax</ajaxhelper>` to the templateDetails.xml of Atum
- Delete the file `administrator/cache/autoload_psr4.php`
- create a file named `administrator/templates/atum/src/Helper/Ajax.php` with the following contents:

```php
<?php

namespace Joomla\Template\Atum\Administrator\Helper;

defined('_JEXEC') || die;


class Ajax
{
    public static function getAjax(): array
    {
        return ['is' => true, 'namespaced' => true, 'from' => 'getAjax'];
    }
    public static function testAjax(): array
    {
        return ['is' => true, 'namespaced' => true, 'from' => 'testAjax'];
    }
}

```

- visit again the same URL as before `administrator/index.php?option=com_ajax&type=template&format=json&template=atum` and you should have a message: `{"success":true,"message":null,"messages":null,"data":{"is":true,"namespaced":true,"from":"getAjax"}}`

- visit again the same URL as before `administrator/index.php?option=com_ajax&type=template&format=json&template=atum&method=test` and you should have a message: `{"success":true,"message":null,"messages":null,"data":{"is":true,"namespaced":true,"from":"testAjax"}}`

### Actual result BEFORE applying this Pull Request

No way to use the namespaced helper

### Expected result AFTER applying this Pull Request

Works

The additional part that is introduced here is the XML tag `<ajaxhelper>` that defines the name of the Helper file in the namespaced Helper directory.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed

@HLeithner could you review this one?
