### PR TITLE
[4.3] Display Contact quickicon

### DIFF
--- a/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
@@ -299,7 +299,7 @@ class QuickIconHelper
                 $this->buttons[$key][] = $tmp;
             }
 
-            if (ComponentHelper::isEnabled('com_contacts') && $params->get('show_contact')) {
+            if (ComponentHelper::isEnabled('com_contact') && $params->get('show_contact')) {
                 $tmp = [
                     'image'   => 'icon-address-book contact',
                     'link'    => Route::_('index.php?option=com_contact&view=contacts'),


### PR DESCRIPTION
Pull Request for Issues #41280 and #41281 .

### Summary of Changes
Fixes a typo introduced with #40715 that prevented the contacts quickicon being displayed



### Testing Instructions
Set the Contact quickicon to show in the admin module


### Actual result BEFORE applying this Pull Request
Contact icon not displayed


### Expected result AFTER applying this Pull Request
Contact icon displayed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
