### PR TITLE
w3c Validation Issue with user menu button

### DIFF
--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -28,12 +28,12 @@ HTMLHelper::_('bootstrap.dropdown', '.dropdown-toggle');
 <div class="header-item-content dropdown header-profile">
     <button class="dropdown-toggle d-flex align-items-center ps-0 py-0" data-bs-toggle="dropdown" type="button"
         title="<?php echo Text::_('MOD_USER_MENU'); ?>">
-        <div class="header-item-icon">
+        <span class="header-item-icon">
             <span class="icon-user-circle" aria-hidden="true"></span>
-        </div>
-        <div class="header-item-text">
+        </span>
+        <span class="header-item-text">
             <?php echo Text::_('MOD_USER_MENU'); ?>
-        </div>
+        </span>
         <span class="icon-angle-down" aria-hidden="true"></span>
     </button>
     <div class="dropdown-menu dropdown-menu-end">


### PR DESCRIPTION
### Summary of Changes

The W3C spec doesn't allow a `div` inside a `button` as block elements are not allowed inside inline elements.

The ATUM topbar user menu contains this code:

![Image](https://i.imgur.com/yT7TDD4.png)

Switching to span resolves the W3C issue.

### Testing Instructions

1. Test ATUM template at [W3C Checker](https://validator.w3.org/nu/)


### Actual result BEFORE applying this Pull Request
Fails W3C validation:

![image](https://i.imgur.com/uJ4o8tc.png)

```
    <button class="dropdown-toggle d-flex align-items-center ps-0 py-0" data-bs-toggle="dropdown" type="button"
        title="<?php echo Text::_('MOD_USER_MENU'); ?>">
        <div class="header-item-icon">
            <span class="icon-user-circle" aria-hidden="true"></span>
        </div>
        <div class="header-item-text">
            <?php echo Text::_('MOD_USER_MENU'); ?>
        </div>
        <span class="icon-angle-down" aria-hidden="true"></span>
    </button>
```

### Expected result AFTER applying this Pull Request

Passes W3C validation


```
    <button class="dropdown-toggle d-flex align-items-center ps-0 py-0" data-bs-toggle="dropdown" type="button"
        title="<?php echo Text::_('MOD_USER_MENU'); ?>">
        <span class="header-item-icon">
            <span class="icon-user-circle" aria-hidden="true"></span>
        </span>
        <span class="header-item-text">
            <?php echo Text::_('MOD_USER_MENU'); ?>
        </span>
        <span class="icon-angle-down" aria-hidden="true"></span>
    </button>
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
