### PR TITLE
[4.4] Fix minor UI issues caused by bootstrap 5.3 version bump

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/_maps-atum.scss
+++ b/build/media_source/templates/administrator/atum/scss/_maps-atum.scss
@@ -1,0 +1,23 @@
+$theme-colors-text: map-merge(
+  $theme-colors-text,
+  (
+    "action": shade-color($base-color, 60%),
+    "error": shade-color($red-dark, 60%)
+  )
+);
+
+$theme-colors-bg-subtle: map-merge(
+  $theme-colors-bg-subtle,
+  (
+    "action": tint-color($base-color, 80%),
+    "error": tint-color($red-dark, 80%)
+  )
+);
+
+$theme-colors-border-subtle: map-merge(
+  $theme-colors-border-subtle,
+  (
+    "action": tint-color($base-color, 60%),
+    "error": tint-color($red-dark, 60%)
+  )
+);

--- a/build/media_source/templates/administrator/atum/scss/_maps-atum.scss
+++ b/build/media_source/templates/administrator/atum/scss/_maps-atum.scss
@@ -1,23 +1,14 @@
-$theme-colors-text: map-merge(
-  $theme-colors-text,
-  (
-    "action": shade-color($base-color, 60%),
-    "error": shade-color($red-dark, 60%)
-  )
-);
+$theme-colors-text: map-merge((
+  "action": shade-color($base-color, 60%),
+  "error": shade-color($red-dark, 60%)
+), $theme-colors-text);
 
-$theme-colors-bg-subtle: map-merge(
-  $theme-colors-bg-subtle,
-  (
-    "action": tint-color($base-color, 80%),
-    "error": tint-color($red-dark, 80%)
-  )
-);
+$theme-colors-bg-subtle: map-merge((
+  "action": tint-color($base-color, 80%),
+  "error": tint-color($red-dark, 80%)
+), $theme-colors-bg-subtle);
 
-$theme-colors-border-subtle: map-merge(
-  $theme-colors-border-subtle,
-  (
-    "action": tint-color($base-color, 60%),
-    "error": tint-color($red-dark, 60%)
-  )
-);
+$theme-colors-border-subtle: map-merge((
+  "action": tint-color($base-color, 60%),
+  "error": tint-color($red-dark, 60%)
+), $theme-colors-border-subtle);

--- a/build/media_source/templates/administrator/atum/scss/_variables.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables.scss
@@ -53,8 +53,7 @@ $theme-colors: (
   "light":                           $gray-100,
   "dark":                            $gray-900,
   "action":                          $base-color,
-  "error":                           $red-dark,
-  "alert-success":                   $green-dark) !default;
+  "error":                           $red-dark) !default;
 
 $atum-colors: (
   template-sidebar-bg:             var(--template-bg-dark-80),
@@ -63,6 +62,7 @@ $atum-colors: (
   template-bg-light:               #f0f4fb, //light background color, frontend dashboard background
   template-link-color:             var(--link-color),
   template-text-light:             $white,
+  template-text-dark:              $atum-text-dark,
   template-special-color:          $dark-blue,
   template-contrast:               $light-blue,
   template-bg-dark:                hsl(var(--hue), 40%, 20%),

--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -163,6 +163,7 @@
     align-self: flex-end;
     width: 100%;
     font-size: ($font-size-base * .875);
+    --body-color: var(--template-text-light);
     color: var(--template-text-light);
     text-align: center;
 

--- a/build/media_source/templates/administrator/atum/scss/template.scss
+++ b/build/media_source/templates/administrator/atum/scss/template.scss
@@ -7,6 +7,7 @@
 @import "../../../../../../media/vendor/bootstrap/scss/variables";
 @import "../../../../../../media/vendor/bootstrap/scss/variables-dark";
 @import "../../../../../../media/vendor/bootstrap/scss/maps";
+@import "maps-atum";
 @import "../../../../../../media/vendor/bootstrap/scss/mixins";
 @import "../../../../../../media/vendor/bootstrap/scss/utilities";
 


### PR DESCRIPTION
Pull Request for Issues [#41284](https://github.com/joomla/joomla-cms/issues/41284) and [#41283](https://github.com/joomla/joomla-cms/issues/41283) .

### Summary of Changes
Dark mode changes by upstream bootstrap caused a few theme variant colors to not be propogated into the template

https://github.com/twbs/bootstrap/commit/fc3f4b67d65c575daa661ecf31cf59b4ff3cced5#diff-be56ca5fb07a1b48548ec8b7ec33a30c15c2f9263a3bcc1c664ade171f7ba264

This also fixes a few other missing bootstrap variables (I'm not sure all of them are due to the template upgrade - but better safe than sorry :) )

### Testing Instructions
Check views explicitly mentioned in the two issues and also have a general browse around the rest of the admin to ensure nothing else is affected by the theme level view change

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
