### PR TITLE
[4.3] PHP 8.2 Dynamic property - com_config request controller

### DIFF
--- a/administrator/components/com_config/src/Controller/RequestController.php
+++ b/administrator/components/com_config/src/Controller/RequestController.php
@@ -65,14 +65,11 @@ class RequestController extends BaseController
 
         try {
             $data = $model->getData();
-            $user = $this->app->getIdentity();
         } catch (\Exception $e) {
             $this->app->enqueueMessage($e->getMessage(), 'error');
 
             return false;
         }
-
-        $this->userIsSuperAdmin = $user->authorise('core.admin');
 
         // Required data
         $requiredData = [


### PR DESCRIPTION
### Summary of Changes

remove unused variable

### Testing Instructions

- error reporting = maximum
- visit `index.php?option=com_config&view=config` in frontend (user with permission)

### Actual result BEFORE applying this Pull Request

`PHP Deprecated: Creation of dynamic property Joomla\Component\Config\Administrator\Controller\RequestController::$userIsSuperAdmin is deprecated in administrator\components\com_config\src\Controller\RequestController.php on line 75`

### Expected result AFTER applying this Pull Request

no warning
