### PR TITLE
[4.3] com_messages typo

### DIFF
--- a/plugins/workflow/notification/notification.php
+++ b/plugins/workflow/notification/notification.php
@@ -199,7 +199,7 @@ class PlgWorkflowNotification extends CMSPlugin implements SubscriberInterface
             foreach ($userIds as $user_id) {
                 $receiver = $container->get(UserFactoryInterface::class)->loadUserById($user_id);
 
-                if ($receiver->authorise('core.manage', 'com_message')) {
+                if ($receiver->authorise('core.manage', 'com_messages')) {
                     // Load language for messaging
                     $lang = $container->get(LanguageFactoryInterface::class)
                         ->createLanguage($user->getParam('admin_language', $defaultLanguage), $debug);


### PR DESCRIPTION
Pull Request for Issue #41294 reported byv @bazmoth

### Summary of Changes
Fixes obvious typo.

### Steps to reproduce the issue
Create a new user group with permission core.manage on com_messages, add user to this group. Create a content transition (workflow) that sends a notification to this new group.
(likely possible to replicate multiple ways)

### Expected result
A new message sent to a user (in a user group that is not super user), when an article transition is performed.

### Actual result
No message is created/emailed to the user in question.