### PR TITLE
Use of $event->getArgument(0) is forbiden

### DIFF
--- a/libraries/src/Event/AbstractEvent.php
+++ b/libraries/src/Event/AbstractEvent.php
@@ -142,6 +142,17 @@ abstract class AbstractEvent extends BaseEvent
     {
         $methodName = 'get' . ucfirst($name);
 
+        // B/C check for numeric access to named argument, eg $event->getArgument('0').
+        if (is_numeric($name) && key($this->arguments) !== 0) {
+            @trigger_error(
+                sprintf('Numeric access to named event arguments is deprecated, and will not work in Joomla 6. Event %s', \get_class($this)),
+                E_USER_DEPRECATED
+            );
+
+            $argNames = \array_keys($this->arguments);
+            $name     = $argNames[$name] ?? '';
+        }
+
         $value = parent::getArgument($name, $default);
 
         if (method_exists($this, $methodName)) {

--- a/libraries/src/Event/AbstractEvent.php
+++ b/libraries/src/Event/AbstractEvent.php
@@ -140,18 +140,24 @@ abstract class AbstractEvent extends BaseEvent
      */
     public function getArgument($name, $default = null)
     {
-        $methodName = 'get' . ucfirst($name);
-
         // B/C check for numeric access to named argument, eg $event->getArgument('0').
-        if (is_numeric($name) && key($this->arguments) !== 0) {
+        if (is_numeric($name)) {
+            if (key($this->arguments) != 0) {
+                $argNames = \array_keys($this->arguments);
+                $name     = $argNames[$name] ?? '';
+            }
+
             @trigger_error(
-                sprintf('Numeric access to named event arguments is deprecated, and will not work in Joomla 6. Event %s', \get_class($this)),
+                sprintf(
+                    'Numeric access to named event arguments is deprecated, and will not work in Joomla 6. Event %s argument %s',
+                    \get_class($this),
+                    $name
+                ),
                 E_USER_DEPRECATED
             );
-
-            $argNames = \array_keys($this->arguments);
-            $name     = $argNames[$name] ?? '';
         }
+
+        $methodName = 'get' . ucfirst($name);
 
         $value = parent::getArgument($name, $default);
 
@@ -181,6 +187,23 @@ abstract class AbstractEvent extends BaseEvent
      */
     public function setArgument($name, $value)
     {
+        // B/C check for numeric access to named argument, eg $event->getArgument('0').
+        if (is_numeric($name)) {
+            if (key($this->arguments) != 0) {
+                $argNames = \array_keys($this->arguments);
+                $name     = $argNames[$name] ?? '';
+            }
+
+            @trigger_error(
+                sprintf(
+                    'Numeric access to named event arguments is deprecated, and will not work in Joomla 6. Event %s argument %s',
+                    \get_class($this),
+                    $name
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+
         $methodName = 'set' . ucfirst($name);
 
         if (method_exists($this, $methodName)) {

--- a/libraries/src/Event/CoreEventAware.php
+++ b/libraries/src/Event/CoreEventAware.php
@@ -46,7 +46,6 @@ use Joomla\CMS\Event\Table\SetNewTagsEvent;
 use Joomla\CMS\Event\View\DisplayEvent;
 use Joomla\CMS\Event\Workflow\WorkflowFunctionalityUsedEvent;
 use Joomla\CMS\Event\Workflow\WorkflowTransitionEvent;
-use Joomla\Event\Event;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('JPATH_PLATFORM') or die;
@@ -129,6 +128,6 @@ trait CoreEventAware
      */
     protected static function getEventClassByEventName(string $eventName): string
     {
-        return self::$eventNameToConcreteClass[$eventName] ?? Event::class;
+        return self::$eventNameToConcreteClass[$eventName] ?? FallbackEvent::class;
     }
 }

--- a/libraries/src/Event/FallbackEvent.php
+++ b/libraries/src/Event/FallbackEvent.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2022 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license        GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event;
+
+use Joomla\Event\Event;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('JPATH_PLATFORM') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * The FallbackEvent class used for b/c $event->getArgument(0).
+ * Is a fallback for CoreEventAware::getEventClassByEventName, when the event class not found.
+ * It should be removed in Joomla 6.
+ *
+ * @since  __DEPLOY_VERSION__
+ *
+ * @deprecated Use event classes, will be removed in Joomla 6.
+ */
+final class FallbackEvent extends Event
+{
+    /**
+     * Get an event argument value.
+     *
+     * @param   string  $name     The argument name.
+     * @param   mixed   $default  The default value if not found.
+     *
+     * @return  mixed  The argument value or the default value.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getArgument($name, $default = null)
+    {
+        // B/C check for numeric access to named argument, eg $event->getArgument('0').
+        if (is_numeric($name)) {
+            if (key($this->arguments) != 0) {
+                $argNames = \array_keys($this->arguments);
+                $name     = $argNames[$name] ?? '';
+            }
+
+            @trigger_error(
+                sprintf(
+                    'Numeric access to named event arguments is deprecated, and will not work in Joomla 6. Event %s argument %s',
+                    \get_class($this),
+                    $name
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+
+        return parent::getArgument($name, $default);
+    }
+
+    /**
+     * Add argument to event.
+     *
+     * @param   string  $name   Argument name.
+     * @param   mixed   $value  Value.
+     *
+     * @return  $this
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function setArgument($name, $value)
+    {
+        // B/C check for numeric access to named argument, eg $event->getArgument('0').
+        if (is_numeric($name)) {
+            if (key($this->arguments) != 0) {
+                $argNames = \array_keys($this->arguments);
+                $name     = $argNames[$name] ?? '';
+            }
+
+            @trigger_error(
+                sprintf(
+                    'Numeric access to named event arguments is deprecated, and will not work in Joomla 6. Event %s argument %s',
+                    \get_class($this),
+                    $name
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+
+        return parent::setArgument($name, $value);
+    }
+}

--- a/libraries/src/Event/FallbackEvent.php
+++ b/libraries/src/Event/FallbackEvent.php
@@ -17,12 +17,12 @@ use Joomla\Event\Event;
 
 /**
  * The FallbackEvent class used for b/c $event->getArgument(0).
- * Is a fallback for CoreEventAware::getEventClassByEventName, when the event class not found.
+ * It is a fallback for CoreEventAware::getEventClassByEventName() when the event class not found.
  * It should be removed in Joomla 6.
  *
  * @since  __DEPLOY_VERSION__
  *
- * @deprecated Use event classes, will be removed in Joomla 6.
+ * @deprecated Will be removed in Joomla 6. Use Joomla\Event\Event.
  */
 final class FallbackEvent extends Event
 {


### PR DESCRIPTION
### Summary of Changes

The PR add deprecation warning about incorectly used event. Also some b/c code.

In general we should not use event object if there no event class for the event.
And so `$event->getArgument(0)` should not be used also.

When it realy realy realy need, then arguments should be accesed as foloving:
```php
[$arg1, $arg2] = array_values($event->getArguments()); 
```




### Testing Instructions
Apply patch. 
Enable deprecation, 
open some form in backend.
You should get deprecation warning "Numeric access to named event arguments is deprecated" 
(make sure Schedule plugin is enabled)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: idk
- [ ] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: tbd
- [ ] No documentation changes for manual.joomla.org needed
