### PR TITLE
[5.0] Remove class aliases to non existing classes

### DIFF
--- a/plugins/behaviour/compat/src/classmap/classmap.php
+++ b/plugins/behaviour/compat/src/classmap/classmap.php
@@ -422,8 +422,6 @@ JLoader::registerAlias('JMailHelper', '\\Joomla\\CMS\\Mail\\MailHelper', '6.0');
 JLoader::registerAlias('JClientHelper', '\\Joomla\\CMS\\Client\\ClientHelper', '6.0');
 JLoader::registerAlias('JClientFtp', '\\Joomla\\CMS\\Client\\FtpClient', '6.0');
 JLoader::registerAlias('JFTP', '\\Joomla\\CMS\\Client\\FtpClient', '4.0');
-JLoader::registerAlias('JClientLdap', '\\Joomla\\Ldap\\LdapClient', '6.0');
-JLoader::registerAlias('JLDAP', '\\Joomla\\Ldap\\LdapClient', '4.0');
 
 JLoader::registerAlias('JUpdate', '\\Joomla\\CMS\\Updater\\Update', '6.0');
 JLoader::registerAlias('JUpdateAdapter', '\\Joomla\\CMS\\Updater\\UpdateAdapter', '6.0');


### PR DESCRIPTION
Pull Request for Issue #40643 

### Summary of Changes
JClientLdap and JLDAP, dependency has been removed. 
Reason for this is that the Joomla framework library is no longer compatible with Joomla 5.0 and is no longer used by the cms.


### Link to documentations

- [X] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/commit/4203f57f68bd8ec81299f641def987964439b2cd
- [ ] No documentation changes for manual.joomla.org needed
