### PR TITLE
[4] webservice categories add description field

### DIFF
--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -172,7 +172,7 @@ class CategoriesModel extends ListModel
                 'a.id, a.title, a.alias, a.note, a.published, a.access' .
                 ', a.checked_out, a.checked_out_time, a.created_user_id' .
                 ', a.path, a.parent_id, a.level, a.lft, a.rgt' .
-                ', a.language'
+                ', a.language, a.description'
             )
         );
         $query->from($db->quoteName('#__categories', 'a'));

--- a/api/components/com_categories/src/View/Categories/JsonapiView.php
+++ b/api/components/com_categories/src/View/Categories/JsonapiView.php
@@ -57,6 +57,7 @@ class JsonapiView extends BaseApiView
         'count_published',
         'count_archived',
         'params',
+        'description',
     ];
 
     /**
@@ -90,6 +91,7 @@ class JsonapiView extends BaseApiView
         'count_published',
         'count_archived',
         'params',
+        'description',
     ];
 
     /**


### PR DESCRIPTION
Pull Request for Issue #41291

### Summary of Changes

return the description field

### Testing Instructions

Do an API call and set the category description:

### Actual result BEFORE applying this Pull Request
the  description field is not returned


### Expected result AFTER applying this Pull Request

 the description field is present

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
