### PR TITLE
[4.3] com_contact in category_view -> Change the language-string for correct table-head-title

### DIFF
--- a/administrator/components/com_contact/forms/filter_contacts.xml
+++ b/administrator/components/com_contact/forms/filter_contacts.xml
@@ -107,8 +107,8 @@
 			<option value="a.featured DESC">JFEATURED_DESC</option>
 			<option value="a.published ASC">JSTATUS_ASC</option>
 			<option value="a.published DESC">JSTATUS_DESC</option>
-			<option value="a.name ASC">JGLOBAL_TITLE_ASC</option>
-			<option value="a.name DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="a.name ASC">JGLOBAL_NAME_ASC</option>
+			<option value="a.name DESC">JGLOBAL_NAME_DESC</option>
 			<option value="category_title ASC">JCATEGORY_ASC</option>
 			<option value="category_title DESC">JCATEGORY_DESC</option>
 			<option value="ul.name ASC">COM_CONTACT_FIELD_LINKED_USER_LABEL_ASC</option>

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -68,7 +68,7 @@ if ($saveOrder && !empty($this->items)) {
                                     <?php echo HTMLHelper::_('searchtools.sort', 'JSTATUS', 'a.published', $listDirn, $listOrder); ?>
                                 </th>
                                 <th scope="col">
-                                    <?php echo HTMLHelper::_('searchtools.sort', 'JGLOBAL_TITLE', 'a.name', $listDirn, $listOrder); ?>
+                                    <?php echo HTMLHelper::_('searchtools.sort', 'COM_CONTACT_FIELD_NAME_LABEL', 'a.name', $listDirn, $listOrder); ?>
                                 </th>
                                 <th scope="col" class="w-10 d-none">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_CONTACT_FIELD_LINKED_USER_LABEL', 'ul.name', $listDirn, $listOrder); ?>

--- a/components/com_contact/forms/filter_contacts.xml
+++ b/components/com_contact/forms/filter_contacts.xml
@@ -98,8 +98,8 @@
 			<option value="a.published DESC">JSTATUS_DESC</option>
 			<option value="a.featured ASC">JFEATURED_ASC</option>
 			<option value="a.featured DESC">JFEATURED_DESC</option>
-			<option value="a.name ASC">JGLOBAL_TITLE_ASC</option>
-			<option value="a.name DESC">JGLOBAL_TITLE_DESC</option>
+			<option value="a.name ASC">JGLOBAL_NAME_ASC</option>
+			<option value="a.name DESC">JGLOBAL_NAME_DESC</option>
 			<option value="category_title ASC">JCATEGORY_ASC</option>
 			<option value="category_title DESC">JCATEGORY_DESC</option>
 			<option value="ul.name ASC">COM_CONTACT_FIELD_LINKED_USER_LABEL_ASC</option>

--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -88,7 +88,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
                 <thead<?php echo $this->params->get('show_headings', '1') ? '' : ' class="visually-hidden"'; ?>>
                     <tr>
                         <th scope="col" id="categorylist_header_title">
-                            <?php echo HTMLHelper::_('grid.sort', 'JGLOBAL_TITLE', 'a.name', $listDirn, $listOrder, null, 'asc', '', 'adminForm'); ?>
+                            <?php echo HTMLHelper::_('grid.sort', 'COM_CONTACT_CONTACT_EMAIL_NAME_LABEL', 'a.name', $listDirn, $listOrder, null, 'asc', '', 'adminForm'); ?>
                         </th>
                         <th scope="col">
                             <?php echo Text::_('COM_CONTACT_CONTACT_DETAILS'); ?>

--- a/components/com_contact/tmpl/category/default_items.php
+++ b/components/com_contact/tmpl/category/default_items.php
@@ -88,7 +88,7 @@ $listDirn   = $this->escape($this->state->get('list.direction'));
                 <thead<?php echo $this->params->get('show_headings', '1') ? '' : ' class="visually-hidden"'; ?>>
                     <tr>
                         <th scope="col" id="categorylist_header_title">
-                            <?php echo HTMLHelper::_('grid.sort', 'COM_CONTACT_CONTACT_EMAIL_NAME_LABEL', 'a.name', $listDirn, $listOrder, null, 'asc', '', 'adminForm'); ?>
+                            <?php echo HTMLHelper::_('grid.sort', 'COM_CONTACT_FIELD_NAME_LABEL', 'a.name', $listDirn, $listOrder, null, 'asc', '', 'adminForm'); ?>
                         </th>
                         <th scope="col">
                             <?php echo Text::_('COM_CONTACT_CONTACT_DETAILS'); ?>


### PR DESCRIPTION
Pull Request for Issue #41318  .

### Summary of Changes

Change the language-string for correct table-head-title

### Testing Instructions

View in frontend a menue item of Menu_item_type "List Contacts in a Category"
index.php?option=com_contact&view=category
with "Table Headings" is "Show" in the "List Layouts"-Tab of this menue-item.
With this PR:
In the head of the table it is the word "Name" for the column of the names of the contacts 

### Actual result BEFORE applying this Pull Request

Bug:
In the head of the table it is the false word "Title" and not "Name" for the column of names of the contacts.

### Expected result AFTER applying this Pull Request

In the head of the table it is the word "Name" for the column of the names of the contacts

Edit:
Same now in Backend-view for table-title and filter as aspected

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed