### PR TITLE
Fixes notice about creating dynamic property currentUpdate on extension adapter

### DIFF
--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -30,6 +30,14 @@ use Joomla\CMS\Version;
 class ExtensionAdapter extends UpdateAdapter
 {
     /**
+     * The update table instance
+     *
+     * @var bool|Table
+     * @since __DEPLOY_VERSION__
+     */
+    private bool|Table $currentUpdate;
+
+    /**
      * Start element parser callback.
      *
      * @param   object  $parser  The parser object.


### PR DESCRIPTION
### Summary of Changes
Add property `currentUpdate` so it is not dynamically created.


### Testing Instructions
1. Make sure you run PHP 8.2
2. Go to the System => Joomla Update
3. Notice the deprecation notice:
    ```Deprecated: Creation of dynamic property Joomla\CMS\Updater\Adapter\ExtensionAdapter::$currentUpdate is deprecated in /var/www/html/joomla5.test/libraries/src/Updater/Adapter/ExtensionAdapter.php on line 57```
4.  Apply patch
5. Refresh page
6. Notice is gone


### Actual result BEFORE applying this Pull Request
A notice is shown:
```
Deprecated: Creation of dynamic property Joomla\CMS\Updater\Adapter\ExtensionAdapter::$currentUpdate is deprecated in /var/www/html/joomla5.test/libraries/src/Updater/Adapter/ExtensionAdapter.php on line 57
```


### Expected result AFTER applying this Pull Request
Notice is gone.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
