### PR TITLE
Add the function to order the categories

### DIFF
--- a/modules/mod_articles_categories/mod_articles_categories.xml
+++ b/modules/mod_articles_categories/mod_articles_categories.xml
@@ -37,6 +37,18 @@
 				/>
 
 				<field
+					name="orderby_pri"
+					type="list"
+					label="JGLOBAL_CATEGORY_ORDER_LABEL"
+					useglobal="true"
+					>
+					<option value="none">JGLOBAL_NO_ORDER</option>
+					<option value="alpha">JGLOBAL_TITLE_ALPHABETICAL</option>
+					<option value="ralpha">JGLOBAL_TITLE_REVERSE_ALPHABETICAL</option>
+					<option value="order">JGLOBAL_CATEGORY_MANAGER_ORDER</option>
+				</field>
+
+				<field
 					name="show_description"
 					type="radio"
 					layout="joomla.form.field.radio.switcher"


### PR DESCRIPTION
Pull Request for Issue #39532 .

### Summary of Changes
1. Create a field to set the ordering of the categories in the backend.
2. Add the functionality to order the categories according to the order by query in the database: To determine the ordering for the database query, include the getCategoryOrdering method. The desired category ordering preference is fetched in the getChildrenCategories method, a SQL query is built based on this preference, and the resulting order is used to sort and restructuring the array of child categories. The resulting array $orderedChildrenCategories will contain the children categories sorted as per the Joomla database query order.

### Testing Instructions
- Create different categories and assign them a parent category. (Menu -> Content-> Categories -> New)
- Move to site modules and add Articles Categories Module (New -> Articles Categories +). Select Parent Category and find the option for Category Ordering just below it and set according to your choice.

![image](https://github.com/joomla/joomla-cms/assets/121369234/a356338a-1ee8-4cd0-b86f-eb9c23bc4bbe)

- Save the module.



### Actual result BEFORE applying this Pull Request
No option to order the categories.


### Expected result AFTER applying this Pull Request
You are able to order the categories according to their title and lft values.

https://github.com/joomla/joomla-cms/assets/121369234/89b42954-8bc8-4a4c-b0e0-b21057c468a1




### Link to documentations
Please select:

- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
