### PR TITLE
[5.0] CHAT GPT Privacy

### DIFF
--- a/robots.txt.dist
+++ b/robots.txt.dist
@@ -27,3 +27,9 @@ Disallow: /logs/
 Disallow: /modules/
 Disallow: /plugins/
 Disallow: /tmp/
+
+# GPTBot is OpenAI’s web crawler. This rule prevents the GPTBot from crawling
+# the web site to use its content when building new models.
+
+User-agent: GPTBot
+Disallow: /


### PR DESCRIPTION
### Summary of Changes
GPTBot is OpenAI’s web crawler. This rule prevents the GPTBot from crawling the web site to use its content when building new models. See https://platform.openai.com/docs/gptbot

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: **if the pr is accepted I will add documentation**
- [ ] No documentation changes for manual.joomla.org needed
