### PR TITLE
[5.0] Fix form bindLevel for objects, wich was cause of warning: SimpleXMLElement::xpath(): Unfinished literal

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -156,7 +156,7 @@ class Form implements CurrentUserInterface
      */
     protected function bindLevel($group, $data)
     {
-        // Ensure the input data is an array.
+        // Check the input data for specific types.
         if (\is_object($data)) {
             if ($data instanceof Registry) {
                 // Handle a Registry.
@@ -164,9 +164,6 @@ class Form implements CurrentUserInterface
             } elseif ($data instanceof CMSObject) {
                 // Handle a CMSObject.
                 $data = $data->getProperties();
-            } else {
-                // Handle other types of objects.
-                $data = (array) $data;
             }
         }
 


### PR DESCRIPTION
Pull Request for Issue #41256 .

### Summary of Changes
After removing CMSObject from User class https://github.com/joomla/joomla-cms/pull/40999, it cause weird issue when binding User data to the form.
The PR is fixing it.


### Testing Instructions
Apply patch,
Make sure errror reaporting on maximum.
On the site open user profile page


### Actual result BEFORE applying this Pull Request
No warnings


### Expected result AFTER applying this Pull Request
Many warnings:
```
Warning: SimpleXMLElement::xpath(): Unfinished literal in /libraries/src/Form/Form.php on line 1250
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
