### PR TITLE
[4.4] Events backward compatibility handling

### DIFF
--- a/libraries/src/Event/AbstractEvent.php
+++ b/libraries/src/Event/AbstractEvent.php
@@ -140,6 +140,23 @@ abstract class AbstractEvent extends BaseEvent
      */
     public function getArgument($name, $default = null)
     {
+        // B/C check for numeric access to named argument, eg $event->getArgument('0').
+        if (is_numeric($name)) {
+            if (key($this->arguments) != 0) {
+                $argNames = \array_keys($this->arguments);
+                $name     = $argNames[$name] ?? '';
+            }
+
+            @trigger_error(
+                sprintf(
+                    'Numeric access to named event arguments is deprecated, and will not work in Joomla 6. Event %s argument %s',
+                    \get_class($this),
+                    $name
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+
         $methodName = 'get' . ucfirst($name);
 
         $value = parent::getArgument($name, $default);
@@ -170,6 +187,23 @@ abstract class AbstractEvent extends BaseEvent
      */
     public function setArgument($name, $value)
     {
+        // B/C check for numeric access to named argument, eg $event->setArgument('0', $value).
+        if (is_numeric($name)) {
+            if (key($this->arguments) != 0) {
+                $argNames = \array_keys($this->arguments);
+                $name     = $argNames[$name] ?? '';
+            }
+
+            @trigger_error(
+                sprintf(
+                    'Numeric access to named event arguments is deprecated, and will not work in Joomla 6. Event %s argument %s',
+                    \get_class($this),
+                    $name
+                ),
+                E_USER_DEPRECATED
+            );
+        }
+
         $methodName = 'set' . ucfirst($name);
 
         if (method_exists($this, $methodName)) {

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -10,6 +10,8 @@
 namespace Joomla\CMS\Plugin;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Event\AbstractImmutableEvent;
+use Joomla\CMS\Event\Result\ResultAwareInterface;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\LanguageAwareInterface;
@@ -291,9 +293,13 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
                     return;
                 }
 
-                // Restore the old results and add the new result from our method call
-                $allResults[]    = $result;
-                $event['result'] = $allResults;
+                if ($event instanceof ResultAwareInterface) {
+                    $event->addResult($result);
+                } elseif (!$event instanceof AbstractImmutableEvent) {
+                    // Restore the old results and add the new result from our method call
+                    $allResults[]    = $result;
+                    $event['result'] = $allResults;
+                }
             }
         );
     }


### PR DESCRIPTION
### Summary of Changes

Same as #41345 but for 4.4.
Fixing possible b/c break for an events.
I have extracted it from https://github.com/joomla/joomla-cms/pull/41226 in to separated PR.

### Testing Instructions
Apply patch.
Edit `plugins/system/sef/src/Extension/Sef.php`, add `return true;` at top of `onAfterDispatch()` function.
Run in index.php of a template:
```php
$event = new class('onAfterDispatch') extends Joomla\CMS\Event\AbstractImmutableEvent{};
$app->getDispatcher()->dispatch('onAfterDispatch', $event);
```


### Actual result BEFORE applying this Pull Request
An error, cannot set result for Imutable event


### Expected result AFTER applying this Pull Request
No error


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: 
- [x] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/169
- [ ] No documentation changes for manual.joomla.org needed
