### PR TITLE
[4.3] uppercase image file in preview

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-media.w-c.es6.js
@@ -302,7 +302,7 @@ class JoomlaFieldMedia extends HTMLElement {
         let type;
         this.buttonClearEl.style.display = '';
         this.previewElement.innerHTML = '';
-        const ext = getExtension(value);
+        const ext = getExtension(value).toLowerCase();
 
         if (supportedExtensions.images.includes(ext)) type = 'images';
         if (supportedExtensions.audios.includes(ext)) type = 'audios';


### PR DESCRIPTION
Pull Request for Issue #41343 . Alternative to #41356

### Summary of Changes

Allow UPPERCASE, and MiXeD case extensions for all the media files

### Testing Instructions

Rename the file `images/joomla_black.png` to `images/joomla_black.PNG` and then select it as the intro image in an article


### Actual result BEFORE applying this Pull Request

Preview broken

### Expected result AFTER applying this Pull Request

Preview works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
