### PR TITLE
[5.0] fix joomla update not download url

### DIFF
--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -232,7 +232,7 @@ class Update
      * @since  3.10.2
      */
     protected $compatibleVersions = [];
-    protected $downloadurl;
+    public $downloadurl;
     protected $tag;
     protected $stability;
     protected $supported_databases;


### PR DESCRIPTION
### Summary of Changes

property `downloadurl` is protected since #41118 by @alikon

so the check fails here now
https://github.com/joomla/joomla-cms/blob/3fa34beb6200af06280a28bdae4d17e42af8999d/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php#L177

### Testing Instructions

enter `Custom URL` for joomla update, for eg. of this pull request
![image](https://github.com/joomla/joomla-cms/assets/66922325/c7b61528-f4d2-42f6-8c73-916f3c500612)

click on joomla update quickicon which shows that an update is available
![image](https://github.com/joomla/joomla-cms/assets/66922325/274f8359-e061-4d8a-82cc-bb838f868a51)

### Actual result BEFORE applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/66922325/06a75708-075c-4edf-9403-a843531dbcf9)

### Expected result AFTER applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/66922325/77aef928-3508-418b-b509-847c7b6831c1)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
