### PR TITLE
[4.3] Re-add minus to allowed filenames in com_templates

### DIFF
--- a/administrator/components/com_templates/src/Controller/TemplateController.php
+++ b/administrator/components/com_templates/src/Controller/TemplateController.php
@@ -479,7 +479,7 @@ class TemplateController extends BaseController
             $this->setMessage(Text::_('COM_TEMPLATES_INVALID_FILE_TYPE'), 'error');
             $url = 'index.php?option=com_templates&view=template&id=' . $id . '&file=' . $file . '&isMedia=' . $this->input->getInt('isMedia', 0);
             $this->setRedirect(Route::_($url, false));
-        } elseif (!preg_match('/^(?!\.)(?!.*\.$)(?!.*\.\.)[a-zA-Z0-9_.]+$/', $name)) {
+        } elseif (!preg_match('/^(?!\.)(?!.*\.$)(?!.*\.\.)[a-zA-Z0-9_.-]+$/', $name)) {
             $this->setMessage(Text::_('COM_TEMPLATES_INVALID_FILE_NAME'), 'error');
             $url = 'index.php?option=com_templates&view=template&id=' . $id . '&file=' . $file . '&isMedia=' . $this->input->getInt('isMedia', 0);
             $this->setRedirect(Route::_($url, false));
@@ -672,7 +672,7 @@ class TemplateController extends BaseController
             $this->setMessage(Text::_('COM_TEMPLATES_ERROR_RENAME_ASSET_FILE'), 'warning');
             $url = 'index.php?option=com_templates&view=template&id=' . $id . '&file=' . $file . '&isMedia=' . $isMedia;
             $this->setRedirect(Route::_($url, false));
-        } elseif (!preg_match('/^(?!\.)(?!.*\.$)(?!.*\.\.)[a-zA-Z0-9_.]+$/', $newName)) {
+        } elseif (!preg_match('/^(?!\.)(?!.*\.$)(?!.*\.\.)[a-zA-Z0-9_.-]+$/', $newName)) {
             $this->setMessage(Text::_('COM_TEMPLATES_INVALID_FILE_NAME'), 'error');
             $url = 'index.php?option=com_templates&view=template&id=' . $id . '&file=' . $file . '&isMedia=' . $isMedia;
             $this->setRedirect(Route::_($url, false));


### PR DESCRIPTION
Pull Request for Issue #41368.

### Summary of Changes
re-add the minus sign to the list of allowed characters, that had been removed in PR #38987.

It restores the behavior that is also described in the error message for in valid filenames.


### Testing Instructions
* Open a template in the com_templates file browser
*  Try to create a (e.g. PHP) file that contains a minus sign, e.g. enter `contains-minus` as a file name

### Actual result BEFORE applying this Pull Request
The file is not created, and an error message is shown:

https://github.com/joomla/joomla-cms/blob/ae2a409d5496a489a2638f0cbf442356aa89a163/administrator/language/en-GB/com_templates.ini#L158


### Expected result AFTER applying this Pull Request
The file `contains-minus.php` is created. This is a totally valid filename.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
