### PR TITLE
[5.0] Update deleted files and folders lists in script.php for 5.0.0-alpha4

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1857,8 +1857,7 @@ class JoomlaInstallerScript
             '/plugins/editors/codemirror/layouts/editors/codemirror/element.php',
             '/plugins/editors/codemirror/layouts/editors/codemirror/styles.php',
             '/plugins/editors/codemirror/src/Field/FontsField.php',
-
-            // From 5.0.0-alpha1 to 5.0.0-alpha4
+            // From 5.0.0-alpha3 to 5.0.0-alpha4
             '/libraries/src/Event/Application/DeamonForkEvent.php',
             '/libraries/src/Event/Application/DeamonReceiveSignalEvent.php',
         ];

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1860,6 +1860,16 @@ class JoomlaInstallerScript
             // From 5.0.0-alpha3 to 5.0.0-alpha4
             '/libraries/src/Event/Application/DeamonForkEvent.php',
             '/libraries/src/Event/Application/DeamonReceiveSignalEvent.php',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/plugin.js',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/plugin.min.js',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/plugin.min.js.gz',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.css',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.html',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.js',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.css',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.css.gz',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.js',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.js.gz',
         ];
 
         $folders = [
@@ -2077,6 +2087,7 @@ class JoomlaInstallerScript
             // From 5.0.0-alpha3 to 5.0.0-alpha4
             '/templates/system/incompatible.html,/includes',
             '/templates/system/incompatible.html,',
+            '/media/plg_editors_tinymce/js/plugins/highlighter',
         ];
 
         $status['files_checked']   = $files;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2075,6 +2075,9 @@ class JoomlaInstallerScript
             '/media/vendor/codemirror/addon/dialog',
             '/media/vendor/codemirror/addon/comment',
             '/media/vendor/codemirror/addon',
+            // From 5.0.0-alpha3 to 5.0.0-alpha4
+            '/templates/system/incompatible.html,/includes',
+            '/templates/system/incompatible.html,',
         ];
 
         $status['files_checked']   = $files;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the lists of files and folders to be deleted on update in file "administrator/components/com_admin/script.php" to recent changes in the 5.0-dev branch in preparation for the upcoming 5.0.0-alpha4 release.

In detail deleted files and folder from following PR's are added:

- PR #41321 empty folders
'/templates/system/incompatible.html,/includes',
'/templates/system/incompatible.html,',
- PR #41289 folder '/media/plg_editors_tinymce/js/plugins/highlighter' and all files in that folder.

**The following is not added due to deliberate decisions of the release managers:**

- PR #41260 renamed file '/plugins/schemaorg/blogposting/src/Extension/Blogposting.php'
Decision see https://github.com/joomla/joomla-cms/issues/41261#issuecomment-1654253587 .
- PR #41276 deleted files and folder and uninstalling the obsolete system plugin on update
Decision see https://github.com/joomla/joomla-cms/pull/41276#issuecomment-1656703209 .

The file from the first point not being renamed might cause schema.org for blog posts not working on Windows hosts after updates from previous 5.0 alpha versions.

The second point leaves an obsolete system plugin installed, which might cause issues when being activated when updating, and also after the update.

**Therefore I have created PR #41394 to fix both mentioned points in case if the release managers think over their decision. That PR also includes the changes from this one here.**

### Testing Instructions

Code review.

Or if you want to make a real test, update a current 4.4-dev nightly build or a 5.0.0-alpha3 to the last 5.0 nightly build to get the actual result, and update a current 4.4-dev nightly build or a 5.0.0-alpha3 to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

The files and folders mentioned above are still present after updating from a current 4.4-dev nightly build or a 5.0.0-alpha3.

### Expected result AFTER applying this Pull Request

The files and folders mentioned above have been deleted after updating from a current 4.4-dev nightly build or a 5.0.0-alpha3.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
