### PR TITLE
[5.0] [RFC] Fix update path from previous 5.0.0 alphas

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1857,10 +1857,17 @@ class JoomlaInstallerScript
             '/plugins/editors/codemirror/layouts/editors/codemirror/element.php',
             '/plugins/editors/codemirror/layouts/editors/codemirror/styles.php',
             '/plugins/editors/codemirror/src/Field/FontsField.php',
-
-            // From 5.0.0-alpha1 to 5.0.0-alpha4
+            // From 5.0.0-alpha3 to 5.0.0-alpha4
+            '/administrator/language/en-GB/plg_system_compat.ini',
+            '/administrator/language/en-GB/plg_system_compat.sys.ini',
             '/libraries/src/Event/Application/DeamonForkEvent.php',
             '/libraries/src/Event/Application/DeamonReceiveSignalEvent.php',
+            '/media/plg_system_compat/es5.asset.json',
+            '/plugins/system/compat/compat.xml',
+            '/plugins/system/compat/services/provider.php',
+            '/plugins/system/compat/src/Extension/Compat.php',
+            '/plugins/system/compat/src/classmap/classmap.php',
+            '/plugins/system/compat/src/classmap/extensions.classmap.php',
         ];
 
         $folders = [
@@ -2075,6 +2082,15 @@ class JoomlaInstallerScript
             '/media/vendor/codemirror/addon/dialog',
             '/media/vendor/codemirror/addon/comment',
             '/media/vendor/codemirror/addon',
+            // From 5.0.0-alpha3 to 5.0.0-alpha4
+            '/templates/system/incompatible.html,/includes',
+            '/templates/system/incompatible.html,',
+            '/plugins/system/compat/src/classmap',
+            '/plugins/system/compat/src/Extension',
+            '/plugins/system/compat/src',
+            '/plugins/system/compat/services',
+            '/plugins/system/compat',
+            '/media/plg_system_compat',
         ];
 
         $status['files_checked']   = $files;
@@ -2318,6 +2334,8 @@ class JoomlaInstallerScript
             // From 4.4 to 5.0
             '/libraries/vendor/web-auth/cose-lib/src/Algorithm/Signature/EdDSA/ED256.php' => '/libraries/vendor/web-auth/cose-lib/src/Algorithm/Signature/EdDSA/Ed256.php',
             '/libraries/vendor/web-auth/cose-lib/src/Algorithm/Signature/EdDSA/ED512.php' => '/libraries/vendor/web-auth/cose-lib/src/Algorithm/Signature/EdDSA/Ed512.php',
+            // From 5.0.0-alpha3 to 5.0.0-alpha4
+            '/plugins/schemaorg/blogposting/src/Extension/Blogposting.php' => '/plugins/schemaorg/blogposting/src/Extension/BlogPosting.php',
         ];
 
         foreach ($files as $old => $expected) {

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1898,7 +1898,6 @@ class JoomlaInstallerScript
             '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.css.gz',
             '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.js',
             '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.js.gz',
-            '/media/plg_system_compat/es5.asset.json',
         ];
 
         $folders = [
@@ -2116,7 +2115,6 @@ class JoomlaInstallerScript
             // From 5.0.0-alpha3 to 5.0.0-alpha4
             '/templates/system/incompatible.html,/includes',
             '/templates/system/incompatible.html,',
-            '/media/plg_system_compat',
             '/media/plg_editors_tinymce/js/plugins/highlighter',
         ];
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1898,6 +1898,7 @@ class JoomlaInstallerScript
             '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.css.gz',
             '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.js',
             '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.js.gz',
+            '/media/plg_system_compat/es5.asset.json',
         ];
 
         $folders = [
@@ -2115,6 +2116,7 @@ class JoomlaInstallerScript
             // From 5.0.0-alpha3 to 5.0.0-alpha4
             '/templates/system/incompatible.html,/includes',
             '/templates/system/incompatible.html,',
+            '/media/plg_system_compat',
             '/media/plg_editors_tinymce/js/plugins/highlighter',
         ];
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1888,6 +1888,16 @@ class JoomlaInstallerScript
             // From 5.0.0-alpha3 to 5.0.0-alpha4
             '/libraries/src/Event/Application/DeamonForkEvent.php',
             '/libraries/src/Event/Application/DeamonReceiveSignalEvent.php',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/plugin.js',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/plugin.min.js',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/plugin.min.js.gz',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.css',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.html',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.js',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.css',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.css.gz',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.js',
+            '/media/plg_editors_tinymce/js/plugins/highlighter/source.min.js.gz',
             '/media/plg_system_compat/es5.asset.json',
         ];
 
@@ -2107,6 +2117,7 @@ class JoomlaInstallerScript
             '/templates/system/incompatible.html,/includes',
             '/templates/system/incompatible.html,',
             '/media/plg_system_compat',
+            '/media/plg_editors_tinymce/js/plugins/highlighter',
         ];
 
         $status['files_checked']   = $files;

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -1886,16 +1886,9 @@ class JoomlaInstallerScript
             '/plugins/editors/codemirror/layouts/editors/codemirror/styles.php',
             '/plugins/editors/codemirror/src/Field/FontsField.php',
             // From 5.0.0-alpha3 to 5.0.0-alpha4
-            '/administrator/language/en-GB/plg_system_compat.ini',
-            '/administrator/language/en-GB/plg_system_compat.sys.ini',
             '/libraries/src/Event/Application/DeamonForkEvent.php',
             '/libraries/src/Event/Application/DeamonReceiveSignalEvent.php',
             '/media/plg_system_compat/es5.asset.json',
-            '/plugins/system/compat/compat.xml',
-            '/plugins/system/compat/services/provider.php',
-            '/plugins/system/compat/src/Extension/Compat.php',
-            '/plugins/system/compat/src/classmap/classmap.php',
-            '/plugins/system/compat/src/classmap/extensions.classmap.php',
         ];
 
         $folders = [
@@ -2113,11 +2106,6 @@ class JoomlaInstallerScript
             // From 5.0.0-alpha3 to 5.0.0-alpha4
             '/templates/system/incompatible.html,/includes',
             '/templates/system/incompatible.html,',
-            '/plugins/system/compat/src/classmap',
-            '/plugins/system/compat/src/Extension',
-            '/plugins/system/compat/src',
-            '/plugins/system/compat/services',
-            '/plugins/system/compat',
             '/media/plg_system_compat',
         ];
 

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -71,6 +71,7 @@ $previousReleaseExclude = [
     $options['from'] . '/plugins/fields/repeatable',
     $options['from'] . '/plugins/quickicon/eos310',
     $options['from'] . '/plugins/search',
+    $options['from'] . '/plugins/system/compat',
     $options['from'] . '/plugins/task/demotasks',
 ];
 
@@ -171,6 +172,8 @@ $filesToKeep = [
     "'/administrator/language/en-GB/en-GB.plg_search_weblinks.sys.ini',",
     "'/administrator/language/en-GB/en-GB.plg_system_weblinks.ini',",
     "'/administrator/language/en-GB/en-GB.plg_system_weblinks.sys.ini',",
+    "'/administrator/language/en-GB/plg_system_compat.ini',",
+    "'/administrator/language/en-GB/plg_system_compat.sys.ini',",
     "'/administrator/language/en-GB/plg_task_demotasks.ini',",
     "'/administrator/language/en-GB/plg_task_demotasks.sys.ini',",
     "'/language/en-GB/en-GB.com_search.ini',",

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -66,7 +66,6 @@ $previousReleaseExclude = [
     $options['from'] . '/images/sampledata',
     $options['from'] . '/installation',
     $options['from'] . '/media/plg_quickicon_eos310',
-    $options['from'] . '/media/plg_system_compat',
     $options['from'] . '/media/system/images',
     $options['from'] . '/modules/mod_search',
     $options['from'] . '/plugins/fields/repeatable',

--- a/build/deleted_file_check.php
+++ b/build/deleted_file_check.php
@@ -66,6 +66,7 @@ $previousReleaseExclude = [
     $options['from'] . '/images/sampledata',
     $options['from'] . '/installation',
     $options['from'] . '/media/plg_quickicon_eos310',
+    $options['from'] . '/media/plg_system_compat',
     $options['from'] . '/media/system/images',
     $options['from'] . '/modules/mod_search',
     $options['from'] . '/plugins/fields/repeatable',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes the currently broken update path from previous 5.0 alpha versions to the upcoming alpha 4 by fixing points mentioned in the description of PR #41393 :
- Add file '/plugins/schemaorg/blogposting/src/Extension/Blogposting.php' from PR #41260 to the list of files to be renamed on update in file "administrator/components/com_admin/script.php".
- Add uninstallation of obsolete system plugin due to PR #41276 and migration of the obsolete plugin's enabled status and parameters to the new behaviour plugin's parameters on update to file "administrator/components/com_admin/script.php", and add file '/media/plg_system_compat/es5.asset.json' to the deleted files list in in file "administrator/components/com_admin/script.php" because that file is not removed when the plugin is uninstalled due to an incomplete manifest xml of that plugin.

In addition, this PR adds the necessary exceptions to the "build/deleted_file_check.php" script so that the files of the obsolete system plugin which will be removed by the installer when uninstalling the plugin are not added to the lists of deleted files and folders generated by the script.

Finally, this PR here includes also the changes from PR #41393 for easier testing.

As described in that PR, the 2 mentioned points result from deliberate decisions of the release managers, so this PR here is just an offer in case if they decide to change their mind.

### Testing Instructions

#### Test 1 update from 5.0.0-alpha3

1. Install a 5.0.0-alpha3.
2. Enable the "System - Backward Compatibility" plugin and change some of its parameters.
3. Switch error reporting to maximum in Global Configuration.
4. Update to the patched update package or custom update URL created by drone for this PR.
Result: The update succeeds.
5. Check if the "System - Backward Compatibility" plugin has been properly uninstalled.
Result: The plugin has been uninstalled.
6. Check the enabled status and parameters of the new "Behaviour - Backward Compatibility" plugin.
Result: The plugin is enabled, the parameters are equal to those set in step 2 for the old system plugin.
7. Repeat steps 1 and 3 to 6 but not step 2 so that the old plugin is disabled on update.
Result: The new plugin "Behaviour - Backward Compatibility" is disabled.
8. Check if the files and folders of the obsolete "System - Backward Compatibility" plugin have been deleted.
Result: All files and folders belonging to that plugin have been deleted.
9. Check if file '/plugins/schemaorg/blogposting/src/Extension/Blogposting.php' has been renamed to '/plugins/schemaorg/blogposting/src/Extension/BlogPosting.php'.
Result: The file has been renamed.

#### Test 2 for the changes in "build/deleted_file_check.php"

1. On a clean, current 5.0-dev branch (no need for having run composer or npm and no need for a Joomla installation), download the following 2 full installation zip packages and save them in the "tmp" folder:
- 5.0.0-alpha3 https://github.com/joomla/joomla-cms/releases/download/5.0.0-alpha3/Joomla_5.0.0-alpha3-Alpha-Full_Package.zip
- Latest 5.0 nightly build https://developer.joomla.org/nightlies/Joomla_5.0.0-alpha4-dev-Development-Full_Package.zip
2. Unpack the 2 previously downloaded zip packages into 2 separate folders in the "tmp" folder, e.g. folders "Joomla_5.0.0-alpha3-Alpha-Full_Package" and "Joomla_5.0.0-alpha4-dev-Development-Update_Package".
3. In a command windows in the directory with your git clone and the branch from step 1, run the following command to check the two folders from the previous step for deleted files and folders (on Windows you have to use backslashes \ instead of slashes / for the paths):
```
php ./build/deleted_file_check.php --from=./tmp/Joomla_5.0.0-alpha3-Alpha-Full_Package --to=./tmp/Joomla_5.0.0-alpha4-dev-Development-Update_Package
```
4. Check the 2 created text files `./build/deleted_files.txt` and `./build/deleted_folders.txt`.
Result: See section "Actual result BEFORE applying this Pull Request" below.
5. Save the 2 text files from step 4 for later comparison.
6. Apply the changes from this PR.
7. Repeat steps 3 and 4 and compare the 2 text files with those saved in step 5.
Result: See section "Expected result AFTER applying this Pull Request" below.

### Actual result BEFORE applying this Pull Request

#### Test 1 update from 5.0.0-alpha3

The files and folders of the obsolete "System - Backward Compatibility" plugin have not been removed.

The plugin has not been uninstalled.

The new "Behaviour - Backward Compatibility" plugin is enabled with the default options.

File '/plugins/schemaorg/blogposting/src/Extension/Blogposting.php' has not been renamed to '/plugins/schemaorg/blogposting/src/Extension/BlogPosting.php'. This will cause schema.org for blog posts not working on Windows or Mac hosts after updates from previous 5.0 alpha versions.

#### Test 2 for the changes in "build/deleted_file_check.php"

All files and folders belonging to the old "System - Backward Compatibility" are in the lists of deleted files and folders.

### Expected result AFTER applying this Pull Request

#### Test 1 update from 5.0.0-alpha3

The files and folders of the obsolete "System - Backward Compatibility" plugin have been removed.

The plugin has been uninstalled.

The new "Behaviour - Backward Compatibility" plugin is disabled  when the old plugin was disabled before the update, and it is enabled and has inherited the old plugin's parameters when the old plugin was enabled before the update.

File '/plugins/schemaorg/blogposting/src/Extension/Blogposting.php' has been renamed to '/plugins/schemaorg/blogposting/src/Extension/BlogPosting.php'.

#### Test 2 for the changes in "build/deleted_file_check.php"

Only folder "/media/plg_system_compat" and files in that folder are in the list of deleted files, no other files or folders of the obsolete "System - Backward Compatibility" plugin are in the lists.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
