### PR TITLE
[5.0] schemaorg remove double space

### DIFF
--- a/administrator/language/en-GB/plg_schemaorg_blogposting.ini
+++ b/administrator/language/en-GB/plg_schemaorg_blogposting.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SCHEMAORG_BLOGPOSTING="Schema.org - BlogPosting"
-PLG_SCHEMAORG_BLOGPOSTING_DESCRIPTION_LABEL="A blog post <a href=\"https://schema.org/BlogPosting\" target=\"_blank\"  rel=\"noopener noreferrer\">More information</a>"
+PLG_SCHEMAORG_BLOGPOSTING_DESCRIPTION_LABEL="A blog post <a href=\"https://schema.org/BlogPosting\" target=\"_blank\" rel=\"noopener noreferrer\">More information</a>"
 PLG_SCHEMAORG_BLOGPOSTING_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_BLOGPOSTING_FIELD_AUTHOR_LABEL="Author"
 PLG_SCHEMAORG_BLOGPOSTING_FIELD_DATE_MODIFIED_LABEL="Date Modified"

--- a/administrator/language/en-GB/plg_schemaorg_book.ini
+++ b/administrator/language/en-GB/plg_schemaorg_book.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SCHEMAORG_BOOK="Schema.org - Book"
-PLG_SCHEMAORG_BOOK_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Book\" target=\"_blank\"  rel=\"noopener noreferrer\">More information</a>"
+PLG_SCHEMAORG_BOOK_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Book\" target=\"_blank\" rel=\"noopener noreferrer\">More information</a>"
 PLG_SCHEMAORG_BOOK_FIELD_ABRIDGED_LABEL="Abridged"
 PLG_SCHEMAORG_BOOK_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_BOOK_FIELD_AUDIOBOOK_LABEL="Audiobook"

--- a/administrator/language/en-GB/plg_schemaorg_event.ini
+++ b/administrator/language/en-GB/plg_schemaorg_event.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SCHEMAORG_EVENT="Schema.org - Event"
-PLG_SCHEMAORG_EVENT_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Event\" target=\"_blank\"  rel=\"noopener noreferrer\">More information</a>"
+PLG_SCHEMAORG_EVENT_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Event\" target=\"_blank\" rel=\"noopener noreferrer\">More information</a>"
 PLG_SCHEMAORG_EVENT_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_EVENT_FIELD_AGGREGATE_RATING_LABEL="Aggregate Rating"
 PLG_SCHEMAORG_EVENT_FIELD_DESCRIPTION_LABEL="Description"

--- a/administrator/language/en-GB/plg_schemaorg_jobposting.ini
+++ b/administrator/language/en-GB/plg_schemaorg_jobposting.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_SCHEMAORG_JOBPOSTING_DESCRIPTION_LABEL="A job post <a href=\"https://schema.org/JobPosting\" target=\"_blank\"  rel=\"noopener noreferrer\">More information</a>"
+PLG_SCHEMAORG_JOBPOSTING_DESCRIPTION_LABEL="A job post <a href=\"https://schema.org/JobPosting\" target=\"_blank\" rel=\"noopener noreferrer\">More information</a>"
 PLG_SCHEMAORG_JOBPOSTING_FIELD_ADDRESS_COUNTRY_LABEL="Country"
 PLG_SCHEMAORG_JOBPOSTING_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_JOBPOSTING_FIELD_ADDRESS_REGION_LABEL="Region"

--- a/administrator/language/en-GB/plg_schemaorg_organization.ini
+++ b/administrator/language/en-GB/plg_schemaorg_organization.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SCHEMAORG_ORGANIZATION="Schema.org - Organization"
-PLG_SCHEMAORG_ORGANIZATION_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Organization\" target=\"_blank\"  rel=\"noopener noreferrer\">More information.</a>"
+PLG_SCHEMAORG_ORGANIZATION_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Organization\" target=\"_blank\" rel=\"noopener noreferrer\">More information.</a>"
 PLG_SCHEMAORG_ORGANIZATION_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_ORGANIZATION_FIELD_EMAIL_LABEL="Email"
 PLG_SCHEMAORG_ORGANIZATION_FIELD_GENERIC_FIELD_LABEL="Generic Field"

--- a/administrator/language/en-GB/plg_schemaorg_person.ini
+++ b/administrator/language/en-GB/plg_schemaorg_person.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SCHEMAORG_PERSON="Schema.org - Person"
-PLG_SCHEMAORG_PERSON_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Person\" target=\"_blank\"  rel=\"noopener noreferrer\">More information.</a>"
+PLG_SCHEMAORG_PERSON_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Person\" target=\"_blank\" rel=\"noopener noreferrer\">More information.</a>"
 PLG_SCHEMAORG_PERSON_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_PERSON_FIELD_EMAIL_LABEL="Email"
 PLG_SCHEMAORG_PERSON_FIELD_GENERIC_FIELD_LABEL="Generic Field"

--- a/administrator/language/en-GB/plg_system_schemaorg.ini
+++ b/administrator/language/en-GB/plg_system_schemaorg.ini
@@ -8,7 +8,7 @@ PLG_SYSTEM_SCHEMAORG_BASETYPE_DESCRIPTION="Choose whether your website represent
 PLG_SYSTEM_SCHEMAORG_BASETYPE_LABEL="Base Type"
 PLG_SYSTEM_SCHEMAORG_BASETYPE_OPTION_ORGANIZATION="Organization"
 PLG_SYSTEM_SCHEMAORG_BASETYPE_OPTION_PERSON="Person"
-PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_DESCRIPTION="Structured data is a standardised format for organising and representing information on the web. It provides a way to describe the content and meaning of data in a structured manner, making it easier for search engines and other applications to understand and process the information. <a href=\"https://schema.org\" target=\"_blank\"  rel=\"noopener noreferrer\">More information on schema.org</a>."
+PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_DESCRIPTION="Structured data is a standardised format for organising and representing information on the web. It provides a way to describe the content and meaning of data in a structured manner, making it easier for search engines and other applications to understand and process the information. <a href=\"https://schema.org\" target=\"_blank\" rel=\"noopener noreferrer\">More information on schema.org</a>."
 PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_DESCRIPTION_NOT_CONFIGURATED="To use the schema.org functionality, you have to configure the plugin first. Please contact an administrator of the page to get it configured."
 PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_DESCRIPTION_NOT_CONFIGURATED_ADMIN="To use the schema.org functionality, you have to configure the plugin first. Please select <a href=\"index.php?option=com_plugins&amp;task=plugin.edit&amp;extension_id=%s\" target=\"_blank\">this link to open the plugin</a>, configure and save."
 PLG_SYSTEM_SCHEMAORG_FIELD_SCHEMA_LABEL="Schema"


### PR DESCRIPTION
### Summary of Changes

unnecessary space removed

### Testing Instructions

check links works for all schemes or code review
![image](https://github.com/joomla/joomla-cms/assets/66922325/38f2a59f-924a-43e1-90ef-020bb67814f7)

### Actual result BEFORE applying this Pull Request

link works

### Expected result AFTER applying this Pull Request

link works

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
