### PR TITLE
[5.0] schemaorg sync translation in joomla.ini

### DIFF
--- a/api/language/en-GB/joomla.ini
+++ b/api/language/en-GB/joomla.ini
@@ -820,7 +820,7 @@ JWARNING_UNPUBLISH_MUST_SELECT="You must select at least one item to unpublish."
 
 ; Schemaorg
 JSCHEMAORG_EXTENSION_ALLOWED_DESCRIPTION="Activate this plugin only for listed extensions. If used all other extensions are disabled."
-JSCHEMAORG_EXTENSION_ALLOWED_LABEL="Allowed Extension"
+JSCHEMAORG_EXTENSION_ALLOWED_LABEL="Allowed Extensions"
 JSCHEMAORG_EXTENSION_FORBIDDEN_DESCRIPTION="Disable this plugin for listed extensions."
 JSCHEMAORG_EXTENSION_FORBIDDEN_LABEL="Forbidden Extensions"
 JSCHEMAORG_FIELD_COMPONENT_SECTIONS_TEXT="%2$s"


### PR DESCRIPTION
### Summary of Changes

sync translation in api file
https://github.com/joomla/joomla-cms/blob/46b5724a7ce0b2e5033bdfe5f18a268abf63219f/administrator/language/en-GB/joomla.ini#L831
https://github.com/joomla/joomla-cms/blob/46b5724a7ce0b2e5033bdfe5f18a268abf63219f/api/language/en-GB/joomla.ini#L823

### Testing Instructions

code review

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
