### PR TITLE
Allow only positive non-decimal values in duration schema

### DIFF
--- a/plugins/schemaorg/recipe/forms/duration.xml
+++ b/plugins/schemaorg/recipe/forms/duration.xml
@@ -4,12 +4,16 @@
         name="hour"
         type="number"
         label="PLG_SCHEMAORG_RECIPE_FIELD_HOUR_LABEL"
+		min="0"
+		pattern="\d+"
     />
 
     <field
         name="min"
         type="number"
         label="PLG_SCHEMAORG_RECIPE_FIELD_MINUTE_LABEL"
-        max="59"
+        min="0"
+		max="59"
+		pattern="\d+"
     />
 </form>


### PR DESCRIPTION
Pull Request for Issue #41399 .

### Summary of Changes
Minimum set to 0 and only numbers are allowed


### Testing Instructions
Add a recipe and try a negative and or decimal duration


### Actual result BEFORE applying this Pull Request
nothing


### Expected result AFTER applying this Pull Request
marked invalid on blur

