### PR TITLE
[5.0] Fix drone failing due to PHPCS error unused import from PR #41322

### DIFF
--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -12,7 +12,6 @@ namespace Joomla\Plugin\System\Schemaorg\Extension;
 
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Event\Model;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Currently drone is failing in the 5.0-dev branch since the merge of PR #41322 : https://ci.joomla.org/joomla/joomla-cms/68541/1/7 

This PR here fixes that.

### Testing Instructions

Check drone logs of this PR and of the last commit in the 5.0.-dev branch.

### Actual result BEFORE applying this Pull Request

Drone PHPCS fails in the 5.0-dev branch.

### Expected result AFTER applying this Pull Request

Drone PHPCS passes with this PR.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
