### PR TITLE
[5.0] replace deprecated Factory::getLanguage() code

### DIFF
--- a/administrator/components/com_actionlogs/src/Field/LogsdaterangeField.php
+++ b/administrator/components/com_actionlogs/src/Field/LogsdaterangeField.php
@@ -60,7 +60,7 @@ class LogsdaterangeField extends PredefinedlistField
         parent::__construct($form);
 
         // Load the required language
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $lang->load('com_actionlogs', JPATH_ADMINISTRATOR);
     }
 }

--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -100,7 +100,7 @@ class ActionlogsHelper
             return;
         }
 
-        $lang   = Factory::getLanguage();
+        $lang   = Factory::getApplication()->getLanguage();
         $source = '';
 
         switch (substr($extension, 0, 3)) {
@@ -268,7 +268,7 @@ class ActionlogsHelper
      */
     public static function loadActionLogPluginsLanguage()
     {
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $db   = Factory::getDbo();
 
         // Get all (both enabled and disabled) actionlog plugins

--- a/administrator/components/com_admin/src/Model/HelpModel.php
+++ b/administrator/components/com_admin/src/Model/HelpModel.php
@@ -110,7 +110,7 @@ class HelpModel extends BaseDatabaseModel
     public function getLangTag()
     {
         if (\is_null($this->lang_tag)) {
-            $this->lang_tag = Factory::getLanguage()->getTag();
+            $this->lang_tag = Factory::getApplication()->getLanguage()->getTag();
 
             if (!is_dir(JPATH_BASE . '/help/' . $this->lang_tag)) {
                 // Use English as fallback

--- a/administrator/components/com_associations/src/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/src/Helper/AssociationsHelper.php
@@ -390,7 +390,7 @@ class AssociationsHelper extends ContentHelper
 
         // Get the translated titles.
         $languagePath = JPATH_ADMINISTRATOR . '/components/' . $extensionName;
-        $lang         = Factory::getLanguage();
+        $lang         = Factory::getApplication()->getLanguage();
 
         $lang->load($extensionName . '.sys', JPATH_ADMINISTRATOR);
         $lang->load($extensionName . '.sys', $languagePath);

--- a/administrator/components/com_categories/src/Field/ComponentsCategoryField.php
+++ b/administrator/components/com_categories/src/Field/ComponentsCategoryField.php
@@ -65,7 +65,7 @@ class ComponentsCategoryField extends ListField
             $section   = (\count($parts) > 1) ? $parts[1] : null;
 
             // Load component language files
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
             $lang->load($component, JPATH_BASE)
             || $lang->load($component, JPATH_ADMINISTRATOR . '/components/' . $component);
 

--- a/administrator/components/com_categories/src/Field/Modal/CategoryField.php
+++ b/administrator/components/com_categories/src/Field/Modal/CategoryField.php
@@ -61,7 +61,7 @@ class CategoryField extends FormField
         $languages = LanguageHelper::getContentLanguages([0, 1], false);
 
         // Load language.
-        Factory::getLanguage()->load('com_categories', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_categories', JPATH_ADMINISTRATOR);
 
         // The active category id field.
         $value = (int) $this->value ?: '';

--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -398,7 +398,7 @@ class CategoryModel extends AdminModel
      */
     protected function preprocessForm(Form $form, $data, $group = 'content')
     {
-        $lang      = Factory::getLanguage();
+        $lang      = Factory::getApplication()->getLanguage();
         $component = $this->getState('category.component');
         $section   = $this->getState('category.section');
         $extension = Factory::getApplication()->getInput()->get('extension', null);

--- a/administrator/components/com_config/src/Field/ConfigComponentsField.php
+++ b/administrator/components/com_config/src/Field/ConfigComponentsField.php
@@ -53,7 +53,7 @@ class ConfigComponentsField extends ListField
         $items = $db->setQuery($query)->loadObjectList();
 
         if ($items) {
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
 
             foreach ($items as &$item) {
                 // Load language

--- a/administrator/components/com_config/src/Helper/ConfigHelper.php
+++ b/administrator/components/com_config/src/Helper/ConfigHelper.php
@@ -142,7 +142,7 @@ class ConfigHelper extends ContentHelper
             return;
         }
 
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         // Load the core file then
         // Load extension-local file.

--- a/administrator/components/com_config/src/Model/ComponentModel.php
+++ b/administrator/components/com_config/src/Model/ComponentModel.php
@@ -94,7 +94,7 @@ class ComponentModel extends FormModel
             return false;
         }
 
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $lang->load($option, JPATH_BASE)
         || $lang->load($option, JPATH_BASE . "/components/$option");
 
@@ -135,7 +135,7 @@ class ComponentModel extends FormModel
         $option = $state->get('component.option');
 
         // Load common and local language files.
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $lang->load($option, JPATH_BASE)
         || $lang->load($option, JPATH_BASE . "/components/$option");
 

--- a/administrator/components/com_contact/src/Extension/ContactComponent.php
+++ b/administrator/components/com_contact/src/Extension/ContactComponent.php
@@ -118,7 +118,7 @@ class ContactComponent extends MVCComponent implements
      */
     public function getContexts(): array
     {
-        Factory::getLanguage()->load('com_contact', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_contact', JPATH_ADMINISTRATOR);
 
         $contexts = [
             'com_contact.contact'    => Text::_('COM_CONTACT_FIELDS_CONTEXT_CONTACT'),
@@ -166,7 +166,7 @@ class ContactComponent extends MVCComponent implements
      */
     public function getSchemaorgContexts(): array
     {
-        Factory::getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
 
         $contexts = [
             'com_contact.contact' => Text::_('COM_CONTACT'),

--- a/administrator/components/com_contact/src/Field/Modal/ContactField.php
+++ b/administrator/components/com_contact/src/Field/Modal/ContactField.php
@@ -55,7 +55,7 @@ class ContactField extends FormField
         $languages = LanguageHelper::getContentLanguages([0, 1], false);
 
         // Load language
-        Factory::getLanguage()->load('com_contact', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_contact', JPATH_ADMINISTRATOR);
 
         // The active contact id field.
         $value = (int) $this->value ?: '';

--- a/administrator/components/com_content/src/Extension/ContentComponent.php
+++ b/administrator/components/com_content/src/Extension/ContentComponent.php
@@ -174,7 +174,7 @@ class ContentComponent extends MVCComponent implements
      */
     public function getContexts(): array
     {
-        Factory::getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
 
         $contexts = [
             'com_content.article'    => Text::_('COM_CONTENT'),
@@ -193,7 +193,7 @@ class ContentComponent extends MVCComponent implements
      */
     public function getSchemaorgContexts(): array
     {
-        Factory::getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
 
         $contexts = [
             'com_content.article' => Text::_('COM_CONTENT'),
@@ -211,7 +211,7 @@ class ContentComponent extends MVCComponent implements
      */
     public function getWorkflowContexts(): array
     {
-        Factory::getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
 
         $contexts = [
             'com_content.article' => Text::_('COM_CONTENT'),

--- a/administrator/components/com_content/src/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/src/Field/Modal/ArticleField.php
@@ -55,7 +55,7 @@ class ArticleField extends FormField
         $languages = LanguageHelper::getContentLanguages([0, 1], false);
 
         // Load language
-        Factory::getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_content', JPATH_ADMINISTRATOR);
 
         // The active article id field.
         $value = (int) $this->value ?: '';

--- a/administrator/components/com_content/src/Helper/ContentHelper.php
+++ b/administrator/components/com_content/src/Helper/ContentHelper.php
@@ -95,7 +95,7 @@ class ContentHelper extends \Joomla\CMS\Helper\ContentHelper
         $data = (array) $data;
 
         // Make workflows translatable
-        Factory::getLanguage()->load('com_workflow', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_workflow', JPATH_ADMINISTRATOR);
 
         $form->setFieldAttribute('workflow_id', 'default', 'inherit');
 

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -574,7 +574,7 @@ class ArticlesModel extends ListModel
 
         try {
             if (count($stage_ids) || count($workflow_ids)) {
-                Factory::getLanguage()->load('com_workflow', JPATH_ADMINISTRATOR);
+                Factory::getApplication()->getLanguage()->load('com_workflow', JPATH_ADMINISTRATOR);
 
                 $query = $db->getQuery(true);
 

--- a/administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
+++ b/administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
@@ -248,7 +248,7 @@ class ContenthistoryHelper
 
         if (is_array($aliasArray) && count($aliasArray) == 2) {
             $component = ($aliasArray[1] == 'category') ? 'com_categories' : $aliasArray[0];
-            $lang      = Factory::getLanguage();
+            $lang      = Factory::getApplication()->getLanguage();
 
             /**
              * Loading language file from the administrator/language directory then

--- a/administrator/components/com_fields/src/Field/ComponentsFieldgroupField.php
+++ b/administrator/components/com_fields/src/Field/ComponentsFieldgroupField.php
@@ -59,7 +59,7 @@ class ComponentsFieldgroupField extends ListField
         $options = [];
 
         if (count($items)) {
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
 
             $components = [];
 

--- a/administrator/components/com_fields/src/Field/ComponentsFieldsField.php
+++ b/administrator/components/com_fields/src/Field/ComponentsFieldsField.php
@@ -59,7 +59,7 @@ class ComponentsFieldsField extends ListField
         $options = [];
 
         if (count($items)) {
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
 
             $components = [];
 

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -410,7 +410,7 @@ class FieldsHelper
             if (!$label) {
                 $key = strtoupper($component . '_FIELDS_' . $section . '_LABEL');
 
-                if (!Factory::getLanguage()->hasKey($key)) {
+                if (!Factory::getApplication()->getLanguage()->hasKey($key)) {
                     $key = 'JGLOBAL_FIELDS';
                 }
 
@@ -420,7 +420,7 @@ class FieldsHelper
             if (!$description) {
                 $key = strtoupper($component . '_FIELDS_' . $section . '_DESC');
 
-                if (Factory::getLanguage()->hasKey($key)) {
+                if (Factory::getApplication()->getLanguage()->hasKey($key)) {
                     $description = $key;
                 }
             }

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -1026,13 +1026,13 @@ class FieldModel extends AdminModel
             // Allow to override the default value label and description through the plugin
             $key = 'PLG_FIELDS_' . strtoupper($dataObject->type) . '_DEFAULT_VALUE_LABEL';
 
-            if (Factory::getLanguage()->hasKey($key)) {
+            if (Factory::getApplication()->getLanguage()->hasKey($key)) {
                 $form->setFieldAttribute('default_value', 'label', $key);
             }
 
             $key = 'PLG_FIELDS_' . strtoupper($dataObject->type) . '_DEFAULT_VALUE_DESC';
 
-            if (Factory::getLanguage()->hasKey($key)) {
+            if (Factory::getApplication()->getLanguage()->hasKey($key)) {
                 $form->setFieldAttribute('default_value', 'description', $key);
             }
 
@@ -1094,7 +1094,7 @@ class FieldModel extends AdminModel
         }
 
         if (file_exists($path)) {
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
             $lang->load($component, JPATH_BASE);
             $lang->load($component, JPATH_BASE . '/components/' . $component);
 

--- a/administrator/components/com_fields/src/Model/GroupModel.php
+++ b/administrator/components/com_fields/src/Model/GroupModel.php
@@ -258,7 +258,7 @@ class GroupModel extends AdminModel
         $path = Path::clean(JPATH_ADMINISTRATOR . '/components/' . $component . '/models/forms/fieldgroup/' . $section . '.xml');
 
         if (file_exists($path)) {
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
             $lang->load($component, JPATH_BASE);
             $lang->load($component, JPATH_BASE . '/components/' . $component);
 

--- a/administrator/components/com_finder/src/Field/ContentmapField.php
+++ b/administrator/components/com_finder/src/Field/ContentmapField.php
@@ -103,7 +103,7 @@ class ContentmapField extends GroupedlistField
      */
     private function prepareLevel($parent, $parents)
     {
-        $lang    = Factory::getLanguage();
+        $lang    = Factory::getApplication()->getLanguage();
         $entries = [];
 
         foreach ($parents[$parent] as $item) {

--- a/administrator/components/com_finder/src/Field/ContenttypesField.php
+++ b/administrator/components/com_finder/src/Field/ContenttypesField.php
@@ -45,7 +45,7 @@ class ContenttypesField extends ListField
      */
     public function getOptions()
     {
-        $lang    = Factory::getLanguage();
+        $lang    = Factory::getApplication()->getLanguage();
         $options = [];
 
         $db    = $this->getDatabase();

--- a/administrator/components/com_finder/src/Helper/LanguageHelper.php
+++ b/administrator/components/com_finder/src/Helper/LanguageHelper.php
@@ -101,7 +101,7 @@ class LanguageHelper
      */
     public static function loadComponentLanguage()
     {
-        Factory::getLanguage()->load('com_finder', JPATH_SITE);
+        Factory::getApplication()->getLanguage()->load('com_finder', JPATH_SITE);
     }
 
     /**
@@ -138,7 +138,7 @@ class LanguageHelper
         }
 
         // Load generic language strings.
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $lang->load('plg_content_finder', JPATH_ADMINISTRATOR);
 
         // Load language file for each plugin.

--- a/administrator/components/com_finder/src/Model/StatisticsModel.php
+++ b/administrator/components/com_finder/src/Model/StatisticsModel.php
@@ -74,7 +74,7 @@ class StatisticsModel extends BaseDatabaseModel
         $db->setQuery($query);
         $data->type_list = $db->loadObjectList();
 
-        $lang    = Factory::getLanguage();
+        $lang    = Factory::getApplication()->getLanguage();
         $plugins = PluginHelper::getPlugin('finder');
 
         foreach ($plugins as $plugin) {

--- a/administrator/components/com_finder/src/Service/HTML/Filter.php
+++ b/administrator/components/com_finder/src/Service/HTML/Filter.php
@@ -145,7 +145,7 @@ class Filter
             }
 
             // Translate node titles if possible.
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
 
             foreach ($nodes as $nk => $nv) {
                 if (trim($nv->parent_title, '*') === 'Language') {
@@ -217,7 +217,7 @@ class Filter
 
         // Try to load the results from cache.
         $cache   = Factory::getCache('com_finder', '');
-        $cacheId = 'filter_select_' . serialize([$idxQuery->filter, $options, $groups, Factory::getLanguage()->getTag()]);
+        $cacheId = 'filter_select_' . serialize([$idxQuery->filter, $options, $groups, Factory::getApplication()->getLanguage()->getTag()]);
 
         // Check the cached results.
         if ($cache->contains($cacheId)) {
@@ -317,7 +317,7 @@ class Filter
                 }
 
                 // Translate branch nodes if possible.
-                $language = Factory::getLanguage();
+                $language = Factory::getApplication()->getLanguage();
 
                 foreach ($branches[$bk]->nodes as $node_id => $node) {
                     if (trim($node->parent_title, '*') === 'Language') {

--- a/administrator/components/com_finder/src/Service/HTML/Finder.php
+++ b/administrator/components/com_finder/src/Service/HTML/Finder.php
@@ -57,7 +57,7 @@ class Finder
         // Compile the options.
         $options = [];
 
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         foreach ($rows as $row) {
             $key       = $lang->hasKey(LanguageHelper::branchPlural($row->text)) ? LanguageHelper::branchPlural($row->text) : $row->text;
@@ -92,7 +92,7 @@ class Finder
         }
 
         // Translate.
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         foreach ($branches as $branch) {
             $key                    = LanguageHelper::branchPlural($branch->text);

--- a/administrator/components/com_finder/src/Service/HTML/Query.php
+++ b/administrator/components/com_finder/src/Service/HTML/Query.php
@@ -82,7 +82,7 @@ class Query
             // Process the taxonomy branches.
             foreach ($query->filters as $branch => $nodes) {
                 // Process the taxonomy nodes.
-                $lang = Factory::getLanguage();
+                $lang = Factory::getApplication()->getLanguage();
 
                 foreach ($nodes as $title => $id) {
                     // Translate the title for Types

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -20,7 +20,7 @@ use Joomla\Component\Finder\Administrator\Helper\LanguageHelper;
 
 $listOrder     = $this->escape($this->state->get('list.ordering'));
 $listDirn      = $this->escape($this->state->get('list.direction'));
-$lang          = Factory::getLanguage();
+$lang          = Factory::getApplication()->getLanguage();
 $branchFilter  = $this->escape($this->state->get('filter.branch'));
 
 Text::script('COM_FINDER_MAPS_CONFIRM_DELETE_PROMPT');

--- a/administrator/components/com_guidedtours/src/Model/StepModel.php
+++ b/administrator/components/com_guidedtours/src/Model/StepModel.php
@@ -237,7 +237,7 @@ class StepModel extends AdminModel
      */
     public function getItem($pk = null)
     {
-        Factory::getLanguage()->load('com_guidedtours.sys', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_guidedtours.sys', JPATH_ADMINISTRATOR);
 
         if ($result = parent::getItem($pk)) {
             if (!empty($result->id)) {

--- a/administrator/components/com_guidedtours/src/Model/StepsModel.php
+++ b/administrator/components/com_guidedtours/src/Model/StepsModel.php
@@ -228,7 +228,7 @@ class StepsModel extends ListModel
     {
         $items = parent::getItems();
 
-        Factory::getLanguage()->load('com_guidedtours.sys', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_guidedtours.sys', JPATH_ADMINISTRATOR);
 
         foreach ($items as $item) {
             $item->title       = Text::_($item->title);

--- a/administrator/components/com_guidedtours/src/Model/TourModel.php
+++ b/administrator/components/com_guidedtours/src/Model/TourModel.php
@@ -195,7 +195,7 @@ class TourModel extends AdminModel
      */
     public function getItem($pk = null)
     {
-        Factory::getLanguage()->load('com_guidedtours.sys', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_guidedtours.sys', JPATH_ADMINISTRATOR);
 
         $result = parent::getItem($pk);
 

--- a/administrator/components/com_guidedtours/src/Model/ToursModel.php
+++ b/administrator/components/com_guidedtours/src/Model/ToursModel.php
@@ -248,7 +248,7 @@ class ToursModel extends ListModel
     {
         $items = parent::getItems();
 
-        Factory::getLanguage()->load('com_guidedtours.sys', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_guidedtours.sys', JPATH_ADMINISTRATOR);
 
         foreach ($items as $item) {
             $item->title       = Text::_($item->title);

--- a/administrator/components/com_installer/src/Model/InstallerModel.php
+++ b/administrator/components/com_installer/src/Model/InstallerModel.php
@@ -146,7 +146,7 @@ class InstallerModel extends ListModel
      */
     protected function translate(&$items)
     {
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         foreach ($items as &$item) {
             if (strlen($item->manifest_cache) && $data = json_decode($item->manifest_cache)) {

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1601,7 +1601,7 @@ ENDDATA;
     protected function translateExtensionName(&$item)
     {
         // @todo: Cleanup duplicated code. from com_installer/models/extension.php
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $path = $item->client_id ? JPATH_ADMINISTRATOR : JPATH_SITE;
 
         $extension = $item->element;

--- a/administrator/components/com_languages/src/Controller/InstalledController.php
+++ b/administrator/components/com_languages/src/Controller/InstalledController.php
@@ -44,7 +44,7 @@ class InstalledController extends BaseController
         if ($model->publish($cid)) {
             // Switching to the new administrator language for the message
             if ($model->getState('client_id') == 1) {
-                $language          = Factory::getLanguage();
+                $language          = Factory::getApplication()->getLanguage();
                 $newLang           = Language::getInstance($cid);
                 Factory::$language = $newLang;
                 $this->app->loadLanguage($language = $newLang);
@@ -92,7 +92,7 @@ class InstalledController extends BaseController
         if ($model->switchAdminLanguage($cid)) {
             // Switching to the new language for the message
             $languageName      = $info['nativeName'];
-            $language          = Factory::getLanguage();
+            $language          = Factory::getApplication()->getLanguage();
             $newLang           = Language::getInstance($cid);
             Factory::$language = $newLang;
             $this->app->loadLanguage($language = $newLang);

--- a/administrator/components/com_languages/src/Model/InstalledModel.php
+++ b/administrator/components/com_languages/src/Model/InstalledModel.php
@@ -178,7 +178,7 @@ class InstalledModel extends ListModel
         if (is_null($this->data)) {
             $this->data = [];
 
-            $isCurrentLanguageRtl = Factory::getLanguage()->isRtl();
+            $isCurrentLanguageRtl = Factory::getApplication()->getLanguage()->isRtl();
             $params               = ComponentHelper::getParams('com_languages');
             $installedLanguages   = LanguageHelper::getInstalledLanguages(null, true, true, null, null, null);
 

--- a/administrator/components/com_login/src/Model/LoginModel.php
+++ b/administrator/components/com_login/src/Model/LoginModel.php
@@ -131,7 +131,7 @@ class LoginModel extends BaseDatabaseModel
         }
 
         $app      = Factory::getApplication();
-        $lang     = Factory::getLanguage()->getTag();
+        $lang     = Factory::getApplication()->getLanguage()->getTag();
         $clientId = (int) $app->getClientId();
 
         /** @var \Joomla\CMS\Cache\Controller\CallbackController $cache */

--- a/administrator/components/com_mails/src/Helper/MailsHelper.php
+++ b/administrator/components/com_mails/src/Helper/MailsHelper.php
@@ -74,7 +74,7 @@ abstract class MailsHelper
             return;
         }
 
-        $lang   = Factory::getLanguage();
+        $lang   = Factory::getApplication()->getLanguage();
         $source = '';
 
         switch (substr($extension, 0, 3)) {

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -172,7 +172,7 @@ class MenuField extends FormField
         $languages   = LanguageHelper::getContentLanguages([0, 1], false);
 
         // Load language
-        Factory::getLanguage()->load('com_menus', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_menus', JPATH_ADMINISTRATOR);
 
         // The active article id field.
         $value = (int) $this->value ?: '';

--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -698,7 +698,7 @@ class ItemModel extends AdminModel
 
                 if (isset($args['option'])) {
                     // Load the language file for the component.
-                    $lang = Factory::getLanguage();
+                    $lang = Factory::getApplication()->getLanguage();
                     $lang->load($args['option'], JPATH_ADMINISTRATOR)
                         || $lang->load($args['option'], JPATH_ADMINISTRATOR . '/components/' . $args['option']);
 

--- a/administrator/components/com_menus/src/Model/ItemsModel.php
+++ b/administrator/components/com_menus/src/Model/ItemsModel.php
@@ -123,7 +123,7 @@ class ItemsModel extends ListModel
 
         // Load mod_menu.ini file when client is administrator
         if ($clientId == 1) {
-            Factory::getLanguage()->load('mod_menu', JPATH_ADMINISTRATOR);
+            Factory::getApplication()->getLanguage()->load('mod_menu', JPATH_ADMINISTRATOR);
         }
 
         $currentMenuType = $app->getUserState($this->context . '.menutype', '');
@@ -571,7 +571,7 @@ class ItemsModel extends ListModel
 
         if (!isset($this->cache[$store])) {
             $items  = parent::getItems();
-            $lang   = Factory::getLanguage();
+            $lang   = Factory::getApplication()->getLanguage();
             $client = $this->state->get('filter.client_id');
 
             if ($items) {

--- a/administrator/components/com_menus/src/Model/MenutypesModel.php
+++ b/administrator/components/com_menus/src/Model/MenutypesModel.php
@@ -81,7 +81,7 @@ class MenutypesModel extends BaseDatabaseModel
      */
     public function getTypeOptions()
     {
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $list = [];
 
         // Get the list of components.
@@ -440,7 +440,7 @@ class MenutypesModel extends BaseDatabaseModel
         $options     = [];
         $layouts     = [];
         $layoutNames = [];
-        $lang        = Factory::getLanguage();
+        $lang        = Factory::getApplication()->getLanguage();
         $client      = ApplicationHelper::getClientInfo($this->getState('client_id'));
 
         // Get the views for this component.

--- a/administrator/components/com_modules/src/Helper/ModulesHelper.php
+++ b/administrator/components/com_modules/src/Helper/ModulesHelper.php
@@ -168,7 +168,7 @@ abstract class ModulesHelper
 
         $db->setQuery($query);
         $modules = $db->loadObjectList();
-        $lang    = Factory::getLanguage();
+        $lang    = Factory::getApplication()->getLanguage();
 
         foreach ($modules as $i => $module) {
             $extension = $module->value;
@@ -219,7 +219,7 @@ abstract class ModulesHelper
     public static function getTranslatedModulePosition($clientId, $template, $position)
     {
         // Template translation
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $path = $clientId ? JPATH_ADMINISTRATOR : JPATH_SITE;
 
         $loaded = $lang->getPaths('tpl_' . $template . '.sys');

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -785,7 +785,7 @@ class ModuleModel extends AdminModel
      */
     protected function preprocessForm(Form $form, $data, $group = 'content')
     {
-        $lang     = Factory::getLanguage();
+        $lang     = Factory::getApplication()->getLanguage();
         $clientId = $this->getState('item.client_id');
         $module   = $this->getState('item.module');
 

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -227,7 +227,7 @@ class ModulesModel extends ListModel
      */
     protected function translate(&$items)
     {
-        $lang       = Factory::getLanguage();
+        $lang       = Factory::getApplication()->getLanguage();
         $clientPath = $this->getState('client_id') ? JPATH_ADMINISTRATOR : JPATH_SITE;
 
         foreach ($items as $item) {
@@ -411,7 +411,7 @@ class ModulesModel extends ListModel
         // Filter on the language.
         if ($language = $this->getState('filter.language')) {
             if ($language === 'current') {
-                $language = [Factory::getLanguage()->getTag(), '*'];
+                $language = [Factory::getApplication()->getLanguage()->getTag(), '*'];
                 $query->whereIn($db->quoteName('a.language'), $language, ParameterType::STRING);
             } else {
                 $query->where($db->quoteName('a.language') . ' = :language')

--- a/administrator/components/com_modules/src/Model/PositionsModel.php
+++ b/administrator/components/com_modules/src/Model/PositionsModel.php
@@ -99,7 +99,7 @@ class PositionsModel extends ListModel
     public function getItems()
     {
         if (!isset($this->items)) {
-            $lang            = Factory::getLanguage();
+            $lang            = Factory::getApplication()->getLanguage();
             $search          = $this->getState('filter.search');
             $state           = $this->getState('filter.state');
             $clientId        = $this->getState('client_id');

--- a/administrator/components/com_modules/src/Model/SelectModel.php
+++ b/administrator/components/com_modules/src/Model/SelectModel.php
@@ -128,7 +128,7 @@ class SelectModel extends ListModel
         $items = parent::getItems();
 
         $client = ApplicationHelper::getClientInfo($this->getState('client_id', 0));
-        $lang   = Factory::getLanguage();
+        $lang   = Factory::getApplication()->getLanguage();
 
         // Loop through the results to add the XML metadata,
         // and load language support.

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -55,7 +55,7 @@ class NewsfeedField extends FormField
         $languages = LanguageHelper::getContentLanguages([0, 1], false);
 
         // Load language
-        Factory::getLanguage()->load('com_newsfeeds', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_newsfeeds', JPATH_ADMINISTRATOR);
 
         // The active newsfeed id field.
         $value = (int) $this->value ?: '';

--- a/administrator/components/com_plugins/src/Model/PluginModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginModel.php
@@ -250,7 +250,7 @@ class PluginModel extends AdminModel
     {
         $folder  = $this->getState('item.folder');
         $element = $this->getState('item.element');
-        $lang    = Factory::getLanguage();
+        $lang    = Factory::getApplication()->getLanguage();
 
         // Load the core and/or local language sys file(s) for the ordering field.
         $db    = $this->getDatabase();

--- a/administrator/components/com_plugins/src/Model/PluginsModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginsModel.php
@@ -183,7 +183,7 @@ class PluginsModel extends ListModel
      */
     protected function translate(&$items)
     {
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         foreach ($items as &$item) {
             $source    = JPATH_PLUGINS . '/' . $item->folder . '/' . $item->element;

--- a/administrator/components/com_privacy/src/Model/ExportModel.php
+++ b/administrator/components/com_privacy/src/Model/ExportModel.php
@@ -168,7 +168,7 @@ class ExportModel extends BaseDatabaseModel implements UserFactoryAwareInterface
          * Error messages will still be displayed to the administrator, so those messages should continue to use the Text class.
          */
 
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         $db = $this->getDatabase();
 

--- a/administrator/components/com_privacy/src/Model/RequestModel.php
+++ b/administrator/components/com_privacy/src/Model/RequestModel.php
@@ -259,7 +259,7 @@ class RequestModel extends AdminModel implements UserFactoryAwareInterface
          * Error messages will still be displayed to the administrator, so those messages should continue to use the Text class.
          */
 
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         $db = $this->getDatabase();
 

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -385,7 +385,7 @@ class StyleModel extends AdminModel
     {
         $clientId = $this->getState('item.client_id');
         $template = $this->getState('item.template');
-        $lang     = Factory::getLanguage();
+        $lang     = Factory::getApplication()->getLanguage();
         $client   = ApplicationHelper::getClientInfo($clientId);
 
         if (!$form->loadFile('style_' . $client->name, true)) {

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -368,7 +368,7 @@ class TemplateModel extends FormModel
             $app    = Factory::getApplication();
             $client = ApplicationHelper::getClientInfo($template->client_id);
             $path   = Path::clean($client->path . '/templates/' . $template->element . '/');
-            $lang   = Factory::getLanguage();
+            $lang   = Factory::getApplication()->getLanguage();
 
             // Load the core and/or local language file(s).
             $lang->load('tpl_' . $template->element, $client->path)

--- a/administrator/components/com_users/src/Helper/DebugHelper.php
+++ b/administrator/components/com_users/src/Helper/DebugHelper.php
@@ -47,7 +47,7 @@ class DebugHelper
         $items = $db->setQuery($query)->loadObjectList();
 
         if (count($items)) {
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
 
             foreach ($items as &$item) {
                 // Load language
@@ -128,7 +128,7 @@ class DebugHelper
                 }
 
                 // Load language
-                $lang      = Factory::getLanguage();
+                $lang      = Factory::getApplication()->getLanguage();
                 $extension = 'com_config';
                 $source    = JPATH_ADMINISTRATOR . '/components/' . $extension;
 

--- a/administrator/components/com_users/src/Model/MailModel.php
+++ b/administrator/components/com_users/src/Model/MailModel.php
@@ -105,7 +105,7 @@ class MailModel extends AdminModel
         $user     = $this->getCurrentUser();
         $access   = new Access();
         $db       = $this->getDatabase();
-        $language = Factory::getLanguage();
+        $language = Factory::getApplication()->getLanguage();
 
         $mode         = array_key_exists('mode', $data) ? (int) $data['mode'] : 0;
         $subject      = array_key_exists('subject', $data) ? $data['subject'] : '';

--- a/administrator/components/com_users/src/Service/HTML/Users.php
+++ b/administrator/components/com_users/src/Service/HTML/Users.php
@@ -399,7 +399,7 @@ class Users
             return static::value($value);
         } else {
             $db    = Factory::getDbo();
-            $lang  = Factory::getLanguage();
+            $lang  = Factory::getApplication()->getLanguage();
             $query = $db->getQuery(true)
                 ->select($db->quoteName('name'))
                 ->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_workflow/src/Field/ComponentsWorkflowField.php
+++ b/administrator/components/com_workflow/src/Field/ComponentsWorkflowField.php
@@ -59,7 +59,7 @@ class ComponentsWorkflowField extends ListField
         $options = [];
 
         if (count($items)) {
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
 
             $components = [];
 

--- a/administrator/modules/mod_submenu/mod_submenu.php
+++ b/administrator/modules/mod_submenu/mod_submenu.php
@@ -26,10 +26,10 @@ if ($menutype === '*') {
 }
 
 if ($root && $root->hasChildren()) {
-    Factory::getLanguage()->load(
+    Factory::getApplication()->getLanguage()->load(
         'mod_menu',
         JPATH_ADMINISTRATOR,
-        Factory::getLanguage()->getTag(),
+        Factory::getApplication()->getLanguage()->getTag(),
         true
     );
 

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -44,7 +44,7 @@ abstract class Menu
         $app      = Factory::getApplication();
         $user     = $app->getIdentity();
         $children = $parent->getChildren();
-        $language = Factory::getLanguage();
+        $language = Factory::getApplication()->getLanguage();
 
         /**
          * Trigger onPreprocessMenuItems for the current level of backend menu items.

--- a/administrator/templates/atum/html/layouts/chromes/body.php
+++ b/administrator/templates/atum/html/layouts/chromes/body.php
@@ -43,7 +43,7 @@ $headerClass = $headerClass ? ' ' . htmlspecialchars($headerClass, ENT_QUOTES, '
 <div class="<?php echo $moduleClass; ?> module-wrapper">
     <<?php echo $moduleTag; ?> class="card pt-3<?php echo $moduleClassSfx; ?>">
         <?php if ($canEdit || $canChange) : ?>
-            <?php $dropdownPosition = Factory::getLanguage()->isRtl() ? 'start' : 'end'; ?>
+            <?php $dropdownPosition = Factory::getApplication()->getLanguage()->isRtl() ? 'start' : 'end'; ?>
             <div class="module-actions dropdown">
                 <button type="button" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false" class="btn" id="dropdownMenuButton-<?php echo $id; ?>">
                     <span class="icon-cogs" aria-hidden="true"></span>

--- a/administrator/templates/atum/html/layouts/chromes/well.php
+++ b/administrator/templates/atum/html/layouts/chromes/well.php
@@ -48,7 +48,7 @@ $headerIcon = $params->get('header_icon') ? '<span class="' . htmlspecialchars($
         <?php if ($canEdit || $canChange || $headerIcon || $module->showtitle) : ?>
             <div class="card-header">
                 <?php if ($canEdit || $canChange) : ?>
-                    <?php $dropdownPosition = Factory::getLanguage()->isRtl() ? 'start' : 'end'; ?>
+                    <?php $dropdownPosition = Factory::getApplication()->getLanguage()->isRtl() ? 'start' : 'end'; ?>
                     <div class="module-actions dropdown">
                         <button type="button" data-bs-toggle="dropdown" data-bs-display="static" aria-haspopup="true" aria-expanded="false" class="btn" id="dropdownMenuButton-<?php echo $id; ?>">
                             <span class="icon-cogs" aria-hidden="true"></span>

--- a/build/helpTOC.php
+++ b/build/helpTOC.php
@@ -104,7 +104,7 @@ $command = new class () extends AbstractCommand {
         }
 
         // Get the language object
-        $language = Factory::getLanguage();
+        $language = Factory::getApplication()->getLanguage();
 
         /*
          * Now we start fancy processing so we can get the language key for the titles

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -94,7 +94,7 @@ if (!$format) {
             if (method_exists($class, $method . 'Ajax')) {
                 // Load language file for module
                 $basePath = JPATH_BASE;
-                $lang     = Factory::getLanguage();
+                $lang     = Factory::getApplication()->getLanguage();
                 $lang->load('mod_' . $module, $basePath)
                 || $lang->load('mod_' . $module, $basePath . '/modules/mod_' . $module);
 
@@ -176,7 +176,7 @@ if (!$format) {
 
             if (method_exists($class, $method . 'Ajax')) {
                 // Load language file for template
-                $lang = Factory::getLanguage();
+                $lang = Factory::getApplication()->getLanguage();
                 $lang->load('tpl_' . $template, $basePath)
                 || $lang->load('tpl_' . $template, $basePath . '/templates/' . $template);
 

--- a/components/com_banners/src/Model/BannersModel.php
+++ b/components/com_banners/src/Model/BannersModel.php
@@ -237,7 +237,7 @@ class BannersModel extends ListModel
 
         // Filter by language
         if ($this->getState('filter.language')) {
-            $query->whereIn($db->quoteName('a.language'), [Factory::getLanguage()->getTag(), '*'], ParameterType::STRING);
+            $query->whereIn($db->quoteName('a.language'), [Factory::getApplication()->getLanguage()->getTag(), '*'], ParameterType::STRING);
         }
 
         $query->order($db->quoteName('a.sticky') . ' DESC, ' . ($randomise ? $query->rand() : $db->quoteName('a.ordering')));

--- a/components/com_config/src/Model/ModulesModel.php
+++ b/components/com_config/src/Model/ModulesModel.php
@@ -82,7 +82,7 @@ class ModulesModel extends FormModel
      */
     protected function preprocessForm(Form $form, $data, $group = 'content')
     {
-        $lang     = Factory::getLanguage();
+        $lang     = Factory::getApplication()->getLanguage();
         $module   = $this->getState()->get('module.name');
         $basePath = JPATH_BASE;
 
@@ -121,7 +121,7 @@ class ModulesModel extends FormModel
      */
     public function getPositions()
     {
-        $lang         = Factory::getLanguage();
+        $lang         = Factory::getApplication()->getLanguage();
         $templateName = Factory::getApplication()->getTemplate();
 
         // Load templateDetails.xml file

--- a/components/com_config/src/Model/TemplatesModel.php
+++ b/components/com_config/src/Model/TemplatesModel.php
@@ -91,7 +91,7 @@ class TemplatesModel extends FormModel
      */
     protected function preprocessForm(Form $form, $data, $group = 'content')
     {
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         $template = Factory::getApplication()->getTemplate();
 

--- a/components/com_contact/src/Model/ContactModel.php
+++ b/components/com_contact/src/Model/ContactModel.php
@@ -151,7 +151,7 @@ class ContactModel extends FormModel
         $data = (array) Factory::getApplication()->getUserState('com_contact.contact.data', []);
 
         if (empty($data['language']) && Multilanguage::isEnabled()) {
-            $data['language'] = Factory::getLanguage()->getTag();
+            $data['language'] = Factory::getApplication()->getLanguage()->getTag();
         }
 
         // Add contact catid to contact form data, so fields plugin can work properly
@@ -331,7 +331,7 @@ class ContactModel extends FormModel
 
             // Filter per language if plugin published
             if (Multilanguage::isEnabled()) {
-                $language = [Factory::getLanguage()->getTag(), $db->quote('*')];
+                $language = [Factory::getApplication()->getLanguage()->getTag(), $db->quote('*')];
                 $query->whereIn($db->quoteName('a.language'), $language, ParameterType::STRING);
             }
 

--- a/components/com_contact/src/Model/FeaturedModel.php
+++ b/components/com_contact/src/Model/FeaturedModel.php
@@ -138,7 +138,7 @@ class FeaturedModel extends ListModel
 
         // Filter by language
         if ($this->getState('filter.language')) {
-            $query->whereIn($db->quoteName('a.language'), [Factory::getLanguage()->getTag(), '*'], ParameterType::STRING);
+            $query->whereIn($db->quoteName('a.language'), [Factory::getApplication()->getLanguage()->getTag(), '*'], ParameterType::STRING);
         }
 
         // Add the list ordering clause.

--- a/components/com_content/src/Helper/AssociationHelper.php
+++ b/components/com_content/src/Helper/AssociationHelper.php
@@ -60,7 +60,7 @@ abstract class AssociationHelper extends CategoryAssociationHelper
                 $advClause[] = 'c2.access IN (' . $groups . ')';
 
                 // Filter by current language
-                $advClause[] = 'c2.language != ' . $db->quote(Factory::getLanguage()->getTag());
+                $advClause[] = 'c2.language != ' . $db->quote(Factory::getApplication()->getLanguage()->getTag());
 
                 if (!$user->authorise('core.edit.state', 'com_content') && !$user->authorise('core.edit', 'com_content')) {
                     // Filter by start and end dates.

--- a/components/com_content/src/Model/ArticleModel.php
+++ b/components/com_content/src/Model/ArticleModel.php
@@ -173,7 +173,7 @@ class ArticleModel extends ItemModel
 
                 // Filter by language
                 if ($this->getState('filter.language')) {
-                    $query->whereIn($db->quoteName('a.language'), [Factory::getLanguage()->getTag(), '*'], ParameterType::STRING);
+                    $query->whereIn($db->quoteName('a.language'), [Factory::getApplication()->getLanguage()->getTag(), '*'], ParameterType::STRING);
                 }
 
                 if (

--- a/components/com_finder/src/Model/SearchModel.php
+++ b/components/com_finder/src/Model/SearchModel.php
@@ -234,7 +234,7 @@ class SearchModel extends ListModel
 
         // Filter by language
         if ($this->getState('filter.language')) {
-            $query->where('l.language IN (' . $db->quote(Factory::getLanguage()->getTag()) . ', ' . $db->quote('*') . ')');
+            $query->where('l.language IN (' . $db->quote(Factory::getApplication()->getLanguage()->getTag()) . ', ' . $db->quote('*') . ')');
         }
 
         // Get the result ordering and direction.

--- a/components/com_finder/src/Model/SuggestionsModel.php
+++ b/components/com_finder/src/Model/SuggestionsModel.php
@@ -161,7 +161,7 @@ class SuggestionsModel extends ListModel
 
         // Set the query language
         if (Multilanguage::isEnabled()) {
-            $lang = Factory::getLanguage()->getTag();
+            $lang = Factory::getApplication()->getLanguage()->getTag();
         } else {
             $lang = Helper::getDefaultLanguage();
         }

--- a/components/com_users/src/Model/RegistrationModel.php
+++ b/components/com_users/src/Model/RegistrationModel.php
@@ -357,7 +357,7 @@ class RegistrationModel extends FormModel implements UserFactoryAwareInterface
         $data = $this->getData();
 
         if (Multilanguage::isEnabled() && empty($data->language)) {
-            $data->language = Factory::getLanguage()->getTag();
+            $data->language = Factory::getApplication()->getLanguage()->getTag();
         }
 
         $this->preprocessData('com_users.registration', $data);

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -113,7 +113,7 @@ final class InstallationApplication extends CMSApplication
             return '';
         }
 
-        $lang   = Factory::getLanguage();
+        $lang   = Factory::getApplication()->getLanguage();
         $output = '<h4>' . Text::_('JDEBUG_LANGUAGE_FILES_IN_ERROR') . '</h4>';
 
         $errorfiles = $lang->getErrorFiles();

--- a/installation/src/Controller/JSONController.php
+++ b/installation/src/Controller/JSONController.php
@@ -45,7 +45,7 @@ abstract class JSONController extends BaseController
         // Very crude workaround to give an error message when JSON is disabled
         if (!function_exists('json_encode') || !function_exists('json_decode')) {
             $this->app->setHeader('status', 500);
-            echo '{"token":"' . Session::getFormToken(true) . '","lang":"' . Factory::getLanguage()->getTag()
+            echo '{"token":"' . Session::getFormToken(true) . '","lang":"' . Factory::getApplication()->getLanguage()->getTag()
                 . '","error":true,"header":"' . Text::_('INSTL_HEADER_ERROR') . '","message":"' . Text::_('INSTL_WARNJSON') . '"}';
 
             return;

--- a/installation/src/Form/Field/Installation/LanguageField.php
+++ b/installation/src/Form/Field/Installation/LanguageField.php
@@ -68,7 +68,7 @@ class LanguageField extends ListField
         $options = LanguageHelper::createLanguageList($native);
 
         // Fix wrongly set parentheses in RTL languages
-        if (Factory::getLanguage()->isRtl()) {
+        if (Factory::getApplication()->getLanguage()->isRtl()) {
             foreach ($options as &$option) {
                 $option['text'] .= '&#x200E;';
             }

--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -59,7 +59,7 @@ class DatabaseModel extends BaseInstallationModel
         $options = ArrayHelper::toObject($options);
 
         // Load the backend language files so that the DB error messages work.
-        $lang        = Factory::getLanguage();
+        $lang        = Factory::getApplication()->getLanguage();
         $currentLang = $lang->getTag();
 
         // Load the selected language

--- a/installation/src/Model/SetupModel.php
+++ b/installation/src/Model/SetupModel.php
@@ -58,7 +58,7 @@ class SetupModel extends BaseInstallationModel
 
         // Ensure that we have language
         if (!isset($options['language']) || empty($options['language'])) {
-            $options['language'] = Factory::getLanguage()->getTag();
+            $options['language'] = Factory::getApplication()->getLanguage()->getTag();
         }
 
         // Store passwords as a separate key that is not used in the forms
@@ -249,7 +249,7 @@ class SetupModel extends BaseInstallationModel
         $options = ArrayHelper::toObject($options);
 
         // Load the backend language files so that the DB error messages work.
-        $lang        = Factory::getLanguage();
+        $lang        = Factory::getApplication()->getLanguage();
         $currentLang = $lang->getTag();
 
         // Load the selected language

--- a/installation/src/Response/JsonResponse.php
+++ b/installation/src/Response/JsonResponse.php
@@ -94,7 +94,7 @@ class JsonResponse
         $this->token = Session::getFormToken(true);
 
         // Get the language and send its tag along
-        $this->lang = Factory::getLanguage()->getTag();
+        $this->lang = Factory::getApplication()->getLanguage()->getTag();
 
         // Get the message queue
         $messages = Factory::getApplication()->getMessageQueue();

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Language\Text;
 
 $params    = $displayData['params'];
 $item      = $displayData['item'];
-$direction = Factory::getLanguage()->isRtl() ? 'left' : 'right';
+$direction = Factory::getApplication()->getLanguage()->isRtl() ? 'left' : 'right';
 ?>
 
 <p class="readmore">

--- a/layouts/joomla/toolbar/basic.php
+++ b/layouts/joomla/toolbar/basic.php
@@ -58,7 +58,7 @@ if (!empty($task)) {
     $htmlAttributes .= ' onclick="' . $onclick . '"';
 }
 
-$direction = Factory::getLanguage()->isRtl() ? 'dropdown-menu-end' : '';
+$direction = Factory::getApplication()->getLanguage()->isRtl() ? 'dropdown-menu-end' : '';
 ?>
 <joomla-toolbar-button <?php echo $idAttr . $taskAttr . $listAttr . $formAttr . $validate . $msgAttr; ?>>
 <<?php echo $tagName; ?>

--- a/layouts/joomla/toolbar/dropdown.php
+++ b/layouts/joomla/toolbar/dropdown.php
@@ -32,7 +32,7 @@ extract($displayData, EXTR_OVERWRITE);
  * @var   string  $toggleSplit
  */
 
-$direction = Factory::getLanguage()->isRtl() ? 'dropdown-menu-end' : '';
+$direction = Factory::getApplication()->getLanguage()->isRtl() ? 'dropdown-menu-end' : '';
 
 /**
  * The dropdown class is also injected on the button from \Joomla\CMS\Toolbar\ToolbarButton::prepareOptions() and therefore we need the dropdown script whether we

--- a/libraries/src/Application/CliApplication.php
+++ b/libraries/src/Application/CliApplication.php
@@ -141,7 +141,7 @@ abstract class CliApplication extends AbstractApplication implements DispatcherA
         }
 
         $this->input    = new \Joomla\CMS\Input\Cli();
-        $this->language = Factory::getLanguage();
+        $this->language = Factory::getApplication()->getLanguage();
         $this->output   = $output ?: new Stdout();
         $this->cliInput = $cliInput ?: new CliInput();
 

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -320,7 +320,7 @@ abstract class WebApplication extends AbstractWebApplication
      */
     public function loadLanguage(Language $language = null)
     {
-        $this->language = $language ?? Factory::getLanguage();
+        $this->language = $language ?? Factory::getApplication()->getLanguage();
         OutputFilter::setLanguage($this->language);
 
         return $this;

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -120,7 +120,7 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
         $options['access']      = $options['access'] ?? 'true';
         $options['published']   = $options['published'] ?? 1;
         $options['countItems']  = $options['countItems'] ?? 0;
-        $options['currentlang'] = Multilanguage::isEnabled() ? Factory::getLanguage()->getTag() : 0;
+        $options['currentlang'] = Multilanguage::isEnabled() ? Factory::getApplication()->getLanguage()->getTag() : 0;
 
         $this->_options = $options;
     }
@@ -327,7 +327,7 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
                     '(' . $db->quoteName('s.lft') . ' < ' . $db->quoteName('c.lft')
                     . ' AND ' . $db->quoteName('c.lft') . ' < ' . $db->quoteName('s.rgt')
                     . ' AND ' . $db->quoteName('c.language')
-                    . ' IN (' . implode(',', $query->bindArray([Factory::getLanguage()->getTag(), '*'], ParameterType::STRING)) . '))'
+                    . ' IN (' . implode(',', $query->bindArray([Factory::getApplication()->getLanguage()->getTag(), '*'], ParameterType::STRING)) . '))'
                     . ' OR (' . $db->quoteName('c.lft') . ' <= ' . $db->quoteName('s.lft')
                     . ' AND ' . $db->quoteName('s.rgt') . ' <= ' . $db->quoteName('c.rgt') . ')'
                 );
@@ -345,7 +345,7 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
             $query->from($db->quoteName('#__categories', 'c'));
 
             if ($app->isClient('site') && Multilanguage::isEnabled()) {
-                $query->whereIn($db->quoteName('c.language'), [Factory::getLanguage()->getTag(), '*'], ParameterType::STRING);
+                $query->whereIn($db->quoteName('c.language'), [Factory::getApplication()->getLanguage()->getTag(), '*'], ParameterType::STRING);
             }
         }
 

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -283,7 +283,7 @@ class ComponentHelper
     public static function renderComponent($option, $params = [])
     {
         $app  = Factory::getApplication();
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         if (!$app->isClient('api')) {
             // Load template language files.

--- a/libraries/src/Console/ExtensionRemoveCommand.php
+++ b/libraries/src/Console/ExtensionRemoveCommand.php
@@ -125,7 +125,7 @@ class ExtensionRemoveCommand extends AbstractCommand
     {
         $this->cliInput = $input;
         $this->ioStyle  = new SymfonyStyle($input, $output);
-        $language       = Factory::getLanguage();
+        $language       = Factory::getApplication()->getLanguage();
         $language->load('', JPATH_ADMINISTRATOR, null, false, false) ||
         $language->load('', JPATH_ADMINISTRATOR, null, true);
         $language->load('com_installer', JPATH_ADMINISTRATOR, null, false, false) ||

--- a/libraries/src/Console/FinderIndexCommand.php
+++ b/libraries/src/Console/FinderIndexCommand.php
@@ -247,7 +247,7 @@ EOF;
             $language = $this->getLanguage();
         } catch (\UnexpectedValueException $e) {
             @trigger_error(sprintf('Language must be set in 6.0 in %s', __METHOD__), E_USER_DEPRECATED);
-            $language = Factory::getLanguage();
+            $language = Factory::getApplication()->getLanguage();
         }
 
         $language->load('', JPATH_ADMINISTRATOR, null, false, false) ||

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -104,7 +104,7 @@ class SetConfigurationCommand extends AbstractCommand
      */
     private function configureIO(InputInterface $input, OutputInterface $output)
     {
-        $language = Factory::getLanguage();
+        $language = Factory::getApplication()->getLanguage();
         $language->load('', JPATH_INSTALLATION, null, false, false) ||
         $language->load('', JPATH_INSTALLATION, null, true);
         $language->load('com_config', JPATH_ADMINISTRATOR, null, false, false) ||

--- a/libraries/src/Document/HtmlDocument.php
+++ b/libraries/src/Document/HtmlDocument.php
@@ -769,7 +769,7 @@ class HtmlDocument extends Document implements CacheControllerFactoryAwareInterf
         }
 
         // Load the language file for the template
-        $lang = CmsFactory::getLanguage();
+        $lang = CmsFactory::getApplication()->getLanguage();
 
         // 1.5 or core then 1.6
         $lang->load('tpl_' . $template, JPATH_BASE)

--- a/libraries/src/Error/AbstractRenderer.php
+++ b/libraries/src/Error/AbstractRenderer.php
@@ -105,8 +105,8 @@ abstract class AbstractRenderer implements RendererInterface
 
         // If there is a Language instance in Factory then let's pull the language and direction from its metadata
         if (Factory::$language) {
-            $attributes['language']  = Factory::getLanguage()->getTag();
-            $attributes['direction'] = Factory::getLanguage()->isRtl() ? 'rtl' : 'ltr';
+            $attributes['language']  = Factory::getApplication()->getLanguage()->getTag();
+            $attributes['direction'] = Factory::getApplication()->getLanguage()->isRtl() ? 'rtl' : 'ltr';
         }
 
         return Factory::getContainer()->get(FactoryInterface::class)->createDocument($this->type, $attributes);

--- a/libraries/src/Filter/OutputFilter.php
+++ b/libraries/src/Filter/OutputFilter.php
@@ -83,7 +83,7 @@ class OutputFilter extends BaseOutputFilter
         $str = str_replace('-', ' ', $string);
 
         // Transliterate on the language requested (fallback to current language if not specified)
-        $lang = $language == '' || $language == '*' ? Factory::getLanguage() : Language::getInstance($language);
+        $lang = $language == '' || $language == '*' ? Factory::getApplication()->getLanguage() : Language::getInstance($language);
         $str  = $lang->transliterate($str);
 
         // Trim white spaces at beginning and end of alias and make lowercase

--- a/libraries/src/Form/Field/AliastagField.php
+++ b/libraries/src/Form/Field/AliastagField.php
@@ -55,7 +55,7 @@ class AliastagField extends ListField
 
         $options = $db->loadObjectList();
 
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         foreach ($options as $i => $item) {
             $parts     = explode('.', $item->value);

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -255,7 +255,7 @@ class CalendarField extends FormField
             if ($translateFormat && $translateFormat !== 'false') {
                 $showTime = (string) $this->element['showtime'];
 
-                $lang  = Factory::getLanguage();
+                $lang  = Factory::getApplication()->getLanguage();
                 $debug = $lang->setDebug(false);
 
                 if ($showTime && $showTime !== 'false') {

--- a/libraries/src/Form/Field/ComponentlayoutField.php
+++ b/libraries/src/Form/Field/ComponentlayoutField.php
@@ -84,7 +84,7 @@ class ComponentlayoutField extends FormField
         // If a template, extension and view are present build the options.
         if ($extension && $view && $client) {
             // Load language file
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
             $lang->load($extension . '.sys', JPATH_ADMINISTRATOR)
             || $lang->load($extension . '.sys', JPATH_ADMINISTRATOR . '/components/' . $extension);
 

--- a/libraries/src/Form/Field/ComponentsField.php
+++ b/libraries/src/Form/Field/ComponentsField.php
@@ -60,7 +60,7 @@ class ComponentsField extends ListField
         $items = $db->setQuery($query)->loadObjectList();
 
         if ($items) {
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
 
             foreach ($items as &$item) {
                 // Load language

--- a/libraries/src/Form/Field/ContenttypeField.php
+++ b/libraries/src/Form/Field/ContenttypeField.php
@@ -62,7 +62,7 @@ class ContenttypeField extends ListField
      */
     protected function getOptions()
     {
-        $lang  = Factory::getLanguage();
+        $lang  = Factory::getApplication()->getLanguage();
         $db    = $this->getDatabase();
         $query = $db->getQuery(true)
             ->select(

--- a/libraries/src/Form/Field/LanguageField.php
+++ b/libraries/src/Form/Field/LanguageField.php
@@ -85,7 +85,7 @@ class LanguageField extends ListField
                 break;
             case 'active':
             case 'auto':
-                $lang        = Factory::getLanguage();
+                $lang        = Factory::getApplication()->getLanguage();
                 $this->value = $lang->getTag();
                 break;
             default:

--- a/libraries/src/Form/Field/LastvisitdaterangeField.php
+++ b/libraries/src/Form/Field/LastvisitdaterangeField.php
@@ -38,7 +38,7 @@ class LastvisitdaterangeField extends PredefinedlistField
         $this->type = 'LastvisitDateRange';
 
         // Load the required language
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $lang->load('com_users', JPATH_ADMINISTRATOR);
 
         // Set the pre-defined options

--- a/libraries/src/Form/Field/ModulelayoutField.php
+++ b/libraries/src/Form/Field/ModulelayoutField.php
@@ -82,7 +82,7 @@ class ModulelayoutField extends FormField
         // If an extension and view are present build the options.
         if ($module && $client) {
             // Load language file
-            $lang = Factory::getLanguage();
+            $lang = Factory::getApplication()->getLanguage();
             $lang->load($module . '.sys', $client->path)
                 || $lang->load($module . '.sys', $client->path . '/modules/' . $module);
 

--- a/libraries/src/Form/Field/PluginsField.php
+++ b/libraries/src/Form/Field/PluginsField.php
@@ -152,7 +152,7 @@ class PluginsField extends ListField
         }
 
         $options   = $db->setQuery($query)->loadObjectList();
-        $lang      = Factory::getLanguage();
+        $lang      = Factory::getApplication()->getLanguage();
         $useGlobal = $this->element['useglobal'];
 
         if ($useGlobal) {

--- a/libraries/src/Form/Field/RegistrationdaterangeField.php
+++ b/libraries/src/Form/Field/RegistrationdaterangeField.php
@@ -59,7 +59,7 @@ class RegistrationdaterangeField extends PredefinedlistField
         parent::__construct($form);
 
         // Load the required language
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $lang->load('com_users', JPATH_ADMINISTRATOR);
     }
 }

--- a/libraries/src/Form/Field/SpacerField.php
+++ b/libraries/src/Form/Field/SpacerField.php
@@ -90,7 +90,7 @@ class SpacerField extends FormField
                     'UTF-8'
                 ) . '"';
 
-                if (Factory::getLanguage()->isRtl()) {
+                if (Factory::getApplication()->getLanguage()->isRtl()) {
                     $label .= ' data-bs-placement="left"';
                 }
             }

--- a/libraries/src/Form/Field/TemplatestyleField.php
+++ b/libraries/src/Form/Field/TemplatestyleField.php
@@ -132,7 +132,7 @@ class TemplatestyleField extends GroupedlistField
     protected function getGroups()
     {
         $groups = [];
-        $lang   = Factory::getLanguage();
+        $lang   = Factory::getApplication()->getLanguage();
 
         // Get the client and client_id.
         $client = ApplicationHelper::getClientInfo($this->clientName, true);

--- a/libraries/src/Form/Field/TransitionField.php
+++ b/libraries/src/Form/Field/TransitionField.php
@@ -128,7 +128,7 @@ class TransitionField extends GroupedlistField
 
         $items = $db->setQuery($query)->loadObjectList();
 
-        Factory::getLanguage()->load('com_workflow', JPATH_ADMINISTRATOR);
+        Factory::getApplication()->getLanguage()->load('com_workflow', JPATH_ADMINISTRATOR);
 
         $parts = explode('.', $extension);
 

--- a/libraries/src/Form/Field/UseractiveField.php
+++ b/libraries/src/Form/Field/UseractiveField.php
@@ -54,7 +54,7 @@ class UseractiveField extends PredefinedlistField
         parent::__construct($form);
 
         // Load the required language
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $lang->load('com_users', JPATH_ADMINISTRATOR);
     }
 }

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1481,7 +1481,7 @@ class Form implements CurrentUserInterface
             $default = (string) ($element['default'] ? $element['default'] : $element->default);
 
             if (($translate = $element['translate_default']) && ((string) $translate === 'true' || (string) $translate === '1')) {
-                $lang = Factory::getLanguage();
+                $lang = Factory::getApplication()->getLanguage();
 
                 if ($lang->hasKey($default)) {
                     $debug   = $lang->setDebug(false);

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -897,7 +897,7 @@ abstract class HTMLHelper
         // If no format is given use the default locale based format.
         if (!$format) {
             $format = Text::_('DATE_FORMAT_LC1');
-        } elseif (Factory::getLanguage()->hasKey($format)) {
+        } elseif (Factory::getApplication()->getLanguage()->hasKey($format)) {
             // $format is an existing language key
             $format = Text::_($format);
         }

--- a/libraries/src/HTML/Helpers/Behavior.php
+++ b/libraries/src/HTML/Helpers/Behavior.php
@@ -292,7 +292,7 @@ abstract class Behavior
             'DRAG_TO_MOVE'    => Text::_('JLIB_HTML_BEHAVIOR_DRAG_TO_MOVE'),
             'PART_TODAY'      => $today,
             'DAY_FIRST'       => Text::_('JLIB_HTML_BEHAVIOR_DISPLAY_S_FIRST'),
-            'WEEKEND'         => Factory::getLanguage()->getWeekEnd(),
+            'WEEKEND'         => Factory::getApplication()->getLanguage()->getWeekEnd(),
             'CLOSE'           => Text::_('JLIB_HTML_BEHAVIOR_CLOSE'),
             'TODAY'           => Text::_('JLIB_HTML_BEHAVIOR_TODAY'),
             'TIME_PART'       => Text::_('JLIB_HTML_BEHAVIOR_SHIFT_CLICK_OR_DRAG_TO_CHANGE_VALUE'),

--- a/libraries/src/Help/Help.php
+++ b/libraries/src/Help/Help.php
@@ -85,7 +85,7 @@ class Help
         /*
          *  Replace substitution codes in the URL.
          */
-        $lang    = Factory::getLanguage();
+        $lang    = Factory::getApplication()->getLanguage();
         $version = new Version();
         $jver    = explode('.', $version->getShortVersion());
         $jlang   = explode('-', $lang->getTag());

--- a/libraries/src/Installer/Adapter/TemplateAdapter.php
+++ b/libraries/src/Installer/Adapter/TemplateAdapter.php
@@ -315,7 +315,7 @@ class TemplateAdapter extends InstallerAdapter
         if (\in_array($this->route, ['install', 'discover_install'])) {
             $db    = $this->getDatabase();
             $query = $db->getQuery(true);
-            $lang  = Factory::getLanguage();
+            $lang  = Factory::getApplication()->getLanguage();
             $debug = $lang->setDebug(false);
 
             $columns = [

--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -500,7 +500,7 @@ abstract class InstallerAdapter implements ContainerAwareInterface, DatabaseAwar
      */
     protected function doLoadLanguage($extension, $source, $base = JPATH_ADMINISTRATOR)
     {
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $lang->load($extension . '.sys', $source) || $lang->load($extension . '.sys', $base);
     }
 

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -66,7 +66,7 @@ class Text
             return $string;
         }
 
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         if ($script) {
             static::$strings[$string] = $lang->_($string, $jsSafe, $interpretBackSlashes);
@@ -96,7 +96,7 @@ class Text
             return false;
         }
 
-        $lang         = Factory::getLanguage();
+        $lang         = Factory::getApplication()->getLanguage();
         $string_parts = explode(',', $string);
 
         // Pass all parts through the Text translator
@@ -151,7 +151,7 @@ class Text
      */
     public static function alt($string, $alt, $jsSafe = false, $interpretBackSlashes = true, $script = false)
     {
-        if (Factory::getLanguage()->hasKey($string . '_' . $alt)) {
+        if (Factory::getApplication()->getLanguage()->hasKey($string . '_' . $alt)) {
             $string .= '_' . $alt;
         }
 
@@ -187,7 +187,7 @@ class Text
      */
     public static function plural($string, $n)
     {
-        $lang  = Factory::getLanguage();
+        $lang  = Factory::getApplication()->getLanguage();
         $args  = \func_get_args();
         $count = \count($args);
 
@@ -255,7 +255,7 @@ class Text
      */
     public static function sprintf($string)
     {
-        $lang  = Factory::getLanguage();
+        $lang  = Factory::getApplication()->getLanguage();
         $args  = \func_get_args();
         $count = \count($args);
 
@@ -294,7 +294,7 @@ class Text
      */
     public static function printf($string)
     {
-        $lang  = Factory::getLanguage();
+        $lang  = Factory::getApplication()->getLanguage();
         $args  = \func_get_args();
         $count = \count($args);
 
@@ -352,7 +352,7 @@ class Text
         // Add the string to the array if not null.
         if ($string !== null) {
             // Normalize the key and translate the string.
-            static::$strings[strtoupper($string)] = Factory::getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
+            static::$strings[strtoupper($string)] = Factory::getApplication()->getLanguage()->_($string, $jsSafe, $interpretBackSlashes);
 
             // Load core.js dependency
             HTMLHelper::_('behavior.core');

--- a/libraries/src/Layout/FileLayout.php
+++ b/libraries/src/Layout/FileLayout.php
@@ -321,7 +321,7 @@ class FileLayout extends BaseLayout
      */
     public function loadLanguageSuffixes()
     {
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         $langTag   = $lang->getTag();
         $langParts = explode('-', $langTag);

--- a/libraries/src/Menu/SiteMenu.php
+++ b/libraries/src/Menu/SiteMenu.php
@@ -69,7 +69,7 @@ class SiteMenu extends AbstractMenu implements CacheControllerFactoryAwareInterf
     {
         // Extract the internal dependencies before calling the parent constructor since it calls $this->load()
         $this->app      = isset($options['app']) && $options['app'] instanceof CMSApplication ? $options['app'] : Factory::getApplication();
-        $this->language = isset($options['language']) && $options['language'] instanceof Language ? $options['language'] : Factory::getLanguage();
+        $this->language = isset($options['language']) && $options['language'] instanceof Language ? $options['language'] : Factory::getApplication()->getLanguage();
 
         if (!isset($options['db']) || !($options['db'] instanceof DatabaseDriver)) {
             @trigger_error(sprintf('Database will be mandatory in 5.0.'), E_USER_DEPRECATED);
@@ -235,7 +235,7 @@ class SiteMenu extends AbstractMenu implements CacheControllerFactoryAwareInterf
             if (($key = array_search('language', $attributes)) === false) {
                 if (Multilanguage::isEnabled()) {
                     $attributes[] = 'language';
-                    $values[]     = [Factory::getLanguage()->getTag(), '*'];
+                    $values[]     = [Factory::getApplication()->getLanguage()->getTag(), '*'];
                 }
             } elseif ($values[$key] === null) {
                 unset($attributes[$key], $values[$key]);

--- a/libraries/src/Pathway/SitePathway.php
+++ b/libraries/src/Pathway/SitePathway.php
@@ -37,7 +37,7 @@ class SitePathway extends Pathway
 
         $app  = $app ?: Factory::getContainer()->get(SiteApplication::class);
         $menu = $app->getMenu();
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
 
         if ($item = $menu->getActive()) {
             $menus = $menu->getMenu();

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -175,7 +175,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
         }
 
         $extension = strtolower($extension);
-        $lang      = $this->getApplication() ? $this->getApplication()->getLanguage() : Factory::getLanguage();
+        $lang      = $this->getApplication() ? $this->getApplication()->getLanguage() : Factory::getApplication()->getLanguage();
 
         // If language already loaded, don't load it again.
         if ($lang->getPaths($extension)) {

--- a/libraries/src/Toolbar/CoreButtonsTrait.php
+++ b/libraries/src/Toolbar/CoreButtonsTrait.php
@@ -515,7 +515,7 @@ trait CoreButtonsTrait
         int $width = 500,
         string $text = 'JTOOLBAR_VERSIONS'
     ): CustomButton {
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $lang->load('com_contenthistory', JPATH_ADMINISTRATOR, $lang->getTag(), true);
 
         // Options array for Layout

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -210,7 +210,7 @@ abstract class ToolbarHelper
         $bar = Toolbar::getInstance('toolbar');
 
         // Add a back button.
-        $arrow  = Factory::getLanguage()->isRtl() ? 'arrow-right' : 'arrow-left';
+        $arrow  = Factory::getApplication()->getLanguage()->isRtl() ? 'arrow-right' : 'arrow-left';
         $bar->appendButton('Link', $arrow, $alt, $href);
     }
 
@@ -671,7 +671,7 @@ abstract class ToolbarHelper
      */
     public static function versions($typeAlias, $itemId, $height = 800, $width = 500, $alt = 'JTOOLBAR_VERSIONS')
     {
-        $lang = Factory::getLanguage();
+        $lang = Factory::getApplication()->getLanguage();
         $lang->load('com_contenthistory', JPATH_ADMINISTRATOR, $lang->getTag(), true);
 
         /** @var \Joomla\CMS\Table\ContentType $contentTypeTable */

--- a/modules/mod_languages/src/Helper/LanguagesHelper.php
+++ b/modules/mod_languages/src/Helper/LanguagesHelper.php
@@ -40,7 +40,7 @@ abstract class LanguagesHelper
     public static function getList(&$params)
     {
         $user       = Factory::getUser();
-        $lang       = Factory::getLanguage();
+        $lang       = Factory::getApplication()->getLanguage();
         $languages  = LanguageHelper::getLanguages();
         $app        = Factory::getApplication();
         $menu       = $app->getMenu();

--- a/modules/mod_menu/src/Helper/MenuHelper.php
+++ b/modules/mod_menu/src/Helper/MenuHelper.php
@@ -233,7 +233,7 @@ class MenuHelper
 
         // Look for the home menu
         if (Multilanguage::isEnabled()) {
-            return $menu->getDefault(Factory::getLanguage()->getTag());
+            return $menu->getDefault(Factory::getApplication()->getLanguage()->getTag());
         }
 
         return $menu->getDefault();

--- a/plugins/content/confirmconsent/src/Field/ConsentBoxField.php
+++ b/plugins/content/confirmconsent/src/Field/ConsentBoxField.php
@@ -277,7 +277,7 @@ class ConsentBoxField extends CheckboxesField
         }
 
         $associatedArticles = Associations::getAssociations('com_content', '#__content', 'com_content.item', $article->id);
-        $currentLang        = Factory::getLanguage()->getTag();
+        $currentLang        = Factory::getApplication()->getLanguage()->getTag();
 
         if (isset($associatedArticles) && $currentLang !== $article->language && \array_key_exists($currentLang, $associatedArticles)) {
             return Route::_(
@@ -312,7 +312,7 @@ class ConsentBoxField extends CheckboxesField
 
         if ($itemId > 0 && Associations::isEnabled()) {
             $privacyAssociated = Associations::getAssociations('com_menus', '#__menu', 'com_menus.item', $itemId, 'id', '', '');
-            $currentLang       = Factory::getLanguage()->getTag();
+            $currentLang       = Factory::getApplication()->getLanguage()->getTag();
 
             if (isset($privacyAssociated[$currentLang])) {
                 $itemId = $privacyAssociated[$currentLang]->id;

--- a/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
+++ b/plugins/editors/tinymce/src/Field/TinymcebuilderField.php
@@ -155,7 +155,7 @@ class TinymcebuilderField extends FormField
         $data['setsForms'] = $setsForms;
 
         // Check for TinyMCE language file
-        $language      = Factory::getLanguage();
+        $language      = Factory::getApplication()->getLanguage();
         $languageFile1 = 'media/vendor/tinymce/langs/' . $language->getTag() . (JDEBUG ? '.js' : '.min.js');
         $languageFile2 = 'media/vendor/tinymce/langs/' . substr($language->getTag(), 0, strpos($language->getTag(), '-')) . (JDEBUG ? '.js' : '.min.js');
 

--- a/plugins/system/debug/src/DataCollector/LanguageErrorsCollector.php
+++ b/plugins/system/debug/src/DataCollector/LanguageErrorsCollector.php
@@ -124,7 +124,7 @@ class LanguageErrorsCollector extends AbstractDataCollector implements AssetProv
      */
     private function getData(): array
     {
-        $errorFiles = Factory::getLanguage()->getErrorFiles();
+        $errorFiles = Factory::getApplication()->getLanguage()->getErrorFiles();
         $errors     = [];
 
         if (\count($errorFiles)) {

--- a/plugins/system/debug/src/DataCollector/LanguageFilesCollector.php
+++ b/plugins/system/debug/src/DataCollector/LanguageFilesCollector.php
@@ -51,7 +51,7 @@ class LanguageFilesCollector extends AbstractDataCollector implements AssetProvi
      */
     public function collect(): array
     {
-        $paths  = Factory::getLanguage()->getPaths();
+        $paths  = Factory::getApplication()->getLanguage()->getPaths();
         $loaded = [];
 
         foreach ($paths as $extension => $files) {

--- a/plugins/system/debug/src/DataCollector/LanguageStringsCollector.php
+++ b/plugins/system/debug/src/DataCollector/LanguageStringsCollector.php
@@ -113,7 +113,7 @@ class LanguageStringsCollector extends AbstractDataCollector implements AssetPro
      */
     private function getData(): array
     {
-        $orphans = Factory::getLanguage()->getOrphans();
+        $orphans = Factory::getApplication()->getLanguage()->getOrphans();
 
         $data = [];
 
@@ -184,6 +184,6 @@ class LanguageStringsCollector extends AbstractDataCollector implements AssetPro
      */
     private function getCount(): int
     {
-        return \count(Factory::getLanguage()->getOrphans());
+        return \count(Factory::getApplication()->getLanguage()->getOrphans());
     }
 }

--- a/plugins/user/profile/src/Field/TosField.php
+++ b/plugins/user/profile/src/Field/TosField.php
@@ -77,7 +77,7 @@ class TosField extends RadioField
                 'UTF-8'
             ) . '"';
 
-            if (Factory::getLanguage()->isRtl()) {
+            if (Factory::getApplication()->getLanguage()->isRtl()) {
                 $label .= ' data-bs-placement="left"';
             }
         }
@@ -103,7 +103,7 @@ class TosField extends RadioField
                 $tosAssociated = Associations::getAssociations('com_content', '#__content', 'com_content.item', $tosArticle);
             }
 
-            $currentLang = Factory::getLanguage()->getTag();
+            $currentLang = Factory::getApplication()->getLanguage()->getTag();
 
             if (isset($tosAssociated) && $currentLang !== $article->language && \array_key_exists($currentLang, $tosAssociated)) {
                 $url  = RouteHelper::getArticleRoute(

--- a/plugins/user/terms/src/Field/TermsField.php
+++ b/plugins/user/terms/src/Field/TermsField.php
@@ -95,7 +95,7 @@ class TermsField extends RadioField
                 $termsAssociated = Associations::getAssociations('com_content', '#__content', 'com_content.item', $termsArticle);
             }
 
-            $currentLang = Factory::getLanguage()->getTag();
+            $currentLang = Factory::getApplication()->getLanguage()->getTag();
 
             if (isset($termsAssociated) && $currentLang !== $article->language && \array_key_exists($currentLang, $termsAssociated)) {
                 $article->link = RouteHelper::getArticleRoute(


### PR DESCRIPTION
### Summary of Changes
Following the dictat that core should not be using any deprecated code this pr replaces all remaining uses of Factory::getLanguage() with its replacement Factory::getApplication()->getLanguage()

### Testing Instructions
1. enable debug lang and navigate the site and check that the languages load and the debug plugin reports no errors
2. change `<rtl>0</rtl>` to `<rtl>1<rtl>` in langmetadata.xml and repeat


### Actual result BEFORE applying this Pull Request
deprecated code is used


### Expected result AFTER applying this Pull Request
no deprecated code and everything still works as expected


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
i assume no documentation is needed for this