### PR TITLE
[5.0] remove unused imports

### DIFF
--- a/administrator/components/com_banners/tmpl/banners/emptystate.php
+++ b/administrator/components/com_banners/tmpl/banners/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_banners/tmpl/clients/emptystate.php
+++ b/administrator/components/com_banners/tmpl/clients/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_contact/tmpl/contacts/emptystate.php
+++ b/administrator/components/com_contact/tmpl/contacts/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_content/tmpl/articles/emptystate.php
+++ b/administrator/components/com_content/tmpl/articles/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_content/tmpl/featured/emptystate.php
+++ b/administrator/components/com_content/tmpl/featured/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_finder/tmpl/filters/emptystate.php
+++ b/administrator/components/com_finder/tmpl/filters/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_guidedtours/tmpl/steps/default.php
+++ b/administrator/components/com_guidedtours/tmpl/steps/default.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\Helpers\StringHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/administrator/components/com_guidedtours/tmpl/steps/emptystate.php
+++ b/administrator/components/com_guidedtours/tmpl/steps/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_guidedtours/tmpl/tours/emptystate.php
+++ b/administrator/components/com_guidedtours/tmpl/tours/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_installer/tmpl/update/emptystate.php
+++ b/administrator/components/com_installer/tmpl/update/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/noupdate.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/noupdate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/reinstall.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/reinstall.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/update.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/update.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;

--- a/administrator/components/com_messages/tmpl/messages/default.php
+++ b/administrator/components/com_messages/tmpl/messages/default.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;

--- a/administrator/components/com_messages/tmpl/messages/emptystate.php
+++ b/administrator/components/com_messages/tmpl/messages/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_modules/tmpl/modules/emptystate.php
+++ b/administrator/components/com_modules/tmpl/modules/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/emptystate.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;

--- a/administrator/components/com_redirect/tmpl/links/emptystate.php
+++ b/administrator/components/com_redirect/tmpl/links/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;

--- a/administrator/components/com_scheduler/tmpl/tasks/empty_state.php
+++ b/administrator/components/com_scheduler/tmpl/tasks/empty_state.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_tags/tmpl/tags/emptystate.php
+++ b/administrator/components/com_tags/tmpl/tags/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/administrator/components/com_users/tmpl/notes/emptystate.php
+++ b/administrator/components/com_users/tmpl/notes/emptystate.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;
 
 $displayData = [

--- a/components/com_content/tmpl/category/blog_children.php
+++ b/components/com_content/tmpl/category/blog_children.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;

--- a/components/com_content/tmpl/category/default_children.php
+++ b/components/com_content/tmpl/category/default_children.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;

--- a/components/com_finder/tmpl/search/default_result.php
+++ b/components/com_finder/tmpl/search/default_result.php
@@ -10,7 +10,6 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;


### PR DESCRIPTION
### Summary of Changes

remove unused imports reported by phan for tmpl files after #41059 merged
`PhanUnreferencedUseNormal Possibly zero references to use statement for classlike/namespace Factory (\Joomla\CMS\Factory)`

### Testing Instructions

code review

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
