### PR TITLE
[5.0] Fix JSON error on update with PostgreSQL

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-08-21.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-08-21.sql
@@ -1,5 +1,9 @@
+--
+-- Attention: In the below SQL statements, the value of the filter is unescaped, i.e. uses "\\", while
+-- in base.sql the same value is using "\\\\". This is expected because of how JSON_REPLACE works.
+--
 UPDATE `#__extensions`
-   SET `params` = JSON_REPLACE(`params`, '$.filter' , JSON_UNQUOTE('\\\\Joomla\\\\CMS\\\\Component\\\\ComponentHelper::filterText'))
+   SET `params` = JSON_REPLACE(`params`, '$.filter' , '\\Joomla\\CMS\\Component\\ComponentHelper::filterText')
  WHERE `type` = 'plugin'
    AND `folder` = 'fields'
    AND `element` IN ('editor', 'text', 'textarea')
@@ -7,7 +11,7 @@ UPDATE `#__extensions`
    AND JSON_EXTRACT(`params`, '$.filter') = 'JComponentHelper::filterText';
 
 UPDATE `#__fields`
-   SET `fieldparams` = JSON_REPLACE(`fieldparams`, '$.filter' , JSON_UNQUOTE('\\\\Joomla\\\\CMS\\\\Component\\\\ComponentHelper::filterText'))
+   SET `fieldparams` = JSON_REPLACE(`fieldparams`, '$.filter' , '\\Joomla\\CMS\\Component\\ComponentHelper::filterText')
  WHERE `type` IN ('editor', 'text', 'textarea')
    AND `fieldparams` <> ''
    AND JSON_EXTRACT(`fieldparams`, '$.filter') = 'JComponentHelper::filterText';

--- a/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-08-21.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-08-21.sql
@@ -1,5 +1,5 @@
 UPDATE `#__extensions`
-   SET `params` = JSON_REPLACE(`params`, '$.filter' , '\\Joomla\\CMS\\Component\\ComponentHelper::filterText')
+   SET `params` = JSON_REPLACE(`params`, '$.filter' , '\\\\Joomla\\\\CMS\\\\Component\\\\ComponentHelper::filterText')
  WHERE `type` = 'plugin'
    AND `folder` = 'fields'
    AND `element` IN ('editor', 'text', 'textarea')
@@ -7,7 +7,7 @@ UPDATE `#__extensions`
    AND JSON_EXTRACT(`params`, '$.filter') = 'JComponentHelper::filterText';
 
 UPDATE `#__fields`
-   SET `fieldparams` = JSON_REPLACE(`fieldparams`, '$.filter' , '\\Joomla\\CMS\\Component\\ComponentHelper::filterText')
+   SET `fieldparams` = JSON_REPLACE(`fieldparams`, '$.filter' , '\\\\Joomla\\\\CMS\\\\Component\\\\ComponentHelper::filterText')
  WHERE `type` IN ('editor', 'text', 'textarea')
    AND `fieldparams` <> ''
    AND JSON_EXTRACT(`fieldparams`, '$.filter') = 'JComponentHelper::filterText';

--- a/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-08-21.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-08-21.sql
@@ -1,5 +1,5 @@
 UPDATE `#__extensions`
-   SET `params` = JSON_REPLACE(`params`, '$.filter' , '\\\\Joomla\\\\CMS\\\\Component\\\\ComponentHelper::filterText')
+   SET `params` = JSON_REPLACE(`params`, '$.filter' , JSON_UNQUOTE('\\\\Joomla\\\\CMS\\\\Component\\\\ComponentHelper::filterText'))
  WHERE `type` = 'plugin'
    AND `folder` = 'fields'
    AND `element` IN ('editor', 'text', 'textarea')
@@ -7,7 +7,7 @@ UPDATE `#__extensions`
    AND JSON_EXTRACT(`params`, '$.filter') = 'JComponentHelper::filterText';
 
 UPDATE `#__fields`
-   SET `fieldparams` = JSON_REPLACE(`fieldparams`, '$.filter' , '\\\\Joomla\\\\CMS\\\\Component\\\\ComponentHelper::filterText')
+   SET `fieldparams` = JSON_REPLACE(`fieldparams`, '$.filter' , JSON_UNQUOTE('\\\\Joomla\\\\CMS\\\\Component\\\\ComponentHelper::filterText'))
  WHERE `type` IN ('editor', 'text', 'textarea')
    AND `fieldparams` <> ''
    AND JSON_EXTRACT(`fieldparams`, '$.filter') = 'JComponentHelper::filterText';

--- a/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-08-21.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-08-21.sql
@@ -1,5 +1,5 @@
 UPDATE "#__extensions"
-   SET "params" = jsonb_set("params"::jsonb, '{filter}' , '"\\Joomla\\CMS\\Component\\ComponentHelper::filterText"')
+   SET "params" = jsonb_set("params"::jsonb, '{filter}' , '"\\\\Joomla\\\\CMS\\\\Component\\\\ComponentHelper::filterText"')
  WHERE "type" = 'plugin'
    AND "folder" = 'fields'
    AND "element" IN ('editor', 'text', 'textarea')
@@ -7,7 +7,7 @@ UPDATE "#__extensions"
    AND "params"::jsonb->>'filter' = 'JComponentHelper::filterText';
 
 UPDATE "#__fields"
-   SET "fieldparams" = jsonb_set("fieldparams"::jsonb, '{filter}' , '"\\Joomla\\CMS\\Component\\ComponentHelper::filterText"')
+   SET "fieldparams" = jsonb_set("fieldparams"::jsonb, '{filter}' , '"\\\\Joomla\\\\CMS\\\\Component\\\\ComponentHelper::filterText"')
  WHERE "type" IN ('editor', 'text', 'textarea')
    AND "fieldparams" <> ''
    AND "fieldparams"::jsonb->>'filter' = 'JComponentHelper::filterText';


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix JSON error when updating with a PostgreSQL database and add explaining comment to update SQL script for MySQL to explain why it's different to the same value in base.sql.

### Testing Instructions

For MySQL code review is sufficient.

On PostgreSQL, update from 4.4 and then check if the filter parameter of the fields plugins "textarea" and "editor" have been migrated correwctly (with "\\" in the database in the filter parameter.

Create a new custom field for 

### Actual result BEFORE applying this Pull Request

Update succeeds on MySQL.

On PostgreSQL it fails with an yellow warning alert:
```
JInstaller: :install: Error SQL 22P02, 7, ERROR: invalid input syntax for type json LINE 2: ...params" = jsonb_set("params"::jsonb, '{filter}' , '"\\Joomla... ^ DETAIL: Escape sequence "\J" is invalid. CONTEXT: JSON data, line 1: "\J...
```

### Expected result AFTER applying this Pull Request

Update still succeeds on MySQL.

Update succeeds without any warning or error on PostgreSQL.

Custom fields of types editor, text and textarea work with the "Text" filter.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
