### PR TITLE
[5.0] Fix codemirror height

### DIFF
--- a/plugins/editors/codemirror/src/Provider/CodeMirrorProvider.php
+++ b/plugins/editors/codemirror/src/Provider/CodeMirrorProvider.php
@@ -84,8 +84,8 @@ final class CodeMirrorProvider extends AbstractEditorProvider
     {
         $col     = $attributes['col'] ?? '';
         $row     = $attributes['row'] ?? '';
-        $width   = $params['width'] ?? '';
-        $height  = $params['height'] ?? '';
+        $width   = $attributes['width'] ?? '';
+        $height  = $attributes['height'] ?? '';
         $id      = $attributes['id'] ?? '';
         $buttons = $params['buttons'] ?? true;
         $asset   = $params['asset'] ?? 0;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix codemirror height


### Testing Instructions
Set default editor to codemirror,
Go to Article editing


### Actual result BEFORE applying this Pull Request
Editor height 100px


### Expected result AFTER applying this Pull Request
Editor height 500px 


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: 
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: 
- [x] No documentation changes for manual.joomla.org needed
