### PR TITLE
Fixed List All Tags view

### DIFF
--- a/components/com_tags/tmpl/tags/default_items.php
+++ b/components/com_tags/tmpl/tags/default_items.php
@@ -88,10 +88,10 @@ $n         = count($this->items);
     <?php else : ?>
         <?php foreach ($this->items as $i => $item) : ?>
             <?php if ($n === 1 || $i === 0 || $bscolumns === 1 || $i % $bscolumns === 0) : ?>
-                <ul class="com-tags__category category list-group">
-            <?php endif; ?>
+                <div class="com-tags__category category row">
 
-            <li class="list-group-item list-group-item-action">
+                <?php endif; ?>
+                <div class="col">
                 <?php if ((!empty($item->access)) && in_array($item->access, $this->user->getAuthorisedViewLevels())) : ?>
                     <h3 class="mb-0">
                         <a href="<?php echo Route::_(RouteHelper::getComponentTagRoute($item->id . ':' . $item->alias, $item->language)); ?>">
@@ -131,10 +131,10 @@ $n         = count($this->items);
                         <?php endif; ?>
                     </div>
                 <?php endif; ?>
-            </li>
+                </div>
 
             <?php if (($i === 0 && $n === 1) || $i === $n - 1 || $bscolumns === 1 || (($i + 1) % $bscolumns === 0)) : ?>
-                </ul>
+            </div>
             <?php endif; ?>
 
         <?php endforeach; ?>


### PR DESCRIPTION
### Summary of Changes

For the `List All Tags` menu type, there are options to set a number of columns. But at present, this does not reflect on the view. This PR will fix this issue and column changes will be reflected on the view. 

I consider this as a bug fix as the current menu setting is not reflected in the view. This might be a breaking change, for some websites as the HTML structure will be changed. 

This Pull Request will fix a partial of the Issue #39177 .


### Testing Instructions

1. Create a new menu item as `List All Tags` 
2. Change the `Number of Columns` from the `Options` tab
3. Follow the changes in column in the view



### Actual result BEFORE applying this Pull Request

Showing all the tags in a single column without respecting the  `Number of Columns` in the `Options` tab. 


### Expected result AFTER applying this Pull Request

`Number of Columns` in the `Options` tab will be reflected in the view. 


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
