### PR TITLE
[5.0]Schemaorg descriptions and links

### DIFF
--- a/administrator/language/en-GB/plg_schemaorg_blogposting.ini
+++ b/administrator/language/en-GB/plg_schemaorg_blogposting.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SCHEMAORG_BLOGPOSTING="Schema.org - BlogPosting"
-PLG_SCHEMAORG_BLOGPOSTING_DESCRIPTION_LABEL="A blog post <a href=\"https://schema.org/BlogPosting\" target=\"_blank\" rel=\"noopener noreferrer\">More information</a>"
+PLG_SCHEMAORG_BLOGPOSTING_DESCRIPTION_LABEL="More information on the Schema.org BlogPosting Type can be found at <a href=\"https://schema.org/BlogPosting\" target=\"_blank\" rel=\"noopener noreferrer\">https://schema.org/BlogPosting</a>"
 PLG_SCHEMAORG_BLOGPOSTING_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_BLOGPOSTING_FIELD_AUTHOR_LABEL="Author"
 PLG_SCHEMAORG_BLOGPOSTING_FIELD_DATE_MODIFIED_LABEL="Date Modified"

--- a/administrator/language/en-GB/plg_schemaorg_book.ini
+++ b/administrator/language/en-GB/plg_schemaorg_book.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SCHEMAORG_BOOK="Schema.org - Book"
-PLG_SCHEMAORG_BOOK_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Book\" target=\"_blank\" rel=\"noopener noreferrer\">More information</a>"
+PLG_SCHEMAORG_BOOK_DESCRIPTION_LABEL="More information on the Schema.org Book Type can be found at <a href=\"https://schema.org/Book\" target=\"_blank\" rel=\"noopener noreferrer\">https://schema.org/Book</a>"
 PLG_SCHEMAORG_BOOK_FIELD_ABRIDGED_LABEL="Abridged"
 PLG_SCHEMAORG_BOOK_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_BOOK_FIELD_AUDIOBOOK_LABEL="Audiobook"

--- a/administrator/language/en-GB/plg_schemaorg_event.ini
+++ b/administrator/language/en-GB/plg_schemaorg_event.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SCHEMAORG_EVENT="Schema.org - Event"
-PLG_SCHEMAORG_EVENT_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Event\" target=\"_blank\" rel=\"noopener noreferrer\">More information</a>"
+PLG_SCHEMAORG_EVENT_DESCRIPTION_LABEL="More information on the Schema.org Event Type can be found at <a href=\"https://schema.org/Event\" target=\"_blank\" rel=\"noopener noreferrer\">https://schema.org/Event</a>"
 PLG_SCHEMAORG_EVENT_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_EVENT_FIELD_AGGREGATE_RATING_LABEL="Aggregate Rating"
 PLG_SCHEMAORG_EVENT_FIELD_DESCRIPTION_LABEL="Description"

--- a/administrator/language/en-GB/plg_schemaorg_jobposting.ini
+++ b/administrator/language/en-GB/plg_schemaorg_jobposting.ini
@@ -3,7 +3,7 @@
 ; License GNU General Public License version 2 or later; see LICENSE.txt
 ; Note : All ini files need to be saved as UTF-8
 
-PLG_SCHEMAORG_JOBPOSTING_DESCRIPTION_LABEL="A job post <a href=\"https://schema.org/JobPosting\" target=\"_blank\" rel=\"noopener noreferrer\">More information</a>"
+PLG_SCHEMAORG_JOBPOSTING_DESCRIPTION_LABEL="More information on the Schema.org JobPosting Type can be found at <a href=\"https://schema.org/JobPosting\" target=\"_blank\" rel=\"noopener noreferrer\">https://schema.org/JobPosting</a>"
 PLG_SCHEMAORG_JOBPOSTING_FIELD_ADDRESS_COUNTRY_LABEL="Country"
 PLG_SCHEMAORG_JOBPOSTING_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_JOBPOSTING_FIELD_ADDRESS_REGION_LABEL="Region"

--- a/administrator/language/en-GB/plg_schemaorg_organization.ini
+++ b/administrator/language/en-GB/plg_schemaorg_organization.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SCHEMAORG_ORGANIZATION="Schema.org - Organization"
-PLG_SCHEMAORG_ORGANIZATION_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Organization\" target=\"_blank\" rel=\"noopener noreferrer\">More information.</a>"
+PLG_SCHEMAORG_ORGANIZATION_DESCRIPTION_LABEL="More information on the Schema.org Organization Type can be found at <a href=\"https://schema.org/Organization\" target=\"_blank\" rel=\"noopener noreferrer\">https://schema.org/Organization</a>"
 PLG_SCHEMAORG_ORGANIZATION_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_ORGANIZATION_FIELD_EMAIL_LABEL="Email"
 PLG_SCHEMAORG_ORGANIZATION_FIELD_GENERIC_FIELD_LABEL="Generic Field"

--- a/administrator/language/en-GB/plg_schemaorg_person.ini
+++ b/administrator/language/en-GB/plg_schemaorg_person.ini
@@ -4,7 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SCHEMAORG_PERSON="Schema.org - Person"
-PLG_SCHEMAORG_PERSON_DESCRIPTION_LABEL="A Schema.org Type <a href=\"https://schema.org/Person\" target=\"_blank\" rel=\"noopener noreferrer\">More information.</a>"
+PLG_SCHEMAORG_PERSON_DESCRIPTION_LABEL="More information on the Schema.org Person Type can be found at <a href=\"https://schema.org/Person\" target=\"_blank\" rel=\"noopener noreferrer\">https://schema.org/Person</a>"
 PLG_SCHEMAORG_PERSON_FIELD_ADDRESS_LABEL="Address"
 PLG_SCHEMAORG_PERSON_FIELD_EMAIL_LABEL="Email"
 PLG_SCHEMAORG_PERSON_FIELD_GENERIC_FIELD_LABEL="Generic Field"

--- a/administrator/language/en-GB/plg_schemaorg_recipe.ini
+++ b/administrator/language/en-GB/plg_schemaorg_recipe.ini
@@ -4,6 +4,7 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_SCHEMAORG_RECIPE="Schema.org - Recipe"
+PLG_SCHEMAORG_RECIPE_DESCRIPTION_LABEL="More information on the Schema.org Recipe Type can be found at <a href=\"https://schema.org/Recipe\" target=\"_blank\" rel=\"noopener noreferrer\">https://schema.org/Recipe</a>"
 PLG_SCHEMAORG_RECIPE_FIELD_AUTHOR_LABEL="Author"
 PLG_SCHEMAORG_RECIPE_FIELD_CALORIES_LABEL="Calories"
 PLG_SCHEMAORG_RECIPE_FIELD_CARBOHYDRATE_LABEL="Carbohydrate"

--- a/plugins/schemaorg/recipe/forms/schemaorg.xml
+++ b/plugins/schemaorg/recipe/forms/schemaorg.xml
@@ -19,6 +19,13 @@
 					/>
 
 					<field
+						name="noteBook"
+						type="note"
+						description="PLG_SCHEMAORG_RECIPE_DESCRIPTION_LABEL"
+						class="alert alert-info w-100"
+					/>
+
+					<field
 						name="image"
 						type="media"
 						label="PLG_SCHEMAORG_RECIPE_FIELD_IMAGE_LABEL"


### PR DESCRIPTION
Pull Request for Issue #41229 .

### Summary of Changes
Standardises the strings so that they are in the same structure
Reworded the strings so that the links are unique and correctly describe where they are going
Adds and displays a missing string for recipes

Web links that are accessible and do not break WCAG standards

- use clear and concise link text that describe the destination
- make sure links take you to where you’d expect
- Do not: have links that are not clear on destination such as ‘click here’ or ‘read more’

### Testing Instructions
setup and configure the new schemaorg plugins. Open an article for editing and check the info box for any of the schema



### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/91ab60bf-d8b5-40ef-ba15-da3c86fd2db9)

![image](https://github.com/joomla/joomla-cms/assets/1296369/7b69b2fa-24b0-4fad-b9c6-40850aa162f3)


### Expected result AFTER applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/1296369/d9021521-a814-431b-9503-657e41a9cbb7)

![image](https://github.com/joomla/joomla-cms/assets/1296369/5274d95a-d790-49e6-9095-d59041ef478d)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
