### PR TITLE
more flexible Bootstrap modal component

### DIFF
--- a/layouts/libraries/html/bootstrap/modal/main.php
+++ b/layouts/libraries/html/bootstrap/modal/main.php
@@ -42,7 +42,7 @@ if (!isset($params['animation']) || $params['animation']) {
 }
 
 $modalWidth       = isset($params['modalWidth']) ? round((int) $params['modalWidth'], -1) : '';
-$modalDialogClass = isset($params['modalDialogClass']) ? $params['modalDialogClass'] : '';
+$modalDialogClass = isset($params['modalDialogClass']) ? $params['modalDialogClass'] : 'modal-lg';
 
 if ($modalWidth && $modalWidth > 0 && $modalWidth <= 100) {
     $modalDialogClass .= ' jviewport-width' . $modalWidth;
@@ -67,7 +67,7 @@ if (isset($params['url'])) {
 }
 ?>
 <div id="<?php echo $selector; ?>" role="dialog" <?php echo ArrayHelper::toString($modalAttributes); ?> <?php echo $url ?? ''; ?> <?php echo isset($url) ? 'data-iframe="' . trim($iframeHtml) . '"' : ''; ?>>
-    <div class="modal-dialog modal-lg <?php echo $modalDialogClass; ?>">
+    <div class="modal-dialog <?php echo $modalDialogClass; ?>">
         <div class="modal-content">
             <?php
                 // Header

--- a/layouts/libraries/html/bootstrap/modal/main.php
+++ b/layouts/libraries/html/bootstrap/modal/main.php
@@ -42,15 +42,15 @@ if (!isset($params['animation']) || $params['animation']) {
 }
 
 $modalWidth       = isset($params['modalWidth']) ? round((int) $params['modalWidth'], -1) : '';
-$modalDialogClass = '';
+$modalDialogClass = isset($params['modalDialogClass']) ? $params['modalDialogClass'] : '';
 
 if ($modalWidth && $modalWidth > 0 && $modalWidth <= 100) {
-    $modalDialogClass = ' jviewport-width' . $modalWidth;
+    $modalDialogClass .= ' jviewport-width' . $modalWidth;
 }
 
 $modalAttributes = [
     'tabindex' => '-1',
-    'class'    => 'joomla-modal ' . implode(' ', $modalClasses)
+    'class'    => 'joomla-modal ' . implode(' ', $modalClasses),
 ];
 
 if (isset($params['backdrop'])) {
@@ -67,7 +67,7 @@ if (isset($params['url'])) {
 }
 ?>
 <div id="<?php echo $selector; ?>" role="dialog" <?php echo ArrayHelper::toString($modalAttributes); ?> <?php echo $url ?? ''; ?> <?php echo isset($url) ? 'data-iframe="' . trim($iframeHtml) . '"' : ''; ?>>
-    <div class="modal-dialog modal-lg<?php echo $modalDialogClass; ?>">
+    <div class="modal-dialog modal-lg <?php echo $modalDialogClass; ?>">
         <div class="modal-content">
             <?php
                 // Header


### PR DESCRIPTION
### Summary of Changes
Possibility to make the bootstrap modal component more flexible by adding classes to `modal-dialog` described here:
https://getbootstrap.com/docs/5.3/components/modal/

Nothing changes if not used.

### Testing Instructions

```
echo HTMLHelper::_(
    'bootstrap.renderModal',
    'log-1',
    ['title'  => 'Title', 'modalDialogClass' => 'modal-dialog-centered modal-xl modal-dialog-scrollable'],
    '<div class="p-3"><div class="row"><div>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua.</div></div></div>'
);
```


### Actual result BEFORE applying this Pull Request
hardcoded modal layout classes

### Expected result AFTER applying this Pull Request
vertically centered, scrollable inside and wider



