### PR TITLE
[5.0] Handle browser page title properly for article view

### DIFF
--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -280,12 +280,10 @@ class HtmlView extends BaseHtmlView
             $this->params->def('page_heading', Text::_('JGLOBAL_ARTICLES'));
         }
 
-        $title = $this->params->get('page_title', '');
-
         // If the menu item is not linked to this article
         if (!$this->menuItemMatchArticle) {
             // If a browser page title is defined, use that, then fall back to the article title if set, then fall back to the page_title option
-            $title = $this->item->params->get('article_page_title', $this->item->title ?: $title);
+            $title = $this->item->params->get('article_page_title', $this->item->title);
 
             // Get ID of the category from active menu item
             if (
@@ -310,15 +308,18 @@ class HtmlView extends BaseHtmlView
             foreach ($path as $item) {
                 $pathway->addItem($item['title'], $item['link']);
             }
-        }
-
-        if (empty($title)) {
+        } else {
             /**
-             * This happens when the current active menu item is linked to the article without browser
-             * page title set, so we use Browser Page Title in article and fallback to article title
-             * if that is not set
+             * This case the menu item links directly to the article, browser will be determined by following
+             * priority:
+             * 1. Browser page title set from menu item itself
+             * 2. Browser page title set for the article
+             * 3. Article title
              */
-            $title = $this->item->params->get('article_page_title', $this->item->title);
+            $title = $this->params->get(
+                'page_title',
+                $this->item->params->get('article_page_title', $this->item->title)
+            );
         }
 
         $this->setDocumentTitle($title);

--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -317,7 +317,7 @@ class HtmlView extends BaseHtmlView
              * 3. Article title
              */
             $menuItemParams = $menu->getParams();
-            $title = $menuItemParams->get(
+            $title          = $menuItemParams->get(
                 'page_title',
                 $this->item->params->get('article_page_title', $this->item->title)
             );

--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -311,12 +311,13 @@ class HtmlView extends BaseHtmlView
         } else {
             /**
              * This case the menu item links directly to the article, browser will be determined by following
-             * priority:
+             * order:
              * 1. Browser page title set from menu item itself
              * 2. Browser page title set for the article
              * 3. Article title
              */
-            $title = $this->params->get(
+            $menuItemParams = $menu->getParams();
+            $title = $menuItemParams->get(
                 'page_title',
                 $this->item->params->get('article_page_title', $this->item->title)
             );


### PR DESCRIPTION
Pull Request for Issue #41372.

### Summary of Changes
Currently, if you create a menu item to display an article and leave browser page title parameter empty in the menu item parameters, the system is using display wrong browser page title. Instead of using browser page title set from article (or article title), it uses Title of menu item and it's not right.  See https://github.com/joomla/joomla-cms/issues/41372 for more more information

I would say that this is a bug fix, but since the issue is marked as new feature, I create a PR to 5.0-branch. Happy to change the PR to 4.3-dev if needed


### Testing Instructions
1. Uses Joomla 5
2. Follow instructions at https://github.com/joomla/joomla-cms/issues/41372 , confirm the issue
3. Apply patch, confirm that the issue is fixed


### Actual result BEFORE applying this Pull Request
Joomla is using menu item title for browser page title of the page


### Expected result AFTER applying this Pull Request
Joomla is using the browser page title set for the article and if that information is not set, use Article title


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
