### PR TITLE
[5.0] Fix deprecated  warnings for calendar form fields in schemaorg

### DIFF
--- a/plugins/schemaorg/blogposting/forms/schemaorg.xml
+++ b/plugins/schemaorg/blogposting/forms/schemaorg.xml
@@ -153,7 +153,7 @@
 						filter="user_utc"
 						showtime="false"
 						todaybutton="true"
-						format="%Y-%m-%d"
+						translateformat="true"
 					/>
 
 					<field
@@ -164,7 +164,7 @@
 						filter="user_utc"
 						showtime="false"
 						todaybutton="true"
-						format="%Y-%m-%d"
+						translateformat="true"
 					/>
 
 					<field

--- a/plugins/schemaorg/book/forms/schemaorg.xml
+++ b/plugins/schemaorg/book/forms/schemaorg.xml
@@ -49,7 +49,7 @@
 						filter="user_utc"
 						showtime="false"
 						todaybutton="true"
-						format="%Y-%m-%d"
+						translateformat="true"
 					/>
 
 					<field

--- a/plugins/schemaorg/event/forms/schemaorg.xml
+++ b/plugins/schemaorg/event/forms/schemaorg.xml
@@ -81,7 +81,7 @@
 						filter="user_utc"
 						showtime="false"
 						todaybutton="true"
-						format="%Y-%m-%d"
+						translateformat="true"
 					/>
 
 					<field

--- a/plugins/schemaorg/jobposting/forms/schemaorg.xml
+++ b/plugins/schemaorg/jobposting/forms/schemaorg.xml
@@ -75,7 +75,7 @@
 						filter="user_utc"
 						showtime="false"
 						todaybutton="true"
-						format="%Y-%m-%d"
+						translateformat="true"
 					/>
 
 					<field
@@ -86,7 +86,7 @@
 						filter="user_utc"
 						showtime="false"
 						todaybutton="true"
-						format="%Y-%m-%d"
+						translateformat="true"
 					/>
 
 					<field
@@ -158,7 +158,7 @@
 								filter="user_utc"
 								showtime="false"
 								todaybutton="true"
-								format="%Y-%m-%d"
+								translateformat="true"
 								showon="@type:Date"
 							/>
 

--- a/plugins/schemaorg/recipe/forms/schemaorg.xml
+++ b/plugins/schemaorg/recipe/forms/schemaorg.xml
@@ -64,7 +64,7 @@
 						filter="user_utc"
 						showtime="false"
 						todaybutton="true"
-						format="%Y-%m-%d"
+						translateformat="true"
 					/>
 
 					<field


### PR DESCRIPTION
Pull Request for Issue #41265.

### Summary of Changes
This PR fixes the deprecated as described in the issue https://github.com/joomla/joomla-cms/issues/41265 . Please look at the issue t understand the actual issue.

Instead of using hardcoded date format, we can set `translateformat="true"` . It has two benefits:

- No deprecated warnings anymore
- The selected date is display in the format controlled by the use language, more friendly than the hardcoded Y-m-d format

### Testing Instructions
1. Use Joomla 5
2. See https://github.com/joomla/joomla-cms/issues/41265 , confirm the issue
3. Apply patch, confirm the issue fixed, no deprecated warnings anymore

### Actual result BEFORE applying this Pull Request
There is deprecated warnings as described in the issue.


### Expected result AFTER applying this Pull Request
No warning anymore. The selected date will still being saved properly. If you use a language which is not using Y-m-d format, the selected date will also be displayed in the date format of your language, too.

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed

- [x] No documentation changes for manual.joomla.org needed