### PR TITLE
Add new input rule for ShowOn field

### DIFF
--- a/administrator/components/com_fields/forms/field.xml
+++ b/administrator/components/com_fields/forms/field.xml
@@ -251,6 +251,7 @@
 					type="text"
 					label="COM_FIELDS_FIELD_SHOWON_LABEL"
 					description="COM_FIELDS_FIELD_SHOWON_DESC"
+					validate="ShowOn"
 				/>
 
 			</fieldset>

--- a/libraries/src/Form/Rule/ShowOnRule.php
+++ b/libraries/src/Form/Rule/ShowOnRule.php
@@ -3,7 +3,7 @@
 /**
  * Joomla! Content Management System
  *
- * @copyright  (C) 2020 Open Source Matters, Inc. <https://www.joomla.org>
+ * @copyright  (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
@@ -20,7 +20,7 @@ use Joomla\Registry\Registry;
 /**
  * Form Rule class for the Joomla Platform.
  *
- * @since  4.0.0
+ * @since  __DEPLOY_VERSION__
  */
 
 class ShowOnRule extends FormRule

--- a/libraries/src/Form/Rule/ShowOnRule.php
+++ b/libraries/src/Form/Rule/ShowOnRule.php
@@ -67,7 +67,7 @@ class ShowOnRule extends FormRule
         }
 
         // Make sure we allow multiple showon rules to be added
-        $rules = [];
+        $rules    = [];
         $andRules = explode('&', $value);
         foreach ($andRules as $andRule) {
             $orRules = explode('|', $andRule);

--- a/libraries/src/Form/Rule/ShowOnRule.php
+++ b/libraries/src/Form/Rule/ShowOnRule.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2020 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Form\Rule;
+
+use Joomla\CMS\Form\Form;
+use Joomla\CMS\Form\FormRule;
+use Joomla\Registry\Registry;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Form Rule class for the Joomla Platform.
+ *
+ * @since  4.0.0
+ */
+
+class ShowOnRule extends FormRule
+{
+    /**
+     * The regular expression to use in testing a form field value.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $regex = '[A-Za-z0-9]+!?:[A-Za-z0-9]+';
+
+    /**
+     * The regular expression modifiers to use when testing a form field value.
+     *
+     * @var    string
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $modifiers = 'i';
+
+    /**
+     * Method to test the value.
+     *
+     * @param \SimpleXMLElement $element The SimpleXMLElement object representing the `<field>` tag for the form field object.
+     * @param mixed $value The form field value to validate.
+     * @param string $group The field name group control value. This acts as as an array container for the field.
+     *                                        For example if the field has name="foo" and the group value is set to "bar" then the
+     *                                        full field name would end up being "bar[foo]".
+     * @param   ?Registry $input An optional Registry object with the entire data set to validate against the entire form.
+     * @param   ?Form $form The form object for which the field is being tested.
+     *
+     * @return  boolean  True if the value is valid, false otherwise.
+     *
+     * @throws  \UnexpectedValueException if rule is invalid.
+     * @since   __DEPLOY_VERSION__
+     */
+    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    {
+        // If the field is empty and not required, the field is valid.
+        $required = ((string)$element['required'] === 'true' || (string)$element['required'] === 'required');
+
+        if (!$required && empty($value) && $value !== '0') {
+            return true;
+        }
+
+        // Make sure we allow multiple showon rules to be added
+        $rules = [];
+        $andRules = explode('&', $value);
+        foreach ($andRules as $andRule) {
+            $orRules = explode('|', $andRule);
+            foreach ($orRules as $orRule) {
+                $rules[] = $orRule;
+            }
+        }
+
+        foreach ($rules as $i => $rule) {
+            if (!parent::test($element, $rule, $group, $input, $form)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}


### PR DESCRIPTION
Pull Request for Issue #41217.

### Summary of Changes
Added a new input rule in oder to check if the show on input text is valid. If not, the user is unable to safe the field


### Testing Instructions
Create a new custom field and edit the Showon Attribute. Enter something invalid and you should be unable to save. If you enter something valid, the field can be saved.


### Actual result BEFORE applying this Pull Request
The user was able to save the field independent on what's in the showon attribute.


### Expected result AFTER applying this Pull Request
The user can only save the field when the showon rule is valid


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
