### PR TITLE
Change hover color of links in footer

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_footer.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_footer.scss
@@ -12,7 +12,7 @@
     padding: 2.5rem ($cassiopeia-grid-gutter * .5);
   }
 
-  a {
+  a, a:hover, a:focus {
     color: currentColor;
   }
 


### PR DESCRIPTION
Pull Request for Issue #41172.

### Summary of Changes
The color of the links stay the same when one hovers or focusses them


### Testing Instructions
Create a footer module and hover over the links, the color should not change


### Actual result BEFORE applying this Pull Request
The color went to a not readable one when the user hovered the links in the footer


### Expected result AFTER applying this Pull Request
The color now stays constant


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
