### PR TITLE
[5.0] User events fix message type

### DIFF
--- a/libraries/src/Event/User/AbstractSaveEvent.php
+++ b/libraries/src/Event/User/AbstractSaveEvent.php
@@ -31,6 +31,25 @@ abstract class AbstractSaveEvent extends UserEvent
     protected $legacyArgumentsOrder = ['subject', 'isNew'];
 
     /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('isNew', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'isNew' of event {$name} is required but has not been provided");
+        }
+    }
+
+    /**
      * Setter for the subject argument.
      *
      * @param   array  $value  The value to set

--- a/libraries/src/Event/User/AfterDeleteEvent.php
+++ b/libraries/src/Event/User/AfterDeleteEvent.php
@@ -33,6 +33,25 @@ class AfterDeleteEvent extends AbstractDeleteEvent
     protected $legacyArgumentsOrder = ['subject', 'deletingResult', 'errorMessage'];
 
     /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('deletingResult', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'deletingResult' of event {$name} is required but has not been provided");
+        }
+    }
+
+    /**
      * Setter for the deletingResult argument.
      *
      * @param   bool  $value  The value to set
@@ -49,13 +68,13 @@ class AfterDeleteEvent extends AbstractDeleteEvent
     /**
      * Setter for the errorMessage argument.
      *
-     * @param   string  $value  The value to set
+     * @param   ?string  $value  The value to set
      *
-     * @return  string
+     * @return  ?string
      *
      * @since  5.0.0
      */
-    protected function setErrorMessage(string $value): string
+    protected function setErrorMessage(?string $value): ?string
     {
         return $value;
     }
@@ -81,6 +100,6 @@ class AfterDeleteEvent extends AbstractDeleteEvent
      */
     public function getErrorMessage(): string
     {
-        return $this->arguments['errorMessage'];
+        return $this->arguments['errorMessage'] ?? '';
     }
 }

--- a/libraries/src/Event/User/AfterSaveEvent.php
+++ b/libraries/src/Event/User/AfterSaveEvent.php
@@ -33,6 +33,25 @@ class AfterSaveEvent extends AbstractSaveEvent
     protected $legacyArgumentsOrder = ['subject', 'isNew', 'savingResult', 'errorMessage'];
 
     /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('savingResult', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'savingResult' of event {$name} is required but has not been provided");
+        }
+    }
+
+    /**
      * Setter for the savingResult argument.
      *
      * @param   bool  $value  The value to set
@@ -49,13 +68,13 @@ class AfterSaveEvent extends AbstractSaveEvent
     /**
      * Setter for the errorMessage argument.
      *
-     * @param   string  $value  The value to set
+     * @param   ?string  $value  The value to set
      *
-     * @return  string
+     * @return  ?string
      *
      * @since  5.0.0
      */
-    protected function setErrorMessage(string $value): string
+    protected function setErrorMessage(?string $value): ?string
     {
         return $value;
     }
@@ -81,6 +100,6 @@ class AfterSaveEvent extends AbstractSaveEvent
      */
     public function getErrorMessage(): string
     {
-        return $this->arguments['errorMessage'];
+        return $this->arguments['errorMessage'] ?? '';
     }
 }

--- a/libraries/src/Event/User/UserEvent.php
+++ b/libraries/src/Event/User/UserEvent.php
@@ -52,10 +52,10 @@ abstract class UserEvent extends AbstractImmutableEvent
             $arguments = $this->reshapeArguments($arguments, $this->legacyArgumentsOrder);
         }
 
-        if (!\array_key_exists('subject', $arguments)) {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('subject', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'subject' of event {$name} is required but has not been provided");
         }
-
-        parent::__construct($name, $arguments);
     }
 }


### PR DESCRIPTION
Pull Request for Issue #41450 .

### Summary of Changes
Fix mesage type, and some required arguments


### Testing Instructions
Please follow #41450 :
> In Joomla 5 go to Users > Manage, click on an Enabled icon to enable or disable a user account

Also try create/edit/delet user


### Actual result BEFORE applying this Pull Request
An error `Argument 1 ($value) must be of type string, null given`


### Expected result AFTER applying this Pull Request
All works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: 
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: 
- [x] No documentation changes for manual.joomla.org needed
