### PR TITLE
Check if the pre update check box actually exists

### DIFF
--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -569,10 +569,15 @@ Joomla = window.Joomla || {};
         status = 'warning';
       }
 
-      if (PreUpdateChecker.nonCoreCriticalPlugins.length === 0 && status === 'success') {
+      if (PreUpdateChecker.nonCoreCriticalPlugins.length === 0 && status === 'success' && document.getElementById('preupdatecheckbox')) {
         document.getElementById('preupdatecheckbox').style.display = 'none';
-        document.getElementById('noncoreplugins').checked = true;
+      }
 
+      if (PreUpdateChecker.nonCoreCriticalPlugins.length === 0 && status === 'success' && document.getElementById('noncoreplugins')) {
+        document.getElementById('noncoreplugins').checked = true;
+      }
+
+      if (PreUpdateChecker.nonCoreCriticalPlugins.length === 0 && status === 'success') {
         [].slice.call(document.querySelectorAll('button.submitupdate')).forEach((el) => {
           el.classList.remove('disabled');
           el.removeAttribute('disabled');


### PR DESCRIPTION
### Summary of Changes
Testing currently the update screens in 4.4. There is a JS error when you install a 3rd party extension. I'v tested it with DPAttachments from [here](https://joomla.digital-peak.com/download/dpattachments).

### Testing Instructions
- Set a a custom url in the Joomla update options for updates the value https://update.joomla.org/core/nightlies/next_major_list.xml
- Install DPAttachments from the link above
- Go to the url /administrator/index.php?option=com_joomlaupdate

### Actual result BEFORE applying this Pull Request
There is a spinner shwon always beside the Extension label and a javascript error in the browser developer console.

### Expected result AFTER applying this Pull Request
Green check images is shown and no JS error.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
