### PR TITLE
Filter for special characters that fail sending test mail

### DIFF
--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -1199,7 +1199,7 @@ class ApplicationModel extends FormModel
         $mailer = new MailTemplate('com_config.test_mail', $user->getParam('language', $app->get('language')), $mail);
         $mailer->addTemplateData(
             [
-                'sitename' => $app->get('sitename'),
+                'sitename' => preg_filter(['/@/', '/\|/'], '', $app->get('sitename'), -1),
                 'method'   => Text::_('COM_CONFIG_SENDMAIL_METHOD_' . strtoupper($mail->Mailer)),
             ]
         );

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -1199,6 +1199,8 @@ class ApplicationModel extends FormModel
         $mailer = new MailTemplate('com_config.test_mail', $user->getParam('language', $app->get('language')), $mail);
         $mailer->addTemplateData(
             [
+                // Replace the occurrences of "@" and "|" in the site name in order to send the test mail, as these
+                // characters produce an error else wise: https://github.com/joomla/joomla-cms/issues/41061
                 'sitename' => preg_filter(['/@/', '/\|/'], '', $app->get('sitename'), -1),
                 'method'   => Text::_('COM_CONFIG_SENDMAIL_METHOD_' . strtoupper($mail->Mailer)),
             ]


### PR DESCRIPTION
Pull Request for Issue #41061.

### Summary of Changes
When trying to send a test mail from the backend, it now filters the site name so the sending does succeed.


### Testing Instructions
Enter a site name containing "@" and/or "|" and try to send a test mail


### Actual result BEFORE applying this Pull Request
The mail could not be sent


### Expected result AFTER applying this Pull Request
The mail can be sent


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
