### PR TITLE
[4] Add multilanguage filter taxonomy rows in com_finder advanced filters

### DIFF
--- a/administrator/components/com_finder/src/Service/HTML/Filter.php
+++ b/administrator/components/com_finder/src/Service/HTML/Filter.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\Component\Finder\Administrator\Helper\LanguageHelper;
 use Joomla\Component\Finder\Administrator\Indexer\Query;
 use Joomla\Database\DatabaseAwareTrait;
+use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -297,6 +298,11 @@ class Filter
                     ->where('t.state = 1')
                     ->where('t.access IN (' . $groups . ')')
                     ->order('t.title');
+
+                if (Multilanguage::isEnabled()) {
+                    $language = [Factory::getLanguage()->getTag(), '*'];
+                    $query->whereIn($db->quoteName('t.language'), $language, ParameterType::STRING);
+                }
 
                 // Self-join to get the parent title.
                 $query->select('e.title AS parent_title')


### PR DESCRIPTION
Pull Request for Issue #41038.

### Summary of Changes
Added the filter declaration


### Testing Instructions
* Create a multilingual site with 2 categories, one being assigned to "all" languages, one being assigned to a non en-GB language 
* create an article per category
* trigger Reindex in com_finder
* open frontend, switch to en-GB as language
* browse to finder search view
* open category filter in the advanced filter section

### Actual result BEFORE applying this Pull Request
* You see the non en-GB category that shouldn't be visible because it's assigned to a different language


### Expected result AFTER applying this Pull Request
* Non en-GB category is gone.
