### PR TITLE
[4] Remove $db->quote call in com_contact query

### DIFF
--- a/components/com_contact/src/Model/ContactModel.php
+++ b/components/com_contact/src/Model/ContactModel.php
@@ -331,7 +331,7 @@ class ContactModel extends FormModel
 
             // Filter per language if plugin published
             if (Multilanguage::isEnabled()) {
-                $language = [Factory::getLanguage()->getTag(), $db->quote('*')];
+                $language = [Factory::getLanguage()->getTag(), '*'];
                 $query->whereIn($db->quoteName('a.language'), $language, ParameterType::STRING);
             }
 


### PR DESCRIPTION
### Summary of Changes
While developing #41470 I looked for similar filtering calls in the codebase and realized that the $db->quote, that I removed in this PR has to be removed because otherwise items assigned to "All" languages won't be filtered. The quote seems to date back to a non-prepared-statement version of the query where it made sense, in the new version however it causes the query to include ```WHERE IN ("en-GB", "\"*\"")``` which doesn't match with `*` what's stored in the DB.

The change is trivial, therefore no detailed testing instructions provided.

### Testing Instructions
Code Review
