### PR TITLE
Remove hitcount variable from URI after voting

### DIFF
--- a/plugins/content/vote/tmpl/vote.php
+++ b/plugins/content/vote/tmpl/vote.php
@@ -26,7 +26,6 @@ use Joomla\CMS\Uri\Uri;
  */
 
 $uri = clone Uri::getInstance();
-$uri->setVar('hitcount', '0');
 
 // Create option list for voting select box
 $options = [];


### PR DESCRIPTION
Pull Request for Issue #41009.

### Summary of Changes
When someone votes for an article, there is no longer a variable added to the URI


### Testing Instructions
Enable the content-vote plugin and make sure that voting is set to sho in the article options.
Visit any article on the front end of the site and vote


### Actual result BEFORE applying this Pull Request
A variable gets added to the URI


### Expected result AFTER applying this Pull Request
No variable gets added to the URI


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
