### PR TITLE
Fix calendar positioning

### DIFF
--- a/build/media_source/system/js/fields/calendar.es5.js
+++ b/build/media_source/system/js/fields/calendar.es5.js
@@ -296,7 +296,9 @@
 
 		if (window.innerHeight < containerTmp.getBoundingClientRect().bottom + 20) {
 			containerTmp.style.marginTop = - (containerTmp.getBoundingClientRect().height + this.inputField.getBoundingClientRect().height) + "px";
-		}
+		} else {
+      containerTmp.style.marginTop = 'initial';
+    }
 
 		this.processCalendar();
 	};


### PR DESCRIPTION
Pull Request for Issue #40577.

### Summary of Changes
Depending on the scroll position of the page, the calendar gets displayed above or below the field, even when the scroll position changes


### Testing Instructions
Open a calendar, scroll on the page and open the calendar again. Depending on the scroll position, it should change if the calendar opens above or below the field


### Actual result BEFORE applying this Pull Request
Sometimes, the calendar got stuck above or below the field when you changed the scroll position


### Expected result AFTER applying this Pull Request
It now gets changed when you scroll


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
