### PR TITLE
[5.0][Events] Fix backward compatibility for onAfterRenderModules

### DIFF
--- a/libraries/src/Document/Renderer/Html/ModulesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModulesRenderer.php
@@ -61,7 +61,7 @@ class ModulesRenderer extends DocumentRenderer
 
         // Dispatch onAfterRenderModules event
         $event = new Module\AfterRenderModulesEvent('onAfterRenderModules', [
-            'subject'    => $buffer,
+            'subject'    => &$buffer, // TODO: Remove reference in Joomla 6, see AfterRenderModulesEvent::__constructor()
             'attributes' => new ArrayProxy($params),
         ]);
         $app->getDispatcher()->dispatch('onAfterRenderModules', $event);

--- a/libraries/src/Event/Module/AfterRenderModulesEvent.php
+++ b/libraries/src/Event/Module/AfterRenderModulesEvent.php
@@ -49,6 +49,15 @@ class AfterRenderModulesEvent extends ModuleEvent
         if (!\array_key_exists('attributes', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'attributes' of event {$name} is required but has not been provided");
         }
+
+        // For backward compatibility make sure the content is referenced
+        // TODO: Remove in Joomla 6
+        // @deprecated: Passing argument by reference is deprecated, and will not work in Joomla 6
+        if (key($arguments) === 0) {
+            $this->arguments['subject'] = &$arguments[0];
+        } elseif (\array_key_exists('subject', $arguments)) {
+            $this->arguments['subject'] = &$arguments['subject'];
+        }
     }
 
     /**
@@ -96,11 +105,11 @@ class AfterRenderModulesEvent extends ModuleEvent
      *
      * @param   string  $value  The value to set
      *
-     * @return  self
+     * @return  static
      *
      * @since  5.0.0
      */
-    public function setContent(string $value): self
+    public function updateContent(string $value): static
     {
         $this->arguments['subject'] = $value;
 

--- a/libraries/src/Event/Module/ModuleEvent.php
+++ b/libraries/src/Event/Module/ModuleEvent.php
@@ -52,10 +52,10 @@ abstract class ModuleEvent extends AbstractImmutableEvent
             $arguments = $this->reshapeArguments($arguments, $this->legacyArgumentsOrder);
         }
 
-        if (!\array_key_exists('subject', $arguments)) {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('subject', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'subject' of event {$name} is required but has not been provided");
         }
-
-        parent::__construct($name, $arguments);
     }
 }


### PR DESCRIPTION
### Summary of Changes
Fix backward compatibility for onAfterRenderModules


### Testing Instructions
Add following listener to Sef system plugin:
```php
public function onAfterRenderModules(&$value) {
      $value .= ' aaaa';
}
```
Open the site, and check rendered modules


### Actual result BEFORE applying this Pull Request
Nothing changed


### Expected result AFTER applying this Pull Request
Every module position now have 'aaaa' appended


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: 
- [x] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/177
- [ ] No documentation changes for manual.joomla.org needed

Reference:
- https://github.com/joomla/joomla-cms/pull/41413