### PR TITLE
[5.0] Point to J5 translations list

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-08-28.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-08-28.sql
@@ -1,0 +1,3 @@
+UPDATE `#__update_sites`
+   SET `location` = 'https://update.joomla.org/language/translationlist_5.xml'
+ WHERE `location` = 'https://update.joomla.org/language/translationlist_4.xml';

--- a/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-08-28.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-08-28.sql
@@ -1,0 +1,3 @@
+UPDATE "#__update_sites"
+   SET "location" = 'https://update.joomla.org/language/translationlist_5.xml'
+ WHERE "location" = 'https://update.joomla.org/language/translationlist_4.xml';

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -21,7 +21,7 @@
 	</files>
 	<updateservers>
 		<server type="collection" priority="1" name="Accredited Joomla! Translations">
-			https://update.joomla.org/language/translationlist_4.xml
+			https://update.joomla.org/language/translationlist_5.xml
 		</server>
 	</updateservers>
 </extension>

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -889,7 +889,7 @@ CREATE TABLE IF NOT EXISTS `#__update_sites` (
 
 INSERT INTO `#__update_sites` (`update_site_id`, `name`, `type`, `location`, `enabled`, `last_check_timestamp`) VALUES
 (1, 'Joomla! Core', 'collection', 'https://update.joomla.org/core/list.xml', 1, 0),
-(2, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_4.xml', 1, 0),
+(2, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_5.xml', 1, 0),
 (3, 'Joomla! Update Component', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
 
 -- --------------------------------------------------------

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -906,7 +906,7 @@ COMMENT ON TABLE "#__update_sites" IS 'Update Sites';
 
 INSERT INTO "#__update_sites" ("update_site_id", "name", "type", "location", "enabled", "last_check_timestamp") VALUES
 (1, 'Joomla! Core', 'collection', 'https://update.joomla.org/core/list.xml', 1, 0),
-(2, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_4.xml', 1, 0),
+(2, 'Accredited Joomla! Translations', 'collection', 'https://update.joomla.org/language/translationlist_5.xml', 1, 0),
 (3, 'Joomla! Update Component', 'extension', 'https://update.joomla.org/core/extensions/com_joomlaupdate.xml', 1, 0);
 
 SELECT setval('#__update_sites_update_site_id_seq', 4, false);


### PR DESCRIPTION
Pull Request for Issue #40718 .

### Summary of Changes

adjust updateserver to translationlists for Joomla 5

### Testing Instructions

- install a new Joomla instance with pre build package from this pr
- update Joomla with pre build package from this pr

### Actual result BEFORE applying this Pull Request

language packs for Joomla 4 are available but can't be installed
![image](https://github.com/joomla/joomla-cms/assets/66922325/a3063483-fb3f-4bb8-aaf1-dad2262b04d6)

### Expected result AFTER applying this Pull Request

language packs (at the moment only german-de) for Joomla 5 are available and can be installed
![image](https://github.com/joomla/joomla-cms/assets/66922325/4cc1e23c-1a5b-4e81-827f-e7a7a8967194)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
