### PR TITLE
[5.0] Smart Search: Fixing missing new events in finder-content-plugin

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Adapter.php
+++ b/administrator/components/com_finder/src/Indexer/Adapter.php
@@ -159,6 +159,23 @@ abstract class Adapter extends CMSPlugin
     }
 
     /**
+     * Returns an array of events this subscriber will listen to.
+     *
+     * @return  array
+     *
+     * @since   5.0.0
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'onBeforeIndex'             => 'onBeforeIndex',
+            'onBuildIndex'              => 'onBuildIndex',
+            'onFinderGarbageCollection' => 'onFinderGarbageCollection',
+            'onStartIndex'              => 'onStartIndex',
+        ];
+    }
+
+    /**
      * Method to get the adapter state and push it into the indexer.
      *
      * @return  void

--- a/plugins/finder/content/src/Extension/Content.php
+++ b/plugins/finder/content/src/Extension/Content.php
@@ -92,13 +92,14 @@ final class Content extends Adapter implements SubscriberInterface
      */
     public static function getSubscribedEvents(): array
     {
-        return [
+
+        return array_merge([
             'onFinderCategoryChangeState' => 'onFinderCategoryChangeState',
             'onFinderChangeState'         => 'onFinderChangeState',
             'onFinderAfterDelete'         => 'onFinderAfterDelete',
             'onFinderBeforeSave'          => 'onFinderBeforeSave',
             'onFinderAfterSave'           => 'onFinderAfterSave',
-        ];
+        ], parent::getSubscribedEvents());
     }
 
     /**

--- a/plugins/finder/content/src/Extension/Content.php
+++ b/plugins/finder/content/src/Extension/Content.php
@@ -92,7 +92,6 @@ final class Content extends Adapter implements SubscriberInterface
      */
     public static function getSubscribedEvents(): array
     {
-
         return array_merge([
             'onFinderCategoryChangeState' => 'onFinderCategoryChangeState',
             'onFinderChangeState'         => 'onFinderChangeState',


### PR DESCRIPTION
### Summary of Changes
The finder content plugin to index articles currently does not work, because events in the new event system are missing.


### Testing Instructions
1. Enable debug mode.
2. Go to Smart Search -> Index
3. Clear the index
4. Click on indexing


### Actual result BEFORE applying this Pull Request
No articles are indexed. In the progress modal, you don't see an entry for Content.


### Expected result AFTER applying this Pull Request
Indexing for articles works again.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
