### PR TITLE
[5.0] Allow onAfterDisplay event to modify view output

### DIFF
--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -202,7 +202,7 @@ class HtmlView extends AbstractView implements CurrentUserInterface
 
         $result = $this->loadTemplate($tpl);
 
-        $eventResult = $app->getDispatcher()->dispatch(
+        $event = $app->getDispatcher()->dispatch(
             'onAfterDisplay',
             AbstractEvent::create(
                 'onAfterDisplay',
@@ -215,9 +215,9 @@ class HtmlView extends AbstractView implements CurrentUserInterface
             )
         );
 
-        $eventResult->getArgument('used', false);
+        $event->getArgument('used', false);
 
-        echo $result;
+        echo $event->getArgument('source');
     }
 
     /**

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -215,9 +215,7 @@ class HtmlView extends AbstractView implements CurrentUserInterface
             )
         );
 
-        $event->getArgument('used', false);
-
-        echo $event->getArgument('source');
+        echo $event->getArgument('source', $result);
     }
 
     /**


### PR DESCRIPTION
### Summary of Changes

Currently, the `onAfterDisplay` event via `Joomla\CMS\Event\View\DisplayEvent` doesn't allow to modify the view output, but it's logical that we should be able to modify the output.

The patch allows 3rd-party plugins to modify the view output by changing the `source` argument.

### Testing Instructions

Try to change smth via `onAfterDisplay` event.

### Actual result BEFORE applying this Pull Request

You can't modify the view output before it's optionally stored to view cache. You can only use `onAfterDispatch` event and modify the `component` document buffer but this event forces the execution of custom code even if the cached output is displayed and results into extra costs.

### Expected result AFTER applying this Pull Request

You can easily modify the view output: add your handler into any system plugin which implements `SubscriberInterface`:

```
    public static function getSubscribedEvents(): array
    {
        return [
            ...
            'onAfterDisplay' => 'onAfterDisplay',
        ];
    }

    public function onAfterDisplay(\Joomla\CMS\Event\View\DisplayEvent $e)
    {
        $e->setArgument('source', '<h1>Hello from onAfterDisplay!</h1>' . $e->getArgument('source'));
    }
```
Now we can modify the view output and add custom scripts which will next be optionally cached in view cache.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
