### PR TITLE
[5.0][Events] More Finder event classes

### DIFF
--- a/administrator/components/com_finder/src/Controller/IndexController.php
+++ b/administrator/components/com_finder/src/Controller/IndexController.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Finder\Administrator\Controller;
 
+use Joomla\CMS\Event\Finder\GarbageCollectionEvent;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Controller\AdminController;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -53,9 +54,11 @@ class IndexController extends AdminController
     {
         $this->checkToken();
 
+        $dispatcher = $this->getDispatcher();
+
         // Optimise the index by first running the garbage collection
-        PluginHelper::importPlugin('finder');
-        $this->app->triggerEvent('onFinderGarbageCollection');
+        PluginHelper::importPlugin('finder', null, true, $dispatcher);
+        $dispatcher->dispatch('onFinderGarbageCollection', new GarbageCollectionEvent('onFinderGarbageCollection', []));
 
         // Now run the optimisation method from the indexer
         $indexer = new Indexer();

--- a/administrator/components/com_finder/src/Controller/IndexerController.php
+++ b/administrator/components/com_finder/src/Controller/IndexerController.php
@@ -11,6 +11,9 @@
 namespace Joomla\Component\Finder\Administrator\Controller;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Event\Finder\BeforeIndexEvent;
+use Joomla\CMS\Event\Finder\BuildIndexEvent;
+use Joomla\CMS\Event\Finder\StartIndexEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
@@ -50,7 +53,8 @@ class IndexerController extends BaseController
             return;
         }
 
-        $params = ComponentHelper::getParams('com_finder');
+        $params     = ComponentHelper::getParams('com_finder');
+        $dispatcher = $this->getDispatcher();
 
         if ($params->get('enable_logging', '0')) {
             $options['format']    = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
@@ -75,7 +79,7 @@ class IndexerController extends BaseController
         Indexer::resetState();
 
         // Import the finder plugins.
-        PluginHelper::importPlugin('finder');
+        PluginHelper::importPlugin('finder', null, true, $dispatcher);
 
         // Add the indexer language to \JS
         Text::script('COM_FINDER_AN_ERROR_HAS_OCCURRED');
@@ -84,7 +88,7 @@ class IndexerController extends BaseController
         // Start the indexer.
         try {
             // Trigger the onStartIndex event.
-            $this->app->triggerEvent('onStartIndex');
+            $dispatcher->dispatch('onStartIndex', new StartIndexEvent('onStartIndex', []));
 
             // Get the indexer state.
             $state        = Indexer::getState();
@@ -120,7 +124,8 @@ class IndexerController extends BaseController
             return;
         }
 
-        $params = ComponentHelper::getParams('com_finder');
+        $params     = ComponentHelper::getParams('com_finder');
+        $dispatcher = $this->getDispatcher();
 
         if ($params->get('enable_logging', '0')) {
             $options['format']    = '{DATE}\t{TIME}\t{LEVEL}\t{CODE}\t{MESSAGE}';
@@ -154,7 +159,7 @@ class IndexerController extends BaseController
         Indexer::setState($state);
 
         // Import the finder plugins.
-        PluginHelper::importPlugin('finder');
+        PluginHelper::importPlugin('finder', null, true, $dispatcher);
 
         /*
          * We are going to swap out the raw document object with an HTML document
@@ -175,10 +180,10 @@ class IndexerController extends BaseController
         // Start the indexer.
         try {
             // Trigger the onBeforeIndex event.
-            $this->app->triggerEvent('onBeforeIndex');
+            $dispatcher->dispatch('onBeforeIndex', new BeforeIndexEvent('onBeforeIndex', []));
 
             // Trigger the onBuildIndex event.
-            $this->app->triggerEvent('onBuildIndex');
+            $dispatcher->dispatch('onBuildIndex', new BuildIndexEvent('onBuildIndex', []));
 
             // Get the indexer state.
             $state           = Indexer::getState();
@@ -230,7 +235,7 @@ class IndexerController extends BaseController
         ob_start();
 
         // Import the finder plugins.
-        PluginHelper::importPlugin('finder');
+        PluginHelper::importPlugin('finder', null, true, $this->getDispatcher());
 
         try {
             // Optimize the index

--- a/libraries/src/Event/CoreEventAware.php
+++ b/libraries/src/Event/CoreEventAware.php
@@ -171,6 +171,10 @@ trait CoreEventAware
         'onFinderAfterSave'           => Finder\AfterSaveEvent::class,
         'onFinderResult'              => Finder\ResultEvent::class,
         'onPrepareFinderContent'      => Finder\PrepareContentEvent::class,
+        'onBeforeIndex'               => Finder\BeforeIndexEvent::class,
+        'onBuildIndex'                => Finder\BuildIndexEvent::class,
+        'onStartIndex'                => Finder\StartIndexEvent::class,
+        'onFinderGarbageCollection'   => Finder\GarbageCollectionEvent::class,
     ];
 
     /**

--- a/libraries/src/Event/Finder/AbstractFinderEvent.php
+++ b/libraries/src/Event/Finder/AbstractFinderEvent.php
@@ -52,10 +52,10 @@ abstract class AbstractFinderEvent extends AbstractImmutableEvent implements Fin
             $arguments = $this->reshapeArguments($arguments, $this->legacyArgumentsOrder);
         }
 
-        if (!\array_key_exists('subject', $arguments)) {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('subject', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'subject' of event {$name} is required but has not been provided");
         }
-
-        parent::__construct($name, $arguments);
     }
 }

--- a/libraries/src/Event/Finder/BeforeIndexEvent.php
+++ b/libraries/src/Event/Finder/BeforeIndexEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Finder;
+
+use Joomla\CMS\Event\AbstractImmutableEvent;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Class for Finder events.
+ * Example:
+ *  new BeforeIndexEvent('onEventName', []);
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class BeforeIndexEvent extends AbstractImmutableEvent implements FinderEventInterface
+{
+}

--- a/libraries/src/Event/Finder/BuildIndexEvent.php
+++ b/libraries/src/Event/Finder/BuildIndexEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Finder;
+
+use Joomla\CMS\Event\AbstractImmutableEvent;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Class for Finder events.
+ * Example:
+ *  new BuildIndexEvent('onEventName', []);
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class BuildIndexEvent extends AbstractImmutableEvent implements FinderEventInterface
+{
+}

--- a/libraries/src/Event/Finder/GarbageCollectionEvent.php
+++ b/libraries/src/Event/Finder/GarbageCollectionEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Finder;
+
+use Joomla\CMS\Event\AbstractImmutableEvent;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Class for Finder events.
+ * Example:
+ *  new GarbageCollectionEvent('onEventName', []);
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class GarbageCollectionEvent extends AbstractImmutableEvent implements FinderEventInterface
+{
+}

--- a/libraries/src/Event/Finder/StartIndexEvent.php
+++ b/libraries/src/Event/Finder/StartIndexEvent.php
@@ -1,0 +1,27 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Finder;
+
+use Joomla\CMS\Event\AbstractImmutableEvent;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Class for Finder events.
+ * Example:
+ *  new StartIndexEvent('onEventName', []);
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class StartIndexEvent extends AbstractImmutableEvent implements FinderEventInterface
+{
+}


### PR DESCRIPTION

### Summary of Changes
Missing classes for Finder

Affected events:

- [x] onStartIndex
- [x] onBeforeIndex
- [x] onBuildIndex
- [x] onFinderGarbageCollection

Currently the events are empty, in the future we can provide an Indexer and State instances with each event, instead of accessing them staticaly. Example `$iState = Indexer::getState()` may become `$iState = $event->getState()`

### Testing Instructions
Use Smart search index


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: https://docs.joomla.org/Plugin/Events#Finder
- [ ] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/177
- [ ] No documentation changes for manual.joomla.org needed

Reference:
 - https://github.com/joomla/joomla-cms/pull/41320