### PR TITLE
[5.0][Events] Event class for com_ajax requests

### DIFF
--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Event\Plugin\AjaxEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
@@ -125,13 +126,16 @@ if (!$format) {
      * (i.e. index.php?option=com_ajax&plugin=foo)
      *
      */
-    $group      = $input->get('group', 'ajax');
-    PluginHelper::importPlugin($group);
-    $plugin     = ucfirst($input->get('plugin'));
-
     try {
-        $results = Factory::getApplication()->triggerEvent('onAjax' . $plugin);
-    } catch (Exception $e) {
+        $dispatcher = $app->getDispatcher();
+        $group      = $input->get('group', 'ajax');
+        $eventName  = 'onAjax' . ucfirst($input->get('plugin', ''));
+        PluginHelper::importPlugin($group, null, true, $dispatcher);
+
+        $results = $dispatcher->dispatch($eventName, new AjaxEvent($eventName, [
+            'subject' => $app,
+        ]))->getArgument('result', []);
+    } catch (Throwable $e) {
         $results = $e;
     }
 } elseif ($input->get('template')) {

--- a/libraries/src/Event/Plugin/AjaxEvent.php
+++ b/libraries/src/Event/Plugin/AjaxEvent.php
@@ -1,0 +1,121 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Plugin;
+
+use Joomla\Application\AbstractApplication;
+use Joomla\CMS\Event\AbstractImmutableEvent;
+use Joomla\CMS\Event\Result\ResultAwareInterface;
+use Joomla\CMS\Event\Result\ResultTypeMixedAware;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Class for onAjax... events
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class AjaxEvent extends AbstractImmutableEvent implements ResultAwareInterface
+{
+    use ResultTypeMixedAware;
+
+    /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('subject', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'subject' of event {$name} is required but has not been provided");
+        }
+    }
+
+    /**
+     * Setter for the subject argument.
+     *
+     * @param   AbstractApplication  $value  The value to set
+     *
+     * @return  AbstractApplication
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function setSubject(AbstractApplication $value): AbstractApplication
+    {
+        return $value;
+    }
+
+    /**
+     * Get the event's application object
+     *
+     * @return  AbstractApplication
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getApplication(): AbstractApplication
+    {
+        return $this->arguments['subject'];
+    }
+
+    /**
+     * Appends data to the result of the event.
+     *
+     * @param   mixed  $data  What to add to the result.
+     *
+     * @return  void
+     * @since   __DEPLOY_VERSION__
+     */
+    public function addResult($data): void
+    {
+        $this->arguments['result'] = $this->arguments['result'] ?? [];
+
+        if (\is_array($this->arguments['result'])) {
+            $this->arguments['result'][] = $data;
+        } elseif (\is_scalar($this->arguments['result']) && \is_scalar($data)) {
+            $this->arguments['result'] .= $data;
+        } else {
+            throw new \UnexpectedValueException('Mixed data in the result for the event ' . $this->getName());
+        }
+    }
+
+    /**
+     * Update the result of the event.
+     *
+     * @param   mixed  $data  What to add to the result.
+     *
+     * @return  static
+     * @since   __DEPLOY_VERSION__
+     */
+    public function updateEventResult($data): static
+    {
+        $this->arguments['result'] = $data;
+
+        return $this;
+    }
+
+    /**
+     * Get the event result.
+     *
+     * @return  mixed
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getEventResult(): mixed
+    {
+        return $this->arguments['result'] ?? null;
+    }
+}

--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -17,6 +17,7 @@ use DebugBar\OpenHandler;
 use Joomla\Application\ApplicationEvents;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Document\HtmlDocument;
+use Joomla\CMS\Event\Plugin\AjaxEvent;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Log\LogEntry;
 use Joomla\CMS\Log\Logger\InMemoryLogger;
@@ -364,13 +365,13 @@ final class Debug extends CMSPlugin implements SubscriberInterface
     /**
      * AJAX handler
      *
-     * @param Joomla\Event\Event $event
+     * @param AjaxEvent $event
      *
      * @return  void
      *
      * @since  4.0.0
      */
-    public function onAjaxDebug($event)
+    public function onAjaxDebug(AjaxEvent $event)
     {
         // Do not render if debugging or language debug is not enabled.
         if (!JDEBUG && !$this->debugLang) {
@@ -384,11 +385,10 @@ final class Debug extends CMSPlugin implements SubscriberInterface
 
         switch ($this->getApplication()->getInput()->get('action')) {
             case 'openhandler':
-                $result  = $event['result'] ?: [];
                 $handler = new OpenHandler($this->debugBar);
+                $result  = $handler->handle($this->getApplication()->getInput()->request->getArray(), false, false);
 
-                $result[]        = $handler->handle($this->getApplication()->getInput()->request->getArray(), false, false);
-                $event['result'] = $result;
+                $event->addResult($result);
         }
     }
 


### PR DESCRIPTION
### Summary of Changes

Event class for com_ajax requests, for 'onAjax...' events.
The event allows not only apped the result, also allows to set a whole result, wich was a missing feature.


### Testing Instructions
Install sample data, or use Debug plugin and view debug history.


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: https://docs.joomla.org/Using_Joomla_Ajax_Interface#Plugin_Response
- [ ] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/177
- [ ] No documentation changes for manual.joomla.org needed
