### PR TITLE
[4.4] Backward compatibility handling for plugins that setting the result directly

### DIFF
--- a/libraries/src/Event/AbstractImmutableEvent.php
+++ b/libraries/src/Event/AbstractImmutableEvent.php
@@ -64,6 +64,18 @@ class AbstractImmutableEvent extends AbstractEvent
      */
     public function offsetSet($name, $value)
     {
+        // B/C check for plugins which use $event['result'] = $result;
+        if ($name === 'result') {
+            parent::offsetSet($name, $value);
+
+            @trigger_error(
+                'Setting a result in to immutable event is deprecated, and will not work in Joomla 6. Event ' . $this->getName(),
+                E_USER_DEPRECATED
+            );
+
+            return;
+        }
+
         throw new \BadMethodCallException(
             sprintf(
                 'Cannot set the argument %s of the immutable event %s.',

--- a/libraries/src/Event/AbstractImmutableEvent.php
+++ b/libraries/src/Event/AbstractImmutableEvent.php
@@ -69,7 +69,7 @@ class AbstractImmutableEvent extends AbstractEvent
             parent::offsetSet($name, $value);
 
             @trigger_error(
-                'Setting a result in to immutable event is deprecated, and will not work in Joomla 6. Event ' . $this->getName(),
+                'Setting a result in an immutable event is deprecated, and will not work in Joomla 6. Event ' . $this->getName(),
                 E_USER_DEPRECATED
             );
 


### PR DESCRIPTION
### Summary of Changes

Addittionaly to #41357 the plugin may set the event result directly `$event['result'] = $result.`
Example in core Debug plugin https://github.com/joomla/joomla-cms/blob/c4ee58371801a720a91792a18bae6a8e1e2a960e/plugins/system/debug/src/Extension/Debug.php#L387-L391

But most of our events will be imutable and it will throw an error.
The patch allow to modyfy `$event['result'] ` in `ImutableEvent` for now, with deprecation waring.


### Testing Instructions
Code review. 
Also can run:
```
$event = new class ('onFooBar') extends Joomla\CMS\Event\AbstractImmutableEvent{};
$event['result'] = 'foobar';
```


### Actual result BEFORE applying this Pull Request
An error


### Expected result AFTER applying this Pull Request
No error


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: 
- [x] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/170
- [ ] No documentation changes for manual.joomla.org needed
