### PR TITLE
Show the plugin name in the update screen

### DIFF
--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -541,7 +541,7 @@ Joomla = window.Joomla || {};
           const pluginTitleTableCell = tableRow.querySelector('.exname');
           pluginTitleTableCell.innerHTML = `${Joomla.sanitizeHtml(pluginTitleTableCell.innerHTML)}
               <div class="small">
-              ${document.querySelector(`td[data-extension-id="${plugin.extension_id}"]`) ? '' : ' - ' + plugin.name}
+              ${document.querySelector(`td[data-extension-id="${plugin.extension_id}"]`) ? '' : ` - ${plugin.name}`}
               <span class="badge bg-warning">
               <span class="icon-warning"></span>
               ${Joomla.Text._('COM_JOOMLAUPDATE_VIEW_DEFAULT_POTENTIALLY_DANGEROUS_PLUGIN')}

--- a/build/media_source/com_joomlaupdate/js/default.es6.js
+++ b/build/media_source/com_joomlaupdate/js/default.es6.js
@@ -541,6 +541,7 @@ Joomla = window.Joomla || {};
           const pluginTitleTableCell = tableRow.querySelector('.exname');
           pluginTitleTableCell.innerHTML = `${Joomla.sanitizeHtml(pluginTitleTableCell.innerHTML)}
               <div class="small">
+              ${document.querySelector(`td[data-extension-id="${plugin.extension_id}"]`) ? '' : ' - ' + plugin.name}
               <span class="badge bg-warning">
               <span class="icon-warning"></span>
               ${Joomla.Text._('COM_JOOMLAUPDATE_VIEW_DEFAULT_POTENTIALLY_DANGEROUS_PLUGIN')}


### PR DESCRIPTION
### Summary of Changes
The update screen shows a potential upgrade issue information for plugins which belong to one of the following groups:
- system
- user
- authentication
- actionlog
- multifactorauth
If that plugin belongs to a package then it shows no information about the plugin, only a generic text.

There is definitely room for improvements of the whole view. But with current the lack of time, I can't do much more.

### Testing Instructions
- Install [DPCalendar](https://joomla.digital-peak.com/download/dpcalendar) or any other package which contains a plugin from the mentioned groups above
- Set in the joomla update options a custom url for the 5.0 nightlies https://update.joomla.org/core/nightlies/next_major_list.xml
- Open the url /administrator/index.php?option=com_joomlaupdate

### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/251072/06ff73af-69cd-4da8-89b8-667b7158b660)

### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/251072/a44c3472-f671-41b1-ad2f-a5d536910a2f)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
