### PR TITLE
Untranslated string on cached pages

### DIFF
--- a/libraries/src/Cache/Controller/CallbackController.php
+++ b/libraries/src/Cache/Controller/CallbackController.php
@@ -77,7 +77,7 @@ class CallbackController extends CacheController
             $data = unserialize(trim($data));
 
             if ($wrkarounds) {
-                echo Cache::getWorkarounds(
+                Cache::getWorkarounds(
                     $data['output'],
                     ['mergehead' => $woptions['mergehead'] ?? 0]
                 );


### PR DESCRIPTION
Pull Request for Issue #41516 .

### Summary of Changes

Wrong use of echo!

### Testing Instructions

Follow the instruction on the issue: https://github.com/joomla/joomla-cms/issues/41516#issuecomment-1702515427

### Actual result BEFORE applying this Pull Request

Broken

### Expected result AFTER applying this Pull Request

Not broken

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
