### PR TITLE
api tests for endpoints for com_privacy consent

### DIFF
--- a/tests/System/integration/api/com_privacy/Consent.cy.js
+++ b/tests/System/integration/api/com_privacy/Consent.cy.js
@@ -1,0 +1,17 @@
+describe('Test privacy consent API endpoint', () => {
+  afterEach(() => cy.task('queryDB', 'DELETE FROM #__privacy_consents'));
+
+  it('can get a list of consents', () => {
+    cy.db_createPrivacyConsent({ body: 'test body' })
+      .then(() => cy.api_get('/privacy/consents'))
+      .then((response) => cy.api_responseContains(response, 'body', 'test body'));
+  });
+
+  it('can list a single consent', () => {
+    cy.db_createPrivacyConsent({ body: 'test body' })
+      .then((id) => cy.api_get(`/privacy/consents/${id}`))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('body')
+        .should('contain', 'test body'));
+  });
+});

--- a/tests/System/support/commands/db.js
+++ b/tests/System/support/commands/db.js
@@ -48,7 +48,7 @@ function createInsertQuery(table, values) {
  * The privacy consent contains some default values when not all required fields are passed in the given data.
  * The id of the inserted privacy consent is returned
  *
- * @param {Object} privacyRequest The consent data to insert
+ * @param {Object} privacyConsent The consent data to insert
  *
  * @returns integer
  */


### PR DESCRIPTION
### Summary of Changes

API tests for following endpoints:

- GET: /api/index.php/v1/privacy/consents
- GET: /api/index.php/v1/privacy/consents/{consent_id}



