### PR TITLE
Revert "[5.0] Smart Search: Use UTF8-aware functions when indexing"

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -836,12 +836,12 @@ class Indexer
                  */
                 if (!feof($input)) {
                     // Find the last space character.
-                    $ls = StringHelper::strrpos($buffer, ' ');
+                    $ls = strrpos($buffer, ' ');
 
                     // Adjust string based on the last space character.
                     if ($ls) {
                         // Truncate the string to the last space character.
-                        $string = StringHelper::substr($buffer, 0, $ls);
+                        $string = substr($buffer, 0, $ls);
 
                         // Adjust the buffer based on the last space for the next iteration and trim.
                         $buffer = StringHelper::trim(substr($buffer, $ls));

--- a/administrator/components/com_finder/src/Indexer/Parser.php
+++ b/administrator/components/com_finder/src/Indexer/Parser.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Finder\Administrator\Indexer;
 
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Text;
-use Joomla\String\StringHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -81,26 +80,26 @@ abstract class Parser
     public function parse($input)
     {
         // If the input is less than 2KB we can parse it in one go.
-        if (StringHelper::strlen($input) <= 2048) {
+        if (strlen($input) <= 2048) {
             return $this->process($input);
         }
 
         // Input is longer than 2Kb so parse it in chunks of 2Kb or less.
         $start  = 0;
-        $end    = StringHelper::strlen($input);
+        $end    = strlen($input);
         $chunk  = 2048;
         $return = null;
 
         while ($start < $end) {
             // Setup the string.
-            $string = StringHelper::substr($input, $start, $chunk);
+            $string = substr($input, $start, $chunk);
 
             // Find the last space character if we aren't at the end.
-            $ls = (($start + $chunk) < $end ? StringHelper::strrpos($string, ' ') : false);
+            $ls = (($start + $chunk) < $end ? strrpos($string, ' ') : false);
 
             // Truncate to the last space character.
             if ($ls !== false) {
-                $string = StringHelper::substr($string, 0, $ls);
+                $string = substr($string, 0, $ls);
             }
 
             // Adjust the start position for the next iteration.

--- a/administrator/components/com_finder/src/Indexer/Parser/Html.php
+++ b/administrator/components/com_finder/src/Indexer/Parser/Html.php
@@ -11,7 +11,6 @@
 namespace Joomla\Component\Finder\Administrator\Indexer\Parser;
 
 use Joomla\Component\Finder\Administrator\Indexer\Parser;
-use Joomla\String\StringHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -118,11 +117,11 @@ class Html extends Parser
     {
         $return         = '';
         $offset         = 0;
-        $startTagLength = StringHelper::strlen($startTag);
-        $endTagLength   = StringHelper::strlen($endTag);
+        $startTagLength = strlen($startTag);
+        $endTagLength   = strlen($endTag);
 
         // Find the first start tag.
-        $start = StringHelper::stripos($input, $startTag);
+        $start = stripos($input, $startTag);
 
         // If no start tags were found, return the string unchanged.
         if ($start === false) {
@@ -132,10 +131,10 @@ class Html extends Parser
         // Look for all blocks defined by the start and end tags.
         while ($start !== false) {
             // Accumulate the substring up to the start tag.
-            $return .= StringHelper::substr($input, $offset, $start - $offset) . ' ';
+            $return .= substr($input, $offset, $start - $offset) . ' ';
 
             // Look for an end tag corresponding to the start tag.
-            $end = StringHelper::stripos($input, $endTag, $start + $startTagLength);
+            $end = stripos($input, $endTag, $start + $startTagLength);
 
             // If no corresponding end tag, leave the string alone.
             if ($end === false) {
@@ -148,11 +147,11 @@ class Html extends Parser
             $offset = $end + $endTagLength;
 
             // Look for the next start tag and loop.
-            $start = StringHelper::stripos($input, $startTag, $offset);
+            $start = stripos($input, $startTag, $offset);
         }
 
         // Add in the final substring after the last end tag.
-        $return .= StringHelper::substr($input, $offset);
+        $return .= substr($input, $offset);
 
         return $return;
     }


### PR DESCRIPTION
Reverts joomla/joomla-cms#41502

Breaks tests because `StringHelper::stripos()`

beside that it seems that the functions already multi byte safe...