### PR TITLE
[5.0] CacheController @mixin Cache

### DIFF
--- a/libraries/src/Cache/CacheController.php
+++ b/libraries/src/Cache/CacheController.php
@@ -20,6 +20,7 @@ use Joomla\Filesystem\Path;
  * Public cache handler
  *
  * @since  1.7.0
+ * @mixin  Cache
  * @note   As of 4.0 this class will be abstract
  */
 class CacheController

--- a/libraries/src/Cache/CacheController.php
+++ b/libraries/src/Cache/CacheController.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Filesystem\Path;
  * Public cache handler
  *
  * @since  1.7.0
+ * @mixin  Cache
  * @note   As of 4.0 this class will be abstract
  */
 class CacheController


### PR DESCRIPTION
### Summary of Changes

Assuming that CacheController proxifies all missed methods to Cache via __call, for IDE code completion can mix Cache methods

### Testing Instructions

Apply patch

### Actual result BEFORE applying this Pull Request

See tons of "Method not found" warnings in IDE, i.e. in `ModuleHelper::moduleCache()`

### Expected result AFTER applying this Pull Request

`$cache->setCaching()` is identified by  IDE if `$cache` is mentioned as i.e. `/** @var CallbackController $cache */`

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
