### PR TITLE
[5.0] Fix wrong names quotes in update SQL for PostgreSQL

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-08-28.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-08-28.sql
@@ -1,6 +1,6 @@
 
 UPDATE "#__guidedtours" SET "extensions" = '["com_content","com_categories"]' WHERE "url" LIKE '%option=com_content%';
-UPDATE "#__guidedtours" SET "extensions" = '["com_content","com_categories"]' WHERE `url` LIKE '%option=com_categories%';
+UPDATE "#__guidedtours" SET "extensions" = '["com_content","com_categories"]' WHERE "url" LIKE '%option=com_categories%';
 UPDATE "#__guidedtours" SET "extensions" = '["com_menus"]' WHERE "url" LIKE '%com_menus%';
 UPDATE "#__guidedtours" SET "extensions" = '["com_tags"]' WHERE "url" LIKE '%com_tags%';
 UPDATE "#__guidedtours" SET "extensions" = '["com_banners"]' WHERE "url" LIKE '%com_banners%';


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix wrong MySQL names quotes in update SQL script from PR #41303 which currently break updating to 5.0 on a PostgreSQL database.

### Testing Instructions

Code review, or update from 4.4-dev or 4.4-alpha4 to the package created by drone for this PR.

### Actual result BEFORE applying this Pull Request

SQL error.

### Expected result AFTER applying this Pull Request

No SQL error.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
