### PR TITLE
[5.0] fix path build_incomplete

### DIFF
--- a/administrator/includes/app.php
+++ b/administrator/includes/app.php
@@ -28,7 +28,7 @@ if (!defined('JPATH_PUBLIC')) {
 
 // Check for presence of vendor dependencies not included in the git repository
 if (!file_exists(JPATH_LIBRARIES . '/vendor/autoload.php') || !is_dir(JPATH_PUBLIC . '/media/vendor')) {
-    echo file_get_contents(JPATH_BASE . '/templates/system/build_incomplete.html');
+    echo file_get_contents(JPATH_ROOT . '/templates/system/build_incomplete.html');
 
     exit;
 }

--- a/includes/app.php
+++ b/includes/app.php
@@ -28,7 +28,7 @@ if (!defined('JPATH_PUBLIC')) {
 
 // Check for presence of vendor dependencies not included in the git repository
 if (!file_exists(JPATH_LIBRARIES . '/vendor/autoload.php') || !is_dir(JPATH_PUBLIC . '/media/vendor')) {
-    echo file_get_contents(JPATH_BASE . '/templates/system/build_incomplete.html');
+    echo file_get_contents(JPATH_ROOT . '/templates/system/build_incomplete.html');
 
     exit;
 }


### PR DESCRIPTION
### Summary of Changes

change start directory from `JPATH_BASE` to `JPATH_ROOT` for `build_incomplete.html`

for reference see #40509 @dgrammatiko 

### Testing Instructions

checkout this repo (without install composer/npm)
- visit `[DOMAIN]/index.php`
- visit `[DOMAIN]/installation/index.php`
- visit `[DOMAIN]/administrator/index.php`

### Actual result BEFORE applying this Pull Request

when visit `[DOMAIN]/administrator/index.php` following warning appears:
`Warning: file_get_contents(/administrator/templates/system/build_incomplete.html): Failed to open stream: No such file or directory in /administrator/includes/app.php on line 31`

### Expected result AFTER applying this Pull Request

always show error page `build_incomplete`
![image](https://github.com/joomla/joomla-cms/assets/66922325/9195c855-9f23-48e4-abbb-d3a43907f228)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
