### PR TITLE
[5.0] Editor xtd buttons use postMessage()

### DIFF
--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -109,7 +109,7 @@ if (!empty($editor)) {
                     }
 
                     $link     = RouteHelper::getArticleRoute($item->id, $item->catid, $item->language);
-                    $itemHtml = '<a href="' . $link . '"' . ($lang ? ' hreflang="' . $lang . '"' : '') . '>' . $item->title . '</a>';
+                    $itemHtml = '<a href="' . $this->escape($link) . '"' . ($lang ? ' hreflang="' . $lang . '"' : '') . '>' . $item->title . '</a>';
                     ?>
                     <tr class="row<?php echo $i % 2; ?>">
                         <td class="text-center">

--- a/administrator/components/com_fields/tmpl/fields/modal.php
+++ b/administrator/components/com_fields/tmpl/fields/modal.php
@@ -23,7 +23,7 @@ if (Factory::getApplication()->isClient('site')) {
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
-$wa->useScript('com_fields.admin-fields-modal');
+$wa->useScript('com_fields.admin-fields-modal')->useScript('modal-content-select');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
@@ -80,6 +80,18 @@ $editor    = Factory::getApplication()->getInput()->get('editor', '', 'cmd');
                         2  => 'icon-folder',
                     ];
                     foreach ($this->items as $i => $item) :
+                        $attrs = 'data-content-select data-content-type="com_fields.field"'
+                            . ' data-id="' . ((int) $item->id) . '"'
+                            . ' data-title="' . $this->escape($item->title) . '"'
+                            . ' data-name="' . $this->escape($item->name) . '"'
+                            . ' data-group="' . ((int) $item->group_id) . '"';
+
+                        $attrs1 = $attrs;
+                        $attrs1 .= ' data-html="{field ' . ((int) $item->id) . '}"';
+                        $attrs2 = $attrs;
+                        $attrs2 .= ' data-html="{fieldgroup ' . ((int) $item->group_id) . '}"';
+
+                        // @TODO: Remove onclick="" after full transition to postMessage()
                         ?>
                     <tr class="row<?php echo $i % 2; ?>">
                         <td class="text-center">
@@ -88,10 +100,16 @@ $editor    = Factory::getApplication()->getInput()->get('editor', '', 'cmd');
                             </span>
                         </td>
                         <th scope="row" class="has-context">
-                            <a class="btn btn-sm btn-success w-100" href="#" onclick="Joomla.fieldIns('<?php echo $this->escape($item->id); ?>', '<?php echo $this->escape($editor); ?>');"><?php echo $this->escape($item->title); ?></a>
+                            <button type="button" class="btn btn-sm btn-success w-100" <?php echo $attrs1; ?>
+                                    onclick="Joomla.fieldIns('<?php echo $this->escape($item->id); ?>', '<?php echo $this->escape($editor); ?>');">
+                                <?php echo $this->escape($item->title); ?>
+                            </button>
                         </th>
                         <td class="small d-none d-md-table-cell">
-                            <a class="btn btn-sm btn-warning w-100" href="#" onclick="Joomla.fieldgroupIns('<?php echo $this->escape($item->group_id); ?>', '<?php echo $this->escape($editor); ?>');"><?php echo $item->group_id ? $this->escape($item->group_title) : Text::_('JNONE'); ?></a>
+                            <button type="button" class="btn btn-sm btn-warning w-100" <?php echo $item->group_id ? $attrs2 : ''; ?>
+                                    onclick="Joomla.fieldgroupIns('<?php echo $this->escape($item->group_id); ?>', '<?php echo $this->escape($editor); ?>');">
+                                <?php echo $item->group_id ? $this->escape($item->group_title) : Text::_('JNONE'); ?>
+                            </button>
                         </td>
                         <td class="small d-none d-md-table-cell">
                             <?php echo $item->type; ?>

--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -105,7 +105,7 @@ if (!empty($editor)) {
                         </span>
                     </td>
                     <th scope="row" class="has-context">
-                        <button type="button" class="js-module-insert btn btn-sm btn-success w-100" <?php echo $attrs1; ?>">
+                        <button type="button" class="js-module-insert btn btn-sm btn-success w-100" <?php echo $attrs1; ?>>
                             <?php echo $this->escape($item->title); ?>
                         </button>
                     </th>

--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -23,7 +23,7 @@ if (Factory::getApplication()->isClient('site')) {
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
-$wa->useScript('com_modules.admin-modules-modal');
+$wa->useScript('com_modules.admin-modules-modal')->useScript('modal-content-select');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
@@ -84,6 +84,19 @@ if (!empty($editor)) {
                     2  => 'icon-folder',
                 ];
                 foreach ($this->items as $i => $item) :
+                    $attrs = 'data-content-select data-content-type="com_modules.module"'
+                        . ' data-id="' . $item->id . '"'
+                        . ' data-title="' . $this->escape($item->title) . '"'
+                        . ' data-position="' . $this->escape($item->position) . '"'
+                        . ' data-module-element="' . $this->escape($item->module) . '"'
+                        // @TODO: Remove data-editor and data-module after full transition to postMessage()
+                        . ' data-editor="' . $this->escape($editor) . '"'
+                        . ' data-module="' . ((int) $item->id) . '"';
+
+                    $attrs1 = $attrs;
+                    $attrs1 .= ' data-html="{loadmoduleid ' . ((int) $item->id) . '}"';
+                    $attrs2 = $attrs;
+                    $attrs2 .= ' data-html="{loadposition ' . $this->escape($item->position) . '}"';
                     ?>
                 <tr class="row<?php echo $i % 2; ?>">
                     <td class="text-center">
@@ -92,13 +105,13 @@ if (!empty($editor)) {
                         </span>
                     </td>
                     <th scope="row" class="has-context">
-                        <a class="js-module-insert btn btn-sm btn-success w-100" href="#" data-module="<?php echo $item->id; ?>" data-editor="<?php echo $this->escape($editor); ?>">
+                        <button type="button" class="js-module-insert btn btn-sm btn-success w-100" <?php echo $attrs1; ?>">
                             <?php echo $this->escape($item->title); ?>
-                        </a>
+                        </button>
                     </th>
                     <td class="small d-none d-md-table-cell">
                         <?php if ($item->position) : ?>
-                        <a class="js-position-insert btn btn-sm btn-warning w-100" href="#" data-position="<?php echo $this->escape($item->position); ?>" data-editor="<?php echo $this->escape($editor); ?>"><?php echo $this->escape($item->position); ?></a>
+                        <button type="button" class="js-position-insert btn btn-sm btn-warning w-100" <?php echo $attrs2; ?>><?php echo $this->escape($item->position); ?></button>
                         <?php else : ?>
                         <span class="btn btn-sm btn-secondary w-100"><?php echo Text::_('JNONE'); ?></span>
                         <?php endif; ?>

--- a/build/media_source/com_content/joomla.asset.json
+++ b/build/media_source/com_content/joomla.asset.json
@@ -59,7 +59,9 @@
       ],
       "attributes": {
         "type": "module"
-      }
+      },
+      "deprecated": true,
+      "deprecatedMsg": "Use postMessage() directly or with help of [modal-content-select] asset. To post the modal selection."
     },
     {
       "name": "com_content.form-edit",

--- a/build/media_source/com_content/js/admin-articles-modal.es6.js
+++ b/build/media_source/com_content/js/admin-articles-modal.es6.js
@@ -5,6 +5,11 @@
 (() => {
   'use strict';
 
+  // Use a JoomlaExpectingPostMessage flag to be able to distinct legacy methods
+  if (window.parent.JoomlaExpectingPostMessage) {
+    return;
+  }
+
   /**
     * Javascript to insert the link
     * View element calls jSelectArticle when an article is clicked

--- a/build/media_source/com_fields/joomla.asset.json
+++ b/build/media_source/com_fields/joomla.asset.json
@@ -58,7 +58,9 @@
       ],
       "attributes": {
         "type": "module"
-      }
+      },
+      "deprecated": true,
+      "deprecatedMsg": "Use postMessage() directly or with help of [modal-content-select] asset. To post the modal selection."
     }
   ]
 }

--- a/build/media_source/com_fields/js/admin-fields-modal.es6.js
+++ b/build/media_source/com_fields/js/admin-fields-modal.es6.js
@@ -14,6 +14,13 @@
   }
 
   Joomla.fieldIns = (id, editor) => {
+    // Use a JoomlaExpectingPostMessage flag to be able to distinct legacy methods
+    if (window.parent.JoomlaExpectingPostMessage) {
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.warn('Method Joomla.fieldIns() is deprecated. Use postMessage() instead.');
+
     window.parent.Joomla.editors.instances[editor].replaceSelection(`{field ${id}}`);
 
     if (window.parent.Joomla.Modal) {
@@ -22,6 +29,13 @@
   };
 
   Joomla.fieldgroupIns = (id, editor) => {
+    // Use a JoomlaExpectingPostMessage flag to be able to distinct legacy methods
+    if (window.parent.JoomlaExpectingPostMessage) {
+      return;
+    }
+    // eslint-disable-next-line no-console
+    console.warn('Method Joomla.fieldgroupIns() is deprecated. Use postMessage() instead.');
+
     window.parent.Joomla.editors.instances[editor].replaceSelection(`{fieldgroup ${id}}`);
 
     if (window.parent.Joomla.Modal) {

--- a/build/media_source/com_modules/joomla.asset.json
+++ b/build/media_source/com_modules/joomla.asset.json
@@ -47,7 +47,9 @@
       ],
       "attributes": {
         "type": "module"
-      }
+      },
+      "deprecated": true,
+      "deprecatedMsg": "Use postMessage() directly or with help of [modal-content-select] asset. To post the modal selection."
     },
     {
       "name": "com_modules.admin-select-modal",

--- a/build/media_source/com_modules/js/admin-modules-modal.es6.js
+++ b/build/media_source/com_modules/js/admin-modules-modal.es6.js
@@ -3,41 +3,48 @@
   * @license    GNU General Public License version 2 or later; see LICENSE.txt
   */
 
-// Assign listener for click event (for single module id insertion)
-document.querySelectorAll('.js-module-insert').forEach((element) => {
-  element.addEventListener('click', (event) => {
-    event.preventDefault();
-    const modid = event.target.getAttribute('data-module');
-    const editor = event.target.getAttribute('data-editor');
+(() => {
+  // Use a JoomlaExpectingPostMessage flag to be able to distinct legacy methods
+  if (window.parent.JoomlaExpectingPostMessage) {
+    return;
+  }
 
-    // Use the API
-    if (window.parent.Joomla && window.parent.Joomla.editors
-      && window.parent.Joomla.editors.instances
-      && Object.prototype.hasOwnProperty.call(window.parent.Joomla.editors.instances, editor)) {
-      window.parent.Joomla.editors.instances[editor].replaceSelection(`{loadmoduleid ${modid}}`);
-    }
+  // Assign listener for click event (for single module id insertion)
+  document.querySelectorAll('.js-module-insert').forEach((element) => {
+    element.addEventListener('click', (event) => {
+      event.preventDefault();
+      const modid = event.target.getAttribute('data-module');
+      const editor = event.target.getAttribute('data-editor');
 
-    if (window.parent.Joomla.Modal) {
-      window.parent.Joomla.Modal.getCurrent().close();
-    }
+      // Use the API
+      if (window.parent.Joomla && window.parent.Joomla.editors
+        && window.parent.Joomla.editors.instances
+        && Object.prototype.hasOwnProperty.call(window.parent.Joomla.editors.instances, editor)) {
+        window.parent.Joomla.editors.instances[editor].replaceSelection(`{loadmoduleid ${modid}}`);
+      }
+
+      if (window.parent.Joomla.Modal) {
+        window.parent.Joomla.Modal.getCurrent().close();
+      }
+    });
   });
-});
 
-// Assign listener for click event (for position insertion)
-document.querySelectorAll('.js-position-insert').forEach((element) => {
-  element.addEventListener('click', (event) => {
-    event.preventDefault();
-    const position = event.target.getAttribute('data-position');
-    const editor = event.target.getAttribute('data-editor');
+  // Assign listener for click event (for position insertion)
+  document.querySelectorAll('.js-position-insert').forEach((element) => {
+    element.addEventListener('click', (event) => {
+      event.preventDefault();
+      const position = event.target.getAttribute('data-position');
+      const editor = event.target.getAttribute('data-editor');
 
-    // Use the API
-    if (window.Joomla && window.Joomla.editors && Joomla.editors.instances
-      && Object.prototype.hasOwnProperty.call(window.parent.Joomla.editors.instances, editor)) {
-      window.parent.Joomla.editors.instances[editor].replaceSelection(`{loadposition ${position}}`);
-    }
+      // Use the API
+      if (window.Joomla && window.Joomla.editors && Joomla.editors.instances
+        && Object.prototype.hasOwnProperty.call(window.parent.Joomla.editors.instances, editor)) {
+        window.parent.Joomla.editors.instances[editor].replaceSelection(`{loadposition ${position}}`);
+      }
 
-    if (window.parent.Joomla.Modal) {
-      window.parent.Joomla.Modal.getCurrent().close();
-    }
+      if (window.parent.Joomla.Modal) {
+        window.parent.Joomla.Modal.getCurrent().close();
+      }
+    });
   });
-});
+})();

--- a/build/media_source/system/js/fields/modal-content-select-field.es6.js
+++ b/build/media_source/system/js/fields/modal-content-select-field.es6.js
@@ -34,6 +34,9 @@ const setValues = (data, inputValue, inputTitle) => {
  * @returns {Promise}
  */
 const doSelect = (inputValue, inputTitle, dialogConfig) => {
+  // Use a JoomlaExpectingPostMessage flag to be able to distinct legacy methods
+  // @TODO: This should be removed after full transition to postMessage()
+  window.JoomlaExpectingPostMessage = true;
   // Create and show the dialog
   const dialog = new JoomlaDialog(dialogConfig);
   dialog.classList.add('joomla-dialog-content-select-field');
@@ -54,6 +57,7 @@ const doSelect = (inputValue, inputTitle, dialogConfig) => {
 
     // Clear all when dialog is closed
     dialog.addEventListener('joomla-dialog:close', () => {
+      delete window.JoomlaExpectingPostMessage;
       window.removeEventListener('message', msgListener);
       dialog.destroy();
       resolve();

--- a/plugins/editors-xtd/article/src/Extension/Article.php
+++ b/plugins/editors-xtd/article/src/Extension/Article.php
@@ -93,8 +93,8 @@ final class Article extends CMSPlugin implements SubscriberInterface
             return;
         }
 
-        $link = 'index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component&amp;'
-            . Session::getFormToken() . '=1&amp;editor=' . $name;
+        $link = 'index.php?option=com_content&view=articles&layout=modal&tmpl=component&'
+            . Session::getFormToken() . '=1&editor=' . $name;
 
         $button = new Button(
             $this->_name,


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This is futher join of: 
- #40462 
- #40202

In this PR I have add use of postMessage to Article, Module, Fields XTD buttons.

This is backward compatible.


### Testing Instructions

Apply patch, run `npm install`.
Edit article, and use Article, Module, Fields XTD buttons.


### Actual result BEFORE applying this Pull Request
All works


### Expected result AFTER applying this Pull Request
All works but better


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/97 https://github.com/joomla/Manual/pull/178
- [ ] No documentation changes for manual.joomla.org needed
