### PR TITLE
[5.0] Allow JPATH constants overridable and make SiteRouter JPATH_PUBLIC aware

### DIFF
--- a/administrator/includes/app.php
+++ b/administrator/includes/app.php
@@ -17,14 +17,7 @@ if (file_exists(dirname(__DIR__) . '/defines.php')) {
     include_once dirname(__DIR__) . '/defines.php';
 }
 
-if (!defined('_JDEFINES')) {
-    define('JPATH_BASE', dirname(__DIR__));
-    require_once JPATH_BASE . '/includes/defines.php';
-}
-
-if (!defined('JPATH_PUBLIC')) {
-    define('JPATH_PUBLIC', JPATH_ROOT);
-}
+require_once __DIR__ . '/defines.php';
 
 // Check for presence of vendor dependencies not included in the git repository
 if (!file_exists(JPATH_LIBRARIES . '/vendor/autoload.php') || !is_dir(JPATH_PUBLIC . '/media/vendor')) {

--- a/administrator/includes/defines.php
+++ b/administrator/includes/defines.php
@@ -9,21 +9,24 @@
 
 defined('_JEXEC') or die;
 
+// Define JPATH constants if not defined yet
+defined('JPATH_BASE') || define('JPATH_BASE', dirname(__DIR__));
+
 // Global definitions
 $parts = explode(DIRECTORY_SEPARATOR, JPATH_BASE);
 array_pop($parts);
 
 // Defines
-define('JPATH_ROOT', implode(DIRECTORY_SEPARATOR, $parts));
-define('JPATH_SITE', JPATH_ROOT);
-define('JPATH_PUBLIC', JPATH_ROOT);
-define('JPATH_CONFIGURATION', JPATH_ROOT);
-define('JPATH_ADMINISTRATOR', JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator');
-define('JPATH_LIBRARIES', JPATH_ROOT . DIRECTORY_SEPARATOR . 'libraries');
-define('JPATH_PLUGINS', JPATH_ROOT . DIRECTORY_SEPARATOR . 'plugins');
-define('JPATH_INSTALLATION', JPATH_ROOT . DIRECTORY_SEPARATOR . 'installation');
-define('JPATH_THEMES', JPATH_BASE . DIRECTORY_SEPARATOR . 'templates');
-define('JPATH_CACHE', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'cache');
-define('JPATH_MANIFESTS', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'manifests');
-define('JPATH_API', JPATH_ROOT . DIRECTORY_SEPARATOR . 'api');
-define('JPATH_CLI', JPATH_ROOT . DIRECTORY_SEPARATOR . 'cli');
+defined('JPATH_ROOT') || define('JPATH_ROOT', implode(DIRECTORY_SEPARATOR, $parts));
+defined('JPATH_SITE') || define('JPATH_SITE', JPATH_ROOT);
+defined('JPATH_PUBLIC') || define('JPATH_PUBLIC', JPATH_ROOT);
+defined('JPATH_CONFIGURATION') || define('JPATH_CONFIGURATION', JPATH_ROOT);
+defined('JPATH_ADMINISTRATOR') || define('JPATH_ADMINISTRATOR', JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator');
+defined('JPATH_LIBRARIES') || define('JPATH_LIBRARIES', JPATH_ROOT . DIRECTORY_SEPARATOR . 'libraries');
+defined('JPATH_PLUGINS') || define('JPATH_PLUGINS', JPATH_ROOT . DIRECTORY_SEPARATOR . 'plugins');
+defined('JPATH_INSTALLATION') || define('JPATH_INSTALLATION', JPATH_ROOT . DIRECTORY_SEPARATOR . 'installation');
+defined('JPATH_THEMES') || define('JPATH_THEMES', JPATH_BASE . DIRECTORY_SEPARATOR . 'templates');
+defined('JPATH_CACHE') || define('JPATH_CACHE', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'cache');
+defined('JPATH_MANIFESTS') || define('JPATH_MANIFESTS', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'manifests');
+defined('JPATH_API') || define('JPATH_API', JPATH_ROOT . DIRECTORY_SEPARATOR . 'api');
+defined('JPATH_CLI') || define('JPATH_CLI', JPATH_ROOT . DIRECTORY_SEPARATOR . 'cli');

--- a/api/includes/app.php
+++ b/api/includes/app.php
@@ -17,14 +17,7 @@ if (file_exists(dirname(__DIR__) . '/defines.php')) {
     include_once dirname(__DIR__) . '/defines.php';
 }
 
-if (!defined('_JDEFINES')) {
-    define('JPATH_BASE', dirname(__DIR__));
-    require_once JPATH_BASE . '/includes/defines.php';
-}
-
-if (!defined('JPATH_PUBLIC')) {
-    define('JPATH_PUBLIC', JPATH_ROOT);
-}
+require_once __DIR__ . '/defines.php';
 
 require_once JPATH_BASE . '/includes/framework.php';
 

--- a/api/includes/defines.php
+++ b/api/includes/defines.php
@@ -9,21 +9,24 @@
 
 defined('_JEXEC') or die;
 
+// Define JPATH constants if not defined yet
+defined('JPATH_BASE') || define('JPATH_BASE', dirname(__DIR__));
+
 // Global definitions
 $parts = explode(DIRECTORY_SEPARATOR, JPATH_BASE);
 array_pop($parts);
 
-// Defines.
-define('JPATH_ROOT', implode(DIRECTORY_SEPARATOR, $parts));
-define('JPATH_SITE', JPATH_ROOT);
-define('JPATH_PUBLIC', JPATH_ROOT);
-define('JPATH_CONFIGURATION', JPATH_ROOT);
-define('JPATH_ADMINISTRATOR', JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator');
-define('JPATH_LIBRARIES', JPATH_ROOT . DIRECTORY_SEPARATOR . 'libraries');
-define('JPATH_PLUGINS', JPATH_ROOT . DIRECTORY_SEPARATOR . 'plugins');
-define('JPATH_INSTALLATION', JPATH_ROOT . DIRECTORY_SEPARATOR . 'installation');
-define('JPATH_THEMES', JPATH_BASE . DIRECTORY_SEPARATOR . 'templates');
-define('JPATH_CACHE', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'cache');
-define('JPATH_MANIFESTS', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'manifests');
-define('JPATH_API', JPATH_ROOT . DIRECTORY_SEPARATOR . 'api');
-define('JPATH_CLI', JPATH_ROOT . DIRECTORY_SEPARATOR . 'cli');
+// Defines
+defined('JPATH_ROOT') || define('JPATH_ROOT', implode(DIRECTORY_SEPARATOR, $parts));
+defined('JPATH_SITE') || define('JPATH_SITE', JPATH_ROOT);
+defined('JPATH_PUBLIC') || define('JPATH_PUBLIC', JPATH_ROOT);
+defined('JPATH_CONFIGURATION') || define('JPATH_CONFIGURATION', JPATH_ROOT);
+defined('JPATH_ADMINISTRATOR') || define('JPATH_ADMINISTRATOR', JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator');
+defined('JPATH_LIBRARIES') || define('JPATH_LIBRARIES', JPATH_ROOT . DIRECTORY_SEPARATOR . 'libraries');
+defined('JPATH_PLUGINS') || define('JPATH_PLUGINS', JPATH_ROOT . DIRECTORY_SEPARATOR . 'plugins');
+defined('JPATH_INSTALLATION') || define('JPATH_INSTALLATION', JPATH_ROOT . DIRECTORY_SEPARATOR . 'installation');
+defined('JPATH_THEMES') || define('JPATH_THEMES', JPATH_BASE . DIRECTORY_SEPARATOR . 'templates');
+defined('JPATH_CACHE') || define('JPATH_CACHE', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'cache');
+defined('JPATH_MANIFESTS') || define('JPATH_MANIFESTS', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'manifests');
+defined('JPATH_API') || define('JPATH_API', JPATH_ROOT . DIRECTORY_SEPARATOR . 'api');
+defined('JPATH_CLI') || define('JPATH_CLI', JPATH_ROOT . DIRECTORY_SEPARATOR . 'cli');

--- a/includes/app.php
+++ b/includes/app.php
@@ -17,10 +17,7 @@ if (file_exists(dirname(__DIR__) . '/defines.php')) {
     include_once dirname(__DIR__) . '/defines.php';
 }
 
-if (!defined('_JDEFINES')) {
-    define('JPATH_BASE', dirname(__DIR__));
-    require_once JPATH_BASE . '/includes/defines.php';
-}
+require_once __DIR__ . '/defines.php';
 
 if (!defined('JPATH_PUBLIC')) {
     define('JPATH_PUBLIC', JPATH_ROOT);

--- a/includes/defines.php
+++ b/includes/defines.php
@@ -9,20 +9,18 @@
 
 defined('_JEXEC') or die;
 
-// Global definitions
-$parts = explode(DIRECTORY_SEPARATOR, JPATH_BASE);
-
-// Defines.
-define('JPATH_ROOT', implode(DIRECTORY_SEPARATOR, $parts));
-define('JPATH_SITE', JPATH_ROOT);
-define('JPATH_CONFIGURATION', JPATH_ROOT);
-define('JPATH_PUBLIC', JPATH_ROOT);
-define('JPATH_ADMINISTRATOR', JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator');
-define('JPATH_LIBRARIES', JPATH_ROOT . DIRECTORY_SEPARATOR . 'libraries');
-define('JPATH_PLUGINS', JPATH_ROOT . DIRECTORY_SEPARATOR . 'plugins');
-define('JPATH_INSTALLATION', JPATH_ROOT . DIRECTORY_SEPARATOR . 'installation');
-define('JPATH_THEMES', JPATH_BASE . DIRECTORY_SEPARATOR . 'templates');
-define('JPATH_CACHE', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'cache');
-define('JPATH_MANIFESTS', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'manifests');
-define('JPATH_API', JPATH_ROOT . DIRECTORY_SEPARATOR . 'api');
-define('JPATH_CLI', JPATH_ROOT . DIRECTORY_SEPARATOR . 'cli');
+// Define JPATH constants if not defined yet
+defined('JPATH_BASE') || define('JPATH_BASE', dirname(__DIR__));
+defined('JPATH_ROOT') || define('JPATH_ROOT', JPATH_BASE);
+defined('JPATH_SITE') || define('JPATH_SITE', JPATH_ROOT);
+defined('JPATH_PUBLIC') || define('JPATH_PUBLIC', JPATH_ROOT);
+defined('JPATH_CONFIGURATION') || define('JPATH_CONFIGURATION', JPATH_ROOT);
+defined('JPATH_ADMINISTRATOR') || define('JPATH_ADMINISTRATOR', JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator');
+defined('JPATH_LIBRARIES') || define('JPATH_LIBRARIES', JPATH_ROOT . DIRECTORY_SEPARATOR . 'libraries');
+defined('JPATH_PLUGINS') || define('JPATH_PLUGINS', JPATH_ROOT . DIRECTORY_SEPARATOR . 'plugins');
+defined('JPATH_INSTALLATION') || define('JPATH_INSTALLATION', JPATH_ROOT . DIRECTORY_SEPARATOR . 'installation');
+defined('JPATH_THEMES') || define('JPATH_THEMES', JPATH_BASE . DIRECTORY_SEPARATOR . 'templates');
+defined('JPATH_CACHE') || define('JPATH_CACHE', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'cache');
+defined('JPATH_MANIFESTS') || define('JPATH_MANIFESTS', JPATH_ADMINISTRATOR . DIRECTORY_SEPARATOR . 'manifests');
+defined('JPATH_API') || define('JPATH_API', JPATH_ROOT . DIRECTORY_SEPARATOR . 'api');
+defined('JPATH_CLI') || define('JPATH_CLI', JPATH_ROOT . DIRECTORY_SEPARATOR . 'cli');

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -149,15 +149,16 @@ class SiteRouter extends Router
         if (preg_match("#.*?\.php#u", $path, $matches)) {
             // Get the current entry point path relative to the site path.
             $scriptPath         = realpath($_SERVER['SCRIPT_FILENAME'] ?: str_replace('\\\\', '\\', $_SERVER['PATH_TRANSLATED']));
-            $relativeScriptPath = str_replace('\\', '/', str_replace(JPATH_SITE, '', $scriptPath));
+            $relativeScriptPath = str_replace('\\', '/', str_replace(JPATH_PUBLIC, '', $scriptPath));
 
             // If a php file has been found in the request path, check to see if it is a valid file.
             // Also verify that it represents the same file from the server variable for entry script.
-            if (is_file(JPATH_SITE . $matches[0]) && ($matches[0] === $relativeScriptPath)) {
+            if (is_file(JPATH_PUBLIC . $matches[0]) && ($matches[0] === $relativeScriptPath)) {
                 // Remove the entry point segments from the request path for proper routing.
                 $path = str_replace($matches[0], '', $path);
             }
         }
+
 
         // Set the route
         $uri->setPath(trim($path, '/'));

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -159,7 +159,6 @@ class SiteRouter extends Router
             }
         }
 
-
         // Set the route
         $uri->setPath(trim($path, '/'));
     }


### PR DESCRIPTION
Useful for public folder for example or only partial overrides.

Followup Pull Request for #40509 and prepare Pull Request for #41446.

### Summary of Changes
Allow each JPATH constant to be overridden individually which allow us to only define 3 constants in the public folder index.php or any other bootstrap file.

Remove the need of _JDEFINED if custom constants have been defined.

SiteRouter uses now the JPATH_PUBLIC constant instead of the JPATH_SITE constant to find the index.php in the path to removes it from the request uri object.

@dgrammatiko @wilsonge 

### Testing Instructions
joomla frontend, backend and api should work normally, with and without public folder


### Actual result BEFORE applying this Pull Request
Works
More files in public folder

### Expected result AFTER applying this Pull Request
Works
Only index.php and extract.php in public folder.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed


