### PR TITLE
Replace the special characters in site name for mail templates

### DIFF
--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -1199,9 +1199,8 @@ class ApplicationModel extends FormModel
         $mailer = new MailTemplate('com_config.test_mail', $user->getParam('language', $app->get('language')), $mail);
         $mailer->addTemplateData(
             [
-                // Replace the occurrences of "@" and "|" in the site name in order to send the test mail, as these
-                // characters produce an error else wise: https://github.com/joomla/joomla-cms/issues/41061
-                'sitename' => preg_filter(['/@/', '/\|/'], '', $app->get('sitename'), -1),
+                // Replace the occurrences of "@" and "|" in the site name
+                'sitename' => str_replace(['@', '|'], '', $app->get('sitename')),
                 'method'   => Text::_('COM_CONFIG_SENDMAIL_METHOD_' . strtoupper($mail->Mailer)),
             ]
         );


### PR DESCRIPTION
Pull Request for pr #41469.

### Summary of Changes
This fixes a regression of #41469. When a test mail is sent without an @ or | sign in the site name, then the preg replace call returns null.

### Testing Instructions
- Make sure you are on PHP 8.2
- Set reporting to maximum in the joomla configuration
- Set a site name without any special character
- Send a test mail 

### Actual result BEFORE applying this Pull Request
A javascript error where the response shows some deprecated warnings that null should not be passed. The test mail doesn't contain the site name in the subject.

### Expected result AFTER applying this Pull Request
Test mail is correctly sent with the sitename in the subject and no JS error.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
