### PR TITLE
[5.0] Category Feed

### DIFF
--- a/libraries/src/MVC/View/CategoriesView.php
+++ b/libraries/src/MVC/View/CategoriesView.php
@@ -55,7 +55,7 @@ class CategoriesView extends HtmlView
      * @var   Registry
      * @since __DEPLOY_VERSION__
      */
-    protected $params;
+    public $params;
 
     /**
      * The parent category
@@ -63,7 +63,7 @@ class CategoriesView extends HtmlView
      * @var   CategoryNode
      * @since __DEPLOY_VERSION__
      */
-    protected $parent;
+    public $parent;
 
     /**
      * Execute and display a template script.

--- a/libraries/src/MVC/View/CategoriesView.php
+++ b/libraries/src/MVC/View/CategoriesView.php
@@ -9,8 +9,10 @@
 
 namespace Joomla\CMS\MVC\View;
 
+use Joomla\CMS\Categories\CategoryNode;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
+use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -46,6 +48,22 @@ class CategoriesView extends HtmlView
      * @since  3.2
      */
     protected $pageHeading;
+
+    /**
+     * The category parameters
+     *
+     * @var   Registry
+     * @since __DEPLOY_VERSION__
+     */
+    protected $params;
+
+    /**
+     * The parent category
+     *
+     * @var   CategoryNode
+     * @since __DEPLOY_VERSION__
+     */
+    protected $parent;
 
     /**
      * Execute and display a template script.

--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -85,7 +85,7 @@ class CategoryFeedView extends AbstractView
 
             // Strip html from feed item title
             if ($titleField) {
-                $title = $this->escape($item->$titleField);
+                $title = htmlspecialchars($item->$titleField, ENT_QUOTES, 'UTF-8');
                 $title = html_entity_decode($title, ENT_QUOTES, 'UTF-8');
             } else {
                 $title = '';

--- a/libraries/src/MVC/View/CategoryFeedView.php
+++ b/libraries/src/MVC/View/CategoryFeedView.php
@@ -25,7 +25,7 @@ use Joomla\CMS\UCM\UCMType;
  *
  * @since  3.2
  */
-class CategoryFeedView extends HtmlView
+class CategoryFeedView extends AbstractView
 {
     /**
      * Execute and display a template script.


### PR DESCRIPTION
### Summary of Changes
Moves the category feed view from extending the base html class to abstract view which is a non-impacting b/c break. Justification being that we aren't using any of the html methods and it's not a HTML view - so it's a good example of extending abstractview.

This is pulled out of the wider view rework in #38937

Whilst I'm at it add class definitions for two missing properties

### Testing Instructions
Check feed view for a category works before and after the patch in the same way (output should be identical)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/commit/6457c2e1988093f0d700e26611045286dcbff650
- [ ] No documentation changes for manual.joomla.org needed
