### PR TITLE
[5.0] Fix wrong language string constant used in database query of privacyconsent task scheduler plugin

### DIFF
--- a/administrator/language/en-GB/plg_task_privacyconsent.ini
+++ b/administrator/language/en-GB/plg_task_privacyconsent.ini
@@ -43,5 +43,4 @@ PLG_TASK_PRIVACYCONSENT_REDIRECT_MESSAGE_DESC="Custom message to be displayed on
 PLG_TASK_PRIVACYCONSENT_REDIRECT_MESSAGE_LABEL="Redirect Message"
 PLG_TASK_PRIVACYCONSENT_REMINDBEFORE_DESC="Number of days to send a reminder before the expiration of the privacy consent."
 PLG_TASK_PRIVACYCONSENT_REMINDBEFORE_LABEL="Remind"
-PLG_TASK_PRIVACYCONSENT_SUBJECT="Privacy Policy"
 PLG_TASK_PRIVACYCONSENT_XML_DESCRIPTION="Task for remind expired consents and delete expired consents"

--- a/plugins/task/privacyconsent/src/Extension/PrivacyConsent.php
+++ b/plugins/task/privacyconsent/src/Extension/PrivacyConsent.php
@@ -127,7 +127,7 @@ final class PrivacyConsent extends CMSPlugin implements SubscriberInterface
         $query->select($db->quoteName(['r.id', 'r.user_id', 'u.email']))
             ->from($db->quoteName('#__privacy_consents', 'r'))
             ->join('LEFT', $db->quoteName('#__users', 'u'), $db->quoteName('u.id') . ' = ' . $db->quoteName('r.user_id'))
-            ->where($db->quoteName('subject') . ' = ' . $db->quote('PLG_TASK_PRIVACYCONSENT_SUBJECT'))
+            ->where($db->quoteName('subject') . ' = ' . $db->quote('PLG_SYSTEM_PRIVACYCONSENT_SUBJECT'))
             ->where($db->quoteName('remind') . ' = 0')
             ->where($query->dateAdd($db->quote($now), $period, 'DAY') . ' > ' . $db->quoteName('created'));
 
@@ -215,7 +215,7 @@ final class PrivacyConsent extends CMSPlugin implements SubscriberInterface
         $query->select($db->quoteName(['id', 'user_id']))
             ->from($db->quoteName('#__privacy_consents'))
             ->where($query->dateAdd($db->quote($now), $period, 'DAY') . ' > ' . $db->quoteName('created'))
-            ->where($db->quoteName('subject') . ' = ' . $db->quote('PLG_TASK_PRIVACYCONSENT_SUBJECT'))
+            ->where($db->quoteName('subject') . ' = ' . $db->quote('PLG_SYSTEM_PRIVACYCONSENT_SUBJECT'))
             ->where($db->quoteName('state') . ' = 1');
 
         $db->setQuery($query);


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/40553#issuecomment-1705561882 .

### Summary of Changes

The new task scheduler plugin "plg_task_privacyconsent" added with PR #40553 queries the database to check for privacy consents for which a reminder should be sent or which are expired.

It uses an own language string key `PLG_TASK_PRIVACYCONSENT_SUBJECT ` for the subject column of the `#__privacy_consents` table in the WHERE condition.

But the privacy consent system plugin which is still handling the non-cyclic functionality inserts the records with language string key `PLG_SYSTEM_PRIVACYCONSENT_SUBJECT`.

See also https://github.com/joomla/joomla-cms/pull/40553#issuecomment-1706100481 .

This is wrong.

The scheduler task should query for records with the `PLG_SYSTEM_PRIVACYCONSENT_SUBJECT`.

The language strings are not translated, only they keys are used, and string `PLG_TASK_PRIVACYCONSENT_SUBJECT ` is not used anywhere else.

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

Wrong language string key used in query.

### Expected result AFTER applying this Pull Request

Right language string key used, and obsolete wrong key removed from the language file of the new scheduler task plugin.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
