### PR TITLE
[5.0] TinyMCE use EditorProvider and Editor event

### DIFF
--- a/plugins/editors/tinymce/src/Extension/TinyMCE.php
+++ b/plugins/editors/tinymce/src/Extension/TinyMCE.php
@@ -10,12 +10,14 @@
 
 namespace Joomla\Plugin\Editors\TinyMCE\Extension;
 
+use Joomla\CMS\Event\Editor\EditorSetupEvent;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
 use Joomla\Database\DatabaseAwareTrait;
-use Joomla\Plugin\Editors\TinyMCE\PluginTraits\DisplayTrait;
+use Joomla\Event\SubscriberInterface;
+use Joomla\Plugin\Editors\CodeMirror\Provider\TinyMCEProvider;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -26,18 +28,38 @@ use Joomla\Plugin\Editors\TinyMCE\PluginTraits\DisplayTrait;
  *
  * @since  1.5
  */
-final class TinyMCE extends CMSPlugin
+final class TinyMCE extends CMSPlugin implements SubscriberInterface
 {
-    use DisplayTrait;
     use DatabaseAwareTrait;
 
     /**
-     * Load the language file on instantiation.
+     * Returns an array of events this subscriber will listen to.
      *
-     * @var    boolean
-     * @since  3.1
+     * @return array
+     *
+     * @since   __DEPLOY_VERSION__
      */
-    protected $autoloadLanguage = true;
+    public static function getSubscribedEvents(): array
+    {
+        return ['onEditorSetup' => 'onEditorSetup'];
+    }
+
+    /**
+     * Register Editor instance
+     *
+     * @param EditorSetupEvent $event
+     *
+     * @return void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function onEditorSetup(EditorSetupEvent $event)
+    {
+        $this->loadLanguage();
+
+        $event->getEditorsRegistry()
+            ->add(new TinyMCEProvider($this->params, $this->getApplication(), $this->getDispatcher()));
+    }
 
     /**
      * Returns the templates
@@ -52,6 +74,8 @@ final class TinyMCE extends CMSPlugin
             echo json_encode([]);
             exit();
         }
+
+        $this->loadLanguage();
 
         $templates = [];
         $language  = $this->getApplication()->getLanguage();

--- a/plugins/editors/tinymce/src/Extension/TinyMCE.php
+++ b/plugins/editors/tinymce/src/Extension/TinyMCE.php
@@ -17,7 +17,7 @@ use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\CMS\Session\Session;
 use Joomla\Database\DatabaseAwareTrait;
 use Joomla\Event\SubscriberInterface;
-use Joomla\Plugin\Editors\CodeMirror\Provider\TinyMCEProvider;
+use Joomla\Plugin\Editors\TinyMCE\Provider\TinyMCEProvider;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -58,7 +58,7 @@ final class TinyMCE extends CMSPlugin implements SubscriberInterface
         $this->loadLanguage();
 
         $event->getEditorsRegistry()
-            ->add(new TinyMCEProvider($this->params, $this->getApplication(), $this->getDispatcher()));
+            ->add(new TinyMCEProvider($this->params, $this->getApplication(), $this->getDispatcher(), $this->getDatabase()));
     }
 
     /**

--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -37,48 +37,43 @@ trait DisplayTrait
     use XTDButtons;
 
     /**
-     * Display the editor area.
+     * Gets the editor HTML markup
      *
-     * @param   string   $name     The name of the editor area.
-     * @param   string   $content  The content of the field.
-     * @param   string   $width    The width of the editor area.
-     * @param   string   $height   The height of the editor area.
-     * @param   int      $col      The number of columns for the editor area.
-     * @param   int      $row      The number of rows for the editor area.
-     * @param   boolean  $buttons  True and the editor buttons will be displayed.
-     * @param   string   $id       An optional ID for the textarea. If not supplied the name is used.
-     * @param   string   $asset    The object asset
-     * @param   object   $author   The author.
-     * @param   array    $params   Associative array of editor parameters.
+     * @param   string  $name        Input name.
+     * @param   string  $content     The content of the field.
+     * @param   array   $attributes  Associative array of editor attributes.
+     * @param   array   $params      Associative array of editor parameters.
      *
-     * @return  string
+     * @return  string  The HTML markup of the editor
+     *
+     * @since   __DEPLOY_VERSION__
      */
-    public function onDisplay(
-        $name,
-        $content,
-        $width,
-        $height,
-        $col,
-        $row,
-        $buttons = true,
-        $id = null,
-        $asset = null,
-        $author = null,
-        $params = []
-    ) {
-        $id              = empty($id) ? $name : $id;
-        $user            = $this->getApplication()->getIdentity();
-        $language        = $this->getApplication()->getLanguage();
-        $doc             = $this->getApplication()->getDocument();
+    public function display(string $name, string $content = '', array $attributes = [], array $params = []): string
+    {
+        // General variables
+        $app             = $this->application;
+        $user            = $app->getIdentity();
+        $language        = $app->getLanguage();
+        $doc             = $app->getDocument();
         $wa              = $doc->getWebAssetManager();
+        $options         = $doc->getScriptOptions('plg_editor_tinymce');
+        $csrf            = Session::getFormToken();
+
+        // Editor variables
+        $col             = $attributes['col'] ?? '';
+        $row             = $attributes['row'] ?? '';
+        $width           = $attributes['width'] ?? '';
+        $height          = $attributes['height'] ?? '';
+        $id              = $attributes['id'] ?? $name;
         $id              = preg_replace('/(\s|[^A-Za-z0-9_])+/', '_', $id);
         $nameGroup       = explode('[', preg_replace('/\[\]|\]/', '', $name));
         $fieldName       = end($nameGroup);
+        $buttons         = $params['buttons'] ?? true;
+        $asset           = $params['asset'] ?? 0;
+        $author          = $params['author'] ?? 0;
         $scriptOptions   = [];
         $externalPlugins = [];
-        $options         = $doc->getScriptOptions('plg_editor_tinymce');
         $theme           = 'silver';
-        $csrf            = Session::getFormToken();
 
         // Data object for the layout
         $textarea           = new \stdClass();
@@ -95,7 +90,7 @@ trait DisplayTrait
         // Render Editor markup
         $editor = '<div class="js-editor-tinymce">';
         $editor .= LayoutHelper::render('joomla.tinymce.textarea', $textarea);
-        $editor .= !$this->getApplication()->client->mobile ? LayoutHelper::render('joomla.tinymce.togglebutton') : '';
+        $editor .= !$app->client->mobile ? LayoutHelper::render('joomla.tinymce.togglebutton') : '';
         $editor .= '</div>';
 
         // Prepare the instance specific options
@@ -119,15 +114,15 @@ trait DisplayTrait
 
         // The ext-buttons
         if (empty($options['tinyMCE'][$fieldName]['joomlaExtButtons'])) {
-            $btns = $this->tinyButtons($id, $buttons);
+            $tinyButtons = $this->tinyButtons($buttons, ['asset' => $asset, 'author' => $author, 'editorId' => $id]);
 
             $options['tinyMCE'][$fieldName]['joomlaMergeDefaults'] = true;
-            $options['tinyMCE'][$fieldName]['joomlaExtButtons']    = $btns;
+            $options['tinyMCE'][$fieldName]['joomlaExtButtons']    = $tinyButtons;
         }
 
         $doc->addScriptOptions('plg_editor_tinymce', $options, false);
-        // Setup Default (common) options for the Editor script
 
+        // Setup Default (common) options for all Editor instances
         // Check whether we already have them
         if (!empty($options['tinyMCE']['default'])) {
             return $editor;
@@ -142,7 +137,7 @@ trait DisplayTrait
         $extraOptionsAll  = (array) $this->params->get('configuration.setoptions', []);
         $toolbarParamsAll = (array) $this->params->get('configuration.toolbars', []);
 
-        // Sort the array in reverse, so the items with lowest access level goes first
+        // Sort the array in reverse, so the items with the lowest access level goes first
         krsort($extraOptionsAll);
 
         // Get configuration depend from User group
@@ -177,7 +172,7 @@ trait DisplayTrait
         $levelParams->loadObject($extraOptions);
 
         // Set the selected skin
-        $skin = $levelParams->get($this->getApplication()->isClient('administrator') ? 'skin_admin' : 'skin', 'oxide');
+        $skin = $levelParams->get($app->isClient('administrator') ? 'skin_admin' : 'skin', 'oxide');
 
         // Check that selected skin exists.
         $skin = Folder::exists(JPATH_ROOT . '/media/vendor/tinymce/skins/ui/' . $skin) ? $skin : 'oxide';
@@ -340,7 +335,7 @@ trait DisplayTrait
         if ($dragdrop && $user->authorise('core.create', 'com_media')) {
             $externalPlugins['jdragndrop'] = HTMLHelper::_('script', 'plg_editors_tinymce/plugins/dragdrop/plugin.min.js', ['relative' => true, 'version' => 'auto', 'pathOnly' => true]);
             $uploadUrl                     = Uri::base(false) . 'index.php?option=com_media&format=json&url=1&task=api.files';
-            $uploadUrl                     = $this->getApplication()->isClient('site') ? htmlentities($uploadUrl, ENT_NOQUOTES, 'UTF-8', false) : $uploadUrl;
+            $uploadUrl                     = $app->isClient('site') ? htmlentities($uploadUrl, ENT_NOQUOTES, 'UTF-8', false) : $uploadUrl;
 
             Text::script('PLG_TINY_ERR_UNSUPPORTEDBROWSER');
             Text::script('ERROR');
@@ -516,6 +511,7 @@ trait DisplayTrait
         $options['tinyMCE']['default']        = $scriptOptions;
 
         $doc->addScriptOptions('plg_editor_tinymce', $options);
+
 
         return $editor;
     }

--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -512,7 +512,6 @@ trait DisplayTrait
 
         $doc->addScriptOptions('plg_editor_tinymce', $options);
 
-
         return $editor;
     }
 }

--- a/plugins/editors/tinymce/src/PluginTraits/XTDButtons.php
+++ b/plugins/editors/tinymce/src/PluginTraits/XTDButtons.php
@@ -13,7 +13,6 @@ namespace Joomla\Plugin\Editors\TinyMCE\PluginTraits;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Event\Event;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -29,110 +28,102 @@ trait XTDButtons
     /**
      * Get the XTD buttons and render them inside tinyMCE
      *
-     * @param   string  $name      the id of the editor field
-     * @param   string  $excluded  the buttons that should be hidden
+     * @param   mixed  $buttons  the buttons that should be hidden
+     * @param   array  $options  Associative array with additional parameters
      *
-     * @return array|void
+     * @return array
      *
      * @since 4.1.0
      */
-    private function tinyButtons($name, $excluded)
+    private function tinyButtons($buttons, array $options = []): array
     {
-        // Get the available buttons
-        $buttonsEvent = new Event(
-            'getButtons',
-            [
-                'editor'  => $name,
-                'buttons' => $excluded,
-            ]
-        );
+        // Get buttons from plugins
+        $buttonsList = $this->getButtons($buttons, $options);
 
-        $buttonsResult = $this->getDispatcher()->dispatch('getButtons', $buttonsEvent);
-        $buttons       = $buttonsResult['result'];
+        if (!$buttonsList) {
+            return [];
+        }
 
         /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
-        $wa = $this->getApplication()->getDocument()->getWebAssetManager();
+        $wa       = $this->application->getDocument()->getWebAssetManager();
+        $editorId = $options['editorId'] ?? '';
 
-        if (is_array($buttons) || (is_bool($buttons) && $buttons)) {
-            Text::script('PLG_TINY_CORE_BUTTONS');
+        Text::script('PLG_TINY_CORE_BUTTONS');
 
-            // Init the arrays for the buttons
-            $btnsNames = [];
+        // Build a buttons option for TinyMCE
+        $tinyButtons = [];
 
-            // Build the script
-            foreach ($buttons as $button) {
-                $title   = $button->get('title') ?: $button->get('text', '');
-                $icon    = $button->get('icon');
-                $link    = $button->get('link');
-                $action  = $button->get('action', '');
-                $options = (array) $button->get('options');
+        foreach ($buttonsList as $button) {
+            $title   = $button->get('title') ?: $button->get('text', '');
+            $icon    = $button->get('icon');
+            $link    = $button->get('link');
+            $action  = $button->get('action', '');
+            $options = (array) $button->get('options');
 
-                $btnAsset = 'editor-button.' . $button->getButtonName();
+            $btnAsset = 'editor-button.' . $button->getButtonName();
 
-                // Enable the button assets if any
-                if ($wa->assetExists('style', $btnAsset)) {
-                    $wa->useStyle($btnAsset);
-                }
-                if ($wa->assetExists('script', $btnAsset)) {
-                    $wa->useScript($btnAsset);
-                }
-
-                // Correct the link
-                if ($link && $link[0] !== '#') {
-                    $link           = str_contains($link, '&amp;') ? htmlspecialchars_decode($link) : $link;
-                    $link           = Uri::base(true) . '/' . $link;
-                    $options['src'] = $options['src'] ?? $link;
-                }
-
-                // Set action to "modal" for legacy buttons, when possible
-                $legacyModal = $button->get('modal') && !empty($options['confirmCallback']);
-
-                if (!$action && $button->get('modal') && !$legacyModal) {
-                    $action = 'modal';
-
-                    // Backward compatibility check, for older options
-                    if (!empty($options['modalWidth'])) {
-                        $options['width'] = $options['modalWidth'] . 'vw';
-                    }
-                    if (!empty($options['bodyHeight'])) {
-                        $options['height'] = $options['bodyHeight'] . 'vh';
-                    }
-                }
-
-                // Prepare default values for modal
-                if ($action === 'modal') {
-                    $this->getApplication()->getDocument()
-                        ->getWebAssetManager()->useScript('joomla.dialog');
-
-                    $options['popupType']  = $options['popupType'] ?? 'iframe';
-                    $options['textHeader'] = $options['textHeader'] ?? $title;
-                    $options['iconHeader'] = $options['iconHeader'] ?? 'icon-' . $icon;
-                }
-
-                $coreButton            = [];
-                $coreButton['name']    = $title;
-                $coreButton['icon']    = $icon;
-                $coreButton['click']   = $button->get('onclick');
-                $coreButton['iconSVG'] = $button->get('iconSVG');
-                $coreButton['action']  = $action;
-                $coreButton['options'] = $options;
-
-                if ($legacyModal) {
-                    $coreButton['bsModal'] = true;
-                    $coreButton['id']      = $name . '_' . $button->name;
-
-                    $button->id = $name . '_' . $button->name . '_modal';
-
-                    echo LayoutHelper::render('joomla.editors.buttons.modal', $button);
-                }
-
-                // The array with the toolbar buttons
-                $btnsNames[] = $coreButton;
+            // Enable the button assets if any
+            if ($wa->assetExists('style', $btnAsset)) {
+                $wa->useStyle($btnAsset);
+            }
+            if ($wa->assetExists('script', $btnAsset)) {
+                $wa->useScript($btnAsset);
             }
 
-            sort($btnsNames);
+            // Correct the link
+            if ($link && $link[0] !== '#') {
+                $link           = str_contains($link, '&amp;') ? htmlspecialchars_decode($link) : $link;
+                $link           = Uri::base(true) . '/' . $link;
+                $options['src'] = $options['src'] ?? $link;
+            }
 
-            return ['names' => $btnsNames];
+            // Set action to "modal" for legacy buttons, when possible
+            $legacyModal = $button->get('modal') && !empty($options['confirmCallback']);
+
+            if (!$action && $button->get('modal') && !$legacyModal) {
+                $action = 'modal';
+
+                // Backward compatibility check, for older options
+                if (!empty($options['modalWidth'])) {
+                    $options['width'] = $options['modalWidth'] . 'vw';
+                }
+                if (!empty($options['bodyHeight'])) {
+                    $options['height'] = $options['bodyHeight'] . 'vh';
+                }
+            }
+
+            // Prepare default values for modal
+            if ($action === 'modal') {
+                $wa->useScript('joomla.dialog');
+
+                $options['popupType']  = $options['popupType'] ?? 'iframe';
+                $options['textHeader'] = $options['textHeader'] ?? $title;
+                $options['iconHeader'] = $options['iconHeader'] ?? 'icon-' . $icon;
+            }
+
+            $coreButton            = [];
+            $coreButton['name']    = $title;
+            $coreButton['icon']    = $icon;
+            $coreButton['click']   = $button->get('onclick');
+            $coreButton['iconSVG'] = $button->get('iconSVG');
+            $coreButton['action']  = $action;
+            $coreButton['options'] = $options;
+
+            if ($legacyModal) {
+                $coreButton['bsModal'] = true;
+                $coreButton['id']      = $editorId . '_' . $button->name;
+
+                $button->id = $editorId . '_' . $button->name . '_modal';
+
+                echo LayoutHelper::render('joomla.editors.buttons.modal', $button);
+            }
+
+            // The array with the toolbar buttons
+            $tinyButtons[] = $coreButton;
         }
+
+        sort($tinyButtons);
+
+        return ['names' => $tinyButtons];
     }
 }

--- a/plugins/editors/tinymce/src/Provider/TinyMCEProvider.php
+++ b/plugins/editors/tinymce/src/Provider/TinyMCEProvider.php
@@ -7,13 +7,14 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-namespace Joomla\Plugin\Editors\CodeMirror\Provider;
+namespace Joomla\Plugin\Editors\TinyMCE\Provider;
 
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Editor\AbstractEditorProvider;
-use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\Uri\Uri;
+use Joomla\Database\DatabaseAwareTrait;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Event\DispatcherInterface;
+use Joomla\Plugin\Editors\TinyMCE\PluginTraits\DisplayTrait;
 use Joomla\Registry\Registry;
 
 /**
@@ -23,6 +24,9 @@ use Joomla\Registry\Registry;
  */
 final class TinyMCEProvider extends AbstractEditorProvider
 {
+    use DisplayTrait;
+    use DatabaseAwareTrait;
+
     /**
      * A Registry object holding the parameters for the plugin
      *
@@ -49,12 +53,17 @@ final class TinyMCEProvider extends AbstractEditorProvider
      *
      * @since  __DEPLOY_VERSION__
      */
-    public function __construct(Registry $params, CMSApplicationInterface $application, DispatcherInterface $dispatcher)
-    {
+    public function __construct(
+        Registry $params,
+        CMSApplicationInterface $application,
+        DispatcherInterface $dispatcher,
+        DatabaseInterface $database
+    ) {
         $this->params      = $params;
         $this->application = $application;
 
         $this->setDispatcher($dispatcher);
+        $this->setDatabase($database);
     }
 
     /**
@@ -66,22 +75,5 @@ final class TinyMCEProvider extends AbstractEditorProvider
     public function getName(): string
     {
         return 'tinymce';
-    }
-
-    /**
-     * Gets the editor HTML markup
-     *
-     * @param   string  $name        Input name.
-     * @param   string  $content     The content of the field.
-     * @param   array   $attributes  Associative array of editor attributes.
-     * @param   array   $params      Associative array of editor parameters.
-     *
-     * @return  string  The HTML markup of the editor
-     *
-     * @since   __DEPLOY_VERSION__
-     */
-    public function display(string $name, string $content = '', array $attributes = [], array $params = []): string
-    {
-        return '';
     }
 }

--- a/plugins/editors/tinymce/src/Provider/TinyMCEProvider.php
+++ b/plugins/editors/tinymce/src/Provider/TinyMCEProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Plugin\Editors\CodeMirror\Provider;
+
+use Joomla\CMS\Application\CMSApplicationInterface;
+use Joomla\CMS\Editor\AbstractEditorProvider;
+use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\CMS\Uri\Uri;
+use Joomla\Event\DispatcherInterface;
+use Joomla\Registry\Registry;
+
+/**
+ * Editor provider class
+ *
+ * @since   __DEPLOY_VERSION__
+ */
+final class TinyMCEProvider extends AbstractEditorProvider
+{
+    /**
+     * A Registry object holding the parameters for the plugin
+     *
+     * @var    Registry
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $params;
+
+    /**
+     * The application object
+     *
+     * @var    CMSApplicationInterface
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $application;
+
+    /**
+     * Class constructor
+     *
+     * @param   Registry                 $params
+     * @param   CMSApplicationInterface  $application
+     * @param   DispatcherInterface      $dispatcher
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function __construct(Registry $params, CMSApplicationInterface $application, DispatcherInterface $dispatcher)
+    {
+        $this->params      = $params;
+        $this->application = $application;
+
+        $this->setDispatcher($dispatcher);
+    }
+
+    /**
+     * Return Editor name, CMD string.
+     *
+     * @return string
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getName(): string
+    {
+        return 'tinymce';
+    }
+
+    /**
+     * Gets the editor HTML markup
+     *
+     * @param   string  $name        Input name.
+     * @param   string  $content     The content of the field.
+     * @param   array   $attributes  Associative array of editor attributes.
+     * @param   array   $params      Associative array of editor parameters.
+     *
+     * @return  string  The HTML markup of the editor
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function display(string $name, string $content = '', array $attributes = [], array $params = []): string
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
### Summary of Changes

Transforming TinyMCE to use EditorProvider and `onEditorSetup` event.
Basicaly just renaming a couple of methods, and variables rearange.



### Testing Instructions
Apply patch.
Use TinyMCE to edit an article.


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, but better.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: IDK
- [ ] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/97
- [ ] No documentation changes for manual.joomla.org needed

Reference:
- https://github.com/joomla/joomla-cms/pull/40082
