### PR TITLE
Update ListPlugin.php fix API

### DIFF
--- a/plugins/fields/list/src/Extension/ListPlugin.php
+++ b/plugins/fields/list/src/Extension/ListPlugin.php
@@ -44,9 +44,20 @@ final class ListPlugin extends FieldsListPlugin
             return;
         }
 
-        $options = $this->getOptionsFromField($field);
+        if (empty($field->value)) {
+            return;
+        }
 
-        $field->apivalue = [$field->value => $options[$field->value]];
+        $options = $this->getOptionsFromField($field);
+        
+        //API
+        if (is_array($field->value)) {
+            foreach ($field->value as $key => $value) {
+                $field->apivalue[$value] = $options[$value];
+            }
+        } else {
+            $field->apivalue[$field->value] = $options[$field->value];
+        }
     }
 
     /**

--- a/plugins/fields/list/src/Extension/ListPlugin.php
+++ b/plugins/fields/list/src/Extension/ListPlugin.php
@@ -49,8 +49,8 @@ final class ListPlugin extends FieldsListPlugin
         }
 
         $options = $this->getOptionsFromField($field);
-        
-        //API
+
+        // API
         if (is_array($field->value)) {
             foreach ($field->value as $key => $value) {
                 $field->apivalue[$value] = $options[$value];


### PR DESCRIPTION
Added two checkers:
if empty
if is array.

The current file gives error 500 in api.

Pull Request for Issue # .

### Summary of Changes

//added return on empty
if (empty($field->value)) {
            return;
 }

//API
//if api and array splits values
if (is_array($field->value)) {
    foreach ($field->value as $key => $value) {
        $field->apivalue[$value] = $options[$value];
    }
} else {
//default values
    $field->apivalue[$field->value] = $options[$field->value];
}

### Testing Instructions



### Actual result BEFORE applying this Pull Request

ERROR 500 on empty values with api query

### Expected result AFTER applying this Pull Request

if multiple:
"name-of-list-field": {
                    "text": "value",
                     "text": "value",
...
}

if single:
"name-of-list-field": {
                    "text": "value"
}


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
