### PR TITLE
[5.0] Fix deprecated null warning, in ModuleAdapter: Deprecated: PDO::quote(): Passing null to parameter 1

### DIFF
--- a/libraries/src/Installer/Adapter/FileAdapter.php
+++ b/libraries/src/Installer/Adapter/FileAdapter.php
@@ -200,7 +200,7 @@ class FileAdapter extends InstallerAdapter
     public function getElement($element = null)
     {
         if (!$element) {
-            $manifestPath = Path::clean($this->parent->getPath('manifest'));
+            $manifestPath = Path::clean($this->parent->getPath('manifest', ''));
             $element      = preg_replace('/\.xml/', '', basename($manifestPath));
         }
 

--- a/libraries/src/Installer/Adapter/ModuleAdapter.php
+++ b/libraries/src/Installer/Adapter/ModuleAdapter.php
@@ -643,6 +643,7 @@ class ModuleAdapter extends InstallerAdapter
             $module->params    = '';
             $module->client_id = $this->clientId;
             $module->language  = '*';
+            $module->position  = '';
 
             $module->store();
         }


### PR DESCRIPTION
### Summary of Changes

Fix deprecation for ModuleAdapter
`Deprecated: PDO::quote(): Passing null to parameter 1 ($string) of type string is deprecated `
And `Patch::clean()` on `null`.

### Testing Instructions
Enable error_reaporting to maximum
Try install any module.


### Actual result BEFORE applying this Pull Request
An error message `Unexpected token ...` 
Open Browser console, in network tab for the POST request will be full deprecation message:
`Deprecated: PDO::quote(): Passing null to parameter 1 ($string) of type string is deprecated ` for line https://github.com/joomla/joomla-cms/blob/f19e3f3e0a28707535c72b09c3341e03b04bcb56/libraries/src/Table/Module.php#L210


### Expected result AFTER applying this Pull Request
Module installed without error.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
