### PR TITLE
Fix double border on toolbar

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_layout.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_layout.scss
@@ -11,7 +11,7 @@
     padding: 0 1rem;
     font-weight: $font-weight-bold;
     color: var(--template-text-dark);
-    background-color: var(--bg-color);
+    background-color: var(--body-bg);
   }
 
   @if $enable-dark-mode {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
@@ -46,7 +46,6 @@
     font-size: 1rem;
     line-height: $atum-toolbar-line-height;
     color: var(--template-text-dark);
-    background: var(--bg-color);
     border-color: hsl(var(--hue),20%,80%);
 
     > span {
@@ -155,6 +154,10 @@
   .dropdown-menu joomla-toolbar-button,
   .btn-group joomla-toolbar-button {
     margin-inline-start: 0;
+
+    button {
+      border-right-width: 0;
+    }
   }
 
   .contentpane & {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
@@ -46,6 +46,7 @@
     font-size: 1rem;
     line-height: $atum-toolbar-line-height;
     color: var(--template-text-dark);
+    background: var(--body-bg);
     border-color: hsl(var(--hue),20%,80%);
 
     > span {
@@ -154,10 +155,6 @@
   .dropdown-menu joomla-toolbar-button,
   .btn-group joomla-toolbar-button {
     margin-inline-start: 0;
-
-    button {
-      border-right-width: 0;
-    }
   }
 
   .contentpane & {

--- a/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -39,7 +39,7 @@ joomla-tab {
       display: block;
       padding: .6rem 1rem;
       text-decoration: none;
-      background-color: var(--bg-color);
+      background-color: var(--body-bg);
       border: 0;
       box-shadow: none;
 


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41571 (Partial).

### Summary of Changes
Fixes the save button toolbar double border when editing and also fixes an undefined variable in the tabs element too that invisible but still was a technical bug. `bg-color` was a bad copy paste from quickicons (where it was correct specifically ther) and should have been `body-bg`

For the toolbar I’ve been consistent with the original dark mode approach and removed the background just hiding the extra border. But if this causes any unexpected issues I’ll revert to using body-bg there too.

### Testing Instructions
Check images from original issue specifically related to the toolbar icon. Should be the same as the Joomla 4.x layout after patch applied

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
