### PR TITLE
[5.0] Fix return type for onContentBeforeDisplay

### DIFF
--- a/plugins/content/pagenavigation/src/Extension/PageNavigation.php
+++ b/plugins/content/pagenavigation/src/Extension/PageNavigation.php
@@ -39,7 +39,7 @@ final class PageNavigation extends CMSPlugin
      * @param   mixed    &$params  The article params
      * @param   integer  $page     The 'page' number
      *
-     * @return  mixed  void or true
+     * @return  void
      *
      * @since   1.6
      */
@@ -50,7 +50,7 @@ final class PageNavigation extends CMSPlugin
         $print = $app->getInput()->getBool('print');
 
         if ($print) {
-            return false;
+            return;
         }
 
         if ($context === 'com_content.article' && $view === 'article' && $params->get('show_item_navigation')) {

--- a/plugins/content/vote/src/Extension/Vote.php
+++ b/plugins/content/vote/src/Extension/Vote.php
@@ -84,7 +84,7 @@ final class Vote extends CMSPlugin
      * @param   object   &$params  The article params
      * @param   integer  $page     The 'page' number
      *
-     * @return  string|boolean  HTML string containing code for the votes if in com_content else boolean false
+     * @return  string  HTML string containing code for the votes if in com_content else empty string
      *
      * @since   3.7.0
      */
@@ -93,7 +93,7 @@ final class Vote extends CMSPlugin
         $parts = explode('.', $context);
 
         if ($parts[0] !== 'com_content') {
-            return false;
+            return '';
         }
 
         if (empty($params) || !$params->get('show_vote', null)) {


### PR DESCRIPTION
Pull Request for Issue #41611 .

### Summary of Changes
Quick fix for return type, for our legacy listener onContentBeforeDisplay.



### Testing Instructions
Enable Voting plugin,
Open any article or tag


### Actual result BEFORE applying this Pull Request
And error


### Expected result AFTER applying this Pull Request
No error


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
