### PR TITLE
[5.0] Include Codemirror Markdown support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@codemirror/lang-html": "^6.4.6",
         "@codemirror/lang-javascript": "^6.2.1",
         "@codemirror/lang-json": "^6.0.1",
+        "@codemirror/lang-markdown": "^6.0.1",
         "@codemirror/lang-php": "^6.0.1",
         "@codemirror/lang-xml": "^6.0.2",
         "@codemirror/language": "^6.9.0",
@@ -1855,6 +1856,20 @@
         "@lezer/json": "^1.0.0"
       }
     },
+    "node_modules/@codemirror/lang-markdown": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-markdown/-/lang-markdown-6.2.0.tgz",
+      "integrity": "sha512-deKegEQVzfBAcLPqsJEa+IxotqPVwWZi90UOEvQbfa01NTAw8jNinrykuYPTULGUj+gha0ZG2HBsn4s5d64Qrg==",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.7.1",
+        "@codemirror/lang-html": "^6.0.0",
+        "@codemirror/language": "^6.3.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/common": "^1.0.0",
+        "@lezer/markdown": "^1.0.0"
+      }
+    },
     "node_modules/@codemirror/lang-php": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@codemirror/lang-php/-/lang-php-6.0.1.tgz",
@@ -2282,6 +2297,15 @@
       "integrity": "sha512-BZfVvf7Re5BIwJHlZXbJn9L8lus5EonxQghyn+ih8Wl36XMFBPTXC0KM0IdUtj9w/diPHsKlXVgL+AlX2jYJ0Q==",
       "dependencies": {
         "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@lezer/markdown": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@lezer/markdown/-/markdown-1.1.0.tgz",
+      "integrity": "sha512-JYOI6Lkqbl83semCANkO3CKbKc0pONwinyagBufWBm+k4yhIcqfCF8B8fpEpvJLmIy7CAfwiq7dQ/PzUZA340g==",
+      "dependencies": {
+        "@lezer/common": "^1.0.0",
+        "@lezer/highlight": "^1.0.0"
       }
     },
     "node_modules/@lezer/php": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@codemirror/lang-html": "^6.4.6",
     "@codemirror/lang-javascript": "^6.2.1",
     "@codemirror/lang-json": "^6.0.1",
+    "@codemirror/lang-markdown": "^6.0.1",
     "@codemirror/lang-php": "^6.0.1",
     "@codemirror/lang-xml": "^6.0.2",
     "@codemirror/language": "^6.9.0",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Add `markdown` mode support for Codemirror.
Any other modes need to be inlcuded by default?


### Testing Instructions
Apply patch. Run `npm install`
Add editor field in mod_custom:
```xml
<field name="editor_test" type="editor" label="Editor" 
  syntax="markdown" editor="codemirror" filter="safehtml"/>
```


### Actual result BEFORE applying this Pull Request
No markdown support


### Expected result AFTER applying this Pull Request
Markdown works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed

Reference:
- https://github.com/joomla/joomla-cms/pull/41070