### PR TITLE
[5.0] Fix events with non required arguments: AfterPurgeEvent::setSubject(): Argument 1 must be of type string, null given

### DIFF
--- a/libraries/src/Event/Cache/AfterPurgeEvent.php
+++ b/libraries/src/Event/Cache/AfterPurgeEvent.php
@@ -48,7 +48,7 @@ class AfterPurgeEvent extends AbstractImmutableEvent
     public function __construct($name, array $arguments = [])
     {
         // Reshape the arguments array to preserve b/c with legacy listeners
-        if ($this->legacyArgumentsOrder) {
+        if ($this->legacyArgumentsOrder && $arguments) {
             $arguments = $this->reshapeArguments($arguments, $this->legacyArgumentsOrder);
         }
 

--- a/libraries/src/Event/Checkin/AfterCheckinEvent.php
+++ b/libraries/src/Event/Checkin/AfterCheckinEvent.php
@@ -48,7 +48,7 @@ class AfterCheckinEvent extends AbstractImmutableEvent
     public function __construct($name, array $arguments = [])
     {
         // Reshape the arguments array to preserve b/c with legacy listeners
-        if ($this->legacyArgumentsOrder) {
+        if ($this->legacyArgumentsOrder && $arguments) {
             $arguments = $this->reshapeArguments($arguments, $this->legacyArgumentsOrder);
         }
 

--- a/libraries/src/Event/Extension/AbstractExtensionEvent.php
+++ b/libraries/src/Event/Extension/AbstractExtensionEvent.php
@@ -48,7 +48,7 @@ abstract class AbstractExtensionEvent extends AbstractImmutableEvent
     public function __construct($name, array $arguments = [])
     {
         // Reshape the arguments array to preserve b/c with legacy listeners
-        if ($this->legacyArgumentsOrder) {
+        if ($this->legacyArgumentsOrder && $arguments) {
             $arguments = $this->reshapeArguments($arguments, $this->legacyArgumentsOrder);
         }
 

--- a/libraries/src/Event/Extension/AbstractExtensionEvent.php
+++ b/libraries/src/Event/Extension/AbstractExtensionEvent.php
@@ -48,7 +48,7 @@ abstract class AbstractExtensionEvent extends AbstractImmutableEvent
     public function __construct($name, array $arguments = [])
     {
         // Reshape the arguments array to preserve b/c with legacy listeners
-        if ($this->legacyArgumentsOrder && $arguments) {
+        if ($this->legacyArgumentsOrder) {
             $arguments = $this->reshapeArguments($arguments, $this->legacyArgumentsOrder);
         }
 

--- a/libraries/src/Event/Privacy/PrivacyEvent.php
+++ b/libraries/src/Event/Privacy/PrivacyEvent.php
@@ -48,7 +48,7 @@ abstract class PrivacyEvent extends AbstractImmutableEvent
     public function __construct($name, array $arguments = [])
     {
         // Reshape the arguments array to preserve b/c with legacy listeners
-        if ($this->legacyArgumentsOrder) {
+        if ($this->legacyArgumentsOrder && $arguments) {
             $arguments = $this->reshapeArguments($arguments, $this->legacyArgumentsOrder);
         }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

`reshapeArguments` should not be called when there no required arguments, and arguments is empty.

Fix error `AfterPurgeEvent::setSubject(): Argument #1 ($value) must be of type string, null given`
When trying to clean all cache, and similar cases


### Testing Instructions
Go to Maintenance: clear cache.
And click "Delete all"


### Actual result BEFORE applying this Pull Request
And error


### Expected result AFTER applying this Pull Request
No error


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
