### PR TITLE
[5.0] Smart Search: Add missing events to debug adapter

### DIFF
--- a/administrator/components/com_finder/src/Indexer/DebugAdapter.php
+++ b/administrator/components/com_finder/src/Indexer/DebugAdapter.php
@@ -157,6 +157,23 @@ abstract class DebugAdapter extends CMSPlugin
     }
 
     /**
+     * Returns an array of events this subscriber will listen to.
+     *
+     * @return  array
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            'onBeforeIndex'             => 'onBeforeIndex',
+            'onBuildIndex'              => 'onBuildIndex',
+            'onFinderGarbageCollection' => 'onFinderGarbageCollection',
+            'onStartIndex'              => 'onStartIndex',
+        ];
+    }
+
+    /**
      * Method to get the adapter state and push it into the indexer.
      *
      * @return  void


### PR DESCRIPTION
### Summary of Changes

Apply changes from #41501 also to debug adapter

### Testing Instructions

Test new Smart Search debugging features (#36753)

### Actual result BEFORE applying this Pull Request

`Call to undefined method Joomla\Component\Finder\Administrator\Indexer\DebugAdapter::getSubscribedEvents()`

![image](https://github.com/joomla/joomla-cms/assets/66922325/9f7385d0-48ee-4612-9709-2ebd3aac2c50)

### Expected result AFTER applying this Pull Request

Result is displayed
![image](https://github.com/joomla/joomla-cms/assets/66922325/0d232ab0-bf28-40a1-8973-5fe795277e82)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
