### PR TITLE
[5.0] Improve tabs hover color

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -50,7 +50,7 @@ joomla-tab {
       &[aria-expanded=true],
       &:focus,
       &:hover {
-        color: var(--primary);
+        color: var(--template-bg-dark-60);
         border: 0;
         border-radius: 0;
         box-shadow: none;
@@ -73,16 +73,22 @@ joomla-tab {
 
       &[aria-expanded=true] {
         font-weight: $font-weight-bold;
-        color: var(--primary);
         background: var(--template-bg-dark-3);
       }
 
       @if $enable-dark-mode {
         @include color-mode(dark) {
           /* stylelint-disable max-nesting-depth */
-          &[aria-expanded=true] {
+          &[aria-expanded=true],
+          &:focus,
+          &:hover {
             /* stylelint-enable max-nesting-depth */
             color: var(--template-text-light);
+          }
+
+          /* stylelint-disable max-nesting-depth */
+          &[aria-expanded=true] {
+            /* stylelint-enable max-nesting-depth */
             background: var(--template-bg-dark-60);
           }
         }


### PR DESCRIPTION
### Summary of Changes
Follow up to an issue raised by @Quy in the dark mode PR. Also improves the experience in light mode by using the template themed color in light mode as well rather than the bootstrap primary color (so in non-blue color schemes the tab color appears more in keeping with the site design)

### Testing Instructions
When editing a template look at the tab presets before and after applying this PR (note this is a SCSS based PR so patchtester will not work)

Validate that the active tab, hover and focus effects on tabs work in both light and dark mode of the template. In light mode there will be a slight shift (which should be borderline unnoticeable unless you change the template theme from the default preset) and in dark mode currently you get a very dark blue color on hover which is now effectively removed by using the template light text color.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
