### PR TITLE
Fix background of installation tables

### DIFF
--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -24,6 +24,7 @@ $fa-font-path: "../../../media/vendor/fontawesome-free/webfonts";
 @import "../../../build/media_source/templates/administrator/atum/scss/variables";
 
 $body-bg: $template-background-light;
+$table-bg: transparent;
 
 @import "../../../media/vendor/bootstrap/scss/variables";
 @import "../../../media/vendor/bootstrap/scss/variables-dark";


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41571 (part)

### Summary of Changes
Fixes the background of tables in the installer per the issue in 41571. It's a slightly weird fix specific to the installer but I can't find anything obvious it breaks and it makes life much easier :)

### Testing Instructions
View table backgrounds  in the before/after screenshots of the original issue. Check any other tables in the installation

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
