### PR TITLE
[5.0] Modal field for Modal_Menu

### DIFF
--- a/administrator/components/com_menus/layouts/joomla/form/field/modal-select/extra-buttons.php
+++ b/administrator/components/com_menus/layouts/joomla/form/field/modal-select/extra-buttons.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean  $autofocus       Is autofocus enabled?
+ * @var   string   $class           Classes for the input.
+ * @var   string   $description     Description of the field.
+ * @var   boolean  $disabled        Is this field disabled?
+ * @var   string   $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean  $hidden          Is this field hidden in the form?
+ * @var   string   $hint            Placeholder for the field.
+ * @var   string   $id              DOM id of the field.
+ * @var   string   $label           Label of the field.
+ * @var   string   $labelclass      Classes to apply to the label.
+ * @var   boolean  $multiple        Does this field support multiple values?
+ * @var   string   $name            Name of the input field.
+ * @var   string   $onchange        Onchange attribute for the field.
+ * @var   string   $onclick         Onclick attribute for the field.
+ * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean  $readonly        Is this field read only?
+ * @var   boolean  $repeat          Allows extensions to duplicate elements.
+ * @var   boolean  $required        Is this field required?
+ * @var   integer  $size            Size attribute of the input.
+ * @var   boolean  $spellcheck      Spellcheck state for the form field.
+ * @var   string   $validate        Validation rules to apply.
+ * @var   string   $value           Value attribute of the field.
+ * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
+ * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*
+ * @var   string   $valueTitle
+ * @var   array    $canDo
+ * @var   string[] $urls
+ * @var   string[] $modalTitles
+ * @var   string   $language
+ */
+
+// Do nothing when propagate is disabled
+if (empty($canDo['propagate'])) {
+    return;
+}
+
+// Scripts for backward compatibility
+/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->useScript('field.modal-fields');
+$wa->addInlineScript(
+    'window.jSelectMenu_' . $id . ' = function (id, title, object) {
+  window.processModalSelect("Item", "' . $id . '", id, title, "", object);
+}',
+    ['name' => 'inline.select_menu_' . $id],
+    ['type' => 'module']
+);
+Text::script('JGLOBAL_ASSOCIATIONS_PROPAGATE_FAILED');
+
+// Language propagate callback name
+// Strip off language tag at the end
+$tagLength            = strlen($language);
+$callbackFunctionStem = substr("jSelectMenu_" . $id, 0, -$tagLength);
+
+?>
+
+<button type="button" class="btn btn-primary" <?php echo $value ? '' : 'hidden'; ?>
+        title="<?php echo $this->escape(Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_TIP')); ?>"
+        data-show-when-value="1"
+        onclick="Joomla.propagateAssociation('<?php echo $id; ?>', '<?php echo $callbackFunctionStem; ?>')">
+    <span class="icon-sync" aria-hidden="true"></span> <?php echo Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_BUTTON'); ?>
+</button>

--- a/administrator/components/com_menus/src/Controller/ItemController.php
+++ b/administrator/components/com_menus/src/Controller/ItemController.php
@@ -173,14 +173,19 @@ class ItemController extends FormController
             $this->app->setUserState($context . '.type', null);
             $this->app->setUserState($context . '.link', null);
 
+
+            // When editing in modal then redirect to modalreturn layout
+            if ($this->input->get('layout') === 'modal') {
+                $id     = $this->input->get('id');
+                $return = 'index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($id)
+                    . '&layout=modalreturn&from-task=cancel';
+            } else {
+                $return = 'index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend()
+                    . '&menutype=' . $this->app->getUserState('com_menus.items.menutype');
+            }
+
             // Redirect to the list screen.
-            $this->setRedirect(
-                Route::_(
-                    'index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend()
-                    . '&menutype=' . $this->app->getUserState('com_menus.items.menutype'),
-                    false
-                )
-            );
+            $this->setRedirect(Route::_($return, false));
         }
 
         return $result;
@@ -463,14 +468,18 @@ class ItemController extends FormController
                 $app->setUserState('com_menus.edit.item.type', null);
                 $app->setUserState('com_menus.edit.item.link', null);
 
-                // Redirect to the list screen.
-                $this->setRedirect(
-                    Route::_(
-                        'index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend()
-                        . '&menutype=' . $app->getUserState('com_menus.items.menutype'),
-                        false
-                    )
-                );
+                // When editing in modal then redirect to modalreturn layout
+                if ($this->input->get('layout') === 'modal') {
+                    $return = 'index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($recordId)
+                        . '&layout=modalreturn&from-task=save';
+                } else {
+                    // Redirect to the list screen.
+                    $return = 'index.php?option=' . $this->option . '&view=' . $this->view_list . $this->getRedirectToListAppend()
+                        . '&menutype=' . $app->getUserState('com_menus.items.menutype');
+                }
+
+
+                $this->setRedirect(Route::_($return, false));
                 break;
         }
 

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -40,6 +40,96 @@ class MenuField extends ModalSelectField
     protected $type = 'Modal_Menu';
 
     /**
+     * Method to get certain otherwise inaccessible properties from the form field object.
+     *
+     * @param   string  $name  The property name for which to get the value.
+     *
+     * @return  mixed  The property value or null.
+     *
+     * @since   3.7.0
+     */
+    public function __get($name)
+    {
+        switch ($name) {
+            case 'allowSelect':
+            case 'allowClear':
+            case 'allowNew':
+            case 'allowEdit':
+            case 'allowPropagate':
+                // @TODO: The override only for backward compatibility. Remove in Joomla 6.
+                $map = [
+                    'allowSelect'    => 'select',
+                    'allowClear'     => 'clear',
+                    'allowNew'       => 'new',
+                    'allowEdit'      => 'edit',
+                    'allowPropagate' => 'propagate',
+                ];
+                $newName = $map[$name];
+
+                @trigger_error(
+                    sprintf(
+                        'MenuField::__get property "%s" is deprecated, and will not work in Joomla 6. Use "%s" property instead.',
+                        $name,
+                        $newName
+                    ),
+                    E_USER_DEPRECATED
+                );
+
+                return parent::__get($newName);
+        }
+
+        return parent::__get($name);
+    }
+
+    /**
+     * Method to set certain otherwise inaccessible properties of the form field object.
+     *
+     * @param   string  $name   The property name for which to set the value.
+     * @param   mixed   $value  The value of the property.
+     *
+     * @return  void
+     *
+     * @since   3.7.0
+     */
+    public function __set($name, $value)
+    {
+        switch ($name) {
+            case 'allowSelect':
+            case 'allowClear':
+            case 'allowNew':
+            case 'allowEdit':
+            case 'allowPropagate':
+                // @TODO: The override only for backward compatibility. Remove in Joomla 6.
+                $map = [
+                    'allowSelect'    => 'select',
+                    'allowClear'     => 'clear',
+                    'allowNew'       => 'new',
+                    'allowEdit'      => 'edit',
+                    'allowPropagate' => 'propagate',
+                ];
+                $newName = $map[$name];
+
+                @trigger_error(
+                    sprintf(
+                        'MenuField::__set property "%s" is deprecated, and will not work in Joomla 6. Use "%s" property instead.',
+                        $name,
+                        $newName
+                    ),
+                    E_USER_DEPRECATED
+                );
+
+                $value = (string) $value;
+                $value = !($value === 'false' || $value === 'off' || $value === '0');
+
+                parent::__set($newName, $value);
+                break;
+
+            default:
+                parent::__set($name, $value);
+        }
+    }
+
+    /**
      * Method to attach a JForm object to the field.
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -11,11 +11,13 @@
 namespace Joomla\Component\Menus\Administrator\Field\Modal;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\Form\Field\ModalSelectField;
 use Joomla\CMS\Form\FormField;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -27,7 +29,7 @@ use Joomla\Database\ParameterType;
  *
  * @since  3.7.0
  */
-class MenuField extends FormField
+class MenuField extends ModalSelectField
 {
     /**
      * The form field type.
@@ -36,96 +38,6 @@ class MenuField extends FormField
      * @since   3.7.0
      */
     protected $type = 'Modal_Menu';
-
-    /**
-     * Determinate, if the select button is shown
-     *
-     * @var     boolean
-     * @since   3.7.0
-     */
-    protected $allowSelect = true;
-
-    /**
-     * Determinate, if the clear button is shown
-     *
-     * @var     boolean
-     * @since   3.7.0
-     */
-    protected $allowClear = true;
-
-    /**
-     * Determinate, if the create button is shown
-     *
-     * @var     boolean
-     * @since   3.7.0
-     */
-    protected $allowNew = false;
-
-    /**
-     * Determinate, if the edit button is shown
-     *
-     * @var     boolean
-     * @since   3.7.0
-     */
-    protected $allowEdit = false;
-
-    /**
-     * Determinate, if the propagate button is shown
-     *
-     * @var     boolean
-     * @since   3.9.0
-     */
-    protected $allowPropagate = false;
-
-    /**
-     * Method to get certain otherwise inaccessible properties from the form field object.
-     *
-     * @param   string  $name  The property name for which to get the value.
-     *
-     * @return  mixed  The property value or null.
-     *
-     * @since   3.7.0
-     */
-    public function __get($name)
-    {
-        switch ($name) {
-            case 'allowSelect':
-            case 'allowClear':
-            case 'allowNew':
-            case 'allowEdit':
-            case 'allowPropagate':
-                return $this->$name;
-        }
-
-        return parent::__get($name);
-    }
-
-    /**
-     * Method to set certain otherwise inaccessible properties of the form field object.
-     *
-     * @param   string  $name   The property name for which to set the value.
-     * @param   mixed   $value  The value of the property.
-     *
-     * @return  void
-     *
-     * @since   3.7.0
-     */
-    public function __set($name, $value)
-    {
-        switch ($name) {
-            case 'allowSelect':
-            case 'allowClear':
-            case 'allowNew':
-            case 'allowEdit':
-            case 'allowPropagate':
-                $value       = (string) $value;
-                $this->$name = !($value === 'false' || $value === 'off' || $value === '0');
-                break;
-
-            default:
-                parent::__set($name, $value);
-        }
-    }
 
     /**
      * Method to attach a JForm object to the field.
@@ -145,290 +57,140 @@ class MenuField extends FormField
     {
         $return = parent::setup($element, $value, $group);
 
-        if ($return) {
-            $this->allowSelect    = ((string) $this->element['select']) !== 'false';
-            $this->allowClear     = ((string) $this->element['clear']) !== 'false';
-            $this->allowPropagate = ((string) $this->element['propagate']) === 'true';
-
-            // Creating/editing menu items is not supported in frontend.
-            $isAdministrator = Factory::getApplication()->isClient('administrator');
-            $this->allowNew  = $isAdministrator ? ((string) $this->element['new']) === 'true' : false;
-            $this->allowEdit = $isAdministrator ? ((string) $this->element['edit']) === 'true' : false;
+        if (!$return) {
+            return $return;
         }
+
+        $app = Factory::getApplication();
+
+        $app->getLanguage()->load('com_menus', JPATH_ADMINISTRATOR);
+
+        $languages = LanguageHelper::getContentLanguages([0, 1], false);
+        $language  = (string) $this->element['language'];
+        $clientId  = (int) $this->element['clientid'];
+
+        // Prepare enabled actions
+        $this->canDo['propagate']  = ((string) $this->element['propagate'] == 'true') && count($languages) > 2;
+
+        // Creating/editing menu items is not supported in frontend.
+        if (!$app->isClient('administrator')) {
+            $this->canDo['new']  = false;
+            $this->canDo['edit'] = false;
+        }
+
+        // Prepare Urls
+        $linkItems = (new Uri())->setPath(Uri::base(true) . '/index.php');
+        $linkItems->setQuery([
+            'option'                => 'com_menus',
+            'view'                  => 'items',
+            'layout'                => 'modal',
+            'tmpl'                  => 'component',
+            'client_id'             => $clientId,
+            Session::getFormToken() => 1,
+        ]);
+        $linkItem = clone $linkItems;
+        $linkItem->setVar('view', 'item');
+        $linkCheckin = (new Uri())->setPath(Uri::base(true) . '/index.php');
+        $linkCheckin->setQuery([
+            'option'                => 'com_menus',
+            'task'                  => 'items.checkin',
+            'format'                => 'json',
+            Session::getFormToken() => 1,
+        ]);
+
+        if ($language) {
+            $linkItems->setVar('forcedLanguage', $language);
+            $linkItem->setVar('forcedLanguage', $language);
+
+            $modalTitle = Text::_('COM_MENUS_SELECT_A_MENUITEM') . ' &#8212; ' . $this->getTitle();
+
+            $this->dataAttributes['data-language'] = $language;
+        } else {
+            $modalTitle = Text::_('COM_MENUS_SELECT_A_MENUITEM');
+        }
+
+        $urlSelect = $linkItems;
+        $urlEdit   = clone $linkItem;
+        $urlEdit->setVar('task', 'item.edit');
+        $urlNew    = clone $linkItem;
+        $urlNew->setVar('task', 'item.add');
+
+        $this->urls['select']  = (string) $urlSelect;
+        $this->urls['new']     = (string) $urlNew;
+        $this->urls['edit']    = (string) $urlEdit;
+        $this->urls['checkin'] = (string) $linkCheckin;
+
+        // Prepare titles
+        $this->modalTitles['select']  = $modalTitle;
+        $this->modalTitles['new']     = Text::_('COM_MENUS_NEW_MENUITEM');
+        $this->modalTitles['edit']    = Text::_('COM_MENUS_EDIT_MENUITEM');
+
+        $this->hint = $this->hint ?: Text::_('COM_MENUS_SELECT_A_MENUITEM');
 
         return $return;
     }
 
     /**
-     * Method to get the field input markup.
+     * Method to retrieve the title of selected item.
      *
-     * @return  string  The field input markup.
+     * @return string
      *
-     * @since   3.7.0
+     * @since   __DEPLOY_VERSION__
      */
-    protected function getInput()
+    protected function getValueTitle()
     {
-        $clientId    = (int) $this->element['clientid'];
-        $languages   = LanguageHelper::getContentLanguages([0, 1], false);
-
-        // Load language
-        Factory::getLanguage()->load('com_menus', JPATH_ADMINISTRATOR);
-
-        // The active article id field.
         $value = (int) $this->value ?: '';
-
-        // Create the modal id.
-        $modalId = 'Item_' . $this->id;
-
-        /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
-        $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-
-        // Add the modal field script to the document head.
-        $wa->useScript('field.modal-fields');
-
-        // Script to proxy the select modal function to the modal-fields.js file.
-        if ($this->allowSelect) {
-            static $scriptSelect = null;
-
-            if (is_null($scriptSelect)) {
-                $scriptSelect = [];
-            }
-
-            if (!isset($scriptSelect[$this->id])) {
-                $wa->addInlineScript(
-                    "
-				window.jSelectMenu_" . $this->id . " = function (id, title, object) {
-					window.processModalSelect('Item', '" . $this->id . "', id, title, '', object);
-				}",
-                    [],
-                    ['type' => 'module']
-                );
-
-                Text::script('JGLOBAL_ASSOCIATIONS_PROPAGATE_FAILED');
-
-                $scriptSelect[$this->id] = true;
-            }
-        }
-
-        // Setup variables for display.
-        $linkSuffix = '&amp;layout=modal&amp;client_id=' . $clientId . '&amp;tmpl=component&amp;' . Session::getFormToken() . '=1';
-        $linkItems  = 'index.php?option=com_menus&amp;view=items' . $linkSuffix;
-        $linkItem   = 'index.php?option=com_menus&amp;view=item' . $linkSuffix;
-        $modalTitle = Text::_('COM_MENUS_SELECT_A_MENUITEM');
-
-        if (isset($this->element['language'])) {
-            $linkItems .= '&amp;forcedLanguage=' . $this->element['language'];
-            $linkItem .= '&amp;forcedLanguage=' . $this->element['language'];
-            $modalTitle .= ' &#8212; ' . $this->element['label'];
-        }
-
-        $urlSelect = $linkItems . '&amp;function=jSelectMenu_' . $this->id;
-        $urlEdit   = $linkItem . '&amp;task=item.edit&amp;id=\' + document.getElementById("' . $this->id . '_id").value + \'';
-        $urlNew    = $linkItem . '&amp;task=item.add';
+        $title = '';
 
         if ($value) {
-            $db    = $this->getDatabase();
-            $query = $db->getQuery(true)
-                ->select($db->quoteName('title'))
-                ->from($db->quoteName('#__menu'))
-                ->where($db->quoteName('id') . ' = :id')
-                ->bind(':id', $value, ParameterType::INTEGER);
-
-            $db->setQuery($query);
-
             try {
+                $db    = $this->getDatabase();
+                $query = $db->getQuery(true)
+                    ->select($db->quoteName('title'))
+                    ->from($db->quoteName('#__menu'))
+                    ->where($db->quoteName('id') . ' = :id')
+                    ->bind(':id', $value, ParameterType::INTEGER);
+                $db->setQuery($query);
+
                 $title = $db->loadResult();
-            } catch (\RuntimeException $e) {
+            } catch (\Throwable $e) {
                 Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
             }
         }
 
-        // Placeholder if option is present or not
-        if (empty($title)) {
-            if ($this->element->option && (string) $this->element->option['value'] == '') {
-                $title_holder = Text::_($this->element->option);
-            } else {
-                $title_holder = Text::_('COM_MENUS_SELECT_A_MENUITEM');
-            }
-        }
-
-        $title = empty($title) ? $title_holder : htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
-
-        // The current menu item display field.
-        $html  = '';
-
-        if ($this->allowSelect || $this->allowNew || $this->allowEdit || $this->allowClear) {
-            $html .= '<span class="input-group">';
-        }
-
-        $html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" disabled="disabled" size="35">';
-
-        // Select menu item button
-        if ($this->allowSelect) {
-            $html .= '<button'
-                . ' class="btn btn-primary' . ($value ? ' hidden' : '') . '"'
-                . ' id="' . $this->id . '_select"'
-                . ' data-bs-toggle="modal"'
-                . ' type="button"'
-                . ' data-bs-target="#ModalSelect' . $modalId . '">'
-                . '<span class="icon-file" aria-hidden="true"></span> ' . Text::_('JSELECT')
-                . '</button>';
-        }
-
-        // New menu item button
-        if ($this->allowNew) {
-            $html .= '<button'
-                . ' class="btn btn-secondary' . ($value ? ' hidden' : '') . '"'
-                . ' id="' . $this->id . '_new"'
-                . ' data-bs-toggle="modal"'
-                . ' type="button"'
-                . ' data-bs-target="#ModalNew' . $modalId . '">'
-                . '<span class="icon-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
-                . '</button>';
-        }
-
-        // Edit menu item button
-        if ($this->allowEdit) {
-            $html .= '<button'
-                . ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
-                . ' id="' . $this->id . '_edit"'
-                . ' data-bs-toggle="modal"'
-                . ' type="button"'
-                . ' data-bs-target="#ModalEdit' . $modalId . '">'
-                . '<span class="icon-pen-square" aria-hidden="true"></span> ' . Text::_('JACTION_EDIT')
-                . '</button>';
-        }
-
-        // Clear menu item button
-        if ($this->allowClear) {
-            $html .= '<button'
-                . ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
-                . ' id="' . $this->id . '_clear"'
-                . ' type="button"'
-                . ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-                . '<span class="icon-times" aria-hidden="true"></span> ' . Text::_('JCLEAR')
-                . '</button>';
-        }
-
-        // Propagate menu item button
-        if ($this->allowPropagate && count($languages) > 2) {
-            // Strip off language tag at the end
-            $tagLength            = (int) strlen($this->element['language']);
-            $callbackFunctionStem = substr("jSelectMenu_" . $this->id, 0, -$tagLength);
-
-            $html .= '<button'
-            . ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
-            . ' type="button"'
-            . ' id="' . $this->id . '_propagate"'
-            . ' title="' . Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_TIP') . '"'
-            . ' onclick="Joomla.propagateAssociation(\'' . $this->id . '\', \'' . $callbackFunctionStem . '\');">'
-            . '<span class="icon-sync" aria-hidden="true"></span> ' . Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_BUTTON')
-            . '</button>';
-        }
-
-        if ($this->allowSelect || $this->allowNew || $this->allowEdit || $this->allowClear) {
-            $html .= '</span>';
-        }
-
-        // Select menu item modal
-        if ($this->allowSelect) {
-            $html .= HTMLHelper::_(
-                'bootstrap.renderModal',
-                'ModalSelect' . $modalId,
-                [
-                    'title'      => $modalTitle,
-                    'url'        => $urlSelect,
-                    'height'     => '400px',
-                    'width'      => '800px',
-                    'bodyHeight' => 70,
-                    'modalWidth' => 80,
-                    'footer'     => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">'
-                                        . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
-                ]
-            );
-        }
-
-        // New menu item modal
-        if ($this->allowNew) {
-            $html .= HTMLHelper::_(
-                'bootstrap.renderModal',
-                'ModalNew' . $modalId,
-                [
-                    'title'       => Text::_('COM_MENUS_NEW_MENUITEM'),
-                    'backdrop'    => 'static',
-                    'keyboard'    => false,
-                    'closeButton' => false,
-                    'url'         => $urlNew,
-                    'height'      => '400px',
-                    'width'       => '800px',
-                    'bodyHeight'  => 70,
-                    'modalWidth'  => 80,
-                    'footer'      => '<button type="button" class="btn btn-secondary"'
-                            . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'item\', \'cancel\', \'item-form\'); return false;">'
-                            . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-                            . '<button type="button" class="btn btn-primary"'
-                            . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'item\', \'save\', \'item-form\'); return false;">'
-                            . Text::_('JSAVE') . '</button>'
-                            . '<button type="button" class="btn btn-success"'
-                            . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'add\', \'item\', \'apply\', \'item-form\'); return false;">'
-                            . Text::_('JAPPLY') . '</button>',
-                ]
-            );
-        }
-
-        // Edit menu item modal
-        if ($this->allowEdit) {
-            $html .= HTMLHelper::_(
-                'bootstrap.renderModal',
-                'ModalEdit' . $modalId,
-                [
-                    'title'       => Text::_('COM_MENUS_EDIT_MENUITEM'),
-                    'backdrop'    => 'static',
-                    'keyboard'    => false,
-                    'closeButton' => false,
-                    'url'         => $urlEdit,
-                    'height'      => '400px',
-                    'width'       => '800px',
-                    'bodyHeight'  => 70,
-                    'modalWidth'  => 80,
-                    'footer'      => '<button type="button" class="btn btn-secondary"'
-                            . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'item\', \'cancel\', \'item-form\'); return false;">'
-                            . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-                            . '<button type="button" class="btn btn-primary"'
-                            . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'item\', \'save\', \'item-form\'); return false;">'
-                            . Text::_('JSAVE') . '</button>'
-                            . '<button type="button" class="btn btn-success"'
-                            . ' onclick="window.processModalEdit(this, \'' . $this->id . '\', \'edit\', \'item\', \'apply\', \'item-form\'); return false;">'
-                            . Text::_('JAPPLY') . '</button>',
-                ]
-            );
-        }
-
-        // Note: class='required' for client side validation.
-        $class = $this->required ? ' class="required modal-value"' : '';
-
-        // Placeholder if option is present or not when clearing field
-        if ($this->element->option && (string) $this->element->option['value'] == '') {
-            $title_holder = Text::_($this->element->option);
-        } else {
-            $title_holder = Text::_('COM_MENUS_SELECT_A_MENUITEM');
-        }
-
-        $html .= '<input type="hidden" id="' . $this->id . '_id" ' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name
-            . '" data-text="' . htmlspecialchars($title_holder, ENT_COMPAT, 'UTF-8') . '" value="' . $value . '">';
-
-        return $html;
+        return $title ?: $value;
     }
 
     /**
-     * Method to get the field label markup.
+     * Method to get the data to be passed to the layout for rendering.
      *
-     * @return  string  The field label markup.
+     * @return  array
      *
-     * @since   3.7.0
+     * @since __DEPLOY_VERSION__
      */
-    protected function getLabel()
+    protected function getLayoutData()
     {
-        return str_replace($this->id, $this->id . '_name', parent::getLabel());
+        $data             = parent::getLayoutData();
+        $data['language'] = (string) $this->element['language'];
+
+        return $data;
+    }
+
+    /**
+     * Get the renderer
+     *
+     * @param   string  $layoutId  Id to load
+     *
+     * @return  FileLayout
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function getRenderer($layoutId = 'default')
+    {
+        $layout = parent::getRenderer($layoutId);
+        $layout->setComponent('com_menus');
+        $layout->setClient(1);
+
+        return $layout;
     }
 }

--- a/administrator/components/com_menus/src/View/Item/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Item/HtmlView.php
@@ -103,6 +103,12 @@ class HtmlView extends BaseHtmlView
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
+        if ($this->getLayout() === 'modalreturn') {
+            parent::display($tpl);
+
+            return;
+        }
+
         // If we are forcing a language in modal (used for associations).
         if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'cmd')) {
             // Set the language field to the forcedLanguage and disable changing it.
@@ -113,8 +119,13 @@ class HtmlView extends BaseHtmlView
             $this->form->setFieldAttribute('parent_id', 'language', '*,' . $forcedLanguage);
         }
 
+        if ($this->getLayout() !== 'modal') {
+            $this->addToolbar();
+        } else {
+            $this->addModalToolbar();
+        }
+
         parent::display($tpl);
-        $this->addToolbar();
     }
 
     /**
@@ -204,5 +215,35 @@ class HtmlView extends BaseHtmlView
         }
 
         $toolbar->help($help->key, $help->local, $url);
+    }
+
+    /**
+     * Add the modal toolbar.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     *
+     * @throws  \Exception
+     */
+    protected function addModalToolbar()
+    {
+        $user       = $this->getCurrentUser();
+        $isNew      = ($this->item->id == 0);
+        $checkedOut = !(is_null($this->item->checked_out) || $this->item->checked_out == $user->get('id'));
+        $canDo      = $this->canDo;
+        $toolbar    = Toolbar::getInstance();
+
+        ToolbarHelper::title(Text::_($isNew ? 'COM_MENUS_VIEW_NEW_ITEM_TITLE' : 'COM_MENUS_VIEW_EDIT_ITEM_TITLE'), 'list menu-add');
+
+        $canSave = !$checkedOut && ($isNew && $canDo->get('core.create') || $canDo->get('core.edit'));
+
+        // For new records, check the create permission.
+        if ($canSave) {
+            $toolbar->apply('item.apply');
+            $toolbar->save('item.save');
+        }
+
+        $toolbar->cancel('item.cancel');
     }
 }

--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -37,7 +37,8 @@ $input = Factory::getApplication()->getInput();
 // In case of modal
 $isModal  = $input->get('layout') === 'modal';
 $layout   = $isModal ? 'modal' : 'edit';
-$tmpl     = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=component' : '';
+$tmpl     = $input->get('tmpl');
+$tmpl     = $tmpl ? '&tmpl=' . $tmpl : '';
 $clientId = $this->state->get('item.client_id', 0);
 $lang     = $this->getLanguage()->getTag();
 

--- a/administrator/components/com_menus/tmpl/item/modal.php
+++ b/administrator/components/com_menus/tmpl/item/modal.php
@@ -11,10 +11,9 @@
 defined('_JEXEC') or die;
 
 ?>
-<button id="applyBtn" type="button" class="visually-hidden" onclick="Joomla.submitbutton('item.apply'); jEditMenuModal();"></button>
-<button id="saveBtn" type="button" class="visually-hidden" onclick="Joomla.submitbutton('item.save'); jEditMenuModal();"></button>
-<button id="closeBtn" type="button" class="visually-hidden" onclick="Joomla.submitbutton('item.cancel');"></button>
-
+<div class="subhead noshadow mb-3">
+    <?php echo $this->document->getToolbar('toolbar')->render(); ?>
+</div>
 <div class="container-popup">
     <?php $this->setLayout('edit'); ?>
     <?php echo $this->loadTemplate(); ?>

--- a/administrator/components/com_menus/tmpl/item/modalreturn.php
+++ b/administrator/components/com_menus/tmpl/item/modalreturn.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_content
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+$icon     = 'icon-check';
+$title    = $this->item ? $this->item->title : '';
+$content  = $this->item ? $this->item->alias : '';
+$data     = ['contentType' => 'com_menus.item'];
+
+if ($this->item) {
+    $data['id']    = $this->item->id;
+    $data['title'] = $this->item->title;
+    $data['uri']   = 'index.php?Itemid=' . $this->item->id;
+}
+
+// Add Content select script
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = $this->document->getWebAssetManager();
+$wa->useScript('modal-content-select');
+
+// The data for Content select script
+$this->document->addScriptOptions('content-select-on-load', $data, false);
+
+?>
+
+<div class="px-4 py-5 my-5 text-center">
+    <span class="fa-8x mb-4 <?php echo $icon; ?>" aria-hidden="true"></span>
+    <h1 class="display-5 fw-bold"><?php echo $title; ?></h1>
+    <div class="col-lg-6 mx-auto">
+        <p class="lead mb-4">
+            <?php echo $content; ?>
+        </p>
+    </div>
+</div>

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -26,8 +26,9 @@ if ($app->isClient('site')) {
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
-$wa->useScript('com_menus.admin-items-modal');
+$wa->useScript('com_menus.admin-items-modal')->useScript('modal-content-select');
 
+// TODO: Use of Function and Editor is deprecated and should be removed in 6.0. It stays only for backward compatibility.
 $function  = $app->getInput()->get('function', 'jSelectMenuItem', 'cmd');
 $editor    = $app->getInput()->getCmd('editor', '');
 $listOrder = $this->escape($this->state->get('list.ordering'));
@@ -87,25 +88,34 @@ if (!empty($editor)) {
                 </thead>
                 <tbody>
                 <?php foreach ($this->items as $i => $item) : ?>
-                    <?php if ($item->language && $multilang) {
+                    <?php
+                    $language = '';
+                    if ($item->language && $multilang) {
                         if ($item->language !== '*') {
                             $language = $item->language;
-                        } else {
-                            $language = '';
                         }
-                    } elseif (!$multilang) {
-                        $language = '';
                     }
+
+                    $link     = 'index.php?Itemid=' . $item->id;
+                    $itemHtml = '<a href="' . $link . ($language ? '&lang=' . $language : '') . '">' . $item->title . '</a>';
+                    $attribs  = 'data-content-select data-content-type="com_menus.item"'
+                        . 'data-function="' . $this->escape($function) . '"'
+                        . ' data-id="' . $item->id . '"'
+                        . ' data-title="' . $this->escape($item->title) . '"'
+                        . ' data-uri="' . $this->escape($link) . '"'
+                        . ' data-language="' . $this->escape($language) . '"'
+                        . ' data-html="' . $this->escape($itemHtml) . '"';
                     ?>
                     <tr class="row<?php echo $i % 2; ?>">
                         <td class="text-center">
                             <?php echo HTMLHelper::_('jgrid.published', $item->published, $i, 'items.', false, 'cb', $item->publish_up, $item->publish_down); ?>
                         </td>
                         <th scope="row">
-                            <?php $prefix = LayoutHelper::render('joomla.html.treeprefix', ['level' => $item->level]); ?>
+                            <?php $prefix  = LayoutHelper::render('joomla.html.treeprefix', ['level' => $item->level]); ?>
                             <?php echo $prefix; ?>
-                            <a class="select-link" href="javascript:void(0)" data-function="<?php echo $this->escape($function); ?>" data-id="<?php echo $item->id; ?>" data-title="<?php echo $this->escape($item->title); ?>" data-uri="<?php echo 'index.php?Itemid=' . $item->id; ?>" data-language="<?php echo $this->escape($language); ?>">
-                            <?php echo $this->escape($item->title); ?></a>
+                            <a class="select-link" href="javascript:void(0)" <?php echo $attribs; ?>>
+                                <?php echo $this->escape($item->title); ?>
+                            </a>
                             <?php echo HTMLHelper::_('menus.visibility', $item->params); ?>
                             <div>
                                 <?php echo $prefix; ?>

--- a/build/media_source/com_menus/joomla.asset.json
+++ b/build/media_source/com_menus/joomla.asset.json
@@ -52,9 +52,7 @@
       ],
       "attributes": {
         "type": "module"
-      },
-      "deprecated": true,
-      "deprecatedMsg": "Replaced with [modal-content-select-field] asset. To be removed in Joomla 6."
+      }
     },
     {
       "name": "com_menus.admin-items-modal",
@@ -65,7 +63,9 @@
       ],
       "attributes": {
         "type": "module"
-      }
+      },
+      "deprecated": true,
+      "deprecatedMsg": "Replaced with [modal-content-select-field] asset. To be removed in Joomla 6."
     },
     {
       "name": "com_menus.admin-menus",

--- a/build/media_source/com_menus/joomla.asset.json
+++ b/build/media_source/com_menus/joomla.asset.json
@@ -52,7 +52,9 @@
       ],
       "attributes": {
         "type": "module"
-      }
+      },
+      "deprecated": true,
+      "deprecatedMsg": "Replaced with [modal-content-select-field] asset. To be removed in Joomla 6."
     },
     {
       "name": "com_menus.admin-items-modal",

--- a/build/media_source/com_menus/js/admin-items-modal.es6.js
+++ b/build/media_source/com_menus/js/admin-items-modal.es6.js
@@ -12,13 +12,13 @@
    * and closes the select frame.
    */
   window.jSelectMenuItem = (id, title, uri, object, link, lang) => {
+    // eslint-disable-next-line no-console
+    console.warn('Method jSelectMenuItem() is deprecated. Use postMessage() instead.');
     let thislang = '';
 
     if (!Joomla.getOptions('xtd-menus')) {
       // Something went wrong!
-      window.parent.Joomla.Modal.getCurrent().close();
-
-      throw new Error('core.js was not properly initialised');
+      return;
     }
 
     // eslint-disable-next-line prefer-destructuring
@@ -38,7 +38,7 @@
     }
 
     // Close the modal
-    if (window.parent.Joomla && window.parent.Joomla.Modal) {
+    if (window.parent.Joomla.Modal && window.parent.Joomla.Modal.getCurrent()) {
       window.parent.Joomla.Modal.getCurrent().close();
     }
   };
@@ -52,16 +52,16 @@
       event.preventDefault();
       const functionName = event.target.getAttribute('data-function');
 
-      if (functionName === 'jSelectMenuItem') {
+      if (functionName === 'jSelectMenuItem' && window[functionName]) {
         // Used in xtd_contacts
         window[functionName](event.target.getAttribute('data-id'), event.target.getAttribute('data-title'), event.target.getAttribute('data-uri'), null, null, event.target.getAttribute('data-language'));
-      } else {
+      } else if (window.parent[functionName]) {
         // Used in com_menus
         window.parent[functionName](event.target.getAttribute('data-id'), event.target.getAttribute('data-title'), null, null, event.target.getAttribute('data-uri'), event.target.getAttribute('data-language'), null);
       }
 
       // Close the modal
-      if (window.parent.Joomla.Modal) {
+      if (window.parent.Joomla.Modal && window.parent.Joomla.Modal.getCurrent()) {
         window.parent.Joomla.Modal.getCurrent().close();
       }
     });


### PR DESCRIPTION
### Summary of Changes

Changing `Modal_Menu` field to use new modal dialog.
The same as https://github.com/joomla/joomla-cms/pull/40462 but for Menu.

It may not hit 5.0, but in future will need to update anyway.

~TODO: Will be need to update after https://github.com/joomla/joomla-cms/pull/41600~

### Testing Instructions
Run `npm install`

Create/edit "Menu Item Type": "Menu Item Alias": create/edit/select "Menu Item" value.


### Actual result BEFORE applying this Pull Request

Works with old bs modal


### Expected result AFTER applying this Pull Request

Works with new dialog.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: 
- [ ] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: as part of https://github.com/joomla/Manual/pull/178
- [ ] No documentation changes for manual.joomla.org needed

Reference:
- https://github.com/joomla/joomla-cms/pull/40462