### PR TITLE
[5.0] Modal field for MenutypeField

### DIFF
--- a/administrator/components/com_menus/src/Field/MenutypeField.php
+++ b/administrator/components/com_menus/src/Field/MenutypeField.php
@@ -105,6 +105,7 @@ class MenutypeField extends ModalSelectField
                 $link = $this->form->getValue('link');
 
                 if ($link !== null) {
+                    /** @var \Joomla\Component\Menus\Administrator\Model\MenutypesModel $model */
                     $model = Factory::getApplication()->bootComponent('com_menus')
                         ->getMVCFactory()->createModel('Menutypes', 'Administrator', ['ignore_request' => true]);
                     $model->setState('client_id', $clientId);

--- a/administrator/components/com_menus/src/Field/MenutypeField.php
+++ b/administrator/components/com_menus/src/Field/MenutypeField.php
@@ -76,7 +76,7 @@ class MenutypeField extends ModalSelectField
      */
     protected function getValueTitle()
     {
-        $title    = $this->value;
+        $title    = '';
         $clientId = (int) $this->element['clientid'] ?: 0;
 
         // Get a reverse lookup of the base link URL to Title
@@ -119,5 +119,29 @@ class MenutypeField extends ModalSelectField
         }
 
         return $title;
+    }
+
+    /**
+     * Method to get the field input markup.
+     *
+     * @return  string  The field input markup.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function getInput()
+    {
+        // Get the layout data
+        $data = $this->getLayoutData();
+
+        // Load the content title here to avoid a double DB Query
+        $data['valueTitle'] = $this->getValueTitle();
+
+        // On new item creation the model forces the value to be 'component',
+        // However this is need to be empty in the input for correct validation and rendering.
+        if ($data['value'] === 'component' && !$data['valueTitle'] && !$this->form->getValue('link')) {
+            $data['value'] = '';
+        }
+
+        return $this->getRenderer($this->layout)->render($data);
     }
 }

--- a/administrator/components/com_menus/src/Field/MenutypeField.php
+++ b/administrator/components/com_menus/src/Field/MenutypeField.php
@@ -12,7 +12,6 @@ namespace Joomla\Component\Menus\Administrator\Field;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\ModalSelectField;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
@@ -119,88 +118,5 @@ class MenutypeField extends ModalSelectField
         }
 
         return $title;
-    }
-
-    /**
-     * Method to get the field input markup.
-     *
-     * @return  string  The field input markup.
-     *
-     * @since   1.6
-     */
-    protected function getInput1()
-    {
-        $html     = [];
-        $recordId = (int) $this->form->getValue('id');
-        $size     = (string) ($v = $this->element['size']) ? ' size="' . $v . '"' : '';
-        $class    = (string) ($v = $this->element['class']) ? ' class="form-control ' . $v . '"' : ' class="form-control"';
-        $required = (string) $this->element['required'] ? ' required="required"' : '';
-        $clientId = (int) $this->element['clientid'] ?: 0;
-
-        // Get a reverse lookup of the base link URL to Title
-        switch ($this->value) {
-            case 'url':
-                $value = Text::_('COM_MENUS_TYPE_EXTERNAL_URL');
-                break;
-
-            case 'alias':
-                $value = Text::_('COM_MENUS_TYPE_ALIAS');
-                break;
-
-            case 'separator':
-                $value = Text::_('COM_MENUS_TYPE_SEPARATOR');
-                break;
-
-            case 'heading':
-                $value = Text::_('COM_MENUS_TYPE_HEADING');
-                break;
-
-            case 'container':
-                $value = Text::_('COM_MENUS_TYPE_CONTAINER');
-                break;
-
-            default:
-                $link  = $this->form->getValue('link');
-                $value = '';
-
-                if ($link !== null) {
-                    $model = Factory::getApplication()->bootComponent('com_menus')
-                        ->getMVCFactory()->createModel('Menutypes', 'Administrator', ['ignore_request' => true]);
-                    $model->setState('client_id', $clientId);
-
-                    $rlu   = $model->getReverseLookup();
-
-                    // Clean the link back to the option, view and layout
-                    $value = Text::_(ArrayHelper::getValue($rlu, MenusHelper::getLinkKey($link)));
-                }
-                break;
-        }
-
-        $link   = Route::_('index.php?option=com_menus&view=menutypes&tmpl=component&client_id=' . $clientId . '&recordId=' . $recordId);
-        $html[] = '<span class="input-group"><input type="text" ' . $required . ' readonly="readonly" id="' . $this->id
-            . '" value="' . $value . '"' . $size . $class . '>';
-        $html[] = '<button type="button" data-bs-target="#menuTypeModal" class="btn btn-primary" data-bs-toggle="modal">'
-            . '<span class="icon-list icon-white" aria-hidden="true"></span> '
-            . Text::_('JSELECT') . '</button></span>';
-        $html[] = HTMLHelper::_(
-            'bootstrap.renderModal',
-            'menuTypeModal',
-            [
-                'url'        => $link,
-                'title'      => Text::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL'),
-                'width'      => '800px',
-                'height'     => '300px',
-                'modalWidth' => 80,
-                'bodyHeight' => 70,
-                'footer'     => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">'
-                        . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
-            ]
-        );
-
-        // This hidden field has an ID so it can be used for showon attributes
-        $html[] = '<input type="hidden" name="' . $this->name . '" value="'
-            . htmlspecialchars($this->value, ENT_COMPAT, 'UTF-8') . '" id="' . $this->id . '_val">';
-
-        return implode("\n", $html);
     }
 }

--- a/administrator/components/com_menus/src/Field/MenutypeField.php
+++ b/administrator/components/com_menus/src/Field/MenutypeField.php
@@ -62,7 +62,9 @@ class MenutypeField extends ModalSelectField
         $url = Route::_('index.php?option=com_menus&view=menutypes&tmpl=component&client_id=' . $clientId . '&recordId=' . $recordId, false);
 
         $this->urls['select']        = $url;
+        $this->canDo['clear']        = false;
         $this->modalTitles['select'] = Text::_('COM_MENUS_ITEM_FIELD_TYPE_LABEL');
+        $this->buttonIcons['select'] = 'icon-list';
 
         return $result;
     }

--- a/administrator/components/com_menus/tmpl/menutypes/default.php
+++ b/administrator/components/com_menus/tmpl/menutypes/default.php
@@ -39,7 +39,7 @@ $wa->useScript('com_menus.admin-item-modal')->useScript('modal-content-select');
                         . ' data-request="' . ($item->request ? $this->escape(json_encode($item->request)) : '') . '"'
                         . ' data-encoded="' . $this->escape($encoded) . '"'
                         . ' data-tmpl-view="' . $tmpl . '"';
-                ?>
+                    ?>
                     <button type="button" class="choose_type list-group-item list-group-item-action" <?php echo $attrs; ?>>
                         <div class="pe-2">
                             <?php echo $title; ?>

--- a/administrator/components/com_menus/tmpl/menutypes/default.php
+++ b/administrator/components/com_menus/tmpl/menutypes/default.php
@@ -33,7 +33,7 @@ $wa->useScript('com_menus.admin-item-modal')->useScript('modal-content-select');
                     $menutype = ['id' => $this->recordId, 'title' => $item->type ?? $item->title, 'request' => $item->request];
                     $encoded  = base64_encode(json_encode($menutype));
 
-                    $attrs = 'data-content-select data-content-type="com_menus.menutype"'
+                    $attrs = 'data-content-select data-content-type="com_menus.menutype" data-message-type="joomla:content-select-menutype"'
                         . ' data-item-id="' . (int) $this->recordId . '"'
                         . ' data-type="' . $this->escape($item->type ?? $item->title) . '"'
                         . ' data-request="' . ($item->request ? $this->escape(json_encode($item->request)) : '') . '"'

--- a/administrator/components/com_menus/tmpl/menutypes/default.php
+++ b/administrator/components/com_menus/tmpl/menutypes/default.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Session\Session;
 
 $input = Factory::getApplication()->getInput();
 
@@ -21,7 +22,11 @@ $tmpl = $input->getCmd('tmpl') ? '1' : '';
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
-$wa->useScript('com_menus.admin-item-modal')->useScript('modal-content-select');
+$wa->useScript('com_menus.admin-item-modal');
+
+if ($tmpl) {
+    $wa->useScript('modal-content-select');
+}
 
 ?>
 <?php echo HTMLHelper::_('bootstrap.startAccordion', 'collapseTypes', ['active' => 'slide1']); ?>
@@ -33,21 +38,27 @@ $wa->useScript('com_menus.admin-item-modal')->useScript('modal-content-select');
                     $menutype = ['id' => $this->recordId, 'title' => $item->type ?? $item->title, 'request' => $item->request];
                     $encoded  = base64_encode(json_encode($menutype));
 
-                    $attrs = 'data-content-select data-content-type="com_menus.menutype" data-message-type="joomla:content-select-menutype"'
-                        . ' data-item-id="' . (int) $this->recordId . '"'
-                        . ' data-type="' . $this->escape($item->type ?? $item->title) . '"'
-                        . ' data-request="' . ($item->request ? $this->escape(json_encode($item->request)) : '') . '"'
-                        . ' data-encoded="' . $this->escape($encoded) . '"'
-                        . ' data-tmpl-view="' . $tmpl . '"';
+                    if ($tmpl) {
+                        $attrs = 'data-content-select data-content-type="com_menus.menutype" data-message-type="joomla:content-select-menutype"'
+                            . ' data-item-id="' . (int) $this->recordId . '"'
+                            . ' data-type="' . $this->escape($item->type ?? $item->title) . '"'
+                            . ' data-request="' . ($item->request ? $this->escape(json_encode($item->request)) : '') . '"'
+                            . ' data-encoded="' . $this->escape($encoded) . '"';
+
+                        $link = '#';
+                    } else {
+                        $attrs = '';
+                        $link  = $this->escape('index.php?option=com_menus&view=item&task=item.setType&layout=edit&type=' . $encoded . '&' . Session::getFormToken() . '=1');
+                    }
                     ?>
-                    <button type="button" class="choose_type list-group-item list-group-item-action" <?php echo $attrs; ?>>
+                    <a href="<?php echo $link; ?>" class="choose_type list-group-item list-group-item-action" <?php echo $attrs; ?>>
                         <div class="pe-2">
                             <?php echo $title; ?>
                         </div>
                         <small class="text-muted">
                             <?php echo Text::_($item->description); ?>
                         </small>
-                    </button>
+                    </a>
                 <?php endforeach; ?>
             </div>
         <?php echo HTMLHelper::_('bootstrap.endSlide'); ?>

--- a/administrator/components/com_menus/tmpl/menutypes/default.php
+++ b/administrator/components/com_menus/tmpl/menutypes/default.php
@@ -17,12 +17,11 @@ use Joomla\CMS\Language\Text;
 $input = Factory::getApplication()->getInput();
 
 // Checking if loaded via index.php or component.php
-$tmpl = ($input->getCmd('tmpl') != '') ? '1' : '';
-$tmpl = json_encode($tmpl, JSON_NUMERIC_CHECK);
+$tmpl = $input->getCmd('tmpl') ? '1' : '';
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
-$wa->useScript('com_menus.admin-item-modal');
+$wa->useScript('com_menus.admin-item-modal')->useScript('modal-content-select');
 
 ?>
 <?php echo HTMLHelper::_('bootstrap.startAccordion', 'collapseTypes', ['active' => 'slide1']); ?>
@@ -30,18 +29,25 @@ $wa->useScript('com_menus.admin-item-modal');
     <?php foreach ($this->types as $name => $list) : ?>
         <?php echo HTMLHelper::_('bootstrap.addSlide', 'collapseTypes', $name, 'collapse' . ($i++)); ?>
             <div class="list-group">
-                <?php foreach ($list as $title => $item) : ?>
-                    <?php $menutype = ['id' => $this->recordId, 'title' => $item->type ?? $item->title, 'request' => $item->request]; ?>
-                    <?php $menutype = base64_encode(json_encode($menutype)); ?>
-                    <a class="choose_type list-group-item list-group-item-action" href="#"
-                        onclick="Joomla.setMenuType('<?php echo $menutype; ?>', '<?php echo $tmpl; ?>')">
+                <?php foreach ($list as $title => $item) :
+                    $menutype = ['id' => $this->recordId, 'title' => $item->type ?? $item->title, 'request' => $item->request];
+                    $encoded  = base64_encode(json_encode($menutype));
+
+                    $attrs = 'data-content-select data-content-type="com_menus.menutype"'
+                        . ' data-item-id="' . (int) $this->recordId . '"'
+                        . ' data-type="' . $this->escape($item->type ?? $item->title) . '"'
+                        . ' data-request="' . ($item->request ? $this->escape(json_encode($item->request)) : '') . '"'
+                        . ' data-encoded="' . $this->escape($encoded) . '"'
+                        . ' data-tmpl-view="' . $tmpl . '"';
+                ?>
+                    <button type="button" class="choose_type list-group-item list-group-item-action" <?php echo $attrs; ?>>
                         <div class="pe-2">
                             <?php echo $title; ?>
                         </div>
                         <small class="text-muted">
                             <?php echo Text::_($item->description); ?>
                         </small>
-                    </a>
+                    </button>
                 <?php endforeach; ?>
             </div>
         <?php echo HTMLHelper::_('bootstrap.endSlide'); ?>

--- a/build/media_source/com_menus/joomla.asset.json
+++ b/build/media_source/com_menus/joomla.asset.json
@@ -52,7 +52,9 @@
       ],
       "attributes": {
         "type": "module"
-      }
+      },
+      "deprecated": true,
+      "deprecatedMsg": "Replaced with [modal-content-select-field] asset. To be removed in Joomla 6."
     },
     {
       "name": "com_menus.admin-items-modal",

--- a/build/media_source/com_menus/js/admin-item-edit.es6.js
+++ b/build/media_source/com_menus/js/admin-item-edit.es6.js
@@ -2,105 +2,116 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-((Joomla) => {
-  'use strict';
 
-  Joomla.submitbutton = (task, type) => {
-    if (task === 'item.setType' || task === 'item.setMenuType') {
-      if (task === 'item.setType') {
-        const list = [].slice.call(document.querySelectorAll('#item-form input[name="jform[type]"]'));
+if (!window.Joomla) {
+  throw new Error('core.js was not properly initialised');
+}
 
-        list.forEach((item) => {
-          item.value = type;
-        });
+Joomla.submitbutton = (task, type) => {
+  if (task === 'item.setType' || task === 'item.setMenuType') {
+    if (task === 'item.setType') {
+      const list = [].slice.call(document.querySelectorAll('#item-form input[name="jform[type]"]'));
 
-        document.getElementById('fieldtype').value = 'type';
-      } else {
-        const list = [].slice.call(document.querySelectorAll('#item-form input[name="jform[menutype]"]'));
+      list.forEach((item) => {
+        item.value = type;
+      });
 
-        list.forEach((item) => {
-          item.value = type;
-        });
-      }
-
-      Joomla.submitform('item.setType', document.getElementById('item-form'));
-    } else if (task === 'item.cancel' || document.formvalidator.isValid(document.getElementById('item-form'))) {
-      Joomla.submitform(task, document.getElementById('item-form'));
+      document.getElementById('fieldtype').value = 'type';
     } else {
-      // special case for modal popups validation response
-      const list = [].slice.call(document.querySelectorAll('#item-form .modal-value.invalid'));
+      const list = [].slice.call(document.querySelectorAll('#item-form input[name="jform[menutype]"]'));
 
-      list.forEach((field) => {
-        const idReversed = field.getAttribute('id').split('').reverse().join('');
-        const separatorLocation = idReversed.indexOf('_');
-        const nameId = `${idReversed.substr(separatorLocation).split('').reverse().join('')}name`;
-        document.getElementById(nameId).classList.add('invalid');
+      list.forEach((item) => {
+        item.value = type;
       });
     }
-  };
 
-  const onChange = ({ target }) => {
-    const menuType = target.value;
+    Joomla.submitform('item.setType', document.getElementById('item-form'));
+  } else if (task === 'item.cancel' || document.formvalidator.isValid(document.getElementById('item-form'))) {
+    Joomla.submitform(task, document.getElementById('item-form'));
+  } else {
+    // special case for modal popups validation response
+    const list = [].slice.call(document.querySelectorAll('#item-form .modal-value.invalid'));
 
-    Joomla.request({
-      url: `index.php?option=com_menus&task=item.getParentItem&menutype=${menuType}`,
-      headers: { 'Content-Type': 'application/json' },
-
-      onSuccess(response) {
-        const data = JSON.parse(response);
-        const fancySelect = document.getElementById('jform_parent_id').closest('joomla-field-fancy-select');
-
-        fancySelect.choicesInstance.clearChoices();
-        fancySelect.choicesInstance.setChoices([{ id: '1', text: Joomla.Text._('JGLOBAL_ROOT_PARENT') }], 'id', 'text', false);
-
-        data.forEach((value) => {
-          const option = {};
-          option.innerText = value.title;
-          option.id = value.id;
-
-          fancySelect.choicesInstance.setChoices([option], 'id', 'innerText', false);
-        });
-
-        fancySelect.choicesInstance.setChoiceByValue('1');
-
-        const newEvent = document.createEvent('HTMLEvents');
-        newEvent.initEvent('change', true, false);
-        document.getElementById('jform_parent_id').dispatchEvent(newEvent);
-      },
-      onError: (xhr) => {
-        Joomla.renderMessages(Joomla.ajaxErrorsMessages(xhr));
-      },
+    list.forEach((field) => {
+      const idReversed = field.getAttribute('id').split('').reverse().join('');
+      const separatorLocation = idReversed.indexOf('_');
+      const nameId = `${idReversed.substr(separatorLocation).split('').reverse().join('')}name`;
+      document.getElementById(nameId).classList.add('invalid');
     });
-  };
-
-  if (!Joomla || typeof Joomla.request !== 'function') {
-    throw new Error('core.js was not properly initialised');
   }
+};
 
-  const element = document.getElementById('jform_menutype');
-
-  if (element) {
-    element.addEventListener('change', onChange);
+// Listen to "joomla:content-select-menutype" message
+window.addEventListener('message', (event) => {
+  // Avoid cross origins
+  if (event.origin !== window.location.origin) return;
+  // Check message type
+  if (event.data.messageType === 'joomla:content-select-menutype') {
+    // Set and submit values
+    Joomla.submitbutton('item.setType', event.data.encoded);
   }
+});
 
-  // Menu type Login Form specific
-  document.getElementById('item-form').addEventListener('submit', () => {
-    if (document.getElementById('jform_params_login_redirect_url') && document.getElementById('jform_params_logout_redirect_url')) {
-      // Login
-      if (!document.getElementById('jform_params_login_redirect_url').closest('.control-group').classList.contains('hidden')) {
-        document.getElementById('jform_params_login_redirect_menuitem_id').value = '';
-      }
-      if (!document.getElementById('jform_params_login_redirect_menuitem_name').closest('.control-group').classList.contains('hidden')) {
-        document.getElementById('jform_params_login_redirect_url').value = '';
-      }
+const onChange = ({ target }) => {
+  const menuType = target.value;
 
-      // Logout
-      if (!document.getElementById('jform_params_logout_redirect_url').closest('.control-group').classList.contains('hidden')) {
-        document.getElementById('jform_params_logout_redirect_menuitem_id').value = '';
-      }
-      if (!document.getElementById('jform_params_logout_redirect_menuitem_id').closest('.control-group').classList.contains('hidden')) {
-        document.getElementById('jform_params_logout_redirect_url').value = '';
-      }
-    }
+  Joomla.request({
+    url: `index.php?option=com_menus&task=item.getParentItem&menutype=${menuType}`,
+    headers: { 'Content-Type': 'application/json' },
+
+    onSuccess(response) {
+      const data = JSON.parse(response);
+      const fancySelect = document.getElementById('jform_parent_id').closest('joomla-field-fancy-select');
+
+      fancySelect.choicesInstance.clearChoices();
+      fancySelect.choicesInstance.setChoices([{
+        id: '1',
+        text: Joomla.Text._('JGLOBAL_ROOT_PARENT'),
+      }], 'id', 'text', false);
+
+      data.forEach((value) => {
+        const option = {};
+        option.innerText = value.title;
+        option.id = value.id;
+
+        fancySelect.choicesInstance.setChoices([option], 'id', 'innerText', false);
+      });
+
+      fancySelect.choicesInstance.setChoiceByValue('1');
+
+      const newEvent = document.createEvent('HTMLEvents');
+      newEvent.initEvent('change', true, false);
+      document.getElementById('jform_parent_id').dispatchEvent(newEvent);
+    },
+    onError: (xhr) => {
+      Joomla.renderMessages(Joomla.ajaxErrorsMessages(xhr));
+    },
   });
-})(Joomla);
+};
+
+const element = document.getElementById('jform_menutype');
+
+if (element) {
+  element.addEventListener('change', onChange);
+}
+
+// Menu type Login Form specific
+document.getElementById('item-form').addEventListener('submit', () => {
+  if (document.getElementById('jform_params_login_redirect_url') && document.getElementById('jform_params_logout_redirect_url')) {
+    // Login
+    if (!document.getElementById('jform_params_login_redirect_url').closest('.control-group').classList.contains('hidden')) {
+      document.getElementById('jform_params_login_redirect_menuitem_id').value = '';
+    }
+    if (!document.getElementById('jform_params_login_redirect_menuitem_name').closest('.control-group').classList.contains('hidden')) {
+      document.getElementById('jform_params_login_redirect_url').value = '';
+    }
+
+    // Logout
+    if (!document.getElementById('jform_params_logout_redirect_url').closest('.control-group').classList.contains('hidden')) {
+      document.getElementById('jform_params_logout_redirect_menuitem_id').value = '';
+    }
+    if (!document.getElementById('jform_params_logout_redirect_menuitem_id').closest('.control-group').classList.contains('hidden')) {
+      document.getElementById('jform_params_logout_redirect_url').value = '';
+    }
+  }
+});

--- a/build/media_source/com_menus/js/admin-item-edit.es6.js
+++ b/build/media_source/com_menus/js/admin-item-edit.es6.js
@@ -30,13 +30,11 @@ Joomla.submitbutton = (task, type) => {
     Joomla.submitform(task, document.getElementById('item-form'));
   } else {
     // special case for modal popups validation response
-    const list = [].slice.call(document.querySelectorAll('#item-form .modal-value.invalid'));
+    const list = document.querySelectorAll('#item-form .modal-value.invalid');
 
     list.forEach((field) => {
-      const idReversed = field.getAttribute('id').split('').reverse().join('');
-      const separatorLocation = idReversed.indexOf('_');
-      const nameId = `${idReversed.substr(separatorLocation).split('').reverse().join('')}name`;
-      document.getElementById(nameId).classList.add('invalid');
+      const textInput = field.parentElement.querySelector('.js-input-title, [type="text"]');
+      textInput.classList.add('invalid');
     });
   }
 };

--- a/build/media_source/com_menus/js/admin-item-modal.es6.js
+++ b/build/media_source/com_menus/js/admin-item-modal.es6.js
@@ -6,7 +6,7 @@ window.Joomla = window.Joomla || {};
 
 Joomla.setMenuType = (type, tmpl) => {
   // eslint-disable-next-line no-console
-  console.warn('Method Joomla.setMenuType() is deprecated. Use "modal-content-select" asset and elements [data-content-select] attribute.');
+  console.warn('Method Joomla.setMenuType() is deprecated. Use "modal-content-select" asset and elements with [data-content-select] attribute.');
 
   if (tmpl !== '') {
     window.parent.Joomla.submitbutton('item.setType', type);
@@ -25,9 +25,8 @@ document.addEventListener('click', (event) => {
   if (!button) return;
   event.preventDefault();
 
-  // Check the data
+  // In non-modal view do redirect to the form with new type pre-selected
   if (!button.dataset.tmplView) {
-    // In non-modal view redirect to form with new type selected
     window.location = `index.php?option=com_menus&view=item&task=item.setType&layout=edit&type=${button.dataset.encoded}`;
   }
 });

--- a/build/media_source/com_menus/js/admin-item-modal.es6.js
+++ b/build/media_source/com_menus/js/admin-item-modal.es6.js
@@ -2,17 +2,32 @@
  * @copyright  (C) 2018 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
-Joomla = window.Joomla || {};
+window.Joomla = window.Joomla || {};
 
-((Joomla) => {
-  'use strict';
+Joomla.setMenuType = (type, tmpl) => {
+  // eslint-disable-next-line no-console
+  console.warn('Method Joomla.setMenuType() is deprecated. Use "modal-content-select" asset and elements [data-content-select] attribute.');
 
-  Joomla.setMenuType = (type, tmpl) => {
-    if (tmpl !== '') {
-      window.parent.Joomla.submitbutton('item.setType', type);
+  if (tmpl !== '') {
+    window.parent.Joomla.submitbutton('item.setType', type);
+
+    if (window.parent.Joomla.Modal && window.parent.Joomla.Modal.getCurrent()) {
       window.parent.Joomla.Modal.getCurrent().close();
-    } else {
-      window.location = `index.php?option=com_menus&view=item&task=item.setType&layout=edit&type=${type}`;
     }
-  };
-})(Joomla);
+  } else {
+    window.location = `index.php?option=com_menus&view=item&task=item.setType&layout=edit&type=${type}`;
+  }
+};
+
+// Bind the buttons
+document.addEventListener('click', (event) => {
+  const button = event.target.closest('[data-content-select]');
+  if (!button) return;
+  event.preventDefault();
+
+  // Check the data
+  if (!button.dataset.tmplView) {
+    // In non-modal view redirect to form with new type selected
+    window.location = `index.php?option=com_menus&view=item&task=item.setType&layout=edit&type=${button.dataset.encoded}`;
+  }
+});

--- a/build/media_source/com_menus/js/admin-item-modal.es6.js
+++ b/build/media_source/com_menus/js/admin-item-modal.es6.js
@@ -18,15 +18,3 @@ Joomla.setMenuType = (type, tmpl) => {
     window.location = `index.php?option=com_menus&view=item&task=item.setType&layout=edit&type=${type}`;
   }
 };
-
-// Bind the buttons
-document.addEventListener('click', (event) => {
-  const button = event.target.closest('[data-content-select]');
-  if (!button) return;
-  event.preventDefault();
-
-  // In non-modal view do redirect to the form with new type pre-selected
-  if (!button.dataset.tmplView) {
-    window.location = `index.php?option=com_menus&view=item&task=item.setType&layout=edit&type=${button.dataset.encoded}`;
-  }
-});

--- a/layouts/joomla/form/field/modal-select.php
+++ b/layouts/joomla/form/field/modal-select.php
@@ -46,6 +46,7 @@ extract($displayData);
  * @var   array    $canDo
  * @var   string[] $urls
  * @var   string[] $modalTitles
+ * @var   string[] $buttonIcons
  */
 
 // Add the field script

--- a/layouts/joomla/form/field/modal-select/buttons.php
+++ b/layouts/joomla/form/field/modal-select/buttons.php
@@ -46,6 +46,7 @@ extract($displayData);
  * @var   array    $canDo
  * @var   string[] $urls
  * @var   string[] $modalTitles
+ * @var   string[] $buttonIcons
  */
 
 // Prepare options for each Modal
@@ -65,12 +66,15 @@ $modalEdit = [
     'textHeader' => $modalTitles['edit'] ?? Text::_('JACTION_EDIT'),
 ];
 
+// Decide when the select button always will be visible
+$isSelectAlways = !empty($canDo['select']) && empty($canDo['clear']);
+
 ?>
 <?php if ($modalSelect['src'] && $canDo['select'] ?? true) : ?>
-<button type="button" class="btn btn-primary" <?php echo $value ? 'hidden' : ''; ?>
-        data-button-action="select" data-show-when-value=""
+<button type="button" class="btn btn-primary" <?php echo $value && !$isSelectAlways ? 'hidden' : ''; ?>
+        data-button-action="select" <?php echo !$isSelectAlways ? 'data-show-when-value=""' : ''; ?>
         data-modal-config="<?php echo $this->escape(json_encode($modalSelect)); ?>">
-    <span class="icon-file" aria-hidden="true"></span> <?php echo Text::_('JSELECT'); ?>
+    <span class="<?php echo $buttonIcons['select'] ?? 'icon-file'; ?>" aria-hidden="true"></span> <?php echo Text::_('JSELECT'); ?>
 </button>
 <?php endif; ?>
 

--- a/layouts/joomla/form/field/modal-select/extra-buttons.php
+++ b/layouts/joomla/form/field/modal-select/extra-buttons.php
@@ -44,4 +44,5 @@ defined('_JEXEC') or die;
  * @var   array    $canDo
  * @var   string[] $urls
  * @var   string[] $modalTitles
+ * @var   string[] $buttonIcons
  */

--- a/libraries/src/Form/Field/ModalSelectField.php
+++ b/libraries/src/Form/Field/ModalSelectField.php
@@ -63,6 +63,14 @@ class ModalSelectField extends FormField
     protected $modalTitles = [];
 
     /**
+     * List of icons for each button type: select, edit, new
+     *
+     * @var    string[]
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $buttonIcons = [];
+
+    /**
      * Method to attach a Form object to the field.
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
@@ -89,7 +97,7 @@ class ModalSelectField extends FormField
         $this->__set('clear', (string) $this->element['clear'] != 'false');
 
         // Prepare Urls and titles
-        foreach (['urlSelect', 'urlNew', 'urlEdit', 'urlCheckin', 'titleSelect', 'titleNew', 'titleEdit'] as $attr) {
+        foreach (['urlSelect', 'urlNew', 'urlEdit', 'urlCheckin', 'titleSelect', 'titleNew', 'titleEdit', 'iconSelect'] as $attr) {
             $this->__set($attr, (string) $this->element[$attr]);
         }
 
@@ -130,6 +138,8 @@ class ModalSelectField extends FormField
                 return $this->modalTitles['new'] ?? '';
             case 'titleEdit':
                 return $this->modalTitles['edit'] ?? '';
+            case 'iconSelect':
+                return $this->buttonIcons['select'] ?? '';
             default:
                 return parent::__get($name);
         }
@@ -180,6 +190,9 @@ class ModalSelectField extends FormField
                 break;
             case 'titleEdit':
                 $this->modalTitles['edit'] = (string) $value;
+                break;
+            case 'iconSelect':
+                $this->buttonIcons['select'] = (string) $value;
                 break;
             default:
                 parent::__set($name, $value);
@@ -233,6 +246,7 @@ class ModalSelectField extends FormField
         $data['canDo']       = $this->canDo;
         $data['urls']        = $this->urls;
         $data['modalTitles'] = $this->modalTitles;
+        $data['buttonIcons'] = $this->buttonIcons;
 
         return $data;
     }


### PR DESCRIPTION
### Summary of Changes

Changing MenutypeField field to use new modal dialog.

It may not hit 5.0, but in future will need to update anyway.

### Testing Instructions
Run `npm install`

Create/Edit menu item, change the menu type.


### Actual result BEFORE applying this Pull Request
Works with old bs modal


### Expected result AFTER applying this Pull Request
Works with new dialog.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: as part of https://github.com/joomla/Manual/pull/178
- [ ] No documentation changes for manual.joomla.org needed

Reference:
- https://github.com/joomla/joomla-cms/pull/40462