### PR TITLE
[5.0] Extensions ChangeLog display not working

### DIFF
--- a/libraries/src/Changelog/Changelog.php
+++ b/libraries/src/Changelog/Changelog.php
@@ -26,6 +26,7 @@ use Joomla\Registry\Registry;
  *
  * @since  4.0.0
  */
+#[\AllowDynamicProperties]
 class Changelog
 {
     use LegacyErrorHandlingTrait;

--- a/libraries/src/Changelog/Changelog.php
+++ b/libraries/src/Changelog/Changelog.php
@@ -26,7 +26,6 @@ use Joomla\Registry\Registry;
  *
  * @since  4.0.0
  */
-#[\AllowDynamicProperties]
 class Changelog
 {
     use LegacyErrorHandlingTrait;
@@ -119,6 +118,30 @@ class Changelog
      * @since  4.0.0
      */
     private $items = [];
+
+    /**
+     * List of node changelogs
+     *
+     * @var    array
+     * @since  5.0.0
+     */
+    private $changelogs = [];
+    
+    /**
+     * List of node changelog
+     *
+     * @var    array
+     * @since  5.0.0
+     */
+    private $changelog = [];
+    
+    /**
+     * List of node item
+     *
+     * @var    array
+     * @since  5.0.0
+     */
+    private $item = [];
 
     /**
      * Resource handle for the XML Parser

--- a/libraries/src/Changelog/Changelog.php
+++ b/libraries/src/Changelog/Changelog.php
@@ -126,7 +126,7 @@ class Changelog
      * @since  5.0.0
      */
     private $changelogs = [];
-    
+
     /**
      * List of node changelog
      *
@@ -134,7 +134,7 @@ class Changelog
      * @since  5.0.0
      */
     private $changelog = [];
-    
+
     /**
      * List of node item
      *


### PR DESCRIPTION
Pull Request for Issue #41635

### Summary of Changes
Define missing fields ( $changelog, $changelog, $item) in libraries/src/Changelog/Changelog.php class.

### Testing Instructions
PHP 8.2, Joomla 5.0 Beta 1, set "error reporting" to maximum
Load any extension that has an associated changelog file, for example https://extensions.joomla.org/extension/edition/editors/switch-editor-2/
Go to System/Extensions, search for switch editor in extensions list and click on underlined version number to display changelog content.

### Actual result BEFORE applying this Pull Request
Error message : SyntaxError: Unexpected token '<', "
"... is not valid JSON
And Error Log shows "PHP Deprecated: Creation of dynamic property"  errors

### Expected result AFTER applying this Pull Request
changelog is displayed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
