### PR TITLE
5.0 invalid array phpdoc

### DIFF
--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -44,7 +44,7 @@ extract($displayData);
  * @var   array    $options         Options available for this field.
  * @var   array    $checked         Is this field checked?
  * @var   array    $position        Position of input.
- * @var   array    $control         The forms control.
+ * @var   string   $control         The forms control.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attributes for eg, data-*.
  */

--- a/layouts/plugins/system/privacyconsent/message.php
+++ b/layouts/plugins/system/privacyconsent/message.php
@@ -38,7 +38,7 @@ extract($displayData);
  * @var   string   $validate               Validation rules to apply.
  * @var   string   $value                  Value attribute of the field.
  * @var   array    $options                Options available for this field.
- * @var   array    $privacynote            The privacy note that needs to be displayed
+ * @var   string   $privacynote            The privacy note that needs to be displayed
  * @var   array    $translateLabel         Should the label be translated?
  * @var   array    $translateHint          Should the hint be translated?
  * @var   array    $privacyArticle         The Article ID holding the Privacy Article

--- a/layouts/plugins/user/terms/message.php
+++ b/layouts/plugins/user/terms/message.php
@@ -38,7 +38,7 @@ extract($displayData);
  * @var   string   $validate               Validation rules to apply.
  * @var   string   $value                  Value attribute of the field.
  * @var   array    $options                Options available for this field.
- * @var   array    $termsnote              The terms note that needs to be displayed
+ * @var   string   $termsnote              The terms note that needs to be displayed
  * @var   array    $translateLabel         Should the label be translated?
  * @var   array    $translateHint          Should the hint be translated?
  * @var   array    $termsArticle           The Article ID holding the Terms Article


### PR DESCRIPTION
### Summary of Changes

Strings are declared as arrays

### Testing Instructions

Apply patch.

### Actual result BEFORE applying this Pull Request

See errors in IDE

### Expected result AFTER applying this Pull Request

No errors in IDE

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
