### PR TITLE
[5.0] invalid call to getCurrentUser()

### DIFF
--- a/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
@@ -279,11 +279,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Add toolbar buttons.
-        $currentUser = version_compare(JVERSION, '4.2.0', '>=')
-            ? $this->getCurrentUser()
-            : Factory::getUser();
-
-        if ($currentUser->authorise('core.admin')) {
+        if ($this->getCurrentUser()->authorise('core.admin')) {
             ToolbarHelper::preferences('com_joomlaupdate');
         }
 

--- a/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
+++ b/administrator/components/com_joomlaupdate/src/View/Joomlaupdate/HtmlView.php
@@ -279,9 +279,9 @@ class HtmlView extends BaseHtmlView
         }
 
         // Add toolbar buttons.
-        $currentUser = version_compare(JVERSION, '4.2.0', 'ge')
+        $currentUser = version_compare(JVERSION, '4.2.0', '>=')
             ? $this->getCurrentUser()
-            : $this->getCurrentUser();
+            : Factory::getUser();
 
         if ($currentUser->authorise('core.admin')) {
             ToolbarHelper::preferences('com_joomlaupdate');


### PR DESCRIPTION
### Summary of Changes

getCurrentUser() is executed before Joomla 4.2

### Testing Instructions

Upgrade from 4.1 or 4.0

### Actual result BEFORE applying this Pull Request

Called to undefined method

### Expected result AFTER applying this Pull Request

No errors

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
