### PR TITLE
5.0 AjaxHandlerLogin::processLoginFailure() has one argument

### DIFF
--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
@@ -113,7 +113,7 @@ trait AjaxHandlerLogin
             Log::add(sprintf("Received login failure. Message: %s", $e->getMessage()), Log::ERROR, 'webauthn.system');
 
             // This also enqueues the login failure message for display after redirection. Look for JLog in that method.
-            $this->processLoginFailure($response, null, 'system');
+            $this->processLoginFailure($response);
         } finally {
             /**
              * This code needs to run no matter if the login succeeded or failed. It prevents replay attacks and takes


### PR DESCRIPTION
### Summary of Changes

AjaxHandlerLogin::processLoginFailure() should be called with one argument.

### Testing Instructions

Apply patch.

### Actual result BEFORE applying this Pull Request

See IDE warning.

### Expected result AFTER applying this Pull Request

No IDE warning.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
