### PR TITLE
5.0 Default value for \Joomla\CMS\Editor\Button\Button::get()

### DIFF
--- a/libraries/src/Editor/Button/Button.php
+++ b/libraries/src/Editor/Button/Button.php
@@ -67,14 +67,15 @@ final class Button implements ButtonInterface
     }
 
     /**
-     * Return Button property or null.
+     * Return Button property.
      *
-     * @param string $name Property name
+     * @param string $name    Property name
+     * @param string $default Default value
      *
      * @return mixed
      * @since   5.0.0
      */
-    public function get(string $name)
+    public function get(string $name, $default = null)
     {
         if ($name === 'options') {
             @trigger_error(
@@ -85,7 +86,7 @@ final class Button implements ButtonInterface
             return $this->getOptions();
         }
 
-        return array_key_exists($name, $this->props) ? $this->props[$name] : null;
+        return array_key_exists($name, $this->props) ? $this->props[$name] : $default;
     }
 
     /**


### PR DESCRIPTION
### Summary of Changes

`\Joomla\CMS\Editor\Button\Button::get()` is called with second parameter as default value, but we don't have this param.

### Testing Instructions

Apply patch.

### Actual result BEFORE applying this Pull Request

See IDE warnings and possible PHP 8.2 warnings for calling strtolower() on NULL.

### Expected result AFTER applying this Pull Request

No, warnings.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
