### PR TITLE
5.0 invalid call to Joomla\CMS\Access::getData()

### DIFF
--- a/administrator/components/com_users/src/Model/GroupModel.php
+++ b/administrator/components/com_users/src/Model/GroupModel.php
@@ -166,7 +166,7 @@ class GroupModel extends AdminModel
         $parentSuperAdmin = Access::checkGroup($data['parent_id'], 'core.admin');
 
         // Get core.admin rules from the root asset
-        $rules = Access::getAssetRules('root.1')->getData('core.admin');
+        $rules = Access::getAssetRules('root.1')->getData();
 
         // Get the value for the current group (will be true (allowed), false (denied), or null (inherit)
         $groupSuperAdmin = $rules['core.admin']->allow($data['id']);


### PR DESCRIPTION
### Summary of Changes

`\Joomla\CMS\Access::getData()` is called with param while we don't have params.

### Testing Instructions

Apply patch.

### Actual result BEFORE applying this Pull Request

See IDE warning.

### Expected result AFTER applying this Pull Request

No IDE warning.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
