### PR TITLE
5.0 invalid arguments for compat plugin constructor

### DIFF
--- a/plugins/behaviour/compat/services/provider.php
+++ b/plugins/behaviour/compat/services/provider.php
@@ -13,8 +13,6 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\CMS\Profiler\Profiler;
-use Joomla\CMS\Router\SiteRouter;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 use Joomla\Event\DispatcherInterface;
@@ -36,10 +34,8 @@ return new class () implements ServiceProviderInterface {
             function (Container $container) {
                 $plugin     = PluginHelper::getPlugin('behaviour', 'compat');
                 $dispatcher = $container->get(DispatcherInterface::class);
-                $profiler   = (defined('JDEBUG') && JDEBUG) ? Profiler::getInstance('Application') : null;
-                $router     = $container->has(SiteRouter::class) ? $container->get(SiteRouter::class) : null;
 
-                $plugin = new Compat($dispatcher, (array) $plugin, $profiler, $router);
+                $plugin = new Compat($dispatcher, (array) $plugin);
                 $plugin->setApplication(Factory::getApplication());
 
                 return $plugin;


### PR DESCRIPTION
### Summary of Changes

Compat plugin constructor is called with extra undeclared arguments

### Testing Instructions

Apply patch

### Actual result BEFORE applying this Pull Request

See IDE warning

### Expected result AFTER applying this Pull Request

No IDE warning

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
