### PR TITLE
5.0 useless breaks

### DIFF
--- a/administrator/components/com_joomlaupdate/extract.php
+++ b/administrator/components/com_joomlaupdate/extract.php
@@ -1080,7 +1080,6 @@ class ZIPExtraction
                 $this->setError($actualMessage);
 
                 return false;
-                break;
         }
 
         // Find hard-coded banned files
@@ -1197,13 +1196,11 @@ class ZIPExtraction
                 $this->debugMsg('Extracting entity of type Directory', self::LOG_DEBUG);
 
                 return $this->processTypeDir();
-                break;
 
             case 'link':
                 $this->debugMsg('Extracting entity of type Symbolic Link', self::LOG_DEBUG);
 
                 return $this->processTypeLink();
-                break;
 
             case 'file':
                 switch ($this->fileHeader->compression) {
@@ -1211,20 +1208,17 @@ class ZIPExtraction
                         $this->debugMsg('Extracting entity of type File (Stored)', self::LOG_DEBUG);
 
                         return $this->processTypeFileUncompressed();
-                        break;
 
                     case 'gzip':
                     case 'bzip2':
                         $this->debugMsg('Extracting entity of type File (Compressed)', self::LOG_DEBUG);
 
                         return $this->processTypeFileCompressed();
-                        break;
 
                     case 'default':
                         $this->setError(sprintf('Unknown compression type %s.', $this->fileHeader->compression));
 
                         return false;
-                        break;
                 }
                 break;
         }
@@ -1552,7 +1546,6 @@ class ZIPExtraction
                 $this->setError(sprintf('Unknown compression method %s', $this->fileHeader->compression));
 
                 return false;
-                break;
         }
 
         unset($zipData);

--- a/components/com_users/src/Controller/DisplayController.php
+++ b/components/com_users/src/Controller/DisplayController.php
@@ -116,8 +116,6 @@ class DisplayController extends BaseController
 
                     return $controller->execute($task);
 
-                    break;
-
                 default:
                     $model = $this->getModel('Login');
                     break;


### PR DESCRIPTION
### Summary of Changes

`break` is useless after `return`

### Testing Instructions

Apply patch,

### Actual result BEFORE applying this Pull Request

Useless breaks.

### Expected result AFTER applying this Pull Request

Nice code.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
