### PR TITLE
5.0 'track_errors' is deprecated since PHP 7.2 and removed as of PHP 8.0.0.

### DIFF
--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -70,10 +70,6 @@ abstract class InstallerHelper
      */
     public static function downloadPackage($url, $target = false)
     {
-        // Capture PHP errors
-        $track_errors = ini_get('track_errors');
-        ini_set('track_errors', true);
-
         // Set user agent
         $version = new Version();
         ini_set('user_agent', $version->getUserAgent('Installer'));
@@ -131,9 +127,6 @@ abstract class InstallerHelper
 
         // Write buffer to file
         File::write($target, $body);
-
-        // Restore error tracking to what it was before
-        ini_set('track_errors', $track_errors);
 
         // Bump the max execution time because not using built in php zip libs are slow
         @set_time_limit(ini_get('max_execution_time'));

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -741,7 +741,6 @@ class Language extends BaseLanguage
         $debug        = $this->getDebug();
         $this->debug  = false;
         $errors       = [];
-        $php_errormsg = null;
 
         // Open the file as a stream.
         $file = new \SplFileObject($filename);
@@ -792,9 +791,9 @@ class Language extends BaseLanguage
         // Check if we encountered any errors.
         if (\count($errors)) {
             $this->errorfiles[$filename] = $errors;
-        } elseif ($php_errormsg) {
+        } elseif ($error = \error_get_last()) {
             // We didn't find any errors but there's probably a parse notice.
-            $this->errorfiles['PHP' . $filename] = 'PHP parser errors :' . $php_errormsg;
+            $this->errorfiles['PHP' . $filename] = 'PHP parser errors :' . $error['message'];
         }
 
         $this->debug = $debug;

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -411,9 +411,6 @@ class LanguageHelper
         if ($debug === true) {
             // See https://www.php.net/manual/en/reserved.variables.phperrormsg.php
             $php_errormsg = null;
-
-            $trackErrors = ini_get('track_errors');
-            ini_set('track_errors', true);
         }
 
         // This was required for https://github.com/joomla/joomla-cms/issues/17198 but not sure what server setup
@@ -426,11 +423,6 @@ class LanguageHelper
             $strings  = @parse_ini_string($contents);
         } else {
             $strings = @parse_ini_file($fileName);
-        }
-
-        // Restore error tracking to what it was before.
-        if ($debug === true) {
-            ini_set('track_errors', $trackErrors);
         }
 
         return \is_array($strings) ? $strings : [];

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -407,12 +407,6 @@ class LanguageHelper
             return [];
         }
 
-        // Capture hidden PHP errors from the parsing.
-        if ($debug === true) {
-            // See https://www.php.net/manual/en/reserved.variables.phperrormsg.php
-            $php_errormsg = null;
-        }
-
         // This was required for https://github.com/joomla/joomla-cms/issues/17198 but not sure what server setup
         // issue it is solving
         $disabledFunctions      = explode(',', ini_get('disable_functions'));


### PR DESCRIPTION
### Summary of Changes

`track_errors` is deprecated as of PHP 7.2.0, removed as of PHP 8.0.0.

enabled `track_errors` results to possible error message in global `$php_errormsg` which is also deprecated in favour of `error_get_last()`.

I didn't see any traces of using `$php_errormsg` with `InstallerHelper::downloadPackage()`
Language package could use `$php_errormsg` to get errors from .ini files.

### Testing Instructions

Apply patch.

### Actual result BEFORE applying this Pull Request

Bad code.

### Expected result AFTER applying this Pull Request

Goof code, rely on exceptions.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
