### PR TITLE
5.0 Prefer is_object() vs gettype()

### DIFF
--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -56,7 +56,7 @@ class ActionlogsHelper
                 sprintf(
                     '%s() requires an array or object implementing the Traversable interface, a %s was given.',
                     __METHOD__,
-                    \gettype($data) === 'object' ? \get_class($data) : \gettype($data)
+                    \is_object($data) ? \get_class($data) : \gettype($data)
                 )
             );
         }

--- a/libraries/src/Document/Document.php
+++ b/libraries/src/Document/Document.php
@@ -981,7 +981,7 @@ class Document
                     'The $date parameter of %1$s must be a string or a %2$s instance, a %3$s was given.',
                     __METHOD__ . '()',
                     'Joomla\\CMS\\Date\\Date',
-                    \gettype($date) === 'object' ? (\get_class($date) . ' instance') : \gettype($date)
+                    \is_object($date) ? (\get_class($date) . ' instance') : \gettype($date)
                 )
             );
         }

--- a/libraries/src/Feed/Feed.php
+++ b/libraries/src/Feed/Feed.php
@@ -90,7 +90,7 @@ class Feed implements \ArrayAccess, \Countable
                 sprintf(
                     '%1$s "author" must be an instance of Joomla\\CMS\\Feed\\FeedPerson. %2$s given.',
                     \get_class($this),
-                    \gettype($value) === 'object' ? \get_class($value) : \gettype($value)
+                    \is_object($value) ? \get_class($value) : \gettype($value)
                 )
             );
         }
@@ -242,7 +242,7 @@ class Feed implements \ArrayAccess, \Countable
                 sprintf(
                     '%1$s entries must be an instance of Joomla\\CMS\\Feed\\FeedPerson. %2$s given.',
                     \get_class($this),
-                    \gettype($value) === 'object' ? \get_class($value) : \gettype($value)
+                    \is_object($value) ? \get_class($value) : \gettype($value)
                 )
             );
         }

--- a/libraries/src/Feed/FeedEntry.php
+++ b/libraries/src/Feed/FeedEntry.php
@@ -85,7 +85,7 @@ class FeedEntry
                 sprintf(
                     '%1$s "author" must be an instance of Joomla\\CMS\\Feed\\FeedPerson. %2$s given.',
                     \get_class($this),
-                    \gettype($value) === 'object' ? \get_class($value) : \gettype($value)
+                    \is_object($value) ? \get_class($value) : \gettype($value)
                 )
             );
         }
@@ -96,7 +96,7 @@ class FeedEntry
                 sprintf(
                     '%1$s "source" must be an instance of Joomla\\CMS\\Feed\\Feed. %2$s given.',
                     \get_class($this),
-                    \gettype($value) === 'object' ? \get_class($value) : \gettype($value)
+                    \is_object($value) ? \get_class($value) : \gettype($value)
                 )
             );
         }


### PR DESCRIPTION
### Summary of Changes

Use `is_object()` instead of `gettype()` comparison to simplify the logic.

### Testing Instructions

Apply patch.

### Actual result BEFORE applying this Pull Request

See usual code.

### Expected result AFTER applying this Pull Request

See nice code.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
