### PR TITLE
5.0 Uncatched PublicFolderGeneratorHelper::createPublicFolder() exception, invalid void result used

### DIFF
--- a/libraries/src/Console/SiteCreatePublicFolderCommand.php
+++ b/libraries/src/Console/SiteCreatePublicFolderCommand.php
@@ -81,7 +81,9 @@ class SiteCreatePublicFolderCommand extends AbstractCommand
         $this->publicFolder = rtrim((new InputFilter())->clean($this->publicFolder, 'PATH'), '/');
         $this->publicFolder = rtrim($this->publicFolder, '\\');
 
-        if (!((new PublicFolderGeneratorHelper())->createPublicFolder($this->publicFolder))) {
+        try {
+            (new PublicFolderGeneratorHelper())->createPublicFolder($this->publicFolder);
+        } catch (\Exception $e) {
             return Command::FAILURE;
         }
 

--- a/libraries/src/Helper/PublicFolderGeneratorHelper.php
+++ b/libraries/src/Helper/PublicFolderGeneratorHelper.php
@@ -88,6 +88,7 @@ PHP;
      * @param string $destinationPath The full path for the public folder
      *
      * @return void
+     * @throws \Exception
      *
      * @since  5.0.0
      */


### PR DESCRIPTION
### Summary of Changes

PublicFolderGeneratorHelper::createPublicFolder() is void, we need to catch exception but not check the return result.


### Testing Instructions

Apply patch.

### Actual result BEFORE applying this Pull Request

See the code.

### Expected result AFTER applying this Pull Request

Good code.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
