### PR TITLE
[5.0] CacheStorageHelper::$size to int

### DIFF
--- a/libraries/src/Cache/Storage/CacheStorageHelper.php
+++ b/libraries/src/Cache/Storage/CacheStorageHelper.php
@@ -31,7 +31,7 @@ class CacheStorageHelper
     /**
      * Cached item size
      *
-     * @var    string
+     * @var    int
      * @since  1.7.0
      */
     public $size = 0;
@@ -39,7 +39,7 @@ class CacheStorageHelper
     /**
      * Counter
      *
-     * @var    integer
+     * @var    int
      * @since  1.7.0
      */
     public $count = 0;
@@ -59,7 +59,7 @@ class CacheStorageHelper
     /**
      * Increase cache items count.
      *
-     * @param   string  $size  Cached item size
+     * @param   int  $size  Cached item size
      *
      * @return  void
      *


### PR DESCRIPTION
### Summary of Changes

Correct PHPDoc for `CacheStorageHelper::$size`

### Testing Instructions

Apply patch

### Actual result BEFORE applying this Pull Request

See IDE errors.

### Expected result AFTER applying this Pull Request

No IDE errors.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
