### PR TITLE
[5.0] Modal Dialog  for User field

### DIFF
--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -79,7 +79,7 @@ $userRequired    = (int) $input->get('required', 0, 'int');
                         . ' data-id="' . ((int) $item->id) . '"'
                         . ' data-name="' . $this->escape($item->name) . '"'
                         // @TODO: data-user-value, data-user-name, data-user-field is for backward compatibility, remove in Joomla 6
-                        . ' data-user-value="' .((int) $item->id) . '"'
+                        . ' data-user-value="' . ((int) $item->id) . '"'
                         . ' data-user-name="' . $this->escape($item->name) . '"'
                         . ' data-user-field="' . $this->escape($field) . '"';
                     ?>

--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -18,16 +18,15 @@ use Joomla\CMS\Router\Route;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
-$wa->useScript('multiselect');
+$wa->useScript('multiselect')->useScript('modal-content-select');
 
 $input           = Factory::getApplication()->getInput();
-$field           = $input->getCmd('field');
-$listOrder       = $this->escape($this->state->get('list.ordering'));
-$listDirn        = $this->escape($this->state->get('list.direction'));
+$field           = $input->getCmd('field', '');
+$listOrder       = $this->escape($this->state->get('list.ordering', ''));
+$listDirn        = $this->escape($this->state->get('list.direction', ''));
 $enabledStates   = [0 => 'icon-check', 1 => 'icon-times'];
 $activatedStates = [0 => 'icon-check', 1 => 'icon-times'];
 $userRequired    = (int) $input->get('required', 0, 'int');
-$onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.getCurrent().close()";
 
 ?>
 <div class="container-popup">
@@ -75,11 +74,18 @@ $onClick         = "window.parent.jSelectUser(this);window.parent.Joomla.Modal.g
             </thead>
             <tbody>
                 <?php $i = 0; ?>
-                <?php foreach ($this->items as $item) : ?>
+                <?php foreach ($this->items as $item) :
+                    $attribs = 'data-content-select data-content-type="com_users.user"'
+                        . ' data-id="' . ((int) $item->id) . '"'
+                        . ' data-name="' . $this->escape($item->name) . '"'
+                        // @TODO: data-user-value, data-user-name, data-user-field is for backward compatibility, remove in Joomla 6
+                        . ' data-user-value="' .((int) $item->id) . '"'
+                        . ' data-user-name="' . $this->escape($item->name) . '"'
+                        . ' data-user-field="' . $this->escape($field) . '"';
+                    ?>
                     <tr class="row<?php echo $i % 2; ?>">
                         <th scope="row">
-                            <a class="pointer button-select" href="#" data-user-value="<?php echo $item->id; ?>" data-user-name="<?php echo $this->escape($item->name); ?>"
-                                data-user-field="<?php echo $this->escape($field); ?>">
+                            <a class="pointer button-select" href="#" <?php echo $attribs; ?>>
                                 <?php echo $this->escape($item->name); ?>
                             </a>
                         </th>

--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -538,7 +538,8 @@
         "type": "module"
       },
       "dependencies": [
-        "webcomponent.field-user-legacy"
+        "webcomponent.field-user-legacy",
+        "joomla.dialog"
       ]
     },
     {

--- a/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-user.w-c.es6.js
@@ -1,152 +1,171 @@
-((customElements, Joomla) => {
-  class JoomlaFieldUser extends HTMLElement {
-    constructor() {
-      super();
+/**
+ * @copyright  (C) 2017 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+// eslint-disable-next-line import/no-unresolved
+import JoomlaDialog from 'joomla.dialog';
 
-      this.onUserSelect = '';
-      this.onchangeStr = '';
+class JoomlaFieldUser extends HTMLElement {
+  constructor() {
+    super();
 
-      // Bind events
-      this.buttonClick = this.buttonClick.bind(this);
-      this.iframeLoad = this.iframeLoad.bind(this);
-      this.modalClose = this.modalClose.bind(this);
-      this.setValue = this.setValue.bind(this);
-    }
+    this.onUserSelect = '';
+    this.onchangeStr = '';
 
-    static get observedAttributes() {
-      return ['url', 'modal', 'modal-width', 'modal-height', 'input', 'input-name', 'button-select'];
-    }
+    // Bind context
+    this.modalClose = this.modalClose.bind(this);
+    this.setValue = this.setValue.bind(this);
+    this.modalOpen = this.modalOpen.bind(this);
+  }
 
-    get url() { return this.getAttribute('url'); }
+  static get observedAttributes() {
+    return ['url', 'modal', 'modal-width', 'modal-height', 'modal-title', 'input', 'input-name', 'button-select'];
+  }
 
-    set url(value) { this.setAttribute('url', value); }
+  get url() {
+    return this.getAttribute('url');
+  }
 
-    get modalClass() { return this.getAttribute('modal'); }
+  set url(value) {
+    this.setAttribute('url', value);
+  }
 
-    set modalClass(value) { this.setAttribute('modal', value); }
+  get modalWidth() {
+    return this.getAttribute('modal-width');
+  }
 
-    get modalWidth() { return this.getAttribute('modal-width'); }
+  set modalWidth(value) {
+    this.setAttribute('modal-width', value);
+  }
 
-    set modalWidth(value) { this.setAttribute('modal-width', value); }
+  get modalTitle() {
+    return this.getAttribute('modal-title');
+  }
 
-    get modalHeight() { return this.getAttribute('modal-height'); }
+  set modalTitle(value) {
+    this.setAttribute('modal-title', value);
+  }
 
-    set modalHeight(value) { this.setAttribute('modal-height', value); }
+  get modalHeight() {
+    return this.getAttribute('modal-height');
+  }
 
-    get inputId() { return this.getAttribute('input'); }
+  set modalHeight(value) {
+    this.setAttribute('modal-height', value);
+  }
 
-    set inputId(value) { this.setAttribute('input', value); }
+  get inputId() {
+    return this.getAttribute('input');
+  }
 
-    get inputNameClass() { return this.getAttribute('input-name'); }
+  set inputId(value) {
+    this.setAttribute('input', value);
+  }
 
-    set inputNameClass(value) { this.setAttribute('input-name', value); }
+  get inputNameClass() {
+    return this.getAttribute('input-name');
+  }
 
-    get buttonSelectClass() { return this.getAttribute('button-select'); }
+  set inputNameClass(value) {
+    this.setAttribute('input-name', value);
+  }
 
-    set buttonSelectClass(value) { this.setAttribute('button-select', value); }
+  get buttonSelectClass() {
+    return this.getAttribute('button-select');
+  }
 
-    connectedCallback() {
-      // Set up elements
-      this.modal = this.querySelector(this.modalClass);
-      this.modalBody = this.querySelector('.modal-body');
-      this.input = this.querySelector(this.inputId);
-      this.inputName = this.querySelector(this.inputNameClass);
-      this.buttonSelect = this.querySelector(this.buttonSelectClass);
+  set buttonSelectClass(value) {
+    this.setAttribute('button-select', value);
+  }
 
-      // Bootstrap modal init
-      if (this.modal
-        && window.bootstrap
-        && window.bootstrap.Modal
-        && !window.bootstrap.Modal.getInstance(this.modal)) {
-        Joomla.initialiseModal(this.modal, { isJoomla: true });
+  connectedCallback() {
+    // Set up elements
+    this.input = this.querySelector(this.inputId);
+    this.inputName = this.querySelector(this.inputNameClass);
+    this.buttonSelect = this.querySelector(this.buttonSelectClass);
+
+    if (this.buttonSelect) {
+      this.buttonSelect.addEventListener('click', this.modalOpen.bind(this));
+      // this.modal.addEventListener('hide', this.removeIframe.bind(this));
+
+      // Check for onchange callback,
+      this.onchangeStr = this.input.getAttribute('data-onchange');
+      if (this.onchangeStr) {
+        // eslint-disable-next-line no-new-func
+        this.onUserSelect = new Function(this.onchangeStr);
+        this.input.addEventListener('change', this.onUserSelect);
       }
-
-      if (this.buttonSelect) {
-        this.buttonSelect.addEventListener('click', this.modalOpen.bind(this));
-        this.modal.addEventListener('hide', this.removeIframe.bind(this));
-
-        // Check for onchange callback,
-        this.onchangeStr = this.input.getAttribute('data-onchange');
-        if (this.onchangeStr) {
-          /* eslint-disable */
-          this.onUserSelect = new Function(this.onchangeStr);
-          this.input.addEventListener('change', this.onUserSelect);
-          /* eslint-enable */
-        }
-      }
-    }
-
-    disconnectedCallback() {
-      if (this.onchangeStr && this.input) {
-        this.input.removeEventListener('change', this.onUserSelect);
-      }
-
-      if (this.buttonSelect) {
-        this.buttonSelect.removeEventListener('click', this);
-      }
-
-      if (this.modal) {
-        this.modal.removeEventListener('hide', this);
-      }
-    }
-
-    buttonClick({ target }) {
-      this.setValue(target.getAttribute('data-user-value'), target.getAttribute('data-user-name'));
-      this.modalClose();
-    }
-
-    iframeLoad() {
-      const iframeDoc = this.iframeEl.contentWindow.document;
-      const buttons = [].slice.call(iframeDoc.querySelectorAll('.button-select'));
-
-      buttons.forEach((button) => {
-        button.addEventListener('click', this.buttonClick);
-      });
-    }
-
-    // Opens the modal
-    modalOpen() {
-      // Reconstruct the iframe
-      this.removeIframe();
-      const iframe = document.createElement('iframe');
-      iframe.setAttribute('name', 'field-user-modal');
-      iframe.src = this.url.replace('{field-user-id}', this.input.getAttribute('id'));
-      iframe.setAttribute('width', this.modalWidth);
-      iframe.setAttribute('height', this.modalHeight);
-
-      this.modalBody.appendChild(iframe);
-
-      this.modal.open();
-
-      this.iframeEl = this.modalBody.querySelector('iframe');
-
-      // handle the selection on the iframe
-      this.iframeEl.addEventListener('load', this.iframeLoad);
-    }
-
-    // Closes the modal
-    modalClose() {
-      Joomla.Modal.getCurrent().close();
-      this.modalBody.innerHTML = '';
-    }
-
-    // Remove the iframe
-    removeIframe() {
-      this.modalBody.innerHTML = '';
-    }
-
-    // Sets the value
-    setValue(value, name) {
-      this.input.setAttribute('value', value);
-      this.inputName.setAttribute('value', name || value);
-      // trigger change event both on the input and on the custom element
-      this.input.dispatchEvent(new Event('change'));
-      this.dispatchEvent(new CustomEvent('change', {
-        detail: { value, name },
-        bubbles: true,
-      }));
     }
   }
 
-  customElements.define('joomla-field-user', JoomlaFieldUser);
-})(customElements, Joomla);
+  disconnectedCallback() {
+    if (this.onUserSelect && this.input) {
+      this.input.removeEventListener('change', this.onUserSelect);
+    }
+
+    if (this.buttonSelect) {
+      this.buttonSelect.removeEventListener('click', this.modalOpen);
+    }
+
+    if (this.modal) {
+      this.modal.removeEventListener('hide', this);
+    }
+  }
+
+  // Opens the modal
+  modalOpen() {
+    // Create and show the dialog
+    const dialog = new JoomlaDialog({
+      popupType: 'iframe',
+      src: this.url,
+      textHeader: this.modalTitle,
+      width: this.modalWidth,
+      height: this.modalHeight,
+    });
+    dialog.classList.add('joomla-dialog-user-field');
+    dialog.show();
+
+    // Wait for message
+    const msgListener = (event) => {
+      // Avoid cross origins
+      if (event.origin !== window.location.origin) return;
+      // Check message type
+      if (event.data.messageType === 'joomla:content-select') {
+        this.setValue(event.data.id, event.data.name);
+        dialog.close();
+      } else if (event.data.messageType === 'joomla:cancel') {
+        dialog.close();
+      }
+    };
+    window.addEventListener('message', msgListener);
+
+    dialog.addEventListener('joomla-dialog:close', () => {
+      window.removeEventListener('message', msgListener);
+      dialog.destroy();
+      this.dialog = null;
+    });
+
+    this.dialog = dialog;
+  }
+
+  // Closes the modal
+  modalClose() {
+    if (this.dialog) {
+      this.dialog.close();
+    }
+  }
+
+  // Sets the value
+  setValue(value, name) {
+    this.input.setAttribute('value', value);
+    this.inputName.setAttribute('value', name || value);
+    // trigger change event both on the input and on the custom element
+    this.input.dispatchEvent(new CustomEvent('change'));
+    this.dispatchEvent(new CustomEvent('change', {
+      detail: { value, name },
+      bubbles: true,
+    }));
+  }
+}
+
+customElements.define('joomla-field-user', JoomlaFieldUser);

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -11,7 +11,6 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Utilities\ArrayHelper;
@@ -50,9 +49,8 @@ extract($displayData);
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*.
  */
-$modalHTML = '';
-$uri = new Uri('index.php?option=com_users&view=users&layout=modal&tmpl=component&required=0');
 
+$uri = new Uri('index.php?option=com_users&view=users&layout=modal&tmpl=component&required=0');
 $uri->setVar('field', $this->escape($id));
 
 if ($required) {
@@ -73,8 +71,12 @@ if ($this->escape($userName) === Text::_('JLIB_FORM_SELECT_USER')) {
 }
 
 $inputAttributes = [
-    'type' => 'text', 'id' => $id, 'class' => 'form-control field-user-input-name', 'value' => $this->escape($userName)
+    'type'  => 'text',
+    'id'    => $id,
+    'class' => 'form-control field-user-input-name',
+    'value' => $this->escape($userName),
 ];
+
 if ($class) {
     $inputAttributes['class'] .= ' ' . $class;
 }
@@ -89,31 +91,14 @@ if (!$readonly) {
 }
 
 if (!$readonly) {
-    $modalHTML = HTMLHelper::_(
-        'bootstrap.renderModal',
-        'userModal_' . $id,
-        [
-            'url'         => $uri,
-            'title'       => Text::_('JLIB_FORM_CHANGE_USER'),
-            'closeButton' => true,
-            'height'      => '100%',
-            'width'       => '100%',
-            'modalWidth'  => 80,
-            'bodyHeight'  => 60,
-            'footer'      => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">' . Text::_('JCANCEL') . '</button>',
-        ]
-    );
-
-    Factory::getDocument()->getWebAssetManager()
+    Factory::getApplication()->getDocument()->getWebAssetManager()
         ->useScript('webcomponent.field-user');
 }
 ?>
 <?php // Create a dummy text field with the user name. ?>
 <joomla-field-user class="field-user-wrapper"
         url="<?php echo (string) $uri; ?>"
-        modal=".modal"
-        modal-width="100%"
-        modal-height="400px"
+        modal-title="<?php echo $this->escape(Text::_('JLIB_FORM_CHANGE_USER')); ?>"
         input=".field-user-input"
         input-name=".field-user-input-name"
         button-select=".button-select">
@@ -131,6 +116,5 @@ if (!$readonly) {
         <input type="hidden" id="<?php echo $id; ?>_id" name="<?php echo $name; ?>" value="<?php echo $this->escape($value); ?>"
             class="field-user-input <?php echo $class ? (string) $class : ''?>"
             data-onchange="<?php echo $this->escape($onchange); ?>">
-        <?php echo $modalHTML; ?>
     <?php endif; ?>
 </joomla-field-user>


### PR DESCRIPTION
### Summary of Changes

Use Joomla dialog and `postMessage` for user field, instead of BS modal.

It may not hit 5.0, but in future will need to update anyway.

### Testing Instructions
Apply patch, run `npm install`
Create User field, or use existing. try select the field value.

```xml
<field type="user" name="user_test" label="User"/>
```


### Actual result BEFORE applying this Pull Request
Works with BS modal


### Expected result AFTER applying this Pull Request
Works with joomla dialog


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: as part of https://github.com/joomla/Manual/pull/178 and https://github.com/joomla/Manual/pull/99
- [ ] No documentation changes for manual.joomla.org needed

References:
- https://github.com/joomla/joomla-cms/pull/40462
- https://github.com/joomla/joomla-cms/pull/40150