### PR TITLE
[5.0][Events] Extension ChangeState event

### DIFF
--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -11,6 +11,7 @@
 namespace Joomla\Component\Installer\Administrator\Model;
 
 use Joomla\CMS\Changelog\Changelog;
+use Joomla\CMS\Event\Model\BeforeChangeStateEvent;
 use Joomla\CMS\Extension\ExtensionHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Installer\Installer;
@@ -129,7 +130,11 @@ class ManageModel extends InstallerModel
         }
 
         // Get a table object for the extension type
-        $table = new Extension($this->getDatabase());
+        $table      = new Extension($this->getDatabase());
+        $context    = $this->option . '.' . $this->name;
+        $dispatcher = $this->getDispatcher();
+
+        PluginHelper::importPlugin('extension', null, true, $dispatcher);
 
         // Enable the extension in the table and store it in the database
         foreach ($eid as $i => $id) {
@@ -159,10 +164,12 @@ class ManageModel extends InstallerModel
                 $table->enabled = $value;
             }
 
-            $context = $this->option . '.' . $this->name;
-
-            PluginHelper::importPlugin('extension');
-            Factory::getApplication()->triggerEvent('onExtensionChangeState', [$context, $eid, $value]);
+            // Trigger the before change state event.
+            $dispatcher->dispatch('onExtensionChangeState', new BeforeChangeStateEvent('onExtensionChangeState', [
+                'context' => $context,
+                'subject' => $eid,
+                'value'   => $value,
+            ]));
 
             if (!$table->store()) {
                 $this->setError($table->getError());

--- a/libraries/src/Event/CoreEventAware.php
+++ b/libraries/src/Event/CoreEventAware.php
@@ -105,9 +105,6 @@ trait CoreEventAware
         'onSchemaPrepareData'       => Plugin\System\Schemaorg\PrepareDataEvent::class,
         'onSchemaPrepareForm'       => Plugin\System\Schemaorg\PrepareFormEvent::class,
         'onSchemaPrepareSave'       => Plugin\System\Schemaorg\PrepareSaveEvent::class,
-        // Extensions
-        'onBeforeExtensionBoot' => BeforeExtensionBootEvent::class,
-        'onAfterExtensionBoot'  => AfterExtensionBootEvent::class,
         // Content
         'onContentPrepare'       => Content\ContentPrepareEvent::class,
         'onContentAfterTitle'    => Content\AfterTitleEvent::class,
@@ -155,6 +152,8 @@ trait CoreEventAware
         'onAfterModuleList'      => Module\AfterModuleListEvent::class,
         'onAfterCleanModuleList' => Module\AfterCleanModuleListEvent::class,
         // Extension
+        'onBeforeExtensionBoot'      => BeforeExtensionBootEvent::class,
+        'onAfterExtensionBoot'       => AfterExtensionBootEvent::class,
         'onExtensionBeforeInstall'   => Extension\BeforeInstallEvent::class,
         'onExtensionAfterInstall'    => Extension\AfterInstallEvent::class,
         'onExtensionBeforeUninstall' => Extension\BeforeUninstallEvent::class,
@@ -164,6 +163,7 @@ trait CoreEventAware
         'onExtensionBeforeSave'      => Model\BeforeSaveEvent::class,
         'onExtensionAfterSave'       => Model\AfterSaveEvent::class,
         'onExtensionAfterDelete'     => Model\AfterDeleteEvent::class,
+        'onExtensionChangeState'     => Model\BeforeChangeStateEvent::class,
         // Installer
         'onInstallerAddInstallationTab'    => Installer\AddInstallationTabEvent::class,
         'onInstallerBeforeInstallation'    => Installer\BeforeInstallationEvent::class,


### PR DESCRIPTION
### Summary of Changes

Add missing event for `onExtensionChangeState`
Was missing in:
- https://github.com/joomla/joomla-cms/pull/41322


### Testing Instructions
Go to extension manager,
Try publish/unpublish extension.


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: https://docs.joomla.org/Plugin/Events#Extensions
- [ ] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/177
- [ ] No documentation changes for manual.joomla.org needed
