### PR TITLE
[5.0] Enable the system plugin on upgrade

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-09-11.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-09-11.sql
@@ -1,0 +1,1 @@
+UPDATE `#__extensions` SET `enabled` = 1 WHERE `name` = 'plg_system_schedulerunner';

--- a/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-09-11.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.0.0-2023-09-11.sql
@@ -1,1 +1,1 @@
-UPDATE `#__extensions` SET `enabled` = 1 WHERE `name` = 'plg_system_schedulerunner';
+UPDATE `#__extensions` SET `enabled` = 1 WHERE `type` = 'plugin' AND `element` = 'schedulerunner' AND `folder` = 'system';

--- a/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-09-11.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-09-11.sql
@@ -1,1 +1,1 @@
-UPDATE "#__extensions" SET "enabled" = 1 WHERE "name" = 'plg_system_schedulerunner';
+UPDATE "#__extensions" SET "enabled" = 1 WHERE "type" = 'plugin' AND "element" = 'schedulerunner' AND "folder" = 'system';

--- a/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-09-11.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.0.0-2023-09-11.sql
@@ -1,0 +1,1 @@
+UPDATE "#__extensions" SET "enabled" = 1 WHERE "name" = 'plg_system_schedulerunner';


### PR DESCRIPTION
### Summary of Changes
Since some system plugin code is moved to tasks, the scheduler system plugin should be activate on update. When it is disabled, then we can run into the issue that the session table doesn't get cleaned up. We all know what the consequences are.

A reason to disable the system plugin is when sites are using the crontab feature of linux as it is more reliable that the lazy scheduler plugin.

This needs to be documented on docs.joomla.org. Any help would be appreciated for the documentation taskas it affects every site with a disabled scheduler system plugin.

### Testing Instructions
- Disable the system scheduler plugin on 4.x
- Update to 5.0

### Actual result BEFORE applying this Pull Request
Scheduler plugin is not activated.

### Expected result AFTER applying this Pull Request
Scheduler plugin is activated.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
