### PR TITLE
[5.0] task sessiongc lang cleanup

### DIFF
--- a/administrator/language/en-GB/plg_task_sessiongc.sys.ini
+++ b/administrator/language/en-GB/plg_task_sessiongc.sys.ini
@@ -4,6 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_TASK_SESSIONGC="Task - Session Data Purge"
-PLG_TASK_SESSIONGC_DESC="Task Plugin that purges expired data and metadata depending on the session handler set in Global Configuration."
-PLG_TASK_SESSIONGC_TITLE="Task - Session Data Purge"
 PLG_TASK_SESSIONGC_XML_DESCRIPTION="Task Plugin that purges expired data and metadata depending on the session handler set in Global Configuration."


### PR DESCRIPTION
### Summary of Changes

The strings of the task should not be in the `sys` file like in all other task plugins

### Testing Instructions

check task title/description

### Actual result BEFORE applying this Pull Request

title and description are in both lang files (`plg_task_sessiongc.ini`, `plg_task_sessiongc.sys.ini`)

### Expected result AFTER applying this Pull Request

title and description are only in one lang files (`plg_task_sessiongc.ini`) and are still displayed correctly
![image](https://github.com/joomla/joomla-cms/assets/66922325/aeb3c453-4cd6-4390-8c50-8139b57c98ea)
![image](https://github.com/joomla/joomla-cms/assets/66922325/65a2bd12-34c5-426d-a4dc-bb2e67740265)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
