### PR TITLE
[5.0] Make sure the editor content is a string, not null

### DIFF
--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -207,7 +207,7 @@ class Editor implements DispatcherAwareInterface
             $params['asset']   = $params['asset'] ?? $asset;
             $params['author']  = $params['author'] ?? $author;
 
-            return $this->provider->display($name, $html, [
+            return $this->provider->display($name, $html ?? '', [
                 'width'  => $width,
                 'height' => $height,
                 'col'    => $col,

--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -206,8 +206,9 @@ class Editor implements DispatcherAwareInterface
             $params['buttons'] = $params['buttons'] ?? $buttons;
             $params['asset']   = $params['asset'] ?? $asset;
             $params['author']  = $params['author'] ?? $author;
+            $content           = $html ?? '';
 
-            return $this->provider->display($name, $html ?? '', [
+            return $this->provider->display($name, $content, [
                 'width'  => $width,
                 'height' => $height,
                 'col'    => $col,


### PR DESCRIPTION
### Summary of Changes

Make sure the editor content is a string.


### Testing Instructions

Run following, somewhere in layout or in template:
```php
$editor = Joomla\CMS\Editor\Editor::getInstance('tinymce');
echo $editor->display('text', null);
```


### Actual result BEFORE applying this Pull Request
An error


### Expected result AFTER applying this Pull Request
You get rendered editor


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
