### PR TITLE
[4.3] fix localised cli installation

### DIFF
--- a/installation/src/Console/InstallCommand.php
+++ b/installation/src/Console/InstallCommand.php
@@ -152,7 +152,7 @@ class InstallCommand extends AbstractCommand
         foreach ($files as $step => $schema) {
             $serverType = $db->getServerType();
 
-            if (\in_array($step, ['custom1', 'custom2']) && !is_file('sql/' . $serverType . '/' . $schema . '.sql')) {
+            if (\in_array($step, ['custom1', 'custom2']) && !is_file(JPATH_INSTALLATION . '/sql/' . $serverType . '/' . $schema . '.sql')) {
                 continue;
             }
 

--- a/installation/src/Controller/InstallationController.php
+++ b/installation/src/Controller/InstallationController.php
@@ -144,7 +144,7 @@ class InstallationController extends JSONController
         $schema     = $files[$step];
         $serverType = $db->getServerType();
 
-        if (in_array($step, ['custom1', 'custom2']) && !is_file('sql/' . $serverType . '/' . $schema . '.sql')) {
+        if (in_array($step, ['custom1', 'custom2']) && !is_file(JPATH_INSTALLATION . '/sql/' . $serverType . '/' . $schema . '.sql')) {
             $this->sendJsonResponse($r);
 
             return;


### PR DESCRIPTION
### Summary of Changes

there are differentes between:
- `php installation/joomla.php install` (in root folder)
- `php joomla.php install` (in install folder)

use same folder constant for `InstallCommand`/`InstallationController` like in `DatabaseModel`:
https://github.com/joomla/joomla-cms/blob/5c8d6df69d75c0cbfde715a061b8a52895f397be/installation/src/Model/DatabaseModel.php#L317

### Testing Instructions

try to install eg. german localised language pack

### Actual result BEFORE applying this Pull Request

only variant 2 is working

### Expected result AFTER applying this Pull Request

both variants are working

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
