### PR TITLE
[5.0] Adds onPrepareModuleList event to ModulesRenderer

### DIFF
--- a/libraries/src/Document/Renderer/Html/ModulesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModulesRenderer.php
@@ -48,7 +48,15 @@ class ModulesRenderer extends DocumentRenderer
         $frontediting = ($app->isClient('site') && $app->get('frontediting', 1) && !$user->guest);
         $menusEditing = ($app->get('frontediting', 1) == 2) && $user->authorise('core.edit', 'com_menus');
 
-        foreach (ModuleHelper::getModules($position) as $mod) {
+        $modules = ModuleHelper::getModules($position);
+
+        // Dispatch onPrepareModuleList event
+        $event = new Module\PrepareModuleListEvent('onPrepareModuleList', [
+            'subject' => new ArrayProxy($modules),
+        ]);
+        $app->getDispatcher()->dispatch('onPrepareModuleList', $event);
+
+        foreach ($modules as $mod) {
             $moduleHtml = $renderer->render($mod, $params, $content);
 
             if ($frontediting && trim($moduleHtml) != '' && $user->authorise('module.edit.frontend', 'com_modules.module.' . $mod->id)) {


### PR DESCRIPTION
There is no onPrepareModuleList event being triggered in the new module position rendering.
This means that plugins cannot change the list of modules before the modules get rendered, which is possible in previous versions of Joomla.

This PR adds the missing onPrepareModuleList event to the ModulesRenderer class.

You can test this by creating a system plugin.
In the main plugin file, add this method:
```
        public function onPrepareModuleList(ArrayProxy &$modules)
        {
            if ( ! JFactory::getApplication()->isClient('site') || ! $modules->count())
            {
                return;
            }

            $modules->offsetUnset(0);
        }
```

Before the patch, nothing will happen.
After the patch, the first module in every module position should be removed from the frontend.