### PR TITLE
[4.4] Use correct priority constants in debug plugin

### DIFF
--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -28,6 +28,7 @@ use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Event\ConnectionEvent;
 use Joomla\Event\DispatcherInterface;
 use Joomla\Event\Event;
+use Joomla\Event\Priority;
 use Joomla\Event\SubscriberInterface;
 use Joomla\Plugin\System\Debug\DataCollector\InfoCollector;
 use Joomla\Plugin\System\Debug\DataCollector\LanguageErrorsCollector;
@@ -146,11 +147,11 @@ final class Debug extends CMSPlugin implements SubscriberInterface
             'onBeforeRespond'     => 'onBeforeRespond',
             'onAfterRespond'      => [
                 'onAfterRespond',
-                PHP_INT_MIN,
+                Priority::MIN,
             ],
             ApplicationEvents::AFTER_RESPOND => [
                 'onAfterRespond',
-                PHP_INT_MIN,
+                Priority::MIN,
             ],
             'onAfterDisconnect' => 'onAfterDisconnect',
         ];


### PR DESCRIPTION
Pull Request for Issue #35655 .

### Summary of Changes
use Joomla priority constant instead of php integer minimum constant


### Testing Instructions
check plugin


### Actual result BEFORE applying this Pull Request
works


### Expected result AFTER applying this Pull Request
works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
