### PR TITLE
[5.0] simplepie

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2044,8 +2044,8 @@ class JoomlaInstallerScript
             '/media/com_contenthistory/js/admin-history-versions.min.js',
             '/media/com_contenthistory/js/admin-history-versions.min.js.gz',
             // From 5.0.0-beta1 to 5.0.0-beta2
-            '/libraries/src/Cache/Storage/WincacheStorage.php',
             '/language/en-GB/lib_simplepie.sys.ini',
+            '/libraries/src/Cache/Storage/WincacheStorage.php',
         ];
 
         $folders = [

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2045,6 +2045,7 @@ class JoomlaInstallerScript
             '/media/com_contenthistory/js/admin-history-versions.min.js.gz',
             // From 5.0.0-beta1 to 5.0.0-beta2
             '/libraries/src/Cache/Storage/WincacheStorage.php',
+            '/language/en-GB/lib_simplepie.sys.ini',
         ];
 
         $folders = [

--- a/language/en-GB/lib_simplepie.sys.ini
+++ b/language/en-GB/lib_simplepie.sys.ini
@@ -1,6 +1,0 @@
-; Joomla! Project
-; (C) 2011 Open Source Matters, Inc. <https://www.joomla.org>
-; License GNU General Public License version 2 or later; see LICENSE.txt
-; Note : All ini files need to be saved as UTF-8
-
-LIB_SIMPLEPIE_XML_DESCRIPTION="PHP based RSS and Atom Feed Framework."


### PR DESCRIPTION
The simplepie library was removed in joomla 4.0 dont know why but this language file was left, probably in error when the language files were renamed
