### PR TITLE
[4.3] Fix untranslated constants in script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -634,7 +634,13 @@ class JoomlaInstallerScript
             if (!$installer->refreshManifestCache($extension->extension_id)) {
                 $this->collectError(
                     __METHOD__,
-                    new \Exception(Text::sprintf('FILES_JOOMLA_ERROR_MANIFEST', $extension->type, $extension->element, $extension->name, $extension->client_id))
+                    new \Exception(sprintf(
+                        'Error on updating manifest cache: (type, element, folder, client) = (%s, %s, %s, %s)',
+                        $extension->type,
+                        $extension->element,
+                        $extension->name,
+                        $extension->client_id
+                    ))
                 );
             }
         }
@@ -8001,7 +8007,7 @@ class JoomlaInstallerScript
                     if (File::delete(JPATH_ROOT . $file)) {
                         $status['files_deleted'][] = $file;
                     } else {
-                        $status['files_errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $file);
+                        $status['files_errors'][] = sprintf('Error on deleting file or folder %s', $file);
                     }
                 }
             }
@@ -8017,7 +8023,7 @@ class JoomlaInstallerScript
                     if (Folder::delete(JPATH_ROOT . $folder)) {
                         $status['folders_deleted'][] = $folder;
                     } else {
-                        $status['folders_errors'][] = Text::sprintf('FILES_JOOMLA_ERROR_FILE_FOLDER', $folder);
+                        $status['folders_errors'][] = sprintf('Error on deleting file or folder %s', $folder);
                     }
                 }
             }

--- a/language/en-GB/files_joomla.sys.ini
+++ b/language/en-GB/files_joomla.sys.ini
@@ -4,6 +4,8 @@
 ; Note : All ini files need to be saved as UTF-8
 
 FILES_JOOMLA="Joomla CMS"
+FILES_JOOMLA_XML_DESCRIPTION="Joomla! 4 Content Management System."
+
+; All the following strings are deprecated and will be removed with 6.0
 FILES_JOOMLA_ERROR_FILE_FOLDER="Error on deleting file or folder %s"
 FILES_JOOMLA_ERROR_MANIFEST="Error on updating manifest cache: (type, element, folder, client) = (%s, %s, %s, %s)"
-FILES_JOOMLA_XML_DESCRIPTION="Joomla! 4 Content Management System."


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Follow up for https://github.com/joomla/joomla-cms/pull/41367
Replace untranslated constants to text


### Testing Instructions
Code review,
Or do Test 7 from @richard67 instruction https://github.com/joomla/joomla-cms/pull/41367#issuecomment-1712791024


### Actual result BEFORE applying this Pull Request
Untranslated lang constant


### Expected result AFTER applying this Pull Request
A fixed text


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
