### PR TITLE
[5.1] Button and link text color issue on focus

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_global.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_global.scss
@@ -60,9 +60,9 @@ a {
     text-decoration: underline;
   }
 
-  &:not(.btn):hover,
-  &:not(.btn):focus {
-    color: var(--cassiopeia-color-hover);
+  &:not([class]):hover,
+  &:not([class]):focus {
+    color: currentColor;
   }
 
   &.navbar-brand {


### PR DESCRIPTION
Text is not readable on focus

Pull Request for Issue #40306, #41153 and #41172

### Summary of Changes

The Pull Request #40435 for issue #40306, caused the issues #41153 and #41172.
Hopefully this PR will provide the overall solution. Or there is possible a better css solution.

### Testing Instructions

Build: npm ci
Clear the browser cache (historie) after the patch if necessary

- Code review

- see #40306
- see #41153
- see #41172

### Actual result BEFORE applying this Pull Request

The button and the link text is NOT readable on focus.

### Expected result AFTER applying this Pull Request

The button and the link text is always readable on focus.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Thanks @RickR2H