### PR TITLE
[5.0] ModalField Fix missing icon for select btn

### DIFF
--- a/layouts/joomla/form/field/modal-select/buttons.php
+++ b/layouts/joomla/form/field/modal-select/buttons.php
@@ -74,7 +74,7 @@ $isSelectAlways = !empty($canDo['select']) && empty($canDo['clear']);
 <button type="button" class="btn btn-primary" <?php echo $value && !$isSelectAlways ? 'hidden' : ''; ?>
         data-button-action="select" <?php echo !$isSelectAlways ? 'data-show-when-value=""' : ''; ?>
         data-modal-config="<?php echo $this->escape(json_encode($modalSelect)); ?>">
-    <span class="<?php echo $buttonIcons['select'] ?: 'icon-file'; ?>" aria-hidden="true"></span> <?php echo Text::_('JSELECT'); ?>
+    <span class="<?php echo !empty($buttonIcons['select']) ? $buttonIcons['select'] : 'icon-file'; ?>" aria-hidden="true"></span> <?php echo Text::_('JSELECT'); ?>
 </button>
 <?php endif; ?>
 

--- a/layouts/joomla/form/field/modal-select/buttons.php
+++ b/layouts/joomla/form/field/modal-select/buttons.php
@@ -74,7 +74,7 @@ $isSelectAlways = !empty($canDo['select']) && empty($canDo['clear']);
 <button type="button" class="btn btn-primary" <?php echo $value && !$isSelectAlways ? 'hidden' : ''; ?>
         data-button-action="select" <?php echo !$isSelectAlways ? 'data-show-when-value=""' : ''; ?>
         data-modal-config="<?php echo $this->escape(json_encode($modalSelect)); ?>">
-    <span class="<?php echo $buttonIcons['select'] ?? 'icon-file'; ?>" aria-hidden="true"></span> <?php echo Text::_('JSELECT'); ?>
+    <span class="<?php echo $buttonIcons['select'] ?: 'icon-file'; ?>" aria-hidden="true"></span> <?php echo Text::_('JSELECT'); ?>
 </button>
 <?php endif; ?>
 


### PR DESCRIPTION
### Summary of Changes

Fix missing icon for select btn 


### Testing Instructions

Go to menu, edit menu Single Article, check "select article" field


### Actual result BEFORE applying this Pull Request
Select button without icon
![Screenshot 2023-09-14_15-21-24](https://github.com/joomla/joomla-cms/assets/1568198/2d4bde84-9422-44cb-93d8-d26c44527e10)



### Expected result AFTER applying this Pull Request
Select button with icon
![Screenshot 2023-09-14_15-21-07](https://github.com/joomla/joomla-cms/assets/1568198/0c5bc2fc-465d-4f94-b2f9-50a8a7ba96df)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
