### PR TITLE
[5.0] Missing  'scope' attribute

### DIFF
--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -68,7 +68,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                 <th scope="col" class="d-none d-md-table-cell">
                                     <?php echo Text::_('COM_INSTALLER_CHANGELOG'); ?>
                                 </th>
-                                <th class="d-none d-md-table-cell">
+                                <th scope="col" class="d-none d-md-table-cell">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_INSTALLER_HEADING_FOLDER', 'folder_translated', $listDirn, $listOrder); ?>
                                 </th>
                                 <th scope="col" class="d-none d-md-table-cell">


### PR DESCRIPTION
Associating `<table>` headers, i.e. `<th>` elements, with their `<td>` cells enables screen readers to announce the header prior to the data. This considerably increases the accessibility of tables to visually impaired users.

The scope=col is missing from the folder column of the Extensions: Update view

If you dont have any extensions listed as needing an update then you can install the German lang pack and this will trigger an entry

Code review or view source will show that the "folder" column is missing a scope before this PR

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
