### PR TITLE
[5.0] Missing doctype

### DIFF
--- a/build/warning_page/template.html
+++ b/build/warning_page/template.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 	<meta charset="utf-8">

--- a/includes/incompatible.html
+++ b/includes/incompatible.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 	<meta charset="utf-8">

--- a/templates/system/build_incomplete.html
+++ b/templates/system/build_incomplete.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 	<meta charset="utf-8">

--- a/templates/system/fatal-error.html
+++ b/templates/system/fatal-error.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 	<meta charset="utf-8">

--- a/templates/system/incompatible.html
+++ b/templates/system/incompatible.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
 	<meta charset="utf-8">


### PR DESCRIPTION
The error pages generated by the build scripts are missing a doctype.

code review



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
