### PR TITLE
[5.0] Missing noopener

### DIFF
--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -100,7 +100,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                         <?php endif; ?>
                                 </td>
                                 <td class="small d-none d-md-table-cell">
-                                    <a href="<?php echo $language->detailsurl; ?>" target="_blank"><?php echo $language->detailsurl; ?></a>
+                                    <a href="<?php echo $language->detailsurl; ?>" target="_blank" rel="noopener noreferrer"><?php echo $language->detailsurl; ?></a>
                                 </td>
                             </tr>
                             <?php $i++; ?>


### PR DESCRIPTION
External links should have  rel="noopener noreferrer"

I am assuming that this one didnt because it was expected to go to a joomla.org domain which we can consider as trusted. However it is possible for a language to use any url so this extra protection should be provided

code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
