### PR TITLE
[5.0] mod feed noopener

### DIFF
--- a/administrator/modules/mod_feed/tmpl/default.php
+++ b/administrator/modules/mod_feed/tmpl/default.php
@@ -51,7 +51,7 @@ if (!empty($feed) && is_string($feed)) {
         // Feed title
         if (!is_null($feed->title) && $params->get('rsstitle', 1)) : ?>
             <h2 class="<?php echo $direction; ?>">
-                <a href="<?php echo str_replace('&', '&amp;', $rssurl); ?>" target="_blank">
+                <a href="<?php echo str_replace('&', '&amp;', $rssurl); ?>" target="_blank" rel="noopener noreferrer">
                 <?php echo $feed->title; ?></a>
             </h2>
         <?php endif;


### PR DESCRIPTION
External links should have rel="noopener noreferrer"

looks like it was missed from the admin version of mod feed

code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
