### PR TITLE
[5.0] guided tours identical expressions

### DIFF
--- a/administrator/components/com_guidedtours/src/Helper/GuidedtoursHelper.php
+++ b/administrator/components/com_guidedtours/src/Helper/GuidedtoursHelper.php
@@ -88,7 +88,7 @@ class GuidedtoursHelper
                 || $lang->load($extension . '.' . str_replace('-', '_', $tourid), $source);
             if ($steps) {
                 $lang->load($extension . '.' . str_replace('-', '_', $tourid) . '_steps', JPATH_ADMINISTRATOR)
-                    || $lang->load($extension . '.' . str_replace('-', '_', $tourid) . '_steps', JPATH_ADMINISTRATOR);
+                    || $lang->load($extension . '.' . str_replace('-', '_', $tourid) . '_steps', $source);
             }
         } else {
             $lang->load('guidedtours.' . str_replace('-', '_', $uid), JPATH_ADMINISTRATOR);


### PR DESCRIPTION
it is obviously incorrect to test for "a" or "a"

I have assumed based on a few lines previous that this PR is what was intended. If not then the second expression should be removed.

 @GeraintEdwards @obuisard 

### Testing Instructions

code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
