### PR TITLE
[5.0] toolbar cancel or close button

### DIFF
--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -201,7 +201,7 @@ class HtmlView extends BaseHtmlView
                 }
             );
 
-            $toolbar->cancel('category.cancel');
+            $toolbar->cancel('category.cancel', 'JTOOLBAR_CANCEL');
         } else {
             // If not checked out, can save the item.
             // Since it's an existing record, check the edit permission, or fall back to edit own if the owner.

--- a/administrator/components/com_contact/src/View/Contact/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contact/HtmlView.php
@@ -134,7 +134,7 @@ class HtmlView extends BaseHtmlView
                 );
             }
 
-            $toolbar->cancel('contact.cancel');
+            $toolbar->cancel('contact.cancel', 'JTOOLBAR_CANCEL');
         } else {
             // Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
             $itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);

--- a/administrator/components/com_fields/src/View/Field/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Field/HtmlView.php
@@ -130,7 +130,7 @@ class HtmlView extends BaseHtmlView
                     $childBar->save2new('field.save2new');
                 }
             );
-            $toolbar->cancel('field.cancel');
+            $toolbar->cancel('field.cancel', 'JTOOLBAR_CANCEL');
         } else {
             // Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
             $itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);

--- a/administrator/components/com_fields/src/View/Group/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Group/HtmlView.php
@@ -154,7 +154,7 @@ class HtmlView extends BaseHtmlView
                 }
             );
 
-            $toolbar->cancel('group.cancel');
+            $toolbar->cancel('group.cancel', 'JTOOLBAR_CANCEL');
         } else {
             // Since it's an existing record, check the edit permission, or fall back to edit own if the owner.
             $itemEditable = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by == $userId);

--- a/administrator/components/com_finder/src/View/Filter/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Filter/HtmlView.php
@@ -140,7 +140,7 @@ class HtmlView extends BaseHtmlView
                 );
             }
 
-            $toolbar->cancel('filter.cancel');
+            $toolbar->cancel('filter.cancel', 'JTOOLBAR_CANCEL');
         } else {
             // Can't save the record if it's checked out.
             // Since it's an existing record, check the edit permission.

--- a/administrator/components/com_languages/src/View/Language/HtmlView.php
+++ b/administrator/components/com_languages/src/View/Language/HtmlView.php
@@ -121,7 +121,7 @@ class HtmlView extends BaseHtmlView
         );
 
         if ($isNew) {
-            $toolbar->cancel('language.cancel');
+            $toolbar->cancel('language.cancel', 'JTOOLBAR_CANCEL');
         } else {
             $toolbar->cancel('language.cancel');
         }


### PR DESCRIPTION
The convention is that when it is a NEW item then its a cancel button and when editing an item its a close button.

During the updates in #39537 it looks like @wilsonge missed a few changes etc

### Testing Instructions
For the components updated check that it correctly uses the close or cancel button text


### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/048fe060-c52d-4804-8bad-078a754e01ad)



### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/8169c782-4d5b-4e62-96d1-ad0f0e35b3b3)

![image](https://github.com/joomla/joomla-cms/assets/1296369/9fcf5873-0e34-49ad-b51a-e72b425e6aa9)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
