### PR TITLE
[5.0] mod_privacy_status a11y

### DIFF
--- a/administrator/modules/mod_privacy_status/tmpl/default.php
+++ b/administrator/modules/mod_privacy_status/tmpl/default.php
@@ -15,6 +15,9 @@ use Joomla\CMS\Router\Route;
 
 ?>
 <table class="table">
+    <caption class="visually-hidden">
+        <?php echo Text::_('MOD_PRIVACY_STATUS'); ?>
+    </caption>
     <thead>
         <tr>
             <th scope="col" class="w-20"><?php echo Text::_('COM_PRIVACY_DASHBOARD_HEADING_STATUS'); ?></th>


### PR DESCRIPTION
### Summary of Changes
In order to be accessible to visually impaired users, it is important that tables provides a description of its content before the data is accessed.

The simplest way to do it, and also the one [recommended by WCAG2](https://www.w3.org/TR/WCAG20-TECHS/H39) is to add a `<caption>` element inside the `<table>`.

**Most** tables already have this caption

### Testing Instructions
Apply the PR and then view the generated source of this admin module on the privacy dashboard


### Actual result BEFORE applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/1296369/b6aebb14-2a3a-471b-a510-e1fe86aa79a8)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/ec48344c-61cf-42d8-aeaa-11f6f08fc078)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
