### PR TITLE
[5.0] Fix color of plus symbol in dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
@@ -128,6 +128,14 @@
         color: var(--template-quickicon-color);
       }
 
+      @if $enable-dark-mode {
+        @include color-mode(dark) {
+          > * {
+            color: var(--template-bg-dark-80);
+          }
+        }
+      }
+
       &:hover,
       &:focus,
       &:active {


### PR DESCRIPTION
Pull Request for Issue raised by @Quy in https://github.com/joomla/joomla-cms/pull/41409 .

### Summary of Changes
Fixes the color of the plus symbol so it's visible


### Testing Instructions
Log into atum and check the color of the plus symbol in the dashboard.


### Actual result BEFORE applying this Pull Request
Note the plus symbol pointed to by the red arrow is effectively invisible (ignore the other arrow at the success box for this PR)

![41409-dashboard](https://github.com/joomla/joomla-cms/assets/368084/76112859-c72a-4080-823f-60df278c7f57)

### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/55b0b57b-a084-4f8b-a2be-b79ecdee613f)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
