### PR TITLE
[5.0] Dark mode config view

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_sidebar-nav.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_sidebar-nav.scss
@@ -26,6 +26,14 @@
       }
     }
 
+    @if $enable-dark-mode {
+      @include color-mode(dark) {
+        a {
+          color: var(--template-text-light);
+        }
+      }
+    }
+
     &.item:hover, &.active {
       background-color: var(--template-bg-dark-60);
 


### PR DESCRIPTION
Pull Request for Issue raised by @Quy in https://github.com/joomla/joomla-cms/pull/41409 .

### Summary of Changes
Fixes text color in the config view when in dark mode. light mode unchanged

### Testing Instructions
Go to system configuration and look at the text color

### Actual result BEFORE applying this Pull Request
![41409-config](https://github.com/joomla/joomla-cms/assets/368084/dd952541-f08c-43f0-94ff-4bcdd161e50d)

### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/31f14fdd-fc4f-454c-8024-d621c740f7a3)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
