### PR TITLE
[5.0] Fix tabs mobile view in dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -106,7 +106,7 @@ joomla-tab {
     color: var(--template-text-light);
     text-align: start;
     background-color: var(--template-link-color);
-    border: 1px solid var(--template-text-light);
+    border: 1px solid var(--template-bg-dark-3);
     border-top: 0;
 
     &[aria-expanded=true],
@@ -118,6 +118,14 @@ joomla-tab {
 
     .text-muted {
       color: var(--template-text-light) !important;
+    }
+  }
+
+  @if $enable-dark-mode {
+    @include color-mode(dark) {
+      > button[role=region] {
+        border-color: var(--template-bg-dark-70);
+      }
     }
   }
 
@@ -274,7 +282,7 @@ joomla-tab[view=accordion] {
 
   [active],
   [aria-expanded=true] {
-    background-color: $white;
+    background-color: var(--body-bg);
   }
 
   .col-md-6,


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fixes the dark mode rendering of tabs (used in any menu item/content item)


### Testing Instructions

### Actual result BEFORE applying this Pull Request
Lots of white!
![image](https://github.com/joomla/joomla-cms/assets/1986000/171e646f-c0b4-4ab7-8492-0cb6afb21aee)



### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/3d2c9abf-d3f5-4789-a572-1ff97e772a29)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
