### PR TITLE
[5.0] Fix filters in dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
@@ -130,7 +130,9 @@
 
       @if $enable-dark-mode {
         @include color-mode(dark) {
+          /* stylelint-disable max-nesting-depth */
           > * {
+            /* stylelint-enable max-nesting-depth */
             color: var(--template-bg-dark-80);
           }
         }

--- a/build/media_source/templates/administrator/atum/scss/system/searchtools/searchtools.scss
+++ b/build/media_source/templates/administrator/atum/scss/system/searchtools/searchtools.scss
@@ -45,7 +45,7 @@
     grid-gap: 8px;
     grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
     padding: 10px;
-    background-color: $white;
+    background-color: var(--body-bg);
   }
 }
 


### PR DESCRIPTION
Dark mode issues

### Summary of Changes
Fixes the search tools background when in dark mode in atum


### Testing Instructions
Check search tools in e.g. menus component (but can be any of them) - you need to actually open the filters. Check the background in light mode is unchanged and dark mode is now appropriately dark

### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/7687d3b9-62c6-4a80-99a8-31c4aab137e3)



### Expected result AFTER applying this Pull Request
![Screenshot from 2023-09-16 10-07-51](https://github.com/joomla/joomla-cms/assets/1986000/d61f1302-9573-40a6-95f6-83fe86f99953)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
