### PR TITLE
[5.0] Better dark mode experience for menu item type selection

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_collapse.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_collapse.scss
@@ -9,7 +9,20 @@
     line-height: $headings-line-height;
   }
 
+  /**
+   * TODO: This seems fairly specifically built for the menu types view and might be better scoped to
+   *       that view rather than just being overridden for everything.
+   */
   .list-group-item {
-    --list-group-color: #{$link-color};
+    --list-group-color: var(--link-color);
+    --list-group-bg: var(--white-offset);
+  }
+
+  @if $enable-dark-mode {
+    @include color-mode(dark) {
+      .list-group-item {
+        --list-group-bg: var(--gray-800);
+      }
+    }
   }
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41571 (partial) .

### Summary of Changes
A improvement on the code removed here https://github.com/joomla/joomla-cms/pull/41409/files#diff-8217546eabc29ea45f71bf3257a82032411b425bf068753096719301bb30563bL3 where we overrode the theme color specific background for white in all cases for no clear reason. It seems it's only used  in the menu item area. For now I've chosen to replace that with scoping it down to lists within accordions and also added some dark color themes and used the template css user selected variable for the blue link color rather than the template one which gives better theming appearances. 


### Testing Instructions
Check in light and dark mode. The original issue background color differences should be fixed back to how things were in 4.3/4.4. Dark mode is also improved with a darker background. 


### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/fa38f7bd-d1c0-49a2-af07-1a3e6d8ae389)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/07c933a3-c022-47b0-923d-f2ede9f37e53)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
