### PR TITLE
[5.0] Improve display of details element

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_edit.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_edit.scss
@@ -21,3 +21,11 @@
     }
   }
 }
+
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    details div.rule-notes {
+      color: var(--template-text-light);
+    }
+  }
+}

--- a/build/media_source/templates/administrator/atum/scss/blocks/_global.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_global.scss
@@ -256,6 +256,14 @@ details {
   }
 }
 
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    details {
+      background: var(--template-bg-dark-90);
+    }
+  }
+}
+
 // meter element
 meter {
   width: 100%;


### PR DESCRIPTION
Improve how the details element is rendered in dark mode

### Summary of Changes
Improves how the notes above rule tabs are rendered (and just generally the details element)


### Testing Instructions
Check the rules tab in the com_content view


### Actual result BEFORE applying this Pull Request
![Screenshot from 2023-09-17 04-13-14](https://github.com/joomla/joomla-cms/assets/1986000/074564ed-01c6-4e3e-8c9a-7189ebef76b1)

### Expected result AFTER applying this Pull Request
![Screenshot from 2023-09-17 04-12-40](https://github.com/joomla/joomla-cms/assets/1986000/277f0ec4-6dfd-45af-8e6d-f5017b32da18)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
