### PR TITLE
[5.0] Fix template styles menu assign in dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/pages/_com_templates.scss
+++ b/build/media_source/templates/administrator/atum/scss/pages/_com_templates.scss
@@ -29,9 +29,14 @@
 
     .menu-links-block {
       padding: 15px;
-      background-color: var(--card-bg);
       border: 1px solid $border-color;
-      border-radius: 3px;
+      border-radius: $border-radius-sm;
+
+      @if $enable-dark-mode {
+        @include color-mode(dark) {
+          --heading-color: var(--body-color)
+        }
+      }
     }
 
     label {

--- a/build/media_source/templates/administrator/atum/scss/pages/_com_templates.scss
+++ b/build/media_source/templates/administrator/atum/scss/pages/_com_templates.scss
@@ -34,7 +34,7 @@
 
       @if $enable-dark-mode {
         @include color-mode(dark) {
-          --heading-color: var(--body-color)
+          --heading-color: var(--body-color);
         }
       }
     }


### PR DESCRIPTION
Pull Request for Issue raised by @Quy in https://github.com/joomla/joomla-cms/pull/41409.

### Summary of Changes
Fixes how the template style menu assignments renders in dark mode


### Testing Instructions
Edit a template style and look in the menu assignments tab. Light mode unchanged (the background applied a 0.7 opacity white background on a white background so was totally invisible there)

### Actual result BEFORE applying this Pull Request
![edit-style](https://github.com/joomla/joomla-cms/assets/368084/fe493263-7719-440d-8d39-a3e439616b69)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/0855d11c-4de9-43b6-b940-d52c6c341aa2)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
