### PR TITLE
[5.0] Remove odd media manager border

### DIFF
--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -2,7 +2,6 @@
 .media-browser {
   position: relative;
   min-height: 70vh;
-  border-inline-start: 1px solid $border-color;
   transition: width .3s cubic-bezier(.4, 0, .2, 1);
 }
 

--- a/build/media_source/com_media/scss/components/_media-tree.scss
+++ b/build/media_source/com_media/scss/components/_media-tree.scss
@@ -33,7 +33,7 @@ ul.media-tree {
 .media-disk-name {
   padding: 4px 1px;
   font-size: 1rem;
-  color: var(--template-bg-dark);
+  color: var(--media-manager-disk-name-color, var(--template-bg-dark));
 
   &:empty {
     display: none;

--- a/build/media_source/templates/administrator/atum/scss/_variables-dark.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables-dark.scss
@@ -4,6 +4,7 @@ $atum-colors-dark: (
   media-manager-overlay-bg:        var(--template-bg-dark-90),
   media-manager-infobar-dt-color:  rgba(255, 255, 255, .54),
   media-manager-overlay-header-bg: var(--template-bg-dark-80),
+  media-manager-disk-name-color:   var(--template-text-light),
 ) !default;
 
 $link-hover-color-dark: lighten($light-blue, 20%);

--- a/build/media_source/templates/administrator/atum/scss/_variables.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables.scss
@@ -88,6 +88,7 @@ $atum-colors: (
   media-manager-infobar-dt-color:  rgba(0, 0, 0, .54),
   media-manager-content-bg:        var(--body-bg),
   media-manager-overlay-bg:        var(--template-bg-dark-3),
+  media-manager-disk-name-color:   var(--template-text-dark),
 );
 
 $colors: (


### PR DESCRIPTION
Pull Request for Issue raised by @Quy in #41409 .

### Summary of Changes
Removes a very odd border in media manager that was basically invisible in light mode and in dark mode looked very weird but doesn't really solve a purpose. Also solves the color of the disk name (N.B. In light mode this color changes fractionally as I've moved the text to use the text color variable rather than the background color variable).


### Testing Instructions
In media manager check the border is removed. Note if you look very carefully in light mode you can also see it extending out the shaded component area too. Check the colors of the disk name


### Actual result BEFORE applying this Pull Request
![41409-media](https://github.com/joomla/joomla-cms/assets/368084/3c0da2cc-1a55-4f14-bc2b-27685bf76690)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/0a14ab16-70d1-4074-bdc1-5c9aa4525261)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
