### PR TITLE
[5.0] Restore array referencing for event arguments

### DIFF
--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -20,7 +20,6 @@ use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\AdministratorMenuItem;
-use Joomla\CMS\Proxy\ArrayProxy;
 use Joomla\CMS\Table\Table;
 use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
@@ -448,12 +447,12 @@ class MenusHelper extends ContentHelper
         }
 
         $dispatcher = Factory::getApplication()->getDispatcher();
-        $dispatcher->dispatch('onPreprocessMenuItems', new PreprocessMenuItemsEvent('onPreprocessMenuItems', [
+        $items      = $dispatcher->dispatch('onPreprocessMenuItems', new PreprocessMenuItemsEvent('onPreprocessMenuItems', [
             'context' => 'com_menus.administrator.import',
-            'subject' => new ArrayProxy($items),
+            'subject' => &$items, // TODO: Remove reference in Joomla 6, see PreprocessMenuItemsEvent::__constructor()
             'params'  => null,
             'enabled' => true,
-        ]));
+        ]))->getArgument('subject', $items);
 
         foreach ($items as $item) {
             /** @var \Joomla\CMS\Table\Menu $table */

--- a/administrator/components/com_menus/src/Model/MenutypesModel.php
+++ b/administrator/components/com_menus/src/Model/MenutypesModel.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Object\CMSObject;
-use Joomla\CMS\Proxy\ArrayProxy;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/administrator/components/com_menus/src/Model/MenutypesModel.php
+++ b/administrator/components/com_menus/src/Model/MenutypesModel.php
@@ -128,12 +128,10 @@ class MenutypesModel extends BaseDatabaseModel
         }
 
         // Allow a system plugin to insert dynamic menu types to the list shown in menus:
-        $this->getDispatcher()->dispatch('onAfterGetMenuTypeOptions', new AfterGetMenuTypeOptionsEvent('onAfterGetMenuTypeOptions', [
-            'items'   => new ArrayProxy($list),
+        return $this->getDispatcher()->dispatch('onAfterGetMenuTypeOptions', new AfterGetMenuTypeOptionsEvent('onAfterGetMenuTypeOptions', [
+            'items'   => &$list, // TODO: Remove reference in Joomla 6, see AfterGetMenuTypeOptionsEvent::__constructor()
             'subject' => $this,
-        ]));
-
-        return $list;
+        ]))->getArgument('items', $list);
     }
 
     /**

--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Event\Menu\PreprocessMenuItemsEvent;
 use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\AdministratorMenuItem;
-use Joomla\CMS\Proxy\ArrayProxy;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
@@ -269,12 +268,12 @@ class CssMenu
          * $children is an array of AdministratorMenuItem objects. A plugin can traverse the whole tree,
          * but new nodes will only be run through this method if their parents have not been processed yet.
          */
-        $dispatcher->dispatch('onPreprocessMenuItems', new PreprocessMenuItemsEvent('onPreprocessMenuItems', [
+        $children = $dispatcher->dispatch('onPreprocessMenuItems', new PreprocessMenuItemsEvent('onPreprocessMenuItems', [
             'context' => 'com_menus.administrator.module',
-            'subject' => new ArrayProxy($children),
+            'subject' => &$children, // TODO: Remove reference in Joomla 6, see PreprocessMenuItemsEvent::__constructor()
             'params'  => $this->params,
             'enabled' => $this->enabled,
-        ]));
+        ]))->getArgument('subject', $children);
 
         foreach ($children as $item) {
             $itemParams = $item->getParams();

--- a/administrator/modules/mod_privacy_status/src/Helper/PrivacyStatusHelper.php
+++ b/administrator/modules/mod_privacy_status/src/Helper/PrivacyStatusHelper.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Event\Privacy\CheckPrivacyPolicyPublishedEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\CMS\Proxy\ArrayProxy;
 use Joomla\CMS\Router\Route;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -52,14 +51,12 @@ class PrivacyStatusHelper
         PluginHelper::importPlugin('privacy', null, true, $dispatcher);
         PluginHelper::importPlugin('user', null, true, $dispatcher);
 
-        $dispatcher->dispatch(
+        return $dispatcher->dispatch(
             'onPrivacyCheckPrivacyPolicyPublished',
             new CheckPrivacyPolicyPublishedEvent('onPrivacyCheckPrivacyPolicyPublished', [
-                'subject' => new ArrayProxy($policy),
+                'subject' => &$policy, // TODO: Remove reference in Joomla 6, see CheckPrivacyPolicyPublishedEvent::__constructor()
             ])
-        );
-
-        return $policy;
+        )->getArgument('subject', $policy);
     }
 
     /**

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Menu\MenuItem;
-use Joomla\CMS\Proxy\ArrayProxy;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 use Joomla\Utilities\ArrayHelper;
@@ -54,12 +53,12 @@ abstract class Menu
          * $children is an array of MenuItem objects. A plugin can traverse the whole tree,
          * but new nodes will only be run through this method if their parents have not been processed yet.
          */
-        $dispatcher->dispatch('onPreprocessMenuItems', new PreprocessMenuItemsEvent('onPreprocessMenuItems', [
+        $children = $dispatcher->dispatch('onPreprocessMenuItems', new PreprocessMenuItemsEvent('onPreprocessMenuItems', [
             'context' => 'administrator.module.mod_submenu',
-            'subject' => new ArrayProxy($children),
+            'subject' => &$children, // TODO: Remove reference in Joomla 6, see PreprocessMenuItemsEvent::__constructor()
             'params'  => null,
             'enabled' => true,
-        ]));
+        ]))->getArgument('subject', $children);
 
         foreach ($children as $item) {
             if (substr($item->link, 0, 8) === 'special:') {

--- a/components/com_contact/src/Controller/ContactController.php
+++ b/components/com_contact/src/Controller/ContactController.php
@@ -19,7 +19,6 @@ use Joomla\CMS\Mail\Exception\MailDisabledException;
 use Joomla\CMS\Mail\MailTemplate;
 use Joomla\CMS\MVC\Controller\FormController;
 use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\CMS\Proxy\ArrayProxy;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Uri\Uri;
@@ -174,10 +173,9 @@ class ContactController extends FormController implements UserFactoryAwareInterf
         }
 
         // Validation succeeded, continue with custom handlers
-        $eventData = new ArrayProxy($data);
-        $results   = $this->getDispatcher()->dispatch('onValidateContact', new ValidateContactEvent('onValidateContact', [
+        $results = $this->getDispatcher()->dispatch('onValidateContact', new ValidateContactEvent('onValidateContact', [
             'subject' => $contact,
-            'data'    => $eventData,
+            'data'    => &$data, // TODO: Remove reference in Joomla 6, @deprecated: Data modification onValidateContact is not allowed, use onSubmitContact instead
         ]))->getArgument('result', []);
 
         $passValidation = true;
@@ -198,10 +196,12 @@ class ContactController extends FormController implements UserFactoryAwareInterf
         }
 
         // Passed Validation: Process the contact plugins to integrate with other applications
-        $this->getDispatcher()->dispatch('onSubmitContact', new SubmitContactEvent('onSubmitContact', [
+        $event = $this->getDispatcher()->dispatch('onSubmitContact', new SubmitContactEvent('onSubmitContact', [
             'subject' => $contact,
-            'data'    => $eventData,
+            'data'    => &$data, // TODO: Remove reference in Joomla 6, see SubmitContactEvent::__constructor()
         ]));
+        // Get the final data
+        $data = $event->getArgument('data', $data);
 
         // Send the email
         $sent = false;

--- a/libraries/src/Document/Renderer/Html/ModulesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModulesRenderer.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Event\Module;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Layout\LayoutHelper;
-use Joomla\CMS\Proxy\ArrayProxy;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -61,12 +60,11 @@ class ModulesRenderer extends DocumentRenderer
 
         // Dispatch onAfterRenderModules event
         $event = new Module\AfterRenderModulesEvent('onAfterRenderModules', [
-            'subject'    => &$buffer, // TODO: Remove reference in Joomla 6, see AfterRenderModulesEvent::__constructor()
-            'attributes' => new ArrayProxy($params),
+            'content'    => &$buffer, // TODO: Remove reference in Joomla 6, see AfterRenderModulesEvent::__constructor()
+            'attributes' => $params,
         ]);
         $app->getDispatcher()->dispatch('onAfterRenderModules', $event);
-        $buffer = $event->getContent();
 
-        return $buffer;
+        return $event->getArgument('content', $content);
     }
 }

--- a/libraries/src/Event/Contact/SubmitContactEvent.php
+++ b/libraries/src/Event/Contact/SubmitContactEvent.php
@@ -49,10 +49,10 @@ class SubmitContactEvent extends AbstractImmutableEvent
     {
         // Reshape the arguments array to preserve b/c with legacy listeners
         if ($this->legacyArgumentsOrder) {
-            $arguments = $this->reshapeArguments($arguments, $this->legacyArgumentsOrder);
+            parent::__construct($name, $this->reshapeArguments($arguments, $this->legacyArgumentsOrder));
+        } else {
+            parent::__construct($name, $arguments);
         }
-
-        parent::__construct($name, $arguments);
 
         if (!\array_key_exists('subject', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'subject' of event {$name} is required but has not been provided");
@@ -60,6 +60,15 @@ class SubmitContactEvent extends AbstractImmutableEvent
 
         if (!\array_key_exists('data', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'data' of event {$name} is required but has not been provided");
+        }
+
+        // For backward compatibility make sure the content is referenced
+        // TODO: Remove in Joomla 6
+        // @deprecated: Passing argument by reference is deprecated, and will not work in Joomla 6
+        if (key($arguments) === 0) {
+            $this->arguments['data'] = &$arguments[1];
+        } elseif (\array_key_exists('data', $arguments)) {
+            $this->arguments['data'] = &$arguments['data'];
         }
     }
 
@@ -80,13 +89,13 @@ class SubmitContactEvent extends AbstractImmutableEvent
     /**
      * Setter for the data argument.
      *
-     * @param   array|\ArrayAccess  $value  The value to set
+     * @param   array  $value  The value to set
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    protected function setData(array|\ArrayAccess $value): array|\ArrayAccess
+    protected function setData(array $value): array
     {
         return $value;
     }
@@ -106,12 +115,28 @@ class SubmitContactEvent extends AbstractImmutableEvent
     /**
      * Getter for the data.
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    public function getData(): array|\ArrayAccess
+    public function getData(): array
     {
         return $this->arguments['data'];
+    }
+
+    /**
+     * Update the data.
+     *
+     * @param   array  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function updateData(array $value): static
+    {
+        $this->arguments['data'] = $this->setData($value);
+
+        return $this;
     }
 }

--- a/libraries/src/Event/Contact/ValidateContactEvent.php
+++ b/libraries/src/Event/Contact/ValidateContactEvent.php
@@ -54,10 +54,10 @@ class ValidateContactEvent extends AbstractImmutableEvent implements ResultAware
     {
         // Reshape the arguments array to preserve b/c with legacy listeners
         if ($this->legacyArgumentsOrder) {
-            $arguments = $this->reshapeArguments($arguments, $this->legacyArgumentsOrder);
+            parent::__construct($name, $this->reshapeArguments($arguments, $this->legacyArgumentsOrder));
+        } else {
+            parent::__construct($name, $arguments);
         }
-
-        parent::__construct($name, $arguments);
 
         if (!\array_key_exists('subject', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'subject' of event {$name} is required but has not been provided");
@@ -65,6 +65,15 @@ class ValidateContactEvent extends AbstractImmutableEvent implements ResultAware
 
         if (!\array_key_exists('data', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'data' of event {$name} is required but has not been provided");
+        }
+
+        // For backward compatibility make sure the content is referenced
+        // TODO: Remove in Joomla 6
+        // @deprecated: Passing argument by reference is deprecated, and will not work in Joomla 6
+        if (key($arguments) === 0) {
+            $this->arguments['data'] = &$arguments[1];
+        } elseif (\array_key_exists('data', $arguments)) {
+            $this->arguments['data'] = &$arguments['data'];
         }
     }
 
@@ -85,13 +94,13 @@ class ValidateContactEvent extends AbstractImmutableEvent implements ResultAware
     /**
      * Setter for the data argument.
      *
-     * @param   array|\ArrayAccess  $value  The value to set
+     * @param   array  $value  The value to set
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    protected function setData(array|\ArrayAccess $value): array|\ArrayAccess
+    protected function setData(array $value): array
     {
         return $value;
     }
@@ -111,11 +120,11 @@ class ValidateContactEvent extends AbstractImmutableEvent implements ResultAware
     /**
      * Getter for the data.
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    public function getData(): array|\ArrayAccess
+    public function getData(): array
     {
         return $this->arguments['data'];
     }

--- a/libraries/src/Event/Installer/BeforePackageDownloadEvent.php
+++ b/libraries/src/Event/Installer/BeforePackageDownloadEvent.php
@@ -67,9 +67,11 @@ class BeforePackageDownloadEvent extends AbstractImmutableEvent
         // TODO: Remove in Joomla 6
         // @deprecated: Passing argument by reference is deprecated, and will not work in Joomla 6
         if (key($arguments) === 0) {
-            $this->arguments['url'] = &$arguments[0];
+            $this->arguments['url']     = &$arguments[0];
+            $this->arguments['headers'] = &$arguments[1];
         } elseif (\array_key_exists('url', $arguments)) {
-            $this->arguments['url'] = &$arguments['url'];
+            $this->arguments['url']     = &$arguments['url'];
+            $this->arguments['headers'] = &$arguments['headers'];
         }
     }
 
@@ -90,13 +92,13 @@ class BeforePackageDownloadEvent extends AbstractImmutableEvent
     /**
      * Setter for the headers argument.
      *
-     * @param   array|\ArrayAccess  $value  The value to set
+     * @param   array  $value  The value to set
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    protected function setHeaders(array|\ArrayAccess $value): array|\ArrayAccess
+    protected function setHeaders(array $value): array
     {
         return $value;
     }
@@ -116,11 +118,11 @@ class BeforePackageDownloadEvent extends AbstractImmutableEvent
     /**
      * Getter for the headers.
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    public function getHeaders(): array|\ArrayAccess
+    public function getHeaders(): array
     {
         return $this->arguments['headers'];
     }
@@ -136,7 +138,23 @@ class BeforePackageDownloadEvent extends AbstractImmutableEvent
      */
     public function updateUrl(string $value): static
     {
-        $this->arguments['url'] = $value;
+        $this->arguments['url'] = $this->setUrl($value);
+
+        return $this;
+    }
+
+    /**
+     * Update the headers.
+     *
+     * @param   array  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function updateHeaders(array $value): static
+    {
+        $this->arguments['headers'] = $this->setHeaders($value);
 
         return $this;
     }

--- a/libraries/src/Event/Installer/InstallerEvent.php
+++ b/libraries/src/Event/Installer/InstallerEvent.php
@@ -91,13 +91,13 @@ abstract class InstallerEvent extends AbstractImmutableEvent
     /**
      * Setter for the package argument.
      *
-     * @param   array|\ArrayAccess|null  $value  The value to set
+     * @param   ?array  $value  The value to set
      *
-     * @return  array|\ArrayAccess|null
+     * @return  ?array
      *
      * @since  5.0.0
      */
-    protected function setPackage(array|\ArrayAccess|null $value): array|\ArrayAccess|null
+    protected function setPackage(?array $value): ?array
     {
         return $value;
     }
@@ -117,11 +117,11 @@ abstract class InstallerEvent extends AbstractImmutableEvent
     /**
      * Getter for the package.
      *
-     * @return  array|\ArrayAccess|null
+     * @return  ?array
      *
      * @since  5.0.0
      */
-    public function getPackage(): array|\ArrayAccess|null
+    public function getPackage(): ?array
     {
         return $this->arguments['package'] ?? null;
     }
@@ -129,13 +129,13 @@ abstract class InstallerEvent extends AbstractImmutableEvent
     /**
      * Update the package.
      *
-     * @param   array|\ArrayAccess|null  $value  The value to set
+     * @param   ?array  $value  The value to set
      *
      * @return  static
      *
      * @since  5.0.0
      */
-    public function updatePackage(array|\ArrayAccess|null $value): static
+    public function updatePackage(?array $value): static
     {
         $this->arguments['package'] = $value;
 

--- a/libraries/src/Event/Menu/PreprocessMenuItemsEvent.php
+++ b/libraries/src/Event/Menu/PreprocessMenuItemsEvent.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Event\Menu;
 
 use Joomla\CMS\Event\AbstractImmutableEvent;
 use Joomla\CMS\Event\ReshapeArgumentsAware;
+use Joomla\CMS\Menu\MenuItem;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -50,10 +51,10 @@ class PreprocessMenuItemsEvent extends AbstractImmutableEvent
     {
         // Reshape the arguments array to preserve b/c with legacy listeners
         if ($this->legacyArgumentsOrder) {
-            $arguments = $this->reshapeArguments($arguments, $this->legacyArgumentsOrder);
+            parent::__construct($name, $this->reshapeArguments($arguments, $this->legacyArgumentsOrder));
+        } else {
+            parent::__construct($name, $arguments);
         }
-
-        parent::__construct($name, $arguments);
 
         if (!\array_key_exists('context', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'context' of event {$name} is required but has not been provided");
@@ -61,6 +62,15 @@ class PreprocessMenuItemsEvent extends AbstractImmutableEvent
 
         if (!\array_key_exists('subject', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'subject' of event {$name} is required but has not been provided");
+        }
+
+        // For backward compatibility make sure the content is referenced
+        // TODO: Remove in Joomla 6
+        // @deprecated: Passing argument by reference is deprecated, and will not work in Joomla 6
+        if (key($arguments) === 0) {
+            $this->arguments['subject'] = &$arguments[1];
+        } elseif (\array_key_exists('subject', $arguments)) {
+            $this->arguments['subject'] = &$arguments['subject'];
         }
     }
 
@@ -81,14 +91,23 @@ class PreprocessMenuItemsEvent extends AbstractImmutableEvent
     /**
      * Setter for the subject argument.
      *
-     * @param   array|\ArrayAccess  $value  The value to set
+     * @param   MenuItem[]  $value  The value to set
      *
-     * @return  array|\ArrayAccess
+     * @return  MenuItem[]
      *
      * @since  5.0.0
      */
-    protected function setSubject(array|\ArrayAccess $value): array|\ArrayAccess
+    protected function setSubject(array $value): array
     {
+        // Filter out MenuItem elements. Non empty result means invalid data
+        $valid = !array_filter($value, function ($item) {
+            return !$item instanceof MenuItem;
+        });
+
+        if (!$valid) {
+            throw new \UnexpectedValueException("Argument 'subject' of event {$this->name} is not of the expected type");
+        }
+
         return $value;
     }
 
@@ -135,11 +154,11 @@ class PreprocessMenuItemsEvent extends AbstractImmutableEvent
     /**
      * Getter for the items.
      *
-     * @return  array|\ArrayAccess
+     * @return  MenuItem[]
      *
      * @since  5.0.0
      */
-    public function getItems(): array|\ArrayAccess
+    public function getItems(): array
     {
         return $this->arguments['subject'];
     }
@@ -166,5 +185,21 @@ class PreprocessMenuItemsEvent extends AbstractImmutableEvent
     public function getEnabled(): ?bool
     {
         return $this->arguments['enabled'] ?? null;
+    }
+
+    /**
+     * Update the items.
+     *
+     * @param   MenuItem[]  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function updateItems(array $value): static
+    {
+        $this->arguments['subject'] = $this->setSubject($value);
+
+        return $this;
     }
 }

--- a/libraries/src/Event/Model/BeforeValidateDataEvent.php
+++ b/libraries/src/Event/Model/BeforeValidateDataEvent.php
@@ -22,4 +22,43 @@ namespace Joomla\CMS\Event\Model;
  */
 class BeforeValidateDataEvent extends FormEvent
 {
+    /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        parent::__construct($name, $arguments);
+
+        // For backward compatibility make sure the content is referenced
+        // TODO: Remove in Joomla 6
+        // @deprecated: Passing argument by reference is deprecated, and will not work in Joomla 6
+        if (key($arguments) === 0) {
+            $this->arguments['data'] = &$arguments[1];
+        } elseif (\array_key_exists('data', $arguments)) {
+            $this->arguments['data'] = &$arguments['data'];
+        }
+    }
+
+    /**
+     * Update the data.
+     *
+     * @param   object|array  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function updateData(object|array $value): static
+    {
+        $this->arguments['data'] = $this->setData($value);
+
+        return $this;
+    }
 }

--- a/libraries/src/Event/Model/FormEvent.php
+++ b/libraries/src/Event/Model/FormEvent.php
@@ -105,6 +105,20 @@ abstract class FormEvent extends AbstractImmutableEvent
     }
 
     /**
+     * Setter for the data argument.
+     *
+     * @param   object|array  $value  The value to set
+     *
+     * @return  object|array
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function setData(object|array $value): object|array
+    {
+        return $value;
+    }
+
+    /**
      * Getter for the form.
      *
      * @return  Form
@@ -123,7 +137,7 @@ abstract class FormEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    public function getData()
+    public function getData(): object|array
     {
         return $this->arguments['data'];
     }

--- a/libraries/src/Event/Model/PrepareDataEvent.php
+++ b/libraries/src/Event/Model/PrepareDataEvent.php
@@ -30,17 +30,78 @@ class PrepareDataEvent extends ModelEvent
      * @since  5.0.0
      * @deprecated 5.0 will be removed in 6.0
      */
-    protected $legacyArgumentsOrder = ['context', 'subject'];
+    protected $legacyArgumentsOrder = ['context', 'data', 'subject'];
+
+    /**
+     * Constructor.
+     *
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
+     *
+     * @throws  \BadMethodCallException
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function __construct($name, array $arguments = [])
+    {
+        // This event has a dummy subject for now
+        $this->arguments['subject'] = $this->arguments['subject'] ?? new \stdClass();
+
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('data', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'data' of event {$name} is required but has not been provided");
+        }
+
+        // For backward compatibility make sure the content is referenced
+        // TODO: Remove in Joomla 6
+        // @deprecated: Passing argument by reference is deprecated, and will not work in Joomla 6
+        if (key($arguments) === 0) {
+            $this->arguments['data'] = &$arguments[1];
+        } elseif (\array_key_exists('data', $arguments)) {
+            $this->arguments['data'] = &$arguments['data'];
+        }
+    }
+
+    /**
+     * Setter for the data argument.
+     *
+     * @param   object|array  $value  The value to set
+     *
+     * @return  object|array
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function setData(object|array $value): object|array
+    {
+        return $value;
+    }
 
     /**
      * Getter for the data.
      *
-     * @return  object
+     * @return  object|array
      *
      * @since  5.0.0
      */
-    public function getData()
+    public function getData(): object|array
     {
-        return $this->arguments['subject'];
+        return $this->arguments['data'];
+    }
+
+    /**
+     * Update the data.
+     *
+     * @param   object|array  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function updateData(object|array $value): static
+    {
+        $this->arguments['data'] = $this->setData($value);
+
+        return $this;
     }
 }

--- a/libraries/src/Event/Module/AfterRenderModulesEvent.php
+++ b/libraries/src/Event/Module/AfterRenderModulesEvent.php
@@ -30,7 +30,7 @@ class AfterRenderModulesEvent extends ModuleEvent
      * @since  5.0.0
      * @deprecated 5.0 will be removed in 6.0
      */
-    protected $legacyArgumentsOrder = ['subject', 'attributes'];
+    protected $legacyArgumentsOrder = ['content', 'attributes', 'subject'];
 
     /**
      * Constructor.
@@ -44,7 +44,14 @@ class AfterRenderModulesEvent extends ModuleEvent
      */
     public function __construct($name, array $arguments = [])
     {
+        // This event has a dummy subject for now
+        $this->arguments['subject'] = $this->arguments['subject'] ?? new \stdClass();
+
         parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('content', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'content' of event {$name} is required but has not been provided");
+        }
 
         if (!\array_key_exists('attributes', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'attributes' of event {$name} is required but has not been provided");
@@ -54,22 +61,22 @@ class AfterRenderModulesEvent extends ModuleEvent
         // TODO: Remove in Joomla 6
         // @deprecated: Passing argument by reference is deprecated, and will not work in Joomla 6
         if (key($arguments) === 0) {
-            $this->arguments['subject'] = &$arguments[0];
-        } elseif (\array_key_exists('subject', $arguments)) {
-            $this->arguments['subject'] = &$arguments['subject'];
+            $this->arguments['content'] = &$arguments[0];
+        } elseif (\array_key_exists('content', $arguments)) {
+            $this->arguments['content'] = &$arguments['content'];
         }
     }
 
     /**
-     * Setter for the subject argument.
+     * Setter for the content argument.
      *
      * @param   string  $value  The value to set
      *
      * @return  object
      *
-     * @since  5.0.0
+     * @since  __DEPLOY_VERSION__
      */
-    protected function setSubject(string $value): string
+    protected function setContent(string $value): string
     {
         return $value;
     }
@@ -77,13 +84,13 @@ class AfterRenderModulesEvent extends ModuleEvent
     /**
      * Setter for the attributes argument.
      *
-     * @param   array|\ArrayAccess  $value  The value to set
+     * @param   array  $value  The value to set
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    protected function setAttributes(array|\ArrayAccess $value): array|\ArrayAccess
+    protected function setAttributes(array $value): array
     {
         return $value;
     }
@@ -97,7 +104,7 @@ class AfterRenderModulesEvent extends ModuleEvent
      */
     public function getContent(): string
     {
-        return $this->arguments['subject'];
+        return $this->arguments['content'];
     }
 
     /**
@@ -111,7 +118,7 @@ class AfterRenderModulesEvent extends ModuleEvent
      */
     public function updateContent(string $value): static
     {
-        $this->arguments['subject'] = $value;
+        $this->arguments['content'] = $this->setContent($value);
 
         return $this;
     }
@@ -119,11 +126,11 @@ class AfterRenderModulesEvent extends ModuleEvent
     /**
      * Getter for the attributes argument.
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    public function getAttributes(): array|\ArrayAccess
+    public function getAttributes(): array
     {
         return $this->arguments['attributes'];
     }

--- a/libraries/src/Event/Module/ModuleListEvent.php
+++ b/libraries/src/Event/Module/ModuleListEvent.php
@@ -28,31 +28,87 @@ abstract class ModuleListEvent extends ModuleEvent
      * @since  5.0.0
      * @deprecated 5.0 will be removed in 6.0
      */
-    protected $legacyArgumentsOrder = ['subject'];
+    protected $legacyArgumentsOrder = ['modules', 'subject'];
 
     /**
-     * Setter for the subject argument.
+     * Constructor.
      *
-     * @param   array|\ArrayAccess  $value  The value to set
+     * @param   string  $name       The event name.
+     * @param   array   $arguments  The event arguments.
      *
-     * @return  array|\ArrayAccess
+     * @throws  \BadMethodCallException
      *
-     * @since  5.0.0
+     * @since   __DEPLOY_VERSION__
      */
-    protected function setSubject(array|\ArrayAccess $value): array|\ArrayAccess
+    public function __construct($name, array $arguments = [])
     {
+        // This event has a dummy subject for now
+        $this->arguments['subject'] = $this->arguments['subject'] ?? new \stdClass();
+
+        parent::__construct($name, $arguments);
+
+        if (!\array_key_exists('modules', $this->arguments)) {
+            throw new \BadMethodCallException("Argument 'modules' of event {$name} is required but has not been provided");
+        }
+
+        // For backward compatibility make sure the content is referenced
+        // TODO: Remove in Joomla 6
+        // @deprecated: Passing argument by reference is deprecated, and will not work in Joomla 6
+        if (key($arguments) === 0) {
+            $this->arguments['modules'] = &$arguments[0];
+        } elseif (\array_key_exists('modules', $arguments)) {
+            $this->arguments['modules'] = &$arguments['modules'];
+        }
+    }
+
+    /**
+     * Setter for the modules argument.
+     *
+     * @param   object[]  $value  The value to set
+     *
+     * @return  object[]
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function setModules(array $value): array
+    {
+        // Filter out Module elements. Non empty result means invalid data
+        $valid = !array_filter($value, function ($item) {
+            return !is_object($item);
+        });
+
+        if (!$valid) {
+            throw new \UnexpectedValueException("Argument 'modules' of event {$this->name} is not of the expected type");
+        }
+
         return $value;
     }
 
     /**
      * Getter for the subject argument.
      *
-     * @return  array|\ArrayAccess
+     * @return  object[]
      *
      * @since  5.0.0
      */
-    public function getModules(): array|\ArrayAccess
+    public function getModules(): array
     {
-        return $this->arguments['subject'];
+        return $this->arguments['modules'];
+    }
+
+    /**
+     * Update the modules.
+     *
+     * @param   object[]  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function updateModules(array $value): static
+    {
+        $this->arguments['modules'] = $this->setModules($value);
+
+        return $this;
     }
 }

--- a/libraries/src/Event/Module/RenderModuleEvent.php
+++ b/libraries/src/Event/Module/RenderModuleEvent.php
@@ -47,6 +47,15 @@ abstract class RenderModuleEvent extends ModuleEvent
         if (!\array_key_exists('attributes', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'attributes' of event {$name} is required but has not been provided");
         }
+
+        // For backward compatibility make sure the content is referenced
+        // TODO: Remove in Joomla 6
+        // @deprecated: Passing argument by reference is deprecated, and will not work in Joomla 6
+        if (key($arguments) === 0) {
+            $this->arguments['attributes'] = &$arguments[1];
+        } elseif (\array_key_exists('attributes', $arguments)) {
+            $this->arguments['attributes'] = &$arguments['attributes'];
+        }
     }
 
     /**
@@ -66,13 +75,13 @@ abstract class RenderModuleEvent extends ModuleEvent
     /**
      * Setter for the attributes argument.
      *
-     * @param   array|\ArrayAccess  $value  The value to set
+     * @param   array  $value  The value to set
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    protected function setAttributes(array|\ArrayAccess $value): array|\ArrayAccess
+    protected function setAttributes(array $value): array
     {
         return $value;
     }
@@ -92,12 +101,28 @@ abstract class RenderModuleEvent extends ModuleEvent
     /**
      * Getter for the attributes argument.
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    public function getAttributes(): array|\ArrayAccess
+    public function getAttributes(): array
     {
         return $this->arguments['attributes'];
+    }
+
+    /**
+     * Update the attributes.
+     *
+     * @param   array  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function updateData(array $value): static
+    {
+        $this->arguments['attributes'] = $this->setAttributes($value);
+
+        return $this;
     }
 }

--- a/libraries/src/Event/Privacy/CheckPrivacyPolicyPublishedEvent.php
+++ b/libraries/src/Event/Privacy/CheckPrivacyPolicyPublishedEvent.php
@@ -49,31 +49,60 @@ class CheckPrivacyPolicyPublishedEvent extends PrivacyEvent
         if (!\array_key_exists('subject', $this->arguments)) {
             throw new \BadMethodCallException("Argument 'subject' of event {$name} is required but has not been provided");
         }
+
+        // For backward compatibility make sure the content is referenced
+        // TODO: Remove in Joomla 6
+        // @deprecated: Passing argument by reference is deprecated, and will not work in Joomla 6
+        if (key($arguments) === 0) {
+            $this->arguments['subject'] = &$arguments[0];
+        } elseif (\array_key_exists('subject', $arguments)) {
+            $this->arguments['subject'] = &$arguments['subject'];
+        }
     }
 
     /**
      * Setter for the subject argument.
      *
-     * @param   array|\ArrayAccess  $value  The value to set
+     * @param   array  $value  The value to set
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    protected function setSubject(array|\ArrayAccess $value): array|\ArrayAccess
+    protected function setSubject(array $value): array
     {
+        if (!\array_key_exists('published', $value) || !\array_key_exists('articlePublished', $value) || !\array_key_exists('editLink', $value)) {
+            throw new \UnexpectedValueException("Argument 'subject' of event {$this->name} is not of the expected type");
+        }
+
         return $value;
     }
 
     /**
      * Getter for the policy check.
      *
-     * @return  array|\ArrayAccess
+     * @return  array
      *
      * @since  5.0.0
      */
-    public function getPolicyInfo(): array|\ArrayAccess
+    public function getPolicyInfo(): array
     {
         return $this->arguments['subject'];
+    }
+
+    /**
+     * Update the PolicyInfo.
+     *
+     * @param   object[]  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function updatePolicyInfo(array $value): static
+    {
+        $this->arguments['subject'] = $this->setSubject($value);
+
+        return $this;
     }
 }

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -20,7 +20,6 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Profiler\Profiler;
-use Joomla\CMS\Proxy\ArrayProxy;
 use Joomla\Database\ParameterType;
 use Joomla\Filesystem\Path;
 use Joomla\Registry\Registry;
@@ -209,11 +208,12 @@ abstract class ModuleHelper
         $module->style = $attribs['style'];
 
         // If the $module is nulled it will return an empty content, otherwise it will render the module normally.
-        $attrProxy = new ArrayProxy($attribs);
-        $dispatcher->dispatch('onRenderModule', new Module\BeforeRenderModuleEvent('onRenderModule', [
+        $brEvent = $dispatcher->dispatch('onRenderModule', new Module\BeforeRenderModuleEvent('onRenderModule', [
             'subject'    => $module,
-            'attributes' => $attrProxy,
+            'attributes' => &$attribs, // TODO: Remove reference in Joomla 6, see BeforeRenderModuleEvent::__constructor()
         ]));
+        // Get final attributes
+        $attribs = $brEvent->getArgument('attributes', $attribs);
 
         if (!isset($module->content)) {
             return '';
@@ -241,7 +241,7 @@ abstract class ModuleHelper
 
         $dispatcher->dispatch('onAfterRenderModule', new Module\AfterRenderModuleEvent('onAfterRenderModule', [
             'subject'    => $module,
-            'attributes' => $attrProxy,
+            'attributes' => $attribs,
         ]));
 
         if (JDEBUG) {
@@ -375,24 +375,24 @@ abstract class ModuleHelper
         $dispatcher = Factory::getApplication()->getDispatcher();
         $modules    = [];
 
-        $dispatcher->dispatch('onPrepareModuleList', new Module\PrepareModuleListEvent('onPrepareModuleList', [
-            'subject' => new ArrayProxy($modules),
-        ]));
+        $modules = $dispatcher->dispatch('onPrepareModuleList', new Module\PrepareModuleListEvent('onPrepareModuleList', [
+            'modules' => &$modules, // TODO: Remove reference in Joomla 6, see PrepareModuleListEvent::__constructor()
+        ]))->getArgument('modules', $modules);
 
         // If the onPrepareModuleList event returns an array of modules, then ignore the default module list creation
         if (!$modules) {
             $modules = static::getModuleList();
         }
 
-        $dispatcher->dispatch('onAfterModuleList', new Module\AfterModuleListEvent('onAfterModuleList', [
-            'subject' => new ArrayProxy($modules),
-        ]));
+        $modules = $dispatcher->dispatch('onAfterModuleList', new Module\AfterModuleListEvent('onAfterModuleList', [
+            'modules' => &$modules, // TODO: Remove reference in Joomla 6, see AfterModuleListEvent::__constructor()
+        ]))->getArgument('modules', $modules);
 
         $modules = static::cleanModuleList($modules);
 
-        $dispatcher->dispatch('onAfterCleanModuleList', new Module\AfterCleanModuleListEvent('onAfterCleanModuleList', [
-            'subject' => new ArrayProxy($modules),
-        ]));
+        $modules = $dispatcher->dispatch('onAfterCleanModuleList', new Module\AfterCleanModuleListEvent('onAfterCleanModuleList', [
+            'modules' => &$modules, // TODO: Remove reference in Joomla 6, see AfterCleanModuleListEvent::__constructor()
+        ]))->getArgument('modules', $modules);
 
         return $modules;
     }

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Http\HttpFactory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\CMS\Proxy\ArrayProxy;
 use Joomla\CMS\Updater\Update;
 use Joomla\CMS\Version;
 use Joomla\Filesystem\File;
@@ -84,10 +83,11 @@ abstract class InstallerHelper
         PluginHelper::importPlugin('installer', null, true, $dispatcher);
         $event = new BeforePackageDownloadEvent('onInstallerBeforePackageDownload', [
             'url'     => &$url, // TODO: Remove reference in Joomla 6, see BeforePackageDownloadEvent::__constructor()
-            'headers' => new ArrayProxy($headers),
+            'headers' => &$headers, // TODO: Remove reference in Joomla 6, see BeforePackageDownloadEvent::__constructor()
         ]);
         $dispatcher->dispatch('onInstallerBeforePackageDownload', $event);
-        $url = $event->getUrl();
+        $url     = $event->getArgument('url', $url);
+        $headers = $event->getArgument('headers', $headers);
 
         try {
             $response = HttpFactory::getHttp()->get($url, $headers);

--- a/libraries/src/MVC/Model/FormBehaviorTrait.php
+++ b/libraries/src/MVC/Model/FormBehaviorTrait.php
@@ -15,7 +15,6 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormFactoryInterface;
 use Joomla\CMS\Form\FormField;
 use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\CMS\Proxy\ArrayProxy;
 use Joomla\CMS\User\CurrentUserInterface;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherInterface;
@@ -158,17 +157,15 @@ trait FormBehaviorTrait
         // Get the dispatcher and load the users plugins.
         PluginHelper::importPlugin($group, null, true, $dispatcher);
 
-        // When the data is an array wrap it in to an array-access object
-        $eventData = $data;
-        if (is_array($data)) {
-            $eventData = new ArrayProxy($data);
-        }
-
         // Trigger the data preparation event.
-        $dispatcher->dispatch(
+        $data = $dispatcher->dispatch(
             'onContentPrepareData',
-            new Model\PrepareDataEvent('onContentPrepareData', ['context' => $context, 'subject' => $eventData])
-        );
+            new Model\PrepareDataEvent('onContentPrepareData', [
+                'context' => $context,
+                'data'    => &$data, // TODO: Remove reference in Joomla 6, see PrepareDataEvent::__constructor()
+                'subject' => new \stdClass(),
+            ])
+        )->getArgument('data', $data);
     }
 
     /**

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -10,7 +10,6 @@
 namespace Joomla\CMS\MVC\Model;
 
 use Joomla\CMS\Event\Model;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Form\FormFactoryAwareInterface;
@@ -20,7 +19,6 @@ use Joomla\CMS\Form\FormRule;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
 use Joomla\CMS\Plugin\PluginHelper;
-use Joomla\CMS\Proxy\ArrayProxy;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -199,29 +197,23 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
         // Include the plugins for the delete events.
         PluginHelper::importPlugin($this->events_map['validate'], null, true, $dispatcher);
 
-        // When the data is an array wrap it in to an array-access object
-        $eventData = $data;
-        if (is_array($data)) {
-            $eventData = new ArrayProxy($data);
-        }
-
         if (!empty($dispatcher->getListeners('onUserBeforeDataValidation'))) {
             @trigger_error(
-                'The `onUserBeforeDataValidation` event is deprecated and will be removed in 5.0.'
+                'The `onUserBeforeDataValidation` event is deprecated and will be removed in 6.0.'
                 . 'Use the `onContentValidateData` event instead.',
                 E_USER_DEPRECATED
             );
 
-            $dispatcher->dispatch('onUserBeforeDataValidation', new Model\BeforeValidateDataEvent('onUserBeforeDataValidation', [
+            $data = $dispatcher->dispatch('onUserBeforeDataValidation', new Model\BeforeValidateDataEvent('onUserBeforeDataValidation', [
                 'subject' => $form,
-                'data'    => $eventData,
-            ]));
+                'data'    => &$data, // TODO: Remove reference in Joomla 6, see BeforeValidateDataEvent::__constructor()
+            ]))->getArgument('data', $data);
         }
 
-        $dispatcher->dispatch('onContentBeforeValidateData', new Model\BeforeValidateDataEvent('onContentBeforeValidateData', [
+        $data = $dispatcher->dispatch('onContentBeforeValidateData', new Model\BeforeValidateDataEvent('onContentBeforeValidateData', [
             'subject' => $form,
-            'data'    => $eventData,
-        ]));
+            'data'    => &$data, // TODO: Remove reference in Joomla 6, see AfterRenderModulesEvent::__constructor()
+        ]))->getArgument('data', $data);
 
         // Filter and validate the form data.
         $return = $form->process($data, $group);


### PR DESCRIPTION
### Summary of Changes

Restore array referencing for arguments that was referenced in past. Instead of ArrayProxy.
This applies only for legacy event listeners. 
New event listeners should explicitly call `$event->updateFoobar($value)` to update the argument (only for arguments that expected to be modified).

@HLeithner @wilsonge please review

### Testing Instructions
All should work as before.


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/194
- [ ] No documentation changes for manual.joomla.org needed
