### PR TITLE
[5.0] Fix typo in event method

### DIFF
--- a/libraries/src/Event/Module/RenderModuleEvent.php
+++ b/libraries/src/Event/Module/RenderModuleEvent.php
@@ -119,7 +119,7 @@ abstract class RenderModuleEvent extends ModuleEvent
      *
      * @since  __DEPLOY_VERSION__
      */
-    public function updateData(array $value): static
+    public function updateAttributes(array $value): static
     {
         $this->arguments['attributes'] = $this->setAttributes($value);
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

@HLeithner sorry, another one. Typo in method name made in https://github.com/joomla/joomla-cms/pull/41780


### Testing Instructions
Code review



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
