### PR TITLE
[5.0] Better check for empty options for legacy XTD Buttons

### DIFF
--- a/libraries/src/Editor/Button/ButtonsRegistry.php
+++ b/libraries/src/Editor/Button/ButtonsRegistry.php
@@ -127,7 +127,7 @@ final class ButtonsRegistry implements ButtonsRegistryInterface, DispatcherAware
                 foreach ($legacyButton as $item) {
                     if ($item instanceof CMSObject) {
                         $props   = $item->getProperties();
-                        $options = $props['options'] ?? [];
+                        $options = !empty($props['options']) ? $props['options'] : [];
                         unset($props['options']);
 
                         $button = new Button($plugin->name, $props, $options);
@@ -136,7 +136,7 @@ final class ButtonsRegistry implements ButtonsRegistryInterface, DispatcherAware
                 }
             } elseif ($legacyButton instanceof CMSObject) {
                 $props   = $legacyButton->getProperties();
-                $options = $props['options'] ?? [];
+                $options = !empty($props['options']) ? $props['options'] : [];
                 unset($props['options']);
 
                 $button = new Button($plugin->name, $props, $options);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

A Better check for empty options for legacy XTD Buttons.
A legacy butons may have an empty options as:

```php
$button = new CMSObject();
$button->options  = '';
```

Then `??` will not work.

### Testing Instructions
Code review




### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
