### PR TITLE
[5.0] Fix choices dropdown in dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
@@ -46,6 +46,14 @@
     color: $gray-700;
     opacity: 1;
   }
+
+  @if $enable-dark-mode {
+    @include color-mode(dark) {
+      &::placeholder {
+        color: var(--gray-200);
+      }
+    }
+  }
 }
 
 .choices__list--dropdown {
@@ -71,12 +79,24 @@
 }
 
 .choices .choices__list--dropdown {
+  background-color: var(--body-bg);
+
   .choices__item {
     padding-inline-end: 10px;
   }
 
-  .choices__item--selectable::after {
-    display: none;
+  .choices__item--selectable {
+    &::after {
+      display: none;
+    }
+
+    @if $enable-dark-mode {
+      @include color-mode(dark) {
+        &.is-highlighted {
+          background-color: var(--gray-800);
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Pull Request for Issue #41782 .

### Summary of Changes
Fixes choices dropdowns in dark mode

### Testing Instructions
Check dropdowns in e.g. article filter views in both light and dark modes. Please check in light mode that this is unchanged

### Actual result BEFORE applying this Pull Request
![dark-mode-filter](https://github.com/joomla/joomla-cms/assets/368084/ba745814-e99c-488b-a2a1-f30cbd56b158)

### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/cb7bc582-792d-447b-90fa-936849897dee)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
