### PR TITLE
[5.0] Increase meta description to 300 characters

### DIFF
--- a/administrator/components/com_categories/forms/category.xml
+++ b/administrator/components/com_categories/forms/category.xml
@@ -140,8 +140,8 @@
 		type="textarea"
 		label="JFIELD_META_DESCRIPTION_LABEL"
 		rows="3"
-		cols="40"
-		maxlength="160"
+		cols="30"
+		maxlength="300"
 		charcounter="true"
 	/>
 

--- a/administrator/components/com_config/forms/application.xml
+++ b/administrator/components/com_config/forms/application.xml
@@ -626,9 +626,9 @@
 			type="textarea"
 			label="COM_CONFIG_FIELD_METADESC_LABEL"
 			filter="string"
-			cols="60"
 			rows="3"
-			maxlength="160"
+			cols="30"
+			maxlength="300"
 			charcounter="true"
 		/>
 

--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -175,7 +175,7 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			maxlength="160"
+			maxlength="300"
 			charcounter="true"
 		/>
 

--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -208,7 +208,7 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			maxlength="160"
+			maxlength="300"
 			charcounter="true"
 		/>
 

--- a/administrator/components/com_languages/forms/language.xml
+++ b/administrator/components/com_languages/forms/language.xml
@@ -94,7 +94,7 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			maxlength="160"
+			maxlength="300"
 			charcounter="true"
 		/>
 	</fieldset>

--- a/administrator/components/com_menus/forms/item_component.xml
+++ b/administrator/components/com_menus/forms/item_component.xml
@@ -105,8 +105,8 @@
 				type="textarea"
 				label="JFIELD_META_DESCRIPTION_LABEL"
 				rows="3"
-				cols="40"
-				maxlength="160"
+				cols="30"
+				maxlength="300"
 				charcounter="true"
 			/>
 

--- a/administrator/components/com_newsfeeds/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/forms/newsfeed.xml
@@ -231,7 +231,7 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			maxlength="160"
+			maxlength="300"
 			charcounter="true"
 		/>
 

--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -130,8 +130,8 @@
 		type="textarea"
 		label="JFIELD_META_DESCRIPTION_LABEL"
 		rows="3"
-		cols="40"
-		maxlength="160"
+		cols="30"
+		maxlength="300"
 		charcounter="true"
 	/>
 

--- a/components/com_config/forms/config.xml
+++ b/components/com_config/forms/config.xml
@@ -8,9 +8,9 @@
 			type="textarea"
 			label="COM_CONFIG_FIELD_METADESC_LABEL"
 			filter="string"
-			cols="60"
 			rows="3"
-			maxlength="160"
+			cols="30"
+			maxlength="300"
 			charcounter="true"
 		/>
 

--- a/components/com_contact/forms/form.xml
+++ b/components/com_contact/forms/form.xml
@@ -333,7 +333,7 @@
 			label="JFIELD_META_DESCRIPTION_LABEL"
 			rows="3"
 			cols="30"
-			maxlength="160"
+			maxlength="300"
 			charcounter="true"
 		/>
 

--- a/components/com_content/forms/article.xml
+++ b/components/com_content/forms/article.xml
@@ -190,9 +190,9 @@
 			name="metadesc"
 			type="textarea"
 			label="JFIELD_META_DESCRIPTION_LABEL"
-			rows="5"
-			cols="50"
-			maxlength="160"
+			rows="3"
+			cols="30"
+			maxlength="300"
 			charcounter="true"
 		/>
 


### PR DESCRIPTION
Pull Request for Issue #36939 .

### Summary of Changes
Normalize the meta description field and increase the max length to 300 characters.

As a compromise to remove the limit completely.

### Testing Instructions
Add meta description longer then 160 characters.


### Actual result BEFORE applying this Pull Request
Max 160 allowed


### Expected result AFTER applying this Pull Request
Max 300 allowed


