### PR TITLE
[5.0] Fix color of text filters info

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_edit.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_edit.scss
@@ -21,11 +21,3 @@
     }
   }
 }
-
-@if $enable-dark-mode {
-  @include color-mode(dark) {
-    details div.rule-notes {
-      color: var(--template-text-light);
-    }
-  }
-}

--- a/build/media_source/templates/administrator/atum/scss/blocks/_layout.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_layout.scss
@@ -22,3 +22,12 @@
     }
   }
 }
+
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    .options-form {
+      color: var(--template-text-light);
+    }
+  }
+}
+


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41796 .

### Summary of Changes
This is the better but also slightly more risky fix than I had in https://github.com/joomla/joomla-cms/pull/41773 that should cover all these dropdowns.

### Testing Instructions
Check global configuration view and validate the text is shown in dark mode in the correct color for both the text filters tab as well as global permissions tab. Check any other tabs in any of core. We use `options-form` as a class in many places and I can't be 100% nothing else will be impacted from this (although I've taken a quick look around and can't find anything too crazy)

### Actual result BEFORE applying this Pull Request
![text-filters](https://github.com/joomla/joomla-cms/assets/368084/ded66161-5687-4e56-b698-c91c5ad8e9f1)

### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/7473dab2-7f51-4be4-b782-9b9f52b4a166)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
