### PR TITLE
[5.0] Rework styling so it's part of SCSS not in the HTML

### DIFF
--- a/administrator/components/com_users/tmpl/methods/list.php
+++ b/administrator/components/com_users/tmpl/methods/list.php
@@ -37,16 +37,16 @@ $canDelete  = MfaHelper::canDeleteMethod($this->user);
         $methodClass = 'com-users-methods-list-method-name-' . htmlentities($method['name'])
             . ($this->defaultMethod == $methodName ? ' com-users-methods-list-method-default' : '');
         ?>
-        <div class="com-users-methods-list-method <?php echo $methodClass?> mx-1 mt-3 mb-4 card <?php echo count($method['active']) ? 'border-secondary' : '' ?>">
-            <div class="com-users-methods-list-method-header card-header <?php echo count($method['active']) ? 'border-secondary bg-secondary text-white' : 'bg-light' ?> d-flex flex-wrap align-items-center gap-2">
-                <div class="com-users-methods-list-method-image pt-1 px-3 pb-2 bg-light rounded-2">
+        <div class="com-users-methods-list-method <?php echo $methodClass?> <?php echo count($method['active']) ? 'com-users-methods-list-method-active' : '' ?>">
+            <div class="com-users-methods-list-method-header">
+                <div class="com-users-methods-list-method-image">
                     <img src="<?php echo Uri::root() . $method['image'] ?>"
                          alt="<?php echo $this->escape($method['display']) ?>"
                          class="img-fluid"
                     >
                 </div>
-                <div class="com-users-methods-list-method-title flex-grow-1 d-flex flex-column">
-                    <h3 class="<?php echo count($method['active']) ? 'text-white' : '' ?> fs-2 p-0 m-0 d-flex gap-3 align-items-center">
+                <div class="com-users-methods-list-method-title">
+                    <h3>
                         <span class="me-1 flex-grow-1">
                             <?php echo $method['display'] ?>
                         </span>
@@ -59,8 +59,8 @@ $canDelete  = MfaHelper::canDeleteMethod($this->user);
                 </div>
             </div>
 
-            <div class="com-users-methods-list-method-records-container card-body">
-                <div class="com-users-methods-list-method-info my-1 pb-1 text-muted">
+            <div class="com-users-methods-list-method-records-container">
+                <div class="com-users-methods-list-method-info">
                     <?php echo $method['shortinfo'] ?>
                 </div>
 

--- a/build/media_source/templates/administrator/atum/scss/pages/_com_users.scss
+++ b/build/media_source/templates/administrator/atum/scss/pages/_com_users.scss
@@ -21,6 +21,75 @@
     }
   }
 
+  &.view-user, &.view-methods {
+    .com-users-methods-list-method {
+      @extend .card;
+      @extend .mx-1;
+      @extend .mt-3;
+      @extend .mb-4;
+
+      &.com-users-methods-list-method-active {
+        @extend .border-secondary;
+
+        .com-users-methods-list-method-title h3 {
+          @extend .text-white;
+        }
+
+        .com-users-methods-list-method-header {
+          @extend .border-secondary;
+          @extend .bg-secondary;
+          @extend .text-white;
+        }
+      }
+
+      /** This is applied to headers that aren't an active method **/
+      &:not(.com-users-methods-list-method-active) .com-users-methods-list-method-header {
+        @extend .bg-light;
+      }
+
+      .com-users-methods-list-method-header {
+        @extend .align-items-center;
+        @extend .gap-2;
+        @extend .flex-wrap;
+        @extend .d-flex;
+        @extend .card-header;
+      }
+
+      .com-users-methods-list-method-image {
+        @extend .pt-1;
+        @extend .px-3;
+        @extend .pb-2;
+        @extend .bg-light;
+        @extend .rounded-2;
+      }
+
+      .com-users-methods-list-method-title {
+        @extend .flex-grow-1;
+        @extend .d-flex;
+        @extend .flex-column;
+
+        h3 {
+          @extend .fs-2;
+          @extend .p-0;
+          @extend .m-0;
+          @extend .d-flex;
+          @extend .gap-3;
+          @extend .align-items-center;
+        }
+      }
+
+      .com-users-methods-list-method-records-container {
+        @extend .card-body;
+      }
+
+      .com-users-methods-list-method-info {
+        @extend .my-1;
+        @extend .pb-1;
+        @extend .text-muted;
+      }
+    }
+  }
+
   #fieldset-groups {
     .controls {
       margin-inline-start: 2rem;


### PR DESCRIPTION
### Summary of Changes
Moves most the CSS classes in the list.php view to SCSS. This allows better control of the classes for things like color and background checks in dark mode in the future. By sticking to the BEM classes we also have better decoupling from bootstrap for any further changes in the future. Importantly all the classes I'm styling on already exist largely which makes this view very easy to convert. The only new class I've added is the one to mark the active MFA Method.

Once this is merged it then allows me to solve https://github.com/joomla/joomla-cms/issues/41794 by removing the bg-light class from the SCSS and adding in media queries for conditional colors and backgrounds.

### Testing Instructions
Check the MFA configuration renders exactly the same as it did before. There should be no differences at this point in either light or dark modes

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
