### PR TITLE
[5.0] Dark mode: dropdown background color fix

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_dropdown.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_dropdown.scss
@@ -2,7 +2,7 @@
 
 .btn-group .dropdown-menu {
   min-width: 100%;
-  background: $white;
+  background: var(--body-bg);
   box-shadow: $dropdown-box-shadow;
 
   joomla-toolbar-button {
@@ -75,3 +75,12 @@
     border-radius: 0;
   }
 }
+
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    .dropdown-item {
+      border-bottom: 1px solid rgba(255, 255, 255, .1);
+    }
+  }
+}
+


### PR DESCRIPTION
Pull Request for Issue #41801 .

### Summary of Changes
Fixes the background of dropdowns in dark mode

### Testing Instructions
Check group  dropdowns (either in com_content or com_users or any other component)_

### Actual result BEFORE applying this Pull Request
![dropdown](https://github.com/joomla/joomla-cms/assets/368084/f4b47b01-6a65-4204-8b94-d8f4d1a82ec1)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/deffd900-ec07-4388-9e17-8ca232bc0ac2)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
