### PR TITLE
[5.0] Fix choices single input in dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
@@ -163,6 +163,18 @@
 }
 
 .choices[data-type*="select-one"] {
+  .choices__input {
+    background-color: var(--body-bg);
+  }
+
+  @if $enable-dark-mode {
+    @include color-mode(dark) {
+      .choices__input {
+        border-color: var(--gray-600);
+      }
+    }
+  }
+
   .choices__item {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41800 .

### Summary of Changes
Fix the category dropdown input field in dark mode. Unchanged in light mode

### Testing Instructions
Check article view category dropdown

### Actual result BEFORE applying this Pull Request
![category](https://github.com/joomla/joomla-cms/assets/368084/d93ce049-dc64-43ed-88a3-3457e89b2ca8)

### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/03897381-09aa-4cb4-8647-fc63437fe9c3)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
