### PR TITLE
[4.4] Add model exception for components to start using

### DIFF
--- a/libraries/src/MVC/Model/Exception/ModelExceptionInterface.php
+++ b/libraries/src/MVC/Model/Exception/ModelExceptionInterface.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\MVC\Model\Exception;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('JPATH_PLATFORM') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Interface that all exceptions stemming from the model should implement for processing by the controller.
+ * It is expected that the controller should catch all exceptions that implement this interface and then
+ * make a decision as to whether the exception can be recovered from or not.
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+interface ModelExceptionInterface extends \Throwable
+{
+}

--- a/libraries/src/MVC/Model/Exception/ModelExceptionInterface.php
+++ b/libraries/src/MVC/Model/Exception/ModelExceptionInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Joomla! Content Management System
  *


### PR DESCRIPTION
This comes from https://github.com/joomla/joomla-cms/pull/38949.

### Summary of Changes
Adds an exception interface that can be used by components looking to use exceptions rather than LegacyErrorTrait. We want to add this into an earlier version as possible (i.e. J4) so as we roll out exceptions in j5. extension developers can still catch these exceptions in J4 and require 4.4 or higher.

### Testing Instructions
N/A Review class is present. See sample code in linked PR but we will not use this interface until 5.x in core.

### Link to documentations
This will be documented once the exceptions have been created for J5 and a note will be added to those docs that exception handling can be ported into extensions and still be 4.4 compatible

Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
