### PR TITLE
[5.0] Move integration points for media manager into the variables file

### DIFF
--- a/build/media_source/com_media/scss/_variables.scss
+++ b/build/media_source/com_media/scss/_variables.scss
@@ -3,34 +3,41 @@ $gutter-width:                      15px;
 $highlight-color:                   #2a69b8;
 $border-color:                      var(--template-bg-dark-7);
 $border-radius:                     .25rem;
+$box-shadow-color:                  var(--template-bg-dark-50);
 
 // Layout
 $col-main-panel-width:              83.3333%;
 $col-side-panel-width:              16.6667%;
 $col-gutter-width:                  $gutter-width;
-$col-box-shadow:                    0 2px 10px -8px var(--template-bg-dark-50);
+$col-box-shadow:                    0 2px 10px -8px $box-shadow-color;
 
 // Sidebar
 $sidebar-drive-bg:                  var(--media-manager-content-bg, #fff);
 $sidebar-tree-line-color:           $border-color;
-$sidebar-tree-icon-color:           #aaa;
+$sidebar-tree-icon-color:           var(--template-bg-dark-60);
 $sidebar-tree-line-height:          26px;
 $sidebar-tree-folder-icon:          "\f07b";
 $sidebar-tree-item-hover-bg:        #e1e1e1;
 $sidebar-active-icon-color:         $highlight-color;
+$sidebar-disk-name-color:           var(--media-manager-disk-name-color, var(--template-bg-dark));
 
 // Toolbar
-$toolbar-height:                    46px;
-$toolbar-bg:                        var(--media-manager-content-bg, #fff);
-$toolbar-icon-width:                50px;
-$toolbar-icon-color:                lighten(#2a69b8,30%);
-$toolbar-icon-bg-hover:             #f0f0f0;
-$toolbar-loader-color:              linear-gradient(to right, #59afff 0, #59daff 100%);
-$toolbar-loader-height:             2px;
+$toolbar-height:                     46px;
+$toolbar-bg:                         var(--media-manager-content-bg, #fff);
+$toolbar-icon-width:                 50px;
+$toolbar-icon-color:                 var(--template-bg-dark-60);
+$toolbar-icon-bg-hover:              #f0f0f0;
+$toolbar-loader-color:               linear-gradient(to right, #59afff 0, #59daff 100%);
+$toolbar-loader-height:              2px;
+$toolbar-icon-active-bg-color:       var(--template-bg-dark-60);
+$toolbar-icon-active-bg-color-hover: var(--template-bg-dark-80);
 
 // Breadcrumbs
-$breadcrumbs-bg:                    var(--template-bg-dark-3);
+$breadcrumbs-bg:                    var(--media-manager-overlay-bg, var(--template-bg-dark-3));
 $breadcrumbs-current-bg:            var(--media-manager-content-bg, #fff);
+
+// Media Browser
+$browser-background-color:          var(--media-manager-overlay-bg, var(--template-bg-dark-3));
 
 // Media Browser Grid
 $grid-gutter-width:                 $col-gutter-width;
@@ -41,7 +48,7 @@ $grid-item-icon-size:               1.3rem;
 $grid-item-icon-color:              #fff;
 $grid-item-icon-bg-color:           rgba(0,0,0,.8);
 $grid-item-icon-color-hover:        rgba(0,0,0,.8);
-$grid-item-icon-bg-color-hover:     #fff;
+$grid-item-icon-bg-color-hover:     var(--template-bg-dark-10);;
 $grid-item-icon-warning-icon-bg:    #d9534f;
 $grid-item-no-preview-bg:           #f5f5f5;
 $grid-item-width-sm:                13%;

--- a/build/media_source/com_media/scss/_variables.scss
+++ b/build/media_source/com_media/scss/_variables.scss
@@ -48,7 +48,7 @@ $grid-item-icon-size:               1.3rem;
 $grid-item-icon-color:              #fff;
 $grid-item-icon-bg-color:           rgba(0,0,0,.8);
 $grid-item-icon-color-hover:        rgba(0,0,0,.8);
-$grid-item-icon-bg-color-hover:     var(--template-bg-dark-10);;
+$grid-item-icon-bg-color-hover:     var(--template-bg-dark-10);
 $grid-item-icon-warning-icon-bg:    #d9534f;
 $grid-item-no-preview-bg:           #f5f5f5;
 $grid-item-width-sm:                13%;

--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -126,10 +126,10 @@
     z-index: 1;
     width: max-content;
     min-width: 100%;
-    background-color: var(--media-manager-overlay-bg, var(--template-bg-dark-3));
+    background-color: $browser-background-color;
     border: 1px solid hsl(var(--hue), 35%, 95%);
     border-radius: .25rem;
-    box-shadow: 0 2px 10px -8px var(--template-bg-dark-50);
+    box-shadow: 0 2px 10px -8px $box-shadow-color;
     > button {
       display: none;
     }
@@ -143,7 +143,7 @@
           width: 100%;
           height: 100%;
           overflow: auto;
-          background-color: var(--template-bg-dark-3);
+          background-color: $browser-background-color;
         }
       }
 
@@ -179,7 +179,8 @@
       opacity: 1;
       transition-duration: .2s;
       &:hover, &:focus {
-        background-color: var(--template-bg-dark-10);
+        color: $grid-item-icon-color-hover;
+        background-color: $grid-item-icon-bg-color-hover;
         &.action-delete {
           color: $grid-item-icon-color;
           background-color: $grid-item-icon-warning-icon-bg;

--- a/build/media_source/com_media/scss/components/_media-edit.scss
+++ b/build/media_source/com_media/scss/components/_media-edit.scss
@@ -54,7 +54,7 @@
   background-image: linear-gradient(45deg,hsl(var(--hue), 20%, 97%) 25%,transparent 0,transparent 75%,#fafafa 0,hsl(var(--hue),20%,97%)),linear-gradient(45deg,#fafafa 25%,transparent 0,transparent 75%,hsl(var(--hue), 20%, 97%) 0,hsl(var(--hue), 20%, 97%));
   background-position: 0 0,10px 10px;
   background-size: 20px 20px;
-  border-left: 1px solid var(--template-bg-dark-7);
+  border-left: 1px solid $border-color;
 
   > div > img {
     padding: 0;

--- a/build/media_source/com_media/scss/components/_media-toolbar.scss
+++ b/build/media_source/com_media/scss/components/_media-toolbar.scss
@@ -18,7 +18,7 @@
     width: $toolbar-icon-width;
     font-size: 1.3rem;
     line-height: $toolbar-height;
-    color: var(--template-bg-dark-60);
+    color: $toolbar-icon-color;
     text-align: center;
     background-color: transparent;
     border: 0;
@@ -26,9 +26,9 @@
     box-shadow: 1px 0 #fefefe inset;
     &.active {
       color: #fff;
-      background-color: var(--template-bg-dark-60);
+      background-color: $toolbar-icon-active-bg-color;
       &:hover {
-        background-color: var(--template-bg-dark-80);
+        background-color: $toolbar-icon-active-bg-color-hover;
       }
     }
     &:hover {

--- a/build/media_source/com_media/scss/components/_media-tree.scss
+++ b/build/media_source/com_media/scss/components/_media-tree.scss
@@ -33,7 +33,7 @@ ul.media-tree {
 .media-disk-name {
   padding: 4px 1px;
   font-size: 1rem;
-  color: var(--media-manager-disk-name-color, var(--template-bg-dark));
+  color: $sidebar-disk-name-color;
 
   &:empty {
     display: none;
@@ -110,7 +110,7 @@ ul.media-tree {
   padding-right: 2px;
   font-size: 15px;
   line-height: normal;
-  color: var(--template-bg-dark-60);
+  color: $sidebar-tree-icon-color;
   vertical-align: middle;
 }
 


### PR DESCRIPTION
### Summary of Changes
Moves all use of CSS variables in media manager to the _variables.scss file. This makes it easier to find for templates what CSS variables are required for integration (i.e. everything that is `var(--template-*` now lives in _variables.scss). For maintainers I've tried to comment all the things that are more than just moving variables around.


### Testing Instructions
Check media manager renders the same as before. The only color changes is on active actions menu items when selecting an item and it should effectively be not noticeable.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
