### PR TITLE
[5.0] Fix info and notice alert colors

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/_variables-dark.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables-dark.scss
@@ -14,3 +14,6 @@ $form-select-indicator-rtl-dark:   url("../images/select-bg-rtl-dark.svg");
 $form-select-bg-dark:              var(--template-bg-dark);
 $form-select-background-dark:      $form-select-bg-dark $form-select-indicator-dark no-repeat right center / $form-select-bg-size; // Used so we can have multiple background elements (e.g. arrow and feedback icon)
 $form-select-background-rtl-dark:  $form-select-bg-dark $form-select-indicator-rtl-dark no-repeat left center / $form-select-bg-size; // Used so we can have multiple background elements (e.g. arrow and feedback icon)
+
+// ALerts
+$state-info-text-dark:             var(--template-bg-dark-50);

--- a/build/media_source/templates/administrator/atum/scss/_variables.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables.scss
@@ -187,7 +187,6 @@ $state-success-border:             hsl(var(--hue),50%,93%);
 
 $state-info-text:                  var(--template-bg-dark-70);
 $state-info-bg:                    var(--body-bg);
-$state-info-border:                var(--template-bg-dark-70);
 
 $state-warning-text:               darken($warning, 24%);
 $state-warning-bg:                 lighten($warning, 44%);

--- a/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -127,10 +127,10 @@
     font-size: 2rem;
     line-height: 1rem;
     color: var(--alert-accent-color);
+    text-shadow: none;
     background: none;
     border: 0;
     opacity: 1;
-    text-shadow: none;
 
     &:hover,
     &:focus {

--- a/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -1,4 +1,5 @@
 @import "../../variables";
+@import "../../variables-dark";
 @import "../../../../../../../../media/vendor/joomla-custom-elements/css/joomla-alert";
 @import "../../../../../../../../media/vendor/bootstrap/scss/mixins/color-mode";
 
@@ -91,6 +92,13 @@
       p {
         color: var(--body-color);
       }
+    }
+  }
+
+  @include color-mode(dark) {
+    &[type="info"],
+    &[type="notice"] {
+      --alert-accent-color: #{$state-info-text-dark};
     }
   }
 

--- a/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -130,6 +130,7 @@
     background: none;
     border: 0;
     opacity: 1;
+    text-shadow: none;
 
     &:hover,
     &:focus {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41813 .

### Summary of Changes
Changes the info color for dark mode and removes an unused border parameter.

### Testing Instructions
In the database maintaince view check the color is now legible and a11y compliant

### Actual result BEFORE applying this Pull Request
![maintenance-database](https://github.com/joomla/joomla-cms/assets/368084/33f90b9d-091a-4173-ac94-834a2e54910f)

### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/79ab908d-5639-4517-85a4-9a263a6c5f57)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
