### PR TITLE
[5.0] Update bootstrap to 5.3.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3285,9 +3285,9 @@
       "dev": true
     },
     "node_modules/bootstrap": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.1.tgz",
-      "integrity": "sha512-jzwza3Yagduci2x0rr9MeFSORjcHpt0lRZukZPZQJT1Dth5qzV7XcgGqYzi39KGAVYR8QEDVoO0ubFKOxzMG+g==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
+      "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
### Summary of Changes
Upgrade bootstrap from 5.3.1 to 5.3.2

https://blog.getbootstrap.com/2023/09/14/bootstrap-5-3-2/

### Testing Instructions
Check frontend and backend. There shouldn't be anymore SCSS compilation errors, but there shouldn't be any noticeable difference looking at their changelog before and after

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
