### PR TITLE
[5.0] Better support for JHtml prefix in HTMLHelper

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -162,7 +162,18 @@ abstract class HTMLHelper
             \JLoader::register($className, $path);
 
             if (!class_exists($className)) {
-                throw new \InvalidArgumentException(sprintf('%s not found.', $className), 500);
+                if ($prefix !== 'Joomla\\CMS\\HTML\\HTMLHelper') {
+                    throw new \InvalidArgumentException(sprintf('%s not found.', $className), 500);
+                }
+
+                // @deprecated with 5.0 remove with 6.0 or 7.0 (depends of other relevant code)
+                $className = 'JHtml' . ucfirst($file);
+
+                \JLoader::register($className, $path);
+
+                if (!class_exists($className)) {
+                    throw new \InvalidArgumentException(sprintf('%s not found.', $className), 500);
+                }
             }
         }
 


### PR DESCRIPTION
Pull Request for Issue #41821 .

### Summary of Changes
Fallback to core naming schema for 3rd party extensions which uses JHtml as prefix for HTMLHelper classes.


### Testing Instructions
Use an extensions which uses JHtmlXXX HTMLHelper


### Actual result BEFORE applying this Pull Request
Doesn't work because we check only for the namespace version `Joomla\CMS\HTML\HTMLHelper`


### Expected result AFTER applying this Pull Request
Work because we now check also for the legacy prefix version `JHtml`

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [X] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
