### PR TITLE
[5.0] Update event argument setters to use onSet callback

### DIFF
--- a/libraries/src/Event/Application/ApplicationConfigurationEvent.php
+++ b/libraries/src/Event/Application/ApplicationConfigurationEvent.php
@@ -51,7 +51,7 @@ abstract class ApplicationConfigurationEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(Registry $value): Registry
+    protected function onSetSubject(Registry $value): Registry
     {
         return $value;
     }

--- a/libraries/src/Event/Application/ApplicationDocumentEvent.php
+++ b/libraries/src/Event/Application/ApplicationDocumentEvent.php
@@ -50,7 +50,7 @@ abstract class ApplicationDocumentEvent extends ApplicationEvent
      *
      * @since  5.0.0
      */
-    protected function setDocument(Document $value): Document
+    protected function onSetDocument(Document $value): Document
     {
         return $value;
     }

--- a/libraries/src/Event/Application/ApplicationEvent.php
+++ b/libraries/src/Event/Application/ApplicationEvent.php
@@ -51,7 +51,7 @@ abstract class ApplicationEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    final protected function setSubject(AbstractApplication $value): AbstractApplication
+    final protected function onSetSubject(AbstractApplication $value): AbstractApplication
     {
         return $value;
     }

--- a/libraries/src/Event/Application/BeforeApiRouteEvent.php
+++ b/libraries/src/Event/Application/BeforeApiRouteEvent.php
@@ -50,7 +50,7 @@ class BeforeApiRouteEvent extends ApplicationEvent
      *
      * @since  5.0.0
      */
-    protected function setRouter(ApiRouter $value): ApiRouter
+    protected function onSetRouter(ApiRouter $value): ApiRouter
     {
         return $value;
     }

--- a/libraries/src/Event/Application/DaemonReceiveSignalEvent.php
+++ b/libraries/src/Event/Application/DaemonReceiveSignalEvent.php
@@ -48,7 +48,7 @@ class DaemonReceiveSignalEvent extends ApplicationEvent
      *
      * @since  5.0.0
      */
-    protected function setSignal(int $value): int
+    protected function onSetSignal(int $value): int
     {
         return $value;
     }

--- a/libraries/src/Event/Cache/AfterPurgeEvent.php
+++ b/libraries/src/Event/Cache/AfterPurgeEvent.php
@@ -64,7 +64,7 @@ class AfterPurgeEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(string $value): string
+    protected function onSetSubject(string $value): string
     {
         return $value;
     }

--- a/libraries/src/Event/Captcha/CaptchaSetupEvent.php
+++ b/libraries/src/Event/Captcha/CaptchaSetupEvent.php
@@ -47,7 +47,7 @@ class CaptchaSetupEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(CaptchaRegistry $value): CaptchaRegistry
+    protected function onSetSubject(CaptchaRegistry $value): CaptchaRegistry
     {
         return $value;
     }

--- a/libraries/src/Event/Checkin/AfterCheckinEvent.php
+++ b/libraries/src/Event/Checkin/AfterCheckinEvent.php
@@ -64,7 +64,7 @@ class AfterCheckinEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(string $value): string
+    protected function onSetSubject(string $value): string
     {
         return $value;
     }

--- a/libraries/src/Event/Contact/SubmitContactEvent.php
+++ b/libraries/src/Event/Contact/SubmitContactEvent.php
@@ -81,7 +81,7 @@ class SubmitContactEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(object $value): object
+    protected function onSetSubject(object $value): object
     {
         return $value;
     }
@@ -95,7 +95,7 @@ class SubmitContactEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setData(array $value): array
+    protected function onSetData(array $value): array
     {
         return $value;
     }
@@ -135,7 +135,7 @@ class SubmitContactEvent extends AbstractImmutableEvent
      */
     public function updateData(array $value): static
     {
-        $this->arguments['data'] = $this->setData($value);
+        $this->arguments['data'] = $this->onSetData($value);
 
         return $this;
     }

--- a/libraries/src/Event/Contact/ValidateContactEvent.php
+++ b/libraries/src/Event/Contact/ValidateContactEvent.php
@@ -86,7 +86,7 @@ class ValidateContactEvent extends AbstractImmutableEvent implements ResultAware
      *
      * @since  5.0.0
      */
-    protected function setSubject(object $value): object
+    protected function onSetSubject(object $value): object
     {
         return $value;
     }
@@ -100,7 +100,7 @@ class ValidateContactEvent extends AbstractImmutableEvent implements ResultAware
      *
      * @since  5.0.0
      */
-    protected function setData(array $value): array
+    protected function onSetData(array $value): array
     {
         return $value;
     }

--- a/libraries/src/Event/Content/ContentEvent.php
+++ b/libraries/src/Event/Content/ContentEvent.php
@@ -72,7 +72,7 @@ abstract class ContentEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setContext(string $value): string
+    protected function onSetContext(string $value): string
     {
         return $value;
     }

--- a/libraries/src/Event/Content/ContentPrepareEvent.php
+++ b/libraries/src/Event/Content/ContentPrepareEvent.php
@@ -43,7 +43,7 @@ class ContentPrepareEvent extends ContentEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(object $value): object
+    protected function onSetSubject(object $value): object
     {
         return $value;
     }
@@ -57,7 +57,7 @@ class ContentPrepareEvent extends ContentEvent
      *
      * @since  5.0.0
      */
-    protected function setParams($value): Registry
+    protected function onSetParams($value): Registry
     {
         // This is for b/c compatibility, because some extensions pass a mixed types
         if (!$value instanceof Registry) {
@@ -82,7 +82,7 @@ class ContentPrepareEvent extends ContentEvent
      *
      * @since  5.0.0
      */
-    protected function setPage(?int $value): ?int
+    protected function onSetPage(?int $value): ?int
     {
         return $value;
     }

--- a/libraries/src/Event/CustomFields/AbstractPrepareFieldEvent.php
+++ b/libraries/src/Event/CustomFields/AbstractPrepareFieldEvent.php
@@ -62,7 +62,7 @@ abstract class AbstractPrepareFieldEvent extends CustomFieldsEvent
      *
      * @since  5.0.0
      */
-    protected function setContext(string $value): string
+    protected function onSetContext(string $value): string
     {
         return $value;
     }
@@ -76,7 +76,7 @@ abstract class AbstractPrepareFieldEvent extends CustomFieldsEvent
      *
      * @since  5.0.0
      */
-    protected function setItem(object $value): object
+    protected function onSetItem(object $value): object
     {
         return $value;
     }

--- a/libraries/src/Event/CustomFields/CustomFieldsEvent.php
+++ b/libraries/src/Event/CustomFields/CustomFieldsEvent.php
@@ -68,7 +68,7 @@ abstract class CustomFieldsEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(object $value): object
+    protected function onSetSubject(object $value): object
     {
         return $value;
     }

--- a/libraries/src/Event/CustomFields/PrepareDomEvent.php
+++ b/libraries/src/Event/CustomFields/PrepareDomEvent.php
@@ -64,7 +64,7 @@ class PrepareDomEvent extends CustomFieldsEvent
      *
      * @since  5.0.0
      */
-    protected function setFieldset(\DOMElement $value): \DOMElement
+    protected function onSetFieldset(\DOMElement $value): \DOMElement
     {
         return $value;
     }
@@ -78,7 +78,7 @@ class PrepareDomEvent extends CustomFieldsEvent
      *
      * @since  5.0.0
      */
-    protected function setForm(Form $value): Form
+    protected function onSetForm(Form $value): Form
     {
         return $value;
     }

--- a/libraries/src/Event/Editor/EditorButtonsSetupEvent.php
+++ b/libraries/src/Event/Editor/EditorButtonsSetupEvent.php
@@ -55,7 +55,7 @@ final class EditorButtonsSetupEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(ButtonsRegistryInterface $value): ButtonsRegistryInterface
+    protected function onSetSubject(ButtonsRegistryInterface $value): ButtonsRegistryInterface
     {
         return $value;
     }
@@ -81,7 +81,7 @@ final class EditorButtonsSetupEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setEditorType(string $value): string
+    protected function onSetEditorType(string $value): string
     {
         return $value;
     }
@@ -107,7 +107,7 @@ final class EditorButtonsSetupEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setDisabledButtons(array $value): array
+    protected function onSetDisabledButtons(array $value): array
     {
         return $value;
     }
@@ -133,7 +133,7 @@ final class EditorButtonsSetupEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setEditorId(string $value): string
+    protected function onSetEditorId(string $value): string
     {
         return $value;
     }
@@ -159,7 +159,7 @@ final class EditorButtonsSetupEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setAsset(int $value): int
+    protected function onSetAsset(int $value): int
     {
         return $value;
     }
@@ -185,7 +185,7 @@ final class EditorButtonsSetupEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setAuthor(int $value): int
+    protected function onSetAuthor(int $value): int
     {
         return $value;
     }

--- a/libraries/src/Event/Editor/EditorSetupEvent.php
+++ b/libraries/src/Event/Editor/EditorSetupEvent.php
@@ -47,7 +47,7 @@ final class EditorSetupEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(EditorsRegistryInterface $value): EditorsRegistryInterface
+    protected function onSetSubject(EditorsRegistryInterface $value): EditorsRegistryInterface
     {
         return $value;
     }

--- a/libraries/src/Event/Extension/AfterInstallEvent.php
+++ b/libraries/src/Event/Extension/AfterInstallEvent.php
@@ -64,7 +64,7 @@ class AfterInstallEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setInstaller(Installer $value): Installer
+    protected function onSetInstaller(Installer $value): Installer
     {
         return $value;
     }
@@ -78,7 +78,7 @@ class AfterInstallEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setEid(int|bool $value): int|bool
+    protected function onSetEid(int|bool $value): int|bool
     {
         return $value;
     }

--- a/libraries/src/Event/Extension/AfterUninstallEvent.php
+++ b/libraries/src/Event/Extension/AfterUninstallEvent.php
@@ -68,7 +68,7 @@ class AfterUninstallEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setInstaller(Installer $value): Installer
+    protected function onSetInstaller(Installer $value): Installer
     {
         return $value;
     }
@@ -82,7 +82,7 @@ class AfterUninstallEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setEid(int $value): int
+    protected function onSetEid(int $value): int
     {
         return $value;
     }
@@ -96,7 +96,7 @@ class AfterUninstallEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setRemoved(bool $value): bool
+    protected function onSetRemoved(bool $value): bool
     {
         return $value;
     }

--- a/libraries/src/Event/Extension/AfterUpdateEvent.php
+++ b/libraries/src/Event/Extension/AfterUpdateEvent.php
@@ -64,7 +64,7 @@ class AfterUpdateEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setInstaller(Installer $value): Installer
+    protected function onSetInstaller(Installer $value): Installer
     {
         return $value;
     }
@@ -78,7 +78,7 @@ class AfterUpdateEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setEid(int|bool $value): int|bool
+    protected function onSetEid(int|bool $value): int|bool
     {
         return $value;
     }

--- a/libraries/src/Event/Extension/BeforeInstallEvent.php
+++ b/libraries/src/Event/Extension/BeforeInstallEvent.php
@@ -62,7 +62,7 @@ class BeforeInstallEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setMethod(string $value): string
+    protected function onSetMethod(string $value): string
     {
         return $value;
     }
@@ -76,7 +76,7 @@ class BeforeInstallEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setType(string $value): string
+    protected function onSetType(string $value): string
     {
         return $value;
     }
@@ -90,7 +90,7 @@ class BeforeInstallEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setManifest(?\SimpleXMLElement $value): ?\SimpleXMLElement
+    protected function onSetManifest(?\SimpleXMLElement $value): ?\SimpleXMLElement
     {
         return $value;
     }
@@ -104,7 +104,7 @@ class BeforeInstallEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setExtension(int $value): int
+    protected function onSetExtension(int $value): int
     {
         return $value;
     }

--- a/libraries/src/Event/Extension/BeforeUninstallEvent.php
+++ b/libraries/src/Event/Extension/BeforeUninstallEvent.php
@@ -58,7 +58,7 @@ class BeforeUninstallEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setEid(int $value): int
+    protected function onSetEid(int $value): int
     {
         return $value;
     }

--- a/libraries/src/Event/Extension/BeforeUpdateEvent.php
+++ b/libraries/src/Event/Extension/BeforeUpdateEvent.php
@@ -62,7 +62,7 @@ class BeforeUpdateEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setType(string $value): string
+    protected function onSetType(string $value): string
     {
         return $value;
     }
@@ -76,7 +76,7 @@ class BeforeUpdateEvent extends AbstractExtensionEvent
      *
      * @since  5.0.0
      */
-    protected function setManifest(?\SimpleXMLElement $value): ?\SimpleXMLElement
+    protected function onSetManifest(?\SimpleXMLElement $value): ?\SimpleXMLElement
     {
         return $value;
     }

--- a/libraries/src/Event/Finder/PrepareContentEvent.php
+++ b/libraries/src/Event/Finder/PrepareContentEvent.php
@@ -43,7 +43,7 @@ class PrepareContentEvent extends AbstractFinderEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(Result $value): Result
+    protected function onSetSubject(Result $value): Result
     {
         return $value;
     }

--- a/libraries/src/Event/Finder/ResultEvent.php
+++ b/libraries/src/Event/Finder/ResultEvent.php
@@ -44,7 +44,7 @@ class ResultEvent extends AbstractFinderEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(Result $value): Result
+    protected function onSetSubject(Result $value): Result
     {
         return $value;
     }
@@ -58,7 +58,7 @@ class ResultEvent extends AbstractFinderEvent
      *
      * @since  5.0.0
      */
-    protected function setQuery(Query $value): Query
+    protected function onSetQuery(Query $value): Query
     {
         return $value;
     }

--- a/libraries/src/Event/Installer/AfterInstallerEvent.php
+++ b/libraries/src/Event/Installer/AfterInstallerEvent.php
@@ -79,7 +79,7 @@ class AfterInstallerEvent extends InstallerEvent
      *
      * @since  5.0.0
      */
-    protected function setInstaller(ExtensionInstaller $value): ExtensionInstaller
+    protected function onSetInstaller(ExtensionInstaller $value): ExtensionInstaller
     {
         return $value;
     }
@@ -93,7 +93,7 @@ class AfterInstallerEvent extends InstallerEvent
      *
      * @since  5.0.0
      */
-    protected function setInstallerResult(bool $value): bool
+    protected function onSetInstallerResult(bool $value): bool
     {
         return $value;
     }
@@ -107,7 +107,7 @@ class AfterInstallerEvent extends InstallerEvent
      *
      * @since  5.0.0
      */
-    protected function setMessage(string $value): string
+    protected function onSetMessage(string $value): string
     {
         return $value;
     }
@@ -159,7 +159,7 @@ class AfterInstallerEvent extends InstallerEvent
      */
     public function updateInstallerResult(bool $value): static
     {
-        $this->arguments['installerResult'] = $value;
+        $this->arguments['installerResult'] = $this->onSetInstallerResult($value);
 
         return $this;
     }
@@ -175,7 +175,7 @@ class AfterInstallerEvent extends InstallerEvent
      */
     public function updateMessage(string $value): static
     {
-        $this->arguments['message'] = $value;
+        $this->arguments['message'] = $this->onSetMessage($value);
 
         return $this;
     }

--- a/libraries/src/Event/Installer/BeforePackageDownloadEvent.php
+++ b/libraries/src/Event/Installer/BeforePackageDownloadEvent.php
@@ -84,7 +84,7 @@ class BeforePackageDownloadEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setUrl(string $value): string
+    protected function onSetUrl(string $value): string
     {
         return $value;
     }
@@ -98,7 +98,7 @@ class BeforePackageDownloadEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setHeaders(array $value): array
+    protected function onSetHeaders(array $value): array
     {
         return $value;
     }
@@ -138,7 +138,7 @@ class BeforePackageDownloadEvent extends AbstractImmutableEvent
      */
     public function updateUrl(string $value): static
     {
-        $this->arguments['url'] = $this->setUrl($value);
+        $this->arguments['url'] = $this->onSetUrl($value);
 
         return $this;
     }
@@ -154,7 +154,7 @@ class BeforePackageDownloadEvent extends AbstractImmutableEvent
      */
     public function updateHeaders(array $value): static
     {
-        $this->arguments['headers'] = $this->setHeaders($value);
+        $this->arguments['headers'] = $this->onSetHeaders($value);
 
         return $this;
     }

--- a/libraries/src/Event/Installer/InstallerEvent.php
+++ b/libraries/src/Event/Installer/InstallerEvent.php
@@ -83,7 +83,7 @@ abstract class InstallerEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(BaseModel $value): BaseModel
+    protected function onSetSubject(BaseModel $value): BaseModel
     {
         return $value;
     }
@@ -97,7 +97,7 @@ abstract class InstallerEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setPackage(?array $value): ?array
+    protected function onSetPackage(?array $value): ?array
     {
         return $value;
     }
@@ -137,7 +137,7 @@ abstract class InstallerEvent extends AbstractImmutableEvent
      */
     public function updatePackage(?array $value): static
     {
-        $this->arguments['package'] = $value;
+        $this->arguments['package'] = $this->onSetPackage($value);
 
         return $this;
     }

--- a/libraries/src/Event/Menu/AfterGetMenuTypeOptionsEvent.php
+++ b/libraries/src/Event/Menu/AfterGetMenuTypeOptionsEvent.php
@@ -82,7 +82,7 @@ class AfterGetMenuTypeOptionsEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(BaseModel $value): BaseModel
+    protected function onSetSubject(BaseModel $value): BaseModel
     {
         return $value;
     }
@@ -96,7 +96,7 @@ class AfterGetMenuTypeOptionsEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setItems(array $value): array
+    protected function onSetItems(array $value): array
     {
         return $value;
     }

--- a/libraries/src/Event/Menu/AfterGetMenuTypeOptionsEvent.php
+++ b/libraries/src/Event/Menu/AfterGetMenuTypeOptionsEvent.php
@@ -136,7 +136,7 @@ class AfterGetMenuTypeOptionsEvent extends AbstractImmutableEvent
      */
     public function updateItems(array $value): static
     {
-        $this->arguments['items'] = $this->setItems($value);
+        $this->arguments['items'] = $this->onSetItems($value);
 
         return $this;
     }

--- a/libraries/src/Event/Menu/BeforeRenderMenuItemsViewEvent.php
+++ b/libraries/src/Event/Menu/BeforeRenderMenuItemsViewEvent.php
@@ -69,7 +69,7 @@ class BeforeRenderMenuItemsViewEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(HtmlView $value): HtmlView
+    protected function onSetSubject(HtmlView $value): HtmlView
     {
         return $value;
     }

--- a/libraries/src/Event/Menu/PreprocessMenuItemsEvent.php
+++ b/libraries/src/Event/Menu/PreprocessMenuItemsEvent.php
@@ -83,7 +83,7 @@ class PreprocessMenuItemsEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setContext(string $value): string
+    protected function onSetContext(string $value): string
     {
         return $value;
     }
@@ -97,7 +97,7 @@ class PreprocessMenuItemsEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(array $value): array
+    protected function onSetSubject(array $value): array
     {
         // Filter out MenuItem elements. Non empty result means invalid data
         $valid = !array_filter($value, function ($item) {
@@ -120,7 +120,7 @@ class PreprocessMenuItemsEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setParams(?Registry $value): ?Registry
+    protected function onSetParams(?Registry $value): ?Registry
     {
         return $value;
     }
@@ -134,7 +134,7 @@ class PreprocessMenuItemsEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setEnabled(?bool $value): ?bool
+    protected function onSetEnabled(?bool $value): ?bool
     {
         return $value;
     }
@@ -198,7 +198,7 @@ class PreprocessMenuItemsEvent extends AbstractImmutableEvent
      */
     public function updateItems(array $value): static
     {
-        $this->arguments['subject'] = $this->setSubject($value);
+        $this->arguments['subject'] = $this->onSetSubject($value);
 
         return $this;
     }

--- a/libraries/src/Event/Model/AfterCleanCacheEvent.php
+++ b/libraries/src/Event/Model/AfterCleanCacheEvent.php
@@ -76,7 +76,7 @@ class AfterCleanCacheEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setDefaultgroup(string $value): string
+    protected function onSetDefaultgroup(string $value): string
     {
         return $value;
     }
@@ -90,7 +90,7 @@ class AfterCleanCacheEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setCachebase(string $value): string
+    protected function onSetCachebase(string $value): string
     {
         return $value;
     }
@@ -104,7 +104,7 @@ class AfterCleanCacheEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setResult(bool $value): bool
+    protected function onSetResult(bool $value): bool
     {
         return $value;
     }

--- a/libraries/src/Event/Model/BeforeValidateDataEvent.php
+++ b/libraries/src/Event/Model/BeforeValidateDataEvent.php
@@ -57,7 +57,7 @@ class BeforeValidateDataEvent extends FormEvent
      */
     public function updateData(object|array $value): static
     {
-        $this->arguments['data'] = $this->setData($value);
+        $this->arguments['data'] = $this->onSetData($value);
 
         return $this;
     }

--- a/libraries/src/Event/Model/ChangeStateEvent.php
+++ b/libraries/src/Event/Model/ChangeStateEvent.php
@@ -39,7 +39,7 @@ abstract class ChangeStateEvent extends ModelEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(array $value): array
+    protected function onSetSubject(array $value): array
     {
         return $value;
     }
@@ -53,7 +53,7 @@ abstract class ChangeStateEvent extends ModelEvent
      *
      * @since  5.0.0
      */
-    protected function setValue($value): int
+    protected function onSetValue($value): int
     {
         return (int) $value;
     }

--- a/libraries/src/Event/Model/DeleteEvent.php
+++ b/libraries/src/Event/Model/DeleteEvent.php
@@ -39,7 +39,7 @@ abstract class DeleteEvent extends ModelEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(object $value): object
+    protected function onSetSubject(object $value): object
     {
         return $value;
     }

--- a/libraries/src/Event/Model/FormEvent.php
+++ b/libraries/src/Event/Model/FormEvent.php
@@ -73,7 +73,7 @@ abstract class FormEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setContext(string $value): string
+    protected function onSetContext(string $value): string
     {
         return $value;
     }
@@ -99,7 +99,7 @@ abstract class FormEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(Form $value): Form
+    protected function onSetSubject(Form $value): Form
     {
         return $value;
     }
@@ -113,7 +113,7 @@ abstract class FormEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setData(object|array $value): object|array
+    protected function onSetData(object|array $value): object|array
     {
         return $value;
     }

--- a/libraries/src/Event/Model/ModelEvent.php
+++ b/libraries/src/Event/Model/ModelEvent.php
@@ -72,7 +72,7 @@ abstract class ModelEvent extends AbstractImmutableEvent
      *
      * @since  5.0.0
      */
-    protected function setContext(string $value): string
+    protected function onSetContext(string $value): string
     {
         return $value;
     }

--- a/libraries/src/Event/Model/PrepareDataEvent.php
+++ b/libraries/src/Event/Model/PrepareDataEvent.php
@@ -72,7 +72,7 @@ class PrepareDataEvent extends ModelEvent
      *
      * @since  5.0.0
      */
-    protected function setData(object|array $value): object|array
+    protected function onSetData(object|array $value): object|array
     {
         return $value;
     }
@@ -100,7 +100,7 @@ class PrepareDataEvent extends ModelEvent
      */
     public function updateData(object|array $value): static
     {
-        $this->arguments['data'] = $this->setData($value);
+        $this->arguments['data'] = $this->onSetData($value);
 
         return $this;
     }

--- a/libraries/src/Event/Model/SaveEvent.php
+++ b/libraries/src/Event/Model/SaveEvent.php
@@ -39,7 +39,7 @@ abstract class SaveEvent extends ModelEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(object $value): object
+    protected function onSetSubject(object $value): object
     {
         return $value;
     }
@@ -53,7 +53,7 @@ abstract class SaveEvent extends ModelEvent
      *
      * @since  5.0.0
      */
-    protected function setIsNew($value): bool
+    protected function onSetIsNew($value): bool
     {
         return (bool) $value;
     }

--- a/libraries/src/Event/Module/AfterRenderModulesEvent.php
+++ b/libraries/src/Event/Module/AfterRenderModulesEvent.php
@@ -76,7 +76,7 @@ class AfterRenderModulesEvent extends ModuleEvent
      *
      * @since  5.0.0
      */
-    protected function setContent(string $value): string
+    protected function onSetContent(string $value): string
     {
         return $value;
     }
@@ -90,7 +90,7 @@ class AfterRenderModulesEvent extends ModuleEvent
      *
      * @since  5.0.0
      */
-    protected function setAttributes(array $value): array
+    protected function onSetAttributes(array $value): array
     {
         return $value;
     }
@@ -118,7 +118,7 @@ class AfterRenderModulesEvent extends ModuleEvent
      */
     public function updateContent(string $value): static
     {
-        $this->arguments['content'] = $this->setContent($value);
+        $this->arguments['content'] = $this->onSetContent($value);
 
         return $this;
     }

--- a/libraries/src/Event/Module/ModuleListEvent.php
+++ b/libraries/src/Event/Module/ModuleListEvent.php
@@ -70,7 +70,7 @@ abstract class ModuleListEvent extends ModuleEvent
      *
      * @since  5.0.0
      */
-    protected function setModules(array $value): array
+    protected function onSetModules(array $value): array
     {
         // Filter out Module elements. Non empty result means invalid data
         $valid = !array_filter($value, function ($item) {
@@ -107,7 +107,7 @@ abstract class ModuleListEvent extends ModuleEvent
      */
     public function updateModules(array $value): static
     {
-        $this->arguments['modules'] = $this->setModules($value);
+        $this->arguments['modules'] = $this->onSetModules($value);
 
         return $this;
     }

--- a/libraries/src/Event/Module/RenderModuleEvent.php
+++ b/libraries/src/Event/Module/RenderModuleEvent.php
@@ -67,7 +67,7 @@ abstract class RenderModuleEvent extends ModuleEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(object $value): object
+    protected function onSetSubject(object $value): object
     {
         return $value;
     }
@@ -81,7 +81,7 @@ abstract class RenderModuleEvent extends ModuleEvent
      *
      * @since  5.0.0
      */
-    protected function setAttributes(array $value): array
+    protected function onSetAttributes(array $value): array
     {
         return $value;
     }
@@ -121,7 +121,7 @@ abstract class RenderModuleEvent extends ModuleEvent
      */
     public function updateAttributes(array $value): static
     {
-        $this->arguments['attributes'] = $this->setAttributes($value);
+        $this->arguments['attributes'] = $this->onSetAttributes($value);
 
         return $this;
     }

--- a/libraries/src/Event/Plugin/AjaxEvent.php
+++ b/libraries/src/Event/Plugin/AjaxEvent.php
@@ -55,7 +55,7 @@ class AjaxEvent extends AbstractImmutableEvent implements ResultAwareInterface
      *
      * @since  5.0.0
      */
-    protected function setSubject(AbstractApplication $value): AbstractApplication
+    protected function onSetSubject(AbstractApplication $value): AbstractApplication
     {
         return $value;
     }

--- a/libraries/src/Event/Plugin/System/Schemaorg/BeforeCompileHeadEvent.php
+++ b/libraries/src/Event/Plugin/System/Schemaorg/BeforeCompileHeadEvent.php
@@ -57,7 +57,7 @@ class BeforeCompileHeadEvent extends AbstractImmutableEvent
      *
      * @since   5.0.0
      */
-    protected function setSubject(Registry $value): Registry
+    protected function onSetSubject(Registry $value): Registry
     {
         return $value;
     }
@@ -71,7 +71,7 @@ class BeforeCompileHeadEvent extends AbstractImmutableEvent
      *
      * @since   5.0.0
      */
-    protected function setContext(string $value): string
+    protected function onSetContext(string $value): string
     {
         return $value;
     }

--- a/libraries/src/Event/Plugin/System/Schemaorg/PrepareDataEvent.php
+++ b/libraries/src/Event/Plugin/System/Schemaorg/PrepareDataEvent.php
@@ -56,7 +56,7 @@ class PrepareDataEvent extends AbstractImmutableEvent
      *
      * @since   5.0.0
      */
-    protected function setSubject(object $value): object
+    protected function onSetSubject(object $value): object
     {
         return $value;
     }
@@ -70,7 +70,7 @@ class PrepareDataEvent extends AbstractImmutableEvent
      *
      * @since   5.0.0
      */
-    protected function setContext(string $value): string
+    protected function onSetContext(string $value): string
     {
         return $value;
     }

--- a/libraries/src/Event/Plugin/System/Schemaorg/PrepareFormEvent.php
+++ b/libraries/src/Event/Plugin/System/Schemaorg/PrepareFormEvent.php
@@ -53,7 +53,7 @@ class PrepareFormEvent extends AbstractImmutableEvent
      *
      * @since   5.0.0
      */
-    protected function setSubject(Form $value): Form
+    protected function onSetSubject(Form $value): Form
     {
         return $value;
     }

--- a/libraries/src/Event/Plugin/System/Schemaorg/PrepareSaveEvent.php
+++ b/libraries/src/Event/Plugin/System/Schemaorg/PrepareSaveEvent.php
@@ -69,7 +69,7 @@ class PrepareSaveEvent extends AbstractImmutableEvent
      *
      * @since   5.0.0
      */
-    protected function setSubject(object $value): object
+    protected function onSetSubject(object $value): object
     {
         return $value;
     }
@@ -83,7 +83,7 @@ class PrepareSaveEvent extends AbstractImmutableEvent
      *
      * @since   5.0.0
      */
-    protected function setContext(string $value): string
+    protected function onSetContext(string $value): string
     {
         return $value;
     }
@@ -97,7 +97,7 @@ class PrepareSaveEvent extends AbstractImmutableEvent
      *
      * @since   5.0.0
      */
-    protected function setItem(TableInterface $value): TableInterface
+    protected function onSetItem(TableInterface $value): TableInterface
     {
         return $value;
     }
@@ -111,7 +111,7 @@ class PrepareSaveEvent extends AbstractImmutableEvent
      *
      * @since   5.0.0
      */
-    protected function setIsNew(bool $value): bool
+    protected function onSetIsNew(bool $value): bool
     {
         return $value;
     }
@@ -125,7 +125,7 @@ class PrepareSaveEvent extends AbstractImmutableEvent
      *
      * @since   5.0.0
      */
-    protected function setSchema(array $value): array
+    protected function onSetSchema(array $value): array
     {
         return $value;
     }

--- a/libraries/src/Event/Privacy/CanRemoveDataEvent.php
+++ b/libraries/src/Event/Privacy/CanRemoveDataEvent.php
@@ -72,7 +72,7 @@ class CanRemoveDataEvent extends PrivacyEvent implements ResultAwareInterface
      *
      * @since  5.0.0
      */
-    protected function setSubject(RequestTable $value): RequestTable
+    protected function onSetSubject(RequestTable $value): RequestTable
     {
         return $value;
     }
@@ -86,7 +86,7 @@ class CanRemoveDataEvent extends PrivacyEvent implements ResultAwareInterface
      *
      * @since  5.0.0
      */
-    protected function setUser(?User $value): ?User
+    protected function onSetUser(?User $value): ?User
     {
         return $value;
     }

--- a/libraries/src/Event/Privacy/CheckPrivacyPolicyPublishedEvent.php
+++ b/libraries/src/Event/Privacy/CheckPrivacyPolicyPublishedEvent.php
@@ -69,7 +69,7 @@ class CheckPrivacyPolicyPublishedEvent extends PrivacyEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(array $value): array
+    protected function onSetSubject(array $value): array
     {
         if (!\array_key_exists('published', $value) || !\array_key_exists('articlePublished', $value) || !\array_key_exists('editLink', $value)) {
             throw new \UnexpectedValueException("Argument 'subject' of event {$this->name} is not of the expected type");
@@ -101,7 +101,7 @@ class CheckPrivacyPolicyPublishedEvent extends PrivacyEvent
      */
     public function updatePolicyInfo(array $value): static
     {
-        $this->arguments['subject'] = $this->setSubject($value);
+        $this->arguments['subject'] = $this->onSetSubject($value);
 
         return $this;
     }

--- a/libraries/src/Event/Privacy/ExportRequestEvent.php
+++ b/libraries/src/Event/Privacy/ExportRequestEvent.php
@@ -72,7 +72,7 @@ class ExportRequestEvent extends PrivacyEvent implements ResultAwareInterface
      *
      * @since  5.0.0
      */
-    protected function setSubject(RequestTable $value): RequestTable
+    protected function onSetSubject(RequestTable $value): RequestTable
     {
         return $value;
     }
@@ -86,7 +86,7 @@ class ExportRequestEvent extends PrivacyEvent implements ResultAwareInterface
      *
      * @since  5.0.0
      */
-    protected function setUser(?User $value): ?User
+    protected function onSetUser(?User $value): ?User
     {
         return $value;
     }

--- a/libraries/src/Event/Privacy/RemoveDataEvent.php
+++ b/libraries/src/Event/Privacy/RemoveDataEvent.php
@@ -67,7 +67,7 @@ class RemoveDataEvent extends PrivacyEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(RequestTable $value): RequestTable
+    protected function onSetSubject(RequestTable $value): RequestTable
     {
         return $value;
     }
@@ -81,7 +81,7 @@ class RemoveDataEvent extends PrivacyEvent
      *
      * @since  5.0.0
      */
-    protected function setUser(?User $value): ?User
+    protected function onSetUser(?User $value): ?User
     {
         return $value;
     }

--- a/libraries/src/Event/User/AbstractDeleteEvent.php
+++ b/libraries/src/Event/User/AbstractDeleteEvent.php
@@ -39,7 +39,7 @@ abstract class AbstractDeleteEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(array $value): array
+    protected function onSetSubject(array $value): array
     {
         return $value;
     }

--- a/libraries/src/Event/User/AbstractLoginEvent.php
+++ b/libraries/src/Event/User/AbstractLoginEvent.php
@@ -39,7 +39,7 @@ abstract class AbstractLoginEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(array $value): array
+    protected function onSetSubject(array $value): array
     {
         return $value;
     }
@@ -53,7 +53,7 @@ abstract class AbstractLoginEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setOptions(array $value): array
+    protected function onSetOptions(array $value): array
     {
         return $value;
     }

--- a/libraries/src/Event/User/AbstractLogoutEvent.php
+++ b/libraries/src/Event/User/AbstractLogoutEvent.php
@@ -39,7 +39,7 @@ abstract class AbstractLogoutEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(array $value): array
+    protected function onSetSubject(array $value): array
     {
         return $value;
     }
@@ -53,7 +53,7 @@ abstract class AbstractLogoutEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setOptions(array $value): array
+    protected function onSetOptions(array $value): array
     {
         return $value;
     }

--- a/libraries/src/Event/User/AbstractSaveEvent.php
+++ b/libraries/src/Event/User/AbstractSaveEvent.php
@@ -58,7 +58,7 @@ abstract class AbstractSaveEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(array $value): array
+    protected function onSetSubject(array $value): array
     {
         return $value;
     }
@@ -72,7 +72,7 @@ abstract class AbstractSaveEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setIsNew($value): bool
+    protected function onSetIsNew($value): bool
     {
         return (bool) $value;
     }

--- a/libraries/src/Event/User/AfterDeleteEvent.php
+++ b/libraries/src/Event/User/AfterDeleteEvent.php
@@ -60,7 +60,7 @@ class AfterDeleteEvent extends AbstractDeleteEvent
      *
      * @since  5.0.0
      */
-    protected function setDeletingResult(bool $value): bool
+    protected function onSetDeletingResult(bool $value): bool
     {
         return $value;
     }
@@ -74,7 +74,7 @@ class AfterDeleteEvent extends AbstractDeleteEvent
      *
      * @since  5.0.0
      */
-    protected function setErrorMessage(?string $value): ?string
+    protected function onSetErrorMessage(?string $value): ?string
     {
         return $value;
     }

--- a/libraries/src/Event/User/AfterRemindEvent.php
+++ b/libraries/src/Event/User/AfterRemindEvent.php
@@ -41,7 +41,7 @@ class AfterRemindEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(object $value): object
+    protected function onSetSubject(object $value): object
     {
         return $value;
     }

--- a/libraries/src/Event/User/AfterSaveEvent.php
+++ b/libraries/src/Event/User/AfterSaveEvent.php
@@ -60,7 +60,7 @@ class AfterSaveEvent extends AbstractSaveEvent
      *
      * @since  5.0.0
      */
-    protected function setSavingResult(bool $value): bool
+    protected function onSetSavingResult(bool $value): bool
     {
         return $value;
     }
@@ -74,7 +74,7 @@ class AfterSaveEvent extends AbstractSaveEvent
      *
      * @since  5.0.0
      */
-    protected function setErrorMessage(?string $value): ?string
+    protected function onSetErrorMessage(?string $value): ?string
     {
         return $value;
     }

--- a/libraries/src/Event/User/AuthenticationEvent.php
+++ b/libraries/src/Event/User/AuthenticationEvent.php
@@ -86,7 +86,7 @@ class AuthenticationEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(AuthenticationResponse $value): AuthenticationResponse
+    protected function onSetSubject(AuthenticationResponse $value): AuthenticationResponse
     {
         return $value;
     }
@@ -100,7 +100,7 @@ class AuthenticationEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setCredentials(array $value): array
+    protected function onSetCredentials(array $value): array
     {
         return $value;
     }
@@ -114,7 +114,7 @@ class AuthenticationEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setOptions(array $value): array
+    protected function onSetOptions(array $value): array
     {
         return $value;
     }

--- a/libraries/src/Event/User/AuthorisationEvent.php
+++ b/libraries/src/Event/User/AuthorisationEvent.php
@@ -47,7 +47,7 @@ class AuthorisationEvent extends UserEvent implements ResultAwareInterface
      *
      * @since  5.0.0
      */
-    protected function setSubject(AuthenticationResponse $value): AuthenticationResponse
+    protected function onSetSubject(AuthenticationResponse $value): AuthenticationResponse
     {
         return $value;
     }
@@ -61,7 +61,7 @@ class AuthorisationEvent extends UserEvent implements ResultAwareInterface
      *
      * @since  5.0.0
      */
-    protected function setOptions(array $value): array
+    protected function onSetOptions(array $value): array
     {
         return $value;
     }

--- a/libraries/src/Event/User/AuthorisationFailureEvent.php
+++ b/libraries/src/Event/User/AuthorisationFailureEvent.php
@@ -41,7 +41,7 @@ class AuthorisationFailureEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setSubject(array $value): array
+    protected function onSetSubject(array $value): array
     {
         return $value;
     }
@@ -55,7 +55,7 @@ class AuthorisationFailureEvent extends UserEvent
      *
      * @since  5.0.0
      */
-    protected function setOptions(array $value): array
+    protected function onSetOptions(array $value): array
     {
         return $value;
     }

--- a/libraries/src/Event/User/BeforeSaveEvent.php
+++ b/libraries/src/Event/User/BeforeSaveEvent.php
@@ -48,7 +48,7 @@ class BeforeSaveEvent extends AbstractSaveEvent implements ResultAwareInterface
      *
      * @since  5.0.0
      */
-    protected function setData(array $value): array
+    protected function onSetData(array $value): array
     {
         return $value;
     }

--- a/libraries/src/Event/User/LoginButtonsEvent.php
+++ b/libraries/src/Event/User/LoginButtonsEvent.php
@@ -48,7 +48,7 @@ class LoginButtonsEvent extends UserEvent implements ResultAwareInterface
      *
      * @since  5.0.0
      */
-    protected function setSubject(string $value): string
+    protected function onSetSubject(string $value): string
     {
         return $value;
     }


### PR DESCRIPTION
### Summary of Changes

The PR changes pre-processing methods from `setFobar` to `onSetFoobar` for all new event classes.
Old event classes is unchanged for now.

Changes for
- https://github.com/joomla/joomla-cms/pull/41722

The PR can be merged only when that PR is accepted and upmerged.


### Testing Instructions
Code review.
Make sure all works as before.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
