### PR TITLE
[5.0] Fix Index button in empty state

### DIFF
--- a/administrator/components/com_finder/tmpl/index/emptystate.php
+++ b/administrator/components/com_finder/tmpl/index/emptystate.php
@@ -22,7 +22,7 @@ $displayData = [
     'icon'       => 'icon-search-plus finder',
     'content'    => Text::_('COM_FINDER_INDEX_NO_DATA') . '<br>' . Text::_('COM_FINDER_INDEX_TIP'),
     'title'      => Text::_('COM_FINDER_HEADING_INDEXER'),
-    'createURL'  => "javascript:document.getElementsByClassName('button-index')[0].click();",
+    'createURL'  => "javascript:document.getElementsByClassName('button-archive')[0].click();",
 ];
 
 echo LayoutHelper::render('joomla.content.emptystate', $displayData);


### PR DESCRIPTION
Pull Request for Issue #41727.

### Summary of Changes

#40359 changed the name of the Index button in the toolbar. The button in the Empty State referenced the old name causing a console error.

### Testing Instructions
Go to Smart Search > Index.
Clear Index.
Click `Start the indexer` button.
See browser's console.


### Actual result BEFORE applying this Pull Request
![index-button](https://github.com/joomla/joomla-cms/assets/368084/27bd3182-941a-4570-a9eb-d16a4b084946)
