### PR TITLE
[5.0] Restore Finder button names

### DIFF
--- a/administrator/components/com_finder/src/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Index/HtmlView.php
@@ -183,7 +183,7 @@ class HtmlView extends BaseHtmlView
 
             $childBar = $dropdown->getChildToolbar();
 
-            $childBar->popupButton('archive', 'COM_FINDER_INDEX')
+            $childBar->popupButton('index', 'COM_FINDER_INDEX')
                 ->popupType('iframe')
                 ->textHeader(Text::_('COM_FINDER_HEADING_INDEXER'))
                 ->url('index.php?option=com_finder&view=indexer&tmpl=component')
@@ -196,7 +196,7 @@ class HtmlView extends BaseHtmlView
                 ->url('index.php?option=com_finder&view=indexer&layout=debug')
                 ->icon('icon-tools');
         } else {
-            $toolbar->popupButton('archive', 'COM_FINDER_INDEX')
+            $toolbar->popupButton('index', 'COM_FINDER_INDEX')
                 ->popupType('iframe')
                 ->textHeader(Text::_('COM_FINDER_HEADING_INDEXER'))
                 ->url('index.php?option=com_finder&view=indexer&tmpl=component')
@@ -223,7 +223,7 @@ class HtmlView extends BaseHtmlView
             }
 
             if ($canDo->get('core.delete')) {
-                $toolbar->confirmButton('', 'JTOOLBAR_DELETE', 'index.delete')
+                $toolbar->confirmButton('delete', 'JTOOLBAR_DELETE', 'index.delete')
                     ->message('COM_FINDER_INDEX_CONFIRM_DELETE_PROMPT')
                     ->icon('icon-delete')
                     ->listCheck(true);
@@ -245,7 +245,7 @@ class HtmlView extends BaseHtmlView
                     ->icon('icon-trash');
             }
 
-            $toolbar->popupButton('bars', 'COM_FINDER_STATISTICS')
+            $toolbar->popupButton('statistics', 'COM_FINDER_STATISTICS')
                 ->popupType('iframe')
                 ->textHeader(Text::_('COM_FINDER_STATISTICS_TITLE'))
                 ->url('index.php?option=com_finder&view=statistics&tmpl=component')


### PR DESCRIPTION

### Summary of Changes
Restore finder button names, was overiden in #40359 

@Quy please check

### Testing Instructions
Code review
Or go to `administrator/index.php?option=com_finder&view=index` and make sure all toolbar button works as before.



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
