### PR TITLE
[5.0] Add asset overrides for overriden css files

### DIFF
--- a/administrator/templates/atum/joomla.asset.json
+++ b/administrator/templates/atum/joomla.asset.json
@@ -94,6 +94,31 @@
       "name": "searchtools",
       "type": "style",
       "uri": "system/searchtools/searchtools.min.css"
+    },
+    {
+      "name": "awesomplete",
+      "type": "style",
+      "uri": "vendor/awesomplete/awesomplete.min.css"
+    },
+    {
+      "name": "choicesjs",
+      "type": "style",
+      "uri": "vendor/choicesjs/choices.min.css"
+    },
+    {
+      "name": "webcomponent.joomla-alert",
+      "type": "style",
+      "uri": "vendor/joomla-custom-elements/joomla-alert.min.css"
+    },
+    {
+      "name": "webcomponent.joomla-tab",
+      "type": "style",
+      "uri": "vendor/joomla-custom-elements/joomla-tab.min.css"
+    },
+    {
+      "name": "minicolors",
+      "type": "style",
+      "uri": "vendor/minicolors/jquery.minicolors.css"
     }
   ]
 }


### PR DESCRIPTION

### Summary of Changes

Resolve an issue when Template override the vendor asset, but it still served with vendor version
https://github.com/joomla/joomla-cms/issues/41823#issuecomment-1727732103


### Testing Instructions

Apply patch, 
Check source code of the page, look for style files of changed assets, 
they should have a hash instead of vendor version


### Actual result BEFORE applying this Pull Request
Vendor version


### Expected result AFTER applying this Pull Request
Media version


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
