### PR TITLE
[5.0] Shorter string for media version

### DIFF
--- a/build/build-modules-js/versioning.es6.js
+++ b/build/build-modules-js/versioning.es6.js
@@ -61,7 +61,7 @@ const updateAsset = async (asset, directory) => {
 
   const hash = await createHashFromFile(path);
 
-  asset.version = hash;
+  asset.version = hash.substring(0, 4);
   final[directory].push(asset);
 };
 

--- a/build/build-modules-js/versioning.es6.js
+++ b/build/build-modules-js/versioning.es6.js
@@ -61,7 +61,7 @@ const updateAsset = async (asset, directory) => {
 
   const hash = await createHashFromFile(path);
 
-  asset.version = hash.substring(0, 4);
+  asset.version = hash.substring(0, 6);
   final[directory].push(asset);
 };
 

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -238,7 +238,7 @@ final class Version
      */
     public function generateMediaVersion(): string
     {
-        return md5($this->getLongVersion() . Factory::getApplication()->get('secret') . (new Date())->toSql());
+        return substr(md5($this->getLongVersion() . Factory::getApplication()->get('secret') . (new Date())->toSql()), 0, 4);
     }
 
     /**

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -238,7 +238,7 @@ final class Version
      */
     public function generateMediaVersion(): string
     {
-        return substr(md5($this->getLongVersion() . Factory::getApplication()->get('secret') . (new Date())->toSql()), 0, 4);
+        return substr(md5($this->getLongVersion() . Factory::getApplication()->get('secret') . (new Date())->toSql()), 0, 6);
     }
 
     /**


### PR DESCRIPTION
### Summary of Changes

Shorter string for media version, 6 symbols instead of 32


### Testing Instructions

Apply patch, and clean the cache.
Check source code of the rendered page, for js/css files hash, example for core.js


### Actual result BEFORE applying this Pull Request
The hash is 32 symbols long


### Expected result AFTER applying this Pull Request
The hash is 6 symbols long


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
