### PR TITLE
[5.0] Remove contenthistory table alias from b/c plugin

### DIFF
--- a/plugins/behaviour/compat/src/classmap/classmap.php
+++ b/plugins/behaviour/compat/src/classmap/classmap.php
@@ -70,12 +70,6 @@ JLoader::registerAlias('JTableMenu', '\\Joomla\\CMS\\Table\\Menu', '6.0');
 JLoader::registerAlias('JTableMenuType', '\\Joomla\\CMS\\Table\\MenuType', '6.0');
 JLoader::registerAlias('JTableModule', '\\Joomla\\CMS\\Table\\Module', '6.0');
 
-// Special cases for renamed PascalCase table names which could not be autodetected by the new Table::getInstance function
-JLoader::registerAlias('\\Joomla\\CMS\\Table\\Updatesite', '\\Joomla\\CMS\\Table\\UpdateSite', '6.0');
-JLoader::registerAlias('\\Joomla\\CMS\\Table\\Viewlevel', '\\Joomla\\CMS\\Table\\ViewLevel', '6.0');
-JLoader::registerAlias('\\Joomla\\CMS\\Table\\Contenttype', '\\Joomla\\CMS\\Table\\ContentType', '6.0');
-JLoader::registerAlias('\\Joomla\\CMS\\Table\\Corecontent', '\\Joomla\\CMS\\Table\\CoreContent', '6.0');
-
 JLoader::registerAlias('JAccess', '\\Joomla\\CMS\\Access\\Access', '6.0');
 JLoader::registerAlias('JAccessRule', '\\Joomla\\CMS\\Access\\Rule', '6.0');
 JLoader::registerAlias('JAccessRules', '\\Joomla\\CMS\\Access\\Rules', '6.0');

--- a/plugins/behaviour/compat/src/classmap/classmap.php
+++ b/plugins/behaviour/compat/src/classmap/classmap.php
@@ -73,7 +73,6 @@ JLoader::registerAlias('JTableModule', '\\Joomla\\CMS\\Table\\Module', '6.0');
 // Special cases for renamed PascalCase table names which could not be autodetected by the new Table::getInstance function
 JLoader::registerAlias('\\Joomla\\CMS\\Table\\Updatesite', '\\Joomla\\CMS\\Table\\UpdateSite', '6.0');
 JLoader::registerAlias('\\Joomla\\CMS\\Table\\Viewlevel', '\\Joomla\\CMS\\Table\\ViewLevel', '6.0');
-JLoader::registerAlias('\\Joomla\\CMS\\Table\\Contenthistory', '\\Joomla\\CMS\\Table\\ContentHistory', '6.0');
 JLoader::registerAlias('\\Joomla\\CMS\\Table\\Contenttype', '\\Joomla\\CMS\\Table\\ContentType', '6.0');
 JLoader::registerAlias('\\Joomla\\CMS\\Table\\Corecontent', '\\Joomla\\CMS\\Table\\CoreContent', '6.0');
 


### PR DESCRIPTION
Pull Request for Issue #41835 .

### Summary of Changes
Removes the contenthistory alias from the b/c plugin


### Testing Instructions
Activate b/c plugin
create an article
check versions


### Actual result BEFORE applying this Pull Request
2 times the error message
```
Warning
: Cannot declare class \joomla\cms\table\contenttype, because the name is already in use in
/web/darmplus.verlauf.at/libraries/loader.php
on line
576
```


### Expected result AFTER applying this Pull Request
no error message

currently with this pr only one time


