### PR TITLE
[5.0] Simplify event class usage

### DIFF
--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -32,6 +32,7 @@ use Joomla\CMS\UCM\UCMType;
 use Joomla\CMS\Versioning\VersionableModelTrait;
 use Joomla\CMS\Workflow\Workflow;
 use Joomla\Component\Categories\Administrator\Helper\CategoriesHelper;
+use Joomla\Component\Content\Administrator\Event\Model\FeatureEvent;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 use Joomla\Database\ParameterType;
 use Joomla\Filter\OutputFilter;
@@ -845,7 +846,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
             AbstractEvent::create(
                 $this->event_before_change_featured,
                 [
-                    'eventClass' => 'Joomla\Component\Content\Administrator\Event\Model\FeatureEvent',
+                    'eventClass' => FeatureEvent::class,
                     'subject'    => $this,
                     'extension'  => $context,
                     'pks'        => $pks,
@@ -950,7 +951,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
             AbstractEvent::create(
                 $this->event_after_change_featured,
                 [
-                    'eventClass' => 'Joomla\Component\Content\Administrator\Event\Model\FeatureEvent',
+                    'eventClass' => FeatureEvent::class,
                     'subject'    => $this,
                     'extension'  => $context,
                     'pks'        => $pks,

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\MVC\View;
 
 use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Event\AbstractEvent;
+use Joomla\CMS\Event\View\DisplayEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
@@ -193,7 +194,7 @@ class HtmlView extends AbstractView implements CurrentUserInterface
             AbstractEvent::create(
                 'onBeforeDisplay',
                 [
-                    'eventClass' => 'Joomla\CMS\Event\View\DisplayEvent',
+                    'eventClass' => DisplayEvent::class,
                     'subject'    => $this,
                     'extension'  => $context,
                 ]
@@ -207,7 +208,7 @@ class HtmlView extends AbstractView implements CurrentUserInterface
             AbstractEvent::create(
                 'onAfterDisplay',
                 [
-                    'eventClass' => 'Joomla\CMS\Event\View\DisplayEvent',
+                    'eventClass' => DisplayEvent::class,
                     'subject'    => $this,
                     'extension'  => $context,
                     'source'     => $result,

--- a/libraries/src/WebAsset/WebAssetRegistry.php
+++ b/libraries/src/WebAsset/WebAssetRegistry.php
@@ -10,6 +10,7 @@
 namespace Joomla\CMS\WebAsset;
 
 use Joomla\CMS\Event\AbstractEvent;
+use Joomla\CMS\Event\WebAsset\WebAssetRegistryAssetChanged;
 use Joomla\CMS\WebAsset\Exception\UnknownAssetException;
 use Joomla\Event\Dispatcher as EventDispatcher;
 use Joomla\Event\DispatcherAwareInterface;
@@ -432,7 +433,7 @@ class WebAssetRegistry implements WebAssetRegistryInterface, DispatcherAwareInte
         $event = AbstractEvent::create(
             'onWebAssetRegistryChangedAsset' . ucfirst($change),
             [
-                'eventClass' => 'Joomla\\CMS\\Event\\WebAsset\\WebAssetRegistryAssetChanged',
+                'eventClass' => WebAssetRegistryAssetChanged::class,
                 'subject'    => $this,
                 'assetType'  => $type,
                 'asset'      => $asset,

--- a/libraries/src/Workflow/Workflow.php
+++ b/libraries/src/Workflow/Workflow.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Workflow;
 
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Event\AbstractEvent;
+use Joomla\CMS\Event\Workflow\WorkflowTransitionEvent;
 use Joomla\CMS\Extension\ComponentInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
@@ -400,7 +401,7 @@ class Workflow
                 AbstractEvent::create(
                     'onWorkflowAfterTransition',
                     [
-                        'eventClass' => 'Joomla\CMS\Event\Workflow\WorkflowTransitionEvent',
+                        'eventClass' => WorkflowTransitionEvent::class,
                         'subject'    => $this,
                         'extension'  => $this->extension,
                         'pks'        => $pks,


### PR DESCRIPTION
### Summary of Changes

It's better to use `::class` references to allow IDE class usage inspections.

### Testing Instructions

Apply path.

### Actual result BEFORE applying this Pull Request

Works.

### Expected result AFTER applying this Pull Request

Works as before, IDE can find the usage of event classes.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
