### PR TITLE
[5.0] Restore possibility to use class for mod chrome

### DIFF
--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -59,7 +59,7 @@ echo HTMLHelper::_(
                 echo ModuleHelper::renderModule($iconmodule, [
                    'style' => 'well',
                    'class' => 'quickicons-for-' . $modParams->get('context', ''),
-               ]);
+                ]);
             }
         endif;
         foreach ($this->modules as $module) {

--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
+use Joomla\Registry\Registry;
 
 // Load JavaScript message titles
 Text::script('ERROR');
@@ -53,7 +54,12 @@ echo HTMLHelper::_(
         <div class="card-columns">
         <?php if ($this->quickicons) :
             foreach ($this->quickicons as $iconmodule) {
-                echo ModuleHelper::renderModule($iconmodule, ['style' => 'well']);
+                $modParams = new Registry($iconmodule->params);
+
+                echo ModuleHelper::renderModule($iconmodule, [
+                   'style' => 'well',
+                   'class' => 'quickicons-for-' . $modParams->get('context', ''),
+               ]);
             }
         endif;
         foreach ($this->modules as $module) {

--- a/administrator/templates/atum/html/layouts/chromes/well.php
+++ b/administrator/templates/atum/html/layouts/chromes/well.php
@@ -36,6 +36,11 @@ $moduleClass    = $bootstrapSize ? 'col-md-' . $bootstrapSize : 'col-md-12';
 $headerTag      = htmlspecialchars($params->get('header_tag', 'h2'), ENT_QUOTES, 'UTF-8');
 $moduleClassSfx = $params->get('moduleclass_sfx', '');
 
+// Add class from attributes if any
+if (!empty($attribs['class'])) {
+    $moduleClass .= ' ' . $attribs['class'];
+}
+
 // Temporarily store header class in variable
 $headerClass = $params->get('header_class') ? ' class="' . htmlspecialchars($params->get('header_class'), ENT_QUOTES, 'UTF-8') . '"' : '';
 

--- a/administrator/templates/atum/html/layouts/chromes/well.php
+++ b/administrator/templates/atum/html/layouts/chromes/well.php
@@ -38,7 +38,7 @@ $moduleClassSfx = $params->get('moduleclass_sfx', '');
 
 // Add class from attributes if any
 if (!empty($attribs['class'])) {
-    $moduleClass .= ' ' . $attribs['class'];
+    $moduleClass .= ' ' . htmlspecialchars($attribs['class'], ENT_QUOTES, 'UTF-8');
 }
 
 // Temporarily store header class in variable

--- a/layouts/chromes/html5.php
+++ b/layouts/chromes/html5.php
@@ -38,7 +38,7 @@ if ($headerClass !== '') {
 
 // Add class from attributes if any
 if (!empty($attribs['class'])) {
-    $moduleAttribs['class'] .= ' ' . $attribs['class'];
+    $moduleAttribs['class'] .= ' ' . htmlspecialchars($attribs['class'], ENT_QUOTES, 'UTF-8');
 }
 
 // Only add aria if the moduleTag is not a div

--- a/layouts/chromes/html5.php
+++ b/layouts/chromes/html5.php
@@ -16,6 +16,7 @@ use Joomla\Utilities\ArrayHelper;
 
 $module  = $displayData['module'];
 $params  = $displayData['params'];
+$attribs = $displayData['attribs'];
 
 if ((string) $module->content === '') {
     return;
@@ -33,6 +34,11 @@ $headerAttribs          = [];
 // Only output a header class if one is set
 if ($headerClass !== '') {
     $headerAttribs['class'] = $headerClass;
+}
+
+// Add class from attributes if any
+if (!empty($attribs['class'])) {
+    $moduleAttribs['class'] .= ' ' . $attribs['class'];
 }
 
 // Only add aria if the moduleTag is not a div

--- a/templates/cassiopeia/html/layouts/chromes/card.php
+++ b/templates/cassiopeia/html/layouts/chromes/card.php
@@ -33,6 +33,11 @@ if ($headerClass !== 'card-title') :
     $headerAttribs['class'] = 'card-header ' . $headerClass;
 endif;
 
+// Add class from attributes if any
+if (!empty($attribs['class'])) {
+    $moduleAttribs['class'] .= ' ' . $attribs['class'];
+}
+
 // Only add aria if the moduleTag is not a div
 if ($moduleTag !== 'div') {
     if ($module->showtitle) :

--- a/templates/cassiopeia/html/layouts/chromes/card.php
+++ b/templates/cassiopeia/html/layouts/chromes/card.php
@@ -35,7 +35,7 @@ endif;
 
 // Add class from attributes if any
 if (!empty($attribs['class'])) {
-    $moduleAttribs['class'] .= ' ' . $attribs['class'];
+    $moduleAttribs['class'] .= ' ' . htmlspecialchars($attribs['class'], ENT_QUOTES, 'UTF-8');
 }
 
 // Only add aria if the moduleTag is not a div


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

In past it was possible to use:
```html
<jdoc:include type="modules" name="main-top" style="card"  class="foobar"/>
```
Addittionaly I have added a default class to quickicon modules, to address `:has` issue in https://github.com/joomla/joomla-cms/pull/41659

### Testing Instructions
Apply patch,
Inspect home dashboard quickicon modules, page source, now they have an extra class in wrapper.

Or edit index.php of site template, change
```html
<jdoc:include type="modules" name="main-top" style="card"/>
```
To:
```html
<jdoc:include type="modules" name="main-top" style="card"  class="foobar"/>
```
Then open home page and Inspect this modules in page source, now they have an extra class in wrapper.


### Actual result BEFORE applying this Pull Request
No extra class


### Expected result AFTER applying this Pull Request
Extra class is there


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
