### PR TITLE
[5.0] Fix missing dependency for editors asset

### DIFF
--- a/build/media_source/system/joomla.asset.json
+++ b/build/media_source/system/joomla.asset.json
@@ -72,7 +72,8 @@
       "dependencies": [
         "core",
         "editor-decorator",
-        "editor-api"
+        "editor-api",
+        "joomla.dialog"
       ]
     },
     {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The editors asset is depend from JoomlaDialog, hovewer the dependency is not defined.


### Testing Instructions
Run `npm install`
In dashboard select Add module => Custom HTML module.
Inspect browser dev console


### Actual result BEFORE applying this Pull Request
An error `Failed to resolve module specifier "joomla.dialog"`


### Expected result AFTER applying this Pull Request
No error


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Reference:
- https://github.com/joomla/joomla-cms/pull/40202