### PR TITLE
[5.0] Dark mode support for guided tours

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_shepard-modals.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_shepard-modals.scss
@@ -1,0 +1,20 @@
+.shepherd-element, .shepherd-arrow:before {
+  background-color: var(--body-bg) !important;
+}
+
+.shepherd-text, .shepherd-title {
+  color: var(--body-color) !important;
+}
+
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    .shepherd-has-title .shepherd-content .shepherd-header, .shepherd-element.shepherd-has-title[data-popper-placement^=bottom]>.shepherd-arrow:before {
+      background-color: var(--dark-bg-subtle) !important;
+    }
+
+    // Matches the bootstrap color on hover for btn-close
+    .shepherd-has-title .shepherd-content .shepherd-cancel-icon:hover {
+      filter: $btn-close-white-filter !important;
+    }
+  }
+}

--- a/build/media_source/templates/administrator/atum/scss/template.scss
+++ b/build/media_source/templates/administrator/atum/scss/template.scss
@@ -50,6 +50,7 @@
 @import "blocks/modals";
 @import "blocks/quickicons";
 @import "blocks/lists";
+@import "blocks/shepard-modals";
 @import "blocks/sidebar";
 @import "blocks/sidebar-nav";
 @import "blocks/switcher";


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41861 .

### Summary of Changes
Adds CSS overrides for the modals that are used in guided tours so they render in dark mode. I'm honestly not convinced the color contrast for the header (using the `--dark-bg-subtle` color) gives enough contrast to the main body background. We may need to go with something a touch lighter. But should be an easy fix if someone can suggest something.

@HLeithner this one is more complicated so recommend we get two good tests here

### Testing Instructions
Please test a few different tours so you get different sized modals and text.


### Actual result BEFORE applying this Pull Request
![dark-tour-guide](https://github.com/joomla/joomla-cms/assets/368084/789104a2-3e98-461a-a3e5-f031d11a3068)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/67321c7c-b5cb-4926-a631-2840641157ad)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
