### PR TITLE
[5.0] Installation Language a11y

### DIFF
--- a/installation/tmpl/remove/default.php
+++ b/installation/tmpl/remove/default.php
@@ -41,17 +41,19 @@ HTMLHelper::_('behavior.formvalidator');
                     class="j-install-step-form flex-column d-none"
                 >
         <?php endif; ?>
-        <p><?php echo Text::_('INSTL_DEFAULTLANGUAGE_DESC'); ?></p>
         <table class="table table-sm">
+            <caption>
+                <?php echo Text::_('INSTL_DEFAULTLANGUAGE_DESC'); ?>
+            </caption>
             <thead>
             <tr>
-                <th>
+                <th scope="col">
                     <?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_SELECT'); ?>
                 </th>
-                <th>
+                <th scope="col">
                     <?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_LANGUAGE'); ?>
                 </th>
-                <th>
+                <th scope="col">
                     <?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_TAG'); ?>
                 </th>
             </tr>
@@ -71,11 +73,11 @@ HTMLHelper::_('behavior.formvalidator');
                             } ?>
                         />
                     </td>
-                    <td>
+                    <th scope="row">
                         <label for="admin-language-cb<?php echo $i; ?>">
                             <?php echo $lang->name; ?>
                         </label>
-                    </td>
+                    </th>
                     <td>
                         <?php echo $lang->language; ?>
                     </td>
@@ -83,17 +85,19 @@ HTMLHelper::_('behavior.formvalidator');
             <?php endforeach; ?>
             </tbody>
         </table>
-        <p><?php echo Text::_('INSTL_DEFAULTLANGUAGE_DESC_FRONTEND'); ?></p>
         <table class="table table-sm">
+            <caption>
+                <?php echo Text::_('INSTL_DEFAULTLANGUAGE_DESC_FRONTEND'); ?>
+            </caption>
             <thead>
             <tr>
-                <th>
+                <th scope="col">
                     <?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_SELECT'); ?>
                 </th>
-                <th>
+                <th scope="col">
                     <?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_LANGUAGE'); ?>
                 </th>
-                <th>
+                <th scope="col">
                     <?php echo Text::_('INSTL_DEFAULTLANGUAGE_COLUMN_HEADER_TAG'); ?>
                 </th>
             </tr>
@@ -113,11 +117,11 @@ HTMLHelper::_('behavior.formvalidator');
                             } ?>
                         />
                     </td>
-                    <td>
+                    <th scope="row">
                         <label for="site-language-cb<?php echo $i; ?>">
                             <?php echo $lang->name; ?>
                         </label>
-                    </td>
+                    </th>
                     <td>
                         <?php echo $lang->language; ?>
                     </td>


### PR DESCRIPTION
Tables should have a caption and use scope for columns and rows

In order to be accessible to visually impaired users, it is important that tables provides a description of its content before the data is accessed.

The simplest way to do it, and also the one recommended by WCAG2 is to add a `<caption>` element inside the `<table>`.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
