### PR TITLE
[5.0]  Privacy: Review Information Request a11y

### DIFF
--- a/administrator/components/com_privacy/tmpl/request/default.php
+++ b/administrator/components/com_privacy/tmpl/request/default.php
@@ -55,23 +55,26 @@ $wa->useScript('keepalive')
                         </div>
                     <?php else : ?>
                         <table class="table">
+                            <caption class="visually-hidden">
+                                <?php echo Text::_('COM_PRIVACY_HEADING_ACTION_LOG'); ?>
+                            </caption>
                             <thead>
-                                <th>
+                                <th scope="col">
                                     <?php echo Text::_('COM_ACTIONLOGS_ACTION'); ?>
                                 </th>
-                                <th>
+                                <th scope="col">
                                     <?php echo Text::_('COM_ACTIONLOGS_DATE'); ?>
                                 </th>
-                                <th>
+                                <th scope="col">
                                     <?php echo Text::_('COM_ACTIONLOGS_NAME'); ?>
                                 </th>
                             </thead>
                             <tbody>
                                 <?php foreach ($this->actionlogs as $i => $item) : ?>
                                     <tr class="row<?php echo $i % 2; ?>">
-                                        <td>
+                                        <th scope="row">
                                             <?php echo ActionlogsHelper::getHumanReadableLogMessage($item); ?>
-                                        </td>
+                                        </th>
                                         <td>
                                             <?php echo HTMLHelper::_('date', $item->log_date, Text::_('DATE_FORMAT_LC6')); ?>
                                         </td>


### PR DESCRIPTION
Tables should have a caption and use scope for columns and rows

In order to be accessible to visually impaired users, it is important that tables provides a description of its content before the data is accessed.

The simplest way to do it, and also the one recommended by WCAG2 is to add a `<caption>` element inside the `<table>`.

![image](https://github.com/joomla/joomla-cms/assets/1296369/ed07b951-52e9-4a83-93c4-749af4bd721c)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
