### PR TITLE
[5.0] Template Overides a11y

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default_updated_files.php
+++ b/administrator/components/com_templates/tmpl/template/default_updated_files.php
@@ -38,6 +38,9 @@ $input = Factory::getApplication()->getInput();
         <div class="row mt-2">
             <div class="col-md-12">
                 <table class="table">
+                    <caption class="visually-hidden">
+                        <?php echo Text::_('COM_TEMPLATES_OVERRIDE_UPDATED_FILES_CAPTION'); ?>
+                    </caption>
                     <thead>
                         <tr>
                             <td class="w-5 text-center">

--- a/administrator/language/en-GB/com_templates.ini
+++ b/administrator/language/en-GB/com_templates.ini
@@ -209,6 +209,7 @@ COM_TEMPLATES_OVERRIDE_NOT_UPTODATE="The original of the template override files
 COM_TEMPLATES_OVERRIDE_SOURCE="Update Source"
 COM_TEMPLATES_OVERRIDE_TEMPLATE_FILE="Template File"
 COM_TEMPLATES_OVERRIDE_UPTODATE="Override files are up to date. Nothing has been changed in the last extension or Joomla update."
+COM_TEMPLATES_OVERRIDE_UPDATED_FILES_CAPTION="Updated files to check."
 COM_TEMPLATES_PREVIEW="Preview"
 COM_TEMPLATES_RENAME_FILE="Rename file %s"
 COM_TEMPLATES_RESIZE_IMAGE="Resize Image"


### PR DESCRIPTION
Tables should have a caption and use scope for columns and rows

In order to be accessible to visually impaired users, it is important that tables provides a description of its content before the data is accessed.

The simplest way to do it, and also the one recommended by WCAG2 is to add a `<caption>` element inside the `<table>`.

![image](https://github.com/joomla/joomla-cms/assets/1296369/765ceb6f-3ef1-4ffc-a50d-5cd0df7d1ad8)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
