### PR TITLE
[5.0] Template filenames

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -59,17 +59,9 @@ if ($this->type == 'font') {
     <?php echo HTMLHelper::_('uitab.addTab', 'myTab', 'editor', Text::_('COM_TEMPLATES_TAB_EDITOR')); ?>
     <div class="row mt-2">
         <div class="col-md-8" id="conditional-section">
-            <?php if ($this->type == 'file') : ?>
+            <?php if ($this->type != 'home') : ?>
                 <p class="lead"><?php echo Text::sprintf('COM_TEMPLATES_TEMPLATE_FILENAME', '&#x200E;' . ($input->get('isMedia', 0) ? '/media/templates/' . ($this->template->client_id === 0 ? 'site' : 'administrator') . '/' . $this->template->element . str_replace('//', '/', base64_decode($this->file)) : '/' . ($this->template->client_id === 0 ? '' : 'administrator/') . 'templates/' . $this->template->element . str_replace('//', '/', base64_decode($this->file))), $this->template->element); ?></p>
                 <p class="lead path hidden"><?php echo $this->source->filename; ?></p>
-            <?php endif; ?>
-            <?php if ($this->type == 'image') : ?>
-                <p class="lead"><?php echo Text::sprintf('COM_TEMPLATES_TEMPLATE_FILENAME', '&#x200E;' . $this->image['path'], $this->template->element); ?></p>
-                <p class="lead path hidden"><?php echo $this->image['path']; ?></p>
-            <?php endif; ?>
-            <?php if ($this->type == 'font') : ?>
-                <p class="lead"><?php echo Text::sprintf('COM_TEMPLATES_TEMPLATE_FILENAME', '&#x200E;' . $this->font['rel_path'], $this->template->element); ?></p>
-                <p class="lead path hidden"><?php echo $this->font['rel_path']; ?></p>
             <?php endif; ?>
         </div>
         <?php if ($this->type == 'file' && !empty($this->source->coreFile)) : ?>


### PR DESCRIPTION
In template manager when you open a file it displays the full path to the file at the top of the page. However for images and fonts this was incorrect and instead of something like

`Editing file "‎/media/templates/site/cassiopeia/images/template_preview.png" in template "cassiopeia".`

It displayed

`Editing file "‎//images/template_preview.png" in template "cassiopeia".`

![image](https://github.com/joomla/joomla-cms/assets/1296369/9b68574e-bf87-4306-871d-64871e66ee17)

![image](https://github.com/joomla/joomla-cms/assets/1296369/8d1bc267-7877-4882-bff0-d47bb6da25fb)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
