### PR TITLE
[5.0] spaces not tabs

### DIFF
--- a/installation/src/Console/InstallCommand.php
+++ b/installation/src/Console/InstallCommand.php
@@ -279,7 +279,7 @@ class InstallCommand extends AbstractCommand
 
         $app->getLanguage()->load('joomla.cli');
         $help = "<info>%command.name%</info> will install Joomla
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         /* @var SetupModel $setupmodel */
         $setupmodel = $app->getMVCFactory()->createModel('Setup', 'Installation');

--- a/libraries/src/Console/AddUserCommand.php
+++ b/libraries/src/Console/AddUserCommand.php
@@ -306,7 +306,7 @@ class AddUserCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> will add a user
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');
         $this->addOption('name', null, InputOption::VALUE_OPTIONAL, 'full name of user');

--- a/libraries/src/Console/AddUserToGroupCommand.php
+++ b/libraries/src/Console/AddUserToGroupCommand.php
@@ -298,7 +298,7 @@ class AddUserToGroupCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> adds a user to a group
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('Add a user to a group');
         $this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');

--- a/libraries/src/Console/ChangeUserPasswordCommand.php
+++ b/libraries/src/Console/ChangeUserPasswordCommand.php
@@ -161,7 +161,7 @@ class ChangeUserPasswordCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> will change a user's password
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');
         $this->addOption('password', null, InputOption::VALUE_OPTIONAL, 'password');

--- a/libraries/src/Console/CheckJoomlaUpdatesCommand.php
+++ b/libraries/src/Console/CheckJoomlaUpdatesCommand.php
@@ -53,7 +53,7 @@ class CheckJoomlaUpdatesCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> will check for Joomla updates
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('Check for Joomla updates');
         $this->setHelp($help);

--- a/libraries/src/Console/CheckUpdatesCommand.php
+++ b/libraries/src/Console/CheckUpdatesCommand.php
@@ -74,7 +74,7 @@ class CheckUpdatesCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> command checks for pending extension updates
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('Check for pending extension updates');
         $this->setHelp($help);

--- a/libraries/src/Console/CleanCacheCommand.php
+++ b/libraries/src/Console/CleanCacheCommand.php
@@ -88,7 +88,7 @@ class CleanCacheCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> will clear entries from the system cache
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->addArgument('expired', InputArgument::OPTIONAL, 'will clear expired entries from the system cache');
         $this->setDescription('Clean cache entries');

--- a/libraries/src/Console/DeleteUserCommand.php
+++ b/libraries/src/Console/DeleteUserCommand.php
@@ -204,7 +204,7 @@ class DeleteUserCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> deletes a user
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('Delete a user');
         $this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');

--- a/libraries/src/Console/ExtensionDiscoverCommand.php
+++ b/libraries/src/Console/ExtensionDiscoverCommand.php
@@ -80,8 +80,8 @@ class ExtensionDiscoverCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> is used to discover extensions
-		\nUsage:
-		\n  <info>php %command.full_name%</info>";
+        \nUsage:
+        \n  <info>php %command.full_name%</info>";
 
         $this->setDescription('Discover extensions');
         $this->setHelp($help);

--- a/libraries/src/Console/ExtensionDiscoverInstallCommand.php
+++ b/libraries/src/Console/ExtensionDiscoverInstallCommand.php
@@ -99,11 +99,11 @@ class ExtensionDiscoverInstallCommand extends AbstractCommand
         $this->addOption('eid', null, InputOption::VALUE_REQUIRED, 'The ID of the extension to discover');
 
         $help = "<info>%command.name%</info> is used to discover extensions
-		\nYou can provide the following option to the command:
-		\n  --eid: The ID of the extension
-		\n  If you do not provide a ID all discovered extensions are installed.
-		\nUsage:
-		\n  <info>php %command.full_name% --eid=<id_of_the_extension></info>";
+        \nYou can provide the following option to the command:
+        \n  --eid: The ID of the extension
+        \n  If you do not provide a ID all discovered extensions are installed.
+        \nUsage:
+        \n  <info>php %command.full_name% --eid=<id_of_the_extension></info>";
 
         $this->setDescription('Install discovered extensions');
         $this->setHelp($help);

--- a/libraries/src/Console/ExtensionDiscoverListCommand.php
+++ b/libraries/src/Console/ExtensionDiscoverListCommand.php
@@ -43,8 +43,8 @@ class ExtensionDiscoverListCommand extends ExtensionsListCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> is used to list all extensions that could be installed via discoverinstall
-		\nUsage:
-		\n  <info>php %command.full_name%</info>";
+        \nUsage:
+        \n  <info>php %command.full_name%</info>";
 
         $this->setDescription('List discovered extensions');
         $this->setHelp($help);

--- a/libraries/src/Console/ExtensionInstallCommand.php
+++ b/libraries/src/Console/ExtensionInstallCommand.php
@@ -92,12 +92,12 @@ class ExtensionInstallCommand extends AbstractCommand
         $this->addOption('url', null, InputOption::VALUE_REQUIRED, 'The url to the extension');
 
         $help = "<info>%command.name%</info> is used to install extensions
-		\nYou must provide one of the following options to the command:
-		\n  --path: The path on your local filesystem to the install package
-		\n  --url: The URL from where the install package should be downloaded
-		\nUsage:
-		\n  <info>php %command.full_name% --path=<path_to_file></info>
-		\n  <info>php %command.full_name% --url=<url_to_file></info>";
+        \nYou must provide one of the following options to the command:
+        \n  --path: The path on your local filesystem to the install package
+        \n  --url: The URL from where the install package should be downloaded
+        \nUsage:
+        \n  <info>php %command.full_name% --path=<path_to_file></info>
+        \n  <info>php %command.full_name% --url=<url_to_file></info>";
 
         $this->setDescription('Install an extension from a URL or from a path');
         $this->setHelp($help);

--- a/libraries/src/Console/ExtensionRemoveCommand.php
+++ b/libraries/src/Console/ExtensionRemoveCommand.php
@@ -148,9 +148,9 @@ class ExtensionRemoveCommand extends AbstractCommand
         );
 
         $help = "<info>%command.name%</info> is used to uninstall extensions.
-		\nThe command requires one argument, the ID of the extension to uninstall.
-		\nYou may find this ID by running the <info>extension:list</info> command.
-		\nUsage: <info>php %command.full_name% <extension_id></info>";
+        \nThe command requires one argument, the ID of the extension to uninstall.
+        \nYou may find this ID by running the <info>extension:list</info> command.
+        \nUsage: <info>php %command.full_name% <extension_id></info>";
 
         $this->setDescription('Remove an extension');
         $this->setHelp($help);

--- a/libraries/src/Console/ExtensionsListCommand.php
+++ b/libraries/src/Console/ExtensionsListCommand.php
@@ -103,9 +103,9 @@ class ExtensionsListCommand extends AbstractCommand
         $this->addOption('type', null, InputOption::VALUE_REQUIRED, 'Type of the extension');
 
         $help = "<info>%command.name%</info> lists all installed extensions
-		\nUsage: <info>php %command.full_name% <extension_id></info>
-		\nYou may filter on the type of extension (component, module, plugin, etc.) using the <info>--type</info> option:
-		\n  <info>php %command.full_name% --type=<type></info>";
+        \nUsage: <info>php %command.full_name% <extension_id></info>
+        \nYou may filter on the type of extension (component, module, plugin, etc.) using the <info>--type</info> option:
+        \n  <info>php %command.full_name% --type=<type></info>";
 
         $this->setDescription('List installed extensions');
         $this->setHelp($help);

--- a/libraries/src/Console/GetConfigurationCommand.php
+++ b/libraries/src/Console/GetConfigurationCommand.php
@@ -312,9 +312,9 @@ class GetConfigurationCommand extends AbstractCommand
         $this->addOption('group', 'g', InputOption::VALUE_REQUIRED, 'Name of the option');
 
         $help = "<info>%command.name%</info> displays the current value of a configuration option
-				\nUsage: <info>php %command.full_name%</info> <option>
-				\nGroup usage: <info>php %command.full_name%</info> --group <groupname>
-				\nAvailable group names: $groupNames";
+		        \nUsage: <info>php %command.full_name%</info> <option>
+		        \nGroup usage: <info>php %command.full_name%</info> --group <groupname>
+		        \nAvailable group names: $groupNames";
 
         $this->setDescription('Display the current value of a configuration option');
         $this->setHelp($help);

--- a/libraries/src/Console/ListUserCommand.php
+++ b/libraries/src/Console/ListUserCommand.php
@@ -134,7 +134,7 @@ class ListUserCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> will list all users
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('List all users');
         $this->setHelp($help);

--- a/libraries/src/Console/RemoveOldFilesCommand.php
+++ b/libraries/src/Console/RemoveOldFilesCommand.php
@@ -127,7 +127,7 @@ class RemoveOldFilesCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> removes old files which should have been deleted during a Joomla update
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('Remove old system files');
         $this->addOption('dry-run', null, InputOption::VALUE_NONE, 'Executes a dry run without deleting anything');

--- a/libraries/src/Console/RemoveUserFromGroupCommand.php
+++ b/libraries/src/Console/RemoveUserFromGroupCommand.php
@@ -300,7 +300,7 @@ class RemoveUserFromGroupCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> removes a user from a group
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('Remove a user from a group');
         $this->addOption('username', null, InputOption::VALUE_OPTIONAL, 'username');

--- a/libraries/src/Console/SessionGcCommand.php
+++ b/libraries/src/Console/SessionGcCommand.php
@@ -84,10 +84,10 @@ class SessionGcCommand extends AbstractCommand implements ContainerAwareInterfac
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> runs PHP's garbage collection operation for session data
-		\nUsage: <info>php %command.full_name%</info>
-		\nThis command defaults to performing garbage collection for the frontend (site) application.
-		\nTo run garbage collection for another application, you can specify it with the <info>--application</info> option.
-		\nUsage: <info>php %command.full_name% --application=[APPLICATION]</info>";
+        \nUsage: <info>php %command.full_name%</info>
+        \nThis command defaults to performing garbage collection for the frontend (site) application.
+        \nTo run garbage collection for another application, you can specify it with the <info>--application</info> option.
+        \nUsage: <info>php %command.full_name% --application=[APPLICATION]</info>";
 
         $this->setDescription('Perform session garbage collection');
         $this->addOption('application', 'app', InputOption::VALUE_OPTIONAL, 'The application to perform garbage collection for.', 'site');

--- a/libraries/src/Console/SessionMetadataGcCommand.php
+++ b/libraries/src/Console/SessionMetadataGcCommand.php
@@ -103,7 +103,7 @@ class SessionMetadataGcCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> runs the garbage collection operation for Joomla session metadata
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('Perform session metadata garbage collection');
         $this->setHelp($help);

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -250,7 +250,7 @@ class SetConfigurationCommand extends AbstractCommand
         );
 
         $help = "<info>%command.name%</info> sets the value for a configuration option
-				\nUsage: <info>php %command.full_name%</info> <option>=<value>";
+		        \nUsage: <info>php %command.full_name%</info> <option>=<value>";
 
         $this->setDescription('Set a value for a configuration option');
         $this->setHelp($help);

--- a/libraries/src/Console/SiteCreatePublicFolderCommand.php
+++ b/libraries/src/Console/SiteCreatePublicFolderCommand.php
@@ -144,7 +144,7 @@ class SiteCreatePublicFolderCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> will create a public folder
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->addOption('public-folder', null, InputOption::VALUE_REQUIRED, 'public folder absolute path');
         $this->setDescription('Create a public folder');

--- a/libraries/src/Console/SiteDownCommand.php
+++ b/libraries/src/Console/SiteDownCommand.php
@@ -79,7 +79,7 @@ class SiteDownCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> puts the site into offline mode
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('Put the site into offline mode');
         $this->setHelp($help);

--- a/libraries/src/Console/SiteUpCommand.php
+++ b/libraries/src/Console/SiteUpCommand.php
@@ -79,7 +79,7 @@ class SiteUpCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> puts the site into online mode
-				\nUsage: <info>php %command.full_name%</info>";
+		        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('Put the site into online mode');
         $this->setHelp($help);

--- a/libraries/src/Console/TasksListCommand.php
+++ b/libraries/src/Console/TasksListCommand.php
@@ -134,7 +134,7 @@ class TasksListCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> lists all scheduled tasks.
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('List all scheduled tasks');
         $this->setHelp($help);

--- a/libraries/src/Console/TasksRunCommand.php
+++ b/libraries/src/Console/TasksRunCommand.php
@@ -145,7 +145,7 @@ class TasksRunCommand extends AbstractCommand
         $this->addOption('all', '', InputOption::VALUE_NONE, 'Run all due tasks. Note that this is overridden if --id is used.');
 
         $help = "<info>%command.name%</info> run scheduled tasks.
-		\nUsage: <info>php %command.full_name% [flags]</info>";
+        \nUsage: <info>php %command.full_name% [flags]</info>";
 
         $this->setDescription('Run one or more scheduled tasks');
         $this->setHelp($help);

--- a/libraries/src/Console/TasksStateCommand.php
+++ b/libraries/src/Console/TasksStateCommand.php
@@ -186,7 +186,7 @@ class TasksStateCommand extends AbstractCommand
         $this->addOption('state', 's', InputOption::VALUE_REQUIRED, 'The new state of the task, can be 1/enable, 0/disable, or -2/trash.');
 
         $help = "<info>%command.name%</info> changes the state of a task.
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('Enable, disable or trash a scheduled task');
         $this->setHelp($help);

--- a/libraries/src/Console/UpdateCoreCommand.php
+++ b/libraries/src/Console/UpdateCoreCommand.php
@@ -231,7 +231,7 @@ class UpdateCoreCommand extends AbstractCommand
     protected function configure(): void
     {
         $help = "<info>%command.name%</info> is used to update Joomla
-		\nUsage: <info>php %command.full_name%</info>";
+        \nUsage: <info>php %command.full_name%</info>";
 
         $this->setDescription('Update Joomla');
         $this->setHelp($help);


### PR DESCRIPTION
The output of the help for cli commands was using tabs not spaces.

there is no visible difference to the output this is just a code style fix

![image](https://github.com/joomla/joomla-cms/assets/1296369/6911587f-7c83-4232-b3cb-8ffa46fee95e)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
