### PR TITLE
[5.0] Extra semi colon

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_header.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_header.scss
@@ -179,7 +179,7 @@
 }
 
 .header-item-count {
-  margin-inline-end: .5rem;;
+  margin-inline-end: .5rem;
 }
 
 .header-item-text {


### PR DESCRIPTION
There was a typo which lead the semicolon to be doubled

code review


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
