### PR TITLE
[5.0] installation rtl fixes

### DIFF
--- a/installation/template/scss/template-rtl.scss
+++ b/installation/template/scss/template-rtl.scss
@@ -31,8 +31,8 @@ textarea.noResize {
 
 .j-install-step-header {
   span {
-    margin-right: 5px;
-    margin-left: auto;
+    margin-right: auto;
+    margin-left: 5px;
   }
 }
 
@@ -78,11 +78,6 @@ textarea.noResize {
 .j-install-last-step [class^="icon-"],
 .j-install-last-step [class*=" icon-"] {
   display: inline;
-}
-
-.j-install-step-header span {
-  margin-right: auto;
-  margin-left: 5px;
 }
 
 #jform_db_prefix {


### PR DESCRIPTION
There are two competing and conflicting declarations for the `j-install-step-header span` This is the css that puts the space between the icon and the header

_Note that the entire RTL css is incorrect but that is for another pr and another time. This PR is only to produce valid css without duplicate classes_


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
