### PR TITLE
[5.0] 500 error when 404 and debug on [BLOCKER]

### DIFF
--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -306,7 +306,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
 
             if ($this->params->get('queries', 1)) {
                 // Close session to collect possible session-related queries.
-                $this->getApplication()->getSession()->close();
+              //  $this->getApplication()->getSession()->close();
 
                 // Call $db->disconnect() here to trigger the onAfterDisconnect() method here in this class!
                 $this->getDatabase()->disconnect();


### PR DESCRIPTION
Enable debug and then trigger a 404 on the frontend

Instead of the regular 404 page we get a 404 and a 500

This is caused by the line commented out in this PR.

That line was added by #35655

**Sorry I can't contribute a _real_ solution as I don't understand the code. I was just able to locate the source and provide this PR to showcase the problem**

![image](https://github.com/joomla/joomla-cms/assets/1296369/99f74c9f-00dc-41ac-9514-5748f12eb989)
