### PR TITLE
[5.0] str_replace is faster

### DIFF
--- a/administrator/components/com_admin/src/Model/SysinfoModel.php
+++ b/administrator/components/com_admin/src/Model/SysinfoModel.php
@@ -414,7 +414,7 @@ class SysinfoModel extends BaseDatabaseModel
         preg_match_all('#<body[^>]*>(.*)</body>#siU', $phpInfo, $output);
         $output         = preg_replace('#<table[^>]*>#', '<table class="table">', $output[1][0]);
         $output         = preg_replace('#(\w),(\w)#', '\1, \2', $output);
-        $output         = preg_replace('#<hr />#', '', $output);
+        $output         = str_replace('<hr />', '', $output);
         $output         = str_replace('<div class="text-center">', '', $output);
         $output         = preg_replace('#<tr class="h">(.*)</tr>#', '<thead><tr class="h">$1</tr></thead><tbody>', $output);
         $output         = str_replace('</table>', '</tbody></table>', $output);


### PR DESCRIPTION
When preg_replace is used, the first argument should be a regular expression. If it’s not a regex then str_replace does exactly the same thing as preg_replace without the performance drawback of the regex.

code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
