### PR TITLE
[4.4] 500 error when 404 and debug on

### DIFF
--- a/plugins/system/debug/src/DataCollector/SessionCollector.php
+++ b/plugins/system/debug/src/DataCollector/SessionCollector.php
@@ -13,6 +13,7 @@ namespace Joomla\Plugin\System\Debug\DataCollector;
 use Joomla\CMS\Factory;
 use Joomla\Plugin\System\Debug\AbstractDataCollector;
 use Joomla\Plugin\System\Debug\Extension\Debug;
+use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -34,31 +35,57 @@ class SessionCollector extends AbstractDataCollector
     private $name = 'session';
 
     /**
+     * Collected data.
+     *
+     * @var   array
+     * @since __DEPLOY_VERSION__
+     */
+    protected $sessionData;
+
+    /**
+     * Constructor.
+     *
+     * @param   Registry  $params  Parameters.
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public function __construct($params, $collect = false)
+    {
+        parent::__construct($params);
+
+        if ($collect) {
+            $this->collect();
+        }
+    }
+
+    /**
      * Called by the DebugBar when data needs to be collected
      *
      * @since  4.0.0
      *
      * @return array Collected data
      */
-    public function collect()
+    public function collect($overwrite = false)
     {
-        $returnData  = [];
-        $sessionData = Factory::getApplication()->getSession()->all();
+        if ($this->sessionData === null || $overwrite) {
+            $this->sessionData  = [];
+            $data               = Factory::getApplication()->getSession()->all();
 
-        // redact value of potentially secret keys
-        array_walk_recursive($sessionData, static function (&$value, $key) {
-            if (!preg_match(Debug::PROTECTED_COLLECTOR_KEYS, $key)) {
-                return;
+            // redact value of potentially secret keys
+            array_walk_recursive($data, static function (&$value, $key) {
+                if (!preg_match(Debug::PROTECTED_COLLECTOR_KEYS, $key)) {
+                    return;
+                }
+
+                $value = '***redacted***';
+            });
+
+            foreach ($data as $key => $value) {
+                $this->sessionData[$key] = $this->getDataFormatter()->formatVar($value);
             }
-
-            $value = '***redacted***';
-        });
-
-        foreach ($sessionData as $key => $value) {
-            $returnData[$key] = $this->getDataFormatter()->formatVar($value);
         }
 
-        return ['data' => $returnData];
+        return ['data' => $this->sessionData];
     }
 
     /**

--- a/plugins/system/debug/src/DataCollector/SessionCollector.php
+++ b/plugins/system/debug/src/DataCollector/SessionCollector.php
@@ -45,7 +45,8 @@ class SessionCollector extends AbstractDataCollector
     /**
      * Constructor.
      *
-     * @param   Registry  $params  Parameters.
+     * @param   Registry  $params   Parameters.
+     * @param   bool      $collect  Collect the session data.
      *
      * @since __DEPLOY_VERSION__
      */
@@ -61,9 +62,11 @@ class SessionCollector extends AbstractDataCollector
     /**
      * Called by the DebugBar when data needs to be collected
      *
-     * @since  4.0.0
+     * @param   bool  $overwrite  Overwrite the previously collected session data.
      *
      * @return array Collected data
+     *
+     * @since  4.0.0
      */
     public function collect($overwrite = false)
     {

--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -296,7 +296,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
             }
 
             if ($this->params->get('session', 1)) {
-                $this->debugBar->addCollector(new SessionCollector($this->params));
+                $this->debugBar->addCollector(new SessionCollector($this->params, true));
             }
 
             if ($this->params->get('profile', 1)) {
@@ -304,6 +304,9 @@ final class Debug extends CMSPlugin implements SubscriberInterface
             }
 
             if ($this->params->get('queries', 1)) {
+                // Remember session form token for possible future usage.
+                $formToken = Session::getFormToken();
+
                 // Close session to collect possible session-related queries.
                 $this->getApplication()->getSession()->close();
 
@@ -332,7 +335,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
 
         $debugBarRenderer = new JavascriptRenderer($this->debugBar, Uri::root(true) . '/media/vendor/debugbar/');
         $openHandlerUrl   = Uri::base(true) . '/index.php?option=com_ajax&plugin=debug&group=system&format=raw&action=openhandler';
-        $openHandlerUrl .= '&' . Session::getFormToken() . '=1';
+        $openHandlerUrl .= '&' . ($formToken ?? Session::getFormToken()) . '=1';
 
         $debugBarRenderer->setOpenHandlerUrl($openHandlerUrl);
 


### PR DESCRIPTION
Pull Request for Issue #41880.

### Summary of Changes

We need to collect session data before closing the session, and the session is closed because we need to collect session write queries.

### Testing Instructions

Enable debug and visit any 404 page.

### Actual result BEFORE applying this Pull Request

Error.

### Expected result AFTER applying this Pull Request

No errors, usual 404 page with debug output.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
