### PR TITLE
Remove box shadow in toolbar

### DIFF
--- a/build/media_source/com_media/scss/components/_media-toolbar.scss
+++ b/build/media_source/com_media/scss/components/_media-toolbar.scss
@@ -23,7 +23,6 @@
     background-color: transparent;
     border: 0;
     border-inline-start: 1px solid $border-color;
-    box-shadow: 1px 0 #fefefe inset;
     &.active {
       color: #fff;
       background-color: $toolbar-icon-active-bg-color;


### PR DESCRIPTION
### Summary of Changes
Fixes the double border showing in media manager toolbar when in dark mode. Note the box shadow removed is basically white which means it's totally invisible (and therefore also useless) in light mode.

### Testing Instructions
Check the toolbar in the media manager view. Light mode no changes. In dark mode the box shadow is removed which is especially noticeable on the checkbox.


### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/2c2499a7-a33d-44a6-ae6f-613c894c9a05)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/dee02653-e279-492e-bee3-e34ff5d501c2)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
