### PR TITLE
[5.0] Remove 'track_errors' and $php_errormsg

### DIFF
--- a/libraries/src/Http/Transport/SocketTransport.php
+++ b/libraries/src/Http/Transport/SocketTransport.php
@@ -231,7 +231,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
 
         // Capture PHP errors
         // PHP sends a warning if the uri does not exist; we silence it and throw an exception instead.
-        set_error_handler(static function($errno, $err) {
+        set_error_handler(static function ($errno, $err) {
             throw new \Exception($err);
         }, \E_WARNING);
 

--- a/libraries/src/Http/Transport/SocketTransport.php
+++ b/libraries/src/Http/Transport/SocketTransport.php
@@ -230,28 +230,28 @@ class SocketTransport extends AbstractTransport implements TransportInterface
         }
 
         // Capture PHP errors
-        $php_errormsg = '';
-        $track_errors = ini_get('track_errors');
-        ini_set('track_errors', true);
+        // PHP sends a warning if the uri does not exist; we silence it and throw an exception instead.
+        set_error_handler(static function($errno, $err) {
+            throw new \Exception($err);
+        }, \E_WARNING);
 
-        // PHP sends a warning if the uri does not exists; we silence it and throw an exception instead.
-        // Attempt to connect to the server
-        $connection = @fsockopen($host, $port, $errno, $err, $timeout);
+        try {
+            // Attempt to connect to the server
+            $connection = fsockopen($host, $port, $errno, $err, $timeout);
 
-        if (!$connection) {
-            if (!$php_errormsg) {
+            if (!$connection) {
                 // Error but nothing from php? Create our own
-                $php_errormsg = sprintf('Could not connect to resource %s: %s (error code %d)', $uri, $err, $errno);
+                if (!$err) {
+                    $err = sprintf('Could not connect to host: %s:%s', $host, $port);
+                }
+
+                throw new \Exception($err);
             }
-
-            // Restore error tracking to give control to the exception handler
-            ini_set('track_errors', $track_errors);
-
-            throw new \RuntimeException($php_errormsg);
+        } catch (\Exception $e) {
+            throw new \RuntimeException($e->getMessage());
+        } finally {
+            restore_error_handler();
         }
-
-        // Restore error tracking to what it was before.
-        ini_set('track_errors', $track_errors);
 
         // Since the connection was successful let's store it in case we need to use it later.
         $this->connections[$key] = $connection;

--- a/libraries/src/Http/Transport/StreamTransport.php
+++ b/libraries/src/Http/Transport/StreamTransport.php
@@ -144,7 +144,7 @@ class StreamTransport extends AbstractTransport implements TransportInterface
 
         // Capture PHP errors
         // PHP sends a warning if the uri does not exist; we silence it and throw an exception instead.
-        set_error_handler(static function($errno, $err) {
+        set_error_handler(static function ($errno, $err) {
             throw new \Exception($err);
         }, \E_WARNING);
 

--- a/libraries/src/Http/Transport/StreamTransport.php
+++ b/libraries/src/Http/Transport/StreamTransport.php
@@ -143,27 +143,24 @@ class StreamTransport extends AbstractTransport implements TransportInterface
         }
 
         // Capture PHP errors
-        $php_errormsg = '';
-        $track_errors = ini_get('track_errors');
-        ini_set('track_errors', true);
+        // PHP sends a warning if the uri does not exist; we silence it and throw an exception instead.
+        set_error_handler(static function($errno, $err) {
+            throw new \Exception($err);
+        }, \E_WARNING);
 
-        // Open the stream for reading.
-        $stream = @fopen((string) $uri, 'r', false, $context);
+        try {
+            // Open the stream for reading.
+            $stream = fopen((string) $uri, 'r', false, $context);
 
-        if (!$stream) {
-            if (!$php_errormsg) {
+            if (!$stream) {
                 // Error but nothing from php? Create our own
-                $php_errormsg = sprintf('Could not connect to resource: %s', $uri);
+                throw new \Exception(sprintf('Could not connect to resource: %s', $uri));
             }
-
-            // Restore error tracking to give control to the exception handler
-            ini_set('track_errors', $track_errors);
-
-            throw new \RuntimeException($php_errormsg);
+        } catch (\Exception $e) {
+            throw new \RuntimeException($e->getMessage());
+        } finally {
+            restore_error_handler();
         }
-
-        // Restore error tracking to what it was before.
-        ini_set('track_errors', $track_errors);
 
         // Get the metadata for the stream, including response headers.
         $metadata = stream_get_meta_data($stream);

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -69,10 +69,6 @@ abstract class InstallerHelper
      */
     public static function downloadPackage($url, $target = false)
     {
-        // Capture PHP errors
-        $track_errors = ini_get('track_errors');
-        ini_set('track_errors', true);
-
         // Set user agent
         $version = new Version();
         ini_set('user_agent', $version->getUserAgent('Installer'));
@@ -133,9 +129,6 @@ abstract class InstallerHelper
 
         // Write buffer to file
         File::write($target, $body);
-
-        // Restore error tracking to what it was before
-        ini_set('track_errors', $track_errors);
 
         // Bump the max execution time because not using built in php zip libs are slow
         if (\function_exists('set_time_limit')) {

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -699,24 +699,24 @@ class Language extends BaseLanguage
     /**
      * Parses a language file.
      *
-     * @param   string  $filename  The name of the file.
+     * @param   string  $fileName  The name of the file.
      *
      * @return  array  The array of parsed strings.
      *
      * @since   1.7.0
      */
-    protected function parse($filename)
+    protected function parse($fileName)
     {
         try {
-            $strings = LanguageHelper::parseIniFile($filename, $this->debug);
+            $strings = LanguageHelper::parseIniFile($fileName, $this->debug);
         } catch (\RuntimeException $e) {
             $strings = [];
 
             // Debug the ini file if needed.
-            if ($this->debug && is_file($filename)) {
-                if (!$this->debugFile($filename)) {
+            if ($this->debug && is_file($fileName)) {
+                if (!$this->debugFile($fileName)) {
                     // We didn't find any errors but there's a parser warning.
-                    $this->errorfiles[$filename] = 'PHP parser errors :' . $e->getMessage();
+                    $this->errorfiles[$fileName] = 'PHP parser errors :' . $e->getMessage();
                 }
             }
         }
@@ -759,7 +759,7 @@ class Language extends BaseLanguage
             $line = trim($line);
 
             // Ignore comment lines.
-            if (!\strlen($line) || $line[0] == ';') {
+            if (!\strlen($line) || $line['0'] == ';') {
                 continue;
             }
 

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -401,6 +401,7 @@ class LanguageHelper
      * @return  array  The strings parsed.
      *
      * @since   3.9.0
+     * @throws  \RuntimeException On debug
      */
     public static function parseIniFile($fileName, $debug = false)
     {
@@ -409,30 +410,31 @@ class LanguageHelper
             return [];
         }
 
-        // Capture hidden PHP errors from the parsing.
-        if ($debug === true) {
-            // See https://www.php.net/manual/en/reserved.variables.phperrormsg.php
-            $php_errormsg = null;
-
-            $trackErrors = ini_get('track_errors');
-            ini_set('track_errors', true);
-        }
-
         // This was required for https://github.com/joomla/joomla-cms/issues/17198 but not sure what server setup
         // issue it is solving
         $disabledFunctions      = explode(',', ini_get('disable_functions'));
         $isParseIniFileDisabled = \in_array('parse_ini_file', array_map('trim', $disabledFunctions));
 
-        if (!\function_exists('parse_ini_file') || $isParseIniFileDisabled) {
-            $contents = file_get_contents($fileName);
-            $strings  = @parse_ini_string($contents);
-        } else {
-            $strings = @parse_ini_file($fileName);
-        }
+        // Capture hidden PHP errors from the parsing.
+        set_error_handler(static function($errno, $err) {
+            throw new \Exception($err);
+        }, \E_WARNING);
 
-        // Restore error tracking to what it was before.
-        if ($debug === true) {
-            ini_set('track_errors', $trackErrors);
+        try {
+            if (!\function_exists('parse_ini_file') || $isParseIniFileDisabled) {
+                $contents = file_get_contents($fileName);
+                $strings  = parse_ini_string($contents);
+            } else {
+                $strings = parse_ini_file($fileName);
+            }
+        } catch (\Exception $e) {
+            if ($debug) {
+               throw new \RuntimeException($e->getMessage());
+            }
+
+            return [];
+        } finally {
+            restore_error_handler();
         }
 
         return \is_array($strings) ? $strings : [];

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -416,7 +416,7 @@ class LanguageHelper
         $isParseIniFileDisabled = \in_array('parse_ini_file', array_map('trim', $disabledFunctions));
 
         // Capture hidden PHP errors from the parsing.
-        set_error_handler(static function($errno, $err) {
+        set_error_handler(static function ($errno, $err) {
             throw new \Exception($err);
         }, \E_WARNING);
 
@@ -429,7 +429,7 @@ class LanguageHelper
             }
         } catch (\Exception $e) {
             if ($debug) {
-               throw new \RuntimeException($e->getMessage());
+                throw new \RuntimeException($e->getMessage());
             }
 
             return [];


### PR DESCRIPTION
Pull Request for Issue #41889 #25789 #17856 #33185

### Summary of Changes

Remove suppressing of methods which produce E_WARNING and necessity of catching the error in deprecated `$php_errormsg`.

I didn't update `Joomla\CMS\Filesystem\Stream` because it's deprecated since 4.4

### Testing Instructions

Try to parse language string with errors (with enabled Joomla debug + language debug)
Try to install the package from invalid URL

### Actual result BEFORE applying this Pull Request

See native Joomla error messages in installer and debug errors in language debug bar.

### Expected result AFTER applying this Pull Request

See the same errors/messages.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
