### PR TITLE
[4.4] template.min.js error upon a fresh install

### DIFF
--- a/build/media_source/templates/administrator/atum/js/template.es6.js
+++ b/build/media_source/templates/administrator/atum/js/template.es6.js
@@ -10,7 +10,7 @@ if (!Joomla) {
 const getCookie = () => document.cookie.length && document.cookie
   .split('; ')
   .find((row) => row.startsWith('atumSidebarState='))
-  .split('=')[1];
+  ?.split('=')[1];
 
 const mobile = window.matchMedia('(max-width: 992px)');
 const small = window.matchMedia('(max-width: 575.98px)');


### PR DESCRIPTION
Pull Request for Issue #40374 and issues encountered while running Cypress.
First fixed for 5.0 until it turned out it was a general issue already spotted in 4.3.

### Summary of Changes

The javascript fails because the cookie that records the state of the sidebar is not yet present.

![image](https://github.com/joomla/joomla-cms/assets/5964177/c41b3ce3-42b6-4b1d-9a0e-a3d27a7e9099)

### Testing Instructions

On a fresh install, upon login, check the browser console.
No javascript error should appear.

Thank you Richard @richard67 for suggesting this fix.

### Actual result BEFORE applying this Pull Request

The error shows in the console.

### Expected result AFTER applying this Pull Request

No longer an error.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
