### PR TITLE
[4.4] add system tests for admin users (group/level)

### DIFF
--- a/tests/System/integration/administrator/components/com_users/Group.cy.js
+++ b/tests/System/integration/administrator/components/com_users/Group.cy.js
@@ -1,0 +1,33 @@
+describe('Test in backend that the user group form', () => {
+  beforeEach(() => cy.doAdministratorLogin());
+  afterEach(() => cy.task('queryDB', "DELETE FROM #__usergroups WHERE title = 'test group'"));
+
+  it('can create a new group', () => {
+    cy.visit('/administrator/index.php?option=com_users&task=group.add');
+
+    cy.get('#jform_title').clear().type('test group');
+    cy.clickToolbarButton('Save & Close');
+
+    cy.get('#system-message-container').contains('Group saved.').should('exist');
+    cy.contains('test group');
+  });
+
+  it('can edit a group', () => {
+    cy.db_createUserGroup().then((group) => {
+      cy.visit(`/administrator/index.php?option=com_users&task=group.edit&id=${group.id}`);
+
+      cy.get('#jform_title').clear().type('test group edited');
+      cy.clickToolbarButton('Save');
+
+      cy.get('#system-message-container').contains('Group saved.').should('exist');
+    });
+  });
+
+  it('check redirection to list view', () => {
+    cy.visit('/administrator/index.php?option=com_users&task=group.add');
+    cy.intercept('index.php?option=com_users&view=groups').as('listview');
+    cy.clickToolbarButton('Cancel');
+
+    cy.wait('@listview');
+  });
+});

--- a/tests/System/integration/administrator/components/com_users/Groups.cy.js
+++ b/tests/System/integration/administrator/components/com_users/Groups.cy.js
@@ -1,0 +1,35 @@
+describe('Test in backend that the user group list', () => {
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    cy.visit('/administrator/index.php?option=com_users&view=groups&filter=');
+  });
+
+  it('has a title', () => {
+    cy.get('h1.page-title').should('contain.text', 'Users: Groups');
+  });
+
+  it('can display a list of groups', () => {
+    cy.db_createUserGroup({ title: 'Test group' }).then(() => {
+      cy.reload();
+
+      cy.contains('Test group');
+    });
+  });
+
+  it('can open the group form', () => {
+    cy.clickToolbarButton('New');
+
+    cy.contains('User Group Details');
+  });
+
+  it('can delete the test group', () => {
+    cy.db_createUserGroup({ title: 'Test group' }).then(() => {
+      cy.searchForItem('Test group');
+      cy.checkAllResults();
+      cy.clickToolbarButton('Delete');
+      cy.on('window:confirm', () => true);
+
+      cy.get('#system-message-container').contains('User Group deleted.').should('exist');
+    });
+  });
+});

--- a/tests/System/integration/administrator/components/com_users/Level.cy.js
+++ b/tests/System/integration/administrator/components/com_users/Level.cy.js
@@ -1,0 +1,33 @@
+describe('Test in backend that the user access level form', () => {
+  beforeEach(() => cy.doAdministratorLogin());
+  afterEach(() => cy.task('queryDB', "DELETE FROM #__viewlevels WHERE title = 'test level'"));
+
+  it('can create a new access level', () => {
+    cy.visit('/administrator/index.php?option=com_users&task=level.add');
+
+    cy.get('#jform_title').clear().type('test level');
+    cy.clickToolbarButton('Save & Close');
+
+    cy.get('#system-message-container').contains('Access level saved.').should('exist');
+    cy.contains('test level');
+  });
+
+  it('can edit an access level', () => {
+    cy.db_createUserLevel().then((level) => {
+      cy.visit(`/administrator/index.php?option=com_users&task=level.edit&id=${level.id}`);
+
+      cy.get('#jform_title').clear().type('test level edited');
+      cy.clickToolbarButton('Save');
+
+      cy.get('#system-message-container').contains('Access level saved.').should('exist');
+    });
+  });
+
+  it('check redirection to list view', () => {
+    cy.visit('/administrator/index.php?option=com_users&task=level.add');
+    cy.intercept('index.php?option=com_users&view=levels').as('listview');
+    cy.clickToolbarButton('Cancel');
+
+    cy.wait('@listview');
+  });
+});

--- a/tests/System/integration/administrator/components/com_users/Levels.cy.js
+++ b/tests/System/integration/administrator/components/com_users/Levels.cy.js
@@ -1,0 +1,35 @@
+describe('Test in backend that the user access level list', () => {
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    cy.visit('/administrator/index.php?option=com_users&view=levels&filter=');
+  });
+
+  it('has a title', () => {
+    cy.get('h1.page-title').should('contain.text', 'Users: Viewing Access Level');
+  });
+
+  it('can display a list of access levels', () => {
+    cy.db_createUserLevel({ title: 'Test level' }).then(() => {
+      cy.reload();
+
+      cy.contains('Test level');
+    });
+  });
+
+  it('can open the access level form', () => {
+    cy.clickToolbarButton('New');
+
+    cy.contains('Level Details');
+  });
+
+  it('can delete the test level', () => {
+    cy.db_createUserLevel({ title: 'Test level' }).then(() => {
+      cy.searchForItem('Test level');
+      cy.checkAllResults();
+      cy.clickToolbarButton('Delete');
+      cy.on('window:confirm', () => true);
+
+      cy.get('#system-message-container').contains('View Access Level removed.').should('exist');
+    });
+  });
+});

--- a/tests/System/support/commands/db.js
+++ b/tests/System/support/commands/db.js
@@ -504,6 +504,54 @@ Cypress.Commands.add('db_createUser', (userData) => {
 });
 
 /**
+ * Creates an user group in the database with the given data. The group contains some default values when
+ * not all required fields are passed in the given data. The data of the inserted group is returned.
+ *
+ * @param {Object} groupData The user group data to insert
+ *
+ * @returns Object
+ */
+Cypress.Commands.add('db_createUserGroup', (groupData) => {
+  const defaultGroupOptions = {
+    title: 'test group',
+    parent_id: 1,
+    lft: 1,
+    rgt: 1,
+  };
+  const group = { ...defaultGroupOptions, ...groupData };
+
+  return cy.task('queryDB', createInsertQuery('usergroups', group))
+    .then(async (info) => {
+      group.id = info.insertId;
+
+      return group;
+    });
+});
+
+/**
+ * Creates an user access level in the database with the given data. The level contains some default values when
+ * not all required fields are passed in the given data. The data of the inserted level is returned.
+ *
+ * @param {Object} levelData The user access level data to insert
+ *
+ * @returns Object
+ */
+Cypress.Commands.add('db_createUserLevel', (levelData) => {
+  const defaultLevelOptions = {
+    title: 'test level',
+    rules: '[1]',
+  };
+  const level = { ...defaultLevelOptions, ...levelData };
+
+  return cy.task('queryDB', createInsertQuery('viewlevels', level))
+    .then(async (info) => {
+      level.id = info.insertId;
+
+      return level;
+    });
+});
+
+/**
  * Sets the parameter for the given extension.
  *
  * @param {string} key The key


### PR DESCRIPTION
### Summary of Changes

add system tests for com_users in administrator (group/level)
this tests will capture #41906

### Testing Instructions

code review / system test

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
