### PR TITLE
[4.4] Fix MFA with WebAuthn failing due to Factory class not found.

### DIFF
--- a/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
+++ b/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
@@ -342,9 +342,7 @@ class Webauthn extends CMSPlugin implements SubscriberInterface
         $wam->getRegistry()->addExtensionRegistryFile('plg_multifactorauth_webauthn');
 
         try {
-            /** @var CMSApplication $app */
-            $app = Factory::getApplication();
-            $app->getDocument()->addScriptOptions('com_users.authData', base64_encode($pkRequest), false);
+            $document->addScriptOptions('com_users.authData', base64_encode($pkRequest), false);
             $layoutPath = PluginHelper::getLayoutPath('multifactorauth', 'webauthn');
             ob_start();
             include $layoutPath;

--- a/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
+++ b/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
@@ -11,7 +11,6 @@
 namespace Joomla\Plugin\Multifactorauth\Webauthn\Extension;
 
 use Exception;
-use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Event\MultiFactor\Captive;
 use Joomla\CMS\Event\MultiFactor\GetMethod;
 use Joomla\CMS\Event\MultiFactor\GetSetup;


### PR DESCRIPTION
Pull Request for Issue #41911 .

### Summary of Changes

Use the `$document` variable which is assigned a few lines above the change of this PR where we already have the result of a `$this->getApplication()->getDocument()` call, so it doesn't need the `$app = Factory::getApplication();` which causes the exception due to a missing `use` statement, and it doesn't need the `$app->getDocument()`.

Same fix as done with PR #41073 in the 5.0-dev branch for issue #41072 .

### Testing Instructions

Use a current 4.4-dev branch or a 4.4.0-beta2.

1. Set up Multi Factor Authentication with Web Authentication as default method for a user.
2. Log out from backend.
3. Try to log-in again with this user and click on button "Validate with your Authenticator".

### Actual result BEFORE applying this Pull Request

See issue #41911 .

### Expected result AFTER applying this Pull Request

The user gets logged in after entering their PIN.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
