### PR TITLE
[5.0] Fix color of icon in dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/pages/_com_cpanel.scss
+++ b/build/media_source/templates/administrator/atum/scss/pages/_com_cpanel.scss
@@ -200,8 +200,7 @@
       padding: 0;
       margin: 0 .85rem;
       font-size: .9rem;
-      color: rgba(1, 1, 1, 1);
-      background: var(--white-offset);
+      color: var(--body-color);
       box-shadow: none;
       transform: scale(1.2);
     }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41818 .

### Summary of Changes
Changes the icon color to reflect text color and removes the near invisible backgroundl


### Testing Instructions
Check icon dashboard per original issue in both light and dark mode. The light mode will change color a fraction but shouldn't be significantly noticeable. 


### Actual result BEFORE applying this Pull Request
![menu-dashboard-home](https://github.com/joomla/joomla-cms/assets/368084/d3e4bb0d-62fe-415b-a6d3-d367dfd76c8c)

### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/cef956d9-68b3-48c9-9814-12d69e777eeb)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
