### PR TITLE
[5.0] Fix styling of create module view in dark mode

### DIFF
--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -68,7 +68,7 @@ endif;
                     aria-label="<?php echo Text::sprintf('COM_MODULES_SELECT_MODULE', $name); ?>">
                     <div class="new-module-details">
                         <h3 class="new-module-title"><?php echo $name; ?></h3>
-                        <p class="card-body new-module-caption p-0">
+                        <p class="new-module-caption p-0">
                             <?php echo $desc; ?>
                         </p>
                     </div>

--- a/build/media_source/templates/administrator/atum/scss/pages/_com_modules.scss
+++ b/build/media_source/templates/administrator/atum/scss/pages/_com_modules.scss
@@ -1,14 +1,32 @@
 .new-modules {
+  // We use the same colors for the new module section as we do for the quickicons.
+  --text-color: var(--template-quickicon-color);
+  --bg-color: hsl(var(--hue), 60%, 97%);
+  --bg-color-hvr: var(--template-bg-dark);
+  --icon-color: var(--template-quickicon-color);
+  --icon-color-hvr: hsl(var(--hue), 50%, 93%);
+
   .card-columns {
     grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  }
+}
+
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    .new-modules {
+      --bg-color: var(--template-bg-dark-80);
+      --bg-color-hvr: var(--template-bg-dark-65);
+      --icon-color: var(--template-bg-dark-80);
+      --icon-color-hvr: var(--template-quickicon-color);
+    }
   }
 }
 
 .new-module {
   display: flex;
   overflow: hidden;
-  color: hsl(var(--hue),30%,40%);
-  background-color: hsl(var(--hue), 60%, 97%);
+  color: var(--text-color);
+  background-color: var(--bg-color);
   border: 1px solid hsl(var(--hue), 50%, 93%);
   border-radius: $border-radius;
 
@@ -43,14 +61,14 @@
 
     span {
       margin-bottom: 10px;
-      color: hsl(var(--hue), 30%, 40%);
+      color: var(--icon-color);
     }
 
     .new-module:hover & {
-      background: var(--template-bg-dark);
+      background: var(--bg-color-hvr);
 
       span {
-        color: $white;
+        color: var(--icon-color-hvr);
       }
     }
   }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41802.

### Summary of Changes
Fixes the styling of the create module view in dark mode. Removes the card body class which as far as I can tell is redundant because we aren't using the parent card class but it does override the color of the text.

This is now explicitly sharing the same colors as the quickicons in cpanel (although the hover effects are slightly different as the plus icon isn't a separate action from the main body of text)


### Testing Instructions
Create a module in light mode. There shouldn't be a significant change (there will be very minor color changes). Create it in dark mode and it looks like the below image


### Actual result BEFORE applying this Pull Request
![modules](https://github.com/joomla/joomla-cms/assets/368084/7dd7946f-1178-411c-b4e5-0123331b2419)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/809b3d9f-f217-44f2-aeb5-59ea40fd8fd3)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
