### PR TITLE
[5.0] Remove very bright backgrounds from mfa configuration screen

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/pages/_com_users.scss
+++ b/build/media_source/templates/administrator/atum/scss/pages/_com_users.scss
@@ -61,7 +61,9 @@
 
       @if $enable-dark-mode {
         @include color-mode(dark) {
+          /* stylelint-disable max-nesting-depth */
           &:not(.com-users-methods-list-method-active) .com-users-methods-list-method-header {
+            /* stylelint-enable max-nesting-depth */
             background-color: var(--dark-bg-subtle);
           }
         }
@@ -86,7 +88,9 @@
 
       @if $enable-dark-mode {
         @include color-mode(dark) {
+          /* stylelint-disable max-nesting-depth */
           .com-users-methods-list-method-image {
+            /* stylelint-enable max-nesting-depth */
             background-color: var(--dark-bg-subtle);
           }
         }

--- a/build/media_source/templates/administrator/atum/scss/pages/_com_users.scss
+++ b/build/media_source/templates/administrator/atum/scss/pages/_com_users.scss
@@ -23,7 +23,15 @@
 
   &.view-user, &.view-methods {
     #com-users-methods-reset-container {
-      @extend .bg-light;
+      background-color: var(--light);
+    }
+
+    @if $enable-dark-mode {
+      @include color-mode(dark) {
+        #com-users-methods-reset-container {
+          background-color: var(--dark-bg-subtle);
+        }
+      }
     }
 
     .com-users-methods-list-method {
@@ -48,7 +56,15 @@
 
       /** This is applied to headers that aren't an active method **/
       &:not(.com-users-methods-list-method-active) .com-users-methods-list-method-header {
-        @extend .bg-light;
+        background-color: var(--light);
+      }
+
+      @if $enable-dark-mode {
+        @include color-mode(dark) {
+          &:not(.com-users-methods-list-method-active) .com-users-methods-list-method-header {
+            background-color: var(--dark-bg-subtle);
+          }
+        }
       }
 
       .com-users-methods-list-method-header {
@@ -63,8 +79,17 @@
         @extend .pt-1;
         @extend .px-3;
         @extend .pb-2;
-        @extend .bg-light;
         @extend .rounded-2;
+
+        background-color: var(--light);
+      }
+
+      @if $enable-dark-mode {
+        @include color-mode(dark) {
+          .com-users-methods-list-method-image {
+            background-color: var(--dark-bg-subtle);
+          }
+        }
       }
 
       .com-users-methods-list-method-title {


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41794 (Partial)  .

### Summary of Changes
Fixes the bright backgrounds in the MFA view. Doesn't fix either the icons themselves or the nearly invisible buttons associated.


### Testing Instructions
Check the MFA view. Before very bright backgrounds and invisible text. After dark backgrounds with visible text (yay!)


### Actual result BEFORE applying this Pull Request
![mfa](https://github.com/joomla/joomla-cms/assets/368084/2708e59f-1374-416a-b004-1d2e51d91776)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/7c64c77a-c592-4127-aabd-b8d598677cde)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
