### PR TITLE
[5.0] Use existing SCSS variable for box shadow so we're more consistent

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_global.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_global.scss
@@ -155,7 +155,7 @@ body .container-main {
 body:not(.contentpane) .main-card {
   background: var(--body-bg);
   border-radius: $border-radius;
-  box-shadow: 0 2px 10px -8px var(--template-bg-dark-50);
+  box-shadow: $atum-box-shadow;
 }
 
 .row-selected {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
@@ -10,7 +10,7 @@
   color: var(--template-text-dark); //#0c192e;
   background: $white;
   background-image: linear-gradient(var(--toolbar-bg), var(--template-bg-dark-3));
-  box-shadow: 0 2px 10px -8px var(--template-bg-dark-50);
+  box-shadow: $atum-box-shadow;
 
   .row {
     margin-right: 0;

--- a/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_table.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_table.scss
@@ -84,6 +84,6 @@
   }
 
   .j-main-container > & {
-    box-shadow: 0 2px 10px -8px var(--template-bg-dark-50);
+    box-shadow: $atum-box-shadow;
   }
 }


### PR DESCRIPTION
### Summary of Changes
Uses a predefined SCSS variable to make our lives easier when trying to identify identical elements.

### Testing Instructions
Code review. SCSS still compiles in drone. Validate the SCSS variable here https://github.com/joomla/joomla-cms/blob/4.3-dev/build/media_source/templates/administrator/atum/scss/_variables.scss#L104 is the same as the code being replaced


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
