### PR TITLE
[5.0] Some toolbar button hover text is invisible in dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
@@ -92,7 +92,7 @@
           --subhead-btn-accent: var(--template-bg-light);
 
           /* stylelint-disable max-nesting-depth */
-          &:hover {
+          &:hover, &:focus, &:active {
             /* stylelint-enable max-nesting-depth */
             --subhead-btn-accent: var(--template-bg-dark-60);
           }
@@ -120,7 +120,7 @@
           --subhead-btn-accent: var(--template-bg-light);
 
           /* stylelint-disable max-nesting-depth */
-          &:hover {
+          &:hover, &:focus, &:active {
             /* stylelint-enable max-nesting-depth */
             --subhead-btn-accent: var(--template-bg-dark-60);
           }

--- a/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
@@ -118,6 +118,12 @@
       @include color-mode(dark) {
         &.btn-action {
           --subhead-btn-accent: var(--template-bg-light);
+
+          /* stylelint-disable max-nesting-depth */
+          &:hover {
+            /* stylelint-enable max-nesting-depth */
+            --subhead-btn-accent: var(--template-bg-dark-60);
+          }
         }
       }
     }

--- a/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
@@ -90,6 +90,12 @@
       @include color-mode(dark) {
         &.btn-info {
           --subhead-btn-accent: var(--template-bg-light);
+
+          /* stylelint-disable max-nesting-depth */
+          &:hover {
+            /* stylelint-enable max-nesting-depth */
+            --subhead-btn-accent: var(--template-bg-dark-60);
+          }
         }
       }
     }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41793 .

### Summary of Changes
Fix the hover color of toolbar icons when in dark mode to something less painful on the eye

### Testing Instructions
Hover over any info buttons. Examples are the help page icon or the toggle inline help icon.

### Actual result BEFORE applying this Pull Request
![toggle-inline-help](https://github.com/joomla/joomla-cms/assets/368084/1559a95e-a6fe-489b-8b29-36d6811ea42f)

### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/91127386-7ce6-4a33-90fb-716e8efb3cf5)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
