### PR TITLE
[4.4] Use composer dependency maximebf/debugbar v1.19.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,7 +87,7 @@
     "symfony/yaml": "^5.4.23",
     "typo3/phar-stream-wrapper": "^3.1.7",
     "wamania/php-stemmer": "^2.2",
-    "maximebf/debugbar": "dev-master",
+    "maximebf/debugbar": "^1.19.0",
     "tobscure/json-api": "dev-joomla-backports",
     "willdurand/negotiation": "^3.1.0",
     "ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "cf71c76df03c81ddf88794c6aee62cdc",
+    "content-hash": "186d1c75ba657af1ae5b59e4bfdafe01",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -2754,7 +2754,7 @@
         },
         {
             "name": "maximebf/debugbar",
-            "version": "dev-master",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maximebf/php-debugbar.git",
@@ -2780,7 +2780,6 @@
                 "monolog/monolog": "Log using Monolog",
                 "predis/predis": "Redis storage"
             },
-            "default-branch": true,
             "type": "library",
             "extra": {
                 "branch-alias": {
@@ -9908,7 +9907,6 @@
     ],
     "minimum-stability": "stable",
     "stability-flags": {
-        "maximebf/debugbar": 20,
         "tobscure/json-api": 20
     },
     "prefer-stable": false,


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

In the 4.4-dev branch we currently have in composer.json `"maximebf/debugbar": "dev-master"`. This resolves in commit "30f65f18f7ac086255a77a079f8e0dcdd35e828e" in the lock file. This commit belongs to their version "1.19.0".

~~In the 5.0-dev branch we have in composer.json `"maximebf/debugbar": "^1.18.2"`, which results in version "1.18.2" being used, which is the version before the "1.19.0", see https://github.com/maximebf/php-debugbar/compare/v1.18.2...v1.19.0 .~~
~~That means that when we currently update the CMS from 4.4 to 5, we downgrade the "maximebf/debugbar" dependency.~~
Update: This has been solved with PR #41932 .

This PR here fixes that by changing the `"dev-master"` to `"^1.19.0"` here in the 4.4-dev branch so we still use the same version but won't get an update when we don't want that, together with PR #41932 for 5.0-dev to change there from `"^1.18.2"` to `"^1.19.0"`, too.

### Testing Instructions

Check that the debug bar works.

### Actual result BEFORE applying this Pull Request

Works.

### Expected result AFTER applying this Pull Request

Still works.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
