### PR TITLE
[5.0] Update composer dependency maximebf/debugbar to v1.19.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,7 @@
     "symfony/yaml": "^6.3.3",
     "typo3/phar-stream-wrapper": "^3.1.7",
     "wamania/php-stemmer": "^3.0.1",
-    "maximebf/debugbar": "^1.18.2",
+    "maximebf/debugbar": "^1.19.0",
     "tobscure/json-api": "dev-joomla-backports",
     "willdurand/negotiation": "^3.1.0",
     "ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0e67017f11ee2998ba0426eb2d563b40",
+    "content-hash": "7832a24f3afbe5ae42cc2f56700e7e5f",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -2740,16 +2740,16 @@
         },
         {
             "name": "maximebf/debugbar",
-            "version": "v1.18.2",
+            "version": "v1.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/maximebf/php-debugbar.git",
-                "reference": "17dcf3f6ed112bb85a37cf13538fd8de49f5c274"
+                "reference": "30f65f18f7ac086255a77a079f8e0dcdd35e828e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/17dcf3f6ed112bb85a37cf13538fd8de49f5c274",
-                "reference": "17dcf3f6ed112bb85a37cf13538fd8de49f5c274",
+                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/30f65f18f7ac086255a77a079f8e0dcdd35e828e",
+                "reference": "30f65f18f7ac086255a77a079f8e0dcdd35e828e",
                 "shasum": ""
             },
             "require": {
@@ -2800,9 +2800,9 @@
             ],
             "support": {
                 "issues": "https://github.com/maximebf/php-debugbar/issues",
-                "source": "https://github.com/maximebf/php-debugbar/tree/v1.18.2"
+                "source": "https://github.com/maximebf/php-debugbar/tree/v1.19.0"
             },
-            "time": "2023-02-04T15:27:00+00:00"
+            "time": "2023-09-19T19:53:10+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

In the 4.4-dev branch we currently have in composer.json `"maximebf/debugbar": "dev-master"`. This resolves in commit "30f65f18f7ac086255a77a079f8e0dcdd35e828e" in the lock file. This commit belongs to their version "1.19.0".

In the 5.0-dev branch we have in composer.json `"maximebf/debugbar": "^1.18.2"`, which results in version "1.18.2" being used, which is the version before the "1.19.0", see https://github.com/maximebf/php-debugbar/compare/v1.18.2...v1.19.0 . 

That means that when we currently update the CMS from 4.4 to 5, we downgrade the "maximebf/debugbar" dependency.

This PR here fixes that by updating the maximebf/debugbar dependency to version "1.19.0" here in the 5.0-dev branch, together with a PR for 4.4-dev to change there from `"dev-master"` to `"^1.19.0"`, too.

The PR here might become obsolete when the other one has been merged into 4.40-dev and that has been upmerged to 5.0-dev then. But it can be used to check the result of that.

### Testing Instructions

Check that the debug bar works.

### Actual result BEFORE applying this Pull Request

Works.

### Expected result AFTER applying this Pull Request

Still works.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
