### PR TITLE
[5.0] Fix installation progressbar broken error handling

### DIFF
--- a/installation/template/js/template.js
+++ b/installation/template/js/template.js
@@ -198,7 +198,22 @@
           progress_text.setAttribute('role', 'alert');
           progress_text.classList.add('error');
           progress_text.innerText = response.message;
-          Joomla.renderMessages({"error": [response.message]});
+
+          if (response.messages) {
+            Joomla.renderMessages(response.messages);
+          }
+
+          if (response.message) {
+            Joomla.renderMessages({"error": [response.message]});
+          }
+
+          // @todo: Add a delay and red background before removing the progress bar?
+          // Reveal the install steps so the user has a chance to resubmit with the data
+          document.getElementById('installStep1').classList.add('active');
+          document.getElementById('installStep2').classList.add('active');
+          document.getElementById('installStep3').classList.add('active');
+          document.getElementById('installStep4').classList.remove('active');
+
           return false;
         }
 


### PR DESCRIPTION
### Summary of Changes
Improves the UX of the installer when an installation fails in some edge cases.

### Testing Instructions

Steps to replicate the bug (thanks @brianteeman !!)

1. install joomla with a db prefix of jos_
2. on the final screen of the installer (where you get the link to site and admin) clear the cookies and delete configuration.php
3. refresh the browser and you are back to the beginning of the installation
4. enter EXACTLY the same values - especially the db prefix of jos_
5. sit back and watch the null error appear

In such a case what happens is the errors are enqueued through enqueueMessage and the progress bar stops, gives a null error message and gives me no way to continue. The only way to bail is to refresh and refill out the passwords all over again (the rest of the data is thankfully stored in the session).

### Actual result BEFORE applying this Pull Request
![Screenshot from 2023-09-26 18-39-28](https://github.com/joomla/joomla-cms/assets/1986000/4161584c-3882-44cf-bc26-73bf0d7acca5)

You can only see the errors in the network request.

### Expected result AFTER applying this Pull Request
The user form is shown to the user and the progress bar is hidden. This allows the user to resubmit their data after fixing any required items without needing to fill out the form all over again.

![image](https://github.com/joomla/joomla-cms/assets/1986000/4ebb6931-e436-4148-87a3-3a991e310144)

Sample screenshot of after.

Note this doesn't fix the error. Just how we handle the errors. Next step is to figure out the root cause.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
