### PR TITLE
[5.0] Fix installer never backing up old tables

### DIFF
--- a/installation/src/Controller/InstallationController.php
+++ b/installation/src/Controller/InstallationController.php
@@ -130,7 +130,10 @@ class InstallationController extends JSONController
             $r->view  = 'setup';
             $r->error = true;
         } else {
-            if (!$databaseModel->handleOldDatabase($options)) {
+            // Re-fetch options from the session as the create database call might modify them.
+            $updatedOptions = $databaseModel->getOptions();
+
+            if (!$databaseModel->handleOldDatabase($updatedOptions)) {
                 $r->view  = 'setup';
                 $r->error = true;
             }


### PR DESCRIPTION
Fixes bug caused by https://github.com/joomla/joomla-cms/pull/38914 which breaks table backups.

### Summary of Changes
Table backups in installation are fixed with this patch

Note there might be a similar bug https://github.com/joomla/joomla-cms/blob/4.3-dev/installation/src/Helper/DatabaseHelper.php#L321 here where we reset the session objects. But I can't see us reusing the options so it's *probably* fine? Definitely needs another review

### Testing Instructions
Steps to replicate the bug (thanks @brianteeman !!)

1. install joomla with a db prefix of jos_
2. on the final screen of the installer (where you get the link to site and admin) clear the cookies and delete configuration.php
3. refresh the browser and you are back to the beginning of the installation
4. enter EXACTLY the same values - especially the db prefix of jos_

Someone should probably validate that this doesn't break the cli installer too.

### Actual result BEFORE applying this Pull Request
Error appears. `null` if you haven't got https://github.com/joomla/joomla-cms/pull/41941 applied or a big list of errors if you do

### Expected result AFTER applying this Pull Request
No errors and tables backed up

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
