### PR TITLE
[4.4] Fix "group by" in com_users users model for strict SQL syntax

### DIFF
--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -312,7 +312,7 @@ class UsersModel extends ListModel
                 )
                 ->from($db->quoteName('#__user_mfa'))
                 ->group($db->quoteName('user_id'));
-            $query->select($db->quoteName('mfa.mfaRecords'))
+            $query->select('MAX(' . $db->quoteName('mfa.mfaRecords') . ') AS ' . $db->quoteName('mfaRecords'))
                 ->join(
                     'left',
                     '(' . $subQuery . ') AS ' . $db->quoteName('mfa'),


### PR DESCRIPTION
Pull Request for Issue #41951 .

### Summary of Changes

For correct SQL syntax of "GROUP BY" statements, all columns in the result set either must be part of the "GROUP BY" clause or be used with an aggregate function.

Examples:
`SELECT id, name, MAX(column1), MIN(column2) FROM sometable GROUP BY id, name` is correct.
`SELECT id, name, column1, MIN(column2) FROM sometable GROUP BY id, name` is **not** correct.
`SELECT id, name, column1, MIN(column2) FROM sometable GROUP BY id, name, column1` is correct.

This is the case for all RDBMS which I know (PostgreSQL, Oracle, MS SQL Server), only MySQL and MariaDB were tolerant with this in past. MySQL 8 might be less tolerant when in strict SQL mode beginning at a particular version.

This PR fixes the SQL in the "getListQuery" method of the "Users" model of com_users to fix the SQL error shown e.g. on PostgreSQL when MFA is enabled.

### Testing Instructions

If possible and available, test with PostgreSQL, MariaDB, MySQL 8 (whatever of these you have) and report back which database(s) you have used.

1. Have some users with MFA enabled and some others without.
2. In the administrator side menu, select "Users" -> "Groups".
3. Click on any entry on the "Enabled Users" or "Blocked Users" column.
4. Check the log file of your database server.

### Actual result BEFORE applying this Pull Request

In the database server's log file:
> An error has occurred.
> 500 42803, 7, ERROR: column "mfa.mfaRecords" must appear in the GROUP BY clause or be used in an aggregate  function LINE 1: SELECT a.*,"mfa"."mfaRecords" ^ 42803, 7, ERROR: column "mfa.mfaRecords" must appear in the GROUP BY clause or be used in an aggregate function LINE 1: SELECT a.*,"mfa"."mfaRecords"

### Expected result AFTER applying this Pull Request

It shows a list of enabled or blocked users with a group.
There is no error like mentioned above in the database server's log file.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
