### PR TITLE
[5.0] Remove unused SCSS

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_login.scss
@@ -75,11 +75,6 @@
         @include media-breakpoint-down(sm) {
           width: 100%;
         }
-
-        &.text-end {
-          font-size: ($font-size-base * .75);
-          color: var(--template-special-color);
-        }
       }
     }
 


### PR DESCRIPTION
### Summary of Changes
Removes some as far as I can tell unused SCSS from the login scss. The motivation is that I'm trying to reduce the amount of places we're using `var(--template-special-color);`

### Testing Instructions
Check the login page (including ideally with some passkey & mfa methods enabled. Ideally there should be no differences.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
