### PR TITLE
[5.0] Error Callstack [a11y]

### DIFF
--- a/layouts/joomla/error/backtrace.php
+++ b/layouts/joomla/error/backtrace.php
@@ -21,50 +21,48 @@ if (!$backtraceList) {
 
 $class = $displayData['class'] ?? 'table table-striped table-bordered';
 ?>
-<table class="<?php echo $class ?>">
-    <tr>
-        <td colspan="3">
-            <strong>Call stack</strong>
-        </td>
-    </tr>
+<h2 id="caption">Call Stack</h2>
+<table class="<?php echo $class ?>" aria-describedby="caption">
+    <thead>
+        <tr>
+            <th scope="col">
+                <strong>#</strong>
+            </th>
+            <th scope="col">
+                <strong>Function</strong>
+            </th>
+            <th scope="col">
+                <strong>Location</strong>
+            </th>
+        </tr>
+    </thead>
+    <tbody>
+        <?php foreach ($backtraceList as $k => $backtrace) : ?>
+            <tr>
+                <td>
+                    <?php echo $k + 1; ?>
+                </td>
 
-    <tr>
-        <td>
-            <strong>#</strong>
-        </td>
-        <td>
-            <strong>Function</strong>
-        </td>
-        <td>
-            <strong>Location</strong>
-        </td>
-    </tr>
+                <?php if (isset($backtrace['class'])) : ?>
+                <td>
+                    <?php echo $backtrace['class'] . $backtrace['type'] . $backtrace['function'] . '()'; ?>
+                </td>
+                <?php else : ?>
+                <td>
+                    <?php echo $backtrace['function'] . '()'; ?>
+                </td>
+                <?php endif; ?>
 
-    <?php foreach ($backtraceList as $k => $backtrace) : ?>
-    <tr>
-        <td>
-            <?php echo $k + 1; ?>
-        </td>
-
-        <?php if (isset($backtrace['class'])) : ?>
-        <td>
-            <?php echo $backtrace['class'] . $backtrace['type'] . $backtrace['function'] . '()'; ?>
-        </td>
-        <?php else : ?>
-        <td>
-            <?php echo $backtrace['function'] . '()'; ?>
-        </td>
-        <?php endif; ?>
-
-        <?php if (isset($backtrace['file'])) : ?>
-        <td>
-            <?php echo HTMLHelper::_('debug.xdebuglink', $backtrace['file'], $backtrace['line']); ?>
-        </td>
-        <?php else : ?>
-        <td>
-            &#160;
-        </td>
-        <?php endif; ?>
-    </tr>
-    <?php endforeach; ?>
+                <?php if (isset($backtrace['file'])) : ?>
+                <td>
+                    <?php echo HTMLHelper::_('debug.xdebuglink', $backtrace['file'], $backtrace['line']); ?>
+                </td>
+                <?php else : ?>
+                <td>
+                    &#160;
+                </td>
+                <?php endif; ?>
+            </tr>
+        <?php endforeach; ?>
+    </tbody>
 </table>


### PR DESCRIPTION
### Summary of Changes
The callstack displayed on error pages when debug is enabled is not accessible. 

1. In order to be accessible to visually impaired users, it is important that tables provides a description of its content before the data is accessed. Usually we do this by adding a `caption` that is only displayed to screen readers but in this case I took an alternative approach (aria-describedy) as I wanted it to be displayed to all users

2. Assistive technologies, such as screen readers, use `<th>` headers to provide some context when users navigates a table. Without it the user gets rapidly lost in the flow of data. In addition the Headers should be properly associated with the corresponding `<td>` cells by using  a scope attribute



### Testing Instructions
Enable debug mode and then on the front end trigger an error such as a 404


### Expected result AFTER applying this Pull Request
Table is accessible with caption, table headers and scope


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
