### PR TITLE
[5.0] Incomplete PHPDoc signature

### DIFF
--- a/administrator/components/com_media/src/Provider/ProviderManagerHelperTrait.php
+++ b/administrator/components/com_media/src/Provider/ProviderManagerHelperTrait.php
@@ -70,10 +70,11 @@ trait ProviderManagerHelperTrait
     /**
      * Returns a provider for the given id.
      *
+     * @param   string  $id
+     *
      * @return  ProviderInterface
      *
-     * @throws  \Exception
-     *
+     * @throws \Exception
      * @since   4.1.0
      */
     public function getProvider(string $id): ProviderInterface
@@ -84,10 +85,11 @@ trait ProviderManagerHelperTrait
     /**
      * Return an adapter for the given name.
      *
+     * @param   string  $name
+     *
      * @return  AdapterInterface
      *
-     * @throws  \Exception
-     *
+     * @throws \Exception
      * @since   4.1.0
      */
     public function getAdapter(string $name): AdapterInterface
@@ -98,10 +100,11 @@ trait ProviderManagerHelperTrait
     /**
      * Returns an array with the adapter name as key and the path of the file.
      *
+     * @param   string  $path
+     *
      * @return  array
      *
-     * @throws  \InvalidArgumentException
-     *
+     * @throws \Exception
      * @since   4.1.0
      */
     protected function resolveAdapterAndPath(string $path): array

--- a/plugins/editors/tinymce/src/Provider/TinyMCEProvider.php
+++ b/plugins/editors/tinymce/src/Provider/TinyMCEProvider.php
@@ -50,6 +50,7 @@ final class TinyMCEProvider extends AbstractEditorProvider
      * @param   Registry                 $params
      * @param   CMSApplicationInterface  $application
      * @param   DispatcherInterface      $dispatcher
+     * @param   DatabaseInterface        $database
      *
      * @since  5.0.0
      */

--- a/plugins/system/httpheaders/src/Extension/Httpheaders.php
+++ b/plugins/system/httpheaders/src/Extension/Httpheaders.php
@@ -160,6 +160,8 @@ final class Httpheaders extends CMSPlugin implements SubscriberInterface
     /**
      * The `applyHashesToCspRule` method makes sure the csp hashes are added to the csp header when enabled
      *
+     * @param   Event  $event
+     *
      * @return  void
      *
      * @since   4.0.0
@@ -234,6 +236,8 @@ final class Httpheaders extends CMSPlugin implements SubscriberInterface
 
     /**
      * The `setHttpHeaders` method handle the setting of the configured HTTP Headers
+     *
+     * @param   Event  $event
      *
      * @return  void
      *

--- a/plugins/workflow/featuring/src/Extension/Featuring.php
+++ b/plugins/workflow/featuring/src/Extension/Featuring.php
@@ -180,6 +180,8 @@ final class Featuring extends CMSPlugin implements SubscriberInterface
      *
      * @param   DisplayEvent  $event
      *
+     * @return  void
+     *
      * @since   4.0.0
      */
     public function onAfterDisplay(DisplayEvent $event)
@@ -195,7 +197,7 @@ final class Featuring extends CMSPlugin implements SubscriberInterface
         $singularsection = Inflector::singularize($section);
 
         if (!$this->isSupported($component . '.' . $singularsection)) {
-            return true;
+            return;
         }
 
         // List of related batch functions we need to hide
@@ -227,8 +229,6 @@ final class Featuring extends CMSPlugin implements SubscriberInterface
 		";
 
         $this->getApplication()->getDocument()->addScriptDeclaration($js);
-
-        return true;
     }
 
     /**

--- a/plugins/workflow/publishing/src/Extension/Publishing.php
+++ b/plugins/workflow/publishing/src/Extension/Publishing.php
@@ -194,7 +194,9 @@ final class Publishing extends CMSPlugin implements SubscriberInterface
     /**
      * Manipulate the generic list view
      *
-     * @param   DisplayEvent    $event
+     * @param   DisplayEvent  $event
+     *
+     * @return  void
      *
      * @since   4.0.0
      */
@@ -211,7 +213,7 @@ final class Publishing extends CMSPlugin implements SubscriberInterface
         $singularsection = Inflector::singularize($section);
 
         if (!$this->isSupported($component . '.' . $singularsection)) {
-            return true;
+            return;
         }
 
         // That's the hard coded list from the AdminController publish method => change, when it's make dynamic in the future
@@ -246,8 +248,6 @@ final class Publishing extends CMSPlugin implements SubscriberInterface
 		";
 
         $this->getApplication()->getDocument()->addScriptDeclaration($js);
-
-        return true;
     }
 
     /**


### PR DESCRIPTION
### Summary of Changes

Add missed params in PHPDoc, don't return anything from event handlers in Featuring and Publishing workflow plugins.

### Testing Instructions

See the method desc in IDE with missed params

### Actual result BEFORE applying this Pull Request

No params or param is missed.

### Expected result AFTER applying this Pull Request

All params are in PHPDoc.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
