### PR TITLE
[5.2] Remove unused ArchiveModel::getData()

### DIFF
--- a/components/com_content/src/Model/ArchiveModel.php
+++ b/components/com_content/src/Model/ArchiveModel.php
@@ -131,33 +131,6 @@ class ArchiveModel extends ArticlesModel
     }
 
     /**
-     * Method to get the archived article list
-     *
-     * @access public
-     * @return array
-     */
-    public function getData()
-    {
-        $app = Factory::getApplication();
-
-        // Lets load the content if it doesn't already exist
-        if (empty($this->_data)) {
-            // Get the page/component configuration
-            $params = $app->getParams();
-
-            // Get the pagination request variables
-            $limit      = $app->getInput()->get('limit', $params->get('display_num', 20), 'uint');
-            $limitstart = $app->getInput()->get('limitstart', 0, 'uint');
-
-            $query = $this->_buildQuery();
-
-            $this->_data = $this->_getList($query, $limitstart, $limit);
-        }
-
-        return $this->_data;
-    }
-
-    /**
      * Gets the archived articles years
      *
      * @return   array


### PR DESCRIPTION
### Summary of Changes

`ArchiveModel::getData()` is unused, even calls the missed `_buildQuery()`

### Testing Instructions

Apply patch.

### Actual result BEFORE applying this Pull Request

Invalid unused method.

### Expected result AFTER applying this Pull Request

No invalid unused method.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
