### PR TITLE
[5.0] Undefined methods

### DIFF
--- a/administrator/components/com_menus/src/View/Menu/XmlView.php
+++ b/administrator/components/com_menus/src/View/Menu/XmlView.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Menus\Administrator\View\Menu;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Menu\AdministratorMenuItem;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
@@ -29,7 +30,7 @@ use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 class XmlView extends BaseHtmlView
 {
     /**
-     * @var  \stdClass[]
+     * @var  AdministratorMenuItem[]
      *
      * @since  3.8.0
      */
@@ -103,8 +104,8 @@ class XmlView extends BaseHtmlView
     /**
      * Add a child node to the xml
      *
-     * @param   \SimpleXMLElement  $xml   The current XML node which would become the parent to the new node
-     * @param   \stdClass          $item  The menuitem object to create the child XML node from
+     * @param   \SimpleXMLElement      $xml   The current XML node which would become the parent to the new node
+     * @param   AdministratorMenuItem  $item  The menuitem object to create the child XML node from
      *
      * @return  void
      *

--- a/administrator/components/com_privacy/src/View/Request/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Request/HtmlView.php
@@ -20,7 +20,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
-use Joomla\Component\Privacy\Administrator\Model\RequestsModel;
+use Joomla\Component\Privacy\Administrator\Model\RequestModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -78,7 +78,7 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        /** @var RequestsModel $model */
+        /** @var RequestModel $model */
         $model       = $this->getModel();
         $this->item  = $model->getItem();
         $this->state = $model->getState();

--- a/components/com_privacy/src/Controller/RequestController.php
+++ b/components/com_privacy/src/Controller/RequestController.php
@@ -15,6 +15,7 @@ use Joomla\CMS\MVC\Controller\BaseController;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Privacy\Site\Model\ConfirmModel;
+use Joomla\Component\Privacy\Site\Model\RemindModel;
 use Joomla\Component\Privacy\Site\Model\RequestModel;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -136,7 +137,7 @@ class RequestController extends BaseController
         // Check the request token.
         $this->checkToken('post');
 
-        /** @var ConfirmModel $model */
+        /** @var RemindModel $model */
         $model = $this->getModel('Remind', 'Site');
         $data  = $this->input->post->get('jform', [], 'array');
 


### PR DESCRIPTION
### Summary of Changes

Fix undefined methods IDE warnings, mostly due to invalid PHPDoc class names

### Testing Instructions

Apply patch.

### Actual result BEFORE applying this Pull Request

See invalid methods IDE warnings.

### Expected result AFTER applying this Pull Request

No IDE warnings.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
