### PR TITLE
[5.0] Error in PrivacyConsent::getPrivacyItemId()

### DIFF
--- a/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
+++ b/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
@@ -433,7 +433,7 @@ final class PrivacyConsent extends CMSPlugin
 
         if ($itemId > 0 && Associations::isEnabled()) {
             $privacyAssociated = Associations::getAssociations('com_menus', '#__menu', 'com_menus.item', $itemId, 'id', '', '');
-            $currentLang       = $this->getApplication()->getTag();
+            $currentLang       = $this->getApplication()->getLanguage()->getTag();
 
             if (isset($privacyAssociated[$currentLang])) {
                 $itemId = $privacyAssociated[$currentLang]->id;


### PR DESCRIPTION
### Summary of Changes

Fix `PrivacyConsent::getPrivacyItemId()` invalid call to `getTag()` on app

### Testing Instructions

Looks complex to reproduce, we need to find the com_privacy menu item with multilingual environment and enabled associations. Anyway, the code error is clear in IDE.

### Actual result BEFORE applying this Pull Request

Error, called to undefined method.

### Expected result AFTER applying this Pull Request

No errors.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
