### PR TITLE
[5.0] ActionsDropdown::$dropDownList issue

### DIFF
--- a/libraries/src/HTML/Helpers/ActionsDropdown.php
+++ b/libraries/src/HTML/Helpers/ActionsDropdown.php
@@ -26,7 +26,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 abstract class ActionsDropdown
 {
     /**
-     * @var    string  HTML markup for the dropdown list
+     * @var    string[]  HTML markup for the dropdown list
      * @since  3.2
      */
     protected static $dropDownList = [];
@@ -56,7 +56,7 @@ abstract class ActionsDropdown
         $html[] = implode('', static::$dropDownList);
         $html[] = '</ul>';
 
-        static::$dropDownList = null;
+        static::$dropDownList = [];
 
         return implode('', $html);
     }


### PR DESCRIPTION
### Summary of Changes

`ActionsDropdown::$dropDownList` is declared as `string` while it's `string[]`

Once rendered, the array is casted to null (I guess to free memory), but it's an array actually and all any next further call to add a button will produce warning on adding element to null.

### Testing Instructions

Apply patch.

### Actual result BEFORE applying this Pull Request

See IDE warning for `static::$dropDownList[] = ...` code.

### Expected result AFTER applying this Pull Request

No IDE warnings.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
