### PR TITLE
[5.0] WebAuthn plugin unused css

### DIFF
--- a/build/media_source/plg_system_webauthn/scss/button.scss
+++ b/build/media_source/plg_system_webauthn/scss/button.scss
@@ -1,24 +1,3 @@
 button[class*=plg_system_webauthn_login_button] {
   padding: .4rem;
-
-  span[class*=icon] {
-    display: inline-block;
-    width: 1em;
-    font-size: 1.25em;
-    text-align: center;
-    vertical-align: sub;
-  }
-
-  img[class*=icon] {
-    display: inline-block;
-    height: 2.5rem;
-    padding: 0 .25em 2px;
-    font-size: 1.5em;
-    text-align: center;
-    vertical-align: middle;
-  }
-
-  span[class*=icon]:not(:last-child) {
-    margin-inline-end: .5em;
-  }
 }


### PR DESCRIPTION
As the button uses an svg and not an icon then these css classes are never used and can be removed without any impact at all.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
