### PR TITLE
[5.0] reactivate disabled system tests

### DIFF
--- a/libraries/src/Form/Field/LimitboxField.php
+++ b/libraries/src/Form/Field/LimitboxField.php
@@ -82,7 +82,7 @@ class LimitboxField extends ListField
             asort($limits);
 
             // Add an option to show all?
-            $showAll = isset($this->element['showall']) && (string) $this->element['showall'] === 'true';
+            $showAll = !isset($this->element['showall']) || (string) $this->element['showall'] === 'true';
 
             if ($showAll) {
                 $limits[] = 0;

--- a/plugins/system/accessibility/src/Extension/Accessibility.php
+++ b/plugins/system/accessibility/src/Extension/Accessibility.php
@@ -89,7 +89,7 @@ final class Accessibility extends CMSPlugin
                             'units' => 'px',
                         ],
                     ],
-                    'useEmojis' => $this->params->get('useEmojis') === 'true',
+                    'useEmojis' => $this->params->get('useEmojis', 'true') === 'true',
                 ],
                 'hotkeys' => [
                     'enabled'    => true,

--- a/tests/System/integration/administrator/components/com_privacy/Consent.cy.js
+++ b/tests/System/integration/administrator/components/com_privacy/Consent.cy.js
@@ -17,7 +17,7 @@ describe('Test in backend that privacy consent component', () => {
     cy.get('tbody > tr > :nth-child(4)').should('contain', 'test user');
     cy.get('table').find('tr').should('have.length', 4);
   });
-  /*
+
   it('can invalidate privacy consent', () => {
     cy.db_enableExtension('0', 'plg_system_privacyconsent');
     cy.db_createUser().then((id) => {
@@ -45,7 +45,7 @@ describe('Test in backend that privacy consent component', () => {
 
     cy.get('.alert-message').should('contain', '2 consents were invalidated');
   });
-  */
+
   it('can filter by valid consent', () => {
     cy.db_enableExtension('0', 'plg_system_privacyconsent');
     cy.db_createUser().then((id) => {
@@ -154,7 +154,7 @@ describe('Test in backend that privacy consent component', () => {
     cy.get('.filter-search-bar__button').click();
     cy.get('.alert').should('contain', 'No Matching Results');
   });
-  /*
+
   it('can displays correct number of consents', () => {
     cy.db_enableExtension('0', 'plg_system_privacyconsent');
     cy.db_createUser().then((id) => {
@@ -187,7 +187,7 @@ describe('Test in backend that privacy consent component', () => {
     cy.get('#list_limit').select('All');
     cy.get('table').find('tr').should('have.length', 551);
   });
-  */
+
   it('can list by status in ascending order', () => {
     cy.db_enableExtension('0', 'plg_system_privacyconsent');
     cy.db_createUser().then((id) => {

--- a/tests/System/integration/administrator/components/com_privacy/Consent.cy.js
+++ b/tests/System/integration/administrator/components/com_privacy/Consent.cy.js
@@ -28,6 +28,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.get('tbody > tr > :nth-child(4)').should('contain', 'test user');
     cy.get('#cb0').click();
     cy.get('.button-trash').click();
+    cy.clickDialogConfirm(true);
+
     cy.get('.alert-message').should('contain', 'The consent was invalidated.');
   });
 
@@ -42,6 +44,7 @@ describe('Test in backend that privacy consent component', () => {
 
     cy.get('.w-1.text-center > .form-check-input').click();
     cy.get('#toolbar-trash').click();
+    cy.clickDialogConfirm(true);
 
     cy.get('.alert-message').should('contain', '2 consents were invalidated');
   });

--- a/tests/System/integration/api/com_users/Users.cy.js
+++ b/tests/System/integration/api/com_users/Users.cy.js
@@ -54,12 +54,12 @@ describe('Test that users API endpoint', () => {
         .its('name')
         .should('include', 'updated automated test user'));
   });
-  /*
+
   it('can delete a user', () => {
     cy.db_createUser({ name: 'automated test user' })
       .then((id) => cy.api_delete(`/users/${id}`));
   });
-  */
+
   it('can login after update a user', () => {
     cy.db_createUser({ name: 'test', password: '098f6bcd4621d373cade4e832627b4f6' })
       .then((id) => {


### PR DESCRIPTION
Reverts part of #41938 @HLeithner 

### Summary of Changes

`tests/System/integration/administrator/components/com_privacy/Consent.cy.js`
_can invalidate (all) privacy consents_: use new joomla dialog
_can displays correct number of consents_: LimitboxField broken in #41655 (`All` is no longer available by default) @Denitz

`tests/System/integration/api/com_users/Users.cy.js`
_can delete a user_: should already work

`plugins/system/accessibility/src/Extension/Accessibility.php`
use emojis as default (like in J4) to match the XML default value

### Testing Instructions

drone

### Actual result BEFORE applying this Pull Request

tests fails in J5

### Expected result AFTER applying this Pull Request

all test working in J5

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
