### PR TITLE
[5.0] Fix contrast color in dark mode installation

### DIFF
--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -387,6 +387,14 @@ legend {
   color: $red;
 }
 
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    .form-control-feedback {
+      color: #DD5555;
+    }
+  }
+}
+
 // Language Table
 caption {
   caption-side: top;

--- a/installation/template/scss/template.scss
+++ b/installation/template/scss/template.scss
@@ -390,7 +390,7 @@ legend {
 @if $enable-dark-mode {
   @include color-mode(dark) {
     .form-control-feedback {
-      color: #DD5555;
+      color: #d55;
     }
   }
 }


### PR DESCRIPTION
Pull Request for Issue  https://github.com/joomla/joomla-cms/issues/41962.

### Summary of Changes
Dark mode fixes

### Testing Instructions
In installation when in dark mode the color now satisfies AA requirements

### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/2019801/c8b3d743-3117-4c31-bcd2-623819d08996)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/ec25adba-6b45-452c-ae2c-6370648a63d3)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
