### PR TITLE
[5.0] Fix permissions list color in dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-tab.scss
@@ -102,6 +102,15 @@ joomla-tab {
       .text-muted {
         color: var(--template-text-dark) !important;
       }
+      @if $enable-dark-mode {
+        @include color-mode(dark) {
+          /* stylelint-disable max-nesting-depth */
+          .text-muted {
+            /* stylelint-enable max-nesting-depth */
+            color: var(--template-text-light) !important;
+          }
+        }
+      }
     }
   }
 
@@ -194,7 +203,6 @@ joomla-tab[orientation=vertical] {
       display: block;
       padding: .75em 1em;
       margin: -1px 0;
-      color: var(--template-special-color);
       text-decoration: none;
       border-top: 1px solid transparent;
       border-bottom: 1px solid $gray-300;
@@ -224,6 +232,15 @@ joomla-tab[orientation=vertical] {
       }
       .text-muted {
         color: var(--template-text-dark) !important;
+      }
+      @if $enable-dark-mode {
+        @include color-mode(dark) {
+          /* stylelint-disable max-nesting-depth */
+          .text-muted {
+            /* stylelint-enable max-nesting-depth */
+            color: var(--template-text-light) !important;
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/41778 (partial).

### Summary of Changes
Removes the color override of specific buttons in joomla tabs. I think this is only used in core with permissions but there might be other 3rd party uses?

### Testing Instructions
Check the permissions tab in dark and light mode. The color change in light mode is to my eyes at least barely noticeable. But there's a clear improvement in dark mode. If people think the light mode color change is more noticable I can make further fixes.

### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/0d3806f6-a406-4e07-9105-567a45a56950)
![image](https://github.com/joomla/joomla-cms/assets/1986000/b2331329-9cf8-42a4-967a-f0ebcce6b4e9)

### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1986000/6a4dad83-77a2-4544-8438-0b5e4f0eee23)
![image](https://github.com/joomla/joomla-cms/assets/1986000/a01f3f99-d562-4bfb-913f-eadc84ed5620)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
