### PR TITLE
[5.1] Initial version bump to 5.1.0-alpha1-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,21 @@
 Joomla! CMS™
 ====================
 
-The Joomla! 5.0 branch is under heavy development and not all links in this document are available yet
+The Joomla! 5.1 branch is under heavy development and not all links in this document are available yet
 ------------------------------------------------------------------------------------------------------
 
 Build Status
 ---------------------
 | Drone-CI                                                                                                                                 | AppVeyor                                                                                                                                                           | PHP                                                                           | Node                                                                                 | npm                                                                             |
 |------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
-| [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg?branch=5.0-dev)](https://ci.joomla.org/joomla/joomla-cms) | [![Build status](https://ci.appveyor.com/api/projects/status/ru6sxal8jmfckvjc/branch/5.0-dev?svg=true)](https://ci.appveyor.com/project/release-joomla/joomla-cms) | [![PHP](https://img.shields.io/badge/PHP-V8.1.0-green)](https://www.php.net/) | [![node-lts](https://img.shields.io/badge/Node-V18.0-green)](https://nodejs.org/en/) | [![npm](https://img.shields.io/badge/npm-v9.6.7-green)](https://nodejs.org/en/) |
+| [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg?branch=5.1-dev)](https://ci.joomla.org/joomla/joomla-cms) | [![Build status](https://ci.appveyor.com/api/projects/status/ru6sxal8jmfckvjc/branch/5.1-dev?svg=true)](https://ci.appveyor.com/project/release-joomla/joomla-cms) | [![PHP](https://img.shields.io/badge/PHP-V8.1.0-green)](https://www.php.net/) | [![node-lts](https://img.shields.io/badge/Node-V18.0-green)](https://nodejs.org/en/) | [![npm](https://img.shields.io/badge/npm-v9.6.7-green)](https://nodejs.org/en/) |
 
 Overview
 ---------------------
 * This is the source of Joomla! 5.x.
 * Joomla's [Official website](https://www.joomla.org).
 * Joomla! 5.1 [version history](https://docs.joomla.org/Special:MyLanguage/Joomla_5.1_version_history).
-* Detailed changes are in the [changelog](https://github.com/joomla/joomla-cms/commits/5.0-dev).
+* Detailed changes are in the [changelog](https://github.com/joomla/joomla-cms/commits/5.1-dev).
 
 What is Joomla?
 ---------------------
@@ -48,9 +48,9 @@ git clone https://github.com/joomla/joomla-cms.git
 ```bash
 cd joomla-cms
 ```
-- Go to the 5.0-dev branch:
+- Go to the 5.1-dev branch:
 ```bash
-git checkout 5.0-dev
+git checkout 5.1-dev
 ```
 - Install all the needed composer packages:
 ```bash

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Overview
 ---------------------
 * This is the source of Joomla! 5.x.
 * Joomla's [Official website](https://www.joomla.org).
-* Joomla! 5.0 [version history](https://docs.joomla.org/Special:MyLanguage/Joomla_5.0_version_history).
+* Joomla! 5.1 [version history](https://docs.joomla.org/Special:MyLanguage/Joomla_5.1_version_history).
 * Detailed changes are in the [changelog](https://github.com/joomla/joomla-cms/commits/5.0-dev).
 
 What is Joomla?

--- a/README.txt
+++ b/README.txt
@@ -6,7 +6,7 @@ The Joomla! 5.0 branch is under heavy development and not all links in this docu
 1- Overview
 	* This is a Joomla! 5.x installation/upgrade package.
 	* Joomla! Official site: https://www.joomla.org
-	* Joomla! 5.0 version history - https://docs.joomla.org/Special:MyLanguage/Joomla_5.0_version_history
+	* Joomla! 5.1 version history - https://docs.joomla.org/Special:MyLanguage/Joomla_5.1_version_history
 	* Detailed changes in the Changelog: https://github.com/joomla/joomla-cms/commits/5.0-dev
 
 2- What is Joomla?

--- a/README.txt
+++ b/README.txt
@@ -1,13 +1,13 @@
 Joomla! CMS™
 
-The Joomla! 5.0 branch is under heavy development and not all links in this document are available yet
+The Joomla! 5.1 branch is under heavy development and not all links in this document are available yet
 ------------------------------------------------------------------------------------------------------
 
 1- Overview
 	* This is a Joomla! 5.x installation/upgrade package.
 	* Joomla! Official site: https://www.joomla.org
 	* Joomla! 5.1 version history - https://docs.joomla.org/Special:MyLanguage/Joomla_5.1_version_history
-	* Detailed changes in the Changelog: https://github.com/joomla/joomla-cms/commits/5.0-dev
+	* Detailed changes in the Changelog: https://github.com/joomla/joomla-cms/commits/5.1-dev
 
 2- What is Joomla?
 	* Joomla! is a Content Management System (CMS) which enables you to build websites and powerful online applications.

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -2,8 +2,8 @@
 <extension client="administrator" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.0.0</version>
-	<creationDate>2023-09</creationDate>
+	<version>5.1.0</version>
+	<creationDate>2023-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/administrator/language/en-GB/langmetadata.xml
+++ b/administrator/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="administrator">
 	<name>English (en-GB)</name>
-	<version>5.0.0</version>
-	<creationDate>2023-09</creationDate>
+	<version>5.1.0</version>
+	<creationDate>2023-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,8 +6,8 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>5.0.0-rc-dev</version>
-	<creationDate>2023-09</creationDate>
+	<version>5.1.0-alpha1-dev</version>
+	<creationDate>2023-10</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 
 	<scriptfile>administrator/components/com_admin/script.php</scriptfile>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,8 +2,8 @@
 <extension type="package" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>5.0.0.1</version>
-	<creationDate>2023-09</creationDate>
+	<version>5.1.0.1</version>
+	<creationDate>2023-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/api/language/en-GB/install.xml
+++ b/api/language/en-GB/install.xml
@@ -2,8 +2,8 @@
 <extension client="api" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.0.0</version>
-	<creationDate>2023-09</creationDate>
+	<version>5.1.0</version>
+	<creationDate>2023-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/api/language/en-GB/langmetadata.xml
+++ b/api/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="api">
 	<name>English (en-GB)</name>
-	<version>5.0.0</version>
-	<creationDate>2023-09</creationDate>
+	<version>5.1.0</version>
+	<creationDate>2023-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/build.xml
+++ b/build.xml
@@ -85,7 +85,7 @@
 			<arg value="--template" />
 			<arg value="joomla" />
 			<arg value="--title" />
-			<arg value="Joomla! CMS 5.0 API" />
+			<arg value="Joomla! CMS 5.1 API" />
 		</exec>
 	</target>
 

--- a/installation/language/en-GB/langmetadata.xml
+++ b/installation/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="installation">
 	<name>English (United Kingdom)</name>
-	<version>5.0.0</version>
-	<creationDate>2023-09</creationDate>
+	<version>5.1.0</version>
+	<creationDate>2023-10</creationDate>
 	<author>Joomla! Project</author>
 	<copyright>(C) 2005 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -2,8 +2,8 @@
 <extension client="site" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.0.0</version>
-	<creationDate>2023-09</creationDate>
+	<version>5.1.0</version>
+	<creationDate>2023-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/language/en-GB/langmetadata.xml
+++ b/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="site">
 	<name>English (en-GB)</name>
-	<version>5.0.0</version>
-	<creationDate>2023-09</creationDate>
+	<version>5.1.0</version>
+	<creationDate>2023-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -47,7 +47,7 @@ final class Version
      * @var    integer
      * @since  3.8.0
      */
-    public const MINOR_VERSION = 0;
+    public const MINOR_VERSION = 1;
 
     /**
      * Patch release version.
@@ -66,7 +66,7 @@ final class Version
      * @var    string
      * @since  3.8.0
      */
-    public const EXTRA_VERSION = 'rc-dev';
+    public const EXTRA_VERSION = 'alpha1-dev';
 
     /**
      * Development status.
@@ -90,7 +90,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const RELDATE = '26-September-2023';
+    public const RELDATE = '1-October-2023';
 
     /**
      * Release time.
@@ -98,7 +98,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const RELTIME = '16:59';
+    public const RELTIME = '14:07';
 
     /**
      * Release timezone.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joomla",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "Joomla CMS",
   "license": "GPL-2.0-or-later",
   "repository": {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

After the 5.1-dev branch has been branched off from the 5.0-dev branch, it needs an initial version bump so that tools like e.g. `build/build.php` use the right version numbers.

### Testing Instructions

Code review, or run `php build/bump.php -v 5.1.0-alpha1-dev` and check the result.

### Actual result BEFORE applying this Pull Request

The 5.1-dev branch has the same version as the 5.0-dev branch.

### Expected result AFTER applying this Pull Request

The 5.1-dev branch has version `5.1.0-alpha1-dev`.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
