### PR TITLE
Revert "[5.0] Error Pages language (#41934)"

### DIFF
--- a/installation/language/en-GB/joomla.ini
+++ b/installation/language/en-GB/joomla.ini
@@ -6,28 +6,28 @@
 ; Fatal error page
 ; These will be processed by the JavaScript Build
 BUILD_FATAL_HEADER="Sorry, there was a problem we could not recover from."
-BUILD_FATAL_LANGUAGE="English GB"; IMPORTANT NOTE FOR TRANSLATORS: Do not literally translate this line, instead add the localised name of the language. For example French will be Français FR
+BUILD_FATAL_LANGUAGE="English GB"
 BUILD_FATAL_TEXT="The server returned a \"{{statusCode_statusText}}\""
 BUILD_FATAL_URL_TEXT="Help me resolve this"
 
 ; Build incomplete error page
 ; These will be processed by the JavaScript Build
 BUILD_INCOMPLETE_HEADER="Environment Setup Incomplete"
-BUILD_INCOMPLETE_LANGUAGE="English GB"; IMPORTANT NOTE FOR TRANSLATORS: Do not literally translate this line, instead add the localised name of the language. For example French will be Français FR
+BUILD_INCOMPLETE_LANGUAGE="English GB"
 BUILD_INCOMPLETE_TEXT="It looks like you are trying to run Joomla! from our git repository. To do so requires you to complete a couple of extra steps first."
 BUILD_INCOMPLETE_URL_TEXT="More Details"
 
 ; No XML PHP error page
 ; These will be processed by the JavaScript Build
 BUILD_NOXML_HEADER="Sorry, your PHP is missing a vital library"
-BUILD_NOXML_LANGUAGE="English GB"; IMPORTANT NOTE FOR TRANSLATORS: Do not literally translate this line, instead add the localised name of the language. For example French will be Français FR
+BUILD_NOXML_LANGUAGE="English GB"
 BUILD_NOXML_TEXT="Your host needs to use PHP with support for the XML library to run this version of Joomla!"
 BUILD_NOXML_URL_TEXT="Help me resolve this"
 
 ; Minimum PHP error page
 ; These will be processed by the JavaScript Build
 BUILD_MIN_PHP_ERROR_HEADER="Sorry, your PHP version is not supported."
-BUILD_MIN_PHP_ERROR_LANGUAGE="English GB"; IMPORTANT NOTE FOR TRANSLATORS: Do not literally translate this line, instead add the localised name of the language. For example French will be Français FR
+BUILD_MIN_PHP_ERROR_LANGUAGE="English GB"
 BUILD_MIN_PHP_ERROR_TEXT="Your host needs to use PHP version {{phpversion}} or newer to run this version of Joomla."
 BUILD_MIN_PHP_ERROR_URL_TEXT="Help me resolve this"
 


### PR DESCRIPTION
This reverts commit 1d137d590cad96aabc52ec7b38a825965eb3c001.

Pull Request for Issue #42016 .

### Summary of Changes
Removed the comment for translators, better fix would be to update our build tools to support this syntax but for now I revert the change.
