### PR TITLE
[4.4] Fix SQL error in template styles view when using text search together with template filter

### DIFF
--- a/administrator/components/com_templates/src/Model/StylesModel.php
+++ b/administrator/components/com_templates/src/Model/StylesModel.php
@@ -240,12 +240,12 @@ class StylesModel extends ListModel
                 $query->extendWhere(
                     'AND',
                     [
-                        'LOWER(' . $db->quoteName('a.template') . ') LIKE :template',
+                        'LOWER(' . $db->quoteName('a.template') . ') LIKE :templatesearch',
                         'LOWER(' . $db->quoteName('a.title') . ') LIKE :title',
                     ],
                     'OR'
                 )
-                    ->bind(':template', $search)
+                    ->bind(':templatesearch', $search)
                     ->bind(':title', $search);
             }
         }


### PR DESCRIPTION
Pull Request for Issue #42011 .

### Summary of Changes

You shall not bind multiple times with different values to the same bind variable in prepared SQL statements.

The `:template` bind variable is used 2 times in the `getListQuery` method of the StylesModel:
1. Here when the filter by the template is used: https://github.com/joomla/joomla-cms/blob/4.4-dev/administrator/components/com_templates/src/Model/StylesModel.php#L185-L189
2. Here when the search box is used with a text search (i.e. _not_ an ID search with `id:`):
https://github.com/joomla/joomla-cms/blob/4.4-dev/administrator/components/com_templates/src/Model/StylesModel.php#L243

If both is used, the search box and the template filter, the same `:template` variable is bound 2 times with different values.

This PR here fixes that by using different bind variables.

### Testing Instructions

In either the admin or site template styles conduct a search that has no results
Then select a value in the "Template" filter.

### Actual result BEFORE applying this Pull Request

SQL error "The number of variables must match the number of parameters in the prepared statement".

The only way to make the Template Styles view work again is to clear the session cookie.

### Expected result AFTER applying this Pull Request

Still see the no matching results message

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
