### PR TITLE
[5.0] Fix the extra quotes on the static error pages

### DIFF
--- a/build/build-modules-js/error-pages.es6.js
+++ b/build/build-modules-js/error-pages.es6.js
@@ -49,7 +49,7 @@ module.exports.createErrorPages = async (options) => {
       global.unsupportedObj = {
         ...global.unsupportedObj,
         [name]: {
-          language: languageStrings.BUILD_MIN_PHP_ERROR_LANGUAGE,
+          language: Ini.unsafe(languageStrings.BUILD_MIN_PHP_ERROR_LANGUAGE),
           header: languageStrings.BUILD_MIN_PHP_ERROR_HEADER,
           text1: languageStrings.BUILD_MIN_PHP_ERROR_TEXT,
           'help-url-text': languageStrings.BUILD_MIN_PHP_ERROR_URL_TEXT,
@@ -63,7 +63,7 @@ module.exports.createErrorPages = async (options) => {
       global.incompleteObj = {
         ...global.incompleteObj,
         [name]: {
-          language: languageStrings.BUILD_INCOMPLETE_LANGUAGE,
+          language: Ini.unsafe(languageStrings.BUILD_INCOMPLETE_LANGUAGE),
           header: languageStrings.BUILD_INCOMPLETE_HEADER,
           text1: languageStrings.BUILD_INCOMPLETE_TEXT,
           'help-url-text': languageStrings.BUILD_INCOMPLETE_URL_TEXT,
@@ -77,7 +77,7 @@ module.exports.createErrorPages = async (options) => {
       global.fatalObj = {
         ...global.fatalObj,
         [name]: {
-          language: languageStrings.BUILD_FATAL_LANGUAGE,
+          language: Ini.unsafe(languageStrings.BUILD_FATAL_LANGUAGE),
           header: languageStrings.BUILD_FATAL_HEADER,
           text1: languageStrings.BUILD_FATAL_TEXT,
           'help-url-text': languageStrings.BUILD_FATAL_URL_TEXT,
@@ -91,7 +91,7 @@ module.exports.createErrorPages = async (options) => {
       global.noxmlObj = {
         ...global.noxmlObj,
         [name]: {
-          language: languageStrings.BUILD_NOXML_LANGUAGE,
+          language: Ini.unsafe(languageStrings.BUILD_NOXML_LANGUAGE),
           header: languageStrings.BUILD_NOXML_HEADER,
           text1: languageStrings.BUILD_NOXML_TEXT,
           'help-url-text': languageStrings.BUILD_NOXML_URL_TEXT,


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Use the `Ini.unsafe()` to skip the double quotes

### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
