### PR TITLE
[5.0] Set organization as default to activate schemaorg by default

### DIFF
--- a/plugins/system/schemaorg/schemaorg.xml
+++ b/plugins/system/schemaorg/schemaorg.xml
@@ -26,6 +26,7 @@
 					type="list"
 					label="PLG_SYSTEM_SCHEMAORG_BASETYPE_LABEL"
 					description="PLG_SYSTEM_SCHEMAORG_BASETYPE_DESCRIPTION"
+					default="organization"
 					validate="options"
 					required="true"
 					>

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -273,7 +273,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
     public function onBeforeCompileHead(): void
     {
         $app      = $this->getApplication();
-        $baseType = $this->params->get('baseType');
+        $baseType = $this->params->get('baseType', 'organization');
 
         $itemId  = (int) $app->getInput()->getInt('id');
         $option  = $app->getInput()->get('option');
@@ -301,10 +301,10 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
 
         $siteSchema = [];
 
-        $siteSchema['@type'] = ucfirst($this->params->get('baseType'));
+        $siteSchema['@type'] = ucfirst($baseType);
         $siteSchema['@id']   = $baseId;
 
-        $name = $this->params->get('name');
+        $name = $this->params->get('name', $app->get('sitename'));
 
         if ($isPerson && $this->params->get('user') > 0) {
             $user = $this->getUserFactory()->loadUserById($this->params->get('user'));


### PR DESCRIPTION
Pull Request for Issue #42035 .

### Summary of Changes
Set organization as default so by default the schema.org is active.


### Testing Instructions
Migrate from 4.4 or do a fresh install. Have some articles installed (sample data or your own).
Go to blog view, archive, article.


### Actual result BEFORE applying this Pull Request
No rich snippets for articles available.


### Expected result AFTER applying this Pull Request
Rich snippets for articles available.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
