### PR TITLE
[5.0] dark mode - quickicon amount

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_quickicons.scss
@@ -60,6 +60,13 @@
         border-radius: $border-radius;
         transition: all .25s ease;
         margin-inline-start: .5rem;
+        @if $enable-dark-mode {
+          /* stylelint-disable max-nesting-depth */
+          @include color-mode(dark) {
+            /* stylelint-enable max-nesting-depth */
+            color: var(--template-bg-dark-80);
+          }
+        }
       }
 
       .j-links-link {


### PR DESCRIPTION
Pull Request for Issue #42045

### Summary of Changes
The count of items was not visible when in dark mode


### Testing Instructions
For a quickicon change the option to include shopwing the count
Switch to dark mode

as this is an scss change you will need to either use a prebuilt package or `npm run build:css`



### Actual result BEFORE applying this Pull Request
Count is white text on a white background

![image](https://github.com/joomla/joomla-cms/assets/1296369/95cff563-cb89-4f6b-95a7-f006b198706b)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/a9e63eee-cf36-4780-b6b8-aded579a9b0d)


No change to light mode

![image](https://github.com/joomla/joomla-cms/assets/1296369/6de1c078-af9d-49aa-b45b-58d6bb674816)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
