### PR TITLE
[5.0] Installer drag'n drop dark mode a11y

### DIFF
--- a/build/media_source/com_installer/css/installer.css
+++ b/build/media_source/com_installer/css/installer.css
@@ -22,10 +22,6 @@
   transition: all .2s ease 0s;
 }
 
-#dragarea p.lead {
-  color: #999;
-}
-
 #upload-icon {
   width: auto;
   height: auto;
@@ -44,6 +40,12 @@
 #dragarea.hover #upload-icon,
 #dragarea p.lead {
   color: #666;
+}
+
+@media (prefers-color-scheme: dark) {
+  #dragarea p.lead {
+    color: #999;
+  }
 }
 
 .upload-progress, .install-progress {


### PR DESCRIPTION
Pull Request for Issue #41970 .

Steps to reproduce the issue
Go to : administrator/index.php?option=com_installer&view=install

### Before
The text highlighted in red fails the WCAG minimum required colour contrast requirements:

### After
WCAG passed
![image](https://github.com/joomla/joomla-cms/assets/1296369/c92a42b9-b441-4111-9b2a-65e8de997342)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
