### PR TITLE
[5.0] Sample Data Titles contrast a11y

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/pages/_com_cpanel.scss
+++ b/build/media_source/templates/administrator/atum/scss/pages/_com_cpanel.scss
@@ -157,7 +157,7 @@
 
 .sample-data__title {
   font-weight: bold;
-  color: var(--template-bg-dark-50);
+  color: var(--heading-color);
 }
 
 .sample-data__icon {


### PR DESCRIPTION
### Summary of Changes
In the changes to support dark mode the color was changed for the titles of the sample data (highlighted below) which unfortunately fails the contrast checks in both light and dark mode.

This PR addresses that. 

It is NOT the same as it was in j4 to make the dark mode change automatic. Its really a minor thing but as its on the home page it would be highlighted immediately by anyone reviewing joomla for accessibility

@wilsonge you ok with this change. its neither the same as j4 nor your version of atum for j5



### Testing Instructions



### Expected result AFTER applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/1296369/a11ec9c6-8ddf-494a-8224-5e9cf1718207)

![image](https://github.com/joomla/joomla-cms/assets/1296369/2d6251f1-bf69-4da3-a855-3eead1114ea5)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
