### PR TITLE
[5.0] Treeselect dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/_variables.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables.scss
@@ -220,6 +220,7 @@ $input-group-addon-border-color:   var(--template-bg-dark);
 // Treeselect
 $treeselect-line-height:           2.2rem;
 $treeselect-indent:                40px;
+$treeselect-line-color:            var(--template-bg-dark-7);
 
 // List
 $list-group-border-color:          var(--template-bg-dark-15);

--- a/build/media_source/templates/administrator/atum/scss/blocks/_treeselect.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_treeselect.scss
@@ -32,7 +32,7 @@
       height: 1px;
       margin: auto;
       content: "";
-      background-color: rgba(0, 0, 0, .2);
+      background-color: $treeselect-line-color;
     }
 
     &::after {
@@ -43,7 +43,7 @@
       width: 1px;
       height: 100%;
       content: "";
-      background-color: rgba(0, 0, 0, .2);
+      background-color: $treeselect-line-color;
     }
 
     &:last-child {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_treeselect.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_treeselect.scss
@@ -7,7 +7,15 @@
 
   .nav-header {
     font-weight: $font-weight-bold;
-    color: $gray-900;
+    color: var(--template-bg-dark);
+  }
+
+  @if $enable-dark-mode {
+    @include color-mode(dark) {
+      .nav-header {
+        color: var(--body-color);
+      }
+    }
   }
 
   li {


### PR DESCRIPTION
Pull Request for Issue #42055 .

### Summary of Changes
menu name is visible in both light and dark modes


### Testing Instructions

npm run build:css

### Actual result BEFORE applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/1296369/4ab4a28c-0f79-4e1e-8718-18e55222e6a2)


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/ad146c72-44cf-413b-8eee-44a03966c49c)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
