### PR TITLE
[5.0] Remove bs2 classes

### DIFF
--- a/administrator/components/com_users/tmpl/method/edit.php
+++ b/administrator/components/com_users/tmpl/method/edit.php
@@ -49,7 +49,7 @@ $hideSubmit   = !$this->renderOptions['show_submit'] && !$this->isEditExisting
             <?php if (!empty($this->renderOptions['help_url'])) : ?>
             <span class="float-end">
                 <a href="<?php echo $this->renderOptions['help_url'] ?>"
-                   class="btn btn-sm btn-default btn-inverse btn-dark"
+                   class="btn btn-sm btn-dark"
                    target="_blank"
                 >
                     <span class="icon icon-question-sign" aria-hidden="true"></span>

--- a/components/com_users/tmpl/method/edit.php
+++ b/components/com_users/tmpl/method/edit.php
@@ -49,7 +49,7 @@ $hideSubmit   = !$this->renderOptions['show_submit'] && !$this->isEditExisting
             <?php if (!empty($this->renderOptions['help_url'])) : ?>
             <span class="float-end">
                 <a href="<?php echo $this->renderOptions['help_url'] ?>"
-                   class="btn btn-sm btn-default btn-inverse btn-dark"
+                   class="btn btn-sm btn-dark"
                    target="_blank"
                 >
                     <span class="icon icon-question-sign" aria-hidden="true"></span>


### PR DESCRIPTION
This button doesnt appear to be displayed but it is presumably there for a reason

The classes on the button appear to be a remnant from nik's own j3 implementation of this as two of the three are bs2 classes that are not present in bs5 and can be safely removed as they do nothing

Thanks to @wilsonge for pointing this out

Testing only by code review
