### PR TITLE
[5.0] com_templates buttons dark mode

### DIFF
--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -262,10 +262,10 @@ class HtmlView extends BaseHtmlView
             } elseif ($this->type === 'home') {
                 // Add a copy/child template button
                 if (isset($this->template->xmldata->inheritable) && (string) $this->template->xmldata->inheritable === '1') {
-                    ToolbarHelper::modal('childModal', 'icon-copy', 'COM_TEMPLATES_BUTTON_TEMPLATE_CHILD', false);
+                    ToolbarHelper::modal('childModal', 'icon-copy', 'COM_TEMPLATES_BUTTON_TEMPLATE_CHILD');
                 } elseif (empty($this->template->xmldata->parent) && empty($this->template->xmldata->namespace)) {
                     // We can't copy parent templates nor namespaced templates
-                    ToolbarHelper::modal('copyModal', 'icon-copy', 'COM_TEMPLATES_BUTTON_COPY_TEMPLATE', false);
+                    ToolbarHelper::modal('copyModal', 'icon-copy', 'COM_TEMPLATES_BUTTON_COPY_TEMPLATE');
                 }
             }
         }


### PR DESCRIPTION
Adds a btn-primary class to the create child template and copy template buttons

Pull Request for Issue #42067 .

### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/c2be88ff-12e5-4172-b10f-59516e05c31c)

![image](https://github.com/joomla/joomla-cms/assets/1296369/6bb9a0c2-381a-4d48-862c-47ab779d0c28)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
