### PR TITLE
[5.0] code-color dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/_variables-dark.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables-dark.scss
@@ -13,3 +13,6 @@ $form-select-background-rtl-dark:  $form-select-bg-dark $form-select-indicator-r
 
 // Alerts
 $state-info-text-dark:             var(--template-bg-dark-50);
+
+// Code-color override bootstrap for accessibility contrast
+$pink: #d7488b; //used in bootstrap

--- a/build/media_source/templates/administrator/atum/scss/_variables-dark.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables-dark.scss
@@ -15,4 +15,4 @@ $form-select-background-rtl-dark:  $form-select-bg-dark $form-select-indicator-r
 $state-info-text-dark:             var(--template-bg-dark-50);
 
 // Code-color override bootstrap for accessibility contrast
-$pink: #d7488b; //used in bootstrap
+$code-color-dark: #d7488b; //used in bootstrap


### PR DESCRIPTION
Overrides the $pink variable from bootstrap to improve contrast and ensure it meets accessibility contrast standards

Pull Request for Issue #42072 .


### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/f2f72b3d-6bad-4608-ac43-c21f6f5f8734)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
