### PR TITLE
[4.4] Check database version before update

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1162,7 +1162,7 @@ ENDDATA;
 
             $option         = new \stdClass();
             $option->label  = Text::sprintf('INSTL_DATABASE_MIN_VERSION', $dbType, $dbMin);
-            $option->state  = $this->isDatabaseVersionSupported($dbType);
+            $option->state  = $dbMin && version_compare($this->getDatabase()->getVersion(), $dbMin, '>=');
             $option->notice = null;
             $options[]      = $option;
         }
@@ -1282,27 +1282,6 @@ ENDDATA;
         }
 
         return true;
-    }
-
-    /**
-     * Returns true, if database version is compatible with the update.
-     *
-     * @pararm  string  $type  The database type
-     *
-     * @return boolean
-     *
-     * @since __DEPLOY_VERSION__
-     */
-    public function isDatabaseVersionSupported(string $type)
-    {
-        $newVer = $this->getTargetMinimumDatabaseVersion($type);
-        $curVer = $this->getDatabase()->getVersion();
-
-        if (!$newVer) {
-            return false;
-        }
-
-        return version_compare($curVer, $newVer, '>=');
     }
 
     /**

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1319,7 +1319,8 @@ ENDDATA;
     {
         $updateInformation = $this->getUpdateInformation();
 
-        return $updateInformation['object']->supported_databases->$type ?? '';
+        return empty($updateInformation['object']->supported_databases->$type) ?
+            '' : $updateInformation['object']->supported_databases->$type;
     }
 
 

--- a/administrator/language/en-GB/com_joomlaupdate.ini
+++ b/administrator/language/en-GB/com_joomlaupdate.ini
@@ -188,7 +188,7 @@ COM_JOOMLAUPDATE_XML_DESCRIPTION="Updates Joomla to the latest version with one 
 ;Copy of INSTL constants (Pre-Update check)
 INSTL_DATABASE_SUPPORT="Database Support:"
 INSTL_DATABASE_SUPPORTED="Database Supported (%s)"
-INSTL_DATABASE_MIN_VERSION="Database Version (%s => %s)"
+INSTL_DATABASE_MIN_VERSION="Database Version (%s >= %s)"
 INSTL_DISPLAY_ERRORS="Display Errors"
 INSTL_EXTENSION_AVAILABLE="%s Available"
 INSTL_FILE_UPLOADS="File Uploads"

--- a/administrator/language/en-GB/com_joomlaupdate.ini
+++ b/administrator/language/en-GB/com_joomlaupdate.ini
@@ -188,6 +188,7 @@ COM_JOOMLAUPDATE_XML_DESCRIPTION="Updates Joomla to the latest version with one 
 ;Copy of INSTL constants (Pre-Update check)
 INSTL_DATABASE_SUPPORT="Database Support:"
 INSTL_DATABASE_SUPPORTED="Database Supported (%s)"
+INSTL_DATABASE_MIN_VERSION="Database Version (%s => %s)"
 INSTL_DISPLAY_ERRORS="Display Errors"
 INSTL_EXTENSION_AVAILABLE="%s Available"
 INSTL_FILE_UPLOADS="File Uploads"


### PR DESCRIPTION
### Summary of Changes
Check database version before update


### Testing Instructions
set update Minimum Stability to RC
Go to update page,
In overview there will be a new Row about DB Version.

![Screenshot 2023-10-07_14-01-08](https://github.com/joomla/joomla-cms/assets/1568198/ebc9eb38-4a50-4e44-95f9-921f998cd844)


Then, edit https://github.com/joomla/joomla-cms/blob/ce0ea351e8655be2474121220ae76227b9eccd09/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php#L1155
Change to `$dbMin  =  '9.0.0';`

And open the update page again.
The row with database version should show  "No" in "Checked" column


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
