### PR TITLE
[5.0] Fix SCSS CS broken by PR #42078

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_custom-forms.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/bootstrap/_custom-forms.scss
@@ -13,7 +13,7 @@
 
   &[multiple] {
     padding: 0;
-    
+
     option {
       padding: $form-select-multiple-padding-y $form-select-padding-x;
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix broken scss-cs test in drone caused by PR #42078 .

I only can recommend to use editors which show white space (tabs and spaces), like e.g. notepad++, or to adjust your IDE to show them or to use a good editor. And maybe switch off automatic indentation on new lines in your editor because that is what causes this issue (spaces in empty lines).

And to maintainers or release managers I only can recommend to check drone and appveyor logs before merging PRs.

### Testing Instructions

Check logs of the scss-cs step in drone.

### Actual result BEFORE applying this Pull Request

The scss-cs step fails in drone for the 5.0-dev branch since PR #42078 has been merged.

### Expected result AFTER applying this Pull Request

The scss-cs step succeeds in drone for the branch of this PR.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
