### PR TITLE
[5.0] Check if the value consist with id:alias, extract the id only

### DIFF
--- a/administrator/components/com_content/src/Field/Modal/ArticleField.php
+++ b/administrator/components/com_content/src/Field/Modal/ArticleField.php
@@ -52,6 +52,12 @@ class ArticleField extends ModalSelectField
      */
     public function setup(\SimpleXMLElement $element, $value, $group = null)
     {
+        // Check if the value consist with id:alias, extract the id only
+        if ($value && str_contains($value, ':')) {
+            [$id]  = explode(':', $value, 2);
+            $value = (int) $id;
+        }
+
         $result = parent::setup($element, $value, $group);
 
         if (!$result) {

--- a/administrator/components/com_menus/src/Field/Modal/MenuField.php
+++ b/administrator/components/com_menus/src/Field/Modal/MenuField.php
@@ -145,6 +145,12 @@ class MenuField extends ModalSelectField
      */
     public function setup(\SimpleXMLElement $element, $value, $group = null)
     {
+        // Check if the value consist with id:alias, extract the id only
+        if ($value && str_contains($value, ':')) {
+            [$id]  = explode(':', $value, 2);
+            $value = (int) $id;
+        }
+
         $return = parent::setup($element, $value, $group);
 
         if (!$return) {


### PR DESCRIPTION
Pull Request for Issue #42087 .

### Summary of Changes

The language association value stored as `id:alias`, however in j4 it was cast to `int` https://github.com/joomla/joomla-cms/blob/1e7527b60ec42032abe7bfb9c000bacf38f65845/administrator/components/com_content/src/Field/Modal/ArticleField.php#L61 that was not obvious change, but that affects evrything.
I have made it a bit more explicit in the afected fields


### Testing Instructions
Please follow #42087


### Actual result BEFORE applying this Pull Request
An error


### Expected result AFTER applying this Pull Request
No error


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Reference:
- https://github.com/joomla/joomla-cms/pull/40462