### PR TITLE
[5.0] Fix language association "clear" button

### DIFF
--- a/build/media_source/com_associations/js/sidebyside.es5.js
+++ b/build/media_source/com_associations/js/sidebyside.es5.js
@@ -46,10 +46,11 @@ jQuery(document).ready(function($) {
       // Remove it on the target
       $('#jform_itemlanguage option').each(function()
       {
-        lang = $(this).val().split('|')[0];
+        lang = $(this).val().split(':')[0];
 
-        if (typeof lang !== 'undefined') {
+        if (lang) {
           lang = lang.replace(/-/,'_');
+
           // - For modal association selectors.
           target.find('#jform_associations_' + lang + '_id').val('');
           // - For chosen association selectors (menus).


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/42087#issuecomment-1751978217 .

### Summary of Changes

The language option has values separated with `:`, but the JS code was looking for `|`.
https://github.com/joomla/joomla-cms/blob/c608616220da9ee346292e5a2c51ed327cb05a2f/administrator/components/com_associations/src/Field/ItemlanguageField.php#L83

### Testing Instructions
Run `npm install`
Edit association "side by side" for existing association,
Push "clear" button


### Actual result BEFORE applying this Pull Request
Nothing happen


### Expected result AFTER applying this Pull Request
Association removed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
