### PR TITLE
[5.0] Media manager list view parity

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/table/row.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/table/row.vue
@@ -6,6 +6,19 @@
     @click="onClick"
   >
     <td
+      v-if="item.mime_type === 'image/svg+xml' && getURL()"
+    >
+      <img
+        :src="getURL()"
+        :width="item.width"
+        :height="item.height"
+        alt=""
+        style="width:100%;height:auto"
+        @load="setSize"
+      >
+    </td>
+    <td
+      v-else
       class="type"
       :data-type="item.extension"
     />
@@ -31,6 +44,7 @@
 </template>
 
 <script>
+import api from '../../../app/Api.es6';
 import * as types from '../../../store/mutation-types.es6';
 import navigable from '../../../mixins/navigable.es6';
 
@@ -67,6 +81,30 @@ export default {
   },
 
   methods: {
+    getURL() {
+      if (!this.item.thumb_path) {
+        return '';
+      }
+
+      return this.item.thumb_path.split(Joomla.getOptions('system.paths').rootFull).length > 1
+        ? `${this.item.thumb_path}?${this.item.modified_date ? new Date(this.item.modified_date).valueOf() : api.mediaVersion}`
+        : `${this.item.thumb_path}`;
+    },
+    width() {
+      return this.item.naturalWidth ? this.item.naturalWidth : 300;
+    },
+    height() {
+      return this.item.naturalHeight ? this.item.naturalHeight : 150;
+    },
+    setSize(event) {
+      if (this.item.mime_type === 'image/svg+xml') {
+        const image = event.target;
+        // Update the item properties
+        this.$store.dispatch('updateItemProperties', { item: this.item, width: image.naturalWidth ? image.naturalWidth : 300, height: image.naturalHeight ? image.naturalHeight : 150 });
+        // @TODO Remove the fallback size (300x150) when https://bugzilla.mozilla.org/show_bug.cgi?id=1328124 is fixed
+        // Also https://github.com/whatwg/html/issues/3510
+      }
+    },
     /* Handle the on row double click event */
     onDblClick() {
       if (this.isDir) {

--- a/build/media_source/com_media/scss/components/_media-browser.scss
+++ b/build/media_source/com_media/scss/components/_media-browser.scss
@@ -374,6 +374,15 @@
       visibility: hidden;
     }
   }
+
+  .selected {
+    background-color: $table-item-icon-bg-selected;
+
+    > td,
+    > th {
+      background-color: $table-item-icon-bg-selected;
+    }
+  }
 }
 
 .action-toggle {


### PR DESCRIPTION
Pull Request for Issue #42101 .

### Problem

- SVG images inserted using the list view have zero width/height

### Summary of Changes

- The list view doesn't have the same data as the thumbnail view. SVG files need to be rendered to get the naturalHeight/naturalWidth
- The selected item styling for the List view now applies the background colour to the whole row: 
<img width="1407" alt="Screenshot 2023-10-11 at 21 59 09" src="https://github.com/joomla/joomla-cms/assets/3889375/9b2e16f1-173c-4316-b2ac-2546456d196c">

### Testing Instructions

- Try to insert an svg into the intro image **FROM THE LIST VIEW**
- Observe that the width and height parts at the end of the URL are not `0`

### Actual result BEFORE applying this Pull Request

Selecting an SVG image either from Grid view or List view *DOESN'T* yield the same URL

### Expected result AFTER applying this Pull Request

Selecting an SVG image either from Grid view or List view should yield the same URL

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed



@laoneo 