### PR TITLE
Private Messages default template remove bg-light class

### DIFF
--- a/administrator/components/com_messages/tmpl/message/default.php
+++ b/administrator/components/com_messages/tmpl/message/default.php
@@ -27,7 +27,7 @@ $wa->useScript('core');
                     <div class="control-label">
                         <?php echo Text::_('COM_MESSAGES_FIELD_USER_ID_FROM_LABEL'); ?>
                     </div>
-                    <div class="p-3 bg-light border rounded">
+                    <div class="p-3 border rounded">
                         <?php echo $this->item->get('from_user_name'); ?>
                     </div>
                 </div>
@@ -35,7 +35,7 @@ $wa->useScript('core');
                     <div class="control-label">
                         <?php echo Text::_('COM_MESSAGES_FIELD_DATE_TIME_LABEL'); ?>
                     </div>
-                    <div class="p-3 bg-light border rounded">
+                    <div class="p-3 border rounded">
                         <?php echo HTMLHelper::_('date', $this->item->date_time, Text::_('DATE_FORMAT_LC2')); ?>
                     </div>
                 </div>
@@ -43,7 +43,7 @@ $wa->useScript('core');
                     <div class="control-label">
                         <?php echo Text::_('COM_MESSAGES_FIELD_SUBJECT_LABEL'); ?>
                     </div>
-                    <div class="p-3 bg-light border rounded">
+                    <div class="p-3 border rounded">
                         <?php echo $this->item->subject; ?>
                     </div>
                 </div>
@@ -51,7 +51,7 @@ $wa->useScript('core');
                     <div class="control-label">
                         <?php echo Text::_('COM_MESSAGES_FIELD_MESSAGE_LABEL'); ?>
                     </div>
-                    <div class="p-3 bg-light border rounded">
+                    <div class="p-3 border rounded">
                         <?php echo $this->item->message; ?>
                     </div>
                 </div>

--- a/administrator/components/com_messages/tmpl/message/default.php
+++ b/administrator/components/com_messages/tmpl/message/default.php
@@ -27,7 +27,7 @@ $wa->useScript('core');
                     <div class="control-label">
                         <?php echo Text::_('COM_MESSAGES_FIELD_USER_ID_FROM_LABEL'); ?>
                     </div>
-                    <div class="p-3 border rounded">
+                    <div class="p-3 bg-readonly border rounded">
                         <?php echo $this->item->get('from_user_name'); ?>
                     </div>
                 </div>
@@ -35,7 +35,7 @@ $wa->useScript('core');
                     <div class="control-label">
                         <?php echo Text::_('COM_MESSAGES_FIELD_DATE_TIME_LABEL'); ?>
                     </div>
-                    <div class="p-3 border rounded">
+                    <div class="p-3 bg-readonly border rounded">
                         <?php echo HTMLHelper::_('date', $this->item->date_time, Text::_('DATE_FORMAT_LC2')); ?>
                     </div>
                 </div>
@@ -43,7 +43,7 @@ $wa->useScript('core');
                     <div class="control-label">
                         <?php echo Text::_('COM_MESSAGES_FIELD_SUBJECT_LABEL'); ?>
                     </div>
-                    <div class="p-3 border rounded">
+                    <div class="p-3 bg-readonly border rounded">
                         <?php echo $this->item->subject; ?>
                     </div>
                 </div>
@@ -51,7 +51,7 @@ $wa->useScript('core');
                     <div class="control-label">
                         <?php echo Text::_('COM_MESSAGES_FIELD_MESSAGE_LABEL'); ?>
                     </div>
-                    <div class="p-3 border rounded">
+                    <div class="p-3 bg-readonly border rounded">
                         <?php echo $this->item->message; ?>
                     </div>
                 </div>

--- a/build/media_source/templates/administrator/atum/scss/_variables-dark.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables-dark.scss
@@ -1,6 +1,7 @@
 $atum-colors-dark: (
   template-quickicon-color:        var(--template-bg-dark-5),
   focus-shadow:                    var(--gray-800),
+  bg-readonly:                     var(--gray-800),
 ) !default;
 
 $link-hover-color-dark: lighten($light-blue, 20%);

--- a/build/media_source/templates/administrator/atum/scss/_variables.scss
+++ b/build/media_source/templates/administrator/atum/scss/_variables.scss
@@ -84,6 +84,8 @@ $atum-colors: (
   template-bg-dark-75:             hsl(var(--hue), 40%, 25%),
   template-bg-dark-80:             hsl(var(--hue), 40%, 20%),
   template-bg-dark-90:             hsl(var(--hue), 40%, 10%),
+
+  bg-readonly:                     var(--gray-200),
 );
 
 $colors: (
@@ -112,6 +114,7 @@ $alert-color-level:                0;
 // Global
 $atum-box-shadow:                  0 2px 10px -8px var(--template-bg-dark-50);
 $btn-disabled-opacity:             .4;
+$bg-readonly:                      var(--bg-readonly);
 
 // Toolbar
 $atum-toolbar-line-height:         2.45rem;

--- a/build/media_source/templates/administrator/atum/scss/template.scss
+++ b/build/media_source/templates/administrator/atum/scss/template.scss
@@ -228,6 +228,10 @@
   background-color: var(--white) !important;
 }
 
+.bg-readonly {
+  background-color: var(--bg-readonly) !important;
+}
+
 .bg-body {
   background-color: var(--body-bg) !important;
 }


### PR DESCRIPTION
Pull Request for Issue #42121

### Summary of Changes

bg-light class removed from div classes

### Testing Instructions

send a private message - read the private message

### Actual result BEFORE applying this Pull Request

light background in dark mode hard to read text

### Expected result AFTER applying this Pull Request

normal background


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ x] No documentation changes for manual.joomla.org needed
