### PR TITLE
Update Uri.php

### DIFF
--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -86,7 +86,7 @@ class Uri extends \Joomla\Uri\Uri
                 if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['PATH_INFO']) && !empty($_SERVER['QUERY_STRING'])) {
 
                     // Convert browser url to uqery string url according to ReWrite rule
-                    $theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['PATH_INFO'] . '?' . $_SERVER['QUERY_STRING'];;
+                    $theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['PATH_INFO'] . '?' . $_SERVER['QUERY_STRING'];
 
                 } else if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['REQUEST_URI'])) {
                     // To build the entire URI we need to prepend the protocol, and the http host

--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -83,7 +83,12 @@ class Uri extends \Joomla\Uri\Uri
                  * are present, we will assume we are running on apache.
                  */
 
-                if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['REQUEST_URI'])) {
+                if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['PATH_INFO']) && !empty($_SERVER['QUERY_STRING'])) {
+
+                    // Convert browser url to uqery string url according to ReWrite rule
+                    $theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['PATH_INFO'] . '?' . $_SERVER['QUERY_STRING'];;
+
+                } else if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['REQUEST_URI'])) {
                     // To build the entire URI we need to prepend the protocol, and the http host
                     // to the URI string.
                     $theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];

--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -86,7 +86,7 @@ class Uri extends \Joomla\Uri\Uri
                 if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['PATH_INFO']) && !empty($_SERVER['QUERY_STRING'])) {
                     // Convert browser url to query string url according to ReWrite rule
                     $theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['PATH_INFO'] . '?' . $_SERVER['QUERY_STRING'];
-                } else if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['REQUEST_URI'])) {
+                } elseif (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['REQUEST_URI'])) {
                     // To build the entire URI we need to prepend the protocol, and the http host
                     // to the URI string.
                     $theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];

--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -84,10 +84,8 @@ class Uri extends \Joomla\Uri\Uri
                  */
 
                 if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['PATH_INFO']) && !empty($_SERVER['QUERY_STRING'])) {
-
-                    // Convert browser url to uqery string url according to ReWrite rule
+                    // Convert browser url to query string url according to ReWrite rule
                     $theURI = 'http' . $https . $_SERVER['HTTP_HOST'] . $_SERVER['PATH_INFO'] . '?' . $_SERVER['QUERY_STRING'];
-
                 } else if (!empty($_SERVER['PHP_SELF']) && !empty($_SERVER['REQUEST_URI'])) {
                     // To build the entire URI we need to prepend the protocol, and the http host
                     // to the URI string.


### PR DESCRIPTION
Pull Request for Issue #42123 .

### Summary of Changes

This change is to fix Joomla router unable to parse custom SEF url. The SEF url has a rewrite rule defined in .htaccess. where the SEF url need to be converted to dynamic url with query string.

The affected function is Uri::getInstance() in libraries/src/Uri directory.


### Testing Instructions

1. create an article "foo-article" and a menu "foo-menu". The "foo-menu" will accept query string, such as

  q=xyz&dir=abc&name=ijk

2. The browser url will look like http://localhost/foo-menu/xyz/abc/ijk.html

3. In .htaccess, add re-write rule below

RewriteRule ^foo-menu/(.*)/(.*)/(.*).html$ index.php/foo-menu?q=$1&dir=$2&name=$3 [NC,L]

4. According to the .htaccess, the browser url needs be converted to

http://localhost/foo-menu?q=xyz&dir=abc&name=ijk

5. The new url can then be passed into the Joomla router for menu entry lookup, resulting in correct parameters being sent to the menu for further processing.

### Actual result BEFORE applying this Pull Request

The .htaccess rewrite rule is not applied prior to calling Joomla's router. A custom router is required.


### Expected result AFTER applying this Pull Request

The rewrite rule in the ,htaccess is the custom router, dynamic url is generated before calling Joomla router. No extra custom router is needed.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ x] No documentation changes for manual.joomla.org needed

### Code changes
Code changes have been uploaded as "Uri.txt"  in the issue tracker at https://issues.joomla.org/tracker/joomla-cms/42123
