### PR TITLE
[5.0] Remove template special color from core use

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
@@ -79,7 +79,7 @@
     }
 
     &.btn-secondary {
-      --subhead-btn-accent: var(--template-special-color);
+      --subhead-btn-accent: var(--secondary-bg);
     }
 
     &.btn-info {


### PR DESCRIPTION
### Summary of Changes
Removes the last usage of template special color from core in anticipation of it's full removal in a future joomla version with https://github.com/joomla/joomla-cms/pull/42017

### Testing Instructions
There is no usage of this button in core. However it's possible third party extensions might use this. You can simulate by replacing a toolbar button class to `btn-secondary` instead of an existing class such as `btn-info`

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
