### PR TITLE
[5.0] Add proper error handling for public folder cli installation

### DIFF
--- a/installation/src/Console/InstallCommand.php
+++ b/installation/src/Console/InstallCommand.php
@@ -175,6 +175,8 @@ class InstallCommand extends AbstractCommand
             $cleanupModel = $app->getMVCFactory()->createModel('Cleanup', 'Installation');
 
             if (!$cleanupModel->deleteInstallationFolder()) {
+                $this->ioStyle->error('Unable to delete installation folder!');
+
                 return Command::FAILURE;
             }
 
@@ -184,7 +186,11 @@ class InstallCommand extends AbstractCommand
         if (!empty($cfg['public_folder'])) {
             $this->ioStyle->write('Creating the public folder...');
 
-            if (!(new PublicFolderGeneratorHelper())->createPublicFolder($cfg['public_folder'])) {
+            try {
+                (new PublicFolderGeneratorHelper())->createPublicFolder($cfg['public_folder']);
+            } catch (\Exception $e) {
+                $this->ioStyle->error($e->getMessage());
+
                 return Command::FAILURE;
             }
 


### PR DESCRIPTION
### Summary of Changes
`PublicFolderGeneratorHelper::createPublicFolder()`  returns void but throw exception


### Testing Instructions
Install with cli and public folder


### Actual result BEFORE applying this Pull Request
Execution stops after
`Creating the public folder...` (no new line)
reason for this is `createPublicFolder()` returns void which converts to false and ends with `Command::FAILURE` you Don't get a success message


### Expected result AFTER applying this Pull Request
You get a success message after cli installation with public folder.

