### PR TITLE
[5.0] Update min PHP requirement to 8.1in installation CLI

### DIFF
--- a/installation/joomla.php
+++ b/installation/joomla.php
@@ -14,7 +14,7 @@
 /**
  * Define the application's minimum supported PHP version as a constant so it can be referenced within the application.
  */
-\define('JOOMLA_MINIMUM_PHP', '7.2.5');
+\define('JOOMLA_MINIMUM_PHP', '8.1.0');
 
 if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<')) {
     echo 'Sorry, your PHP version is not supported.' . PHP_EOL;


### PR DESCRIPTION
### Summary of Changes

This increases the minimum PHP version to 8.1 for the CLI installer

### Testing Instructions

Run a fresh installation via CLI and a PHP version below 8.1

### Actual result BEFORE applying this Pull Request

No clean error message

### Expected result AFTER applying this Pull Request

Clean error message
