### PR TITLE
FIX calendar picker if weeknumbers hidden and time format 24h

### DIFF
--- a/build/media_source/system/js/fields/calendar.es5.js
+++ b/build/media_source/system/js/fields/calendar.es5.js
@@ -779,16 +779,27 @@
 					cell.colSpan = 1;
 				}
 
-				H.addEventListener("change", function (event) {
-					self.updateTime(event.target.parentNode.parentNode.childNodes[1].childNodes[0].value,
-						event.target.parentNode.parentNode.childNodes[2].childNodes[0].value,
-						event.target.parentNode.parentNode.childNodes[3].childNodes[0].value);
-				}, false);
-				M.addEventListener("change", function (event) {
-					self.updateTime(event.target.parentNode.parentNode.childNodes[1].childNodes[0].value,
-						event.target.parentNode.parentNode.childNodes[2].childNodes[0].value,
-						event.target.parentNode.parentNode.childNodes[3].childNodes[0].value);
-				}, false);
+				if (self.params.weekNumbers) {
+					H.addEventListener("change", function (event) {
+						self.updateTime(event.target.parentNode.parentNode.childNodes[1].childNodes[0].value,
+							event.target.parentNode.parentNode.childNodes[2].childNodes[0].value,
+							event.target.parentNode.parentNode.childNodes[3].childNodes[0].value);
+					}, false);
+					M.addEventListener("change", function (event) {
+						self.updateTime(event.target.parentNode.parentNode.childNodes[1].childNodes[0].value,
+							event.target.parentNode.parentNode.childNodes[2].childNodes[0].value,
+							event.target.parentNode.parentNode.childNodes[3].childNodes[0].value);
+					}, false);
+				} else {
+					H.addEventListener("change", function (event) {
+						self.updateTime(event.target.parentNode.parentNode.childNodes[1].childNodes[0].value,
+							event.target.parentNode.parentNode.childNodes[2].childNodes[0].value);
+					}, false);
+					M.addEventListener("change", function (event) {
+						self.updateTime(event.target.parentNode.parentNode.childNodes[1].childNodes[0].value,
+							event.target.parentNode.parentNode.childNodes[2].childNodes[0].value);
+					}, false);
+				}
 			})();
 		}
 


### PR DESCRIPTION
Pull Request for Issue introduced (by me 🥇 ) in PR #40761.

Affected Joomla versions: 4.4.0 and 5.0.0

### Summary of Changes
Quick FIX
Check if weeknumbers is true or false to listen to correct number of childNodes.
Calendar form field with 12h (AM/PM) time format is not affected by the issue, as well as calendar picker with week numbers (so Joomla core not affected).


### Testing Instructions
Set 2 form fields of type calendar like this (with and without week numbers):

_Note: default timeformat is 24 and dedault weeknumbers is true._
```
<field
	name="no_week_numbers"
	type="calendar"
	label="Test"
	description="Test without weeknumbers and time 24h"
	showtime="true"
	weeknumbers="false"
/>

<field
	name="week_numbers"
	type="calendar"
	label="Test"
	description="Test with weeknumbers and time 24h"
	showtime="true"
/>
```


### Actual result BEFORE applying this Pull Request
You can't change Time (hour and/or minutes) with the `no_week_numbers` calendar picker.
It's working with the other form field.


### Expected result AFTER applying this Pull Request
It's working in both cases.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
