### PR TITLE
[4.4] Update phpseclib/phpseclib PHP dependency to fix issue with JIT on Windows 11

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3193,16 +3193,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.23",
+            "version": "3.0.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "866cc78fbd82462ffd880e3f65692afe928bed50"
+                "reference": "33fa69b2514a61138dd48e7a49f99445711e0ad0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/866cc78fbd82462ffd880e3f65692afe928bed50",
-                "reference": "866cc78fbd82462ffd880e3f65692afe928bed50",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/33fa69b2514a61138dd48e7a49f99445711e0ad0",
+                "reference": "33fa69b2514a61138dd48e7a49f99445711e0ad0",
                 "shasum": ""
             },
             "require": {
@@ -3283,7 +3283,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.23"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.33"
             },
             "funding": [
                 {
@@ -3299,7 +3299,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-09-18T17:22:01+00:00"
+            "time": "2023-10-21T14:00:39+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
Pull Request for Issue #42142 .

### Summary of Changes

This pull request (PR) updates the composer dependency "phpseclib/phpseclib" from version 3.0.23 to the just released version 3.0.33. Despite of the increase of the patch version by 10 it is the next version after 3.0.23. See https://github.com/phpseclib/phpseclib/releases .

This solves issue #42142 .

According to their list of changes for that release it doesn't seem to include any breaking changes, only bugfixes.

### Testing Instructions

It needs Windows 11 and [just-in-time (JIT) compilation](https://en.wikipedia.org/wiki/Just-in-time_compilation) enabled.

Install Joomla.

Check that everything works as expected.

### Actual result BEFORE applying this Pull Request

Execution fails with exception "JIT on Windows is not currently supported"
caused by "../libraries/vendor/phpseclib/phpseclib/bootstrap.php" at line 24

### Expected result AFTER applying this Pull Request

Site (frontend) and admin (backend) work as expected.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
