### PR TITLE
fix #42191 Unknown column 'id' in 'field list'

### DIFF
--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -182,7 +182,7 @@ class InstallerScript
                 ->from($db->quoteName('#__modules'))
                 ->where($db->quoteName('module') . ' = :extension');
         } else {
-            $query->select($db->quoteName('extension_id') . ' AS id')
+            $query->select($db->quoteName('extension_id', 'id'))
                 ->from($db->quoteName('#__extensions'))
                 ->where($db->quoteName('element') . ' = :extension');
         }

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -177,13 +177,13 @@ class InstallerScript
         $query = $db->getQuery(true);
 
         // Select the item(s) and retrieve the id
-        $query->select($db->quoteName('id'));
-
         if ($isModule) {
-            $query->from($db->quoteName('#__modules'))
+            $query->select($db->quoteName('id'))
+                ->from($db->quoteName('#__modules'))
                 ->where($db->quoteName('module') . ' = :extension');
         } else {
-            $query->from($db->quoteName('#__extensions'))
+            $query->select($db->quoteName('extension_id') . ' AS id')
+                ->from($db->quoteName('#__extensions'))
                 ->where($db->quoteName('element') . ' = :extension');
         }
 


### PR DESCRIPTION
In this method it tries to load the field 'id' from the extensions table. But there isn't any field called id in this table. The id field for the extenions table is called extension_id

Pull Request for Issue #42191 .

### Summary of Changes
Moved the select id statement into the module if clause and create a new select extension_id as id clause for the else branch


### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
