### PR TITLE
[5.0] Event PrepareModuleList use "loaded" flag

### DIFF
--- a/libraries/src/Event/Module/AfterCleanModuleListEvent.php
+++ b/libraries/src/Event/Module/AfterCleanModuleListEvent.php
@@ -16,7 +16,7 @@ namespace Joomla\CMS\Event\Module;
 /**
  * Class for Module events.
  * Example:
- *  new AfterCleanModuleListEvent('onEventName', ['subject' => $modules]);
+ *  new AfterCleanModuleListEvent('onEventName', ['modules' => $modules]);
  *
  * @since  5.0.0
  */

--- a/libraries/src/Event/Module/AfterModuleListEvent.php
+++ b/libraries/src/Event/Module/AfterModuleListEvent.php
@@ -16,7 +16,7 @@ namespace Joomla\CMS\Event\Module;
 /**
  * Class for Module events.
  * Example:
- *  new AfterModuleListEvent('onEventName', ['subject' => $modules]);
+ *  new AfterModuleListEvent('onEventName', ['modules' => $modules]);
  *
  * @since  5.0.0
  */

--- a/libraries/src/Event/Module/PrepareModuleListEvent.php
+++ b/libraries/src/Event/Module/PrepareModuleListEvent.php
@@ -16,10 +16,73 @@ namespace Joomla\CMS\Event\Module;
 /**
  * Class for Module events.
  * Example:
- *  new AfterModuleListEvent('onEventName', ['subject' => $modules]);
+ *  new AfterModuleListEvent('onEventName', ['modules' => $modules, 'loaded' => false]);
  *
  * @since  5.0.0
  */
 class PrepareModuleListEvent extends ModuleListEvent
 {
+    /**
+     * The argument names, in order expected by legacy plugins.
+     *
+     * @var array
+     *
+     * @since  __DEPLOY_VERSION__
+     * @deprecated 5.0 will be removed in 6.0
+     */
+    protected $legacyArgumentsOrder = ['modules', 'loaded', 'subject'];
+
+    /**
+     * Setter for the loaded argument.
+     *
+     * @param   ?bool  $value  The value to set
+     *
+     * @return  ?bool
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function onSetLoaded(?bool $value): ?bool
+    {
+        return $value;
+    }
+
+    /**
+     * Getter for the loaded argument.
+     *
+     * @return  bool
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function onGetLoaded(): bool
+    {
+        return $this->arguments['loaded'] ?? false;
+    }
+
+    /**
+     * Getter for the loaded argument.
+     *
+     * @return  bool
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getLoaded(): bool
+    {
+        return $this->onGetLoaded();
+    }
+
+    /**
+     * Update the loaded value.
+     *
+     * @param   bool  $value  The value to set
+     *
+     * @return  static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function setLoaded(bool $value): static
+    {
+        $this->arguments['loaded'] = $this->onSetLoaded($value);
+
+        return $this;
+    }
 }

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -375,12 +375,15 @@ abstract class ModuleHelper
         $dispatcher = Factory::getApplication()->getDispatcher();
         $modules    = [];
 
-        $modules = $dispatcher->dispatch('onPrepareModuleList', new Module\PrepareModuleListEvent('onPrepareModuleList', [
+        $event = $dispatcher->dispatch('onPrepareModuleList', new Module\PrepareModuleListEvent('onPrepareModuleList', [
             'modules' => &$modules, // @todo: Remove reference in Joomla 6, see PrepareModuleListEvent::__constructor()
-        ]))->getArgument('modules', $modules);
+            'loaded'  => false,
+        ]));
+        $modules = $event->getArgument('modules', $modules);
+        $loaded  = $event->getArgument('loaded');
 
         // If the onPrepareModuleList event returns an array of modules, then ignore the default module list creation
-        if (!$modules) {
+        if (!$modules && !$loaded) {
             $modules = static::getModuleList();
         }
 


### PR DESCRIPTION
Pull Request for Issue #42149 .

### Summary of Changes

Kind of b/c fix.
Adding a "loaded" flag to be able to distinct initialised $modules array from empty.
And fixed some comments.


### Testing Instructions
Add to sytem plugin the event listener:
```php
public function onPrepareModuleList(\Joomla\CMS\Event\Module\PrepareModuleListEvent $event)
{
  $event->updateModules([]);
  $event->setLoaded(true);
}
```
Example add it around here https://github.com/joomla/joomla-cms/blob/4c799de22c35981eb8373d3a7cfaa276b505275a/plugins/system/sef/src/Extension/Sef.php#L26-L27

And visit the site page.


### Actual result BEFORE applying this Pull Request
All modules is rendered 


### Expected result AFTER applying this Pull Request
No modules is rendered, only content is rendered


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
