### PR TITLE
Changes to AbstractView.php

### DIFF
--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -125,14 +125,15 @@ abstract class AbstractView extends CMSObject implements ViewInterface, Dispatch
     /**
      * Method to get data from a registered model or a property of the view
      *
-     * @param   string  $property  The name of the method to call on the model or the property to get
-     * @param   string  $default   The name of the model to reference or the default value [optional]
+     * @param   string  $property   The name of the method to call on the model or the property to get
+     * @param   string  $default    The name of the model to reference or the default value [optional]
+     * @param   mixed   $parameters Arguments for the method to call with
      *
      * @return  mixed  The return value of the method
      *
      * @since   3.0
      */
-    public function get($property, $default = null)
+    public function get($property, $default = null, ...$parameters)
     {
         // If $model is null we use the default model
         if ($default === null) {
@@ -149,7 +150,7 @@ abstract class AbstractView extends CMSObject implements ViewInterface, Dispatch
             // Does the method exist?
             if (method_exists($this->_models[$model], $method)) {
                 // The method exists, let's call it and return what we get
-                return $this->_models[$model]->$method();
+                return $this->_models[$model]->$method(...$parameters);
             }
         }
 

--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -159,6 +159,31 @@ abstract class AbstractView extends CMSObject implements ViewInterface, Dispatch
     }
 
     /**
+     * Method to get all data fields from a registerd model or a property of the view.
+     *
+     * @param string      $default The name of the model to reference or the default value [optional]
+     * @param ?string $property The name of the model to reference or the default value [optional]
+     *
+     * @return  mixed  The return value of the method
+     *
+     * @since   4.4
+     */
+    public function getAll($default, $property) {
+        // Create manual property based on the name of the model, if a specific property is not set
+        // E.g. if $default is article, $property will be set to Articles
+        if (!isset($property)) {
+            if (str_ends_with($property, "y")) {
+                $property = substr($property, 0, -1) . "ies";
+            } else {
+                $property = $property . "s";
+            }
+        }
+        $property = ucfirst($property);
+
+        return $this->get($property, $default);
+    }
+
+    /**
      * Method to get the model object
      *
      * @param   string  $name  The name of the model (optional)

--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -168,14 +168,15 @@ abstract class AbstractView extends CMSObject implements ViewInterface, Dispatch
      *
      * @since   4.4
      */
-    public function getAll($default, $property) {
+    public function getAll($default, $property)
+    {
         // Create manual property based on the name of the model, if a specific property is not set
         // E.g. if $default is article, $property will be set to Articles
         if (!isset($property)) {
-            if (str_ends_with($property, "y")) {
-                $property = substr($property, 0, -1) . "ies";
+            if (str_ends_with($default, "y")) {
+                $property = substr($default, 0, -1) . "ies";
             } else {
-                $property = $property . "s";
+                $property = $default . "s";
             }
         }
         $property = ucfirst($property);


### PR DESCRIPTION
### Summary of Changes

I've added to methods to the Joomla\CMS\MVC\View\AbstractView Class:
 - Added `$properties` to `get` method. If you want to also provide properties to the model method, you can use other 
parameters after the $properties and $default parameter. Until now, you could only call a method of a model with specific properties by accessing the model diretly:
`$this->getModel("Article")->getById($id)`
But now you can just use the `get` method:
`$this->get("ById", "Article", $id)`
 - Added new method `getAll` as a shorthand to get all Data of a Model. Until now, you could also only call a method to display all data via the model directly:
`$this->getModel("Article")->getArticles()`
Now you can just use the `getAll` method:
`$this->getAll("Article")` -> `$this->get("Articles, "Article")
If you have a specific list function (e.g. getAllArticles), you can also provide a second parameter $property, otherwise the model name will automatically be transformed into a plural noun.
`$this->getAll("Article", "Fields")` -> `$this->get("Fields", "Article")`

### Testing Instructions

s. above.

### Actual result BEFORE applying this Pull Request

Accessing the model directly in Views needed to call specific methods

### Expected result AFTER applying this Pull Request

More convenient methods in AbstractView

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
