### PR TITLE
[5.0] Load Behaviour - Backward Compatibility in the ConsoleApplication

### DIFF
--- a/libraries/src/Application/ConsoleApplication.php
+++ b/libraries/src/Application/ConsoleApplication.php
@@ -252,6 +252,7 @@ class ConsoleApplication extends Application implements DispatcherAwareInterface
         $this->populateHttpHost();
 
         // Import CMS plugin groups to be able to subscribe to events
+        PluginHelper::importPlugin('behaviour', null, true, $this->getDispatcher());
         PluginHelper::importPlugin('system', null, true, $this->getDispatcher());
         PluginHelper::importPlugin('console', null, true, $this->getDispatcher());
 


### PR DESCRIPTION
Pull Request for Issue #42210 .

### Summary of Changes
Load 'behaviour' plugins before 'system' group so that the Backward Compatibility plugin can run and provide aliases for deprecated code.


### Testing Instructions
See issue description


### Actual result BEFORE applying this Pull Request
```
 #message: """
    Attempted to load class "JPlugin" from the global namespace.\n
    Did you forget a "use" statement?
    """
  #code: 0
```

### Expected result AFTER applying this Pull Request
`php cli/joomla.php` running fine without any errors


### Link to documentations
- [x] No documentation changes for docs.joomla.org needed

- [x] No documentation changes for manual.joomla.org needed
