### PR TITLE
[5.0][bug] TinyMCE Setting linebreak with doesn´t work

### DIFF
--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -467,7 +467,7 @@ trait DisplayTrait
             $scriptOptions['newline_behavior'] = 'invert';
         } else {
             // Paragraph
-            $scriptOptions['newline_behavior'] = 'default';
+            $scriptOptions['newline_behavior']  = 'default';
             $scriptOptions['forced_root_block'] = 'p';
         }
 

--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -464,10 +464,10 @@ trait DisplayTrait
 
         if ($levelParams->get('newlines')) {
             // Break
-            $scriptOptions['force_br_newlines'] = true;
+            $scriptOptions['newline_behavior'] = 'invert';
         } else {
             // Paragraph
-            $scriptOptions['force_br_newlines'] = false;
+            $scriptOptions['newline_behavior'] = 'default';
             $scriptOptions['forced_root_block'] = 'p';
         }
 


### PR DESCRIPTION
Pull Request for Issue #42224 .

### Summary of Changes

Use correctly the [`newline_behavior`](https://www.tiny.cloud/docs/tinymce/6/content-behavior-options/#newline_behavior) parameter

### Testing Instructions

Follow the issue description

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
