### PR TITLE
[5.0] Update TinyMCE to 6.7.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
         "shepherd.js": "^11.2.0",
         "short-and-sweet": "^1.0.4",
         "skipto": "^4.1.7",
-        "tinymce": "^6.7.0",
+        "tinymce": "^6.7.1",
         "vue": "3.2.45",
         "vue-focus-lock": "^2.0.5",
         "vuex": "^4.1.0",
@@ -9914,9 +9914,9 @@
       "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA=="
     },
     "node_modules/tinymce": {
-      "version": "6.7.0",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.7.0.tgz",
-      "integrity": "sha512-Wf2RSobIXQ7XNw3/v4z1lPGiH3Pjsmc/6/7fG28aIS6uVWj/7IhvOPuwfJJDeOx0o0D3nSnoLHgR2KU8JAdE+w=="
+      "version": "6.7.2",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.7.2.tgz",
+      "integrity": "sha512-6h/02jHmXyghekFzmzccZxUUEFtlPEKHxOd+gd49bjno3ybavZInPIaDd/pp2GeEwsFm20oGgJCL7UiebXm9dw=="
     },
     "node_modules/tippy.js": {
       "version": "6.3.7",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "shepherd.js": "^11.2.0",
     "short-and-sweet": "^1.0.4",
     "skipto": "^4.1.7",
-    "tinymce": "^6.7.0",
+    "tinymce": "^6.7.1",
     "vue": "3.2.45",
     "vue-focus-lock": "^2.0.5",
     "vuex": "^4.1.0",

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_tinymce</name>
-	<version>6.7.0</version>
+	<version>6.7.2</version>
 	<creationDate>2005-08</creationDate>
 	<author>Tiny Technologies, Inc</author>
 	<authorEmail>N/A</authorEmail>


### PR DESCRIPTION
### Summary of Changes
Updating TinyMCE to 6.7.2 to fix a mXSS vulnerability, see:
https://github.com/tinymce/tinymce/security/advisories/GHSA-v65r-p3vv-jjfv


### Testing Instructions
Apply patch, run npm install to download the updated Tiny version, test the editor.

```

6.7.2 - 2023-10-25
Fixed
The function getModifierState did not work on events passed through the editor as expected.

Indenting or outdenting a list item that contained non list item siblings after it would result in those siblings being removed.

Removed use of async for editor rendering which caused visual blinking when reloading the editor in-place.

Toggling a list that contained a list item element — <li> — which, in turn, contained another list item element as its first child, removed other content within the first list item element.

6.7.1 - 2023-10-19
Fixed
Specific HTML content caused mXSS when using undo/redo.

Specific HTML content caused mXSS when using the getContent and setContent APIs with the format: 'raw' option, which also affected the resetContent API and the draft restoration feature of the Autosave plugin.

Notification messages containing HTML were not properly XSS sanitized before being displayed.
```
