### PR TITLE
[5.0] User field: fix "No user" selection

### DIFF
--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -33,8 +33,9 @@ $userRequired    = (int) $input->get('required', 0, 'int');
     <form action="<?php echo Route::_('index.php?option=com_users&view=users&layout=modal&tmpl=component&groups=' . $input->get('groups', '', 'BASE64') . '&excluded=' . $input->get('excluded', '', 'BASE64')); ?>" method="post" name="adminForm" id="adminForm">
         <?php if (!$userRequired) : ?>
         <div>
-            <button type="button" class="btn btn-primary button-select" data-user-value="0" data-user-name="<?php echo $this->escape(Text::_('JLIB_FORM_SELECT_USER')); ?>"
-                data-user-field="<?php echo $this->escape($field); ?>"><?php echo Text::_('JOPTION_NO_USER'); ?></button>&nbsp;
+            <button type="button" class="btn btn-primary button-select"
+                data-content-select data-content-type="com_users.user" data-id="" data-name=""
+                data-user-value="" data-user-name="" data-user-field="<?php echo $this->escape($field); ?>"><?php echo Text::_('JOPTION_NO_USER'); ?></button>&nbsp;
         </div>
         <?php endif; ?>
         <?php echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>


### PR DESCRIPTION
Pull Request for Issue #42255 .

### Summary of Changes

User field: fix button "No user"


### Testing Instructions
Edit any Contact,
Asign User,
Then open User selection dialog again and click "- No User -"


### Actual result BEFORE applying this Pull Request
Nothing happened


### Expected result AFTER applying this Pull Request
Dialog is closed and User is unselected


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Reference:
 - https://github.com/joomla/joomla-cms/pull/41680