### PR TITLE
Feature/4.4 dev api tag relationship content serializer

### DIFF
--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Helper\TagsHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\CMS\Tag\TagApiSerializerTrait;
 use Joomla\Component\Content\Api\Helper\ContentHelper;
 use Joomla\Component\Content\Api\Serializer\ContentSerializer;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
@@ -31,6 +32,8 @@ use Joomla\Registry\Registry;
  */
 class JsonapiView extends BaseApiView
 {
+    use TagApiSerializerTrait;
+
     /**
      * The fields to render item in the documents
      *


### PR DESCRIPTION
Based on the feedback of maintainers 
- https://github.com/joomla/joomla-cms/pull/42244#issuecomment-1787098055
- https://github.com/joomla/joomla-cms/pull/42244#issuecomment-1787155157

Pull Request for Issue # .
No issues for this pull request

### Summary of Changes
Add the Tag Relationship for ContentSerializer


### Testing Instructions
Apply the patch
Run this command curl -X GET -H "X-Joomla-Token: YOUR_JOOMLA_API_TOKEN" -H "Accept: application/vnd.api+json" --url "https://example.org/api/index.php/v1/content/articles"
It should return a response in JSON:API format containing the tags relationship


### Actual result BEFORE applying this Pull Request
The tag relationship does not appear when doing a GET request on /api/index.php/v1/content/articles


### Expected result AFTER applying this Pull Request
The tag relationship appears successfully alongside the other relationships like category and created_by


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
