### PR TITLE
[5.0] Fix j+a shortcut in TinyMCE JoomlaHighlighter plugin

### DIFF
--- a/build/media_source/plg_system_shortcut/js/shortcut.es6.js
+++ b/build/media_source/plg_system_shortcut/js/shortcut.es6.js
@@ -49,6 +49,13 @@
       if (target.type === 'checkbox') {
         return true;
       }
+
+      // Ignore TinyMCE joomlaHighlighter plugin,
+      // @TODO: remove this when the joomlaHighlighter plugin will use JoomlaDialog
+      if (target.classList.contains('tox-textarea-wrap') && target.closest('.joomla-highlighter-dialog')) {
+        return false;
+      }
+
       // Default hotkeys filter behavior
       return !(target.isContentEditable || tagName === 'INPUT' || tagName === 'SELECT' || tagName === 'TEXTAREA');
     };


### PR DESCRIPTION
Pull Request for Issue #42235 .

### Summary of Changes

Fix j+a shortcut in TinyMCE JoomlaHighlighter plugin
The bug happen because the Highlighter located in shadow DOM.


### Testing Instructions
Run `npm install`
Please follow #42235 
Or open article editing, open source editor in TinyMCE, and type `ja`

### Actual result BEFORE applying this Pull Request
The page reloads, you get a message "Article saved"


### Expected result AFTER applying this Pull Request
You can type  `ja`


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Reference:
- https://github.com/joomla/joomla-cms/pull/41289
