### PR TITLE
[5.0] Filter values of custom field, fix #42259

### DIFF
--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -227,7 +227,8 @@ class FieldsHelper
                     ]))->getArgument('result', []);
 
                     if (\is_array($value)) {
-                        $value = implode(' ', $value);
+                        $value = array_filter($value, 'strlen');
+                        $value = $value ? implode(' ', $value) : '';
                     }
 
                     /*

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -227,7 +227,9 @@ class FieldsHelper
                     ]))->getArgument('result', []);
 
                     if (\is_array($value)) {
-                        $value = array_filter($value, 'strlen');
+                        $value = array_filter($value, function ($v) {
+                            return $v !== '' && $v !== null;
+                        });
                         $value = $value ? implode(' ', $value) : '';
                     }
 

--- a/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
+++ b/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
@@ -92,7 +92,7 @@ abstract class FieldsPlugin extends CMSPlugin
     {
         $result = $this->onCustomFieldsPrepareField($event->getContext(), $event->getItem(), $event->getField());
 
-        if ($result) {
+        if ($result !== '' && $result !== null) {
             $event->addResult($result);
         }
     }


### PR DESCRIPTION
Pull Request for Issue #42259 .

### Summary of Changes

Filter field value after onCustomFieldsPrepareField


### Testing Instructions
Please follow #42259
Create a Text field,
Save it,
And check the field rendering in the layout override.
Or use `dump($this->item->jcfields);` to see the field `->value`


### Actual result BEFORE applying this Pull Request
Value contain an empty space


### Expected result AFTER applying this Pull Request
Value is empty


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Reference:
- https://github.com/joomla/joomla-cms/pull/41495