### PR TITLE
[5.0] Cassiopeia should respect inheritance

### DIFF
--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -21,7 +21,7 @@ $wa  = $this->getWebAssetManager();
 // Color Theme
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
-$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css', ['relative' => true]);
+$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css');
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);

--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -21,7 +21,7 @@ $wa  = $this->getWebAssetManager();
 // Color Theme
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
-$wa->registerAndUseStyle($assetColorName, 'media/templates/site/cassiopeia/css/global/' . $paramsColorName . '.css');
+$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css', ['relative' => true]);
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -34,7 +34,7 @@ $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 // Color Theme
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
-$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css', ['relative' => true]);
+$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css');
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);

--- a/templates/cassiopeia/error.php
+++ b/templates/cassiopeia/error.php
@@ -31,13 +31,10 @@ $sitename = htmlspecialchars($app->get('sitename'), ENT_QUOTES, 'UTF-8');
 $menu     = $app->getMenu()->getActive();
 $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 
-// Template path
-$templatePath = 'media/templates/site/cassiopeia';
-
 // Color Theme
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
-$wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $paramsColorName . '.css');
+$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css', ['relative' => true]);
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -39,7 +39,7 @@ $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 // Color Theme
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
-$wa->registerAndUseStyle($assetColorName, 'media/templates/site/cassiopeia/css/global/' . $paramsColorName . '.css');
+$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css', ['relative' => true]);
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);

--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -39,7 +39,7 @@ $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 // Color Theme
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
-$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css', ['relative' => true]);
+$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css');
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -28,7 +28,7 @@ $fullWidth = 1;
 // Color Theme
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
-$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css', ['relative' => true]);
+$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css');
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -25,13 +25,10 @@ $wa               = $this->getWebAssetManager();
 
 $fullWidth = 1;
 
-// Template path
-$templatePath = 'media/templates/site/cassiopeia';
-
 // Color Theme
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
-$wa->registerAndUseStyle($assetColorName, $templatePath . '/css/global/' . $paramsColorName . '.css');
+$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css', ['relative' => true]);
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);


### PR DESCRIPTION
Pull Request for Issue #42260 .

### Summary of Changes

- The code for the `Colour Theme` should respect inheritance and allow overrides, right now it's hardcoded to the parent template

### Testing Instructions

- Apply the patch
- Check that the `Colour Theme` value is respected
- Create a child template `test`
- Create a file `media/templates/site/cassiopeia_test/css/global/colors_standard.css` and a file `media/templates/site/cassiopeia_test/css/global/colors_standard.min.css` with contents: 
```css
:root {
  --cassiopeia-color-primary: rebeccapurple;
  --cassiopeia-color-link: rebeccapurple;
  --link-color: rebeccapurple;
  --link-color-rgb: 34, 79, 170;
  --cassiopeia-color-hover: rebeccapurple;
}
```
Check that when the field `Colour Theme` has a value `standard` the template has a purple colour for the links and header

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

@astridx 