### PR TITLE
[5.0] Fix tinymce error on mobile

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/tinymce.es6.js
@@ -94,7 +94,7 @@ Joomla.JoomlaTinyMCE = {
     editors.forEach((editor) => {
       const currentEditor = editor.querySelector('textarea');
       const toggleButton = editor.querySelector('.js-tiny-toggler-button');
-      const toggleIcon = toggleButton.querySelector('.icon-eye');
+      const toggleIcon = toggleButton ? toggleButton.querySelector('.icon-eye') : false;
 
       // Set up the editor
       Joomla.JoomlaTinyMCE.setupEditor(currentEditor, pluginOptions);


### PR DESCRIPTION
Pull Request for Issue #42304 .

### Summary of Changes

The error hapen because toggleButton is not available on mobile, and script crashes.


### Testing Instructions

Run `npm install`
Open Article editing on mobile



### Actual result BEFORE applying this Pull Request
TinyMCE does not work


### Expected result AFTER applying this Pull Request
TinyMCE works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
