### PR TITLE
Fix getting `function` parameter from POST requests too

### DIFF
--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -28,7 +28,7 @@ if ($app->isClient('site')) {
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_menus.admin-items-modal');
 
-$function  = $app->getInput()->get('function', 'jSelectMenuItem', 'cmd');
+$function  = $app->getInput()->getCmd('function', 'jSelectMenuItem');
 $editor    = $app->getInput()->getCmd('editor', '');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));


### PR DESCRIPTION
Currently if you are switching the menu filter in the menu item select modal, the `function` parameter will be ignored, as it's read from GET parameters only.

All other modal views (article, categories, contacts, ...) already use the `getCmd()` function.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
