### PR TITLE
Fix missing archive icon

### DIFF
--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -92,6 +92,7 @@ if (!empty($editor)) {
                     -2 => 'icon-trash',
                     0  => 'icon-times',
                     1  => 'icon-check',
+                    2 => 'icon-archive',
                 ];
                 ?>
                 <?php foreach ($this->items as $i => $item) : ?>

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -92,7 +92,7 @@ if (!empty($editor)) {
                     -2 => 'icon-trash',
                     0  => 'icon-times',
                     1  => 'icon-check',
-                    2 => 'icon-archive',
+                    2  => 'icon-archive',
                 ];
                 ?>
                 <?php foreach ($this->items as $i => $item) : ?>


### PR DESCRIPTION
This PR fixes a php warning for archived articles.

### Summary of Changes

Add missing icon state.

### Testing Instructions

Bring up the article select modal in the Joomla content editor and filter by archived articles. Turn on PHP error_reporting and display the errors.

### Actual result BEFORE applying this Pull Request

PHP warning for archived articles and no icon shown.

### Expected result AFTER applying this Pull Request

No PHP warning and archive icon shown.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
