### PR TITLE
Fix field Color (Simple) rendering

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-simple-color.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-simple-color.w-c.es6.js
@@ -246,7 +246,7 @@
       const close = document.createElement('button');
       close.setAttribute('class', 'btn-close');
       close.setAttribute('type', 'button');
-      close.innerHTML = Joomla.sanitizeHtml(this.textClose);
+      close.setAttribute('aria-label', this.textClose);
 
       this.buttons.push(close);
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fix field Color (Simple) rendering. rendering of the close button.


### Testing Instructions
Run `npm install`
Add Color field somewhere, example in mod_custome XML, or in template XML.
```xml
<field type="color" name="color" label="Color" control="simple"/>
```



### Actual result BEFORE applying this Pull Request
Close button looks bad
![Screenshot 2023-11-09_11-58-15](https://github.com/joomla/joomla-cms/assets/1568198/74ff0b84-0121-46c1-b015-13ca40e45474)



### Expected result AFTER applying this Pull Request
Close button looks good
![Screenshot 2023-11-09_12-01-20](https://github.com/joomla/joomla-cms/assets/1568198/6bdc5344-7cab-4784-ada4-6fd6b1fc578b)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
