### PR TITLE
[5.1] Use Dialog field for Modal_Newsfeed

### DIFF
--- a/administrator/components/com_newsfeeds/layouts/joomla/form/field/modal-select/extra-buttons.php
+++ b/administrator/components/com_newsfeeds/layouts/joomla/form/field/modal-select/extra-buttons.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @package     Joomla.Site
+ * @subpackage  Layout
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\Factory;
+use Joomla\CMS\Language\Text;
+
+extract($displayData);
+
+/**
+ * Layout variables
+ * -----------------
+ * @var   string   $autocomplete    Autocomplete attribute for the field.
+ * @var   boolean  $autofocus       Is autofocus enabled?
+ * @var   string   $class           Classes for the input.
+ * @var   string   $description     Description of the field.
+ * @var   boolean  $disabled        Is this field disabled?
+ * @var   string   $group           Group the field belongs to. <fields> section in form XML.
+ * @var   boolean  $hidden          Is this field hidden in the form?
+ * @var   string   $hint            Placeholder for the field.
+ * @var   string   $id              DOM id of the field.
+ * @var   string   $label           Label of the field.
+ * @var   string   $labelclass      Classes to apply to the label.
+ * @var   boolean  $multiple        Does this field support multiple values?
+ * @var   string   $name            Name of the input field.
+ * @var   string   $onchange        Onchange attribute for the field.
+ * @var   string   $onclick         Onclick attribute for the field.
+ * @var   string   $pattern         Pattern (Reg Ex) of value of the form field.
+ * @var   boolean  $readonly        Is this field read only?
+ * @var   boolean  $repeat          Allows extensions to duplicate elements.
+ * @var   boolean  $required        Is this field required?
+ * @var   integer  $size            Size attribute of the input.
+ * @var   boolean  $spellcheck      Spellcheck state for the form field.
+ * @var   string   $validate        Validation rules to apply.
+ * @var   string   $value           Value attribute of the field.
+ * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
+ * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*
+ * @var   string   $valueTitle
+ * @var   array    $canDo
+ * @var   string[] $urls
+ * @var   string[] $modalTitles
+ * @var   string   $language
+ */
+
+// Do nothing when propagate is disabled
+if (empty($canDo['propagate'])) {
+    return;
+}
+
+// Scripts for backward compatibility
+/** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->useScript('field.modal-fields');
+$wa->addInlineScript(
+    'window.jSelectNewsfeed_' . $id . ' = function (id, title, object) {
+  window.processModalSelect("Newsfeed", "' . $id . '", id, title, "", object);
+}',
+    ['name' => 'inline.select_newsfeed_' . $id],
+    ['type' => 'module']
+);
+Text::script('JGLOBAL_ASSOCIATIONS_PROPAGATE_FAILED');
+
+// Language propagate callback name
+// Strip off language tag at the end
+$tagLength            = \strlen($language);
+$callbackFunctionStem = substr("jSelectNewsfeed_" . $id, 0, -$tagLength);
+
+?>
+
+<button type="button" class="btn btn-primary" <?php echo $value ? '' : 'hidden'; ?>
+        title="<?php echo $this->escape(Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_TIP')); ?>"
+        data-show-when-value="1"
+        onclick="Joomla.propagateAssociation('<?php echo $id; ?>', '<?php echo $callbackFunctionStem; ?>')">
+    <span class="icon-sync" aria-hidden="true"></span> <?php echo Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_BUTTON'); ?>
+</button>

--- a/administrator/components/com_newsfeeds/newsfeeds.xml
+++ b/administrator/components/com_newsfeeds/newsfeeds.xml
@@ -49,6 +49,7 @@
 			<filename>newsfeeds.xml</filename>
 			<folder>forms</folder>
 			<folder>helpers</folder>
+			<folder>layouts</folder>
 			<folder>services</folder>
 			<folder>sql</folder>
 			<folder>src</folder>

--- a/administrator/components/com_newsfeeds/src/Controller/NewsfeedController.php
+++ b/administrator/components/com_newsfeeds/src/Controller/NewsfeedController.php
@@ -11,6 +11,7 @@
 namespace Joomla\Component\Newsfeeds\Administrator\Controller;
 
 use Joomla\CMS\MVC\Controller\FormController;
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Versioning\VersionableControllerTrait;
 use Joomla\Utilities\ArrayHelper;
@@ -111,5 +112,53 @@ class NewsfeedController extends FormController
         $this->setRedirect(Route::_('index.php?option=com_newsfeeds&view=newsfeeds' . $this->getRedirectToListAppend(), false));
 
         return parent::batch($model);
+    }
+
+    /**
+     * Method to cancel an edit.
+     *
+     * @param   string  $key  The name of the primary key of the URL variable.
+     *
+     * @return  boolean  True if access level checks pass, false otherwise.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function cancel($key = null)
+    {
+        $result = parent::cancel($key);
+
+        // When editing in modal then redirect to modalreturn layout
+        if ($result && $this->input->get('layout') === 'modal') {
+            $id     = $this->input->get('id');
+            $return = 'index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($id)
+                . '&layout=modalreturn&from-task=cancel';
+
+            $this->setRedirect(Route::_($return, false));
+        }
+
+        return $result;
+    }
+
+    /**
+     * Function that allows child controller access to model data
+     * after the data has been saved.
+     *
+     * @param   BaseDatabaseModel  $model      The data model object.
+     * @param   array              $validData  The validated data.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    protected function postSaveHook(BaseDatabaseModel $model, $validData = [])
+    {
+        // When editing in modal then redirect to modalreturn layout
+        if ($this->input->get('layout') === 'modal' && $this->task === 'save') {
+            $id     = $model->getState('newsfeed.id', '');
+            $return = 'index.php?option=' . $this->option . '&view=' . $this->view_item . $this->getRedirectToItemAppend($id)
+                . '&layout=modalreturn&from-task=save';
+
+            $this->setRedirect(Route::_($return, false));
+        }
     }
 }

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -12,11 +12,11 @@ namespace Joomla\Component\Newsfeeds\Administrator\Field\Modal;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Field\ModalSelectField;
-use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Session\Session;
+use Joomla\CMS\Uri\Uri;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -72,275 +72,55 @@ class NewsfeedField extends ModalSelectField
         // Prepare enabled actions
         $this->canDo['propagate']  = ((string) $this->element['propagate'] == 'true') && \count($languages) > 2;
 
+        // Prepare Urls
+        $linkitems = (new Uri())->setPath(Uri::base(true) . '/index.php');
+        $linkitems->setQuery([
+            'option'                => 'com_newsfeeds',
+            'view'                  => 'newsfeeds',
+            'layout'                => 'modal',
+            'tmpl'                  => 'component',
+            Session::getFormToken() => 1,
+        ]);
+        $linkItem = clone $linkitems;
+        $linkItem->setVar('view', 'newsfeed');
+        $linkCheckin = (new Uri())->setPath(Uri::base(true) . '/index.php');
+        $linkCheckin->setQuery([
+            'option'                => 'com_newsfeeds',
+            'task'                  => 'newsfeeds.checkin',
+            'format'                => 'json',
+            Session::getFormToken() => 1,
+        ]);
+
+        if ($language) {
+            $linkitems->setVar('forcedLanguage', $language);
+            $linkItem->setVar('forcedLanguage', $language);
+
+            $modalTitle = Text::_('COM_NEWSFEEDS_SELECT_A_FEED') . ' &#8212; ' . $this->getTitle();
+
+            $this->dataAttributes['data-language'] = $language;
+        } else {
+            $modalTitle = Text::_('COM_NEWSFEEDS_SELECT_A_FEED');
+        }
+
+        $urlSelect = $linkitems;
+        $urlEdit   = clone $linkItem;
+        $urlEdit->setVar('task', 'newsfeed.edit');
+        $urlNew    = clone $linkItem;
+        $urlNew->setVar('task', 'newsfeed.add');
+
+        $this->urls['select']  = (string) $urlSelect;
+        $this->urls['new']     = (string) $urlNew;
+        $this->urls['edit']    = (string) $urlEdit;
+        $this->urls['checkin'] = (string) $linkCheckin;
+
+        // Prepare titles
+        $this->modalTitles['select']  = $modalTitle;
+        $this->modalTitles['new']     = Text::_('COM_NEWSFEEDS_NEW_NEWSFEED');
+        $this->modalTitles['edit']    = Text::_('COM_NEWSFEEDS_EDIT_NEWSFEED');
+
+        $this->hint = $this->hint ?: Text::_('COM_NEWSFEEDS_SELECT_A_FEED');
 
         return $result;
-    }
-
-    /**
-     * Method to get the field input markup.
-     *
-     * @return  string  The field input markup.
-     *
-     * @since   1.6
-     */
-    protected function getInput1()
-    {
-        $allowNew       = ((string) $this->element['new'] == 'true');
-        $allowEdit      = ((string) $this->element['edit'] == 'true');
-        $allowClear     = ((string) $this->element['clear'] != 'false');
-        $allowSelect    = ((string) $this->element['select'] != 'false');
-        $allowPropagate = ((string) $this->element['propagate'] == 'true');
-
-        $languages = LanguageHelper::getContentLanguages([0, 1], false);
-
-        // Load language
-        Factory::getLanguage()->load('com_newsfeeds', JPATH_ADMINISTRATOR);
-
-        // The active newsfeed id field.
-        $value = (int) $this->value ?: '';
-
-        // Create the modal id.
-        $modalId = 'Newsfeed_' . $this->id;
-
-        /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
-        $wa = Factory::getApplication()->getDocument()->getWebAssetManager();
-
-        // Add the modal field script to the document head.
-        $wa->useScript('field.modal-fields');
-
-        // Script to proxy the select modal function to the modal-fields.js file.
-        if ($allowSelect) {
-            static $scriptSelect = null;
-
-            if (\is_null($scriptSelect)) {
-                $scriptSelect = [];
-            }
-
-            if (!isset($scriptSelect[$this->id])) {
-                $wa->addInlineScript(
-                    "
-				window.jSelectNewsfeed_" . $this->id . " = function (id, title, object) {
-					window.processModalSelect('Newsfeed', '" . $this->id . "', id, title, '', object);
-				}",
-                    [],
-                    ['type' => 'module']
-                );
-
-                Text::script('JGLOBAL_ASSOCIATIONS_PROPAGATE_FAILED');
-
-                $scriptSelect[$this->id] = true;
-            }
-        }
-
-        // Setup variables for display.
-        $linkNewsfeeds = 'index.php?option=com_newsfeeds&amp;view=newsfeeds&amp;layout=modal&amp;tmpl=component&amp;' . Session::getFormToken() . '=1';
-        $linkNewsfeed  = 'index.php?option=com_newsfeeds&amp;view=newsfeed&amp;layout=modal&amp;tmpl=component&amp;' . Session::getFormToken() . '=1';
-        $modalTitle    = Text::_('COM_NEWSFEEDS_SELECT_A_FEED');
-
-        if (isset($this->element['language'])) {
-            $linkNewsfeeds .= '&amp;forcedLanguage=' . $this->element['language'];
-            $linkNewsfeed .= '&amp;forcedLanguage=' . $this->element['language'];
-            $modalTitle .= ' &#8212; ' . $this->element['label'];
-        }
-
-        $urlSelect = $linkNewsfeeds . '&amp;function=jSelectNewsfeed_' . $this->id;
-        $urlEdit   = $linkNewsfeed . '&amp;task=newsfeed.edit&amp;id=\' + document.getElementById("' . $this->id . '_id").value + \'';
-        $urlNew    = $linkNewsfeed . '&amp;task=newsfeed.add';
-
-        if ($value) {
-            $id    = (int) $value;
-            $db    = $this->getDatabase();
-            $query = $db->getQuery(true)
-                ->select($db->quoteName('name'))
-                ->from($db->quoteName('#__newsfeeds'))
-                ->where($db->quoteName('id') . ' = :id')
-                ->bind(':id', $id, ParameterType::INTEGER);
-            $db->setQuery($query);
-
-            try {
-                $title = $db->loadResult();
-            } catch (\RuntimeException $e) {
-                Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
-            }
-        }
-
-        $title = empty($title) ? Text::_('COM_NEWSFEEDS_SELECT_A_FEED') : htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
-
-        // The current newsfeed display field.
-        $html  = '';
-
-        if ($allowSelect || $allowNew || $allowEdit || $allowClear) {
-            $html .= '<span class="input-group">';
-        }
-
-        $html .= '<input class="form-control" id="' . $this->id . '_name" type="text" value="' . $title . '" readonly size="35">';
-
-        // Select newsfeed button
-        if ($allowSelect) {
-            $html .= '<button'
-                . ' class="btn btn-primary' . ($value ? ' hidden' : '') . '"'
-                . ' id="' . $this->id . '_select"'
-                . ' data-bs-toggle="modal"'
-                . ' type="button"'
-                . ' data-bs-target="#ModalSelect' . $modalId . '">'
-                . '<span class="icon-file" aria-hidden="true"></span> ' . Text::_('JSELECT')
-                . '</button>';
-        }
-
-        // New newsfeed button
-        if ($allowNew) {
-            $html .= '<button'
-                . ' class="btn btn-secondary' . ($value ? ' hidden' : '') . '"'
-                . ' id="' . $this->id . '_new"'
-                . ' data-bs-toggle="modal"'
-                . ' type="button"'
-                . ' data-bs-target="#ModalNew' . $modalId . '">'
-                . '<span class="icon-plus" aria-hidden="true"></span> ' . Text::_('JACTION_CREATE')
-                . '</button>';
-        }
-
-        // Edit newsfeed button
-        if ($allowEdit) {
-            $html .= '<button'
-                . ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
-                . ' id="' . $this->id . '_edit"'
-                . ' data-bs-toggle="modal"'
-                . ' type="button"'
-                . ' data-bs-target="#ModalEdit' . $modalId . '">'
-                . '<span class="icon-pen-square" aria-hidden="true"></span> ' . Text::_('JACTION_EDIT')
-                . '</button>';
-        }
-
-        // Clear newsfeed button
-        if ($allowClear) {
-            $html .= '<button'
-                . ' class="btn btn-secondary' . ($value ? '' : ' hidden') . '"'
-                . ' id="' . $this->id . '_clear"'
-                . ' type="button"'
-                . ' onclick="window.processModalParent(\'' . $this->id . '\'); return false;">'
-                . '<span class="icon-times" aria-hidden="true"></span> ' . Text::_('JCLEAR')
-                . '</button>';
-        }
-
-        // Propagate newsfeed button
-        if ($allowPropagate && \count($languages) > 2) {
-            // Strip off language tag at the end
-            $tagLength            = (int) \strlen($this->element['language']);
-            $callbackFunctionStem = substr("jSelectNewsfeed_" . $this->id, 0, -$tagLength);
-
-            $html .= '<button'
-            . ' class="btn btn-primary' . ($value ? '' : ' hidden') . '"'
-            . ' type="button"'
-            . ' id="' . $this->id . '_propagate"'
-            . ' title="' . Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_TIP') . '"'
-            . ' onclick="Joomla.propagateAssociation(\'' . $this->id . '\', \'' . $callbackFunctionStem . '\');">'
-            . '<span class="icon-sync" aria-hidden="true"></span> ' . Text::_('JGLOBAL_ASSOCIATIONS_PROPAGATE_BUTTON')
-            . '</button>';
-        }
-
-        if ($allowSelect || $allowNew || $allowEdit || $allowClear) {
-            $html .= '</span>';
-        }
-
-        // Select newsfeed modal
-        if ($allowSelect) {
-            $html .= HTMLHelper::_(
-                'bootstrap.renderModal',
-                'ModalSelect' . $modalId,
-                [
-                    'title'      => $modalTitle,
-                    'url'        => $urlSelect,
-                    'height'     => '400px',
-                    'width'      => '800px',
-                    'bodyHeight' => 70,
-                    'modalWidth' => 80,
-                    'footer'     => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">'
-                                        . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>',
-                ]
-            );
-        }
-
-        // New newsfeed modal
-        if ($allowNew) {
-            $html .= HTMLHelper::_(
-                'bootstrap.renderModal',
-                'ModalNew' . $modalId,
-                [
-                    'title'       => Text::_('COM_NEWSFEEDS_NEW_NEWSFEED'),
-                    'backdrop'    => 'static',
-                    'keyboard'    => false,
-                    'closeButton' => false,
-                    'url'         => $urlNew,
-                    'height'      => '400px',
-                    'width'       => '800px',
-                    'bodyHeight'  => 70,
-                    'modalWidth'  => 80,
-                    'footer'      => '<button type="button" class="btn btn-secondary"'
-                            . ' onclick="window.processModalEdit(this, \''
-                            . $this->id . '\', \'add\', \'newsfeed\', \'cancel\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
-                            . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-                            . '<button type="button" class="btn btn-primary"'
-                            . ' onclick="window.processModalEdit(this, \''
-                            . $this->id . '\', \'add\', \'newsfeed\', \'save\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
-                            . Text::_('JSAVE') . '</button>'
-                            . '<button type="button" class="btn btn-success"'
-                            . ' onclick="window.processModalEdit(this, \''
-                            . $this->id . '\', \'add\', \'newsfeed\', \'apply\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
-                            . Text::_('JAPPLY') . '</button>',
-                ]
-            );
-        }
-
-        // Edit newsfeed modal.
-        if ($allowEdit) {
-            $html .= HTMLHelper::_(
-                'bootstrap.renderModal',
-                'ModalEdit' . $modalId,
-                [
-                    'title'       => Text::_('COM_NEWSFEEDS_EDIT_NEWSFEED'),
-                    'backdrop'    => 'static',
-                    'keyboard'    => false,
-                    'closeButton' => false,
-                    'url'         => $urlEdit,
-                    'height'      => '400px',
-                    'width'       => '800px',
-                    'bodyHeight'  => 70,
-                    'modalWidth'  => 80,
-                    'footer'      => '<button type="button" class="btn btn-secondary"'
-                            . ' onclick="window.processModalEdit(this, \'' . $this->id
-                            . '\', \'edit\', \'newsfeed\', \'cancel\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
-                            . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-                            . '<button type="button" class="btn btn-primary"'
-                            . ' onclick="window.processModalEdit(this, \''
-                            . $this->id . '\', \'edit\', \'newsfeed\', \'save\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
-                            . Text::_('JSAVE') . '</button>'
-                            . '<button type="button" class="btn btn-success"'
-                            . ' onclick="window.processModalEdit(this, \''
-                            . $this->id . '\', \'edit\', \'newsfeed\', \'apply\', \'newsfeed-form\', \'jform_id\', \'jform_name\'); return false;">'
-                            . Text::_('JAPPLY') . '</button>',
-                ]
-            );
-        }
-
-        // Add class='required' for client side validation
-        $class = $this->required ? ' class="required modal-value"' : '';
-
-        $html .= '<input type="hidden" id="' . $this->id . '_id"' . $class . ' data-required="' . (int) $this->required . '" name="' . $this->name
-            . '" data-text="' . htmlspecialchars(Text::_('COM_NEWSFEEDS_SELECT_A_FEED', true), ENT_COMPAT, 'UTF-8') . '" value="' . $value . '">';
-
-        return $html;
-    }
-
-    /**
-     * Method to get the field label markup.
-     *
-     * @return  string  The field label markup.
-     *
-     * @since   3.4
-     */
-    protected function getLabel1()
-    {
-        return str_replace($this->id, $this->id . '_name', parent::getLabel());
     }
 
     /**

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -182,7 +182,7 @@ class NewsfeedField extends ModalSelectField
     {
         $layout = parent::getRenderer($layoutId);
         $layout->setComponent('com_newsfeeds');
-        $layout->setClient(1);
+        $layout->setClient(1);;
 
         return $layout;
     }

--- a/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
+++ b/administrator/components/com_newsfeeds/src/Field/Modal/NewsfeedField.php
@@ -182,7 +182,7 @@ class NewsfeedField extends ModalSelectField
     {
         $layout = parent::getRenderer($layoutId);
         $layout->setComponent('com_newsfeeds');
-        $layout->setClient(1);;
+        $layout->setClient(1);
 
         return $layout;
     }

--- a/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/administrator/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -73,6 +73,12 @@ class HtmlView extends BaseHtmlView
         $this->item  = $this->get('Item');
         $this->form  = $this->get('Form');
 
+        if ($this->getLayout() === 'modalreturn') {
+            parent::display($tpl);
+
+            return;
+        }
+
         // Check for errors.
         if (\count($errors = $this->get('Errors'))) {
             throw new GenericDataException(implode("\n", $errors), 500);
@@ -91,7 +97,12 @@ class HtmlView extends BaseHtmlView
             $this->form->setFieldAttribute('tags', 'language', '*,' . $forcedLanguage);
         }
 
-        $this->addToolbar();
+        if ($this->getLayout() !== 'modal') {
+            $this->addToolbar();
+        } else {
+            $this->addModalToolbar();
+        }
+
         parent::display($tpl);
     }
 
@@ -160,5 +171,38 @@ class HtmlView extends BaseHtmlView
 
         $toolbar->divider();
         $toolbar->help('News_Feeds:_Edit');
+    }
+
+    /**
+     * Add the modal toolbar.
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     *
+     * @throws  \Exception
+     */
+    protected function addModalToolbar()
+    {
+        $user       = $this->getCurrentUser();
+        $isNew      = ($this->item->id == 0);
+        $toolbar    = Toolbar::getInstance();
+
+        // Since we don't track these assets at the item level, use the category id.
+        $canDo = ContentHelper::getActions('com_newsfeeds', 'category', $this->item->catid);
+
+        $title = $isNew ? Text::_('COM_NEWSFEEDS_MANAGER_NEWSFEED_NEW') : Text::_('COM_NEWSFEEDS_MANAGER_NEWSFEED_EDIT');
+        ToolbarHelper::title($title, 'rss newsfeeds');
+
+        $canCreate = $isNew && (\count($user->getAuthorisedCategories('com_newsfeeds', 'core.create')) > 0);
+        $canEdit   = $canDo->get('core.edit');
+
+        // For new records, check the create permission.
+        if ($canCreate || $canEdit) {
+            $toolbar->apply('newsfeed.apply');
+            $toolbar->save('newsfeed.save');
+        }
+
+        $toolbar->cancel('newsfeed.cancel');
     }
 }

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/modal.php
@@ -10,6 +10,9 @@
 
 defined('_JEXEC') or die;
 ?>
+<div class="subhead noshadow mb-3">
+    <?php echo $this->document->getToolbar('toolbar')->render(); ?>
+</div>
 <div class="container-popup">
     <?php $this->setLayout('edit'); ?>
     <?php echo $this->loadTemplate(); ?>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/modalreturn.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/modalreturn.php
@@ -13,13 +13,13 @@ defined('_JEXEC') or die;
 use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 
 $icon     = 'icon-check';
-$title    = $this->item ? $this->item->title : '';
+$title    = $this->item ? $this->item->name : '';
 $content  = $this->item ? $this->item->alias : '';
 $data     = ['contentType' => 'com_newsfeeds.newsfeed'];
 
 if ($this->item) {
     $data['id']    = $this->item->id;
-    $data['title'] = $this->item->title;
+    $data['title'] = $this->item->name;
     $data['catId'] = $this->item->catid;
     $data['uri']   = RouteHelper::getNewsfeedRoute($this->item->id, $this->item->catid, $this->item->language);
 }

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/modalreturn.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/modalreturn.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ * @package     Joomla.Administrator
+ * @subpackage  com_content
+ *
+ * @copyright   (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+defined('_JEXEC') or die;
+
+use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
+
+$icon     = 'icon-check';
+$title    = $this->item ? $this->item->title : '';
+$content  = $this->item ? $this->item->alias : '';
+$data     = ['contentType' => 'com_newsfeeds.newsfeed'];
+
+if ($this->item) {
+    $data['id']    = $this->item->id;
+    $data['title'] = $this->item->title;
+    $data['catId'] = $this->item->catid;
+    $data['uri']   = RouteHelper::getNewsfeedRoute($this->item->id, $this->item->catid, $this->item->language);
+}
+
+// Add Content select script
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = $this->document->getWebAssetManager();
+$wa->useScript('modal-content-select');
+
+// The data for Content select script
+$this->document->addScriptOptions('content-select-on-load', $data, false);
+
+?>
+
+<div class="px-4 py-5 my-5 text-center">
+    <span class="fa-8x mb-4 <?php echo $icon; ?>" aria-hidden="true"></span>
+    <h1 class="display-5 fw-bold"><?php echo $title; ?></h1>
+    <div class="col-lg-6 mx-auto">
+        <p class="lead mb-4">
+            <?php echo $content; ?>
+        </p>
+    </div>
+</div>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -24,6 +24,7 @@ $wa->useScript('core');
 
 $app = Factory::getApplication();
 
+// @todo: Use of Function is deprecated and should be removed in 6.0. It stays only for backward compatibility.
 $function  = $app->getInput()->getCmd('function', 'jSelectNewsfeed');
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
@@ -90,6 +91,10 @@ $multilang = Multilanguage::isEnabled();
                     } elseif (!$multilang) {
                         $lang = '';
                     }
+
+                    $link     = RouteHelper::getNewsfeedRoute($item->id, $item->catid, $item->language);
+                    $itemHtml = '<a href="' . $this->escape($link) . '"' . ($lang ? ' hreflang="' . $lang . '"' : '') . '>' . $item->name . '</a>';
+
                     ?>
                     <tr class="row<?php echo $i % 2; ?>">
                         <td class="text-center">
@@ -98,7 +103,16 @@ $multilang = Multilanguage::isEnabled();
                             </span>
                         </td>
                         <th scope="row">
-                            <a href="javascript:void(0)" onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape(RouteHelper::getNewsfeedRoute($item->id, $item->catid, $item->language)); ?>', '<?php echo $this->escape($lang); ?>', null);">
+                            <?php $attribs = 'data-content-select data-content-type="com_newsfeeds.newsfeed"'
+                                . ' data-id="' . $item->id . '"'
+                                . ' data-title="' . $this->escape($item->title) . '"'
+                                . ' data-cat-id="' . $this->escape($item->catid) . '"'
+                                . ' data-uri="' . $this->escape($link) . '"'
+                                . ' data-language="' . $this->escape($lang) . '"'
+                                . ' data-html="' . $this->escape($itemHtml) . '"';
+                            ?>
+                            <a href="javascript:void(0)" <?php echo $attribs; ?>
+                               onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape($link); ?>', '<?php echo $this->escape($lang); ?>', null);">
                             <?php echo $this->escape($item->name); ?></a>
                             <div class="small">
                                 <?php echo Text::_('JCATEGORY') . ': ' . $this->escape($item->category_title); ?>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -79,22 +79,19 @@ $multilang = Multilanguage::isEnabled();
                 ];
                 ?>
                 <?php foreach ($this->items as $i => $item) : ?>
-                    <?php if ($item->language && $multilang) {
-                        $tag = strlen($item->language);
+                    <?php
+                    $lang = '';
+                    if ($item->language && $multilang) {
+                        $tag = \strlen($item->language);
                         if ($tag == 5) {
                             $lang = substr($item->language, 0, 2);
                         } elseif ($tag == 6) {
                             $lang = substr($item->language, 0, 3);
-                        } else {
-                            $lang = '';
                         }
-                    } elseif (!$multilang) {
-                        $lang = '';
                     }
 
                     $link     = RouteHelper::getNewsfeedRoute($item->id, $item->catid, $item->language);
                     $itemHtml = '<a href="' . $this->escape($link) . '"' . ($lang ? ' hreflang="' . $lang . '"' : '') . '>' . $item->name . '</a>';
-
                     ?>
                     <tr class="row<?php echo $i % 2; ?>">
                         <td class="text-center">
@@ -112,7 +109,7 @@ $multilang = Multilanguage::isEnabled();
                                 . ' data-html="' . $this->escape($itemHtml) . '"';
                             ?>
                             <a href="javascript:void(0)" <?php echo $attribs; ?>
-                               onclick="if (window.parent) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape($link); ?>', '<?php echo $this->escape($lang); ?>', null);">
+                               onclick="if (window.parent && !window.parent.JoomlaExpectingPostMessage) window.parent.<?php echo $this->escape($function); ?>('<?php echo $item->id; ?>', '<?php echo $this->escape(addslashes($item->name)); ?>', '<?php echo $this->escape($item->catid); ?>', null, '<?php echo $this->escape($link); ?>', '<?php echo $this->escape($lang); ?>', null);">
                             <?php echo $this->escape($item->name); ?></a>
                             <div class="small">
                                 <?php echo Text::_('JCATEGORY') . ': ' . $this->escape($item->category_title); ?>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -20,7 +20,8 @@ use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
-$wa->useScript('core');
+$wa->useScript('core')
+    ->useScript('modal-content-select');
 
 $app = Factory::getApplication();
 
@@ -102,7 +103,7 @@ $multilang = Multilanguage::isEnabled();
                         <th scope="row">
                             <?php $attribs = 'data-content-select data-content-type="com_newsfeeds.newsfeed"'
                                 . ' data-id="' . $item->id . '"'
-                                . ' data-title="' . $this->escape($item->title) . '"'
+                                . ' data-title="' . $this->escape($item->name) . '"'
                                 . ' data-cat-id="' . $this->escape($item->catid) . '"'
                                 . ' data-uri="' . $this->escape($link) . '"'
                                 . ' data-language="' . $this->escape($lang) . '"'


### PR DESCRIPTION
### Summary of Changes

Changing Modal_Newsfeed field to use new modal dialog.
The same as https://github.com/joomla/joomla-cms/pull/40462 but for Newsfeed.


### Testing Instructions

Create a menu for Newsfeed item,
Select/edit value in "Feed" field.


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Reference:
- https://github.com/joomla/joomla-cms/pull/40462