### PR TITLE
[4.x] Don't force the process to terminate

### DIFF
--- a/build/build-modules-js/compilecss.es6.js
+++ b/build/build-modules-js/compilecss.es6.js
@@ -33,7 +33,7 @@ module.exports.stylesheets = async (options, path) => {
     } else {
       // eslint-disable-next-line no-console
       console.error(`Unknown path ${path}`);
-      process.exit(1);
+      process.exitCode = 1;
     }
   } else {
     folders = [

--- a/build/build-modules-js/compilejs.es6.js
+++ b/build/build-modules-js/compilejs.es6.js
@@ -35,7 +35,7 @@ module.exports.scripts = async (options, path) => {
     } else {
       // eslint-disable-next-line no-console
       console.error(`Unknown path ${path}`);
-      process.exit(1);
+      process.exitCode = 1;
     }
   } else {
     folders = [

--- a/build/build-modules-js/error-pages.es6.js
+++ b/build/build-modules-js/error-pages.es6.js
@@ -112,7 +112,7 @@ module.exports.createErrorPages = async (options) => {
   await Promise.all(iniFilesProcess).catch((err) => {
     // eslint-disable-next-line no-console
     console.error(err);
-    process.exit(-1);
+    process.exitCode = -1;
   });
 
   const processPage = async (name) => {
@@ -163,6 +163,6 @@ module.exports.createErrorPages = async (options) => {
   return Promise.all(processPages).catch((err) => {
     // eslint-disable-next-line no-console
     console.error(err);
-    process.exit(-1);
+    process.exitCode = -1;
   });
 };

--- a/build/build-modules-js/init/cleanup-media.es6.js
+++ b/build/build-modules-js/init/cleanup-media.es6.js
@@ -40,6 +40,6 @@ module.exports.cleanVendors = async () => {
   } else {
     // eslint-disable-next-line no-console
     console.error('You need to run `npm install` AFTER the command `composer install`!!!. The debug plugin HASN\'T installed all its front end assets');
-    process.exit(1);
+    process.exitCode = 1;
   }
 };

--- a/build/build-modules-js/javascript/build-bootstrap-js.es6.js
+++ b/build/build-modules-js/javascript/build-bootstrap-js.es6.js
@@ -147,7 +147,7 @@ module.exports.bootstrapJs = async () => {
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error);
-    process.exit(1);
+    process.exitCode = 1;
   }
 
   (await readdir(outputFolder)).forEach((file) => {
@@ -168,11 +168,11 @@ module.exports.bootstrapJs = async () => {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.error(error);
-      process.exit(1);
+      process.exitCode = 1;
     }
   }).catch((er) => {
     // eslint-disable-next-line no-console
     console.log(er);
-    process.exit(1);
+    process.exitCode = 1;
   });
 };

--- a/build/build-modules-js/stylesheets/handle-scss.es6.js
+++ b/build/build-modules-js/stylesheets/handle-scss.es6.js
@@ -16,7 +16,7 @@ module.exports.handleScssFile = async (file) => {
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error.formatted);
-    process.exit(1);
+    process.exitCode = 1;
   }
 
   let contents = LightningCSS.transform({

--- a/build/build-modules-js/stylesheets/scss-transform.es6.js
+++ b/build/build-modules-js/stylesheets/scss-transform.es6.js
@@ -14,7 +14,7 @@ module.exports.compile = async (file) => {
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error(error.formatted);
-    process.exit(1);
+    process.exitCode = 1;
   }
 
   // Auto prefixing

--- a/build/build.js
+++ b/build/build.js
@@ -42,7 +42,7 @@ const settings = require('./build-modules-js/settings.json');
 
 const handleError = (err, terminateCode) => {
   console.error(err); // eslint-disable-line no-console
-  process.exit(terminateCode);
+  process.exitCode = terminateCode;
 };
 
 if (semver.gte(semver.minVersion(options.engines.node), semver.clean(process.version))) {
@@ -95,9 +95,6 @@ if (cliOptions.copyAssets) {
     .then(() => localisePackages(options))
     .then(() => patchPackages(options))
     .then(() => minifyVendor())
-    .then(() => {
-      process.exit(0);
-    })
     .catch((error) => handleError(error, 1));
 }
 
@@ -170,6 +167,5 @@ if (cliOptions.prepare) {
       ],
     ))
     .then(() => bench.stop('Build'))
-    .then(() => { process.exit(0); })
     .catch((err) => handleError(err, -1));
 }


### PR DESCRIPTION
Pull Request for Issues discussed in https://github.com/joomla/joomla-cms/pull/42325

### Summary of Changes

This stops the build scripts forcing the process to terminate, which is preventing the Media Manager build task from completing.
Instead, this PR sets the exit code to be used when Node.js gracefully exists....on its own.

### Testing Instructions

1. Run `npm i`
2. Check to see if `media-manager-es5.js` and `media-manager-es5.min.js` exist in `media/com_media/js`
