### PR TITLE
[5.0] Fix URLs and hardcoded keyName for editing URL, in ModalSelectField

### DIFF
--- a/build/media_source/system/js/fields/modal-content-select-field.es6.js
+++ b/build/media_source/system/js/fields/modal-content-select-field.es6.js
@@ -112,6 +112,7 @@ const setupField = (container) => {
     // Extract the data
     const action = button.dataset.buttonAction;
     const dialogConfig = button.dataset.modalConfig ? JSON.parse(button.dataset.modalConfig) : {};
+    const keyName = container.dataset.keyName || 'id';
 
     // Handle requested action
     let handle;
@@ -123,7 +124,7 @@ const setupField = (container) => {
       case 'edit': {
         // Update current value in the URL
         const url = dialogConfig.src.indexOf('http') === 0 ? new URL(dialogConfig.src) : new URL(dialogConfig.src, window.location.origin);
-        url.searchParams.set('id', inputValue.value);
+        url.searchParams.set(keyName, inputValue.value);
         dialogConfig.src = url.toString();
 
         handle = doSelect(inputValue, inputTitle, dialogConfig);
@@ -142,7 +143,7 @@ const setupField = (container) => {
         const chckUrl = button.dataset.checkinUrl;
         const url = chckUrl.indexOf('http') === 0 ? new URL(chckUrl) : new URL(chckUrl, window.location.origin);
         // Add value to request
-        url.searchParams.set('id', inputValue.value);
+        url.searchParams.set(keyName, inputValue.value);
         url.searchParams.set('cid[]', inputValue.value);
         // Also add value to POST, because Controller may expect it from there
         const data = new FormData();

--- a/layouts/joomla/form/field/modal-select/buttons.php
+++ b/layouts/joomla/form/field/modal-select/buttons.php
@@ -11,6 +11,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+use Joomla\CMS\Router\Route;
 
 extract($displayData);
 
@@ -52,17 +53,17 @@ extract($displayData);
 // Prepare options for each Modal
 $modalSelect = [
     'popupType'  => 'iframe',
-    'src'        => $urls['select'] ?? '',
+    'src'        => empty($urls['select']) ? '' : Route::_($urls['select'], false),
     'textHeader' => $modalTitles['select'] ?? Text::_('JSELECT'),
 ];
 $modalNew = [
     'popupType'  => 'iframe',
-    'src'        => $urls['new'] ?? '',
+    'src'        => empty($urls['new']) ? '' : Route::_($urls['new'], false),
     'textHeader' => $modalTitles['new'] ?? Text::_('JACTION_CREATE'),
 ];
 $modalEdit = [
     'popupType'  => 'iframe',
-    'src'        => $urls['edit'] ?? '',
+    'src'        => empty($urls['edit']) ? '' : Route::_($urls['edit'], false),
     'textHeader' => $modalTitles['edit'] ?? Text::_('JACTION_EDIT'),
 ];
 
@@ -73,7 +74,7 @@ $isSelectAlways = !empty($canDo['select']) && empty($canDo['clear']);
 <?php if ($modalSelect['src'] && $canDo['select'] ?? true) : ?>
 <button type="button" class="btn btn-primary" <?php echo $value && !$isSelectAlways ? 'hidden' : ''; ?>
         data-button-action="select" <?php echo !$isSelectAlways ? 'data-show-when-value=""' : ''; ?>
-        data-modal-config="<?php echo $this->escape(json_encode($modalSelect)); ?>">
+        data-modal-config="<?php echo $this->escape(json_encode($modalSelect, JSON_UNESCAPED_SLASHES)); ?>">
     <span class="<?php echo !empty($buttonIcons['select']) ? $buttonIcons['select'] : 'icon-file'; ?>" aria-hidden="true"></span> <?php echo Text::_('JSELECT'); ?>
 </button>
 <?php endif; ?>
@@ -81,7 +82,7 @@ $isSelectAlways = !empty($canDo['select']) && empty($canDo['clear']);
 <?php if ($modalNew['src'] && $canDo['new'] ?? false) : ?>
 <button type="button" class="btn btn-secondary" <?php echo $value ? 'hidden' : ''; ?>
         data-button-action="create" data-show-when-value=""
-        data-modal-config="<?php echo $this->escape(json_encode($modalNew)); ?>">
+        data-modal-config="<?php echo $this->escape(json_encode($modalNew, JSON_UNESCAPED_SLASHES)); ?>">
     <span class="icon-plus" aria-hidden="true"></span> <?php echo Text::_('JACTION_CREATE'); ?>
 </button>
 <?php endif; ?>
@@ -89,8 +90,8 @@ $isSelectAlways = !empty($canDo['select']) && empty($canDo['clear']);
 <?php if ($modalEdit['src'] && $canDo['edit'] ?? false) : ?>
 <button type="button" class="btn btn-primary" <?php echo $value ? '' : 'hidden'; ?>
         data-button-action="edit" data-show-when-value="1"
-        data-modal-config="<?php echo $this->escape(json_encode($modalEdit)); ?>"
-        data-checkin-url="<?php echo $this->escape($urls['checkin'] ?? ''); ?>">
+        data-modal-config="<?php echo $this->escape(json_encode($modalEdit, JSON_UNESCAPED_SLASHES)); ?>"
+        data-checkin-url="<?php echo empty($urls['checkin']) ? '' : Route::_($urls['checkin']); ?>">
     <span class="icon-pen-square" aria-hidden="true"></span> <?php echo Text::_('JACTION_EDIT'); ?>
 </button>
 <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Adds Route::_() for URLs to make sure they are corectly prefixed with a base URL.
Fix hardoced keyName `id` to allow other var name.


### Testing Instructions
Run `npm install`

Add the field somewhere, example in mod_custom:
```xml
<field 
    type="ModalSelect"
    name="test"
    label="Test"
    default="1"
    urlSelect="index.php?tmpl=component"
    urlEdit="index.php?tmpl=component"
    edit="true"
    data-key-name="foo"
/>
```

Then open the form and click Edit button.
Check the popup content.
Also check the iframe url, in the browser console.


### Actual result BEFORE applying this Pull Request
Depend from installation, you wil get 404 not found (for installations in subfolder) or home page.
Iframe url containe `&id=1`


### Expected result AFTER applying this Pull Request
You get dashboard in popup.
Iframe url containe `&foo=1`


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Reference;
- https://github.com/joomla/joomla-cms/pull/40462