### PR TITLE
[5.0] revert string removal

### DIFF
--- a/administrator/language/en-GB/com_users.ini
+++ b/administrator/language/en-GB/com_users.ini
@@ -222,6 +222,7 @@ COM_USERS_MAIL_NO_USERS_COULD_BE_FOUND_IN_THIS_GROUP="No users could be found in
 COM_USERS_MAIL_ONLY_YOU_COULD_BE_FOUND_IN_THIS_GROUP="You are the only user in this group."
 COM_USERS_MAIL_PASSWORD_RESET_DESC="Sent to a user by the &quot;Forgot your password?&quot; link eg in a login form."
 COM_USERS_MAIL_PASSWORD_RESET_TITLE="Users: Password Reset"
+COM_USERS_MAIL_PLEASE_FILL_IN_THE_FORM_CORRECTLY="Please fill in the form correctly."
 COM_USERS_MAIL_REGISTRATION_ADMIN_NEW_NOTIFICATION_DESC="Notification to the admin that a new, activated account has been created."
 COM_USERS_MAIL_REGISTRATION_ADMIN_NEW_NOTIFICATION_TITLE="Users: New account notification to admin"
 COM_USERS_MAIL_REGISTRATION_ADMIN_VERIFICATION_REQUEST_DESC="Notification to admins to verify a new, verified account."


### PR DESCRIPTION
COM_USERS_MAIL_PLEASE_FILL_IN_THE_FORM_CORRECTLY="Please fill in the form correctly."

This string was marked as deprecated in #39374 and removed from 5.0 as a result of the deprecation

However this was in error as the string is used https://github.com/joomla/joomla-cms/blob/43a9aab4992d3048e8f2ee5091cd76959fc52acc/administrator/components/com_users/src/Model/MailModel.php#L126

This simple PR restores the string.

I have made it against 5.0 as I see this as a bugfix but maintainers may decide its a new string and therefore must be in 5.1

Pull Request for Issue # .

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
