### PR TITLE
[5.0] Correct language string workflows

### DIFF
--- a/administrator/components/com_workflow/src/Table/WorkflowTable.php
+++ b/administrator/components/com_workflow/src/Table/WorkflowTable.php
@@ -82,7 +82,7 @@ class WorkflowTable extends Table implements CurrentUserInterface
         $isDefault = $db->setQuery($query)->loadResult();
 
         if ($isDefault) {
-            $app->enqueueMessage(Text::_('COM_WORKFLOW_MSG_DELETE_DEFAULT'), 'error');
+            $app->enqueueMessage(Text::_('COM_WORKFLOW_MSG_DELETE_IS_DEFAULT'), 'error');
 
             return false;
         }


### PR DESCRIPTION
The language key used in the code was incorrect. This simple PR updates the code to use the correct string

as its an error message code review should be ok for testing



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
