### PR TITLE
[5.0] Revert TinyMCE builder dark skin

### DIFF
--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -62,7 +62,6 @@ $wa  = $doc->getWebAssetManager();
 
 $wa->getRegistry()->addExtensionRegistryFile('plg_editors_tinymce');
 $wa->registerAndUseStyle('tinymce.skin', 'media/vendor/tinymce/skins/ui/oxide/skin.min.css')
-    ->registerAndUseStyle('tinymce.skin.dark', 'media/vendor/tinymce/skins/ui/oxide-dark/skin.min.css')
     ->registerAndUseStyle('plg_editors_tinymce.builder', 'plg_editors_tinymce/tinymce-builder.css', [], [], ['tinymce.skin', 'dragula'])
     ->registerScript('plg_editors_tinymce.builder', 'plg_editors_tinymce/tinymce-builder.js', [], ['type' => 'module'], ['dragula', 'plg_editors_tinymce'])
     ->useScript('plg_editors_tinymce.builder')


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/42378 .

### Summary of Changes

Revert TinyMCE builder dark skin, for now,


### Testing Instructions
disable darkmode
open options of TinyMCE plugin


### Actual result BEFORE applying this Pull Request
TinyMCE is displayed with dark skin


### Expected result AFTER applying this Pull Request
TinyMCE is display with light skin


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

Reference:
- https://github.com/joomla/joomla-cms/pull/42322