### PR TITLE
[5.0] Add renamed vendor files to fixFilenameCasing

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2907,6 +2907,9 @@ class JoomlaInstallerScript
             '/libraries/vendor/web-auth/cose-lib/src/Algorithm/Signature/EdDSA/ED512.php' => '/libraries/vendor/web-auth/cose-lib/src/Algorithm/Signature/EdDSA/Ed512.php',
             // From 5.0.0-alpha3 to 5.0.0-alpha4
             '/plugins/schemaorg/blogposting/src/Extension/Blogposting.php' => '/plugins/schemaorg/blogposting/src/Extension/BlogPosting.php',
+            // From 5.0.0 to 5.0.1
+            '/libraries/vendor/web-auth/cose-lib/src/Algorithm/Signature/EdDSA/ED256.php' => '/libraries/vendor/web-auth/cose-lib/src/Algorithm/Signature/EdDSA/Ed256.php',
+            '/libraries/vendor/web-auth/cose-lib/src/Algorithm/Signature/EdDSA/ED512.php' => '/libraries/vendor/web-auth/cose-lib/src/Algorithm/Signature/EdDSA/Ed512.php',
         ];
 
         foreach ($files as $old => $expected) {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) adds 2 vendor files to the list of files to be renamed on update in script.php.

That should have been done already with 5.0.0 stable, but it seems I have missed that or my tool has missed that when I made the checks for the deleted files and folders and renamed files.

### Testing Instructions

On an OS with a case-sensitive file system, i.e. on Linux, download and unpack the full installation packages of 5.0.0 stable or a 5.0.1 or 5.1.0 development version and of 4.4.0 stable or a 4.4.1 development version.

Compare the 5.x and 4.4.x folders with a suitable tool or run `php build/deleted_file_check.php` and then check the content of the `build/renamed_files.txt` file, e.g. here with my folder paths:
```
php build/deleted_file_check.php --from=/home/richard/Joomla_4.4.1-rc2-dev-Development-Full_Package --to=/home/richard/Joomla_5.0.0-Stable-Full_Package
```

Check that there are only the 2 files added by this PR which have just been renamed regarding the case.

Or for a real test, update a 4.4.0 stable or 4.4.1-dev to a regular 5.0.0 stable or 5.0.1-dev for the actual result, and update from  a 4.4.0 stable or 4.4.1-dev to the patched package of this PR for the expected result.

### Actual result BEFORE applying this Pull Request

The 2 files are not renamed with the update.

### Expected result AFTER applying this Pull Request

The 2 files are renamed with the update.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
