### PR TITLE
[5.0.1] TinyMCE 6.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9361,9 +9361,9 @@
       "integrity": "sha512-RX35iq/D+lrsqhcPWIazM9ELkjOe30MSeoBHQHSsRwd1YuhJO5ui1K1/R0r7N3mFvbLBs33idw+eR6j+w6i/DA=="
     },
     "node_modules/tinymce": {
-      "version": "6.7.3",
-      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.7.3.tgz",
-      "integrity": "sha512-J7WmYIi/gt1RvZ6Ap2oQiUjzAoiS9pfV+d4GnKuZuPu8agmlAEAInNmMvMjfCNBzHv4JnZXY7qlHUAI0IuYQVA=="
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/tinymce/-/tinymce-6.8.0.tgz",
+      "integrity": "sha512-WSQlyfW8aPkOVMmmHmSVeA5Dq4JuUZjTB+PmePJ27oQ+ruv3Zn4KSTsvSnDUrHlqygjDvRidrCB/m5nTWCC2nA=="
     },
     "node_modules/tippy.js": {
       "version": "6.3.7",

--- a/plugins/editors/tinymce/tinymce.xml
+++ b/plugins/editors/tinymce/tinymce.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <extension type="plugin" group="editors" method="upgrade">
 	<name>plg_editors_tinymce</name>
-	<version>6.7.3</version>
+	<version>6.8.0</version>
 	<creationDate>2005-08</creationDate>
 	<author>Tiny Technologies, Inc</author>
 	<authorEmail>N/A</authorEmail>


### PR DESCRIPTION
## 6.8.0 - 2023-11-22

### Added
- CSS files are now also generated as separate JS files to improve bundling of all resources. #TINY-10352
- Added new `StylesheetLoader.loadRawCss` API that can be used to load CSS into a style element. #TINY-10352
- Added new `StylesheetLoader.unloadRawCss` API that can be used to unload CSS that was loaded into a style element. #TINY-10352
- Added `force_hex_color` editor option. Option `'always'` converts all RGB & RGBA colours to hex, `'rgb_only'` will only convert RGB and *not* RGBA colours to hex, `'off'` won't convert any colours to hex. #TINY-9819
- Added `default_font_stack` editor option that makes it possible to define what is considered a system font stack. #TINY-10290
- New `sandbox_iframes` option that controls whether iframe elements will be added a `sandbox=""` attribute to mitigate malicious intent. #TINY-10348
- New `convert_unsafe_embeds` option that controls whether `<object>` and `<embed>` elements will be converted to more restrictive alternatives, namely `<img>` for image MIME types, `<video>` for video MIME types, `<audio>` audio MIME types, or `<iframe>` for other or unspecified MIME types. #TINY-10349

### Improved
- Colorpicker now includes the Brightness/Saturation selector and hue slider in the keyboard navigable items. #TINY-9287
- Improved the tooltips of picker buttons for the urlinput components in the "Insert/Edit Image" and "Insert/Edit Link" dialogs. #TINY-10155
- Inline dialog will now respect `size: 'large'` argument in the dialog spec. #TINY-10209
- SVG elements and their children are now retained when configured as valid elements. #TINY-10237
- Bespoke dropdown toolbar buttons including `align`, `fontfamily`, `fontsize`, `blocks`, and `styles` did not include their visible text labels in their accessible names. #TINY-10147

### Fixed
- Editor would convert urls that are not http/s or relative resulting in broken links. #TINY-10153
- Calling the `setProgressState` API would cause the window to be scrolled when the editor wasn't fully visible. #TINY-10172
- Applying heading formatting to the content of the `summary` element extended its application to the content of the parent `details` element. #TINY-10154
- Setting the content with an attribute that contains a self-closing HTML tag did not preserve the tag. #TINY-10088
- Screen readers now announce the selected color of `forecolor` and `backcolor` buttons. #TINY-9796
- Resize handles would not appear on editable images in a non-editable context. #TINY-10118
- Corrections and copy-edits to the `addIcon` API documentation. #TINY-10230
- The dialog size was not updated when the `size` argument was changed when redialling a dialog. #TINY-10209
- Toggling a list that contains an LI element having another list as its first child would remove the remaining content within that LI element. #TINY-10213
- Custom block element wasn't considered block element in some cases. #TINY-10139
- The editor no longer forcefully takes focus when a notification closes while the focus is outside of the editor. #TINY-10282
- An empty element with a `contenteditable="true"` attribute within a table cell would not be treated as content and get removed if backspace or delete was being pressed. #TINY-10010
- Removing an LI element containing a `details` element would incorrectly merge its content. #TINY-10133
- The function `getModifierState` did not work on events passed through the editor as expected. #TINY-10263
- Search and replace plugin would incorrectly find matching text inside non-editable root elements. #TINY-10162
- Removed use of `async` for editor rendering which caused visual blinking when reloading the editor in-place. #TINY-10249
- Toggling off one format on the caret when multiple formats was toggled on would toggle all of them off. #TINY-10132
- Merging an external `p` inside a `list` via delete or backspace would incorrectly try to move a parent element inside a child element. #TINY-10289
- Directionality would not be consistently applied to the entire `accordion` block. #TINY-10291
- The `fontsizeinput` toolbar item was causing console warnings when toolbar items were clicked. #TINY-10330
- Menubar buttons with more than one word would sometimes wrap into two lines. #TINY-10343
- Creating a new `li` via enter inside a nested list would not inherit styles from the source `li`. #TINY-10316
- Screen readers now announce the active autocompleter item. #TINY-9393
- Dialog collection items would not display any icons chosen from icon pack. #TINY-10174

Pull Request for Issue # .

### Summary of Changes



### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
