### PR TITLE
[5.0] Finder: Do not show error messages for suggestions

### DIFF
--- a/build/media_source/com_finder/js/finder.es6.js
+++ b/build/media_source/com_finder/js/finder.es6.js
@@ -23,14 +23,18 @@
           response = JSON.parse(xhr.responseText);
         } catch (e) {
           // Something went wrong, but we are not going to bother the enduser with this
+          // eslint-disable-next-line no-console
+          console.error(e);
           return;
         }
 
         if (Object.prototype.toString.call(response.suggestions) === '[object Array]') {
           target.awesomplete.list = response.suggestions;
         }
-      }).catch(() => {
+      }).catch((xhr) => {
         // Something went wrong, but we are not going to bother the enduser with this
+        // eslint-disable-next-line no-console
+        console.error(xhr);
       });
     }
   };

--- a/build/media_source/com_finder/js/finder.es6.js
+++ b/build/media_source/com_finder/js/finder.es6.js
@@ -23,6 +23,7 @@
           response = JSON.parse(xhr.responseText);
         } catch (e) {
           // Something went wrong, but we are not going to bother the enduser with this
+          return;
         }
 
         if (Object.prototype.toString.call(response.suggestions) === '[object Array]') {

--- a/build/media_source/com_finder/js/finder.es6.js
+++ b/build/media_source/com_finder/js/finder.es6.js
@@ -22,15 +22,14 @@
         try {
           response = JSON.parse(xhr.responseText);
         } catch (e) {
-          Joomla.renderMessages(Joomla.ajaxErrorsMessages(xhr, 'parsererror'));
-          return;
+          // Something went wrong, but we are not going to bother the enduser with this
         }
 
         if (Object.prototype.toString.call(response.suggestions) === '[object Array]') {
           target.awesomplete.list = response.suggestions;
         }
       }).catch((xhr) => {
-        Joomla.renderMessages(Joomla.ajaxErrorsMessages(xhr));
+        // Something went wrong, but we are not going to bother the enduser with this
       });
     }
   };

--- a/build/media_source/com_finder/js/finder.es6.js
+++ b/build/media_source/com_finder/js/finder.es6.js
@@ -29,7 +29,7 @@
         if (Object.prototype.toString.call(response.suggestions) === '[object Array]') {
           target.awesomplete.list = response.suggestions;
         }
-      }).catch((xhr) => {
+      }).catch(() => {
         // Something went wrong, but we are not going to bother the enduser with this
       });
     }


### PR DESCRIPTION
### Summary of Changes
~~There are situations where for some reason the AJAX call for suggestions in Smart Search fails.~~ When typing very fast into the search box and hitting enter, the browser has fired an AJAX call for every character typed and the server might not have responded. When hitting enter, the form is send and all AJAX requests are aborted. This lets the JS code return and run into the failure condition, resulting in a flash of error messages being displayed. While it is nice to know that something failed for a developer, this should not be displayed to the general enduser. The JS code right now can spam the screen with system messages for these failed calls, especially since a call is triggered for each character entered into the search box. This PR removes this error handling.


### Testing Instructions
1. Go to `/components/com_finder/src/Controller/SuggestionsController.php` and insert 
	```echo '1';```
	in line 43 to create a broken output from the controller.
2. Type into the search box of mod_finder and see loads of system error messages displayed.
3. Apply the patch. (remember to run npm)
4. Type into the search box and don't see the previous messages.
5. Remove the code from line 43 and type again. See the suggestions appearing again.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
