### PR TITLE
Update LanguageHelper.php - Extension language translation failing

### DIFF
--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -413,17 +413,7 @@ class LanguageHelper
             ini_set('track_errors', true);
         }
 
-        // This was required for https://github.com/joomla/joomla-cms/issues/17198 but not sure what server setup
-        // issue it is solving
-        $disabledFunctions      = explode(',', ini_get('disable_functions'));
-        $isParseIniFileDisabled = \in_array('parse_ini_file', array_map('trim', $disabledFunctions));
-
-        if (!\function_exists('parse_ini_file') || $isParseIniFileDisabled) {
-            $contents = file_get_contents($fileName);
-            $strings  = @parse_ini_string($contents, false, INI_SCANNER_RAW);
-        } else {
-            $strings = self::parseMultilineIniFile($fileName);
-        }
+        $strings = self::parseMultilineIniFile($fileName);
 
         // Ini files are processed in the "RAW" mode of parse_ini_string, leaving escaped quotes untouched - lets postprocess them
         $strings = str_replace('\"', '"', $strings);
@@ -512,6 +502,17 @@ class LanguageHelper
         if ($unexpectedFileContents)
         {
             // Handle file like Joomla 4.1.1
+
+            // This was required for https://github.com/joomla/joomla-cms/issues/17198 but not sure what server setup
+            // issue it is solving
+            $disabledFunctions      = explode(',', ini_get('disable_functions'));
+            $isParseIniFileDisabled = \in_array('parse_ini_file', array_map('trim', $disabledFunctions));
+
+            if (!\function_exists('parse_ini_file') || $isParseIniFileDisabled) {
+                $contents = file_get_contents($fileName);
+                return @parse_ini_string($contents, false, INI_SCANNER_RAW);
+            }
+            
             return @parse_ini_file($fileName, false, INI_SCANNER_RAW);
         }
 

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -467,7 +467,7 @@ class LanguageHelper
             $lineParts[1] = ltrim($lineParts[1]);
 
             // We are only expecting strings for language translation
-            if (!str_starts_with($lineParts[0], '"')) {
+            if (!str_starts_with($lineParts[1], '"')) {
                 $unexpectedFileContents = true;
 
                 break;

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -466,6 +466,13 @@ class LanguageHelper
             $lineParts[0] = rtrim($lineParts[0]);
             $lineParts[1] = ltrim($lineParts[1]);
 
+            // We are only expecting strings for language translation
+            if (!str_starts_with($lineParts[0], '"')) {
+                $unexpectedFileContents = true;
+
+                break;
+            }
+
             if (str_ends_with($lineParts[1], '"')) {
                 // Just in case we have a line ending with an escaped "
                 if (!str_ends_with($line, '\\"')) {

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -469,7 +469,11 @@ class LanguageHelper
             if (str_ends_with($lineParts[1], '"')) {
                 // Just in case we have a line ending with an escaped "
                 if (!str_ends_with($line, '\\"')) {
-                    $nameValuePairs[$lineParts[0]] = $lineParts[1];
+                    if (strlen($lineParts[1]) == 2) {
+                        $nameValuePairs[$lineParts[0]] = '';
+                        continue;
+                    }
+                    $nameValuePairs[$lineParts[0]] = substr($lineParts[1], 1, strlen($lineParts[1])-2);
 
                     continue;
                 }
@@ -487,7 +491,7 @@ class LanguageHelper
                 if (str_ends_with($line, '"')) {
 
                     if (!str_ends_with($line, '\\"')) {
-                        $nameValuePairs[$lineParts[0]] = $nameValuePair;
+                        $nameValuePairs[$lineParts[0]] = substr($nameValuePair, 1, strlen($nameValuePair)-1);
 
                         continue 2;
                     }

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -429,7 +429,7 @@ class LanguageHelper
     /**
      * Parse strings from a language file.
      * Caters for multi-line text strings.
-     * See issue https://github.com/joomla/joomla-cms/issues/42416     *
+     * See issue https://github.com/joomla/joomla-cms/issues/42416
      *
      * @param   string   $fileName  The language ini file path.
      * @param   boolean  $debug     If set to true debug language ini file.
@@ -455,35 +455,39 @@ class LanguageHelper
             if ($line[0] == ';') continue;
 
             // Should not happen, but if it does let parse_ini_file() deal with it
-            if (strpos($line, '=') === false) {
+            $lineParts = explode('=', $line);
+            if (count($lineParts) != 2) {
                 $unexpectedFileContents = true;
 
                 break;
             }
 
-            if (str_ends_with($line, '"')) {
+            // In case there is a space before / after =
+            $lineParts[0] = rtrim($lineParts[0]);
+            $lineParts[1] = ltrim($lineParts[1]);
+
+            if (str_ends_with($lineParts[1], '"')) {
                 // Just in case we have a line ending with an escaped "
                 if (!str_ends_with($line, '\\"')) {
-                    $nameValuePairs[] = $line;
+                    $nameValuePairs[$lineParts[0]] = $lineParts[1];
 
                     continue;
                 }
             }
 
             // Found a string with embedded new lines
-            $nameValuePair = $line;
+            $nameValuePair = $lineParts[1];
 
             while (($line = fgets($fd)) !== false)
             {
                 $line = trim($line);
 
-                // If current value ends with " we don't want to add a space following it
-                $nameValuePair .= (str_ends_with($nameValuePair, '"') ? '' : ' ') . $line;
+                $nameValuePair .= "\n" . $line;
 
                 if (str_ends_with($line, '"')) {
 
                     if (!str_ends_with($line, '\\"')) {
-                        $nameValuePairs[] = $nameValuePair;
+                        $nameValuePairs[$lineParts[0]] = $nameValuePair;
 
                         continue 2;
                     }
@@ -516,7 +520,7 @@ class LanguageHelper
             return @parse_ini_file($fileName, false, INI_SCANNER_RAW);
         }
 
-        return @parse_ini_string(implode("\n", $nameValuePairs), false, INI_SCANNER_RAW);
+        return $nameValuePairs;
     }
 
     /**


### PR DESCRIPTION
Caters for multi-line text.

Pull Request for Issue #42416 .

### Summary of Changes

Allow embedded newlines in text (i.e. between quotes ").
Using them to structure very large areas of text makes maintenance easier.
In some cases using linewrap in IDE slightly helps, but one is left with trying to read / unravel a massive jumble of text.

Newlines in text worked up to v4.4.0
Security related change in v4.4.1 removed this functionality.

This change detects and removes the embedded newlines before using PHP ini parsing as before.
The security related change introduced in v4.4.1 is maintained.

### Testing Instructions

Install this plugin.
[plg_system_bflanguagetest.zip](https://github.com/joomla/joomla-cms/files/13527659/plg_system_bflanguagetest.zip)

Go to plugin admin page.

### Actual result BEFORE applying this Pull Request

With v4.4.1 the plugin name and description not translated.
The language labels are displayed.

### Expected result AFTER applying this Pull Request

Name and description translated.

### Link to documentations
Please select:
- [X] Documentation link for docs.joomla.org: <link>
- [] No documentation changes for docs.joomla.org needed

- [X ] Pull Request link for manual.joomla.org: <link>
- [] No documentation changes for manual.joomla.org needed

Line breaks in character string have worked for a very long time.
The documentation says they are not allowed - that needs to be corrected.
