### PR TITLE
[5] install from CLI deprecation php 8

### DIFF
--- a/installation/src/Application/CliInstallationApplication.php
+++ b/installation/src/Application/CliInstallationApplication.php
@@ -77,6 +77,14 @@ final class CliInstallationApplication extends Application implements CMSApplica
     protected $session;
 
     /**
+     * The client application Id
+     *
+     * @var Integer
+     * @since __DEPLOY_VERSION__
+     */
+    protected $clientId;
+
+    /**
      * Class constructor.
      *
      * @param   Input|null      $input      An optional argument to provide dependency injection for the application's input


### PR DESCRIPTION
Pull Request for Issue #42436 .

### Summary of Changes

declare $clientId

### Testing Instructions
Install Joomla via CLI with PHP 8.x

php installation/joomla.php install --site-name="My Site name" --admin-user="Some name" --admin-username="admin" --admin-password="qwertyuiop123" --admin-email="[your@emailaddress.nl](mailto:your@emailaddress.nl)" --db-type="mysqli" --db-host="localhost" --db-user="root" --db-pass="" --db-name="demoDB" --db-prefix="demo_" --db-encryption="0"


### Actual result BEFORE applying this Pull Request
Deprecated: Creation of dynamic property Joomla\CMS\Installation\Application\CliInstallationApplication::$clientId is deprecated in ...\installation\src\Application\CliInstallationApplication.php on line 107


### Expected result AFTER applying this Pull Request
no more deprecation


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
