### PR TITLE
[5.1] Use Dialog for ContentHistory field

### DIFF
--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -38,7 +38,7 @@ $wa->useScript('multiselect')
     ->useScript('list-view')
     ->addInlineScript($inlineJS, [], ['type' => 'module']);
 ?>
-<div class="container-popup">
+<div class="container-popup p-3">
     <div id="subhead" class="subhead noshadow mb-3">
         <?php echo $this->toolbar->render(); ?>
     </div>

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -38,7 +38,7 @@ $wa->useScript('multiselect')
     ->useScript('list-view')
     ->addInlineScript($inlineJS, [], ['type' => 'module']);
 ?>
-<div class="container-popup p-3">
+<div class="container-popup">
     <div id="subhead" class="subhead noshadow mb-3">
         <?php echo $this->toolbar->render(); ?>
     </div>

--- a/layouts/joomla/form/field/contenthistory.php
+++ b/layouts/joomla/form/field/contenthistory.php
@@ -10,8 +10,7 @@
 
 defined('_JEXEC') or die;
 
-use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\CMS\Language\Text;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Router\Route;
 
 extract($displayData);
@@ -51,27 +50,21 @@ extract($displayData);
  * @var   array    $dataAttributes  Miscellaneous data attributes for eg, data-*.
  */
 
-echo HTMLHelper::_(
-    'bootstrap.renderModal',
-    'versionsModal',
-    [
-        'url'    => Route::_($link),
-        'title'  => $label,
-        'height' => '100%',
-        'width'  => '100%',
-        'modalWidth'  => '80',
-        'bodyHeight'  => '60',
-        'footer' => '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal" aria-hidden="true">'
-            . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
-    ]
-);
+/** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
+$wa = Factory::getApplication()->getDocument()->getWebAssetManager();
+$wa->useScript('joomla.dialog-autocreate');
+
+$dialogOptions = [
+    'popupType'  => 'iframe',
+    'src'        => Route::_($link, false),
+    'textHeader' => $label,
+];
 
 ?>
 <button
     type="button"
     class="btn btn-secondary"
-    data-bs-toggle="modal"
-    data-bs-target="#versionsModal"
+    data-joomla-dialog="<?php echo $this->escape(json_encode($dialogOptions, JSON_UNESCAPED_SLASHES)); ?>"
     <?php echo $dataAttribute; ?>>
         <span class="icon-code-branch" aria-hidden="true"></span>
         <?php echo $label; ?>

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -52,7 +52,7 @@ $dialogOptions = [
 <joomla-toolbar-button id="toolbar-versions">
     <button
         class="btn btn-primary"
-        data-joomla-dialog="<?php echo $this->escape(json_encode($dialogOptions)); ?>"
+        data-joomla-dialog="<?php echo $this->escape(json_encode($dialogOptions, JSON_UNESCAPED_SLASHES)); ?>"
         type="button">
         <span class="icon-code-branch" aria-hidden="true"></span>
         <?php echo $title; ?>

--- a/templates/cassiopeia/component.php
+++ b/templates/cassiopeia/component.php
@@ -81,7 +81,7 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
     <jdoc:include type="styles" />
     <jdoc:include type="scripts" />
 </head>
-<body class="<?php echo $this->direction === 'rtl' ? 'rtl' : ''; ?>">
+<body class="contentpane component <?php echo $this->direction === 'rtl' ? 'rtl' : ''; ?>">
     <jdoc:include type="message" />
     <jdoc:include type="component" />
 </body>


### PR DESCRIPTION
### Summary of Changes
Use Dialog for ContentHistory field


### Testing Instructions
Do frontend Content editing.
Click Versions button to open Content history.
Try to use diferent Content history features in this popup.



### Actual result BEFORE applying this Pull Request
Works with BS Modal


### Expected result AFTER applying this Pull Request
Works with Joomla Dialog


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed

References:

- https://github.com/joomla/joomla-cms/pull/40150