### PR TITLE
Update LanguageHelper.php to handle translated text with embedded new lines.

### DIFF
--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -441,6 +441,10 @@ class LanguageHelper
 
                 return [];
             }
+
+            // Ini file processing has left escaped quotes untouched - lets postprocess them
+            $strings = str_replace('\"', '"', $strings);
+
         } finally {
             restore_error_handler();
         }

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -428,11 +428,19 @@ class LanguageHelper
                 $strings = parse_ini_file($fileName, false, INI_SCANNER_RAW);
             }
         } catch (\Exception $e) {
-            if ($debug) {
-                throw new \RuntimeException($e->getMessage());
-            }
+            // Emulate Java 4.4.0 and earlier handling of multi-line text strings.
+            // Some developers prefer to format long descriptive strings in that way for easier maintenance.
+            // For performance reasons we only do this as a last resort as most .ini files are not affected by this.
+            $strings = self::parseMultilineIni(isset($contents) ? $contents : file_get_contents($fileName));
 
-            return [];
+            if ($strings === false) {
+                if ($debug)
+                {
+                    throw new \RuntimeException($e->getMessage());
+                }
+
+                return [];
+            }
         } finally {
             restore_error_handler();
         }
@@ -441,6 +449,87 @@ class LanguageHelper
         $strings = str_replace('\"', '"', $strings);
 
         return \is_array($strings) ? $strings : [];
+    }
+
+    /**
+     * Parse strings from a language file.
+     * See issue https://github.com/joomla/joomla-cms/issues/42416
+     * Emulates Joomla v4.4.0 and earlier behaviour with multi-line text strings without the potential security concerns.
+     *
+     * @param   string   $fileName  The language ini file path.
+     * @param   boolean  $debug     If set to true debug language ini file.
+     *
+     * @return  array | false  The strings parsed.
+     *
+     * @since   4.1.1
+     */
+    protected static function parseMultilineIni($inifileContents) {
+        $lines = explode("\n", $inifileContents);
+
+        $nameValuePairs = [];
+
+        for ($l=0; $l<count($lines); $l++) {
+            $line = trim($lines[$l]);
+
+            if (empty($line)) continue;
+
+            if ($line[0] == ';') continue;
+
+            $lineParts = explode('=', $line);
+            if (count($lineParts) != 2) {
+                // Unexpected file contents
+                return false;
+            }
+
+            // In case there is a space before / after =
+            $lineParts[0] = rtrim($lineParts[0]);
+            $lineParts[1] = ltrim($lineParts[1]);
+            
+            // We are only expecting strings for language translation
+            if (!str_starts_with($lineParts[1], '"')) {
+                // Unexpected file contents
+                return false;
+            }
+
+            if (str_ends_with($lineParts[1], '"')) {
+                // Just in case we have a line ending with an escaped "
+                if (!str_ends_with($line, '\\"')) {
+                    if (strlen($lineParts[1]) == 2) {
+                        $nameValuePairs[$lineParts[0]] = '';
+                        continue;
+                    }
+                    $nameValuePairs[$lineParts[0]] = substr($lineParts[1], 1, strlen($lineParts[1])-2);
+
+                    continue;
+                }
+            }
+
+            // Found a string with embedded new lines
+            $nameValuePair = $lineParts[1];
+
+            while (++$l<count($lines))
+            {
+                $line = trim($lines[$l]);
+
+                $nameValuePair .= "\n" . $line;
+
+                if (str_ends_with($line, '"')) {
+
+                    if (!str_ends_with($line, '\\"')) {
+                        $nameValuePairs[$lineParts[0]] = substr($nameValuePair, 1, strlen($nameValuePair)-1);
+
+                        continue 2;
+                    }
+                }
+            }
+
+            if (!str_starts_with($lineParts[1], '"')) {
+                // Unexpected file contents
+                return false;
+            }
+        }
+
+        return $nameValuePairs;
     }
 
     /**

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -428,7 +428,7 @@ class LanguageHelper
                 $strings = parse_ini_file($fileName, false, INI_SCANNER_RAW);
             }
         } catch (\Exception $e) {
-            // Emulate Java 4.4.0 and earlier handling of multi-line text strings.
+            // Emulate Joomla 4.4.0 and earlier handling of multi-line text strings.
             // Some developers prefer to format long descriptive strings in that way for easier maintenance.
             // For performance reasons we only do this as a last resort as most .ini files are not affected by this.
             $strings = self::parseMultilineIni(isset($contents) ? $contents : file_get_contents($fileName));


### PR DESCRIPTION
Emulate Joomla v4.4.0 and earlier behaviour when multi-line text strings present.

Pull Request for Issue #42416 .

### Summary of Changes

Allow embedded newlines in text (i.e. between quotes ").
Using them to structure very large areas of text makes maintenance easier.
In some cases using linewrap in IDE slightly helps, but one is left with trying to read / unravel a massive jumble of text.

Newlines in text worked up to v4.4.0
Security related change in v4.4.1 removed this functionality.

This change detects and removes the embedded newlines before using PHP ini parsing as before.
The security related change introduced in v4.4.1 is maintained.

### Testing Instructions

Install this plugin.
[plg_system_bflanguagetest.zip](https://github.com/joomla/joomla-cms/files/13539483/plg_system_bflanguagetest.zip)

Go to plugin admin page.

### Actual result BEFORE applying this Pull Request

The plugin name and description not translated.
The language labels are displayed.

### Expected result AFTER applying this Pull Request

Name and description translated.
As previous behavious in J4.1.0 and earlier.

### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed

Line breaks in characters string have worked for a very long time.
Mention made in another conversation that somewhere in the documentation it says they are not allowed.
Is so the location where that appears needs to be found and corrected.

Also mention was made that the JED needs to be changed to prevent the use of such line breaks.
Such a change will no longer be necessary - assume the developer wants such included.

