### PR TITLE
[4.4] Improve com users list view

### DIFF
--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -147,14 +147,14 @@ $mfa        = PluginHelper::isEnabled('multifactorauth');
                                     <?php endif; ?>
                                 </td>
                                 <td class="text-center d-md-table-cell">
-									<?php if (empty($item->activation)) : ?>
-										<span class="icon-check" aria-hidden="true" aria-describedby="tip-activated<?php echo $i; ?>"></span>
+                                    <?php if (empty($item->activation)) : ?>
+                                        <span class="icon-check" aria-hidden="true" aria-describedby="tip-activated<?php echo $i; ?>"></span>
                                         <div role="tooltip" id="tip-activated<?php echo $i; ?>">
                                             <?php echo Text::_('COM_USERS_ACTIVATED'); ?>
                                         </div>
-									<?php else : ?>
+                                    <?php else : ?>
                                         <?php echo HTMLHelper::_('jgrid.state', HTMLHelper::_('users.activateStates'), 1, $i, 'users.', true); ?>
-									<?php endif; ?>
+                                    <?php endif; ?>
                                 </td>
                                 <?php if ($mfa) : ?>
                                 <td class="text-center d-none d-md-table-cell">

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -153,8 +153,7 @@ $mfa        = PluginHelper::isEnabled('multifactorauth');
                                             <?php echo Text::_('COM_USERS_ACTIVATED'); ?>
                                         </div>
 									<?php else : ?>
-                                        <?php $activated = empty($item->activation) ? 0 : 1; ?>
-										<?php echo HTMLHelper::_('jgrid.state', HTMLHelper::_('users.activateStates'), $activated, $i, 'users.', (bool) $activated); ?>
+                                        <?php echo HTMLHelper::_('jgrid.state', HTMLHelper::_('users.activateStates'), 1, $i, 'users.', true); ?>
 									<?php endif; ?>
                                 </td>
                                 <?php if ($mfa) : ?>

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -147,15 +147,15 @@ $mfa        = PluginHelper::isEnabled('multifactorauth');
                                     <?php endif; ?>
                                 </td>
                                 <td class="text-center d-md-table-cell">
-                                    <?php $activated = empty($item->activation) ? 1 : 0; ?>
-                                    <?php if ($activated) : ?>
-                                        <span class="icon-check" aria-hidden="true" aria-describedby="tip-activated<?php echo $i; ?>"></span>
+									<?php if (empty($item->activation)) : ?>
+										<span class="icon-check" aria-hidden="true" aria-describedby="tip-activated<?php echo $i; ?>"></span>
                                         <div role="tooltip" id="tip-activated<?php echo $i; ?>">
                                             <?php echo Text::_('COM_USERS_ACTIVATED'); ?>
                                         </div>
-                                    <?php else : ?>
-                                        <?php echo HTMLHelper::_('jgrid.state', HTMLHelper::_('users.activateStates'), $activated, $i, 'users.', (bool) $activated); ?>
-                                    <?php endif; ?>
+									<?php else : ?>
+                                        <?php $activated = empty($item->activation) ? 0 : 1; ?>
+										<?php echo HTMLHelper::_('jgrid.state', HTMLHelper::_('users.activateStates'), $activated, $i, 'users.', (bool) $activated); ?>
+									<?php endif; ?>
                                 </td>
                                 <?php if ($mfa) : ?>
                                 <td class="text-center d-none d-md-table-cell">

--- a/administrator/components/com_users/tmpl/users/default.php
+++ b/administrator/components/com_users/tmpl/users/default.php
@@ -147,14 +147,18 @@ $mfa        = PluginHelper::isEnabled('multifactorauth');
                                     <?php endif; ?>
                                 </td>
                                 <td class="text-center d-md-table-cell">
-                                    <?php
-                                    $activated = empty($item->activation) ? 0 : 1;
-                                    echo HTMLHelper::_('jgrid.state', HTMLHelper::_('users.activateStates'), $activated, $i, 'users.', (bool) $activated);
-                                    ?>
+                                    <?php $activated = empty($item->activation) ? 1 : 0; ?>
+                                    <?php if ($activated) : ?>
+                                        <span class="icon-check" aria-hidden="true" aria-describedby="tip-activated<?php echo $i; ?>"></span>
+                                        <div role="tooltip" id="tip-activated<?php echo $i; ?>">
+                                            <?php echo Text::_('COM_USERS_ACTIVATED'); ?>
+                                        </div>
+                                    <?php else : ?>
+                                        <?php echo HTMLHelper::_('jgrid.state', HTMLHelper::_('users.activateStates'), $activated, $i, 'users.', (bool) $activated); ?>
+                                    <?php endif; ?>
                                 </td>
                                 <?php if ($mfa) : ?>
                                 <td class="text-center d-none d-md-table-cell">
-                                    <span class="tbody-icon">
                                     <?php if ($item->mfaRecords > 0 || !empty($item->otpKey)) : ?>
                                         <span class="icon-check" aria-hidden="true" aria-describedby="tip-mfa<?php echo $i; ?>"></span>
                                         <div role="tooltip" id="tip-mfa<?php echo $i; ?>">
@@ -166,7 +170,6 @@ $mfa        = PluginHelper::isEnabled('multifactorauth');
                                             <?php echo Text::_('COM_USERS_MFA_NOTACTIVE'); ?>
                                         </div>
                                     <?php endif; ?>
-                                    </span>
                                 </td>
                                 <?php endif; ?>
                                 <td class="d-none d-md-table-cell">


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
See users overview in backend. There are Informations ( user is activated, usage of MFA) which  look  like buttons but are only static informations. Just tried to click one of them and was surprised. 
This is misleading. 

### Testing Instructions
See users overview in backend before and after patch: Hover the different buttons  and information.

### Actual result BEFORE applying this Pull Request

![grafik](https://github.com/joomla/joomla-cms/assets/1035262/833d3718-ce27-4bda-a5de-05a773537eda)


### Expected result AFTER applying this Pull Request

![grafik](https://github.com/joomla/joomla-cms/assets/1035262/dd194e50-4ab3-438c-8573-a9dfa94fd45b)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
