### PR TITLE
[4.4] Fix error editor not found in contenthistory modal

### DIFF
--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -100,7 +100,7 @@ $wa->useScript('multiselect')
                             <?php endif; ?>
                         </td>
                         <td class="d-none d-md-table-cell">
-                            <?php echo htmlspecialchars($item->editor); ?>
+                            <?php echo empty($item->editor) ? (int) $item->editor_user_id : htmlspecialchars($item->editor); ?>
                         </td>
                         <td class="text-end">
                             <?php echo number_format((int) $item->character_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')); ?>

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -100,7 +100,7 @@ $wa->useScript('multiselect')
                             <?php endif; ?>
                         </td>
                         <td class="d-none d-md-table-cell">
-                            <?php echo empty($item->editor) ? ((int) $item->editor_user_id) : htmlspecialchars($item->editor); ?>
+                            <?php echo empty($item->editor) ? $item->editor_user_id : htmlspecialchars($item->editor); ?>
                         </td>
                         <td class="text-end">
                             <?php echo number_format((int) $item->character_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')); ?>

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -100,7 +100,7 @@ $wa->useScript('multiselect')
                             <?php endif; ?>
                         </td>
                         <td class="d-none d-md-table-cell">
-                            <?php echo empty($item->editor) ? (int) $item->editor_user_id : htmlspecialchars($item->editor); ?>
+                            <?php echo empty($item->editor) ? ((int) $item->editor_user_id) : htmlspecialchars($item->editor); ?>
                         </td>
                         <td class="text-end">
                             <?php echo number_format((int) $item->character_count, 0, Text::_('DECIMALS_SEPARATOR'), Text::_('THOUSANDS_SEPARATOR')); ?>


### PR DESCRIPTION
Pull Request for Issue #42445 .

### Summary of Changes
Show the user_id in created_by if the user is not found. 


### Testing Instructions
see #42445


### Actual result BEFORE applying this Pull Request
see #42445



### Expected result AFTER applying this Pull Request

![grafik](https://github.com/joomla/joomla-cms/assets/1035262/081058d1-6650-4068-b95d-dfa0853dff98)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
