### PR TITLE
Fix escaping of $ and reverts old language file format

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2957,7 +2957,7 @@ class JoomlaInstallerScript
      *
      * @return  void
      *
-     * @since   4.4.2
+     * @since   __DEPLOY_VERSION__
      */
     protected function fixLanguageOverrides()
     {

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2975,7 +2975,8 @@ class JoomlaInstallerScript
             $files = Folder::files($client_path . '/language/overrides', '\.override\.ini$');
 
             foreach ($files as $filename) {
-                $contents = file_get_contents($filename);
+                $override_path = $client_path . '/language/overrides/' . $filename;
+                $contents = file_get_contents($override_path);
 
                 // Check file contains dollar sign
                 if (strpos($contents, '$') !== false) {
@@ -2984,7 +2985,7 @@ class JoomlaInstallerScript
 
                     if ($count > 0) {
                         // Save on change
-                        File::write($filename, $contents);
+                        File::write($override_path, $contents);
                     }
                 }
             }

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2976,7 +2976,7 @@ class JoomlaInstallerScript
 
             foreach ($files as $filename) {
                 $override_path = $client_path . '/language/overrides/' . $filename;
-                $contents = file_get_contents($override_path);
+                $contents      = file_get_contents($override_path);
 
                 // Check file contains dollar sign
                 if (strpos($contents, '$') !== false) {

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -423,9 +423,9 @@ class LanguageHelper
         try {
             if (!\function_exists('parse_ini_file') || $isParseIniFileDisabled) {
                 $contents = file_get_contents($fileName);
-                $strings  = parse_ini_string($contents, false, INI_SCANNER_RAW);
+                $strings  = parse_ini_string($contents);
             } else {
-                $strings = parse_ini_file($fileName, false, INI_SCANNER_RAW);
+                $strings = parse_ini_file($fileName);
             }
         } catch (\Exception $e) {
             if ($debug) {
@@ -436,9 +436,6 @@ class LanguageHelper
         } finally {
             restore_error_handler();
         }
-
-        // Ini files are processed in the "RAW" mode of parse_ini_string, leaving escaped quotes untouched - lets postprocess them
-        $strings = str_replace('\"', '"', $strings);
 
         return \is_array($strings) ? $strings : [];
     }
@@ -455,9 +452,9 @@ class LanguageHelper
      */
     public static function saveToIniFile($fileName, array $strings)
     {
-        // Escape double quotes.
+        // Escape double quotes and dollars.
         foreach ($strings as $key => $string) {
-            $strings[$key] = addcslashes($string, '"');
+            $strings[$key] = addcslashes($string, '"$');
         }
 
         // Write override.ini file with the strings.

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -454,7 +454,7 @@ class LanguageHelper
     {
         // Escape double quotes and dollars.
         foreach ($strings as $key => $string) {
-            $strings[$key] = addcslashes($string, '"$');
+            $strings[$key] = addcslashes($string, '"$\\');
         }
 
         // Write override.ini file with the strings.


### PR DESCRIPTION
The recent change in the language file format (from the "normal" to "raw" parser) in Joomla 4.4.1/5.0.1 resulted in broken backwards compatibility:
- Escaped backslashes are not handled
- Multiline values are not supported
- Single quoted strings are not supported

There are many related discussions and attempts to "fix" new behaviour: #42416 #42425 #42432 #42440 #42441 #42455 #42456

This patch fixes the escaping of the `$` character in the Language Override and reverts the old language file format.

For thorough testing, I'd recommend the following steps:
1) Install 5.0.0 -> install patch -> confirm that no errors occur.
2) Install 5.0.1 -> install patch -> confirm that no errors occur.
3) Install 5.0.0 -> create a language override with `${test}` substring (invisible in the Languages Overrides after saving) -> install patch -> the substring is visible in the Languages Overrides.
4) Install 5.0.1 -> create a language override with `${test}` substring (visible in the Languages Overrides after saving) -> install patch -> the substring is visible in the Languages Overrides.

PS. But using a raw ini parser (without post-processing language strings) is a good idea, so I have started a feature request discussion (please join): https://github.com/joomla/joomla-cms/issues/42462