### PR TITLE
Set correct AssetTitle and AssetParentId

### DIFF
--- a/administrator/components/com_scheduler/src/Table/TaskTable.php
+++ b/administrator/components/com_scheduler/src/Table/TaskTable.php
@@ -172,7 +172,7 @@ class TaskTable extends Table implements CurrentUserInterface
      *
      * @return  string
      *
-     * @since   5.0.2
+     * @since   __DEPLOY_SINCE__
      */
     protected function _getAssetTitle(): string
     {
@@ -191,7 +191,7 @@ class TaskTable extends Table implements CurrentUserInterface
      *
      * @return  integer
      *
-     * @since   5.0.2
+     * @since   __DEPLOY_SINCE__
      */
     protected function _getAssetParentId(Table $table = null, $id = null): int
     {

--- a/administrator/components/com_scheduler/src/Table/TaskTable.php
+++ b/administrator/components/com_scheduler/src/Table/TaskTable.php
@@ -167,6 +167,44 @@ class TaskTable extends Table implements CurrentUserInterface
         return 'com_scheduler.task.' . (int) $this->$k;
     }
 
+	/**
+	 * Method to return the title to use for the asset table.
+	 *
+	 * @return  string
+	 *
+	 * @since   5.0.2
+	 */
+	protected function _getAssetTitle(): string
+	{
+		return $this->title;
+	}
+
+	/**
+	 * Method to get the parent asset under which to register this one.
+	 * By default, all assets are registered to the ROOT node with ID,
+	 * which will default to 1 if none exists.
+	 * The extended class can define a table and id to lookup.  If the
+	 * asset does not exist it will be created.
+	 *
+	 * @param   Table|null  $table  A Table object for the asset parent.
+	 * @param   null        $id     Id to look up
+	 *
+	 * @return  integer
+	 *
+	 * @since   5.0.2
+	 */
+	protected function _getAssetParentId(Table $table = null, $id = null): int
+	{
+		$assetId = null;
+		$asset   = new Asset($this->getDbo(), $this->getDispatcher());
+
+		if ($asset->loadByName('com_scheduler')) {
+			$assetId = $asset->id;
+		}
+
+		return $assetId ?? parent::_getAssetParentId($table, $id);
+	}
+
     /**
      * Override {@see Table::bind()} to bind some fields even if they're null given they're present in $src.
      * This override is needed specifically for DATETIME fields, of which the `next_execution` field is updated to

--- a/administrator/components/com_scheduler/src/Table/TaskTable.php
+++ b/administrator/components/com_scheduler/src/Table/TaskTable.php
@@ -172,7 +172,7 @@ class TaskTable extends Table implements CurrentUserInterface
      *
      * @return  string
      *
-     * @since   __DEPLOY_SINCE__
+     * @since   __DEPLOY_VERSION__
      */
     protected function _getAssetTitle(): string
     {
@@ -191,7 +191,7 @@ class TaskTable extends Table implements CurrentUserInterface
      *
      * @return  integer
      *
-     * @since   __DEPLOY_SINCE__
+     * @since   __DEPLOY_VERSION__
      */
     protected function _getAssetParentId(Table $table = null, $id = null): int
     {

--- a/administrator/components/com_scheduler/src/Table/TaskTable.php
+++ b/administrator/components/com_scheduler/src/Table/TaskTable.php
@@ -167,43 +167,43 @@ class TaskTable extends Table implements CurrentUserInterface
         return 'com_scheduler.task.' . (int) $this->$k;
     }
 
-	/**
-	 * Method to return the title to use for the asset table.
-	 *
-	 * @return  string
-	 *
-	 * @since   5.0.2
-	 */
-	protected function _getAssetTitle(): string
-	{
-		return $this->title;
-	}
-
-	/**
-	 * Method to get the parent asset under which to register this one.
-	 * By default, all assets are registered to the ROOT node with ID,
-	 * which will default to 1 if none exists.
-	 * The extended class can define a table and id to lookup.  If the
-	 * asset does not exist it will be created.
-	 *
-	 * @param   Table|null  $table  A Table object for the asset parent.
-	 * @param   null        $id     Id to look up
-	 *
-	 * @return  integer
-	 *
-	 * @since   5.0.2
-	 */
-	protected function _getAssetParentId(Table $table = null, $id = null): int
-	{
-		$assetId = null;
-		$asset   = new Asset($this->getDbo(), $this->getDispatcher());
-
-		if ($asset->loadByName('com_scheduler')) {
-			$assetId = $asset->id;
-		}
-
-		return $assetId ?? parent::_getAssetParentId($table, $id);
-	}
+    /**
+     * Method to return the title to use for the asset table.
+     *
+     * @return  string
+     *
+     * @since   5.0.2
+     */
+    protected function _getAssetTitle(): string
+    {
+        return $this->title;
+    }
+    
+    /**
+     * Method to get the parent asset under which to register this one.
+     * By default, all assets are registered to the ROOT node with ID,
+     * which will default to 1 if none exists.
+     * The extended class can define a table and id to lookup.  If the
+     * asset does not exist it will be created.
+     *
+     * @param   Table|null  $table  A Table object for the asset parent.
+     * @param   null        $id     Id to look up
+     *
+     * @return  integer
+     *
+     * @since   5.0.2
+     */
+    protected function _getAssetParentId(Table $table = null, $id = null): int
+    {
+        $assetId = null;
+        $asset   = new Asset($this->getDbo(), $this->getDispatcher());
+    
+        if ($asset->loadByName('com_scheduler')) {
+            $assetId = $asset->id;
+        }
+    
+        return $assetId ?? parent::_getAssetParentId($table, $id);
+    }
 
     /**
      * Override {@see Table::bind()} to bind some fields even if they're null given they're present in $src.

--- a/administrator/components/com_scheduler/src/Table/TaskTable.php
+++ b/administrator/components/com_scheduler/src/Table/TaskTable.php
@@ -178,7 +178,7 @@ class TaskTable extends Table implements CurrentUserInterface
     {
         return $this->title;
     }
-    
+
     /**
      * Method to get the parent asset under which to register this one.
      * By default, all assets are registered to the ROOT node with ID,
@@ -197,11 +197,11 @@ class TaskTable extends Table implements CurrentUserInterface
     {
         $assetId = null;
         $asset   = new Asset($this->getDbo(), $this->getDispatcher());
-    
+
         if ($asset->loadByName('com_scheduler')) {
             $assetId = $asset->id;
         }
-    
+
         return $assetId ?? parent::_getAssetParentId($table, $id);
     }
 


### PR DESCRIPTION
Pull Request for Issue #42484.

### Summary of Changes
Currently the asset title and parent asset id are not set for the Scheduled Tasks, so ending up incorrectly in the database. This PR sets the correct values for both

### Testing Instructions
- Check #__assets database table for the scheduled taks and not the incorrect title and parent ID
- Open Tasks via admin, re-save them
- Check #__assets database table for the scheduled taks and notice the correct title and parent ID are set

### Actual result BEFORE applying this Pull Request
<img width="676" alt="Schermafbeelding 2023-12-08 om 11 47 28" src="https://github.com/joomla/joomla-cms/assets/522834/89983e2e-b47f-49cd-b9fa-787de2af02e3">

### Expected result AFTER applying this Pull Request
<img width="644" alt="Schermafbeelding 2023-12-08 om 11 47 46" src="https://github.com/joomla/joomla-cms/assets/522834/7edc9a61-3b27-48a5-bda8-ddddfc2b161a">

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
