### PR TITLE
[4.4] Finder: Do not show error messages for suggestions

### DIFF
--- a/build/media_source/com_finder/js/finder.es6.js
+++ b/build/media_source/com_finder/js/finder.es6.js
@@ -22,7 +22,9 @@
         try {
           response = JSON.parse(xhr.responseText);
         } catch (e) {
-          Joomla.renderMessages(Joomla.ajaxErrorsMessages(xhr, 'parsererror'));
+          // Something went wrong, but we are not going to bother the enduser with this
+          // eslint-disable-next-line no-console
+          console.error(e);
           return;
         }
 
@@ -30,7 +32,9 @@
           target.awesomplete.list = response.suggestions;
         }
       }).catch((xhr) => {
-        Joomla.renderMessages(Joomla.ajaxErrorsMessages(xhr));
+        // Something went wrong, but we are not going to bother the enduser with this
+        // eslint-disable-next-line no-console
+        console.error(xhr);
       });
     }
   };


### PR DESCRIPTION
This is a re-do of #42437 for 4.4 instead of 5.x, since this is actually a bug and not a change request anymore.

### Summary of Changes
When typing very fast into the search box and hitting enter, the browser has fired an AJAX call for every character typed and the server might not have responded. When hitting enter, the form is send and all AJAX requests are aborted. This lets the JS code return and run into the failure condition, resulting in a flash of error messages being displayed. While it is nice to know that something failed for a developer, this should not be displayed to the general enduser. The JS code right now can spam the screen with system messages for these failed calls, especially since a call is triggered for each character entered into the search box. This PR removes this error handling.


### Testing Instructions
1. Go to `/components/com_finder/src/Controller/SuggestionsController.php` and insert 
	```echo '1';```
	in line 43 to create a broken output from the controller.
2. Type into the search box of mod_finder and see loads of system error messages displayed.
3. Apply the patch. (remember to run npm)
4. Type into the search box and don't see the previous messages.
5. Remove the code from line 43 and type again. See the suggestions appearing again.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
