### PR TITLE
[5.1] Api redirect tests

### DIFF
--- a/tests/System/integration/api/com_redirect/Redirect.cy.js
+++ b/tests/System/integration/api/com_redirect/Redirect.cy.js
@@ -14,7 +14,7 @@ describe('Test that redirect API endpoint', () => {
         .should('include', 'automated test redirect'));
   });
 
-  it('can deliver a list of redirect', () => {
+  it('can deliver a list of redirects', () => {
     cy.api_get('/redirects')
       .then((response) => cy.wrap(response).its('body').its('data.0').its('attributes')
         .its('comment')


### PR DESCRIPTION
Corrects the grammar for the description of a redirect test.

simple PR that can be "tested" by code review
