### PR TITLE
[4.4] Fixes to form validation process

### DIFF
--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -182,9 +182,9 @@ class Form
     }
 
     /**
-     * Return all errors, if any.
+     * Return Exceptions thrown during the form validation process.
      *
-     * @return  \Exception[]  Array of error messages or RuntimeException objects.
+     * @return  \Exception[]
      *
      * @since   1.7.0
      */
@@ -1055,8 +1055,8 @@ class Form
     /**
      * Method to validate form data.
      *
-     * Validation warnings will be pushed into JForm::errors and should be
-     * retrieved with JForm::getErrors() when validate returns boolean false.
+     * Validation warnings will be pushed into Form::$errors and should be
+     * retrieved with Form::getErrors() when validate returns boolean false.
      *
      * @param   array   $data   An array of field values to validate.
      * @param   string  $group  The optional dot-separated form group path on which to filter the
@@ -1134,6 +1134,7 @@ class Form
                 // The field returned false from setup and shouldn't be included in the page body - yet we received
                 // a value for it. This is probably some sort of injection attack and should be rejected
                 $this->errors[] = new \RuntimeException(Text::sprintf('JLIB_FORM_VALIDATE_FIELD_INVALID', $key));
+                $return         = false;
             }
         }
 


### PR DESCRIPTION
Fixes hardening measure introduced in https://github.com/joomla/joomla-cms/pull/23716

### Summary of Changes
In the linked PR I forbid submitting by adding an exception into the validation process. Unfortunately I didn't make the method return false in order to make sure that message was used. This fixes that.

Alongside it improves the documentation around the getError's method. It hasn't returned any strings since 3.0 (and even maybe further - I wasn't sure about how the JException objects were exactly being passed around).

### Testing Instructions
Code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
