### PR TITLE
[4][com_actionlogs] missed load plugin languages

### DIFF
--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -324,6 +324,12 @@ class ActionlogsHelper
         // Load plg_system_actionlogs too
         $lang->load('plg_system_actionlogs', JPATH_ADMINISTRATOR);
 
+        // Load plg_system_privacyconsent too
+        $lang->load('plg_system_privacyconsent', JPATH_ADMINISTRATOR);
+
+        // Load plg_user_terms too
+        $lang->load('plg_user_terms', JPATH_ADMINISTRATOR);
+
         // Load com_privacy too.
         $lang->load('com_privacy', JPATH_ADMINISTRATOR);
     }

--- a/tests/System/integration/administrator/components/com_privacy/Consent.cy.js
+++ b/tests/System/integration/administrator/components/com_privacy/Consent.cy.js
@@ -2,6 +2,7 @@ describe('Test in backend that privacy consent component', () => {
   beforeEach(() => cy.doAdministratorLogin());
   afterEach(() => {
     cy.task('queryDB', 'DELETE FROM #__privacy_consents');
+    cy.task('queryDB', "DELETE FROM #__users WHERE name = 'test user'");
     cy.get('.js-stools-btn-clear').click({ force: true });
   });
 


### PR DESCRIPTION
Pull Request for Issue #28540.

### Summary of Changes
load language from:

- plg_system_privacyconsent
- plg_user_terms


### Testing Instructions

enable user term plugin  - register a new user and consent to the terms and conditions during registration.
enable sytem privacy plugin - and consent to the privacy policy.

on dashboard Latest Actions module check that string are translated correctly

### Actual result BEFORE applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/181681/e96d4657-6840-421e-a225-c2ba312cb552)


### Expected result AFTER applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/181681/58d6d868-a2ca-4aa6-bd72-9558892450c8)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
