### PR TITLE
[4.4] Better message on package uninstallation when an extension is missing

### DIFF
--- a/administrator/language/en-GB/lib_joomla.ini
+++ b/administrator/language/en-GB/lib_joomla.ini
@@ -614,8 +614,10 @@ JLIB_INSTALLER_ERROR_PACK_UNINSTALL_INVALID_MANIFEST="Package Uninstall: Invalid
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_INVALID_NOTFOUND_MANIFEST="Package Uninstall: Manifest file invalid or not found: %s"
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_LOAD_MANIFEST="Package Uninstall: Could not load manifest file."
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_MANIFEST_NOT_REMOVED="Package Uninstall: Errors were detected, manifest file not removed!"
+JLIB_INSTALLER_ERROR_PACK_UNINSTALL_MISSING_EXTENSION="Package Uninstall: This extension is missing or has already been uninstalled: %s"
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_MISSINGMANIFEST="Package Uninstall: Missing manifest file."
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_NOT_PROPER="Package Uninstall: This extension may have already been uninstalled or might not have been uninstalled properly: %s"
+; The following string is deprecated and will be removed with 6.0
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_UNKNOWN_EXTENSION="Trying to uninstall unknown extension from package. This extension may have already been removed earlier."
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_WARNCOREPACK="Package Uninstall: Trying to uninstall core package."
 JLIB_INSTALLER_ERROR_PLG_DISCOVER_STORE_DETAILS="Plugin Discover install: Failed to store plugin details."

--- a/language/en-GB/lib_joomla.ini
+++ b/language/en-GB/lib_joomla.ini
@@ -611,8 +611,10 @@ JLIB_INSTALLER_ERROR_PACK_UNINSTALL_INVALID_MANIFEST="Package Uninstall: Invalid
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_INVALID_NOTFOUND_MANIFEST="Package Uninstall: Manifest file invalid or not found: %s"
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_LOAD_MANIFEST="Package Uninstall: Could not load manifest file."
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_MANIFEST_NOT_REMOVED="Package Uninstall: Errors were detected, manifest file not removed!"
+JLIB_INSTALLER_ERROR_PACK_UNINSTALL_MISSING_EXTENSION="Package Uninstall: This extension is missing or has already been uninstalled: %s"
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_MISSINGMANIFEST="Package Uninstall: Missing manifest file."
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_NOT_PROPER="Package Uninstall: This extension may have already been uninstalled or might not have been uninstalled properly: %s"
+; The following string is deprecated and will be removed with 6.0
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_UNKNOWN_EXTENSION="Trying to uninstall unknown extension from package. This extension may have already been removed earlier."
 JLIB_INSTALLER_ERROR_PACK_UNINSTALL_WARNCOREPACK="Package Uninstall: Trying to uninstall core package."
 JLIB_INSTALLER_ERROR_PLG_DISCOVER_STORE_DETAILS="Plugin Discover install: Failed to store plugin details."

--- a/libraries/src/Installer/Adapter/PackageAdapter.php
+++ b/libraries/src/Installer/Adapter/PackageAdapter.php
@@ -430,7 +430,7 @@ class PackageAdapter extends InstallerAdapter
                     Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_NOT_PROPER', basename($extension->filename)), Log::WARNING, 'jerror');
                 }
             } else {
-                Log::add(Text::_('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_UNKNOWN_EXTENSION'), Log::WARNING, 'jerror');
+                Log::add(Text::sprintf('JLIB_INSTALLER_ERROR_PACK_UNINSTALL_MISSING_EXTENSION', basename($extension->filename)), Log::WARNING, 'jerror');
             }
         }
 


### PR DESCRIPTION
Pull Request for Issue #42537 .

### Summary of Changes

Provide a better warning message on package uninstallation when an extension from that package is missing by mentioning the name of that extension in the message.

A new language string is added for this purpose, which is more or less the same as the first part of the existing `JLIB_INSTALLER_ERROR_PACK_UNINSTALL_NOT_PROPER` string and uses the same parameter.

The package adapter uses the new string in the same way as the `JLIB_INSTALLER_ERROR_PACK_UNINSTALL_NOT_PROPER` string, i.e. the extensions name is obtained with `basename($extension->filename))`.

The old language string `JLIB_INSTALLER_ERROR_PACK_UNINSTALL_UNKNOWN_EXTENSION` is obsolete and therefore deprecated.

### Testing Instructions

Packages for new installation and updates and a custom update URL created by Drone for this PR can be found here: https://artifacts.joomla.org/drone/joomla/joomla-cms/4.4-dev/42570/downloads/72522 .

1. Install some 3rd party package extension which contains a few extensions of different type, e.g. a component and some modules or plugins.
2. Uninstall one of these extensions (modules or plugins) from that package.
3. Uninstall the package and check the warning messages.

### Actual result BEFORE applying this Pull Request

There is a warning message "Trying to uninstall unknown extension from package. This extension may have already been removed earlier.".

### Expected result AFTER applying this Pull Request

There is a warning message which contains the name of the extensions, e.g. "Package Uninstall: This extension is missing or has already been uninstalled: mod_helloworld".

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
