### PR TITLE
[4]]webservice] get privacy request export

### DIFF
--- a/api/components/com_privacy/src/Serializer/ExportSerializer.php
+++ b/api/components/com_privacy/src/Serializer/ExportSerializer.php
@@ -16,7 +16,7 @@ use Joomla\CMS\Serializer\JoomlaSerializer;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * Pricacy export serializer
+ * Privacy export serializer
  *
  * @since  __DEPLOY_VERSION__
  */

--- a/api/components/com_privacy/src/Serializer/ExportSerializer.php
+++ b/api/components/com_privacy/src/Serializer/ExportSerializer.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2023 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\Component\Privacy\Api\Serializer;
+
+use Joomla\CMS\Serializer\JoomlaSerializer;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Pricacy export serializer
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class ExportSerializer extends JoomlaSerializer
+{
+    /**
+     * Override the model id
+     *
+     * @param   \stdClass  $model  Item model
+     *
+     * @return  \stdClass  $model  Item model
+     *
+     * @since __DEPLOY_VERSION__
+     */
+    public function getId($model)
+    {
+        $model['id'] = '1';
+        return $model['id'];
+    }
+
+}

--- a/api/components/com_privacy/src/Serializer/ExportSerializer.php
+++ b/api/components/com_privacy/src/Serializer/ExportSerializer.php
@@ -34,6 +34,7 @@ class ExportSerializer extends JoomlaSerializer
     public function getId($model)
     {
         $model['id'] = '1';
+
         return $model['id'];
     }
 

--- a/api/components/com_privacy/src/View/Requests/JsonapiView.php
+++ b/api/components/com_privacy/src/View/Requests/JsonapiView.php
@@ -12,9 +12,9 @@ namespace Joomla\Component\Privacy\Api\View\Requests;
 
 use Joomla\CMS\MVC\View\JsonApiView as BaseApiView;
 use Joomla\CMS\Router\Exception\RouteNotFoundException;
-use Joomla\CMS\Serializer\JoomlaSerializer;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Privacy\Administrator\Model\ExportModel;
+use Joomla\Component\Privacy\Api\Serializer\ExportSerializer;
 use Tobscure\JsonApi\Resource;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -62,7 +62,7 @@ class JsonapiView extends BaseApiView
             throw new RouteNotFoundException('Item does not exist');
         }
 
-        $serializer = new JoomlaSerializer('export');
+        $serializer = new ExportSerializer('export');
         $element    = (new Resource($exportData, $serializer));
 
         $this->getDocument()->setData($element);


### PR DESCRIPTION
Pull Request for Issue #41465 .

### Summary of Changes
extend `JoomlaSerializer`



### Testing Instructions
GET {{base_path}}/api/index.php/v1/privacy/requests/export/{request_id} with the id of a privacy request
via postman or whatever
php 8.2
Error Reporting  maximum


### Actual result BEFORE applying this Pull Request
`Warning: Attempt to read property "id" on array in...`


### Expected result AFTER applying this Pull Request
no more warning


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
