### PR TITLE
[4.4] Fix missing 'separator' lines between sub menus in Admin Components

### DIFF
--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -1068,7 +1068,7 @@ class ComponentAdapter extends InstallerAdapter
             $data['menutype']     = 'main';
             $data['client_id']    = 1;
             $data['title']        = (string) trim($child);
-            $data['alias']        = (string) $child;
+            $data['alias']        = ((string) $child->attributes()->alias) ?: (string) $child;
             $data['type']         = ((string) $child->attributes()->type) ?: 'component';
             $data['published']    = 1;
             $data['parent_id']    = $parent_id;

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -1069,7 +1069,7 @@ class ComponentAdapter extends InstallerAdapter
             $data['client_id']    = 1;
             $data['title']        = (string) trim($child);
             $data['alias']        = (string) $child;
-            $data['type']         = 'component';
+            $data['type']         = ((string) $child->attributes()->type) ?: 'component';
             $data['published']    = 1;
             $data['parent_id']    = $parent_id;
             $data['component_id'] = $componentId;


### PR DESCRIPTION
Adds separators as submenu's items for Components

Pull Request for Issue #41123 .

### Summary of Changes
Alters the 'type' attribute for sub-menus when installing a Component to allow for separator lines to be added to the sub menu of a Component. For use when you need to break up or group sub-menu items of a Component.

In the manifest .xml file for a components you can indicate the placement of the separator by adding the element `<menu type=separator>--<menu>`  between a set of  <submenu></subment> elements. 

<submenu>
    <menu ....>
    <menu type="separator">---</menu>
    <menu ...>
</submenu>

The processing to read and render the separator already exists in the Joomla core, all that was missing was the ability to specify the  'type' of separator when installing a component. The rendering of the separator will either use the characters defined between the <menu> and </menu> elements or the characters are stripped and the separator is rendered as a line with CSS.

### Testing Instructions
Add the `<menu type=separator>--<menu>` element to the manifest .xml file of a component and Install the component in an instance of Joomla. 

Below is a sample manifest .xml file that can be .zipped and installed to create a dummy component menu and sub-menu that will create the various separators.
```
<?xml version="1.0" encoding="utf-8" ?>
<extension type="component" method="upgrade">
    <name>com_testing</name>
    <creationDate>2024</creationDate>
    <author>someone</author>
    <authorEmail>somethingsomewhere.com</authorEmail>
    <authorUrl>something</authorUrl>
    <copyright>something</copyright>
    <license>GNU General Public License version 2 or later;</license>
    <version>1.0.0</version>
    <description>Testing</description>

    <!-- Back-end files -->
    <administration>
        <!-- Menu entries -->
        <menu view="emporium">Testing</menu>
        <submenu>
            <menu link="option=com_testing">Menu Item 1</menu>
            <menu type="separator">-----------------------</menu>
            <menu link="option=com_testing">Menu Item 2</menu>
            <menu type="separator" alias="second">.....................</menu>
            <menu link="option=com_testing">Menu Item 3</menu>
            <menu type="separator" alias="third">______________________</menu>
        </submenu>
        <files>
            <filename>testing.xml</filename>
        </files>
    </administration>
</extension>
```


### Actual result BEFORE applying this Pull Request

Nothing happened. 'type=separator' is ignored and replaced with 'component'

### Expected result AFTER applying this Pull Request
Expand your Component name under the Admin area Component Menu on the left and you should see the separator displayed as a sub menu item. 

In the #__menu table the entry for your separator will have a field of type with the value 'separator' and the alias will be the current date


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>https://docs.joomla.org/Manifest_files</link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
