### PR TITLE
[4.4] check for valid referrer

### DIFF
--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -1039,7 +1039,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
         if (!$valid && $redirect) {
             $referrer = $this->input->server->getString('HTTP_REFERER');
 
-            if (!Uri::isInternal($referrer)) {
+            if (\is_null($referrer) || !Uri::isInternal($referrer)) {
                 $referrer = 'index.php';
             }
 


### PR DESCRIPTION
### Summary of Changes

check if `$_SERVER['HTTP_REFERER']` is valid before call `Uri::isInternal()`

### Testing Instructions

- login as super user in backend
- visit `https://example.tl/administrator/index.php?option=com_admin&view=sysinfo&format=text` (note: link is without token!)
- check php warnings (PHP >= 8.1 required)

### Actual result BEFORE applying this Pull Request

`PHP Deprecated:  str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in libraries/src/Uri/Uri.php on line 243`

### Expected result AFTER applying this Pull Request

No deprecation warning

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
