### PR TITLE
[4.4] Improve Totp code input

### DIFF
--- a/plugins/multifactorauth/email/src/Extension/Email.php
+++ b/plugins/multifactorauth/email/src/Extension/Email.php
@@ -190,7 +190,7 @@ class Email extends CMSPlugin implements SubscriberInterface
                     'input_type' => 'text',
                     // The attributes for the HTML input box.
                     'input_attributes' => [
-                        'pattern' => "{0,9}", 'maxlength' => "6", 'inputmode' => "numeric",
+                        'pattern' => '[0-9]{6}', 'maxlength' => '6', 'inputmode' => 'numeric', 'required' => 'true', 'autocomplete' => 'one-time-code', 'aria-autocomplete' => 'none',
                     ],
                     // Placeholder text for the HTML input box. Leave empty if you don't need it.
                     'placeholder' => Text::_('PLG_MULTIFACTORAUTH_EMAIL_LBL_SETUP_PLACEHOLDER'),
@@ -264,7 +264,7 @@ class Email extends CMSPlugin implements SubscriberInterface
                         'field_type'       => 'input',
                         'input_type'       => 'text',
                         'input_attributes' => [
-                            'pattern' => "{0,9}", 'maxlength' => "6", 'inputmode' => "numeric",
+                            'pattern' => '[0-9]{6}', 'maxlength' => '6', 'inputmode' => 'numeric', 'required' => 'true', 'autocomplete' => 'one-time-code', 'aria-autocomplete' => 'none',
                         ],
                         'input_value' => '',
                         'placeholder' => Text::_('PLG_MULTIFACTORAUTH_EMAIL_LBL_SETUP_PLACEHOLDER'),

--- a/plugins/multifactorauth/totp/src/Extension/Totp.php
+++ b/plugins/multifactorauth/totp/src/Extension/Totp.php
@@ -150,7 +150,7 @@ class Totp extends CMSPlugin implements SubscriberInterface
                     'input_type' => 'text',
                     // The attributes for the HTML input box.
                     'input_attributes' => [
-                        'pattern' => "[0-9]{6}", 'maxlength' => "6", 'inputmode' => "numeric", "autocomplete" => "one-time-code", "aria-autocomplete" => "none",
+                        'pattern' => '[0-9]{6}', 'maxlength' => '6', 'inputmode' => 'numeric', 'required' => 'true', 'autocomplete' => 'one-time-code', 'aria-autocomplete' => 'none',
                     ],
                     // Placeholder text for the HTML input box. Leave empty if you don't need it.
                     'placeholder' => '',
@@ -239,7 +239,7 @@ class Totp extends CMSPlugin implements SubscriberInterface
                     ],
                     'input_type'       => $isConfigured ? 'hidden' : 'text',
                     'input_attributes' => [
-                        'pattern' => "[0-9]{6}", 'maxlength' => "6", 'inputmode' => "numeric", "autocomplete" => "one-time-code", "aria-autocomplete" => "none",
+                        'pattern' => '[0-9]{6}', 'maxlength' => '6', 'inputmode' => 'numeric', 'required' => 'true', 'autocomplete' => 'one-time-code', 'aria-autocomplete' => 'none',
                     ],
                     'input_value' => '',
                     'placeholder' => Text::_('PLG_MULTIFACTORAUTH_TOTP_LBL_SETUP_PLACEHOLDER'),

--- a/plugins/multifactorauth/totp/src/Extension/Totp.php
+++ b/plugins/multifactorauth/totp/src/Extension/Totp.php
@@ -150,7 +150,7 @@ class Totp extends CMSPlugin implements SubscriberInterface
                     'input_type' => 'text',
                     // The attributes for the HTML input box.
                     'input_attributes' => [
-                        'pattern' => "[0-9]{,6}", 'maxlength' => "6", 'inputmode' => "numeric", "autocomplete" => "one-time-code", "aria-autocomplete" => "none",
+                        'pattern' => "[0-9]{6}", 'maxlength' => "6", 'inputmode' => "numeric", "autocomplete" => "one-time-code", "aria-autocomplete" => "none",
                     ],
                     // Placeholder text for the HTML input box. Leave empty if you don't need it.
                     'placeholder' => '',
@@ -239,7 +239,7 @@ class Totp extends CMSPlugin implements SubscriberInterface
                     ],
                     'input_type'       => $isConfigured ? 'hidden' : 'text',
                     'input_attributes' => [
-                        'pattern' => "[0-9]{,6}", 'maxlength' => "6", 'inputmode' => "numeric", "autocomplete" => "one-time-code", "aria-autocomplete" => "none",
+                        'pattern' => "[0-9]{6}", 'maxlength' => "6", 'inputmode' => "numeric", "autocomplete" => "one-time-code", "aria-autocomplete" => "none",
                     ],
                     'input_value' => '',
                     'placeholder' => Text::_('PLG_MULTIFACTORAUTH_TOTP_LBL_SETUP_PLACEHOLDER'),

--- a/plugins/multifactorauth/totp/src/Extension/Totp.php
+++ b/plugins/multifactorauth/totp/src/Extension/Totp.php
@@ -150,7 +150,7 @@ class Totp extends CMSPlugin implements SubscriberInterface
                     'input_type' => 'text',
                     // The attributes for the HTML input box.
                     'input_attributes' => [
-                        'pattern' => "{0,9}", 'maxlength' => "6", 'inputmode' => "numeric",
+                        'pattern' => "[0-9]{,6}", 'maxlength' => "6", 'inputmode' => "numeric", "autocomplete" => "one-time-code", "aria-autocomplete" => "none",
                     ],
                     // Placeholder text for the HTML input box. Leave empty if you don't need it.
                     'placeholder' => '',
@@ -239,7 +239,7 @@ class Totp extends CMSPlugin implements SubscriberInterface
                     ],
                     'input_type'       => $isConfigured ? 'hidden' : 'text',
                     'input_attributes' => [
-                        'pattern' => "{0,9}", 'maxlength' => "6", 'inputmode' => "numeric",
+                        'pattern' => "[0-9]{,6}", 'maxlength' => "6", 'inputmode' => "numeric", "autocomplete" => "one-time-code", "aria-autocomplete" => "none",
                     ],
                     'input_value' => '',
                     'placeholder' => Text::_('PLG_MULTIFACTORAUTH_TOTP_LBL_SETUP_PLACEHOLDER'),


### PR DESCRIPTION
* Fix code input pattern attribute

* Specify autocomplete on code input

Pull Request for Issue # .

### Summary of Changes

Fix JS pattern attribute error for code input element: `Pattern attribute value {0,9} is not a valid regular expression: Uncaught SyntaxError: Invalid regular expression: /{0,9}/v: Nothing to repeat`

Prevent auto completion of code input element. Can cause trouble for certain users, when the browser tries to autofill past values as they enter in the current code.

**I intend this fix to also apply to Joomla 5.** I assume that this pull request will magically apply there as well. Otherwise please instruct me how to pull that off assuming this moves forward.

### Testing Instructions

In Chrome go to setup MFA, start typing code in code input element and JS pattern error appears in console.

### Actual result BEFORE applying this Pull Request

* JS error.
* Autocomplete entries show from past codes entered.

### Expected result AFTER applying this Pull Request

* JS error resolved, doesn't show. And form submission not allowed until 6 numbers entered.
* Code input element doesn't remember past entries.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
