### PR TITLE
Update SiteRouter.php - check $force_ssl non type safe

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -68,7 +68,7 @@ class SiteRouter extends Router
         $this->menu = $menu ?: $this->app->getMenu();
 
         // Add core rules
-        if ($this->app->get('force_ssl') === 2) {
+        if ($this->app->get('force_ssl') == 2) {
             $this->attachParseRule([$this, 'parseCheckSSL'], self::PROCESS_BEFORE);
         }
 


### PR DESCRIPTION
### Summary of Changes
When updateing joomla from joomla 3 to joomla 4.4 the value in cofiguration.php is still saved with `public $force_ssl = '2'` instead of `public $force_ssl = 2`. If set as string, the force_ssl setting has no effect, the redirection to https is not working.

Furthermore, the cli command '/cli/joomla.php config:set force_ssl=2' also sets the configuration.php to `public $force_ssl = '2'`.

The change should have no further effect, everywhere else in the code force_ssl is checked non type-safe.


### Testing Instructions
Joomla 4.4.1
Run '/cli/joomla.php config:set force_ssl=2' and you will get `public $force_ssl = '2';` in configuration.php


### Actual result BEFORE applying this Pull Request
redirection to https is not wotking, site loads with http://...


### Expected result AFTER applying this Pull Request
Force SSL ist working, when opening with http://... the site is redirected to https://...


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
