### PR TITLE
[4.4] text not visible (error_login)

### DIFF
--- a/administrator/templates/atum/error_login.php
+++ b/administrator/templates/atum/error_login.php
@@ -124,7 +124,7 @@ $statusModules = LayoutHelper::render('status', ['modules' => 'status']);
                             <div class="main-brand d-flex align-items-center justify-content-center">
                                 <?php echo HTMLHelper::_('image', $loginLogo, $loginLogoAlt, ['loading' => 'eager', 'decoding' => 'async'], false, 0); ?>
                             </div>
-                            <h1><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
+                            <h1 class="text-dark"><?php echo Text::_('JERROR_AN_ERROR_HAS_OCCURRED'); ?></h1>
                             <jdoc:include type="message" />
                             <blockquote class="blockquote">
                                 <span class="badge bg-secondary"><?php echo $this->error->getCode(); ?></span>


### PR DESCRIPTION
Pull Request for Issue #42600 .

### Summary of Changes
add class text-dark to the h1 to force it to be visible


### Testing Instructions
do not log in to the backend
visit https://example.tl/administrator/index.php?option=com_admin&view=sysinfo&format=text


### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/d90ca48c-1232-437d-9811-4be40a0644e8)



### Expected result AFTER applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/1296369/088e5e54-1587-42bf-b6cc-fd1d8e10eed8)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
