### PR TITLE
Update SetConfigurationCommand.php - save int as int and not string

### DIFF
--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -446,7 +446,7 @@ class SetConfigurationCommand extends AbstractCommand
             $value = $value === 'false' ? false : $value;
             $value = $value === 'true' ? true : $value;
             
-            $value = ctype_digit( (string) $value) ? (int) $value : $value;
+            $value = ctype_digit((string) $value) ? (int) $value : $value;
             
             $options[$key] = $value;
         }

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -445,9 +445,8 @@ class SetConfigurationCommand extends AbstractCommand
         foreach ($options as $key => $value) {
             $value = $value === 'false' ? false : $value;
             $value = $value === 'true' ? true : $value;
-            
             $value = ctype_digit((string) $value) ? (int) $value : $value;
-            
+
             $options[$key] = $value;
         }
 

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -432,7 +432,7 @@ class SetConfigurationCommand extends AbstractCommand
     }
 
     /**
-     * Sanitize the options array for boolean
+     * Sanitize the options array for boolean and integer
      *
      * @param   array  $options  Options array
      *
@@ -445,7 +445,9 @@ class SetConfigurationCommand extends AbstractCommand
         foreach ($options as $key => $value) {
             $value = $value === 'false' ? false : $value;
             $value = $value === 'true' ? true : $value;
-
+            
+            $value = ctype_digit( (string) $value) ? (int) $value : $value;
+            
             $options[$key] = $value;
         }
 


### PR DESCRIPTION
### Summary of Changes
cli command `config:set` should save integer values in configuration.php as integer, not string
this change affects all integer values independent of the transmitted cli param. it is the same behavior as with boolean

### Testing Instructions
Run `/cli/joomla.php config:set force_ssl=2` to update configuration.php


### Actual result BEFORE applying this Pull Request
`public $force_ssl = '2';` in configuration.php


### Expected result AFTER applying this Pull Request
`public $force_ssl = 2;` in configuration.php


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
