### PR TITLE
[5.x] Fix broken parameters for bzip2 and zstd packages in the build/build.php script

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -403,6 +403,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 0e5edd7d08f5ba19a156ad97cc733ebe28bca4fd63958be1ada1391170e0c327
+hmac: 09263f5870c96f3436bcc924a10b5757f764b91a0ca63413d99c44dcac669b5f
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -354,7 +354,7 @@ steps:
       - mkdir -p transfer
       - date +%s > transfer/$MINORVERSION-time.txt
       - git rev-parse origin/$MINORVERSION-dev > transfer/$MINORVERSION.txt
-      - php build/build.php --remote=origin/$MINORVERSION-dev --exclude-gzip --exclude-bzip2 --disable-patch-packages
+      - php build/build.php --remote=origin/$MINORVERSION-dev --exclude-gzip --disable-patch-packages
       - mv build/tmp/packages/* transfer/
 
   - name: upload

--- a/build/build.php
+++ b/build/build.php
@@ -232,7 +232,7 @@ $tmp      = $here . '/tmp';
 $fullpath = $tmp . '/' . $time;
 
 // Parse input options
-$options = getopt('', ['help', 'remote::', 'exclude-zip', 'exclude-gzip', 'exclude-bzip2', 'include-zstd', 'disable-patch-packages']);
+$options = getopt('', ['help', 'remote::', 'exclude-zip', 'exclude-gzip', 'include-bzip2', 'exclude-zstd', 'disable-patch-packages']);
 
 $remote             = $options['remote'] ?? false;
 $excludeZip         = isset($options['exclude-zip']);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

With pull request (PR) #42152 , parameters `--exclude-bzip2` and `--include-zstd` of the `build/build.php` PHP CLI script have been changed to `--include-bzip2` and `--exclude-zstd`.

That has been made in the help method of that script, so the help outputs the new parameters, and the logic to check the parameters also has been adapted. See here for the changes: https://github.com/joomla/joomla-cms/pull/42152/files .

But it has been forgotten to change the parameter names in the call to the `getopts` PHP function which reads in those parameters from the command line, and so the new parameters will never be set in the script.

The mentioned PR was the last change for the `build/build.php` script, so we can be sure that the `getopts` really just has been forgotten and not been changed with a later quick fix for whatever reason.

This PR here fixes that by adapting the `getopts` call to the right parameter names.

In addition, this PR updates the `.drone.yml` file by removing the old `--exclude-bzip2` parameter from the call to the build script in the "prepare" step. That has no practical consequences as that parameter had been renamed before and so the bzip2 files were never built and will still not be built with that call. This should also have been done with the previously mentioned other PR.

### Testing Instructions

Use the `build/build.php` on a clean, current 5.0-dev branch (no need for `composer install` or `npm ci` before that) on an environment where PHP CLI is available.

1. Run the build script with the `--include-bzip2` parameter (using the `--exclude-gzip` just to save time):
```
php ./build/build.php --remote=HEAD --exclude-gzip --include-bzip2
```
2. Run the build script without the `--include-bzip2` parameter (using the `--exclude-gzip` just to save time):
```
php ./build/build.php --remote=HEAD --exclude-gzip
```
3. Run the build script with the `--exclude-zstd` parameter (using the `--exclude-gzip` just to save time):
```
php ./build/build.php --remote=HEAD --exclude-gzip --exclude-zstd
```
4. Run the build script without the `--exclude-zstd` parameter (using the `--exclude-gzip` just to save time):
```
php ./build/build.php --remote=HEAD --exclude-gzip
```

### Actual result BEFORE applying this Pull Request

1. No packages "tar.bz2" have been built. That's not as expected, they should have been built. See the bottom of the script's output at the command line:
```
Build full package files.
Building Joomla_5.0.2-rc2-dev-Development-Full_Package.zip... done.
Building Joomla_5.0.2-rc2-dev-Development-Full_Package.tar.zst... done.
Build full update package.
Building Joomla_5.0.2-rc2-dev-Development-Update_Package.zip... done.
Building Joomla_5.0.2-rc2-dev-Development-Update_Package.tar.zst... done.
Build of version 5.0.2-rc2-dev complete!
```
2. No packages "tar.bz2" have been built. That's as expected. Output is same as above.
3. Packages "tar.zst" have been built. That's not as expected, they should not have been built. Output is same as above.
4. Packages "tar.zst" have been built. That's as expected. Output is same as above.

### Expected result AFTER applying this Pull Request

1. Packages "tar.bz2" have been built (besides the "zip" and "tar.zst"):
```
Build full package files.
Building Joomla_5.0.2-rc2-dev-Development-Full_Package.zip... done.
Building Joomla_5.0.2-rc2-dev-Development-Full_Package.tar.bz2... done.
Building Joomla_5.0.2-rc2-dev-Development-Full_Package.tar.zst... done.
Build full update package.
Building Joomla_5.0.2-rc2-dev-Development-Update_Package.zip... done.
Building Joomla_5.0.2-rc2-dev-Development-Update_Package.tar.bz2... done.
Building Joomla_5.0.2-rc2-dev-Development-Update_Package.tar.zst... done.
Build of version 5.0.2-rc2-dev complete!
```
2. No packages "tar.bz2" have been built. Same as actual result (except that now the "tar.zst" are build, too):
```
Build full package files.
Building Joomla_5.0.2-rc2-dev-Development-Full_Package.zip... done.
Building Joomla_5.0.2-rc2-dev-Development-Full_Package.tar.zst... done.
Build full update package.
Building Joomla_5.0.2-rc2-dev-Development-Update_Package.zip... done.
Building Joomla_5.0.2-rc2-dev-Development-Update_Package.tar.zst... done.
Build of version 5.0.2-rc2-dev complete!
```
3. No packages "tar.zst" have been built:
```
Build full package files.
Building Joomla_5.0.2-rc2-dev-Development-Full_Package.zip... done.
Build full update package.
Building Joomla_5.0.2-rc2-dev-Development-Update_Package.zip... done.
Build of version 5.0.2-rc2-dev complete!
```
5. Packages "tar.zst" have been built. Same as actual result. Output is the same as for test 2.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
