### PR TITLE
[5.0] Fix missing 'separator' lines between sub menus in Admin Components

### DIFF
--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -1068,8 +1068,8 @@ class ComponentAdapter extends InstallerAdapter
             $data['menutype']     = 'main';
             $data['client_id']    = 1;
             $data['title']        = (string) trim($child);
-            $data['alias']        = (string) $child;
-            $data['type']         = 'component';
+            $data['alias']        = ((string) $child->attributes()->alias) ?: (string) $child;
+            $data['type']         = ((string) $child->attributes()->type) ?: 'component';
             $data['published']    = 1;
             $data['parent_id']    = $parent_id;
             $data['component_id'] = $componentId;


### PR DESCRIPTION
Adds separators as submenu's items for Components.

Pull Request for Issue #41123 . And reflect change as in #42588 for 5.0

### Summary of Changes

Alters the 'type' attribute for sub-menus when installing a Component to allow for separator lines to be added to the sub menu of a Component. For use when you need to break up or group sub-menu items of a Component.

In the manifest .xml file for a components you can indicate the placement of the separator by adding the element <menu type=separator>--<menu> between a set of elements. ---

The processing to read and render the separator already exists in the Joomla core, all that was missing was the ability to specify the 'type' of separator when installing a component. The rendering of the separator will either use the characters defined between the and elements or the characters are stripped and the separator is rendered as a line with CSS.


### Testing Instructions

Add the <menu type="separator" alias="optional-n">--<menu> element to the manifest .xml file of a component and Install the component in an instance of Joomla. 

If there is only one separator you don't need to set an alias. If you want to add multiple you need to set an unique alias for the separators. 

### Actual result BEFORE applying this Pull Request

Nothing happened. 'type=separator' is ignored and replaced with 'component'. It will render the content in the XML Defintion like "--" for example.

### Expected result AFTER applying this Pull Request

Expand your Component name under the Admin area Component Menu on the left and you should see the separator(s) displayed as a sub menu item(s).

In the #__menu table the entry for your separator will have a field of type with the value 'separator' and the alias will be the current date Link to documentations


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
