### PR TITLE
Define correct type for field helper doc

### DIFF
--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -92,11 +92,11 @@ class FieldsHelper
      * The values of the fields can be overridden by an associative array where the keys
      * have to be a name and its corresponding value.
      *
-     * @param   string      $context              The context of the content passed to the helper
-     * @param   null        $item                 The item being edited in the form
-     * @param   int|bool    $prepareValue         (if int is display event): 1 - AfterTitle, 2 - BeforeDisplay, 3 - AfterDisplay, 0 - OFF
-     * @param   array|null  $valuesToOverride     The values to override
-     * @param   bool        $includeSubformFields Should I include fields marked as Only Use In Subform?
+     * @param   string             $context              The context of the content passed to the helper
+     * @param   object|array|null  $item                 The item being edited in the form
+     * @param   int|bool           $prepareValue         (if int is display event): 1 - AfterTitle, 2 - BeforeDisplay, 3 - AfterDisplay, 0 - OFF
+     * @param   array|null         $valuesToOverride     The values to override
+     * @param   bool               $includeSubformFields Should I include fields marked as Only Use In Subform?
      *
      * @return  array
      *


### PR DESCRIPTION
The $item parameter `FieldsHelper::getFields` has to be an object or array and not null.