### PR TITLE
[4.4] Fix parameter type for whereIn query in ExtensionsHelper - issue 42637

### DIFF
--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -409,7 +409,8 @@ class ExtensionHelper
                 ],
                 '|'
             ),
-            $values
+            $values,
+            ParameterType::STRING
         );
 
         $db->setQuery($query);


### PR DESCRIPTION
Pull Request for Issue #42637 .

### Summary of Changes

This pull request (PR) adds the missing `$dataType` parameter to the call of `$query->whereIn` for the query which has been modified with PR #42576 , which caused a regression in Joomla 4.4.2 and 5.0.2 regarding filtering for core or non-core extensions in the Extensions Manager.

The default value of that parameter is `ParameterType::INTEGER`, so the missing parameter in the call caused the strings to be bound as integers. Depending on the database type and version, this may cause the regression or it may not cause it when the database does an implicit cast to string. This might be the reason why I haven't noticed my mistake when testing my PR #42576 .

### Testing Instructions

#### Pre-conditions

This PR should be tested on a current 4.4-dev branch or on a 4.4.2. Do not use 4.4.1 or older because with that you will not be able to reproduce the issue.

If you can test only with Joomla 5, use a current 5.0-dev branch or a 5.0.2. You can apply the same change from this PR here also on a 5.0-dev branch or a 5.0.2 by manual edit of the modified file. Do not use 5.0.1 or 5.0.0 because with that you will not be able to reproduce the issue.

It might also depend on the database type (MySQL or MariaDB) and the database version if you can reproduce the issue or not.

#### Procedure

Go to extensions manage and filter by core/non-core extensions.

### Actual result BEFORE applying this Pull Request

Non-core filter produces zero results.

Core filter produces results for the non-core extensions only.

### Expected result AFTER applying this Pull Request

Filtering works as expected.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
