### PR TITLE
[4.4] Codemirror RTL fix in com_templates

### DIFF
--- a/build/media_source/com_templates/css/admin-templates-default.css
+++ b/build/media_source/com_templates/css/admin-templates-default.css
@@ -74,12 +74,12 @@
 
 [dir=rtl] #core-pane textarea,
 #override-pane textarea {
-  text-align: left;
+  direction: ltr;
 }
 
 [dir=rtl] #core-pane joomla-editor-codemirror,
 #override-pane joomla-editor-codemirror {
-  text-align: left;
+  direction: ltr;
 }
 
 [dir=rtl] #toggle-buttons {


### PR DESCRIPTION
Text-align is not the same as direction.

As this is a css change you will need to test with a prebuilt package or with the build scripts

Pull Request for Issue #42654 .

### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/48f5cf36-436e-4e32-8de6-86bcff33e9cb)



### Expected result AFTER applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/1296369/dfc5d87f-646d-405e-8cf4-d0e725ee600a)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
