### PR TITLE
[4.4] Atom Feed: Prevent notice from empty description

### DIFF
--- a/libraries/src/Document/Renderer/Feed/AtomRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/AtomRenderer.php
@@ -86,7 +86,7 @@ class AtomRenderer extends DocumentRenderer
 
         $feed .= ">\n";
         $feed .= "	<title type=\"text\">" . $feed_title . "</title>\n";
-        $feed .= "	<subtitle type=\"text\">" . htmlspecialchars($data->getDescription(), ENT_COMPAT, 'UTF-8') . "</subtitle>\n";
+        $feed .= "	<subtitle type=\"text\">" . htmlspecialchars($data->getDescription() ?? '', ENT_COMPAT, 'UTF-8') . "</subtitle>\n";
 
         if (!empty($data->category)) {
             if (\is_array($data->category)) {


### PR DESCRIPTION
Pull Request for Issue #41824.

### Summary of Changes
In PHP 8.2, the changed line creates a notice when calling a category blog view with `?format=feed&type=atom` attached to the URL. This fixes that.


### Testing Instructions
1. Open a category blog page on a site on PHP 8.2 and attach `?format=feed&type=atom` to the URL.
2. Look at the output.


### Actual result BEFORE applying this Pull Request
A notice is shown:
Deprecated: htmlspecialchars(): Passing null to parameter https://github.com/joomla/joomla-cms/pull/1 ($string) of type string is deprecated in /home/www/libraries/src/Document/Renderer/Feed/AtomRenderer.php on line 89


### Expected result AFTER applying this Pull Request
The notice is not there.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
