### PR TITLE
[5.0] Codemirror Full Screen background

### DIFF
--- a/build/media_source/plg_editors_codemirror/css/codemirror.css
+++ b/build/media_source/plg_editors_codemirror/css/codemirror.css
@@ -27,6 +27,7 @@ joomla-editor-codemirror.fullscreen {
 joomla-editor-codemirror.fullscreen .cm-editor {
   width: auto !important;
   height: 90vh !important;
+  background-color: var(--body-bg);
 }
 
 


### PR DESCRIPTION
Pull Request for Issue #42647  .

### Summary of Changes
Add a background color to the codemirror editor qwhen in full screen


### Testing Instructions
In template manager open a file for editing and press f10 to ernter full screen mode


### Actual result BEFORE applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/c16be3eb-3bd8-45d4-9699-af50affefebf)



### Expected result AFTER applying this Pull Request
![image](https://github.com/joomla/joomla-cms/assets/1296369/d2c08572-6c83-45f2-8758-fbce0bee8fd8)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
