### PR TITLE
[5.x] Indexer taxonomy language strings

### DIFF
--- a/.github/workflows/create-translation-pull-request-v4.yml
+++ b/.github/workflows/create-translation-pull-request-v4.yml
@@ -37,7 +37,7 @@ jobs:
           git remote add upstream https://github.com/joomla/joomla-cms.git
           git fetch upstream
           git checkout --progress --force -B translation refs/remotes/origin/translation
-          git merge upstream/4.3-dev
+          git merge upstream/4.4-dev
 
       - name: Fetch and extract translations
         run: |
@@ -74,4 +74,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.API_TOKEN_GITHUB }}
         run: |
           gh pr list -R joomla/joomla-cms --state open --author joomla-translation-bot -S "Translation Update" | grep -v "No pull" || \
-            gh pr create --title "Translation Update" --body "Automatically created pull request based on core-translation repository changes" -R joomla/joomla-cms --base 4.3-dev
+            gh pr create --title "Translation Update" --body "Automatically created pull request based on core-translation repository changes" -R joomla/joomla-cms --base 4.4-dev

--- a/.github/workflows/create-translation-pull-request-v4.yml
+++ b/.github/workflows/create-translation-pull-request-v4.yml
@@ -28,7 +28,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-node@v3
         with:
-          node-version: 16
+          node-version: 20
 
       - name: Fetch latest cms changes
         run: |

--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -19,7 +19,8 @@ use Joomla\CMS\Version;
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')
-    ->useScript('multiselect');
+    ->useScript('multiselect')
+    ->useScript('webcomponent.core-loader');
 
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
@@ -72,7 +73,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                 <td>
                                     <?php $buttonText = (isset($this->installedLang[0][$language->code]) || isset($this->installedLang[1][$language->code])) ? 'REINSTALL' : 'INSTALL'; ?>
                                     <?php $buttonClass = (isset($this->installedLang[0][$language->code]) || isset($this->installedLang[1][$language->code])) ? 'btn btn-success btn-sm' : 'btn btn-primary btn-sm'; ?>
-                                    <?php $onclick = 'document.getElementById(\'install_url\').value = \'' . $language->detailsurl . '\'; Joomla.submitbutton(\'install.install\');'; ?>
+                                    <?php $onclick = 'document.getElementById(\'install_url\').value = \'' . $language->detailsurl . '\'; Joomla.submitbutton(\'install.install\'); document.body.appendChild(document.createElement(\'joomla-core-loader\'));'; ?>
                                     <input type="button"
                                         class="<?php echo $buttonClass; ?>"
                                         value="<?php echo Text::_('COM_INSTALLER_' . $buttonText . '_BUTTON'); ?>"

--- a/build/build.php
+++ b/build/build.php
@@ -679,21 +679,26 @@ if ($includeExtraTextfiles) {
         }
     }
 
-    echo "Generating checksums.txt file\n";
+    echo "Generating checksums files\n";
 
-    $checksumsContent = '';
+    $checksumsContent       = '';
+    $checksumsContentUpdate = '';
 
     foreach ($checksums as $packageName => $packageHashes) {
         $checksumsContent .= "Filename: $packageName\n";
 
         foreach ($packageHashes as $hashType => $hash) {
             $checksumsContent .= "$hashType: $hash\n";
+            if (strpos($packageName, 'Update_Package.zip') !== false) {
+                $checksumsContentUpdate .= "<$hashType>$hash</$hashType>\n";
+            }
         }
 
         $checksumsContent .= "\n";
     }
 
     file_put_contents('checksums.txt', $checksumsContent);
+    file_put_contents('checksums_update.txt', $checksumsContentUpdate);
 
     echo "Generating github_release.txt file\n";
 

--- a/components/com_users/src/Controller/UserController.php
+++ b/components/com_users/src/Controller/UserController.php
@@ -203,7 +203,7 @@ class UserController extends BaseController
         }
 
         // Logout and redirect
-        $this->setRedirect('index.php?option=com_users&task=user.logout&' . Session::getFormToken() . '=1&return=' . base64_encode($url));
+        $this->setRedirect(Route::_('index.php?option=com_users&task=user.logout&' . Session::getFormToken() . '=1&return=' . base64_encode($url), false));
     }
 
     /**

--- a/libraries/src/Document/Renderer/Feed/AtomRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/AtomRenderer.php
@@ -86,7 +86,7 @@ class AtomRenderer extends DocumentRenderer
 
         $feed .= ">\n";
         $feed .= "	<title type=\"text\">" . $feed_title . "</title>\n";
-        $feed .= "	<subtitle type=\"text\">" . htmlspecialchars($data->getDescription(), ENT_COMPAT, 'UTF-8') . "</subtitle>\n";
+        $feed .= "	<subtitle type=\"text\">" . htmlspecialchars($data->getDescription() ?? '', ENT_COMPAT, 'UTF-8') . "</subtitle>\n";
 
         if (!empty($data->category)) {
             if (\is_array($data->category)) {

--- a/plugins/multifactorauth/email/src/Extension/Email.php
+++ b/plugins/multifactorauth/email/src/Extension/Email.php
@@ -190,7 +190,7 @@ class Email extends CMSPlugin implements SubscriberInterface
                     'input_type' => 'text',
                     // The attributes for the HTML input box.
                     'input_attributes' => [
-                        'pattern' => "{0,9}", 'maxlength' => "6", 'inputmode' => "numeric",
+                        'pattern' => '[0-9]{6}', 'maxlength' => '6', 'inputmode' => 'numeric', 'required' => 'true', 'autocomplete' => 'one-time-code', 'aria-autocomplete' => 'none',
                     ],
                     // Placeholder text for the HTML input box. Leave empty if you don't need it.
                     'placeholder' => Text::_('PLG_MULTIFACTORAUTH_EMAIL_LBL_SETUP_PLACEHOLDER'),
@@ -264,7 +264,7 @@ class Email extends CMSPlugin implements SubscriberInterface
                         'field_type'       => 'input',
                         'input_type'       => 'text',
                         'input_attributes' => [
-                            'pattern' => "{0,9}", 'maxlength' => "6", 'inputmode' => "numeric",
+                            'pattern' => '[0-9]{6}', 'maxlength' => '6', 'inputmode' => 'numeric', 'required' => 'true', 'autocomplete' => 'one-time-code', 'aria-autocomplete' => 'none',
                         ],
                         'input_value' => '',
                         'placeholder' => Text::_('PLG_MULTIFACTORAUTH_EMAIL_LBL_SETUP_PLACEHOLDER'),

--- a/plugins/multifactorauth/totp/src/Extension/Totp.php
+++ b/plugins/multifactorauth/totp/src/Extension/Totp.php
@@ -150,7 +150,7 @@ class Totp extends CMSPlugin implements SubscriberInterface
                     'input_type' => 'text',
                     // The attributes for the HTML input box.
                     'input_attributes' => [
-                        'pattern' => "{0,9}", 'maxlength' => "6", 'inputmode' => "numeric",
+                        'pattern' => '[0-9]{6}', 'maxlength' => '6', 'inputmode' => 'numeric', 'required' => 'true', 'autocomplete' => 'one-time-code', 'aria-autocomplete' => 'none',
                     ],
                     // Placeholder text for the HTML input box. Leave empty if you don't need it.
                     'placeholder' => '',
@@ -239,7 +239,7 @@ class Totp extends CMSPlugin implements SubscriberInterface
                     ],
                     'input_type'       => $isConfigured ? 'hidden' : 'text',
                     'input_attributes' => [
-                        'pattern' => "{0,9}", 'maxlength' => "6", 'inputmode' => "numeric",
+                        'pattern' => '[0-9]{6}', 'maxlength' => '6', 'inputmode' => 'numeric', 'required' => 'true', 'autocomplete' => 'one-time-code', 'aria-autocomplete' => 'none',
                     ],
                     'input_value' => '',
                     'placeholder' => Text::_('PLG_MULTIFACTORAUTH_TOTP_LBL_SETUP_PLACEHOLDER'),

--- a/tests/System/integration/api/com_menus/Administrator.cy.js
+++ b/tests/System/integration/api/com_menus/Administrator.cy.js
@@ -1,0 +1,43 @@
+describe('Test that menus administrator API endpoint', () => {
+  afterEach(() => cy.task('queryDB', "DELETE FROM #__menu_types WHERE title = 'automated test administrator menu' "));
+
+  it('can deliver a list of administrator menus', () => {
+    cy.api_get('/menus/administrator')
+      .then((response) => cy.wrap(response).its('body').its('data.0').its('attributes')
+        .its('title')
+        .should('include', 'Main Menu'));
+  });
+
+  it('can deliver a single administrator menu', () => {
+    cy.db_createMenuType({ title: 'automated test administrator menu', client_id: 1 })
+      .then((id) => cy.api_get(`/menus/administrator/${id}`))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'automated test administrator menu'));
+  });
+
+  it('can create an administrator menu', () => {
+    cy.api_post('/menus/administrator', {
+      client_id: 1,
+      description: 'The menu for the administrator',
+      menutype: 'menu',
+      title: 'automated test administrator menu',
+    })
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'automated test administrator menu'));
+  });
+
+  it('can update an administrator menu', () => {
+    cy.db_createMenuType({ title: 'automated test administrator menu', client_id: 1 })
+      .then((id) => cy.api_patch(`/menus/administrator/${id}`, { title: 'updated automated test administrator menu' }))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'updated automated test administrator menu'));
+  });
+
+  it('can delete an administrator menu', () => {
+    cy.db_createMenuType({ title: 'automated test administrator menu', client_id: 1 })
+      .then((id) => cy.api_delete(`/menus/administrator/${id}`));
+  });
+});

--- a/tests/System/integration/api/com_menus/Site.cy.js
+++ b/tests/System/integration/api/com_menus/Site.cy.js
@@ -1,0 +1,42 @@
+describe('Test that menus site API endpoint', () => {
+  afterEach(() => cy.task('queryDB', "DELETE FROM #__menu_types WHERE title = 'automated test site menu' "));
+
+  it('can deliver a list of site menus', () => {
+    cy.db_createMenuType({ title: 'automated test site menu' })
+      .then(() => cy.api_get('/menus/site'))
+      .then((response) => cy.api_responseContains(response, 'title', 'automated test site menu'));
+  });
+
+  it('can deliver a single site menu', () => {
+    cy.db_createMenuType({ title: 'automated test site menu' })
+      .then((id) => cy.api_get(`/menus/site/${id}`))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'automated test site menu'));
+  });
+
+  it('can create a site menu', () => {
+    cy.api_post('/menus/site', {
+      client_id: 0,
+      description: 'The menu for the site',
+      menutype: 'menu',
+      title: 'automated test site menu',
+    })
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'automated test site menu'));
+  });
+
+  it('can update a site menu', () => {
+    cy.db_createMenuType({ title: 'automated test site menu' })
+      .then((id) => cy.api_patch(`/menus/site/${id}`, { title: 'updated automated test site menu' }))
+      .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
+        .its('title')
+        .should('include', 'updated automated test site menu'));
+  });
+
+  it('can delete a site menu', () => {
+    cy.db_createMenuType({ title: 'automated test site menu' })
+      .then((id) => cy.api_delete(`/menus/site/${id}`));
+  });
+});

--- a/tests/System/support/commands/db.js
+++ b/tests/System/support/commands/db.js
@@ -403,6 +403,18 @@ Cypress.Commands.add('db_createTag', (tag) => {
   return cy.task('queryDB', createInsertQuery('tags', { ...defaultTagOptions, ...tag })).then(async (info) => info.insertId);
 });
 
+Cypress.Commands.add('db_createMenuType', (menuTypeData) => {
+  const defaultMenuTypeOptions = {
+    title: 'test menu',
+    menutype: 'test-menu',
+    description: '',
+    client_id: 0,
+    asset_id: 0,
+  };
+
+  return cy.task('queryDB', createInsertQuery('menu_types', { ...defaultMenuTypeOptions, ...menuTypeData })).then(async (info) => info.insertId);
+});
+
 /**
  * Creates an menu item in the database with the given data. The menu item contains some default values when
  * not all required fields are passed in the given data. The id of the inserted menu item is returned.


### PR DESCRIPTION
### Summary of Changes

With #36748 

> "This PR checks if a translation for the language key exists and if there is none (and debug is not enabled) it will instead display the taxonomy title instead."

It is confusing that this doesnt work if debug is enabled. There is nothing else in Joomla where this is the case and I just wasted a lot of time trying to see why the string wasnt displayed.

I believe that the **_intention_** of the code was to display the language key when "debug language" was enabled not when "debug" was enabled

If you want to create your own value for the key as an override you would expect the key to be displayed in debug language mode (which it is not) and you would not expect the key to be displayed in debug mode 
### Testing Instructions
Perform a search on the front with Debug enabled and a new search with debug language enabled


### Actual result BEFORE applying this Pull Request
#### Debug
![image](https://github.com/joomla/joomla-cms/assets/1296369/71eec922-6496-463b-bdba-a706c8aed1ac)

#### Debug Language
![image](https://github.com/joomla/joomla-cms/assets/1296369/4c1129c0-af24-46ab-9ce8-8206aa6195c4)


### Expected result AFTER applying this Pull Request
#### Debug
![image](https://github.com/joomla/joomla-cms/assets/1296369/fb15171f-cf53-4b4a-8390-f6f8f10c9450)

#### Debug Language
![image](https://github.com/joomla/joomla-cms/assets/1296369/c64f7fce-5d26-417c-9272-f3043afb56d1)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
