### PR TITLE
Update Nested.php to support aliasing the 'checked_out' column.

### DIFF
--- a/libraries/src/Table/Nested.php
+++ b/libraries/src/Table/Nested.php
@@ -874,10 +874,11 @@ class Nested extends Table
     {
         $k = $this->_tbl_key;
 
-        $query     = $this->_db->getQuery(true);
-        $table     = $this->_db->quoteName($this->_tbl);
-        $published = $this->_db->quoteName($this->getColumnAlias('published'));
-        $key       = $this->_db->quoteName($k);
+        $query      = $this->_db->getQuery(true);
+        $table      = $this->_db->quoteName($this->_tbl);
+        $published  = $this->_db->quoteName($this->getColumnAlias('published'));
+        $checkedOut = $this->_db->quoteName($this->getColumnAlias('checked_out'));
+        $key        = $this->_db->quoteName($k);
 
         // Sanitize input.
         $pks    = ArrayHelper::toInteger($pks);
@@ -919,7 +920,7 @@ class Nested extends Table
                     ->select('COUNT(' . $k . ')')
                     ->from($this->_tbl)
                     ->where('lft BETWEEN ' . (int) $node->lft . ' AND ' . (int) $node->rgt)
-                    ->where('(checked_out <> 0 AND checked_out <> ' . (int) $userId . ')');
+                    ->where('(' . $checkedOut . ' <> 0 AND ' . $checkedOut . ' <> ' . (int) $userId . ')');
                 $this->_db->setQuery($query);
 
                 // Check for checked out children.


### PR DESCRIPTION
Removed hard-coded references to the 'checked_out' database column and replaced them with variables containing the column alias, obtained through a $this->getColumnAlias() call. Now, the 'checked_out' column references mirror the 'published' column references in their respect for column aliasing.

Pull Request for Issue #42688 .

### Summary of Changes
Removed hard-coded references to the 'checked_out' database column and replaced them with variables containing the column alias, obtained through a $this->getColumnAlias() call. Now, the 'checked_out' column references mirror the 'published' column references in their respect for column aliasing. Also made sure the '=' operators lined up nicely in the variable declaration/initialization lines while I was at it.


### Testing Instructions
Change the published state of one or more items whose data are stored in a nested table, i.e. the Tags component to ensure the change did not break existing functionality. To verify new support for aliasing, instantiate the class and call the publish() method from a client that uses an alias for the 'checked_out' column.


### Actual result BEFORE applying this Pull Request
Attempting to change the published state of an item in a custom admin list view failed with error message, "Unknown column 'checked_out' in 'where clause'". The database column was properly aliased in the table's __construct() method with the following code:

`$this->setColumnAlias('checked_out', 'checked_out_user_id');`

### Expected result AFTER applying this Pull Request
Attempting to change the published state of an item in a custom admin list view succeeds.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
