### PR TITLE
Tags router fix

### DIFF
--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -255,13 +255,13 @@ class Router extends RouterBase
 
         $ids = [];
 
-        if ($item && $item->query['view'] == 'tag') {
-            $ids = $item->query['id'];
-        }
-
         while (count($segments)) {
             $id    = array_shift($segments);
             $ids[] = $this->fixSegment($id);
+        }
+
+        if ($item && $item->query['view'] == 'tag') {
+            $ids = array_intersect($ids, $item->query['id']);
         }
 
         if (count($ids)) {

--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -261,7 +261,17 @@ class Router extends RouterBase
         }
 
         if ($item && $item->query['view'] == 'tag') {
-            $ids = array_intersect($ids, $item->query['id']);
+            $ids = array_filter($ids, function ($id) use ($item) {
+                // Get the id from the segment
+                [$id] = explode(':', $id, 2);
+
+                return in_array($id, $item->query['id']);
+            });
+
+            // If we have no ids, we use the menu item ids
+            if (!count($ids)) {
+                $ids = $item->query['id'];
+            }
         }
 
         if (count($ids)) {


### PR DESCRIPTION
# Summary of Changes
Fixes the mismatch when SEF is enabled or disabled for the menu type "Tagged Items".

# Testing Instructions
1. Create two tags in Components > Tags.
2. Create three Articles in Content > Articles where:
    1. The first article has the first tag;
    2. The second article has the second tag;
    3. And a article has both tags.
3. Create a menu item with the type "Tags > Tagged Items" and with both the tags selected.
4. View the menu item in the front-end
5. Click on the first article.
6. Click on the (first) tag.

See issue #42529 for more info.

# Actual result BEFORE applying this Pull Request
You will see articles from both first and second tag.

# Expected result AFTER applying this Pull Request
You will see articles from only the first tag.

# Related Issues
#42529
