### PR TITLE
[5.1] Update FontAwesome to 6.5.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joomla",
-  "version": "5.0.1",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joomla",
-      "version": "5.0.1",
+      "version": "5.1.0",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -26,7 +26,7 @@
         "@codemirror/state": "^6.2.1",
         "@codemirror/theme-one-dark": "^6.1.2",
         "@codemirror/view": "^6.17.1",
-        "@fortawesome/fontawesome-free": "^6.4.2",
+        "@fortawesome/fontawesome-free": "^6.5.1",
         "@joomla/joomla-a11y-checker": "^1.0.0",
         "@popperjs/core": "^2.11.8",
         "@webcomponents/webcomponentsjs": "^2.8.0",
@@ -2209,9 +2209,9 @@
       "integrity": "sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw=="
     },
     "node_modules/@fortawesome/fontawesome-free": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.2.tgz",
-      "integrity": "sha512-m5cPn3e2+FDCOgi1mz0RexTUvvQibBebOUlUlW0+YrMjDTPkiJ6VTKukA1GRsvRw+12KyJndNjj0O4AgTxm2Pg==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.1.tgz",
+      "integrity": "sha512-CNy5vSwN3fsUStPRLX7fUYojyuzoEMSXPl7zSLJ8TgtRfjv24LOnOWKT2zYwaHZCJGkdyRnTmstR0P+Ah503Gw==",
       "hasInstallScript": true,
       "engines": {
         "node": ">=6"

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@codemirror/state": "^6.2.1",
     "@codemirror/theme-one-dark": "^6.1.2",
     "@codemirror/view": "^6.17.1",
-    "@fortawesome/fontawesome-free": "^6.4.2",
+    "@fortawesome/fontawesome-free": "^6.5.1",
     "@joomla/joomla-a11y-checker": "^1.0.0",
     "@popperjs/core": "^2.11.8",
     "@webcomponents/webcomponentsjs": "^2.8.0",


### PR DESCRIPTION
### Summary of Changes

Update FontAwesome to 6.5.1

This also [fixes a bug](https://github.com/FortAwesome/Font-Awesome/issues/19925) that was showing a warning in the Firefox dev console:

![image](https://github.com/joomla/joomla-cms/assets/2019801/949d040c-3fcd-4021-9b05-e743fe2a9eef)
