### PR TITLE
[4.4] Smart Search: Don't search for alternative images

### DIFF
--- a/components/com_finder/tmpl/search/default_result.php
+++ b/components/com_finder/tmpl/search/default_result.php
@@ -72,10 +72,10 @@ if ($this->params->get('show_url', 1)) {
         <figure class="<?php echo htmlspecialchars($imageClass, ENT_COMPAT, 'UTF-8'); ?> result__image">
             <?php if ($this->params->get('link_image') && $this->result->route) : ?>
                 <a href="<?php echo Route::_($this->result->route); ?>">
-                    <?php echo HTMLHelper::_('image', $this->result->imageUrl, $this->result->imageAlt, $extraAttr); ?>
+                    <?php echo HTMLHelper::_('image', $this->result->imageUrl, $this->result->imageAlt, $extraAttr, false, -1); ?>
                 </a>
             <?php else : ?>
-                <?php echo HTMLHelper::_('image', $this->result->imageUrl, $this->result->imageAlt, $extraAttr); ?>
+                <?php echo HTMLHelper::_('image', $this->result->imageUrl, $this->result->imageAlt, $extraAttr, false, -1); ?>
             <?php endif; ?>
         </figure>
     <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #42320.

### Summary of Changes
When an articles intro image contains a blank space, our code to search for related files in the media folder strips the whole image from the output of the search results. This change prevents this. The images of a search result should be the exact images, not the potential compressed files or similar from the media folder.


### Testing Instructions
1. Add an image with a space in the filename in the /images folder
2. Edit an article and set the intro image to that image. By saving, the index should be updated.
3. Set the image to be displayed in the search results in the configuration of either the search menu item or in the smart search global configuration.
4. Search for the article


### Actual result BEFORE applying this Pull Request
The article is displayed without the image.


### Expected result AFTER applying this Pull Request
The article is displayed WITH the image.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
