### PR TITLE
[4.4] Hide columns in mobile view

### DIFF
--- a/administrator/components/com_cache/tmpl/cache/default.php
+++ b/administrator/components/com_cache/tmpl/cache/default.php
@@ -58,10 +58,10 @@ $wa->useScript('keepalive')
                                 <th scope="col" class="title">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_CACHE_GROUP', 'group', $listDirn, $listOrder); ?>
                                 </th>
-                                <th scope="col" class="w-10 text-center">
+                                <th scope="col" class="w-10 text-center d-none d-md-table-cell">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_CACHE_NUMBER_OF_FILES', 'count', $listDirn, $listOrder); ?>
                                 </th>
-                                <th scope="col" class="w-10 text-end">
+                                <th scope="col" class="w-10 text-end d-none d-md-table-cell">
                                     <?php echo HTMLHelper::_('searchtools.sort', 'COM_CACHE_SIZE', 'size', $listDirn, $listOrder); ?>
                                 </th>
                             </tr>
@@ -76,10 +76,10 @@ $wa->useScript('keepalive')
                                     <th scope="row">
                                         <?php echo $this->escape($item->group); ?>
                                     </th>
-                                    <td class="text-center">
+                                    <td class="text-center d-none d-md-table-cell">
                                         <?php echo $item->count; ?>
                                     </td>
-                                    <td class="text-end">
+                                    <td class="text-end d-none d-md-table-cell">
                                         <?php echo '&#x200E;' . HTMLHelper::_('number.bytes', $item->size); ?>
                                     </td>
                                 </tr>


### PR DESCRIPTION
Pull Request for Issue #42689 .

### Summary of Changes
On mobile, the submenu icon is not visible that requires a swipe to the right to see due to too many columns forcing the width to be wider than the viewport. 
This PR hides some of these columns.


### Testing Instructions
In Home Dashboard, click the Cache icon.
Use browser's developer tools to show mobile view or reduce width of browser.



### Actual result BEFORE applying this Pull Request
![42689-before](https://github.com/joomla/joomla-cms/assets/368084/40ed07d3-9624-4b07-9b29-4fefa0bed3c2)



### Expected result AFTER applying this Pull Request
![42689-after](https://github.com/joomla/joomla-cms/assets/368084/e84708d1-8f9b-4e97-b054-436c536982ce)


