### PR TITLE
[#42733] Fixes menu verification check for menu types with Unicode characters

### DIFF
--- a/administrator/components/com_menus/src/Controller/DisplayController.php
+++ b/administrator/components/com_menus/src/Controller/DisplayController.php
@@ -48,7 +48,7 @@ class DisplayController extends BaseController
     public function display($cachable = false, $urlparams = false)
     {
         // Verify menu
-        $menuType = $this->input->post->getCmd('menutype', '');
+        $menuType = $this->input->post->getString('menutype', '');
 
         if ($menuType !== '') {
             $uri = Uri::getInstance();


### PR DESCRIPTION
Pull Request for Issue #42733.

### Summary of Changes

This small change fixes the menu verification check for menu types with Unicode characters, such as German umlauts (ä, ü, ö).

### Testing Instructions

1) Enable the option "Unicode Aliases" in the global settings
2) Create a new menu with the name "Menü" and the unique name "menü"
3) Open the "All Menu Items" page and select the newly created menu from the drop-down list

### Actual result BEFORE applying this Pull Request

You will see the error "The Menu type doesn't exist." and all menu items are loaded.

### Expected result AFTER applying this Pull Request

No error is displayed, and the correct menu items are loaded.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>

- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
