### PR TITLE
[4.4] process fields on fulltext

### DIFF
--- a/plugins/content/fields/src/Extension/Fields.php
+++ b/plugins/content/fields/src/Extension/Fields.php
@@ -66,6 +66,11 @@ final class Fields extends CMSPlugin
         if (property_exists($item, 'introtext') && is_string($item->introtext) && strpos($item->introtext, 'field') !== false) {
             $item->introtext = $this->prepare($item->introtext, $context, $item);
         }
+
+        // Prepare the full text
+        if (property_exists($item, 'fulltext') && strpos($item->fulltext, 'field') !== false) {
+            $item->fulltext = $this->prepare($item->fulltext, $context, $item);
+        }
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #42740 .

### Summary of Changes



### Testing Instructions
Add a field to the content of an article eg `{{field 74} after the readmore

creat an override of an article view to restructure the content.
For example seperate the intro and full text and position the article image in between.

```
<?php echo $this->item->introtext; ?>
....
<?php echo LayoutHelper::render('joomla.content.full_image', $this->item); ?>
...
<?php echo $this->item->fulltext; ?>
```


### Actual result BEFORE applying this Pull Request
When displayed on the site the field is not processed and is displayed as `{field 74}


### Expected result AFTER applying this Pull Request
Field correctly displayed


### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
