### PR TITLE
[4][cli] - HTMLHelper timezone

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -864,6 +864,11 @@ abstract class HTMLHelper
     {
         $app = Factory::getApplication();
 
+        if (!$app->getIdentity()) {
+            // UTC date converted to server time zone.
+            $tz = false;
+        }
+
         // UTC date converted to user time zone.
         if ($tz === true) {
             // Get a date object based on UTC.


### PR DESCRIPTION
Pull Request for Issue #41263 .

### Summary of Changes
default to server tz if no user tz



### Testing Instructions
edit your `libraries/src/Console/ListUserCommand.php`
```use Joomla\CMS\HTML\HTMLHelper;```
https://github.com/joomla/joomla-cms/blob/4.4-dev/libraries/src/Console/ListUserCommand.php#L18
and this line
```$a=HTMLHelper::_('date', 'now', 'd F Y');```

https://github.com/joomla/joomla-cms/blob/4.4-dev/libraries/src/Console/ListUserCommand.php#L108

run `cli\joomla.php user:list`


### Actual result BEFORE applying this Pull Request

Call to a member function getTimezone() on null

### Expected result AFTER applying this Pull Request

no error

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
