### PR TITLE
[4.4] Fix strpos(): Passing null is deprecated

### DIFF
--- a/plugins/content/fields/src/Extension/Fields.php
+++ b/plugins/content/fields/src/Extension/Fields.php
@@ -68,7 +68,7 @@ final class Fields extends CMSPlugin
         }
 
         // Prepare the full text
-        if (property_exists($item, 'fulltext') && strpos($item->fulltext, 'field') !== false) {
+        if (property_exists($item, 'fulltext') && is_string($item->fulltext) && strpos($item->fulltext, 'field') !== false) {
             $item->fulltext = $this->prepare($item->fulltext, $context, $item);
         }
     }

--- a/plugins/content/fields/src/Extension/Fields.php
+++ b/plugins/content/fields/src/Extension/Fields.php
@@ -68,7 +68,7 @@ final class Fields extends CMSPlugin
         }
 
         // Prepare the full text
-        if (property_exists($item, 'fulltext') && is_string($item->fulltext) && strpos($item->fulltext, 'field') !== false) {
+        if (!empty($item->fulltext) && strpos($item->fulltext, 'field') !== false) {
             $item->fulltext = $this->prepare($item->fulltext, $context, $item);
         }
     }


### PR DESCRIPTION
Pull Request for Issue #42744.

### Summary of Changes
When `fulltext` is null, the following occurs:

`PHP Deprecated:  strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in \plugins\content\fields\src\Extension\Fields.php on line 71`

### Testing Instructions
Enable Maximum Error Reporting.
Install Blog Sample Data.
See warning `There is an error in a sample data plugin. Response is invalid.`
See PHP error log.