### PR TITLE
[5.1] Update deleted files list in script.php for 5.1.0-alpha4

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2204,6 +2204,9 @@ class JoomlaInstallerScript
             '/administrator/components/com_newsfeeds/tmpl/newsfeeds/default_batch_footer.php',
             '/administrator/components/com_tags/tmpl/tags/default_batch_footer.php',
             '/administrator/components/com_users/tmpl/users/default_batch_footer.php',
+            // From 5.1.0-alpha3 to 5.1.0-alpha4
+            '/administrator/components/com_redirect/tmpl/links/default_batch_footer.php',
+            '/modules/mod_banners/mod_banners.php',
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the lists of files and folders to be deleted on update in script.php by the PHP files from PRs #42355 and #42214 for the next alpha release (5.1.0-alpha4).

There are no other deleted files and folders to be added to the lists up to now.

Javascript files removed with PRs like e.g. #42082 and #42423 will not be added to the list because we don't want to delete them on update for b/c reasons, see PR #42567 . I will create a separate PR to add them to the list of exceptions in file `build/deleted_file_check.php` so they will not be reported by that tool.

### Testing Instructions

Code review.

Or update from 4.4.x or 5.0.x to the latest 5.1 nightly for the actual result and to the patched update package or custom update URL created by Drone for this PR for the expected result.

### Actual result BEFORE applying this Pull Request

The files added by this PR to the list in script.php are still present after the update.

### Expected result AFTER applying this Pull Request

The files added by this PR to the list in script.php have been deleted with the update.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
