### PR TITLE
"Serialization of 'Closure' is not allowed" fix

### DIFF
--- a/libraries/src/Mail/MailerFactory.php
+++ b/libraries/src/Mail/MailerFactory.php
@@ -54,7 +54,7 @@ class MailerFactory implements MailerFactoryInterface
      */
     public function createMailer(?Registry $settings = null): MailerInterface
     {
-        $configuration = clone $this->defaultConfiguration;
+        $configuration = new Registry($this->defaultConfiguration);
 
         if ($settings) {
             $configuration->merge($settings);


### PR DESCRIPTION
Pull Request for Issue #42482.

### Summary of Changes
This change addresses a fatal error encountered in the `MailerFactory::createMailer` method due to the cloning of a `Registry` object containing closures. The proposed fix involves creating a new `Registry` instance with the existing `$defaultConfiguration` instead of cloning it, effectively preventing the "Serialization of 'Closure' is not allowed" error.

### Testing Instructions

```
$app = Factory::getApplication();

// Add a closure to the global configuration.
$closure = function() {};
$app->set('closureTest', $closure);

// Attempt to send mail using the MailerFactory.
$mail = Factory::getMailer();
$mail->clearAttachments()->clearAllRecipients();
$mail->sendMail(
    (string) $app->get('mailfrom'),
    (string) $app->get('fromname'),
    'example@example.com',
    'A test email subject!',
    'A test body.'
);
```
### Actual result BEFORE applying this Pull Request
Attempting to send an email through certain configurations of Joomla 4.x with PHP 8.1 results in a fatal error: "Serialization of 'Closure' is not allowed".

### Expected result AFTER applying this Pull Request
The fatal error is resolved, and emails can be sent successfully without encountering the "Serialization of 'Closure' is not allowed" error.


### Link to documentations
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
