### PR TITLE
[6.2] fix missing / in url Route:link on cli

### DIFF
--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -166,8 +166,8 @@ class Uri extends \Joomla\Uri\Uri
             }
         }
 
-        if (!empty(static::$base['path']) && substr(static::$base['path'], 0, 1) !== "/") {
-            static::$base['path'] = '/' . static::$base['path'];
+        if (!empty(static::$base['path'])) {
+            static::$base['path'] = '/' . ltrim(static::$base['path'], '/');
         }
 
         return $pathonly === false ? static::$base['prefix'] . static::$base['path'] . '/' : static::$base['path'];

--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -166,7 +166,7 @@ class Uri extends \Joomla\Uri\Uri
             }
         }
 
-        static::$base['path'] = substr(static::$base['path'], 0, 1) === "/" ? static::$base['path'] : '/' . static::$base['path'];
+        static::$base['path'] = substr(static::$base['path'], 0, 1) === '/' ? static::$base['path'] : '/' . static::$base['path'];
 
         return $pathonly === false ? static::$base['prefix'] . static::$base['path'] . '/' : static::$base['path'];
     }

--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -166,7 +166,9 @@ class Uri extends \Joomla\Uri\Uri
             }
         }
 
-        static::$base['path'] = substr(static::$base['path'], 0, 1) === '/' ? static::$base['path'] : '/' . static::$base['path'];
+        if (!empty(static::$base['path']) && substr(static::$base['path'], 0, 1) !== "/") {
+            static::$base['path'] = '/' . static::$base['path'];
+        }
 
         return $pathonly === false ? static::$base['prefix'] . static::$base['path'] . '/' : static::$base['path'];
     }

--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -166,6 +166,8 @@ class Uri extends \Joomla\Uri\Uri
             }
         }
 
+        static::$base['path'] = substr(static::$base['path'], 0, 1) === "/" ? static::$base['path'] : '/' . static::$base['path'];
+
         return $pathonly === false ? static::$base['prefix'] . static::$base['path'] . '/' : static::$base['path'];
     }
 


### PR DESCRIPTION
### Summary of Changes
Every `statis:$base['path']` is prefixed with / except `$_SERVER[] `ones. This leads to URLs like

http://xyz.decli instead of http://xyz.de/cli

to be sure that this does not happen a check if `static:$base['path']` is prefixed correctly bevor returning the base path is added.

This issue exists in J4 and J5


### Testing Instructions
- create a cli task
- This cli task needs to use `Route::link('site', 'index.php?SomeValidURL', true, true, true);`
- call the task with `php cli/joomla.php scheduler:run -i <TASKID> --live-site 'http://localhost/'`


### Actual result BEFORE applying this Pull Request
Task#TASKID 'TASKNAME' exited with code 5 in 14.10 seconds.


### Expected result AFTER applying this Pull Request
successful run


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
