### PR TITLE
[4.4] Fix System - Page Cache plugin ignore Exclude URLs parameter

### DIFF
--- a/plugins/system/cache/src/Extension/Cache.php
+++ b/plugins/system/cache/src/Extension/Cache.php
@@ -321,6 +321,7 @@ final class Cache extends CMSPlugin implements SubscriberInterface
             // Convert the exclusions into a normalised array
             $exclusions       = str_replace(["\r\n", "\r"], "\n", $exclusions);
             $exclusions       = explode("\n", $exclusions);
+            $exclusions       = array_map('trim', $exclusions);
             $filterExpression = function ($x) {
                 return $x !== '';
             };
@@ -331,19 +332,17 @@ final class Cache extends CMSPlugin implements SubscriberInterface
                 . Uri::getInstance()->buildQuery($this->router->getVars());
             $externalUrl = Uri::getInstance()->toString();
 
-            $reduceCallback
-                = function (bool $carry, string $exclusion) use ($internalUrl, $externalUrl) {
-                    // Test both external and internal URIs
-                    return $carry && preg_match(
-                        '#' . $exclusion . '#i',
-                        $externalUrl . ' ' . $internalUrl,
-                        $match
-                    );
-                };
-            $excluded       = array_reduce($exclusions, $reduceCallback, false);
-
-            if ($excluded) {
-                return true;
+            // Loop through each pattern.
+            if ($exclusions)
+            {
+                foreach ($exclusions as $exclusion)
+                {
+                    // Test both external and internal URI
+                    if (preg_match('#' . $exclusion . '#i', $externalUrl . ' ' . $internalUrl, $match))
+                    {
+                        return true;
+                    }
+                }
             }
         }
 

--- a/plugins/system/cache/src/Extension/Cache.php
+++ b/plugins/system/cache/src/Extension/Cache.php
@@ -333,13 +333,10 @@ final class Cache extends CMSPlugin implements SubscriberInterface
             $externalUrl = Uri::getInstance()->toString();
 
             // Loop through each pattern.
-            if ($exclusions)
-            {
-                foreach ($exclusions as $exclusion)
-                {
+            if ($exclusions) {
+                foreach ($exclusions as $exclusion) {
                     // Test both external and internal URI
-                    if (preg_match('#' . $exclusion . '#i', $externalUrl . ' ' . $internalUrl, $match))
-                    {
+                    if (preg_match('#' . $exclusion . '#i', $externalUrl . ' ' . $internalUrl, $match)) {
                         return true;
                     }
                 }


### PR DESCRIPTION
Pull Request for Issue #42477.

### Summary of Changes
There is a bug in System - Page Cache plugin causes **Exclude URLs** never works as explained in original issue. This PR just fixes that issue. Plus I change the code for checking URLs exclusion to use the same code like in Joomla 3 because:

- It is easier to read
- It is faster because it uses early return, so it not having to loop over all array elements.

### Testing Instructions
1. Uses Joomla 4.4
2. Create a menu item to link to a Joomla article, set it's alias to something like test-page-cache-exclusion (this alias will will be configured in Exclude URLs parameter)
3. Edit System - Page Cache plugin, look at Advanced tab, enter Alias of the menu item which you created above into **Exclude URLs** parameter. Make sure **Status** set to **Enabled**, save it.

### Actual result BEFORE applying this Pull Request
The page is always being cached. To see that, you can access to that menu item for the first page. Then try to edit code in the file components/com_content/tmpl/article/default.php , add some random string to it. Then access to the menu item again, you do not see any change (because the system uses a cached version of the page)


### Expected result AFTER applying this Pull Request
The page is not being cached as expected. To see that, you can access to that menu item for the first page. Then try to edit code in the file components/com_content/tmpl/article/default.php , add some random string to it. Then access to the menu item again, you will see the change you applied.

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
