### PR TITLE
[5.1] Extend CMS Filesystem classes from Framework

### DIFF
--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\Filesystem\File as FrameworkFile;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -27,7 +28,7 @@ use Joomla\CMS\Log\Log;
  * @deprecated  4.4 will be removed in 6.0
  *              Use Joomla\Filesystem\File instead.
  */
-class File
+class File extends FrameworkFile
 {
     /**
      * @var    boolean  true if OPCache enabled, and we have permission to invalidate files

--- a/libraries/src/Filesystem/FilesystemHelper.php
+++ b/libraries/src/Filesystem/FilesystemHelper.php
@@ -9,6 +9,8 @@
 
 namespace Joomla\CMS\Filesystem;
 
+use Joomla\Filesystem\Helper;
+
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
@@ -22,7 +24,7 @@ namespace Joomla\CMS\Filesystem;
  * @deprecated  4.4 will be removed in 6.0
  *              Use Joomla\Filesystem\Helper instead.
  */
-class FilesystemHelper
+class FilesystemHelper extends Helper
 {
     /**
      * Remote file size function for streams that don't support it

--- a/libraries/src/Filesystem/Folder.php
+++ b/libraries/src/Filesystem/Folder.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Client\FtpClient;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\Filesystem\Folder as FrameworkFolder;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -26,7 +27,7 @@ use Joomla\CMS\Log\Log;
  * @deprecated  4.4 will be removed in 6.0
  *              Use Joomla\Filesystem\Folder instead.
  */
-abstract class Folder
+abstract class Folder extends FrameworkFolder
 {
     /**
      * Copy a folder.

--- a/libraries/src/Filesystem/Patcher.php
+++ b/libraries/src/Filesystem/Patcher.php
@@ -10,6 +10,7 @@
 namespace Joomla\CMS\Filesystem;
 
 use Joomla\CMS\Language\Text;
+use Joomla\Filesystem\Patcher as FrameworkPatcher;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -23,7 +24,7 @@ use Joomla\CMS\Language\Text;
  * @deprecated  4.4 will be removed in 6.0
  *              Use Joomla\Filesystem\Patcher instead.
  */
-class Patcher
+class Patcher extends FrameworkPatcher
 {
     /**
      * Regular expression for searching source files


### PR DESCRIPTION
### Summary of Changes
The CMS Filesystem classes have been deprecated in Joomla 4 and will be removed in Joomla 6. We need to migrate all calls to the CMS classes to the framework classes and in almost all cases this is a drop-in replacement. This PR is meant to give developers hints that they need to change their code by converting from one to the other class. I first thought we might just delete all duplicate code from the CMS classes, but practically those PRs are never merged, so I've closed those again and hope that the hint by extending is already enough. 


### Testing Instructions
Codereview



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
