### PR TITLE
[4.4] Fix of unnecessary SQL query for Fields, get the field value already loaded by getFields()

### DIFF
--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -454,24 +454,14 @@ class FieldsHelper
         // Loading the XML fields string into the form
         $form->load($xml->saveXML());
 
-        $model = Factory::getApplication()->bootComponent('com_fields')
-            ->getMVCFactory()->createModel('Field', 'Administrator', ['ignore_request' => true]);
-
-        if (
-            (!isset($data->id) || !$data->id) && Factory::getApplication()->getInput()->getCmd('controller') == 'modules'
-            && Factory::getApplication()->isClient('site')
-        ) {
-            // Modules on front end editing don't have data and an id set
-            $data->id = Factory::getApplication()->getInput()->getInt('id');
-        }
-
         // Looping through the fields again to set the value
         if (!isset($data->id) || !$data->id) {
             return true;
         }
 
         foreach ($fields as $field) {
-            $value = $model->getFieldValue($field->id, $data->id);
+            // Get the value already loaded by static::getFields()
+            $value = $field->rawvalue;
 
             if ($value === null) {
                 continue;


### PR DESCRIPTION
### Summary of Changes

The same as https://github.com/joomla/joomla-cms/pull/42861 but for j4

Remove unnecessary SQL query for the custom fields, during the form rendering.
`FieldsHelper::getFields()` load the field value, however `FieldsHelper::prepareForm()` also loading them wthout a reason.
Also removed some dead code.


### Testing Instructions

Enable debug and debug query.
Create a couple of Custom fields, let say 10.
Open article editing.


### Actual result BEFORE applying this Pull Request
Notice amount of query in debug.
Let say 75


### Expected result AFTER applying this Pull Request
The amount of query will be 10 less, 65


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed