### PR TITLE
[4.4] Smart Search, limit the highlight

### DIFF
--- a/plugins/system/highlight/src/Extension/Highlight.php
+++ b/plugins/system/highlight/src/Extension/Highlight.php
@@ -121,7 +121,7 @@ final class Highlight extends CMSPlugin
             && empty($item->mime)
             && $params->get('highlight_terms', 1)
         ) {
-            $item->route .= '&highlight=' . base64_encode(json_encode($query->highlight));
+            $item->route .= '&highlight=' . base64_encode(json_encode(array_slice($query->highlight, 0, 10)));
         }
     }
 }


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/42889

### Summary of Changes

Same as https://github.com/joomla/joomla-cms/pull/41463 but for `highlight` plugin

### Testing Instructions

In testing installation.
In Smart Search config set "Word Match" to "Match words containing the search term anywhere".
Go to search page, and search for `joomla 1`.
Notice the length of the link for each search result.


### Actual result BEFORE applying this Pull Request
it is long


### Expected result AFTER applying this Pull Request
it is shorter


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
