### PR TITLE
[5.1] PHPStan: Adding type hints for $this to all backend component layouts

### DIFF
--- a/administrator/components/com_admin/tmpl/help/langforum.php
+++ b/administrator/components/com_admin/tmpl/help/langforum.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Admin\Administrator\View\Help\HtmlView $this */
+
 $this->getLanguage()->load('mod_menu', JPATH_ADMINISTRATOR);
 
 $forumId   = (int) Text::_('MOD_MENU_HELP_SUPPORT_OFFICIAL_LANGUAGE_FORUM_VALUE');

--- a/administrator/components/com_associations/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_associations/layouts/joomla/searchtools/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\CMS\Layout\FileLayout $this */
+
 $data = $displayData;
 
 // Receive overridable options

--- a/administrator/components/com_associations/tmpl/associations/default.php
+++ b/administrator/components/com_associations/tmpl/associations/default.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Associations\Administrator\Helper\AssociationsHelper;
 
+/** @var Joomla\Component\Associations\Administrator\View\Associations\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_associations.admin-associations-default')

--- a/administrator/components/com_associations/tmpl/associations/modal.php
+++ b/administrator/components/com_associations/tmpl/associations/modal.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\Component\Associations\Administrator\Helper\AssociationsHelper;
 
+/** @var Joomla\Component\Associations\Administrator\View\Associations\HtmlView $this */
+
 $app = Factory::getApplication();
 
 if ($app->isClient('site')) {

--- a/administrator/components/com_banners/tmpl/banners/emptystate.php
+++ b/administrator/components/com_banners/tmpl/banners/emptystate.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Banners\Administrator\View\Banners\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_BANNERS',
     'formURL'    => 'index.php?option=com_banners&view=banners',

--- a/administrator/components/com_banners/tmpl/clients/emptystate.php
+++ b/administrator/components/com_banners/tmpl/clients/emptystate.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Banners\Administrator\View\Clients\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_BANNERS_CLIENT',
     'formURL'    => 'index.php?option=com_banners&view=clients',

--- a/administrator/components/com_banners/tmpl/tracks/default.php
+++ b/administrator/components/com_banners/tmpl/tracks/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Banners\Administrator\View\Tracks\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns');

--- a/administrator/components/com_categories/layouts/joomla/form/field/categoryedit.php
+++ b/administrator/components/com_categories/layouts/joomla/form/field/categoryedit.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\CMS\Layout\FileLayout $this */
+
 extract($displayData);
 
 /**

--- a/administrator/components/com_categories/layouts/joomla/form/field/modal-select/extra-buttons.php
+++ b/administrator/components/com_categories/layouts/joomla/form/field/modal-select/extra-buttons.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\CMS\Layout\FileLayout $this */
+
 extract($displayData);
 
 /**

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\String\Inflector;
 
+/** @var \Joomla\Component\Categories\Administrator\View\Categories\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_categories/tmpl/categories/default_batch_body.php
+++ b/administrator/components/com_categories/tmpl/categories/default_batch_body.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Categories\Administrator\View\Categories\HtmlView $this */
+
 $published = (int) $this->state->get('filter.published');
 $extension = $this->escape($this->state->get('filter.extension'));
 

--- a/administrator/components/com_categories/tmpl/categories/emptystate.php
+++ b/administrator/components/com_categories/tmpl/categories/emptystate.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Categories\Administrator\View\Categories\HtmlView $this */
+
 $extension = $this->state->get('filter.extension');
 $component = $this->state->get('filter.component');
 $section = $this->state->get('filter.section');

--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -19,6 +19,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
+/** @var \Joomla\Component\Categories\Administrator\View\Categories\HtmlView $this */
+
 $app = Factory::getApplication();
 
 if ($app->isClient('site')) {

--- a/administrator/components/com_categories/tmpl/category/edit.php
+++ b/administrator/components/com_categories/tmpl/category/edit.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Workflow\WorkflowServiceInterface;
 
+/** @var \Joomla\Component\Categories\Administrator\View\Category\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_categories/tmpl/category/modal.php
+++ b/administrator/components/com_categories/tmpl/category/modal.php
@@ -9,6 +9,9 @@
  */
 
 defined('_JEXEC') or die;
+
+/** @var \Joomla\Component\Categories\Administrator\View\Category\HtmlView $this */
+
 ?>
 <div class="subhead noshadow mb-3">
     <?php echo $this->document->getToolbar('toolbar')->render(); ?>

--- a/administrator/components/com_categories/tmpl/category/modalreturn.php
+++ b/administrator/components/com_categories/tmpl/category/modalreturn.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
+/** @var \Joomla\Component\Categories\Administrator\View\Category\HtmlView $this */
+
 $icon     = 'icon-check';
 $title    = $this->item ? $this->item->title : '';
 $content  = $this->item ? $this->item->alias : '';

--- a/administrator/components/com_checkin/tmpl/checkin/default.php
+++ b/administrator/components/com_checkin/tmpl/checkin/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Checkin\Administrator\View\Checkin\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('multiselect');

--- a/administrator/components/com_config/tmpl/application/default.php
+++ b/administrator/components/com_config/tmpl/application/default.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_config/tmpl/application/default_cache.php
+++ b/administrator/components/com_config/tmpl/application/default_cache.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_CACHE_SETTINGS');
 $this->fieldsname = 'cache';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_cookie.php
+++ b/administrator/components/com_config/tmpl/application/default_cookie.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_COOKIE_SETTINGS');
 $this->fieldsname = 'cookie';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_database.php
+++ b/administrator/components/com_config/tmpl/application/default_database.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_DATABASE_SETTINGS');
 $this->fieldsname = 'database';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_debug.php
+++ b/administrator/components/com_config/tmpl/application/default_debug.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_DEBUG_SETTINGS');
 $this->fieldsname = 'debug';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_filters.php
+++ b/administrator/components/com_config/tmpl/application/default_filters.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_TEXT_FILTER_SETTINGS');
 $this->fieldsname = 'filters';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_locale.php
+++ b/administrator/components/com_config/tmpl/application/default_locale.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_LOCATION_SETTINGS');
 $this->fieldsname = 'locale';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_logging.php
+++ b/administrator/components/com_config/tmpl/application/default_logging.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_LOGGING_SETTINGS');
 $this->fieldsname = 'logging';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_logging_custom.php
+++ b/administrator/components/com_config/tmpl/application/default_logging_custom.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_LOGGING_CUSTOM_SETTINGS');
 $this->fieldsname = 'logging_custom';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_mail.php
+++ b/administrator/components/com_config/tmpl/application/default_mail.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Router\Route;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 HTMLHelper::_('form.csrf');
 $this->document->getWebAssetManager()
     ->useScript('webcomponent.field-send-test-mail');

--- a/administrator/components/com_config/tmpl/application/default_metadata.php
+++ b/administrator/components/com_config/tmpl/application/default_metadata.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_METADATA_SETTINGS');
 $this->fieldsname = 'metadata';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_navigation.php
+++ b/administrator/components/com_config/tmpl/application/default_navigation.php
@@ -11,6 +11,9 @@
 use Joomla\CMS\Language\Text;
 
 defined('_JEXEC') or die;
+
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 ?>
 <ul class="nav flex-column">
     <?php if ($this->userIsSuperAdmin) : ?>

--- a/administrator/components/com_config/tmpl/application/default_navigation.php
+++ b/administrator/components/com_config/tmpl/application/default_navigation.php
@@ -13,7 +13,6 @@ use Joomla\CMS\Language\Text;
 defined('_JEXEC') or die;
 
 /** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
-
 ?>
 <ul class="nav flex-column">
     <?php if ($this->userIsSuperAdmin) : ?>

--- a/administrator/components/com_config/tmpl/application/default_permissions.php
+++ b/administrator/components/com_config/tmpl/application/default_permissions.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name        = Text::_('COM_CONFIG_PERMISSION_SETTINGS');
 $this->description = '';
 $this->fieldsname  = 'permissions';

--- a/administrator/components/com_config/tmpl/application/default_proxy.php
+++ b/administrator/components/com_config/tmpl/application/default_proxy.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_PROXY_SETTINGS');
 $this->fieldsname = 'proxy';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_seo.php
+++ b/administrator/components/com_config/tmpl/application/default_seo.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_SEO_SETTINGS');
 $this->fieldsname = 'seo';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_server.php
+++ b/administrator/components/com_config/tmpl/application/default_server.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_SERVER_SETTINGS');
 $this->fieldsname = 'server';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_session.php
+++ b/administrator/components/com_config/tmpl/application/default_session.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_SESSION_SETTINGS');
 $this->fieldsname = 'session';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_site.php
+++ b/administrator/components/com_config/tmpl/application/default_site.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_SITE_SETTINGS');
 $this->fieldsname = 'site';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/application/default_webservices.php
+++ b/administrator/components/com_config/tmpl/application/default_webservices.php
@@ -13,6 +13,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Config\Administrator\View\Application\HtmlView $this */
+
 $this->name = Text::_('COM_CONFIG_WEBSERVICES_SETTINGS');
 $this->fieldsname = 'webservices';
 $this->formclass = 'options-form';

--- a/administrator/components/com_config/tmpl/component/default.php
+++ b/administrator/components/com_config/tmpl/component/default.php
@@ -16,6 +16,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Config\Administrator\View\Component\HtmlView $this */
+
 $app = Factory::getApplication();
 $template = $app->getTemplate();
 

--- a/administrator/components/com_config/tmpl/component/default_navigation.php
+++ b/administrator/components/com_config/tmpl/component/default_navigation.php
@@ -11,6 +11,8 @@
 use Joomla\CMS\Language\Text;
 
 defined('_JEXEC') or die;
+
+/** @var \Joomla\Component\Config\Administrator\View\Component\HtmlView $this */
 ?>
 <ul class="nav flex-column">
     <?php if ($this->userIsSuperAdmin) : ?>

--- a/administrator/components/com_contact/layouts/joomla/form/field/modal-select/extra-buttons.php
+++ b/administrator/components/com_contact/layouts/joomla/form/field/modal-select/extra-buttons.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\CMS\Layout\FileLayout $this */
+
 extract($displayData);
 
 /**

--- a/administrator/components/com_contact/tmpl/contact/edit.php
+++ b/administrator/components/com_contact/tmpl/contact/edit.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Contact\Administrator\View\Contact\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_contact/tmpl/contact/modal.php
+++ b/administrator/components/com_contact/tmpl/contact/modal.php
@@ -9,6 +9,8 @@
  */
 
 defined('_JEXEC') or die;
+
+/** @var \Joomla\Component\Contact\Administrator\View\Contact\HtmlView $this */
 ?>
 <div class="subhead noshadow mb-3">
     <?php echo $this->document->getToolbar('toolbar')->render(); ?>

--- a/administrator/components/com_contact/tmpl/contact/modalreturn.php
+++ b/administrator/components/com_contact/tmpl/contact/modalreturn.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
+/** @var \Joomla\Component\Contact\Administrator\View\Contact\HtmlView $this */
+
 $icon     = 'icon-check';
 $title    = $this->item ? $this->item->name : '';
 $content  = $this->item ? $this->item->alias : '';

--- a/administrator/components/com_contact/tmpl/contacts/default.php
+++ b/administrator/components/com_contact/tmpl/contacts/default.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Contact\Administrator\View\Contacts\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_contact/tmpl/contacts/default_batch_body.php
+++ b/administrator/components/com_contact/tmpl/contacts/default_batch_body.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Contact\Administrator\View\Contacts\HtmlView $this */
+
 $published = (int) $this->state->get('filter.published');
 $noUser    = true;
 ?>

--- a/administrator/components/com_contact/tmpl/contacts/emptystate.php
+++ b/administrator/components/com_contact/tmpl/contacts/emptystate.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Contact\Administrator\View\Contacts\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_CONTACT',
     'formURL'    => 'index.php?option=com_contact',

--- a/administrator/components/com_contact/tmpl/contacts/modal.php
+++ b/administrator/components/com_contact/tmpl/contacts/modal.php
@@ -19,6 +19,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\Component\Contact\Site\Helper\RouteHelper;
 
+/** @var \Joomla\Component\Contact\Administrator\View\Contacts\HtmlView $this */
+
 $app = Factory::getApplication();
 
 if ($app->isClient('site')) {

--- a/administrator/components/com_content/layouts/joomla/form/field/modal-select/extra-buttons.php
+++ b/administrator/components/com_content/layouts/joomla/form/field/modal-select/extra-buttons.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\CMS\Layout\FileLayout $this */
+
 extract($displayData);
 
 /**

--- a/administrator/components/com_content/tmpl/article/modal.php
+++ b/administrator/components/com_content/tmpl/article/modal.php
@@ -9,6 +9,8 @@
  */
 
 defined('_JEXEC') or die;
+
+/** @var \Joomla\Component\Content\Administrator\View\Article\HtmlView $this */
 ?>
 <div class="subhead noshadow mb-3">
     <?php echo $this->document->getToolbar('toolbar')->render(); ?>

--- a/administrator/components/com_content/tmpl/article/modalreturn.php
+++ b/administrator/components/com_content/tmpl/article/modalreturn.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
+/** @var \Joomla\Component\Content\Administrator\View\Article\HtmlView $this */
+
 $icon     = 'icon-check';
 $title    = $this->item ? $this->item->title : '';
 $content  = $this->item ? $this->item->alias : '';

--- a/administrator/components/com_content/tmpl/article/pagebreak.php
+++ b/administrator/components/com_content/tmpl/article/pagebreak.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Content\Administrator\View\Article\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_content.admin-article-pagebreak');

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -25,6 +25,8 @@ use Joomla\CMS\Session\Session;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 use Joomla\Utilities\ArrayHelper;
 
+/** @var \Joomla\Component\Content\Administrator\View\Articles\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_content/tmpl/articles/default_batch_body.php
+++ b/administrator/components/com_content/tmpl/articles/default_batch_body.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Content\Administrator\View\Articles\HtmlView $this */
+
 $params = ComponentHelper::getParams('com_content');
 
 $published = (int) $this->state->get('filter.published');

--- a/administrator/components/com_content/tmpl/articles/emptystate.php
+++ b/administrator/components/com_content/tmpl/articles/emptystate.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Content\Administrator\View\Articles\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_CONTENT',
     'formURL'    => 'index.php?option=com_content&view=articles',

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -19,6 +19,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
+/** @var \Joomla\Component\Content\Administrator\View\Articles\HtmlView $this */
+
 $app = Factory::getApplication();
 
 if ($app->isClient('site')) {

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -25,6 +25,8 @@ use Joomla\CMS\Session\Session;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
 use Joomla\Utilities\ArrayHelper;
 
+/** @var \Joomla\Component\Content\Administrator\View\Featured\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_content/tmpl/featured/default_stage_footer.php
+++ b/administrator/components/com_content/tmpl/featured/default_stage_footer.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Content\Administrator\View\Featured\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_content.admin-articles-stage');

--- a/administrator/components/com_content/tmpl/featured/emptystate.php
+++ b/administrator/components/com_content/tmpl/featured/emptystate.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Content\Administrator\View\Featured\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_CONTENT',
     'formURL'    => 'index.php?option=com_content&view=featured',

--- a/administrator/components/com_contenthistory/tmpl/compare/compare.php
+++ b/administrator/components/com_contenthistory/tmpl/compare/compare.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Contenthistory\Administrator\View\Compare\HtmlView $this */
+
 Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 
 $version2 = $this->items[0];

--- a/administrator/components/com_contenthistory/tmpl/history/modal.php
+++ b/administrator/components/com_contenthistory/tmpl/history/modal.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Contenthistory\Administrator\View\History\HtmlView $this */
+
 Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 
 $hash           = $this->state->get('sha1_hash');

--- a/administrator/components/com_contenthistory/tmpl/preview/preview.php
+++ b/administrator/components/com_contenthistory/tmpl/preview/preview.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Contenthistory\Administrator\View\Preview\HtmlView $this */
+
 Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 
 ?>

--- a/administrator/components/com_cpanel/tmpl/cpanel/default.php
+++ b/administrator/components/com_cpanel/tmpl/cpanel/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\Registry\Registry;
 
+/** @var \Joomla\Component\Cpanel\Administrator\View\Cpanel\HtmlView $this */
+
 // Load JavaScript message titles
 Text::script('ERROR');
 Text::script('WARNING');

--- a/administrator/components/com_fields/tmpl/field/edit.php
+++ b/administrator/components/com_fields/tmpl/field/edit.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Fields\Administrator\View\Field\HtmlView $this */
+
 $app = Factory::getApplication();
 $input = $app->getInput();
 

--- a/administrator/components/com_fields/tmpl/fields/default.php
+++ b/administrator/components/com_fields/tmpl/fields/default.php
@@ -20,6 +20,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 
+/** @var \Joomla\Component\Fields\Administrator\View\Fields\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_fields/tmpl/fields/default_batch_body.php
+++ b/administrator/components/com_fields/tmpl/fields/default_batch_body.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Fields\Administrator\View\Fields\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('com_fields.admin-fields-batch');

--- a/administrator/components/com_fields/tmpl/fields/modal.php
+++ b/administrator/components/com_fields/tmpl/fields/modal.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Fields\Administrator\View\Fields\HtmlView $this */
+
 if (Factory::getApplication()->isClient('site')) {
     Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 }

--- a/administrator/components/com_fields/tmpl/group/edit.php
+++ b/administrator/components/com_fields/tmpl/group/edit.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Fields\Administrator\View\Group\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_fields/tmpl/groups/default.php
+++ b/administrator/components/com_fields/tmpl/groups/default.php
@@ -19,6 +19,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
 
+/** @var \Joomla\Component\Fields\Administrator\View\Groups\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_finder/tmpl/filter/edit.php
+++ b/administrator/components/com_finder/tmpl/filter/edit.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Finder\Administrator\View\Filter\HtmlView $this */
+
 Text::script('COM_FINDER_FILTER_SHOW_ALL', true);
 Text::script('COM_FINDER_FILTER_HIDE_ALL', true);
 

--- a/administrator/components/com_finder/tmpl/filters/default.php
+++ b/administrator/components/com_finder/tmpl/filters/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Finder\Administrator\View\Filters\HtmlView $this */
+
 $user      = $this->getCurrentUser();
 $userId    = $user->get('id');
 $listOrder = $this->escape($this->state->get('list.ordering'));

--- a/administrator/components/com_finder/tmpl/filters/emptystate.php
+++ b/administrator/components/com_finder/tmpl/filters/emptystate.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Finder\Administrator\View\Filters\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_FINDER',
     'formURL'    => 'index.php?option=com_finder&view=filters',

--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Finder\Administrator\Helper\LanguageHelper;
 
+/** @var \Joomla\Component\Finder\Administrator\View\Index\HtmlView $this */
+
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $lang      = $this->getLanguage();

--- a/administrator/components/com_finder/tmpl/index/emptystate.php
+++ b/administrator/components/com_finder/tmpl/index/emptystate.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Finder\Administrator\View\Index\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_FINDER',
     'formURL'    => 'index.php?option=com_finder&view=index',

--- a/administrator/components/com_finder/tmpl/indexer/default.php
+++ b/administrator/components/com_finder/tmpl/indexer/default.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Finder\Administrator\View\Indexer\HtmlView $this */
+
 Text::script('COM_FINDER_INDEXER_MESSAGE_COMPLETE');
 Text::script('COM_FINDER_AN_ERROR_HAS_OCCURRED');
 Text::script('COM_FINDER_MESSAGE_RETURNED');

--- a/administrator/components/com_finder/tmpl/item/default.php
+++ b/administrator/components/com_finder/tmpl/item/default.php
@@ -11,6 +11,8 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
+
+/** @var \Joomla\Component\Finder\Administrator\View\Item\HtmlView $this */
 ?>
 <div role="main">
     <h1 class="mb-3"><?php echo $this->item->title; ?></h1>

--- a/administrator/components/com_finder/tmpl/maps/default.php
+++ b/administrator/components/com_finder/tmpl/maps/default.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Finder\Administrator\Helper\LanguageHelper;
 
+/** @var \Joomla\Component\Finder\Administrator\View\Maps\HtmlView $this */
+
 $listOrder     = $this->escape($this->state->get('list.ordering'));
 $listDirn      = $this->escape($this->state->get('list.direction'));
 $lang          = Factory::getLanguage();

--- a/administrator/components/com_finder/tmpl/searches/default.php
+++ b/administrator/components/com_finder/tmpl/searches/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Finder\Administrator\View\Searches\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('multiselect');

--- a/administrator/components/com_finder/tmpl/statistics/default.php
+++ b/administrator/components/com_finder/tmpl/statistics/default.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Finder\Administrator\View\Statistics\HtmlView $this */
 ?>
 <div class="container-popup">
     <table class="table table-sm">

--- a/administrator/components/com_guidedtours/tmpl/step/edit.php
+++ b/administrator/components/com_guidedtours/tmpl/step/edit.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\MVC\View\GenericDataException;
 
+/** @var \Joomla\Component\Guidedtours\Administrator\View\Step\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_guidedtours/tmpl/steps/emptystate.php
+++ b/administrator/components/com_guidedtours/tmpl/steps/emptystate.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Guidedtours\Administrator\View\Steps\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_GUIDEDTOURS_STEPS',
     'formURL'    => 'index.php?option=com_guidedtours&view=steps',

--- a/administrator/components/com_guidedtours/tmpl/tour/edit.php
+++ b/administrator/components/com_guidedtours/tmpl/tour/edit.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Guidedtours\Administrator\View\Tour\HtmlView $this */
+
 $app   = Factory::getApplication();
 $user  = $app->getIdentity();
 $input = $app->getInput();

--- a/administrator/components/com_guidedtours/tmpl/tours/emptystate.php
+++ b/administrator/components/com_guidedtours/tmpl/tours/emptystate.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Guidedtours\Administrator\View\Tours\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_GUIDEDTOURS_TOURS_LIST',
     'formURL'    => 'index.php?option=com_guidedtours&view=tours',

--- a/administrator/components/com_installer/tmpl/database/default.php
+++ b/administrator/components/com_installer/tmpl/database/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Database\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_installer/tmpl/discover/default.php
+++ b/administrator/components/com_installer/tmpl/discover/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Discover\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_installer/tmpl/discover/emptystate.php
+++ b/administrator/components/com_installer/tmpl/discover/emptystate.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Discover\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_INSTALLER',
     'formURL'    => 'index.php?option=com_installer&task=discover.refresh',

--- a/administrator/components/com_installer/tmpl/install/default.php
+++ b/administrator/components/com_installer/tmpl/install/default.php
@@ -16,6 +16,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Install\HtmlView $this */
+
 // Load JavaScript message titles
 Text::script('ERROR');
 Text::script('WARNING');

--- a/administrator/components/com_installer/tmpl/installer/default_message.php
+++ b/administrator/components/com_installer/tmpl/installer/default_message.php
@@ -10,6 +10,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Installer\HtmlView $this */
+
 $state    = $this->get('State');
 $message1 = $state->get('message');
 $message2 = $state->get('extension_message');

--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Version;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Languages\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_installer/tmpl/manage/default.php
+++ b/administrator/components/com_installer/tmpl/manage/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Manage\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_installer/tmpl/update/default.php
+++ b/administrator/components/com_installer/tmpl/update/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Update\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('multiselect')

--- a/administrator/components/com_installer/tmpl/update/emptystate.php
+++ b/administrator/components/com_installer/tmpl/update/emptystate.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Update\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_INSTALLER',
     'formURL'    => 'index.php?option=com_installer&view=update',

--- a/administrator/components/com_installer/tmpl/updatesite/edit.php
+++ b/administrator/components/com_installer/tmpl/updatesite/edit.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Updatesite\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('form.validate');

--- a/administrator/components/com_installer/tmpl/updatesites/default.php
+++ b/administrator/components/com_installer/tmpl/updatesites/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Updatesites\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_installer/tmpl/warnings/default.php
+++ b/administrator/components/com_installer/tmpl/warnings/default.php
@@ -14,6 +14,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Installer\Administrator\View\Warnings\HtmlView $this */
 ?>
 <div id="installer-warnings" class="clearfix">
     <form action="<?php echo Route::_('index.php?option=com_installer&view=warnings'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/complete.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/complete.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
+/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView $this */
+
 $hadErrors    = $this->state->get('update_finished_with_error');
 $errors       = $this->state->get('update_errors');
 $logFile      = $this->state->get('log_file');

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/noupdate.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/noupdate.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView $this */
+
 $uploadLink       = 'index.php?option=com_joomlaupdate&view=upload';
 $reasonNoDownload = '';
 

--- a/administrator/components/com_joomlaupdate/tmpl/update/default.php
+++ b/administrator/components/com_joomlaupdate/tmpl/update/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
+/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Update\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('core')

--- a/administrator/components/com_joomlaupdate/tmpl/update/finaliseconfirm.php
+++ b/administrator/components/com_joomlaupdate/tmpl/update/finaliseconfirm.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Update\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive');

--- a/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
+++ b/administrator/components/com_joomlaupdate/tmpl/upload/captive.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Upload\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('core')

--- a/administrator/components/com_languages/tmpl/installed/default.php
+++ b/administrator/components/com_languages/tmpl/installed/default.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\String\PunycodeHelper;
 use Joomla\CMS\Version;
 
+/** @var \Joomla\Component\Languages\Administrator\View\Installed\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns');

--- a/administrator/components/com_languages/tmpl/language/edit.php
+++ b/administrator/components/com_languages/tmpl/language/edit.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Languages\Administrator\View\Language\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_languages/tmpl/languages/default.php
+++ b/administrator/components/com_languages/tmpl/languages/default.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Languages\Administrator\View\Languages\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_languages/tmpl/multilangstatus/default.php
+++ b/administrator/components/com_languages/tmpl/multilangstatus/default.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Languages\Administrator\View\Multilangstatus\HtmlView $this */
+
 $notice_disabled  = !$this->language_filter && ($this->homes > 1 || $this->switchers != 0);
 $notice_switchers = !$this->switchers && ($this->homes > 1 || $this->language_filter);
 

--- a/administrator/components/com_languages/tmpl/override/edit.php
+++ b/administrator/components/com_languages/tmpl/override/edit.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Languages\Administrator\View\Override\HtmlView $this */
+
 $expired = ($this->state->get('cache_expired') == 1 ) ? '1' : '';
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */

--- a/administrator/components/com_languages/tmpl/overrides/default.php
+++ b/administrator/components/com_languages/tmpl/overrides/default.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Languages\Administrator\View\Overrides\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_mails/tmpl/template/edit.php
+++ b/administrator/components/com_mails/tmpl/template/edit.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Mails\Administrator\Helper\MailsHelper;
 
+/** @var \Joomla\Component\Mails\Administrator\View\Template\HtmlView $this */
+
 $app = Factory::getApplication();
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */

--- a/administrator/components/com_mails/tmpl/templates/default.php
+++ b/administrator/components/com_mails/tmpl/templates/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Mails\Administrator\View\Templates\HtmlView $this */
+
 HTMLHelper::_('bootstrap.dropdown', '.dropdown-toggle');
 
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */

--- a/administrator/components/com_media/tmpl/file/default.php
+++ b/administrator/components/com_media/tmpl/file/default.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 
+/** @var \Joomla\Component\Media\Administrator\View\File\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_media/tmpl/media/default.php
+++ b/administrator/components/com_media/tmpl/media/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 
+/** @var \Joomla\Component\Media\Administrator\View\Media\HtmlView $this */
+
 $app    = Factory::getApplication();
 $params = ComponentHelper::getParams('com_media');
 $input  = $app->getInput();

--- a/administrator/components/com_menus/layouts/joomla/form/field/modal-select/extra-buttons.php
+++ b/administrator/components/com_menus/layouts/joomla/form/field/modal-select/extra-buttons.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\CMS\Layout\FileLayout $this */
+
 extract($displayData);
 
 /**

--- a/administrator/components/com_menus/layouts/joomla/searchtools/default.php
+++ b/administrator/components/com_menus/layouts/joomla/searchtools/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\CMS\Layout\FileLayout $this */
+
 $data = $displayData;
 
 // Receive overridable options

--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Menus\Administrator\View\Item\HtmlView $this */
+
 $this->useCoreUI = true;
 
 Text::script('ERROR');

--- a/administrator/components/com_menus/tmpl/item/edit_container.php
+++ b/administrator/components/com_menus/tmpl/item/edit_container.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 use Joomla\Registry\Registry;
 
+/** @var \Joomla\Component\Menus\Administrator\View\Item\HtmlView $this */
+
 // Initialise related data.
 $menuLinks = MenusHelper::getMenuLinks('main');
 

--- a/administrator/components/com_menus/tmpl/item/edit_modules.php
+++ b/administrator/components/com_menus/tmpl/item/edit_modules.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Menus\Administrator\View\Item\HtmlView $this */
+
 foreach ($this->levels as $key => $value) {
     $allLevels[$value->id] = $value->title;
 }

--- a/administrator/components/com_menus/tmpl/item/modal.php
+++ b/administrator/components/com_menus/tmpl/item/modal.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Menus\Administrator\View\Item\HtmlView $this */
 ?>
 <div class="subhead noshadow mb-3">
     <?php echo $this->document->getToolbar('toolbar')->render(); ?>

--- a/administrator/components/com_menus/tmpl/item/modalreturn.php
+++ b/administrator/components/com_menus/tmpl/item/modalreturn.php
@@ -10,6 +10,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Menus\Administrator\View\Item\HtmlView $this */
+
 $icon     = 'icon-check';
 $title    = $this->item ? $this->item->title : '';
 $content  = $this->item ? $this->item->alias : '';

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -19,6 +19,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Menus\Administrator\View\Items\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_menus/tmpl/items/default_batch_body.php
+++ b/administrator/components/com_menus/tmpl/items/default_batch_body.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Menus\Administrator\View\Items\HtmlView $this */
+
 $options = [
     HTMLHelper::_('select.option', 'c', Text::_('JLIB_HTML_BATCH_COPY')),
     HTMLHelper::_('select.option', 'm', Text::_('JLIB_HTML_BATCH_MOVE'))

--- a/administrator/components/com_menus/tmpl/items/modal.php
+++ b/administrator/components/com_menus/tmpl/items/modal.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Menus\Administrator\View\Items\HtmlView $this */
+
 $app = Factory::getApplication();
 
 if ($app->isClient('site')) {

--- a/administrator/components/com_menus/tmpl/menu/edit.php
+++ b/administrator/components/com_menus/tmpl/menu/edit.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Menus\Administrator\View\Menu\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('core')

--- a/administrator/components/com_menus/tmpl/menus/default.php
+++ b/administrator/components/com_menus/tmpl/menus/default.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Uri\Uri;
 
+/** @var \Joomla\Component\Menus\Administrator\View\Menus\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_menus/tmpl/menutypes/default.php
+++ b/administrator/components/com_menus/tmpl/menutypes/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Menus\Administrator\View\Menutypes\HtmlView $this */
+
 $input = Factory::getApplication()->getInput();
 
 // Checking if loaded via index.php or component.php

--- a/administrator/components/com_messages/tmpl/config/default.php
+++ b/administrator/components/com_messages/tmpl/config/default.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Messages\Administrator\View\Config\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_messages/tmpl/message/default.php
+++ b/administrator/components/com_messages/tmpl/message/default.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Messages\Administrator\View\Message\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('core');

--- a/administrator/components/com_messages/tmpl/message/edit.php
+++ b/administrator/components/com_messages/tmpl/message/edit.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Messages\Administrator\View\Message\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_messages/tmpl/messages/default.php
+++ b/administrator/components/com_messages/tmpl/messages/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Messages\Administrator\View\Messages\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('multiselect');

--- a/administrator/components/com_messages/tmpl/messages/emptystate.php
+++ b/administrator/components/com_messages/tmpl/messages/emptystate.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Messages\Administrator\View\Messages\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_MESSAGES',
     'formURL'    => 'index.php?option=com_messages&view=messages',

--- a/administrator/components/com_modules/layouts/joomla/form/field/modulespositionedit.php
+++ b/administrator/components/com_modules/layouts/joomla/form/field/modulespositionedit.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\CMS\Layout\FileLayout $this */
+
 extract($displayData);
 
 /**

--- a/administrator/components/com_modules/tmpl/module/edit.php
+++ b/administrator/components/com_modules/tmpl/module/edit.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Modules\Administrator\View\Module\HtmlView $this */
+
 HTMLHelper::_('behavior.combobox');
 
 $hasContent          = isset($this->item->xml->customContent);

--- a/administrator/components/com_modules/tmpl/module/edit_assignment.php
+++ b/administrator/components/com_modules/tmpl/module/edit_assignment.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 use Joomla\Component\Modules\Administrator\Helper\ModulesHelper;
 
+/** @var \Joomla\Component\Modules\Administrator\View\Module\HtmlView $this */
+
 // Initialise related data.
 $menuTypes = MenusHelper::getMenuLinks();
 

--- a/administrator/components/com_modules/tmpl/module/modal.php
+++ b/administrator/components/com_modules/tmpl/module/modal.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Modules\Administrator\View\Module\HtmlView $this */
 ?>
 <div class="subhead noshadow mb-3">
     <?php echo $this->document->getToolbar('toolbar')->render(); ?>

--- a/administrator/components/com_modules/tmpl/module/modalreturn.php
+++ b/administrator/components/com_modules/tmpl/module/modalreturn.php
@@ -10,6 +10,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Modules\Administrator\View\Module\HtmlView $this */
+
 $icon     = 'icon-check';
 $title    = $this->item ? $this->item->title : '';
 $content  = $this->item ? $this->item->position : '';

--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Modules\Administrator\View\Modules\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_modules/tmpl/modules/default_batch_body.php
+++ b/administrator/components/com_modules/tmpl/modules/default_batch_body.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\Component\Modules\Administrator\Helper\ModulesHelper;
 
+/** @var \Joomla\Component\Modules\Administrator\View\Modules\HtmlView $this */
+
 $clientId  = $this->state->get('client_id');
 
 // Show only Module Positions of published Templates

--- a/administrator/components/com_modules/tmpl/modules/emptystate.php
+++ b/administrator/components/com_modules/tmpl/modules/emptystate.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Modules\Administrator\View\Modules\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_MODULES',
     'formURL'    => 'index.php?option=com_modules&view=select&client_id=' . $this->clientId,

--- a/administrator/components/com_modules/tmpl/modules/modal.php
+++ b/administrator/components/com_modules/tmpl/modules/modal.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Modules\Administrator\View\Modules\HtmlView $this */
+
 if (Factory::getApplication()->isClient('site')) {
     Session::checkToken('get') or die(Text::_('JINVALID_TOKEN'));
 }

--- a/administrator/components/com_modules/tmpl/select/default.php
+++ b/administrator/components/com_modules/tmpl/select/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Modules\Administrator\View\Select\HtmlView $this */
+
 $app = Factory::getApplication();
 
 $function  = $app->getInput()->getCmd('function');

--- a/administrator/components/com_modules/tmpl/select/modal.php
+++ b/administrator/components/com_modules/tmpl/select/modal.php
@@ -10,6 +10,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Modules\Administrator\View\Select\HtmlView $this */
+
 $this->modalLink = '&tmpl=component&view=module&layout=modal';
 ?>
 <div class="container-popup">

--- a/administrator/components/com_newsfeeds/layouts/joomla/form/field/modal-select/extra-buttons.php
+++ b/administrator/components/com_newsfeeds/layouts/joomla/form/field/modal-select/extra-buttons.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\CMS\Layout\FileLayout $this */
+
 extract($displayData);
 
 /**

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/edit.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Newsfeeds\Administrator\View\Newsfeed\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/edit_display.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/edit_display.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Newsfeeds\Administrator\View\Newsfeed\HtmlView $this */
+
 $this->fieldset = 'jbasic';
 ?>
 

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/modal.php
@@ -9,6 +9,8 @@
  */
 
 defined('_JEXEC') or die;
+
+/** @var \Joomla\Component\Newsfeeds\Administrator\View\Newsfeed\HtmlView $this */
 ?>
 <div class="subhead noshadow mb-3">
     <?php echo $this->document->getToolbar('toolbar')->render(); ?>

--- a/administrator/components/com_newsfeeds/tmpl/newsfeed/modalreturn.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeed/modalreturn.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 
+/** @var \Joomla\Component\Newsfeeds\Administrator\View\Newsfeed\HtmlView $this */
+
 $icon     = 'icon-check';
 $title    = $this->item ? $this->item->name : '';
 $content  = $this->item ? $this->item->alias : '';

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Newsfeeds\Administrator\View\Newsfeeds\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/default_batch_body.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/default_batch_body.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Newsfeeds\Administrator\View\Newsfeeds\HtmlView $this */
+
 $published = (int) $this->state->get('filter.published');
 ?>
 

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/emptystate.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/emptystate.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Newsfeeds\Administrator\View\Newsfeeds\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_NEWSFEEDS',
     'formURL'    => 'index.php?option=com_newsfeeds&view=newsfeeds',

--- a/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
+++ b/administrator/components/com_newsfeeds/tmpl/newsfeeds/modal.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
 
+/** @var \Joomla\Component\Newsfeeds\Administrator\View\Newsfeeds\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('core')

--- a/administrator/components/com_plugins/tmpl/plugin/edit.php
+++ b/administrator/components/com_plugins/tmpl/plugin/edit.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Plugins\Administrator\View\Plugin\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_plugins/tmpl/plugin/modal.php
+++ b/administrator/components/com_plugins/tmpl/plugin/modal.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Plugins\Administrator\View\Plugin\HtmlView $this */
 ?>
 <div class="subhead noshadow mb-3">
     <?php echo $this->document->getToolbar('toolbar')->render(); ?>

--- a/administrator/components/com_plugins/tmpl/plugin/modalreturn.php
+++ b/administrator/components/com_plugins/tmpl/plugin/modalreturn.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Plugins\Administrator\View\Plugin\HtmlView $this */
+
 $icon     = 'icon-check';
 $title    = $this->item ? Text::_($this->item->name) : '';
 $content  = $this->item ? $this->item->folder . '/' . $this->item->element : '';

--- a/administrator/components/com_plugins/tmpl/plugins/default.php
+++ b/administrator/components/com_plugins/tmpl/plugins/default.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Plugins\Administrator\View\Plugins\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_postinstall/tmpl/messages/default.php
+++ b/administrator/components/com_postinstall/tmpl/messages/default.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Postinstall\Administrator\View\Messages\HtmlView $this */
+
 $adminFormClass = count($this->extension_options) > 1 ? 'form-inline mb-3' : 'visually-hidden';
 ?>
 

--- a/administrator/components/com_postinstall/tmpl/messages/emptystate.php
+++ b/administrator/components/com_postinstall/tmpl/messages/emptystate.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Postinstall\Administrator\View\Messages\HtmlView $this */
+
 $adminFormClass = count($this->extension_options) > 1 ? 'form-inline mb-3' : 'visually-hidden';
 ?>
 

--- a/administrator/components/com_redirect/tmpl/link/edit.php
+++ b/administrator/components/com_redirect/tmpl/link/edit.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Redirect\Administrator\View\Link\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Redirect\Administrator\Helper\RedirectHelper;
 
+/** @var \Joomla\Component\Redirect\Administrator\View\Link\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_redirect/tmpl/links/default_batch_body.php
+++ b/administrator/components/com_redirect/tmpl/links/default_batch_body.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Redirect\Administrator\View\Links\HtmlView $this */
+
 $published = $this->state->get('filter.published');
 $params    = $this->params;
 $separator = $params->get('separator', '|');

--- a/administrator/components/com_redirect/tmpl/links/emptystate.php
+++ b/administrator/components/com_redirect/tmpl/links/emptystate.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Redirect\Administrator\Helper\RedirectHelper;
 
+/** @var \Joomla\Component\Redirect\Administrator\View\Links\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_REDIRECT',
     'formURL'    => 'index.php?option=com_redirect&view=links',

--- a/administrator/components/com_scheduler/tmpl/tasks/empty_state.php
+++ b/administrator/components/com_scheduler/tmpl/tasks/empty_state.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Scheduler\Administrator\View\Tasks\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_SCHEDULER',
     'formURL' => 'index.php?option=com_scheduler&task=task.add',

--- a/administrator/components/com_tags/tmpl/tag/edit.php
+++ b/administrator/components/com_tags/tmpl/tag/edit.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Tags\Administrator\View\Tag\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -19,6 +19,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\String\Inflector;
 
+/** @var \Joomla\Component\Tags\Administrator\View\Tags\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_tags/tmpl/tags/emptystate.php
+++ b/administrator/components/com_tags/tmpl/tags/emptystate.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Tags\Administrator\View\Tags\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_TAGS',
     'formURL'    => 'index.php?option=com_tags&task=tag.add',

--- a/administrator/components/com_templates/tmpl/style/edit.php
+++ b/administrator/components/com_templates/tmpl/style/edit.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Style\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_templates/tmpl/style/edit_assignment.php
+++ b/administrator/components/com_templates/tmpl/style/edit_assignment.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Style\HtmlView $this */
+
 // Initialise related data.
 $menuTypes = MenusHelper::getMenuLinks();
 $user      = $this->getCurrentUser();

--- a/administrator/components/com_templates/tmpl/styles/default.php
+++ b/administrator/components/com_templates/tmpl/styles/default.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Styles\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_templates/tmpl/template/default.php
+++ b/administrator/components/com_templates/tmpl/template/default.php
@@ -19,6 +19,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 HTMLHelper::_('behavior.multiselect', 'updateForm');
 HTMLHelper::_('bootstrap.modal');
 

--- a/administrator/components/com_templates/tmpl/template/default_description.php
+++ b/administrator/components/com_templates/tmpl/template/default_description.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\Component\Templates\Administrator\Helper\TemplatesHelper;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 ?>
 
 <div class="clearfix">

--- a/administrator/components/com_templates/tmpl/template/default_folders.php
+++ b/administrator/components/com_templates/tmpl/template/default_folders.php
@@ -10,6 +10,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 ksort($this->files, SORT_STRING);
 ?>
 

--- a/administrator/components/com_templates/tmpl/template/default_media_folders.php
+++ b/administrator/components/com_templates/tmpl/template/default_media_folders.php
@@ -10,6 +10,8 @@
 
 defined('_JEXEC') or die;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 // Legacy is the default
 if (!count($this->mediaFiles)) {
     return;

--- a/administrator/components/com_templates/tmpl/template/default_modal_child_body.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_child_body.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 Factory::getDocument()->getWebAssetManager()->usePreset('choicesjs');
 
 // Generate a list of styles for the child creation modal

--- a/administrator/components/com_templates/tmpl/template/default_modal_delete_body.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_delete_body.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
 ?>
 <div id="template-manager-delete" class="container-fluid">
     <div class="mt-2">

--- a/administrator/components/com_templates/tmpl/template/default_modal_delete_footer.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_delete_footer.php
@@ -14,6 +14,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 $input = Factory::getApplication()->getInput();
 ?>
 <form method="post" action="">

--- a/administrator/components/com_templates/tmpl/template/default_modal_file_body.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_file_body.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Utility\Utility;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 $input = Factory::getApplication()->getInput();
 ?>
 <div id="#template-manager-file" class="container-fluid">

--- a/administrator/components/com_templates/tmpl/template/default_modal_folder_body.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_folder_body.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 $input = Factory::getApplication()->getInput();
 ?>
 <div id="#template-manager-folder" class="container-fluid">

--- a/administrator/components/com_templates/tmpl/template/default_modal_folder_footer.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_folder_footer.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 $input = Factory::getApplication()->getInput();
 ?>
 <form id="deleteFolder" method="post" action="<?php echo Route::_('index.php?option=com_templates&task=template.deleteFolder&id=' . $input->getInt('id') . '&file=' . $this->file); ?>">

--- a/administrator/components/com_templates/tmpl/template/default_modal_rename_body.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_rename_body.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
 ?>
 <div id="template-manager-rename" class="container-fluid">
     <div class="mt-2">

--- a/administrator/components/com_templates/tmpl/template/default_modal_resize_body.php
+++ b/administrator/components/com_templates/tmpl/template/default_modal_resize_body.php
@@ -12,6 +12,7 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
 ?>
 <div id="template-manager-resize" class="container-fluid">
     <div class="mt-2">

--- a/administrator/components/com_templates/tmpl/template/default_tree.php
+++ b/administrator/components/com_templates/tmpl/template/default_tree.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 ksort($this->files, SORT_NATURAL);
 ?>
 

--- a/administrator/components/com_templates/tmpl/template/default_tree_media.php
+++ b/administrator/components/com_templates/tmpl/template/default_tree_media.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 // Legacy is the default
 if (!count($this->mediaFiles)) {
     return;

--- a/administrator/components/com_templates/tmpl/template/default_updated_files.php
+++ b/administrator/components/com_templates/tmpl/template/default_updated_files.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 HTMLHelper::_('bootstrap.dropdown', '.dropdown-toggle');
 
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */

--- a/administrator/components/com_templates/tmpl/template/readonly.php
+++ b/administrator/components/com_templates/tmpl/template/readonly.php
@@ -15,6 +15,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Template\HtmlView $this */
+
 $input = Factory::getApplication()->getInput();
 ?>
 <form action="<?php echo Route::_('index.php?option=com_templates&view=template&id=' . $input->getInt('id') . '&file=' . $this->file); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/components/com_templates/tmpl/templates/default.php
+++ b/administrator/components/com_templates/tmpl/templates/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Templates\Administrator\View\Templates\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Users\Administrator\View\Debuggroup\HtmlView $this */
+
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 

--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Users\Administrator\View\Debuguser\HtmlView $this */
+
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 

--- a/administrator/components/com_users/tmpl/group/edit.php
+++ b/administrator/components/com_users/tmpl/group/edit.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Users\Administrator\View\Group\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_users/tmpl/groups/default.php
+++ b/administrator/components/com_users/tmpl/groups/default.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Users\Administrator\View\Groups\HtmlView $this */
+
 $user        = $this->getCurrentUser();
 $listOrder   = $this->escape($this->state->get('list.ordering'));
 $listDirn    = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_users/tmpl/level/edit.php
+++ b/administrator/components/com_users/tmpl/level/edit.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Users\Administrator\View\Level\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_users/tmpl/levels/default.php
+++ b/administrator/components/com_users/tmpl/levels/default.php
@@ -18,6 +18,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\Component\Users\Administrator\Helper\UsersHelper;
 
+/** @var \Joomla\Component\Users\Administrator\View\Levels\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_users/tmpl/note/edit.php
+++ b/administrator/components/com_users/tmpl/note/edit.php
@@ -14,6 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Users\Administrator\View\Note\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_users/tmpl/notes/default.php
+++ b/administrator/components/com_users/tmpl/notes/default.php
@@ -15,6 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Users\Administrator\View\Notes\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_users/tmpl/notes/emptystate.php
+++ b/administrator/components/com_users/tmpl/notes/emptystate.php
@@ -12,6 +12,8 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 
+/** @var \Joomla\Component\Users\Administrator\View\Notes\HtmlView $this */
+
 $displayData = [
     'textPrefix' => 'COM_USERS_NOTES',
     'formURL'    => 'index.php?option=com_users&view=notes',

--- a/administrator/components/com_users/tmpl/notes/modal.php
+++ b/administrator/components/com_users/tmpl/notes/modal.php
@@ -13,6 +13,7 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Users\Administrator\View\Notes\HtmlView $this */
 ?>
 <div class="unotes">
     <h1><?php echo Text::sprintf('COM_USERS_NOTES_FOR_USER', $this->user->name, $this->user->id); ?></h1>

--- a/administrator/components/com_users/tmpl/users/default_batch_body.php
+++ b/administrator/components/com_users/tmpl/users/default_batch_body.php
@@ -13,6 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
+/** @var \Joomla\Component\Users\Administrator\View\Users\HtmlView $this */
+
 // Create the copy/move options.
 $options = [
     HTMLHelper::_('select.option', 'add', Text::_('COM_USERS_BATCH_ADD')),

--- a/administrator/components/com_users/tmpl/users/modal.php
+++ b/administrator/components/com_users/tmpl/users/modal.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Users\Administrator\View\Users\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('multiselect')->useScript('modal-content-select');

--- a/administrator/components/com_workflow/tmpl/stage/edit.php
+++ b/administrator/components/com_workflow/tmpl/stage/edit.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Workflow\Administrator\View\Stage\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_workflow/tmpl/stages/default.php
+++ b/administrator/components/com_workflow/tmpl/stages/default.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Workflow\Administrator\View\Stages\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_workflow/tmpl/transition/edit.php
+++ b/administrator/components/com_workflow/tmpl/transition/edit.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Workflow\Administrator\View\Transition\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_workflow/tmpl/transitions/default.php
+++ b/administrator/components/com_workflow/tmpl/transitions/default.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Workflow\Administrator\View\Transitions\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')

--- a/administrator/components/com_workflow/tmpl/workflow/edit.php
+++ b/administrator/components/com_workflow/tmpl/workflow/edit.php
@@ -16,6 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 
+/** @var \Joomla\Component\Workflow\Administrator\View\Workflow\HtmlView $this */
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('keepalive')

--- a/administrator/components/com_workflow/tmpl/workflows/default.php
+++ b/administrator/components/com_workflow/tmpl/workflows/default.php
@@ -17,6 +17,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 
+/** @var \Joomla\Component\Workflow\Administrator\View\Workflows\HtmlView $this */
+
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->document->getWebAssetManager();
 $wa->useScript('table.columns')


### PR DESCRIPTION
### Summary of Changes
This PR adds doctype hints for all backend component layouts and tmpls for $this.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
