### PR TITLE
[4.4] Fix articles categories module bug

### DIFF
--- a/modules/mod_articles_categories/src/Helper/ArticlesCategoriesHelper.php
+++ b/modules/mod_articles_categories/src/Helper/ArticlesCategoriesHelper.php
@@ -60,7 +60,7 @@ class ArticlesCategoriesHelper implements DatabaseAwareInterface
         }
 
         // Get all the children categories of this node
-        $childrenCategories = $parentCategory->getChildren(true);
+        $childrenCategories = $parentCategory->getChildren();
 
         $count = $moduleParams->get('count', 0);
 


### PR DESCRIPTION
Pull Request for Issue #42924.

### Summary of Changes
Currently, children categories are being displayed multiple times on articles categories module, see https://github.com/joomla/joomla-cms/issues/42924 to understand more about the issue. This PR just fixes that wrong behavior.

### Testing Instructions
Follow instructions at https://github.com/joomla/joomla-cms/issues/42924 to create the module and confirm the issue

### Actual result BEFORE applying this Pull Request
Children categories are being displayed multiple times, both at top level and children level


### Expected result AFTER applying this Pull Request
Each category will only be displayed one time as expected.


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
