### PR TITLE
[5.1] Message and subject violated in "Privacy: Consent"

### DIFF
--- a/administrator/components/com_privacy/src/View/Consents/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Consents/HtmlView.php
@@ -131,7 +131,7 @@ class HtmlView extends BaseHtmlView
         // Add a button to invalidate a consent
         if (!$this->isEmptyState) {
             $toolbar->confirmButton('trash', 'COM_PRIVACY_CONSENTS_TOOLBAR_INVALIDATE', 'consents.invalidate')
-                ->message('COM_PRIVACY_CONSENTS_TOOLBAR_INVALIDATE')
+                ->message('COM_PRIVACY_CONSENTS_TOOLBAR_INVALIDATE_CONFIRM_MSG')
                 ->icon('icon-trash')
                 ->listCheck(true);
         }

--- a/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
+++ b/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
@@ -174,7 +174,7 @@ final class PrivacyConsent extends CMSPlugin
             // Create the user note
             $userNote = (object) [
                 'user_id' => $userId,
-                'subject' => 'PLG_SYSTEM_PRIVACYCONSENT_SUBJECT',
+                'subject' => Text::_('PLG_SYSTEM_PRIVACYCONSENT_SUBJECT'),
                 'body'    => Text::sprintf('PLG_SYSTEM_PRIVACYCONSENT_BODY', $ip, $userAgent),
                 'created' => Factory::getDate()->toSql(),
             ];


### PR DESCRIPTION
Pull Request for Issue # .

1. Enable the System - Privacy Consent plugin,
2. Create a user and authorize them in the front. The site will require consent.
3. Go to the admin panel to the Privacy: Consents page:

Broken subject of consent + when revoking consent, incorrect message.

### Actual result BEFORE applying this Pull Request

![Screenshot_1](https://github.com/joomla/joomla-cms/assets/8440661/250fb2fe-89d7-4e1f-86f8-2f8c52d6eea5)

### Expected result AFTER applying this Pull Request

![Screenshot_2](https://github.com/joomla/joomla-cms/assets/8440661/66946498-ed00-47cb-b448-32aa1129e452)