### PR TITLE
[5.1] Update deleted files list in script.php for 5.1.0-beta1

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2207,6 +2207,31 @@ class JoomlaInstallerScript
             // From 5.1.0-alpha3 to 5.1.0-alpha4
             '/administrator/components/com_redirect/tmpl/links/default_batch_footer.php',
             '/modules/mod_banners/mod_banners.php',
+            // From 5.1.0-alpha4 to 5.1.0-beta1
+            '/administrator/modules/mod_custom/mod_custom.php',
+            '/administrator/modules/mod_frontend/mod_frontend.php',
+            '/administrator/modules/mod_latestactions/mod_latestactions.php',
+            '/administrator/modules/mod_loginsupport/mod_loginsupport.php',
+            '/administrator/modules/mod_messages/mod_messages.php',
+            '/administrator/modules/mod_multilangstatus/mod_multilangstatus.php',
+            '/administrator/modules/mod_sampledata/mod_sampledata.php',
+            '/administrator/modules/mod_stats_admin/mod_stats_admin.php',
+            '/administrator/modules/mod_title/mod_title.php',
+            '/administrator/modules/mod_toolbar/mod_toolbar.php',
+            '/administrator/modules/mod_user/mod_user.php',
+            '/administrator/modules/mod_version/mod_version.php',
+            '/media/plg_system_jooa11y/css/jooa11y.css',
+            '/media/plg_system_jooa11y/css/jooa11y.min.css',
+            '/media/plg_system_jooa11y/css/jooa11y.min.css.gz',
+            '/media/plg_system_jooa11y/scss/jooa11y.scss',
+            '/media/vendor/joomla-a11y-checker/LICENSE.md',
+            '/modules/mod_feed/mod_feed.php',
+            '/modules/mod_languages/mod_languages.php',
+            '/modules/mod_stats/mod_stats.php',
+            '/modules/mod_syndicate/mod_syndicate.php',
+            '/modules/mod_tags_popular/mod_tags_popular.php',
+            '/modules/mod_tags_similar/mod_tags_similar.php',
+            '/modules/mod_wrapper/mod_wrapper.php',
         ];
 
         $folders = [
@@ -2441,6 +2466,10 @@ class JoomlaInstallerScript
             '/libraries/vendor/fgrosse/phpasn1/lib',
             '/libraries/vendor/fgrosse/phpasn1',
             '/libraries/vendor/fgrosse',
+            // From 5.1.0-alpha4 to 5.1.0-beta1
+            '/media/vendor/joomla-a11y-checker',
+            '/media/plg_system_jooa11y/scss',
+            '/media/plg_system_jooa11y/css',
         ];
 
         $status['files_checked']   = $files;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in file `administrator/components/com_admin/script.php` to recent changes in the 5.1-dev branch in preparation for the upcoming 5.1.0-beta1 release.

In detail deleted files and folder from following PR's are added:
- From PR #42877 file
`/administrator/modules/mod_custom/mod_custom.php`
- From PR #42853 file
`/administrator/modules/mod_frontend/mod_frontend.php`
- From PR #42910 file
`/administrator/modules/mod_latestactions/mod_latestactions.php`
- From PR #42827 file
`/administrator/modules/mod_loginsupport/mod_loginsupport.php`
- From PR #42735 file
`/administrator/modules/mod_messages/mod_messages.php`
- From PR #42845 file
`/administrator/modules/mod_multilangstatus/mod_multilangstatus.php`
- From PR #42866 file
`/administrator/modules/mod_sampledata/mod_sampledata.php`
- From PR #42886 file
`/administrator/modules/mod_stats_admin/mod_stats_admin.php`
- From PR #42801 file
`/administrator/modules/mod_title/mod_title.php`
- From PR #42838 file
`/administrator/modules/mod_toolbar/mod_toolbar.php`
- From PR #42852 file
`/administrator/modules/mod_user/mod_user.php`
- From PR #42814 file
`/administrator/modules/mod_version/mod_version.php`
- From PR #42215 file
`/modules/mod_feed/mod_feed.php`
- From PR #42929 file
`/modules/mod_languages/mod_languages.php`
- From PR #42781 file
`/modules/mod_stats/mod_stats.php`
- From PR #42883 file
`/modules/mod_syndicate/mod_syndicate.php`
- From PR #42899 file
`/modules/mod_tags_popular/mod_tags_popular.php`
- From PR #42898 file
`/modules/mod_tags_similar/mod_tags_similar.php`
- From PR #42792 file
`/modules/mod_wrapper/mod_wrapper.php`
- From PR #42780 files
`/media/plg_system_jooa11y/css/jooa11y.css`
`/media/plg_system_jooa11y/css/jooa11y.min.css`
`/media/plg_system_jooa11y/css/jooa11y.min.css.gz`
`/media/plg_system_jooa11y/scss/jooa11y.scss`
`/media/vendor/joomla-a11y-checker/LICENSE.md`
and folders
`/media/vendor/joomla-a11y-checker`
`/media/plg_system_jooa11y/scss`
`/media/plg_system_jooa11y/css`

The following JS files which were deleted with PR #42776 in the source code shall not be deleted on update for b/c reasons, so they are not added to the list in file `administrator/components/com_admin/script.php` with this PR:
`/media/legacy/js/treeselectmenu.js`
`/media/legacy/js/treeselectmenu.min.js`
`/media/legacy/js/treeselectmenu.min.js.gz`

These files need to be added to the list of exceptions in the `build/deleted_file_check.php` so they will not be reported in future as false alarms by the tool which I used to generate the changes of this PR. See my current PR #42936 for that.

### Testing Instructions

Code review.

Or if you want to make a real test, update a 5.1.0-alpha4 or older version to the last 5.1 nightly build to get the actual result, and update a 5.1.0-alpha4 or older version to to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

The files and folders mentioned above are still present after updating from a 5.1.0-alpha4 or older version.

### Expected result AFTER applying this Pull Request

The files mentioned above have been deleted after updating from a 5.1.0-alpha4 or older version.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
