### PR TITLE
[4.4] [BUGFIX] Enforce UTF-8 on CSS Files

### DIFF
--- a/build/build-modules-js/stylesheets/handle-css.es6.js
+++ b/build/build-modules-js/stylesheets/handle-css.es6.js
@@ -22,7 +22,7 @@ module.exports.handleCssFile = async (file) => {
     });
 
     // Ensure the folder exists or create it
-    await writeFile(outputFile.replace('.css', '.min.css'), code, { encoding: 'utf8', mode: 0o644 });
+    await writeFile(outputFile.replace('.css', '.min.css'), `@charset "UTF-8";${code}`, { encoding: 'utf8', mode: 0o644 });
 
     // eslint-disable-next-line no-console
     console.log(`✅ CSS file copied/minified: ${file}`);

--- a/build/build-modules-js/stylesheets/handle-scss.es6.js
+++ b/build/build-modules-js/stylesheets/handle-scss.es6.js
@@ -32,7 +32,8 @@ module.exports.handleScssFile = async (file) => {
   await ensureDir(dirname(cssFile), {});
   await writeFile(
     cssFile,
-    contents,
+    `@charset "UTF-8";
+${contents}`,
     { encoding: 'utf8', mode: 0o644 },
   );
 
@@ -46,7 +47,7 @@ module.exports.handleScssFile = async (file) => {
   await ensureDir(dirname(cssFile.replace('.css', '.min.css')), {});
   await writeFile(
     cssFile.replace('.css', '.min.css'),
-    cssMin.code,
+    `@charset "UTF-8";${cssMin.code}`,
     { encoding: 'utf8', mode: 0o644 },
   );
 

--- a/build/build-modules-js/stylesheets/scss-transform.es6.js
+++ b/build/build-modules-js/stylesheets/scss-transform.es6.js
@@ -27,7 +27,8 @@ module.exports.compile = async (file) => {
   await FsExtra.mkdirs(dirname(cssFile), {});
   await Fs.writeFile(
     cssFile,
-    code,
+    `@charset "UTF-8";
+${code}`,
     { encoding: 'utf8', mode: 0o644 },
   );
 
@@ -41,7 +42,7 @@ module.exports.compile = async (file) => {
   FsExtra.mkdirs(dirname(cssFile.replace('.css', '.min.css')), {});
   await Fs.writeFile(
     cssFile.replace('.css', '.min.css'),
-    cssMin.code,
+    `@charset "UTF-8";${cssMin.code}`,
     { encoding: 'utf8', mode: 0o644 },
   );
 


### PR DESCRIPTION
Pull Request for Issue #42611 .

### Summary of Changes

Adds `@charset "UTF-8";` as a first line on all the CSS files. Docs: https://developer.mozilla.org/en-US/docs/Web/CSS/@charset

### Testing Instructions

- ~~Ensure your browser default encoding IS NOT `UTF-8`~~
- Download and install Joomla from this Pull Request
- Check that icons don't get weird...

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
