### PR TITLE
[4.4] Spelling mistake

### DIFF
--- a/administrator/language/en-GB/plg_system_jooa11y.ini
+++ b/administrator/language/en-GB/plg_system_jooa11y.ini
@@ -11,7 +11,7 @@ PLG_SYSTEM_JOOA11Y_FIELD_CONTAINER_IGNORE_DESC="Ignore specific regions within t
 PLG_SYSTEM_JOOA11Y_FIELD_READABILITY_ROOT="Readability Container"
 PLG_SYSTEM_JOOA11Y_FIELD_READABILITY_ROOT_DESC="Landmark on the page that will be checked for readability. The default setting is the landmark <strong>main</strong>. Alternatives to landmarks are classes, elements or ARIA roles (eg #example, .example, [role=example])."
 PLG_SYSTEM_JOOA11Y_FIELD_SHOW_ALWAYS="Show Always"
-PLG_SYSTEM_JOOA11Y_FIELD_SHOW_ALWAYS_DESC="Load the accessiblity checker on all pages. This is useful when developing the website but should not be left on when the website is live."
+PLG_SYSTEM_JOOA11Y_FIELD_SHOW_ALWAYS_DESC="Load the accessibility checker on all pages. This is useful when developing the website but should not be left on when the website is live."
 PLG_SYSTEM_JOOA11Y_XML_DESCRIPTION="The Joomla Accessibility Checker visually highlights common accessibility and usability issues. Geared towards content authors, the plugin identifies errors or warnings and provides guidance on how to fix them."
 
 ;Global text


### PR DESCRIPTION
accessiblity ==> accessibility  (missing i)

code review