### PR TITLE
[5.1] Add missing import

### DIFF
--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\Database\ParameterType;
 use Joomla\Filesystem\File;
+use Joomla\Filesystem\Path;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;


### PR DESCRIPTION
Pull Request for Issue #40131.

 `Class "Joomla\CMS\Installer\Path" not found`.

### Testing Instructions
Install PatchTester.
See error.


