### PR TITLE
[5.1] Fix PHP warnings on newly created custom fields

### DIFF
--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -122,13 +122,11 @@ class FieldModel extends AdminModel
                 if ($data['params']['searchindex'] > 0) {
                     Factory::getApplication()->enqueueMessage(Text::_('COM_FIELDS_SEARCHINDEX_MIGHT_REQUIRE_REINDEXING'), 'notice');
                 }
-            } else {
-                if (
-                    $field->params['searchindex'] != $data['params']['searchindex']
-                    || ($data['params']['searchindex'] > 0 && ($field->state != $data['state'] || $field->access != $data['access']))
-                ) {
-                    Factory::getApplication()->enqueueMessage(Text::_('COM_FIELDS_SEARCHINDEX_MIGHT_REQUIRE_REINDEXING'), 'notice');
-                }
+            } elseif (
+                $field->params['searchindex'] != $data['params']['searchindex']
+                || ($data['params']['searchindex'] > 0 && ($field->state != $data['state'] || $field->access != $data['access']))
+            ) {
+                Factory::getApplication()->enqueueMessage(Text::_('COM_FIELDS_SEARCHINDEX_MIGHT_REQUIRE_REINDEXING'), 'notice');
             }
         }
 

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -117,13 +117,19 @@ class FieldModel extends AdminModel
             $field = $this->getItem($data['id']);
         }
 
-        if (
-            isset($data['params']['searchindex'])
-            && ((\is_null($field) && $data['params']['searchindex'] > 0)
-                || ($field->params['searchindex'] != $data['params']['searchindex'])
-                || ($data['params']['searchindex'] > 0 && ($field->state != $data['state'] || $field->access != $data['access'])))
-        ) {
-            Factory::getApplication()->enqueueMessage(Text::_('COM_FIELDS_SEARCHINDEX_MIGHT_REQUIRE_REINDEXING'), 'notice');
+        if (isset($data['params']['searchindex'])) {
+            if (\is_null($field)) {
+                if ($data['params']['searchindex'] > 0) {
+                    Factory::getApplication()->enqueueMessage(Text::_('COM_FIELDS_SEARCHINDEX_MIGHT_REQUIRE_REINDEXING'), 'notice');
+                }
+            } else {
+                if (
+                    $field->params['searchindex'] != $data['params']['searchindex']
+                    || ($data['params']['searchindex'] > 0 && ($field->state != $data['state'] || $field->access != $data['access']))
+                ) {
+                    Factory::getApplication()->enqueueMessage(Text::_('COM_FIELDS_SEARCHINDEX_MIGHT_REQUIRE_REINDEXING'), 'notice');
+                }
+            }
         }
 
         if (!isset($data['label']) && isset($data['params']['label'])) {


### PR DESCRIPTION
Pull Request for Issue #40681 .

### Summary of Changes
Separate conditions of the if statement to apply to new fields vs existing fields accordingly.

When creating a new field and the `Search Index` setting is `Don't make searchable`, the last 2 conditions are not applicable thus php warnings.

```
PHP Warning:  Attempt to read property "params" on null in \administrator\components\com_fields\src\Model\FieldModel.php on line 123
PHP Warning:  Trying to access array offset on value of type null in \administrator\components\com_fields\src\Model\FieldModel.php on line 123
```

### Testing Instructions
Install Blog Sample Data.
No errors in PHP log.

Add a new custom field.
Save field.
No errors  in PHP log.
