### PR TITLE
[5.1] remove duplicate strings from up-merge #42950

### DIFF
--- a/administrator/language/en-GB/plg_system_privacyconsent.ini
+++ b/administrator/language/en-GB/plg_system_privacyconsent.ini
@@ -5,8 +5,6 @@
 
 PLG_SYSTEM_PRIVACYCONSENT="System - Privacy Consent"
 PLG_SYSTEM_PRIVACYCONSENT_BODY="<p>The user consented to storing their user information using the IP address <strong>%s</strong></p><p>The user agent string of the user's browser was:<br>%s</p><p>This information was automatically recorded when the user submitted their details on the website and checked the confirm box.</p>"
-PLG_SYSTEM_PRIVACYCONSENT_CACHETIMEOUT_DESC="How often the check is performed."
-PLG_SYSTEM_PRIVACYCONSENT_CACHETIMEOUT_LABEL="Periodic check (days)"
 PLG_SYSTEM_PRIVACYCONSENT_CONSENT="User <a href='{accountlink}'>{username}</a> consented to the privacy policy."
 PLG_SYSTEM_PRIVACYCONSENT_FIELD_ARTICLE_DESC="Select the article from the list or create a new one."
 PLG_SYSTEM_PRIVACYCONSENT_FIELD_ARTICLE_LABEL="Privacy Article"


### PR DESCRIPTION
Pull Request for PR #42950 .

### Summary of Changes

The upmerge added two lines that were already marked as deprecated.

### Testing Instructions

code review

### Actual result BEFORE applying this Pull Request

Doublet
https://github.com/joomla/joomla-cms/blob/d834f8123870c53cf908927de85c8bae368407af/administrator/language/en-GB/plg_system_privacyconsent.ini#L8-L9

Correct line marked as deprecated
https://github.com/joomla/joomla-cms/blob/d834f8123870c53cf908927de85c8bae368407af/administrator/language/en-GB/plg_system_privacyconsent.ini#L32-L33

### Expected result AFTER applying this Pull Request

only
https://github.com/joomla/joomla-cms/blob/d834f8123870c53cf908927de85c8bae368407af/administrator/language/en-GB/plg_system_privacyconsent.ini#L32-L33

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
