### PR TITLE
[5.1] Remove unused use statements to fix PHPCS

### DIFF
--- a/tests/Unit/Libraries/Cms/Updater/ConstraintCheckerTest.php
+++ b/tests/Unit/Libraries/Cms/Updater/ConstraintCheckerTest.php
@@ -12,7 +12,6 @@ namespace Joomla\Tests\Unit\Libraries\Cms\Updater;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Updater\ConstraintChecker;
-use Joomla\CMS\Version;
 use Joomla\Database\DatabaseDriver;
 use Joomla\Tests\Unit\UnitTestCase;
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Currently the PHPCS step is failing in Drone in the 5.1-dev branch because php-cs-fixer finds an unused `use` statement, see drone logs https://ci.joomla.org/joomla/joomla-cms/74369/1/7 and https://ci.joomla.org/joomla/joomla-cms/74368/1/7 of the last 2 commits in the 5.1-dev branch.

### Testing Instructions

Check if the PHPCS step succeeds in drone for this PR and for the last commit in the 5.1-dev branch.

Or instead of checking Drone logs, run php-cs-fixer locally on the current 5.1-dev branch and on the branch of this PR.

### Actual result BEFORE applying this Pull Request

The php-cs-fixer fails the 5.1-dev branch.

### Expected result AFTER applying this Pull Request

The php-cs-fixer succeeds for this PR.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
