### PR TITLE
Shorten path to global CSS folder

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -66,7 +66,7 @@ if ($paramsFontScheme) {
 // Enable assets
 $wa->usePreset('template.cassiopeia.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
     ->useStyle('template.active.language')
-    ->registerAndUseStyle($assetColorName, 'media/templates/site/cassiopeia/css/global/' . $paramsColorName . '.css')
+    ->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css')
     ->useStyle('template.user')
     ->useScript('template.user')
     ->addInlineStyle(":root {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The path to the /global CSS folder is unnecessary long. The WebAssetManager recognizes the short path too because the path to the CSS folder known.

### Testing Instructions
Check if in the source code before an after this PR if the **colors_standard.min.css** file is loaded
The path should be: media/templates/site/cassiopeia/css/global/colors_standard.min.css

### Actual result BEFORE applying this Pull Request
Everything works

### Expected result AFTER applying this Pull Request
Everything works

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
