### PR TITLE
[5.1] Fix fatal error during Joomla update

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -22,7 +22,6 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Database\ParameterType;
-use Joomla\Filesystem\Path;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -573,8 +573,6 @@ class JoomlaInstallerScript
             'folders_deleted' => [],
             'files_errors'    => [],
             'folders_errors'  => [],
-            'folders_checked' => [],
-            'files_checked'   => [],
         ];
 
         $files = [
@@ -2540,7 +2538,7 @@ class JoomlaInstallerScript
         $status['folders_checked'] = $folders;
 
         foreach ($files as $file) {
-            if ($fileExists = is_file(JPATH_ROOT . $file)) {
+            if (is_file(JPATH_ROOT . $file)) {
                 $status['files_exist'][] = $file;
 
                 if ($dryRun === false) {
@@ -2554,7 +2552,7 @@ class JoomlaInstallerScript
         }
 
         foreach ($folders as $folder) {
-            if ($folderExists = is_dir(Path::clean(JPATH_ROOT . $folder))) {
+            if (is_dir(JPATH_ROOT . $folder)) {
                 $status['folders_exist'][] = $folder;
 
                 if ($dryRun === false) {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
As of right now, update to Joomla 5.1 nightly build package will get fatal error. It is because the code for delete folders using `Path::clean` method which is not available for using. You can read the discussion at https://github.com/joomla/joomla-cms/issues/42971 to understand more if needed

As the list of folders are provided by us, so it is clean and trusted, we can remove Path::clean call here. I also made some minor clean up to the code, too.

### Testing Instructions
- Uses Joomla 5 
- Change settings of Joomla update component. Set **Update Channel** to  **Custom URL**, and set **Custom URL** to https://artifacts.joomla.org/drone/joomla/joomla-cms/5.1-dev/42976/downloads/74420/pr_list.xml

### Actual result BEFORE applying this Pull Request
If you update your site to Joomla nightly build package, you will get fatal error


### Expected result AFTER applying this Pull Request
No error updating to package generated by this PR.


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
