### PR TITLE
[5.1] Fix Send Email button class name

### DIFF
--- a/administrator/components/com_users/src/View/Mail/HtmlView.php
+++ b/administrator/components/com_users/src/View/Mail/HtmlView.php
@@ -72,7 +72,7 @@ class HtmlView extends BaseHtmlView
 
         ToolbarHelper::title(Text::_('COM_USERS_MASS_MAIL'), 'users massmail');
         $toolbar = Toolbar::getInstance();
-        $toolbar->standardButton('COM_USERS_TOOLBAR_MAIL_SEND_MAIL', 'COM_USERS_TOOLBAR_MAIL_SEND_MAIL', 'mail.send')
+        $toolbar->standardButton('send', 'COM_USERS_TOOLBAR_MAIL_SEND_MAIL', 'mail.send')
             ->icon('icon-envelope')
             ->formValidation(true);
 


### PR DESCRIPTION
### Testing Instructions
Go to Users > Mass Mail Users
Use the browser's inspector to inspect the class name of `Send Email` button.


### Actual result BEFORE applying this Pull Request
`<button class="button-COM_USERS_TOOLBAR_MAIL_SEND_MAIL btn btn-primary" type="button">`


### Expected result AFTER applying this Pull Request
`<button class="button-send btn btn-primary" type="button">`
