### PR TITLE
[4.x] Fix JHTTP socket transport http version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -55,7 +55,7 @@
     "joomla/event": "^2.0.2",
     "joomla/filter": "^2.0.4",
     "joomla/filesystem": "^2.0.2",
-    "joomla/http": "^2.0.2",
+    "joomla/http": "^2.0.4",
     "joomla/input": "^2.0.4",
     "joomla/ldap": "~2.0.0",
     "joomla/oauth1": "^2.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca2cb7d978f989ce1eb25dcef54db239",
+    "content-hash": "8827e815417f1cda4554b7748d884cea",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -1769,16 +1769,16 @@
         },
         {
             "name": "joomla/http",
-            "version": "2.0.2",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/http.git",
-                "reference": "abcd087d83d317434457a79755cdde1d57fde8c6"
+                "reference": "b20fe5c8c3a30d7660ac6e032640a11d84cf29a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/http/zipball/abcd087d83d317434457a79755cdde1d57fde8c6",
-                "reference": "abcd087d83d317434457a79755cdde1d57fde8c6",
+                "url": "https://api.github.com/repos/joomla-framework/http/zipball/b20fe5c8c3a30d7660ac6e032640a11d84cf29a1",
+                "reference": "b20fe5c8c3a30d7660ac6e032640a11d84cf29a1",
                 "shasum": ""
             },
             "require": {
@@ -1821,7 +1821,7 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/http/issues",
-                "source": "https://github.com/joomla-framework/http/tree/2.0.2"
+                "source": "https://github.com/joomla-framework/http/tree/2.0.4"
             },
             "funding": [
                 {
@@ -1833,7 +1833,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-01-31T21:23:35+00:00"
+            "time": "2024-03-12T10:38:28+00:00"
         },
         {
             "name": "joomla/input",
@@ -9921,5 +9921,5 @@
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/libraries/src/Http/Transport/SocketTransport.php
+++ b/libraries/src/Http/Transport/SocketTransport.php
@@ -86,7 +86,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
 
         // Build the request payload.
         $request   = [];
-        $request[] = strtoupper($method) . ' ' . ((empty($path)) ? '/' : $path) . ' HTTP/1.1';
+        $request[] = strtoupper($method) . ' ' . ((empty($path)) ? '/' : $path) . ' HTTP/1.0';
         $request[] = 'Host: ' . $uri->getHost();
 
         // If an explicit user agent is given use it.


### PR DESCRIPTION
Pull Request for Issue #38963 and #42973 

### Summary of Changes
In #35568 a change was merged into the JHTTP socket driver, increasing the accepted HTTP version for the client from 1.0 to 1.1.

That change introduce the issue described in #38963: HTTP 1.1 defines the chunked transfer mode which is mandatory for all clients implementing HTTP 1.1 - as our socket-based client however does not support chunked responses, a chunked response causes an infinite loop.

### Framework implications
Once tested, please also merge https://github.com/joomla-framework/http/pull/54

### Testing Instructions
* Create a socket-based JHTTP request to a server responding with a chunked response, i.e. by using this code block:
`$http = \Joomla\CMS\Http\HttpFactory::getHttp([], 'socket');
$response = $http->get('https://update.joomla.org/cms/root.json');`


### Actual result BEFORE applying this Pull Request
* Infinite loop


### Expected result AFTER applying this Pull Request
* Response returned


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
