### PR TITLE
[5.1] - Fix JHTTP socket transport http version

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1848,16 +1848,16 @@
         },
         {
             "name": "joomla/http",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/http.git",
-                "reference": "ec389a64def1d71d145fdcc06895cbd960f5d805"
+                "reference": "3379b5a0c68524685b89d6997e5fec56c6ad3d43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/http/zipball/ec389a64def1d71d145fdcc06895cbd960f5d805",
-                "reference": "ec389a64def1d71d145fdcc06895cbd960f5d805",
+                "url": "https://api.github.com/repos/joomla-framework/http/zipball/3379b5a0c68524685b89d6997e5fec56c6ad3d43",
+                "reference": "3379b5a0c68524685b89d6997e5fec56c6ad3d43",
                 "shasum": ""
             },
             "require": {
@@ -1903,7 +1903,7 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/http/issues",
-                "source": "https://github.com/joomla-framework/http/tree/3.0.0"
+                "source": "https://github.com/joomla-framework/http/tree/3.0.1"
             },
             "funding": [
                 {
@@ -1915,7 +1915,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-10-07T21:22:46+00:00"
+            "time": "2024-03-11T18:42:37+00:00"
         },
         {
             "name": "joomla/input",
@@ -9987,5 +9987,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/libraries/src/Http/Transport/SocketTransport.php
+++ b/libraries/src/Http/Transport/SocketTransport.php
@@ -86,7 +86,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
 
         // Build the request payload.
         $request   = [];
-        $request[] = strtoupper($method) . ' ' . ((empty($path)) ? '/' : $path) . ' HTTP/1.1';
+        $request[] = strtoupper($method) . ' ' . ((empty($path)) ? '/' : $path) . ' HTTP/1.0';
         $request[] = 'Host: ' . $uri->getHost();
 
         // If an explicit user agent is given use it.


### PR DESCRIPTION
Pull Request for Issue #38963 and #42973 

### Summary of Changes
In #35568 a change was merged into the JHTTP socket driver, increasing the accepted HTTP version for the client from 1.0 to 1.1.

That change introduce the issue described in #38963: HTTP 1.1 defines the chunked transfer mode which is mandatory for all clients implementing HTTP 1.1 - as our socket-based client however does not support chunked responses, a chunked response causes an infinite loop.

### Testing Instructions
* Create a socket-based JHTTP request to a server responding with a chunked response, i.e. by using this code block:
`$http = \Joomla\CMS\Http\HttpFactory::getHttp([], 'socket');
$response = $http->get('https://update.joomla.org/cms/root.json');`

### Actual result BEFORE applying this Pull Request
* Infinite loop

### Expected result AFTER applying this Pull Request
* Response returned

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
