### PR TITLE
[5.1] Update TUF client version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -106,7 +106,7 @@
     "phpseclib/bcmath_compat": "^2.0.1",
     "jfcherng/php-diff": "^6.15.3",
     "voku/portable-utf8": "^6.0.13",
-    "php-tuf/php-tuf": "^1.0.0"
+    "php-tuf/php-tuf": "^1.0.1"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6.17",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83b305bd9267a11c4b499d2bcdbdea4e",
+    "content-hash": "46bb31ea65a45346eaa1f0639fe10f0b",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -3083,16 +3083,16 @@
         },
         {
             "name": "php-tuf/php-tuf",
-            "version": "1.0.0",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-backports/php-tuf.git",
-                "reference": "1961502dff73cc2d2a3f19b930516a18bc0ccd22"
+                "reference": "ca2039924ddc6ccd510c67e88e3b337b2395989f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-backports/php-tuf/zipball/1961502dff73cc2d2a3f19b930516a18bc0ccd22",
-                "reference": "1961502dff73cc2d2a3f19b930516a18bc0ccd22",
+                "url": "https://api.github.com/repos/joomla-backports/php-tuf/zipball/ca2039924ddc6ccd510c67e88e3b337b2395989f",
+                "reference": "ca2039924ddc6ccd510c67e88e3b337b2395989f",
                 "shasum": ""
             },
             "require": {
@@ -3153,7 +3153,7 @@
                 "MIT"
             ],
             "description": "PHP implementation of The Update Framework (TUF)",
-            "time": "2024-01-26T15:28:14+00:00"
+            "time": "2024-03-11T19:10:07+00:00"
         },
         {
             "name": "phpmailer/phpmailer",
@@ -9987,5 +9987,5 @@
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
### Summary of Changes
This PR updates the TUF client version to include a fix merged in the upstream repo. The patch fixes an issue where the verification of update data, that has been signed by new keys, failed.


### Testing Instructions
* Try fetching updates in the current 5.1 branch, verify that no signature error is shown.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x ] No documentation changes for manual.joomla.org needed
