### PR TITLE
[5.1] Fix fancy-select for Dark Mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/choicesjs/choices.scss
@@ -71,6 +71,16 @@
   }
 }
 
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    .choices__list--multiple .choices__item {
+      &.is-highlighted {
+        background-color: var(--gray-800);
+      }
+    }
+  }
+}
+
 .choices .choices__list--dropdown {
   background-color: var(--body-bg);
 
@@ -82,9 +92,13 @@
     &::after {
       display: none;
     }
+  }
+}
 
-    @if $enable-dark-mode {
-      @include color-mode(dark) {
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    .choices .choices__list--dropdown {
+      .choices__item--selectable {
         &.is-highlighted {
           background-color: var(--gray-800);
         }
@@ -139,9 +153,12 @@
       background-color: $form-select-bg;
     }
   }
+}
 
-  @if $enable-dark-mode {
-    @include color-mode(dark) {
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    .choices[data-type*="select-one"],
+    .choices[data-type*="select-multiple"] {
       .choices__inner {
         background: url("../../../images/select-bg-dark.svg") no-repeat 100%/116rem;
         background-color: $form-select-bg-dark;
@@ -150,6 +167,18 @@
           background: url("../../../images/select-bg-rtl-dark.svg") no-repeat 0/116rem;
           background-color: $form-select-bg-dark;
         }
+      }
+    }
+  }
+}
+
+@if $enable-dark-mode {
+  [dir="rtl"][data-bs-theme="dark"] {
+    .choices[data-type*="select-one"],
+    .choices[data-type*="select-multiple"] {
+      .choices__inner {
+        background: url("../../../images/select-bg-rtl-dark.svg") no-repeat 0/116rem;
+        background-color: $form-select-bg-dark;
       }
     }
   }
@@ -201,4 +230,12 @@
 
 .choices__heading {
   font-size: 1.2rem;
+}
+
+@if $enable-dark-mode {
+  @include color-mode(dark) {
+    .choices__heading {
+      color: var(--gray-500);
+    }
+  }
 }


### PR DESCRIPTION
Pull Request for Issue #[42221#issuecomment-1989830009](https://github.com/joomla/joomla-cms/pull/42221#issuecomment-1989830009).

### Summary of Changes

Fix for Fancy-Select with new Dark Mode Switch


### Testing Instructions

Apply patch run `npm install`.
Check the template Atum parameters `Dark mode`.

### Actual result BEFORE applying this Pull Request

![311917953-7d0dfbe1-0793-4d4b-b0de-5807c0b24331](https://github.com/joomla/joomla-cms/assets/64533137/38e12da1-0bbe-4d08-8db2-b4da597828fe)

### Expected result AFTER applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/64533137/803decb7-a922-44f9-b896-191e75890665)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
