### PR TITLE
[5.1] Dark mode settings block - to template settings

### DIFF
--- a/administrator/components/com_users/forms/user.xml
+++ b/administrator/components/com_users/forms/user.xml
@@ -152,6 +152,19 @@
 			</field>
 
 			<field
+				name="colorScheme"
+				type="list"
+				label="COM_USERS_USER_COLORSCHEME_LABEL"
+				default=""
+				validate="options"
+				>
+				<option value="">JOPTION_USE_DEFAULT</option>
+				<option value="os">COM_USERS_USER_COLORSCHEME_OPTION_FOLLOW_OS</option>
+				<option value="light">COM_USERS_USER_COLORSCHEME_OPTION_LIGHT</option>
+				<option value="dark">COM_USERS_USER_COLORSCHEME_OPTION_DARK</option>
+			</field>
+
+			<field
 				name="admin_language"
 				type="language"
 				label="COM_USERS_USER_FIELD_BACKEND_LANGUAGE_LABEL"
@@ -185,19 +198,6 @@
 				layout="joomla.form.field.groupedlist-fancy-select"
 				>
 				<option value="">JOPTION_USE_DEFAULT</option>
-			</field>
-
-			<field
-				name="colorScheme"
-				type="list"
-				label="COM_USERS_USER_COLORSCHEME_LABEL"
-				default=""
-				validate="options"
-				>
-				<option value="">JOPTION_USE_DEFAULT</option>
-				<option value="os">COM_USERS_USER_COLORSCHEME_OPTION_FOLLOW_OS</option>
-				<option value="light">COM_USERS_USER_COLORSCHEME_OPTION_LIGHT</option>
-				<option value="dark">COM_USERS_USER_COLORSCHEME_OPTION_DARK</option>
 			</field>
 
 		</fieldset>

--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -54,10 +54,10 @@ HTMLHelper::_('bootstrap.dropdown', '.dropdown-toggle');
         <?php if ($colorSchemeSwitch) : ?>
             <button type="button" class="dropdown-item" data-color-scheme-switch>
                 <span class="d-dark-scheme-none">
-                    <span class="fa fa-sun icon-fw me-2" aria-hidden="true"></span> <?php echo Text::_('MOD_USER_LIGHT_MODE'); ?>
+                    <span class="fa fa-sun icon-fw me-1" aria-hidden="true"></span> <?php echo Text::_('MOD_USER_LIGHT_MODE'); ?>
                 </span>
                 <span class="d-light-scheme-none">
-                    <span class="fa fa-moon icon-fw me-2" aria-hidden="true"></span> <?php echo Text::_('MOD_USER_DARK_MODE'); ?>
+                    <span class="fa fa-moon icon-fw me-1" aria-hidden="true"></span> <?php echo Text::_('MOD_USER_DARK_MODE'); ?>
                 </span>
             </button>
         <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Moves the dark mode settings block - to the template settings in the profile + reduces the indentation from the icon in the user menu.

### Testing Instructions
Go to the user's drop-down menu, the indents in the items are the same.
Go to edit profile, the item with the template theme has moved to setting up the template for the admin panel.

![Screenshot_1](https://github.com/joomla/joomla-cms/assets/8440661/437efe06-8fe0-45b8-a471-f347ca69bff3)

![Screenshot_2](https://github.com/joomla/joomla-cms/assets/8440661/04ad2e9b-e309-43b2-8eb1-3ceebd998b11)

