### PR TITLE
CMSObject should extend stdClass

### DIFF
--- a/libraries/src/Object/CMSObject.php
+++ b/libraries/src/Object/CMSObject.php
@@ -25,8 +25,7 @@ namespace Joomla\CMS\Object;
  *              Use \stdClass or \Joomla\Registry\Registry instead.
  *              Example: new \Joomla\Registry\Registry();
  */
-#[\AllowDynamicProperties]
-class CMSObject
+class CMSObject extends \stdClass
 {
     use LegacyErrorHandlingTrait;
     use LegacyPropertyManagementTrait;


### PR DESCRIPTION
### Summary of Changes
This is a backport of #42717. Read there for more details. Adding this to 4.4 allows extension developers to update their code already away from CMSObject to stdClass as long as they support Joomla 4.

### Testing Instructions
Create an article in the back end. With as many content plugins as possible.

### Actual result BEFORE applying this Pull Request
All works.

### Expected result AFTER applying this Pull Request
All works.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/232
- [x] No documentation changes for manual.joomla.org needed
