### PR TITLE
[5.1] Update TourTable.php to allow save on tours

### DIFF
--- a/administrator/components/com_guidedtours/src/Table/TourTable.php
+++ b/administrator/components/com_guidedtours/src/Table/TourTable.php
@@ -111,7 +111,7 @@ class TourTable extends Table implements CurrentUserInterface
 
         // set autostart
         // @todo: remove once autostart has been added to the tour form
-        if (empty($this->autostart)) {
+        if (is_null($this->autostart)) {
             $this->autostart = 0;
         }
 

--- a/administrator/components/com_guidedtours/src/Table/TourTable.php
+++ b/administrator/components/com_guidedtours/src/Table/TourTable.php
@@ -109,6 +109,11 @@ class TourTable extends Table implements CurrentUserInterface
             $this->setTourUid();
         }
 
+        // set autostart - won't be needed once we add autostart to the user interface
+        if (empty($this->autostart)) {
+            $this->autostart = 0;
+        }
+
         // make sure the uid is unique
         $this->ensureUniqueUid();
 

--- a/administrator/components/com_guidedtours/src/Table/TourTable.php
+++ b/administrator/components/com_guidedtours/src/Table/TourTable.php
@@ -109,7 +109,8 @@ class TourTable extends Table implements CurrentUserInterface
             $this->setTourUid();
         }
 
-        // set autostart - won't be needed once we add autostart to the user interface
+        // set autostart
+        // @todo: remove once autostart has been added to the tour form
         if (empty($this->autostart)) {
             $this->autostart = 0;
         }

--- a/administrator/components/com_guidedtours/src/Table/TourTable.php
+++ b/administrator/components/com_guidedtours/src/Table/TourTable.php
@@ -111,7 +111,7 @@ class TourTable extends Table implements CurrentUserInterface
 
         // set autostart
         // @todo: remove once autostart has been added to the tour form
-        if (is_null($this->autostart)) {
+        if (\is_null($this->autostart)) {
             $this->autostart = 0;
         }
 


### PR DESCRIPTION
### Summary of Changes

Since the introduction of the welcome tour, the addition of the autostart column fails the saving of tours.

### Testing Instructions

Go to System -> Guided Tours, create a tour and save.
Try also 'duplicate' and 'save as copy'.

### Actual result BEFORE applying this Pull Request

Error 'Save failed with the following error: Column 'autostart' cannot be null'.

### Expected result AFTER applying this Pull Request

No error on save.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
