### PR TITLE
[5.1] Guided tours dialog box outline is invisible in dark mode

### DIFF
--- a/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
+++ b/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
@@ -5,6 +5,12 @@
 
 @import "../../../../node_modules/shepherd.js/dist/css/shepherd";
 
+.shepherd-content {
+    border: 1px solid var(--border-color-translucent);
+    box-shadow: var(--modal-joomla-dialog-box-shadow);
+    border-radius: .3rem;
+}
+
 .shepherd-content img {
   max-width: 100%;
   height: auto;

--- a/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
+++ b/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
@@ -6,9 +6,9 @@
 @import "../../../../node_modules/shepherd.js/dist/css/shepherd";
 
 .shepherd-content {
-    border: 1px solid var(--border-color-translucent);
-    box-shadow: var(--modal-joomla-dialog-box-shadow);
-    border-radius: .3rem;
+  border: 1px solid var(--border-color-translucent);
+  border-radius: .3rem;
+  box-shadow: var(--modal-joomla-dialog-box-shadow);
 }
 
 .shepherd-content img {


### PR DESCRIPTION
### Summary of Changes

Add CSS to make the Shepherd dialog match the rest of the dialog windows in the interface

### Testing Instructions

Use the latest 5.1 version available. 
Turn into dark mode if your browser is not using it already.
Start a tour.
Check that the outline is present.
Turn light mode.
Check that the dialog box looks alright.

### Actual result BEFORE applying this Pull Request

The dialog box does not seem to have boundaries or any outline.

![guidedtours_outlines](https://github.com/joomla/joomla-cms/assets/5964177/1e47548e-ea54-4150-9ec0-da43b49db85d)

### Expected result AFTER applying this Pull Request

The dialog box has an outline like the rest of the modals in the interface.

![guidedtours_outline_after](https://github.com/joomla/joomla-cms/assets/5964177/cce707e4-97bd-4c6a-b8e8-4f0ca28886e8)

Note: the outline may look dim, but this is something that can be changed in the template.
Any change in the overall interface will be reflected in the guided tours dialog boxes.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
