### PR TITLE
[4.4] Prevent step target to be recorded with empty spaces and prevent tour run fails

### DIFF
--- a/administrator/components/com_guidedtours/src/Table/StepTable.php
+++ b/administrator/components/com_guidedtours/src/Table/StepTable.php
@@ -85,4 +85,28 @@ class StepTable extends Table
 
         return parent::store($updateNulls);
     }
+
+    /**
+     * Overloaded check function
+     *
+     * @return  boolean  True on success, false on failure
+     *
+     * @see     \Joomla\CMS\Table\Table::check
+     * @since   1.5
+     */
+    public function check()
+    {
+        try {
+            parent::check();
+        } catch (\Exception $e) {
+            $this->setError($e->getMessage());
+
+            return false;
+        }
+
+        // Make sure the target is trimmed to avoid tours failing to start
+        $this->target = trim($this->target);
+
+        return true;
+    }
 }

--- a/administrator/components/com_guidedtours/src/Table/StepTable.php
+++ b/administrator/components/com_guidedtours/src/Table/StepTable.php
@@ -92,7 +92,7 @@ class StepTable extends Table
      * @return  boolean  True on success, false on failure
      *
      * @see     \Joomla\CMS\Table\Table::check
-     * @since   1.5
+     * @since   __DEPLOY_VERSION__
      */
     public function check()
     {

--- a/plugins/system/guidedtours/src/Extension/GuidedTours.php
+++ b/plugins/system/guidedtours/src/Extension/GuidedTours.php
@@ -221,7 +221,7 @@ final class GuidedTours extends CMSPlugin implements SubscriberInterface
             $temp->title            = $this->getApplication()->getLanguage()->_($step->title);
             $temp->description      = $this->getApplication()->getLanguage()->_($step->description);
             $temp->position         = $step->position;
-            $temp->target           = $step->target;
+            $temp->target           = trim($step->target);
             $temp->type             = $this->stepType[$step->type];
             $temp->interactive_type = $this->stepInteractiveType[$step->interactive_type];
             $temp->url              = $step->url;


### PR DESCRIPTION
### Summary of Changes

The step target is trimmed to avoid javascript errors and preventing a tour to start (with an error message that does not really explain what was wrong)

### Testing Instructions

Edit a tour step and edit the target, adding spaces before and after the content of the field.
Run the tour you have edited the step from.
The tour MAY fail (depending on the browser/system used). It failed on Safari.
Apply the patch.
Edit the target field for the step (so it can be saved). Once saved, the step target field should not contain any space.

### Actual result BEFORE applying this Pull Request

The tour may not start (an error message is shown when you start the tour).

### Expected result AFTER applying this Pull Request

The tour runs.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
