### PR TITLE
[4.4] When duplicating a tour with 0 (no) steps, SQL fails

### DIFF
--- a/administrator/components/com_guidedtours/src/Model/TourModel.php
+++ b/administrator/components/com_guidedtours/src/Model/TourModel.php
@@ -350,7 +350,6 @@ class TourModel extends AdminModel
                 $rows = $db->loadObjectList();
 
                 if ($rows) {
-
                     $query = $db->getQuery(true)
                         ->insert($db->quoteName('#__guidedtour_steps'))
                         ->columns(

--- a/administrator/components/com_guidedtours/src/Model/TourModel.php
+++ b/administrator/components/com_guidedtours/src/Model/TourModel.php
@@ -313,7 +313,7 @@ class TourModel extends AdminModel
                 // Reset the id to create a new record.
                 $table->id = 0;
 
-                $table->published   = 0;
+                $table->published = 0;
 
                 if (!$table->check() || !$table->store()) {
                     throw new \Exception($table->getError());
@@ -349,82 +349,85 @@ class TourModel extends AdminModel
                 $db->setQuery($query);
                 $rows = $db->loadObjectList();
 
-                $query = $db->getQuery(true)
-                    ->insert($db->quoteName('#__guidedtour_steps'))
-                    ->columns(
-                        [
-                            $db->quoteName('tour_id'),
-                            $db->quoteName('title'),
-                            $db->quoteName('description'),
-                            $db->quoteName('ordering'),
-                            $db->quoteName('position'),
-                            $db->quoteName('target'),
-                            $db->quoteName('type'),
-                            $db->quoteName('interactive_type'),
-                            $db->quoteName('url'),
-                            $db->quoteName('created'),
-                            $db->quoteName('created_by'),
-                            $db->quoteName('modified'),
-                            $db->quoteName('modified_by'),
-                            $db->quoteName('language'),
-                            $db->quoteName('note'),
-                        ]
-                    );
+                if ($rows) {
 
-                foreach ($rows as $step) {
-                    $dataTypes = [
-                        ParameterType::INTEGER,
-                        ParameterType::STRING,
-                        ParameterType::STRING,
-                        ParameterType::INTEGER,
-                        ParameterType::STRING,
-                        ParameterType::STRING,
-                        ParameterType::INTEGER,
-                        ParameterType::INTEGER,
-                        ParameterType::STRING,
-                        ParameterType::STRING,
-                        ParameterType::INTEGER,
-                        ParameterType::STRING,
-                        ParameterType::INTEGER,
-                        ParameterType::STRING,
-                        ParameterType::STRING,
-                    ];
+                    $query = $db->getQuery(true)
+                        ->insert($db->quoteName('#__guidedtour_steps'))
+                        ->columns(
+                            [
+                                $db->quoteName('tour_id'),
+                                $db->quoteName('title'),
+                                $db->quoteName('description'),
+                                $db->quoteName('ordering'),
+                                $db->quoteName('position'),
+                                $db->quoteName('target'),
+                                $db->quoteName('type'),
+                                $db->quoteName('interactive_type'),
+                                $db->quoteName('url'),
+                                $db->quoteName('created'),
+                                $db->quoteName('created_by'),
+                                $db->quoteName('modified'),
+                                $db->quoteName('modified_by'),
+                                $db->quoteName('language'),
+                                $db->quoteName('note'),
+                            ]
+                        );
 
-                    $query->values(
-                        implode(
-                            ',',
-                            $query->bindArray(
-                                [
-                                    $table->id,
-                                    $step->title,
-                                    $step->description,
-                                    $step->ordering,
-                                    $step->position,
-                                    $step->target,
-                                    $step->type,
-                                    $step->interactive_type,
-                                    $step->url,
-                                    $date,
-                                    $user->id,
-                                    $date,
-                                    $user->id,
-                                    $step->language,
-                                    $step->note,
-                                ],
-                                $dataTypes
+                    foreach ($rows as $step) {
+                        $dataTypes = [
+                            ParameterType::INTEGER,
+                            ParameterType::STRING,
+                            ParameterType::STRING,
+                            ParameterType::INTEGER,
+                            ParameterType::STRING,
+                            ParameterType::STRING,
+                            ParameterType::INTEGER,
+                            ParameterType::INTEGER,
+                            ParameterType::STRING,
+                            ParameterType::STRING,
+                            ParameterType::INTEGER,
+                            ParameterType::STRING,
+                            ParameterType::INTEGER,
+                            ParameterType::STRING,
+                            ParameterType::STRING,
+                        ];
+
+                        $query->values(
+                            implode(
+                                ',',
+                                $query->bindArray(
+                                    [
+                                        $table->id,
+                                        $step->title,
+                                        $step->description,
+                                        $step->ordering,
+                                        $step->position,
+                                        $step->target,
+                                        $step->type,
+                                        $step->interactive_type,
+                                        $step->url,
+                                        $date,
+                                        $user->id,
+                                        $date,
+                                        $user->id,
+                                        $step->language,
+                                        $step->note,
+                                    ],
+                                    $dataTypes
+                                )
                             )
-                        )
-                    );
-                }
+                        );
+                    }
 
-                $db->setQuery($query);
+                    $db->setQuery($query);
 
-                try {
-                    $db->execute();
-                } catch (\RuntimeException $e) {
-                    Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
+                    try {
+                        $db->execute();
+                    } catch (\RuntimeException $e) {
+                        Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
-                    return false;
+                        return false;
+                    }
                 }
             } else {
                 throw new \Exception($table->getError());


### PR DESCRIPTION
### Summary of Changes

When using the 'Duplicate' action for tours, if a tour has no steps, we get a SQL error.

### Testing Instructions

Go to System -> Guided Tours.
Select a tour that has no steps or first create a tour but do not add steps.
Go to Actions -> Duplicate

### Actual result BEFORE applying this Pull Request

Error message about an SQL fail. The tour is created nevertheless.

### Expected result AFTER applying this Pull Request

No error message, the tour is created.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
