### PR TITLE
[5.1] Fix Sample data installation, fix finder helper addContentType null value

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Helper.php
+++ b/administrator/components/com_finder/src/Indexer/Helper.php
@@ -250,7 +250,7 @@ class Helper
         $query->clear()
             ->insert($db->quoteName('#__finder_types'))
             ->columns([$db->quoteName('title'), $db->quoteName('mime')])
-            ->values($db->quote($title) . ', ' . $db->quote($mime));
+            ->values($db->quote($title) . ', ' . $db->quote($mime ?? ''));
         $db->setQuery($query);
         $db->execute();
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Helper::addContentType() allows null for mime however  $db->quote() does not.


### Testing Instructions
Use PHP 8+
On clean installation, set error reaporting to Maximum
Then try install "Blog Sample Data"


### Actual result BEFORE applying this Pull Request
An error `There is an error in a sample data plugin ...`


### Expected result AFTER applying this Pull Request
All works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
