### PR TITLE
[4.4] Fix Sample data installation, fix finder helper addContentType null value

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Helper.php
+++ b/administrator/components/com_finder/src/Indexer/Helper.php
@@ -243,7 +243,7 @@ class Helper
         $query->clear()
             ->insert($db->quoteName('#__finder_types'))
             ->columns([$db->quoteName('title'), $db->quoteName('mime')])
-            ->values($db->quote($title) . ', ' . $db->quote($mime));
+            ->values($db->quote($title) . ', ' . $db->quote($mime ?? ''));
         $db->setQuery($query);
         $db->execute();
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Helper::addContentType() allows null for mime, however  $db->quote() does not.
Same as https://github.com/joomla/joomla-cms/pull/43051 but for 4.4


### Testing Instructions
Use PHP 8+, set error reaporting to Maximum.
Set DB driver to use MySQL PDO
~~On clean installation, try install "Blog Sample Data"~~

Run following code (example in index.php of the template):
```php
$name = uniqid(); // Imitating a new content type name, can be any string
var_dump(Joomla\Component\Finder\Administrator\Indexer\Helper::addContentType($name));
```


### Actual result BEFORE applying this Pull Request
PHP warning `Deprecated: PDO::quote(): Passing null to parameter 1 ($string) of type string is deprecated`


### Expected result AFTER applying this Pull Request
No warning


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
