### PR TITLE
[4.x] Add support for brotli

### DIFF
--- a/htaccess.txt
+++ b/htaccess.txt
@@ -136,7 +136,7 @@ Options -Indexes
 	</IfModule>
 </IfModule>
 
-## GZIP
+## GZIP & BROTLI
 ## These directives are only enabled if the Apache mod_headers module is enabled.
 ## This section will check if a .gz file exists and if so will stream it
 ##     directly or fallback to gzip any asset on the fly
@@ -158,8 +158,8 @@ Options -Indexes
 	RewriteRule "^(.*)\.js" "$1\.js\.gz" [QSA]
 
 	# Serve correct content types, and prevent mod_deflate double gzip.
-	RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1]
-	RewriteRule "\.js\.gz$" "-" [T=text/javascript,E=no-gzip:1]
+	RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1,E=no-brotli:1]
+	RewriteRule "\.js\.gz$" "-" [T=text/javascript,E=no-gzip:1,E=no-brotli:1]
 
 	<FilesMatch "(\.js\.gz|\.css\.gz)$">
 		# Serve correct encoding type.

--- a/htaccess.txt
+++ b/htaccess.txt
@@ -157,7 +157,7 @@ Options -Indexes
 	RewriteCond "%{REQUEST_FILENAME}\.gz" -s
 	RewriteRule "^(.*)\.js" "$1\.js\.gz" [QSA]
 
-	# Serve correct content types, and prevent mod_deflate double gzip.
+	# Serve correct content types, and prevent mod_deflate double compression.
 	RewriteRule "\.css\.gz$" "-" [T=text/css,E=no-gzip:1,E=no-brotli:1]
 	RewriteRule "\.js\.gz$" "-" [T=text/javascript,E=no-gzip:1,E=no-brotli:1]
 


### PR DESCRIPTION
Add support for brotli gz compression in htaccess.txt

From [Wikipedia](https://en.wikipedia.org/wiki/Brotli):
> Brotli is a [lossless data compression algorithm](https://en.wikipedia.org/wiki/Lossless_compression) developed by [Google](https://en.wikipedia.org/wiki/Google). It uses a combination of the general-purpose [LZ77](https://en.wikipedia.org/wiki/LZ77_and_LZ78) [lossless compression](https://en.wikipedia.org/wiki/Lossless_compression) algorithm, [Huffman coding](https://en.wikipedia.org/wiki/Huffman_coding) and 2nd-order [context modelling](https://en.wikipedia.org/wiki/Context_model). Brotli is primarily used by [web servers](https://en.wikipedia.org/wiki/Web_servers) and [content delivery networks](https://en.wikipedia.org/wiki/Content_delivery_networks) to [compress HTTP content](https://en.wikipedia.org/wiki/HTTP_compression), making internet websites load faster. A successor to [gzip](https://en.wikipedia.org/wiki/Gzip), it is supported by all major web browsers and has become increasingly popular, as it provides better compression than gzip.

### Summary of Changes
Webservers that use brotli and have Joomla's htaccess enabled will fail the website in HTTPS unless you comment/delete the code block related to GZIP.
After the change, the problem no longer occurs.

### Testing Instructions
1. Check if your hosting uses brotli.
2. Apply the patch and copy the text from `htaccess.txt` to `.htaccess`
3. Indicate in the test whether you tested with a hosting that uses brotli or not. I think it is useful to have tests for both cases.


### Actual result BEFORE applying this Pull Request
#### If your hosting does not use brotli
Joomla works properly

#### If your hosting use brotli
Joomla in HTTP works correctly.
Joomla in HTTP**S** does not load the CSS and JS resources, and investigating the error in the console is: `ERR_CONTENT_DECODING_FAILED`


### Expected result AFTER applying this Pull Request
#### If your hosting does not use brotli
Joomla still works properly

#### If your hosting use brotli
Joomla works properly

### NOTE
[ServerPlan](https://www.serverplan.com/) uses brotli.

### Thanks
Thanks to ServerPlan for supporting the tests and finding the solution

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
