### PR TITLE
[4.4] Cassiopeia back to top

### DIFF
--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_back-to-top.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_back-to-top.scss
@@ -3,7 +3,7 @@
 */
 
 .back-to-top-link {
-  position: absolute;
+  position: fixed;
   inset-inline-end: 1rem;
   bottom: 1rem;
   z-index: 10000;


### PR DESCRIPTION
Pull Request for Issue #42312 .

### Summary of Changes
When enabled the back to top button should be visible as soon as you have scrolled


### Testing Instructions
Apply pr and `run npm build:css` or use a prebuilt package in this pr

In the cassiopeia template style enable the back to top button

In the front end test on a short page (no scrolling possible) and a long page (with scrolling)
### Expected result BEFORE applying this Pull Request
back to top button is not present on the short page
back to top button is visible on the long page only when you have reached the very bottom of the page

### Expected result AFTER applying this Pull Request
back to top button is not present on the short page
back to top button is visible on the long page as soon as you start scrolling and disapears as soon as you scroll nack to the top


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
