### PR TITLE
[5.1] Trailing slash: Don't redirect for homepage

### DIFF
--- a/plugins/system/sef/src/Extension/Sef.php
+++ b/plugins/system/sef/src/Extension/Sef.php
@@ -343,7 +343,11 @@ final class Sef extends CMSPlugin implements SubscriberInterface
     {
         $originalUri = Uri::getInstance();
 
-        if ((int)$this->params->get('trailingslash') === 1 && str_ends_with($originalUri->getPath(), '/') && $originalUri->toString() !== Uri::root()) {
+        if (
+            (int)$this->params->get('trailingslash') === 1
+            && str_ends_with($originalUri->getPath(), '/')
+            && $originalUri->toString(['scheme', 'host', 'port', 'path']) !== Uri::root()
+        ) {
             // Remove trailingslash
             $originalUri->setPath(substr($originalUri->getPath(), 0, -1));
             $this->getApplication()->redirect($originalUri->toString(), 301);


### PR DESCRIPTION
Pull Request for Issue #43056 .

### Summary of Changes
When you open the homepage and have additional query parameters appended, you can encounter an infinite redirect loop.


### Testing Instructions
1. Go to the System - SEF plugin and set "Trailing Slash for URLs" to "Enforce URLs without trailing slash".
2. Go to your frontend and open the homepage. Append query parameters like `?test=1` to the URL.


### Actual result BEFORE applying this Pull Request
You encounter a redirect loop.


### Expected result AFTER applying this Pull Request
You don't get a redirect.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
