### PR TITLE
[5.0] Cassiopeia. Load colors_xyz.css after template.css

### DIFF
--- a/templates/cassiopeia/index.php
+++ b/templates/cassiopeia/index.php
@@ -39,7 +39,7 @@ $pageclass = $menu !== null ? $menu->getParams()->get('pageclass_sfx', '') : '';
 // Color Theme
 $paramsColorName = $this->params->get('colorName', 'colors_standard');
 $assetColorName  = 'theme.' . $paramsColorName;
-$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css');
+$wa->registerAndUseStyle($assetColorName, 'global/' . $paramsColorName . '.css', ['weight' => 100]);
 
 // Use a font scheme if set in the template style options
 $paramsFontScheme = $this->params->get('useFontScheme', false);


### PR DESCRIPTION
Pull Request for Issue #43071

### Summary of Changes
- Add a weight attribute to registerAndUseStyle().

### Testing Instructions
- Have a brand new site with a Cassiopeia theme.
- Switch to the "Alternative" color theme.
- Go to frontend. Open a page. Inspect an A tag somewhere in text.

### Actual result BEFORE applying this Pull Request
- Value of `--link-color` is not from loaded file media/templates/site/cassiopeia/css/global/colors_alternative.min.css which `is --link-color: #30638d;`
- but is (see image)
![grafik](https://github.com/joomla/joomla-cms/assets/20780646/7ae66b60-3c40-4574-ba62-64951e7e84bb)

### Expected result AFTER applying this Pull Request
- See image:
![grafik](https://github.com/joomla/joomla-cms/assets/20780646/382fa013-e2ba-4430-840a-7f279e383a4f)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
