### PR TITLE
[4.x] Update punycode library to include security fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,7 @@
     "joomla/string": "^2.0.1",
     "joomla/uri": "^2.0.4",
     "joomla/utilities": "^2.0.1",
-    "algo26-matthias/idna-convert": "^3.1.0",
+    "algo26-matthias/idna-convert": "^3.1.1",
     "defuse/php-encryption": "^2.4.0",
     "doctrine/inflector": "^1.4.4",
     "fig/link-util": "^1.1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8827e815417f1cda4554b7748d884cea",
+    "content-hash": "42465ec1c271f017d4e38a4f6ab0f2f9",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
-            "version": "v3.1.0",
+            "version": "v3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/algo26-matthias/idna-convert.git",
-                "reference": "340a4dc65f6b0d9884853a3d32895d82f0c1502a"
+                "reference": "d8dbf18599548b8460ab0c462f299a15cacf6e66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/340a4dc65f6b0d9884853a3d32895d82f0c1502a",
-                "reference": "340a4dc65f6b0d9884853a3d32895d82f0c1502a",
+                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/d8dbf18599548b8460ab0c462f299a15cacf6e66",
+                "reference": "d8dbf18599548b8460ab0c462f299a15cacf6e66",
                 "shasum": ""
             },
             "require": {
@@ -58,9 +58,9 @@
             ],
             "support": {
                 "issues": "https://github.com/algo26-matthias/idna-convert/issues",
-                "source": "https://github.com/algo26-matthias/idna-convert/tree/v3.1.0"
+                "source": "https://github.com/algo26-matthias/idna-convert/tree/v3.1.1"
             },
-            "time": "2023-02-17T10:08:02+00:00"
+            "time": "2024-03-18T16:24:08+00:00"
         },
         {
             "name": "beberlei/assert",


### PR DESCRIPTION
### Summary of Changes
Updates the punycode library to 3.1.1 to include a backported security fix, see:
https://github.com/algo26-matthias/idna-convert/commit/d8dbf18599548b8460ab0c462f299a15cacf6e66


### Testing Instructions
Code Review


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
