### PR TITLE
[5.1] Finder: Allow finder plugins to output spaces

### DIFF
--- a/administrator/components/com_finder/src/Controller/IndexerController.php
+++ b/administrator/components/com_finder/src/Controller/IndexerController.php
@@ -96,7 +96,8 @@ class IndexerController extends BaseController
 
             $output = ob_get_contents();
 
-            if ($output) {
+            // Finder plugins should not create output of any kind. If there is output, that very likely is the result of a PHP error.
+            if (trim($output)) {
                 throw new \Exception(Text::_('COM_FINDER_AN_ERROR_HAS_OCCURRED'));
             }
 
@@ -201,7 +202,8 @@ class IndexerController extends BaseController
 
             $output = ob_get_contents();
 
-            if ($output) {
+            // Finder plugins should not create output of any kind. If there is output, that very likely is the result of a PHP error.
+            if (trim($output)) {
                 throw new \Exception(Text::_('COM_FINDER_INDEXER_ERROR_PLUGIN_FAILURE'));
             }
 
@@ -251,7 +253,8 @@ class IndexerController extends BaseController
 
             $output = ob_get_contents();
 
-            if ($output) {
+            // Finder plugins should not create output of any kind. If there is output, that very likely is the result of a PHP error.
+            if (trim($output)) {
                 throw new \Exception(Text::_('COM_FINDER_AN_ERROR_HAS_OCCURRED'));
             }
 


### PR DESCRIPTION
Pull Request for Issue #43000 .

### Summary of Changes
Finder plugins should not generate any output when being run. If they create output, we expect this to be the output of notices, errors or warnings from PHP directly. This check has been added in 5.0, however some finder plugins out there seem to generate output, most likely from switching between PHP and HTML context. This PR makes this a bit less strict by allowing spaces and new line characters as output. I consider this an acceptable compromise.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
