### PR TITLE
[5.1] Update deleted files list in script.php for 5.1.0-rc1

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2289,7 +2289,6 @@ class JoomlaInstallerScript
             '/modules/mod_wrapper/mod_wrapper.php',
             // From 5.1.0-beta1 to 5.1.0-beta2
             '/administrator/modules/mod_login/mod_login.php',
-            '/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php',
             '/libraries/src/Event/Router/AfterInitialiseRouterEvent.php',
             '/libraries/src/Event/Router/RouterEvent.php',
             '/libraries/src/Http/HttpFactoryInterface.php',
@@ -2322,6 +2321,8 @@ class JoomlaInstallerScript
             '/libraries/vendor/web-token/jwt-signature-algorithm-hmac/LICENSE',
             '/libraries/vendor/web-token/jwt-signature-algorithm-none/LICENSE',
             '/libraries/vendor/web-token/jwt-signature-algorithm-rsa/LICENSE',
+            // From 5.1.0-beta2 to 5.1.0-rc1
+            '/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php',
         ];
 
         $folders = [

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2289,6 +2289,7 @@ class JoomlaInstallerScript
             '/modules/mod_wrapper/mod_wrapper.php',
             // From 5.1.0-beta1 to 5.1.0-beta2
             '/administrator/modules/mod_login/mod_login.php',
+            '/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php',
             '/libraries/src/Event/Router/AfterInitialiseRouterEvent.php',
             '/libraries/src/Event/Router/RouterEvent.php',
             '/libraries/src/Http/HttpFactoryInterface.php',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Follow up PR to #42955 and #43045 .

This pull request (PR) updates the list of files to be deleted on update in file `administrator/components/com_admin/script.php` to recent changes in the 5.1-dev branch in preparation for the upcoming 5.1.0-beta2 release.

There is only one file added to the list of files, which is file `/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php` from PR #42987 .

### Testing Instructions

Code review.

Or if you want to make a real test, update a 5.1.0-beta2 or older version to the last 5.1 nightly build to get the actual result, and update a 5.1.0-beta1 or older version to to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

The file mentioned above is still present after updating from a 5.1.0-beta2 or older version.

### Expected result AFTER applying this Pull Request

The file mentioned above has been deleted after updating from a 5.1.0-beta2 or older version.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
