### PR TITLE
[5.1] Alert links system container

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_alerts.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_alerts.scss
@@ -23,30 +23,45 @@
     color: var(--state-info-text);
     background-color: var(--state-info-bg);
     border: var(--state-info-border);
+    a {
+      color: var(--state-info-text);
+    }
   }
 
   &.alert-warning {
     color: var(--state-warning-text);
     background-color: var(--state-warning-bg);
     border: var(--state-warning-border);
+    a {
+      color: var(--state-warning-text);
+    }
   }
 
   &.alert-success {
     color: var(--state-success-text);
     background-color: var(--state-success-bg);
     border: var(--state-success-border);
+    a {
+      color: var(--state-success-text);
+    }
   }
 
   &.alert-error {
     color: var(--state-error-text);
     background-color: var(--state-error-bg);
     border: var(--state-error-border);
+    a {
+      color: var(--state-error-text);
+    }
   }
 
   &.alert-danger {
     color: var(--state-danger-text);
     background-color: var(--state-danger-bg);
     border-color: var(--state-danger-border);
+    a {
+      color: var(--state-danger-text);
+    }
   }
 }
 

--- a/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
+++ b/build/media_source/templates/administrator/atum/scss/vendor/joomla-custom-elements/joomla-alert.scss
@@ -35,6 +35,10 @@
     --alert-border: var(--state-success-bg-hvr);
     --alert-heading-bg: var(--state-success-bg-hvr);
     --alert-link-color: var(--state-success-link-color, var(--states-link-color));
+    a {
+      color: var(--state-success-text);
+      text-decoration: underline;
+    }
   }
 
   &[type="info"],
@@ -44,6 +48,10 @@
     --alert-border: var(--state-info-bg-hvr);
     --alert-heading-bg: var(--state-info-bg-hvr);
     --alert-link-color: var(--state-success-link-color, var(--states-link-color));
+    a {
+      color: var(--state-info-text);
+      text-decoration: underline;
+    }
   }
 
   &[type="warning"] {
@@ -56,6 +64,10 @@
     --alert-border: var(--state-warning-border); //TODO Change to --state-warning-heading-bg in another PR
     --alert-heading-bg: var(--state-warning-heading-bg); //TODO Change to --state-warning-heading-bg in another PR
     --alert-link-color: var(--state-success-link-color, var(--states-link-color));
+    a {
+      color: var(--state-warning-text);
+      text-decoration: underline;
+    }
   }
 
   &[type="error"],
@@ -65,6 +77,10 @@
     --alert-border: var(--state-danger-bg-hvr);
     --alert-heading-bg: var(--state-danger-bg-hvr);
     --alert-link-color: var(--state-success-link-color, var(--states-link-color));
+    a {
+      color: var(--state-danger-text);
+      text-decoration: underline;
+    }
   }
 
   .alert-heading {
@@ -123,6 +139,7 @@
 
   .alert-link {
     font-weight: normal;
+    color: var(--states-link-color);
     text-decoration: underline;
   }
 


### PR DESCRIPTION
Pull Request for Issue #[42995#issuecomment](https://github.com/joomla/joomla-cms/pull/42995#issuecomment-1988316730) .

### Summary of Changes

Fix alert-link colors in autum backend template.

This commit was originally included in the final dark mode PR #42986  and was lost - Thank you @coolcat-creations 

### Actual result BEFORE applying this Pull Request

![grafik](https://github.com/joomla/joomla-cms/assets/64533137/74b54430-08c4-4c8a-abe4-847da56b2f59)

![grafik](https://github.com/joomla/joomla-cms/assets/64533137/4e2ed9e9-94d5-474b-8f3f-e4fb1bc22571)

![grafik](https://github.com/joomla/joomla-cms/assets/64533137/50167a08-7fd7-48a3-b9ee-05ddb8df6fe5)

![grafik](https://github.com/joomla/joomla-cms/assets/64533137/847ab1ec-dd46-4801-bd4c-e4941087e532)

### Expected result AFTER applying this Pull Request

![grafik](https://github.com/joomla/joomla-cms/assets/64533137/5b24e2a8-57e1-4bf7-bd8d-fdff5550dc3a)

![grafik](https://github.com/joomla/joomla-cms/assets/64533137/d58361a7-d7eb-4094-a922-40909ff899d0)

![grafik](https://github.com/joomla/joomla-cms/assets/64533137/c489de34-676c-4e94-b732-9c331ced76d6)

![grafik](https://github.com/joomla/joomla-cms/assets/64533137/2f223749-0934-4587-8c01-0dc2795174cc)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
