### PR TITLE
[5.1] toolbar button wrap

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
@@ -24,6 +24,10 @@
   joomla-toolbar-button,
   .btn-group {
     margin-inline-end: .75rem;
+
+    &:last-of-type {
+      margin-inline-end: 0;
+    }
   }
 
   joomla-toolbar-button {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
@@ -219,13 +219,15 @@
     .btn-group,
     .btn {
       width: 100%;
-      margin-left: 0;
+      margin-inline-start: 0;
+      margin-inline-end: 0;
       text-align: left;
     }
 
     .btn-toolbar > .btn-group,
     .btn-toolbar > joomla-toolbar-button {
-      margin-left: 0;
+      margin-inline-start: 0;
+      margin-inline-end: 0;
     }
 
     .btn.btn-action::after {

--- a/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_toolbar.scss
@@ -23,11 +23,7 @@
 
   joomla-toolbar-button,
   .btn-group {
-    margin-inline-start: .75rem;
-
-    &:first-child {
-      margin-inline-start: 0;
-    }
+    margin-inline-end: .75rem;
   }
 
   joomla-toolbar-button {


### PR DESCRIPTION
Pull Request for Issue #43030 .

### Summary of Changes
By changing the margin to after (inline-end) it is possible to align the buttons correctly when the button row collapses


### Testing Instructions
As this is a scss change ether use a pre-built package or `npm run build:css`

Go to a page with a lot of toolbar buttons such as the extensions manage page and resize your browser window until the row of buttons wraps onto a second row


### Actual result BEFORE applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/1296369/6d9f68a8-053d-4bd4-878e-d66cce4b58b1)


### Expected result AFTER applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/1296369/dc21f0aa-cc85-428a-8dc9-a8398e507841)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
