### PR TITLE
[5.1] menu icon js fix [a11y]

### DIFF
--- a/build/media_source/mod_menu/js/menu.es6.js
+++ b/build/media_source/mod_menu/js/menu.es6.js
@@ -38,7 +38,9 @@
       }
       const spanEl = topLevelEl.querySelector('span');
       if (spanEl) {
-        spanEl.tabIndex = '0';
+        if (spanEl.parentNode.nodeName !== 'A') {
+           spanEl.tabIndex = '0';
+        }
         spanEl.addEventListener('mouseover', topLevelMouseOver(topLevelEl, settings));
         spanEl.addEventListener('mouseout', topLevelMouseOut(topLevelEl, settings));
       }

--- a/build/media_source/mod_menu/js/menu.es6.js
+++ b/build/media_source/mod_menu/js/menu.es6.js
@@ -39,7 +39,7 @@
       const spanEl = topLevelEl.querySelector('span');
       if (spanEl) {
         if (spanEl.parentNode.nodeName !== 'A') {
-           spanEl.tabIndex = '0';
+          spanEl.tabIndex = '0';
         }
         spanEl.addEventListener('mouseover', topLevelMouseOver(topLevelEl, settings));
         spanEl.addEventListener('mouseout', topLevelMouseOut(topLevelEl, settings));


### PR DESCRIPTION
Pull Request for Issue #43101 .

### Summary of Changes
Only add a tabindex to menu items that are not links


### Testing Instructions
1. Create a menu module that is using the default layout (not the cassiopeia layout) and publish in the menu position
2. Create a menu item of type url and add a link icon class of "fas fa-envelope"
3. Create a menu item of type url and add a link icon class of "fas fa-envelope" and Display Menu Item Title - No
4. Create a menu item of type header

as it is a js change you will need to either use a pre-built package or `npm build:js"

### Actual result BEFORE applying this Pull Request
When using the keyboard to navigate the menu using the tab key there will be multiple extra tab stops as shown below

![tab-bad](https://github.com/joomla/joomla-cms/assets/1296369/d680bdef-52b7-4b87-9f4d-89aea77381d5)



### Expected result AFTER applying this Pull Request
extra tab stops are no longer present as shown below

![tab-good](https://github.com/joomla/joomla-cms/assets/1296369/59c302c7-fc86-470b-ad2a-a06134788fde)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

thanks @C-Lodder 