### PR TITLE
[5.2] Router: Only throw 404 exception when parsing current URL

### DIFF
--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -153,9 +153,9 @@ class Router
         if (\strlen($uri->getPath()) > 0) {
             if ($setVars) {
                 throw new RouteNotFoundException(Text::_('JERROR_PAGE_NOT_FOUND'));
-            } else {
-                return [];
             }
+
+            return [];
         }
 
         if ($setVars) {

--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -149,10 +149,13 @@ class Router
         // Do the postprocess stage of the URL parse process
         $this->processParseRules($uri, self::PROCESS_AFTER);
 
-        // Check if all parts of the URL have been parsed.
-        // Otherwise we have an invalid URL
+        // Check if all parts of the URL have been parsed. Otherwise we have an invalid URL
         if (\strlen($uri->getPath()) > 0) {
-            throw new RouteNotFoundException(Text::_('JERROR_PAGE_NOT_FOUND'));
+            if ($setVars) {
+                throw new RouteNotFoundException(Text::_('JERROR_PAGE_NOT_FOUND'));
+            } else {
+                return [];
+            }
         }
 
         if ($setVars) {


### PR DESCRIPTION
Pull Request for Issue #42766, #27356 .

### Summary of Changes
Right now, when the router is called to parse a URL, a failing parse always throws a 404 exception. This is actually not something that we want. This PR changes the router to only throw a 404 when the $setvars switch is set, since we do that only when we do the initial parsing. If parsing a URL fails without the switch, the returned array should be empty.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
