### PR TITLE
[5.2] Router: Check directly for RouterInterface

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -588,9 +588,7 @@ class SiteRouter extends Router
      */
     public function setComponentRouter($component, $router)
     {
-        $reflection = new \ReflectionClass($router);
-
-        if (\in_array('Joomla\\CMS\\Component\\Router\\RouterInterface', $reflection->getInterfaceNames())) {
+        if ($router instanceof RouterInterface) {
             $this->componentRouters[$component] = $router;
 
             return true;


### PR DESCRIPTION
### Summary of Changes
I have no idea why I took this complicated approach of using Reflection to see if the given object implements the RouterInterface. This PR changes the code to be simpler and to just use the instanceof operator.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
