### PR TITLE
[5] Contacts Options: Image not shown in Frontend

### DIFF
--- a/components/com_contact/tmpl/contact/default.php
+++ b/components/com_contact/tmpl/contact/default.php
@@ -111,6 +111,16 @@ $htag2   = ($tparams->get('show_page_heading') && $tparams->get('show_name')) ? 
                         ]
                     ); ?>
                 </div>
+            <?php elseif ($this->params->get('image') && $this->params->get('show_image')) : ?>
+                <div class="com-contact__thumbnail thumbnail">
+                    <?php echo LayoutHelper::render(
+                        'joomla.html.image',
+                        [
+                            'src'      => $this->params->get('image'),
+                            'alt'      => $this->item->name,
+                        ]
+                    ); ?>
+                </div>
             <?php endif; ?>
 
             <?php if ($this->item->con_position && $tparams->get('show_position')) : ?>


### PR DESCRIPTION
Pull Request for Issue #42362 .

### Summary of Changes
use component settings as default


### Testing Instructions

set show image in Contact options

### Actual result BEFORE applying this Pull Request
no Image is shown


### Expected result AFTER applying this Pull Request
Image is shown 


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
