### PR TITLE
[5.2] Adding bootstrap.rtl.css file

### DIFF
--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -48,7 +48,9 @@
           "dist/css/bootstrap-grid.css": "css/bootstrap-grid.css",
           "dist/css/bootstrap-grid.min.css": "css/bootstrap-grid.min.css",
           "dist/css/bootstrap-reboot.css": "css/bootstrap-reboot.css",
-          "dist/css/bootstrap-reboot.min.css": "css/bootstrap-reboot.min.css"
+          "dist/css/bootstrap-reboot.min.css": "css/bootstrap-reboot.min.css",
+          "dist/css/bootstrap.rtl.css": "css/boostrap.rtl.css",
+          "dist/css/bootstrap.rtl.min.css": "css/boostrap.rtl.min.css"
         },
         "filesExtra": {
           "dist/css/bootstrap.css.map": "css/bootstrap.css.map",
@@ -57,6 +59,8 @@
           "dist/css/bootstrap-grid.min.css.map": "css/bootstrap-grid.min.css.map",
           "dist/css/bootstrap-reboot.css.map": "css/bootstrap-reboot.css.map",
           "dist/css/bootstrap-reboot.min.css.map": "css/bootstrap-reboot.min.css.map",
+          "dist/css/bootstrap.rtl.css.map": "css/boostrap.rtl.css.map",
+          "dist/css/bootstrap.rtl.min.css.map": "css/boostrap.rtl.min.css.map",
           "scss": "scss"
         },
         "provideAssets": [


### PR DESCRIPTION
Pull Request for Issue #42653 .

### Summary of Changes
In the linked issue, the user complained that the rtl stylesheet is missing from our media folder. This PR adds that file. I'm not sure if it is necessary, but here it is.


### Testing Instructions
Run `npm i` in your git checkout.


### Actual result BEFORE applying this Pull Request
There is neither a `media/vendor/bootstrap/css/bootstrap.rtl.css` nor a `media/vendor/bootstrap/css/bootstrap.rtl.min.css` file present.


### Expected result AFTER applying this Pull Request
The two above files have been generated.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
