### PR TITLE
[5.1] pixel shift from dark to light

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_header.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_header.scss
@@ -231,9 +231,6 @@
 
 @if $enable-dark-mode {
   @include color-mode(dark) {
-    .header-item-content:not(.joomlaversion) {
-      border: map-get($atum-colors-dark, "atum-btn-primary-border");
-    }
     .header-item-icon > * {
       background: var(--header-bg);
     }


### PR DESCRIPTION
Pull Request for Issue #43029 .

### Summary of Changes
remove additional border on header buttons in dark mode 
this prevents the layout shift between light/dark templates

### Actual result BEFORE applying this Pull Request
![beforeshift](https://github.com/joomla/joomla-cms/assets/1296369/f4ea6b4c-84a2-45f2-922e-361eb0fda7c5)



### Expected result AFTER applying this Pull Request
![shift](https://github.com/joomla/joomla-cms/assets/1296369/4d7b8758-07a0-4e83-8c6f-5ca788d74455)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
