### PR TITLE
[4.4] User profile edit: No notice when no active menu item

### DIFF
--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -139,13 +139,14 @@ class HtmlView extends BaseHtmlView
         unset($this->data->text);
 
         // Check for layout from menu item.
-        $query = Factory::getApplication()->getMenu()->getActive()->query;
+        $active = Factory::getApplication()->getMenu()->getActive();
 
         if (
-            isset($query['layout']) && isset($query['option']) && $query['option'] === 'com_users'
-            && isset($query['view']) && $query['view'] === 'profile'
+            $active && isset($active->query['layout'])
+            && isset($active->query['option']) && $active->query['option'] === 'com_users'
+            && isset($active->query['view']) && $active->query['view'] === 'profile'
         ) {
-            $this->setLayout($query['layout']);
+            $this->setLayout($active->query['layout']);
         }
 
         // Escape strings for HTML output


### PR DESCRIPTION
Pull Request for Issue #40499 .

### Summary of Changes
When there is not active menu item and you edit your user profile, you get a notice at the top.


### Testing Instructions
1. Enable error reporting
2. Make sure you have no menu item pointing to the user profile view or the profile edit view.
3. Login to the frontend
4. Go to `index.php?option=com_users&view=profile&layout=edit&Itemid=444444` (The 444444 is supposed to be a non-existing menu item)


### Actual result BEFORE applying this Pull Request
You get a notice about accessing query on null.


### Expected result AFTER applying this Pull Request
No notice.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
