### PR TITLE
[4.4] add PHP8.3 to PhpVersionCheck quickicon

### DIFF
--- a/plugins/quickicon/phpversioncheck/src/Extension/PhpVersionCheck.php
+++ b/plugins/quickicon/phpversioncheck/src/Extension/PhpVersionCheck.php
@@ -143,6 +143,10 @@ final class PhpVersionCheck extends CMSPlugin implements SubscriberInterface
                 'security' => '2024-12-08',
                 'eos'      => '2025-12-08',
             ],
+            '8.3' => [
+                'security' => '2025-11-23',
+                'eos'      => '2026-11-23',
+            ],
         ];
 
         // Fill our return array with default values


### PR DESCRIPTION
### Summary of Changes

add PHP8.3 to PhpVersionCheck quickicon

### Testing Instructions

check dates here: https://www.php.net/supported-versions.php
![image](https://github.com/joomla/joomla-cms/assets/66922325/a4188248-4953-40d7-9e80-4fa94af0446d)

### Actual result BEFORE applying this Pull Request

no check for PHP8.3

### Expected result AFTER applying this Pull Request

check PHP8.3

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
