### PR TITLE
[5.1] Dark Mode menu select toggle colour

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_treeselect.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_treeselect.scss
@@ -64,6 +64,7 @@
     display: inline-block;
     padding: 0;
     margin-right: .1rem;
+    color: var(--atum-btn-bg);
     text-align: center;
     cursor: pointer;
   }


### PR DESCRIPTION
final part Pull Request for Issue #43068 .

### Summary of Changes
Change the colour of the icon in the treeselect for assigning modules to pages to satisfy contrast rules


### Testing Instructions
see #43068 for more details


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
