### PR TITLE
[5.1] sidebar-wrapper border

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_sidebar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_sidebar.scss
@@ -292,7 +292,6 @@
   @include color-mode(dark) {
     .sidebar-wrapper {
       overflow: hidden;
-      border: 1px solid rgba(255, 255, 255, .05);
       box-shadow: none;
       .main-nav {
         .badge {


### PR DESCRIPTION
Removes the extra border on the sidebar that is producing a pixel shift between light and dark mode.

I can't see the need for this border buy maybe @coolcat-creations sees something I am missing and it should remain

Pull Request for Issue #43159


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
