### PR TITLE
[5.1] media punycode folder

### DIFF
--- a/build/build-modules-js/settings.json
+++ b/build/build-modules-js/settings.json
@@ -553,10 +553,6 @@
         "dependencies": [],
         "licenseFilename": ""
       },
-      "punycode": {
-        "name": "punycode",
-        "licenseFilename": "LICENSE-MIT.txt"
-      },
       "@claviska/jquery-minicolors": {
         "name": "minicolors",
         "js": {


### PR DESCRIPTION
Due to the changes in the way punycode is used now we no longer need to have a media/punycode folder. (it only has a licence file in it now)

code review only

Pull Request for Issue #43148 .


@richard67 do i need to add this to the removed files/folders or will you do it in your script?



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
