### PR TITLE
[5.1] Update deleted files list in script.php for 5.1.0-rc1 (2)

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2323,6 +2323,7 @@ class JoomlaInstallerScript
             '/libraries/vendor/web-token/jwt-signature-algorithm-rsa/LICENSE',
             // From 5.1.0-beta2 to 5.1.0-rc1
             '/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php',
+            '/media/vendor/punycode/LICENSE-MIT.txt',
         ];
 
         $folders = [
@@ -2580,6 +2581,8 @@ class JoomlaInstallerScript
             '/libraries/vendor/web-token/jwt-experimental/ContentEncryption',
             '/libraries/vendor/web-token/jwt-experimental',
             '/libraries/src/Event/Router',
+            // From 5.1.0-beta2 to 5.1.0-rc1
+            '/media/vendor/punycode',
         ];
 
         $status['files_checked']   = $files;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Follow up PR to #43095 .

This pull request (PR) updates the list of files to be deleted on update in file `administrator/components/com_admin/script.php` to recent changes in the 5.1-dev branch in preparation for the upcoming 5.1.0-rc1 release.

Up to now there is only one file `/media/vendor/punycode/LICENSE-MIT.txt` added to the list of files and one folder `/media/vendor/punycode` to the list of folder, both from PR #43162 , but we should check again tomorrow afternoon if something new comes.

### Testing Instructions

Code review.

Or if you want to make a real test, update a 5.1.0-beta2 or older version to the last 5.1 nightly build to get the actual result, and update a 5.1.0-beta1 or older version to to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

The file and the folder mentioned above are still present after updating from a 5.1.0-beta2 or older version.

### Expected result AFTER applying this Pull Request

The file and the folder mentioned above have been deleted after updating from a 5.1.0-beta2 or older version.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
