### PR TITLE
[5.1] Fix SQL syntax error when updating to 5.1 on PostgreSQL

### DIFF
--- a/administrator/components/com_admin/sql/updates/postgresql/5.1.0-2024-03-08.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.1.0-2024-03-08.sql
@@ -1,4 +1,4 @@
-INSERT IGNORE INTO "#__guidedtour_steps" ("tour_id", "title", "published", "description", "ordering", "position", "target", "type", "interactive_type", "url", "created", "created_by", "modified", "modified_by", "language") VALUES
+INSERT INTO "#__guidedtour_steps" ("tour_id", "title", "published", "description", "ordering", "position", "target", "type", "interactive_type", "url", "created", "created_by", "modified", "modified_by", "language") VALUES
 (0, 'COM_GUIDEDTOURS_TOUR_WELCOMETOJOOMLA_STEP_MENUS_TITLE', 1, 'COM_GUIDEDTOURS_TOUR_WELCOMETOJOOMLA_STEP_MENUS_DESCRIPTION', 1, 'right', '#sidebarmenu', 0, 1, '', CURRENT_TIMESTAMP, 0, CURRENT_TIMESTAMP, 0, '*'),
 (0, 'COM_GUIDEDTOURS_TOUR_WELCOMETOJOOMLA_STEP_QUICKACCESS_TITLE', 1, 'COM_GUIDEDTOURS_TOUR_WELCOMETOJOOMLA_STEP_QUICKACCESS_DESCRIPTION', 2, 'center', '', 0, 1, '', CURRENT_TIMESTAMP, 0, CURRENT_TIMESTAMP, 0, '*'),
 (0, 'COM_GUIDEDTOURS_TOUR_WELCOMETOJOOMLA_STEP_NOTIFICATIONS_TITLE', 1, 'COM_GUIDEDTOURS_TOUR_WELCOMETOJOOMLA_STEP_NOTIFICATIONS_DESCRIPTION', 3, 'left', '.quickicons-for-update_quickicon .card', 0, 1, '', CURRENT_TIMESTAMP, 0, CURRENT_TIMESTAMP, 0, '*'),
@@ -8,7 +8,7 @@ ON CONFLICT DO NOTHING;
 
 ALTER TABLE "#__guidedtours" ADD COLUMN "autostart" int NOT NULL DEFAULT 0 /** CAN FAIL **/;
 
-INSERT IGNORE INTO "#__guidedtours" ("title", "uid", "description", "ordering", "extensions", "url", "created", "created_by", "modified", "modified_by", "published", "language", "access", "autostart") VALUES
+INSERT INTO "#__guidedtours" ("title", "uid", "description", "ordering", "extensions", "url", "created", "created_by", "modified", "modified_by", "published", "language", "access", "autostart") VALUES
 ('COM_GUIDEDTOURS_TOUR_WELCOMETOJOOMLA_TITLE', 'joomla-welcome', 'COM_GUIDEDTOURS_TOUR_WELCOMETOJOOMLA_DESCRIPTION', 1, '["com_cpanel"]', 'administrator/index.php', CURRENT_TIMESTAMP, 0, CURRENT_TIMESTAMP, 0, 1, '*', 1, 0)
 ON CONFLICT DO NOTHING;
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

The update SQL script `administrator/components/com_admin/sql/updates/postgresql/5.1.0-2024-03-08.sql` introduced with PR #41659 contains 2 syntax errors which cause updating to 5.1 fail with PostgreSQL.

`INSERT IGNORE` is MySQL/MariaDB syntax which does not work on PostgreSQL. The same thing is already achieved with the `ON CONFLICT DO NOTHING` at the end of the statement for PostgreSQL. 
 
### Testing Instructions

Code review by a PostgreSQL expert, of update to the latest 5.1 nightly build for the actual result, and to the patched package or custom update URL created by Drone for this PR for the expected result, using a PostgreSQL database.

### Actual result BEFORE applying this Pull Request

![2024-03-28_pg-error](https://github.com/joomla/joomla-cms/assets/7413183/97dab2b9-9246-4ab2-9833-359d7b4c2301)

### Expected result AFTER applying this Pull Request

Update succeeds (or at least does not show an SQL error).

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
