### PR TITLE
[5.1] Fix Joomla Update component not respecting the update channel when using TUF

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/5.1.0-2024-03-31.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.1.0-2024-03-31.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__update_sites` ADD COLUMN `channel` varchar(20) DEFAULT '' AFTER `location` /** CAN FAIL **/;

--- a/administrator/components/com_admin/sql/updates/postgresql/5.1.0-2024-03-31.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.1.0-2024-03-31.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "#__update_sites" ADD COLUMN "channel" varchar(20) DEFAULT '' /** CAN FAIL **/;

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -86,7 +86,7 @@ class UpdateModel extends BaseDatabaseModel
     public function applyUpdateSite()
     {
         // Determine the intended update URL and channel.
-        $params  = ComponentHelper::getParams('com_joomlaupdate');
+        $params = ComponentHelper::getParams('com_joomlaupdate');
 
         switch ($params->get('updatesource', 'default')) {
             case 'custom':

--- a/installation/sql/mysql/base.sql
+++ b/installation/sql/mysql/base.sql
@@ -903,6 +903,7 @@ CREATE TABLE IF NOT EXISTS `#__update_sites` (
   `name` varchar(100) DEFAULT '',
   `type` varchar(20) DEFAULT '',
   `location` text NOT NULL,
+  `channel` varchar(20) DEFAULT '',
   `enabled` int DEFAULT 0,
   `last_check_timestamp` bigint DEFAULT 0,
   `extra_query` varchar(1000) DEFAULT '',

--- a/installation/sql/postgresql/base.sql
+++ b/installation/sql/postgresql/base.sql
@@ -919,6 +919,7 @@ CREATE TABLE IF NOT EXISTS "#__update_sites" (
   "name" varchar(100) DEFAULT '',
   "type" varchar(20) DEFAULT '',
   "location" text NOT NULL,
+  "channel" varchar(20) DEFAULT '',
   "enabled" bigint DEFAULT 0,
   "last_check_timestamp" bigint DEFAULT 0,
   "extra_query" varchar(1000) DEFAULT '',

--- a/libraries/src/Updater/Adapter/TufAdapter.php
+++ b/libraries/src/Updater/Adapter/TufAdapter.php
@@ -106,6 +106,10 @@ class TufAdapter extends UpdateAdapter
         $constraintChecker = new ConstraintChecker();
 
         foreach ($versions as $version) {
+            // Ignore version if not from the right channel
+            if ($options['channel'] !== $version['channel']) {
+                continue;
+            }
             // Return the version as a match if either all constraints are matched
             // or "only" env related constraints fail - the later one is the existing behavior of the XML updater
             if (

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -552,6 +552,10 @@ class Update
         $constraintChecker = new ConstraintChecker();
 
         foreach ($data['signed']['targets'] as $target) {
+            // Check if target channel matches
+            if (isset($channel) && $target['custom']['channel'] !== $channel) {
+                continue;
+            }
             // Check if this target is newer than the current version
             if (isset($this->latest) && version_compare($target['custom']['version'], $this->latest->version, '<')) {
                 continue;

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -200,6 +200,7 @@ class Updater extends Adapter
                 'DISTINCT ' . $db->quoteName('a.update_site_id'),
                 $db->quoteName('a.type'),
                 $db->quoteName('a.location'),
+                $db->quoteName('a.channel'),
                 $db->quoteName('a.last_check_timestamp'),
                 $db->quoteName('a.extra_query'),
             ]


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) changes the Joomla Update component and the updater so that the right update channel is used when using TUF, which is the default for the core.

It fixes the issue that currently when being on 5.1.0 Beta 1, and update to Beta 2 is found if you have selected a suitable minimum stability (Beta or lower), regardless if you have selected the "Default" or the "Joomla Next" channel.

The `#__update_sites` table is extended by a new column where the desired update channel is saved. This allows the Joomla Update component to detect changes on that and to purge old updates from the `#__updates` table when that value has changed, and the updater is able to check that value.

Theoretically the channel and so this PR would not be necessary if we would make sure by the `targetplatform` that one can update only to 5.1 when they are at the latest 4.4 version (which currently is 4.4.3 and will be 4.4.4 soon).

But that would mean that we would have to update the targetplatform for every 5.1.x update with every new 4.4.y release, and in future we would have to do that for 6.x releases with every new 5.y.z release, where y is the last minor for J5.

And as you can see here https://update.joomla.org/cms/targets.json , we would not require that if 4.4 would already use the TUF-based update site. The `targetplatform` versions of the 5.1.0 Beta 1 and 2 targets are `"(5\\.[0-4])|^(4\\.4)"`, so we currently allow updating to 5.1 also from versions 4.4.0 to 4.4.2. And so I assume it will be the same in future with 5.x to 6.

And with the XML based update site which is currently used by 4.4. it is the same, see https://update.joomla.org/core/list.xml and https://update.joomla.org/core/j4/default.xml , the targetplatform of both the list and the details XML only requires 4.4, not 4.4.3.

So if we keep it like that for now and in future, this PR here makes sense in my opinion.

If we change that and require always the latest 4.4, then this PR here is obsolete, and we should delete the "4.4.4-2024-03-28.sql" update SQL scripts and add them to the list of deleted files in script.php, but as said, it would mean to change the `targetplatform` versions all the time.

@bembelimen @LadySolveig @Razzo1987 I think it needs a decision here.

### Testing Instructions

1. On a Joomla installation with a current 5.1-dev branch or recent 5.1 nightly build, edit file `libraries/src/Version.php` and change `public const EXTRA_VERSION = 'beta3-dev';` to `public const EXTRA_VERSION = 'beta1';`.
2. Go to System - Maintenance - Database. There should be one error about not matching update version shown for the CMS.
3. Select the CMS record and use the "Update Structure" button to adjust the version in the database.
4. Go to the Joomla Update component's options, set the update channel to "Default" and the minimum stability to "Beta" or lower and save the changes.
Result: An update to 5.1.0 Beta 2 is found. If not, it is found after using the "Check for Updates" button.
5. Change the update channel to "Joomla Next".
Result: No change, the update to  5.1.0 Beta 2 is still found.
6. Use the "Check for Updates" button.
Result: No change, the update to  5.1.0 Beta 2 is still found.
7. Apply the changes from this PR.
8. Go to System - Maintenance - Database and fix the structure error for the CMS to apply the database structure changes from this PR.
9. Go back to the Joomla Update component and use the "Check for Updates" button.
Result: No update found.
10. Change the update channel a few times between "Default" and "Joomla Next".
Result: When the update channel is "Joomla Next", no update is found. When the update channel is "Default", an update to 5.1.0 Beta 2 is found (it might need to use the "Check for Updates" button).
11. Change the update channel to "Custom URL" and enter the update site URL created by Drone for a recent PR for the 5.1-dev branch, e.g. the one for this PR here: https://artifacts.joomla.org/drone/joomla/joomla-cms/5.1-dev/43184/downloads/75152/pr_list.xml
Result: An update to that PR is found.
11. Change the update channel a few times between "Default", "Joomla Next" and "Custom URL" and use the "Check for Updates" button.
Result: The update channel is respected, and after using the "Check for Updates" button an update is found or not depending on the selected channel.
12. Check the Joomla Update notification icon in the Home Dashboard.
Result: The status of the Joomla Update notification icon in the Home Dashboard is consistent with the Jomla Update component's view.
13. Change the update channel to "Default" so that the update to 5.1.0 Beta 2 is found again.
14. Perform the update.
Result: The update succeeds.

### Actual result BEFORE applying this Pull Request

The Joomla Update component doesn't care whether you select "Default" or "Joomla Next" as update channel.

### Expected result AFTER applying this Pull Request

The Joomla Update component uses the right TUF update channel for the "Default" or "Joomla Next" channels.

Using the "Custom URL" channel works as well as before.

The Joomla Update notification icon in the Home Dashboard works as well as before.

Updating works as well as before.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
