### PR TITLE
[5.1] Delete 4.4.4-2024-03-28.sql update SQL scripts and update deleted files list in script.php

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2322,6 +2322,8 @@ class JoomlaInstallerScript
             '/libraries/vendor/web-token/jwt-signature-algorithm-none/LICENSE',
             '/libraries/vendor/web-token/jwt-signature-algorithm-rsa/LICENSE',
             // From 5.1.0-beta2 to 5.1.0-rc1
+            '/administrator/components/com_admin/sql/updates/mysql/4.4.4-2024-03-28.sql',
+            '/administrator/components/com_admin/sql/updates/postgresql/4.4.4-2024-03-28.sql',
             '/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php',
             '/media/vendor/punycode/LICENSE-MIT.txt',
         ];

--- a/administrator/components/com_admin/sql/updates/mysql/4.4.4-2024-03-28.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/4.4.4-2024-03-28.sql
@@ -1,5 +1,0 @@
---
--- Add post-installation message about setting the Content-Encoding header in .htaccess
---
-INSERT IGNORE INTO `#__postinstall_messages` (`extension_id`, `title_key`, `description_key`, `action_key`, `language_extension`, `language_client_id`, `type`, `action_file`, `action`, `condition_file`, `condition_method`, `version_introduced`, `enabled`)
-SELECT `extension_id`, 'COM_ADMIN_POSTINSTALL_MSG_HTACCESS_BROTLI_TITLE', 'COM_ADMIN_POSTINSTALL_MSG_HTACCESS_BROTLI_DESCRIPTION', '', 'com_admin', 1, 'message', '', '', 'admin://components/com_admin/postinstall/htaccessbrotli.php', 'admin_postinstall_htaccessbrotli_condition', '4.4.4', 1 FROM `#__extensions` WHERE `name` = 'files_joomla';

--- a/administrator/components/com_admin/sql/updates/postgresql/4.4.4-2024-03-28.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/4.4.4-2024-03-28.sql
@@ -1,6 +1,0 @@
---
--- Add post-installation message about setting the Content-Encoding header in .htaccess
---
-INSERT INTO "#__postinstall_messages" ("extension_id", "title_key", "description_key", "action_key", "language_extension", "language_client_id", "type", "action_file", "action", "condition_file", "condition_method", "version_introduced", "enabled")
-SELECT "extension_id", 'COM_ADMIN_POSTINSTALL_MSG_HTACCESS_BROTLI_TITLE', 'COM_ADMIN_POSTINSTALL_MSG_HTACCESS_BROTLI_DESCRIPTION', '', 'com_admin', 1, 'message', '', '', 'admin://components/com_admin/postinstall/htaccessbrotli.php', 'admin_postinstall_htaccessbrotli_condition', '4.4.4', 1 FROM "#__extensions" WHERE "name" = 'files_joomla'
-	ON CONFLICT DO NOTHING;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) deletes the update SQL scripts "4.4.4-2024-03-28.sql" from the sources and adds these files to the list of files to be deleted on update in file `administrator/components/com_admin/script.php` so they will be deleted when updating from 4.4 to 5.1.

In general we do not require to be at the latest 4.4.x version for updating to 5.1. The targetplatform values of the 5.0.3 version on https://update.joomla.org/core/list.xml and https://update.joomla.org/core/j4/default.xml allows updating to 5.0.3 from any 4.4.x version, and I assume it will be like that for 5.1.

So theoretically we should keep any 4.4.x update SQL scripts with x > 0 in 5.1 because it could be that people update from a 4.4.0.

Practically that is not necessary as we have to provide another pair of SQL update scripts in 5.1 for people updating from 5.0.x to make the same changes for these cases if not already done. In this case here these are the scripts "5.1.0-2024-03-28.sql". They need a fix for the "if not already done" part, see my other PR #43182 , which hopefully will be accepted.

So it is safe to delete the "4.4.4-2024-03-28.sql" here, and I think it makes sense to do that as that is how we proceeded in past with update SQL scripts from the previous major version.

### Testing Instructions

Code review.

Or if you want to make a real test, update the latest 4.4 nightly build to the latest 5.1 nightly build to get the actual result, and update the latest 4.4 nightly build to the update package built by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

The file mentioned above is still present after updating from the latest 4.4 nightly build, and so it will when updating from 4.4.4.

### Expected result AFTER applying this Pull Request

The file mentioned above has been deleted with the update from the latest 4.4 nightly build, and so it will when updating from 4.4.4.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
