### PR TITLE
[4.4] Mfa: Setting timezone for dates in profile

### DIFF
--- a/administrator/components/com_users/src/Model/MethodsModel.php
+++ b/administrator/components/com_users/src/Model/MethodsModel.php
@@ -127,6 +127,7 @@ class MethodsModel extends BaseDatabaseModel
         $utcTimeZone = new \DateTimeZone('UTC');
         $jDate       = new Date($dateTimeText, $utcTimeZone);
         $unixStamp   = $jDate->toUnix();
+        $app         = Factory::getApplication();
 
         // I'm pretty sure we didn't have MFA in Joomla back in 1970 ;)
         if ($unixStamp < 0) {
@@ -135,7 +136,7 @@ class MethodsModel extends BaseDatabaseModel
 
         // I need to display the date in the user's local timezone. That's how you do it.
         $user   = $this->getCurrentUser();
-        $userTZ = $user->getParam('timezone', 'UTC');
+        $userTZ = $user->getParam('timezone', $app->get('offset', 'UTC'));
         $tz     = new \DateTimeZone($userTZ);
         $jDate->setTimezone($tz);
 


### PR DESCRIPTION
Pull Request for Issue #41003 .

### Summary of Changes
When a user does not have a timezone set and the multifactorauthentication is enabled, the timestamps shown in the profile are not in the timezone of the site, but in UTC.


### Testing Instructions
1. Set the timezone of your site in the global configuration to something else than UTC so that you have an offset to UTC.
2. Create a user and enable Mfa for that user, for example the fixed code Mfa, which you can enable in the Mfa plugins. Leave the timezone at "Default".
3. Login to the frontend with that user and go to its profile


### Actual result BEFORE applying this Pull Request
The datetimes in the Mfa methods box are in UTC.


### Expected result AFTER applying this Pull Request
The datetimes in the Mfa methods box are in the timezone of the site.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
