### PR TITLE
[5.1] Full path in error log

### DIFF
--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -303,8 +303,7 @@ class File
                     return false;
                 }
             } else {
-                $filename = basename($file);
-                Log::add(Text::sprintf('JLIB_FILESYSTEM_DELETE_FAILED', $filename), Log::WARNING, 'jerror');
+                Log::add(Text::sprintf('JLIB_FILESYSTEM_DELETE_FAILED', $file), Log::WARNING, 'jerror');
 
                 return false;
             }


### PR DESCRIPTION
This PR changes the error message so that the full path and not just the filename is displayed in the error log

Pull Request for Issue #43105 .

### Testing Instructions
see original issue

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
