### PR TITLE
[5.1] Fix the build tools

### DIFF
--- a/build/build-modules-js/css-versioning.es6.js
+++ b/build/build-modules-js/css-versioning.es6.js
@@ -62,8 +62,8 @@ const fixVersion = async (file) => {
       minify: file.endsWith('.min.css'),
       visitor: composeVisitors([urlVersioning(file)]),
     });
-    await writeFile(file, `@charset "UTF-8";${file.endsWith(".min.css") ? '' : '\n'}${code}`, {
-      encoding: "utf8",
+    await writeFile(file, `@charset "UTF-8";${file.endsWith('.min.css') ? '' : '\n'}${code}`, {
+      encoding: 'utf8',
       mode: 0o644,
     });
   } catch (error) {

--- a/build/build-modules-js/css-versioning.es6.js
+++ b/build/build-modules-js/css-versioning.es6.js
@@ -1,10 +1,11 @@
 const { createHash } = require('node:crypto');
-const { readdir, readFile, writeFile } = require('fs/promises');
+const { readdir, readFile, writeFile } = require('node:fs/promises');
 const { existsSync, readFileSync } = require('node:fs');
 const { dirname, extname, resolve } = require('node:path');
 const { transform, composeVisitors } = require('lightningcss');
 const { Timer } = require('./utils/timer.es6.js');
 
+const RootPath = process.cwd();
 const skipExternal = true;
 const variable = 'v';
 
@@ -56,13 +57,15 @@ function urlVersioning(fromFile) {
  */
 const fixVersion = async (file) => {
   try {
-    const cssString = await readFile(file);
     const { code } = transform({
-      code: cssString,
-      minify: false,
+      code: await readFile(file),
+      minify: file.endsWith('.min.css'),
       visitor: composeVisitors([urlVersioning(file)]),
     });
-    await writeFile(file, code, { encoding: 'utf8', mode: 0o644 });
+    await writeFile(file, `@charset "UTF-8";${file.endsWith(".min.css") ? '' : '\n'}${code}`, {
+      encoding: "utf8",
+      mode: 0o644,
+    });
   } catch (error) {
     throw new Error(error);
   }
@@ -76,7 +79,7 @@ const fixVersion = async (file) => {
 module.exports.cssVersioning = async () => {
   const bench = new Timer('Versioning');
 
-  const cssFiles = (await readdir('media', { withFileTypes: true, recursive: true }))
+  const cssFiles = (await readdir(`${RootPath}/media`, { withFileTypes: true, recursive: true }))
     .filter((file) => (!file.isDirectory() && extname(file.name) === '.css'))
     .map((file) => `${file.path}/${file.name}`);
 

--- a/build/build.php
+++ b/build/build.php
@@ -271,6 +271,11 @@ echo "Copy the files from the git repository.\n";
 chdir($repo);
 system($systemGit . ' archive ' . $remote . ' | tar -x -C ' . $fullpath);
 system('cp build/fido.jwt ' . $fullpath . '/plugins/system/webauthn/fido.jwt');
+
+// Get the Node tools from the current header of the repository
+system('rm -rf ' . $fullpath . '/build/build-modules-js');
+system('cp -r ' . $repo . '/build/build-modules-js ' . $fullpath . '/build/build-modules-js');
+
 // Install PHP and NPM dependencies and compile required media assets, skip Composer autoloader until post-cleanup
 chdir($fullpath);
 system('composer install --no-dev --no-autoloader --ignore-platform-reqs', $composerReturnCode);

--- a/build/build.php
+++ b/build/build.php
@@ -271,7 +271,6 @@ echo "Copy the files from the git repository.\n";
 chdir($repo);
 system($systemGit . ' archive ' . $remote . ' | tar -x -C ' . $fullpath);
 system('cp build/fido.jwt ' . $fullpath . '/plugins/system/webauthn/fido.jwt');
-
 // Install PHP and NPM dependencies and compile required media assets, skip Composer autoloader until post-cleanup
 chdir($fullpath);
 system('composer install --no-dev --no-autoloader --ignore-platform-reqs', $composerReturnCode);

--- a/build/build.php
+++ b/build/build.php
@@ -272,10 +272,6 @@ chdir($repo);
 system($systemGit . ' archive ' . $remote . ' | tar -x -C ' . $fullpath);
 system('cp build/fido.jwt ' . $fullpath . '/plugins/system/webauthn/fido.jwt');
 
-// Get the Node tools from the current header of the repository
-system('rm -rf ' . $fullpath . '/build/build-modules-js');
-system('cp -r ' . $repo . '/build/build-modules-js ' . $fullpath . '/build/build-modules-js');
-
 // Install PHP and NPM dependencies and compile required media assets, skip Composer autoloader until post-cleanup
 chdir($fullpath);
 system('composer install --no-dev --no-autoloader --ignore-platform-reqs', $composerReturnCode);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- the JS cssversioning script needs to be aware where is the current `cmd`
- it needs to respect `.min` files


### Testing Instructions

~~Run `php build/build.php` and check the `build/tmp/media` folder that all the css files with a `URL()` (ie font awesome) end with something like `?3jhff`~~

Download the package from https://artifacts.joomla.org/drone/joomla/joomla-cms/5.1-dev/43207/downloads/75243/

Extract the files

Check that the file `media/templates/administrator/atum/css/vendor/fontawesome-free/fontawesome.css` and `media/templates/administrator/atum/css/vendor/fontawesome-free/fontawesome..min.css` start with `@charset "UTF-8";`


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed


@bembelimen @LadySolveig 