### PR TITLE
[6.1] Allow access of default language home with "Remove lang code" parameter

### DIFF
--- a/plugins/system/languagefilter/src/Extension/LanguageFilter.php
+++ b/plugins/system/languagefilter/src/Extension/LanguageFilter.php
@@ -335,13 +335,7 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
             if (!isset($this->sefs[$sef])) {
                 // Check if remove default URL language code is set
                 if ($this->params->get('remove_default_prefix', 0)) {
-                    if ($parts[0]) {
-                        // We load a default site language page
-                        $lang_code = $this->default_lang;
-                    } else {
-                        // We check for an existing language cookie
-                        $lang_code = $this->getLanguageCookie();
-                    }
+                    $lang_code = $this->default_lang;
                 } else {
                     $lang_code = $this->getLanguageCookie();
                 }


### PR DESCRIPTION
### Summary of Changes
This PR suppresses the currently enforce dredirect to the language stored in the session (or language cookie) if the "/" page is called on a mulitlingual site with the "remove URL lang code"-parameter being enabled.


### Testing Instructions
1. configure a multilingual site
2. configure the languagefilter plugin like this:
   * Language Selection for new Visitors: "site language"
   * Remove URL Language Code: "Yes"
3. open a "private mode" browser window to ensure that you visit the site frontend without an existing session
4. open the "/" URL of the site -> the default language will be used
5. switch to the non-default language
6. open the "/" URL of the site -> a redirect to the homepage of the non-default language is triggered

### Actual result BEFORE applying this Pull Request
In step 6 of the instructions above,  a redirect to the homepage of the non-default language is triggered


### Expected result AFTER applying this Pull Request
In step 6 of the instructions above,  the home page of the default language is opened.
