### PR TITLE
5.2 Update ListView.php - Review addToolbar function

### DIFF
--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -17,7 +17,6 @@ use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Registry\Registry;
 
-
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
@@ -107,8 +106,7 @@ class ListView extends HtmlView
      * @var string
      */
     protected $helpLink;
-    
-    
+
     /**
      * All transition, which can be executed of one if the items
      *
@@ -193,7 +191,7 @@ class ListView extends HtmlView
         }
 
         // Build toolbar
-        $this->addToolbar();        
+        $this->addToolbar();
 
         parent::display($tpl);
     }

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -10,12 +10,9 @@
 namespace Joomla\CMS\MVC\View;
 
 use Doctrine\Inflector\InflectorFactory;
-use Joomla\CMS\Component\ComponentHelper;
-use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Layout\FileLayout;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Registry\Registry;
@@ -283,8 +280,17 @@ class ListView extends HtmlView
         $singularViewName = InflectorFactory::create()->build()->singularize($viewName);
         $componentName = substr($this->option, 4);
         $extensionClass   = ucfirst($componentName) . 'Component';
-        $developer = explode('\\', get_class($this))[0];    
-        $trashCondition = (constant($developer."\\Component\\".ucfirst($componentName)."\\Administrator\\Extension\\".$extensionClass."::CONDITION_TRASHED")) ?: -2;
+        $developer = strstr(get_class($this), '\\', true);
+        
+        $constantName = $developer . "\\Component\\" . ucfirst($componentName) . "\\Administrator\\Extension\\" . $extensionClass . "::CONDITION_TRASHED";
+        if (defined($constantName))
+        {
+            $trashCondition = constant($constantName);
+        }
+        else 
+        {
+            $trashCondition = -2;
+        }        
 
         $user    = $this->getCurrentUser();
         $toolbar = Toolbar::getInstance();

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -281,7 +281,7 @@ class ListView extends HtmlView
 
         $constantName = $developer . "\\Component\\" . ucfirst($componentName) . "\\Administrator\\Extension\\" . $extensionClass . "::CONDITION_TRASHED";
         if (\defined($constantName)) {
-            $trashCondition = constant($constantName);
+            $trashCondition = \constant($constantName);
         } else {
             $trashCondition = -2;
         }

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -311,7 +311,7 @@ class ListView extends HtmlView
                     ->text('JTOOLBAR_RUN_TRANSITIONS')
                     ->buttonClass('text-center py-2 h3');
 
-                $cmd      = "Joomla.submitbutton(".$viewName."'.runTransition');";
+                $cmd      = "Joomla.submitbutton(" . $viewName . "'.runTransition');";
                 $messages = "{error: [Joomla.JText._('JLIB_HTML_PLEASE_MAKE_A_SELECTION_FROM_THE_LIST')]}";
                 $alert    = 'Joomla.renderMessages(' . $messages . ')';
                 $cmd      = 'if (document.adminForm.boxchecked.value == 0) { ' . $alert . ' } else { ' . $cmd . ' }';
@@ -361,7 +361,7 @@ class ListView extends HtmlView
         $this->appendMoreButton();
 
         if (!$this->isEmptyState && $this->state->get('filter.published') == $trashCondition && $this->canDo->get('core.delete')) {
-            $toolbar->delete($viewName.'.delete', 'JTOOLBAR_EMPTY_TRASH')
+            $toolbar->delete($viewName . '.delete', 'JTOOLBAR_EMPTY_TRASH')
                 ->message('JGLOBAL_CONFIRM_DELETE')
                 ->listCheck(true);
         }

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -248,7 +248,7 @@ class ListView extends HtmlView
 
     /**
     * Append more buttons before trash button
-    * 
+    *
     * @return void
     *
     * @since 5.2
@@ -263,7 +263,7 @@ class ListView extends HtmlView
         }
         */
     }
-    
+
     /**
     * Prepare toolbar
     *
@@ -277,15 +277,12 @@ class ListView extends HtmlView
         $singularViewName = InflectorFactory::create()->build()->singularize($viewName);
         $componentName    = substr($this->option, 4);
         $extensionClass   = ucfirst($componentName) . 'Component';
-        $developer        = strstr(get_class($this), '\\', true);
+        $developer        = strstr(\get_class($this), '\\', true);
 
         $constantName = $developer . "\\Component\\" . ucfirst($componentName) . "\\Administrator\\Extension\\" . $extensionClass . "::CONDITION_TRASHED";
-        if (defined($constantName))
-        {
+        if (\defined($constantName)) {
             $trashCondition = constant($constantName);
-        }
-        else
-        {
+        } else {
             $trashCondition = -2;
         }
 
@@ -351,11 +348,10 @@ class ListView extends HtmlView
 
             // Add a batch button
             if (
-            $this->supportsBatch && $this->canDo->get('core.create')
-            && $this->canDo->get('core.edit')
-            && $this->canDo->get('core.edit.state')
-            )
-            {
+                $this->supportsBatch && $this->canDo->get('core.create')
+                && $this->canDo->get('core.edit')
+                && $this->canDo->get('core.edit.state')
+            ) {
                 $childBar->popupButton('batch', 'JTOOLBAR_BATCH')
                     ->selector('collapseModal')
                     ->listCheck(true);

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -222,7 +222,7 @@ class ListView extends HtmlView
         $this->state         = $this->get('State');
         $this->filterForm    = $this->get('FilterForm');
         $this->activeFilters = $this->get('ActiveFilters');
-        
+
         $this->canDo   = ContentHelper::getActions($this->option, 'category', $this->state->get('filter.category_id'));
     }
 
@@ -233,66 +233,65 @@ class ListView extends HtmlView
      *
      * @since   1.6
      */
-    protected function addToolbar() 
-    {        
+    protected function addToolbar()
+    {
         $this->initializeToolbar();
-        
+
         if ($this->canDo->get('core.admin') || $this->canDo->get('core.options')) {
             ToolbarHelper::preferences($this->option);
         }
-        
+
         if ($this->helpLink) {
             ToolbarHelper::help($this->helpLink);
         }
     }
-    
+
     /**
-    *  Append more buttons before trash button
-    *  
-    *  @return void
+    * Append more buttons before trash button
+    * 
+    * @return void
     *
-    *  @since 5.2
+    * @since 5.2
     */
     protected function appendMoreButton()
     {
         /*
         For example:
-        if (($this->canDo->get('core.edit')) || ($this->canDo->get('core.edit.own'))) 
+        if (($this->canDo->get('core.edit')) || ($this->canDo->get('core.edit.own')))
         {
            ToolbarHelper::editList($singularViewName . '.edit');
         }
         */
     }
     
-    
     /**
-    *  Prepare toolbar
-    *  
-    *  @return void
+    * Prepare toolbar
     *
-    *  @since 5.2
+    * @return void
+    *
+    * @since 5.2
     */
-    protected function initializeToolbar() 
+    protected function initializeToolbar()
     {
         $viewName         = $this->getName();
         $singularViewName = InflectorFactory::create()->build()->singularize($viewName);
-        $componentName = substr($this->option, 4);
+        $componentName    = substr($this->option, 4);
         $extensionClass   = ucfirst($componentName) . 'Component';
-        $developer = strstr(get_class($this), '\\', true);
-        
+        $developer        = strstr(get_class($this), '\\', true);
+
         $constantName = $developer . "\\Component\\" . ucfirst($componentName) . "\\Administrator\\Extension\\" . $extensionClass . "::CONDITION_TRASHED";
         if (defined($constantName))
         {
             $trashCondition = constant($constantName);
         }
-        else 
+        else
         {
             $trashCondition = -2;
-        }        
+        }
 
         $user    = $this->getCurrentUser();
         $toolbar = Toolbar::getInstance();
-       
+
         ToolbarHelper::title(Text::_($this->toolbarTitle), $this->toolbarIcon);
 
         if ($this->canDo->get('core.create') || \count($user->getAuthorisedCategories($this->option, 'core.create')) > 0) {
@@ -329,12 +328,11 @@ class ListView extends HtmlView
 
                 $childBar->separatorButton('transition-separator');
             }
-                        
 
             if ($this->canDo->get('core.edit.state')) {
                 $childBar->publish($viewName . '.publish')->listCheck(true);
                 $childBar->unpublish($viewName . '.unpublish')->listCheck(true);
-                
+
                 if (isset($this->items[0]->featured)) {
                     $childBar->standardButton('featured', 'JFEATURE', $viewName . '.featured')
                     ->listCheck(true);
@@ -363,7 +361,7 @@ class ListView extends HtmlView
                     ->listCheck(true);
             }
         }
-        
+
         $this->appendMoreButton();
 
         if (!$this->isEmptyState && $this->state->get('filter.published') == $trashCondition && $this->canDo->get('core.delete')) {

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -251,7 +251,7 @@ class ListView extends HtmlView
     *
     * @return void
     *
-    * @since 5.2
+    * @since __DEPLOY_VERSION__
     */
     protected function appendMoreButton()
     {
@@ -269,7 +269,7 @@ class ListView extends HtmlView
     *
     * @return void
     *
-    * @since 5.2
+    * @since __DEPLOY_VERSION__
     */
     protected function initializeToolbar()
     {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This class is responsible for displaying presentation data in list format. 
This class is a typical example of a Model-View-Controller (MVC) pattern in Joomla, where ListView handles the presentation logic for list-type views. It's designed to be flexible and customizable through configuration options and subclassing. The use of properties like $items and $pagination suggests that this class is used to render lists of data, such as articles or products, with support for features like filtering, sorting, and pagination. The canDo property is likely used to determine user permissions for various actions within the list, ensuring that users can only perform actions they're authorized to do.

- addToolbar(): This method adds the page title and toolbar to the view. It calls another method to initialize the toolbar and adds preferences and help buttons if the user has the appropriate permissions.
- appendMoreButton(): This method is a placeholder for appending additional buttons to the toolbar. It provides an example of how to add an edit button based on user permissions.
The class uses Joomla's MVC pattern and provides a structured way to handle list views with support for pagination, filtering, and toolbars. The use of comments and PHPDoc blocks helps to understand the purpose and functionality of each method. The class is designed to be extensible, allowing developers to customize the view by overriding these methods in subclasses.


- Variables Initialization:
    - $viewName: Stores the name of the current view.
    - $singularViewName: Stores the singular form of the view name, which is useful for singular actions like 'add new item'.
    - $componentName: Extracts the component name from the class property option.
    - $extensionClass: Constructs the class name of the component.
    - $developer: Extracts the developer's name from the namespace.
    - $trashCondition: Determines the state value for trashed items.
- Toolbar Configuration:
    - Sets the title of the toolbar using the toolbarTitle and toolbarIcon properties.
    - Adds a 'New' button if the user has the 'create' permission.
    - Configures a dropdown button for changing the status of items if the user has the 'edit state' permission or there are transitions available.
    - Adds buttons for publishing, unpublishing, featuring, archiving, checking in, and trashing items based on user permissions and the current state of the items.
    - Adds a batch processing button if batch operations are supported and the user has the necessary permissions.
- Transitions Handling:
    - If transitions are available and the user can execute them, the method adds a section in the dropdown for running transitions.
    - Each transition is represented by a button that, when clicked, sets the transition ID and submits the form to execute the transition.
This method is a good example of how Joomla! provides a structured approach to managing toolbars in MVC components, allowing for a clean separation of concerns and making it easy to customize toolbar actions based on user permissions and component state.


It has already been discussed here
#43070 




### Testing Instructions
class HtmlView extends ListView
{
	public function __construct($config = [])
    {
		$config['toolbar_title'] = Text::_('COM_XYZ');
		$config['option'] = ApplicationHelper::getComponentName();
		$config['toolbar_icon'] = 'signup';
		$config['help_link'] = '#';
                parent::__construct($config);
	}
}


### Actual result BEFORE applying this Pull Request
Toolbar show buttons side by side


### Expected result AFTER applying this Pull Request
Toolbar show dropdown button


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed



