### PR TITLE
[4.4] Determine the next task run date with the timezone of the site

### DIFF
--- a/administrator/components/com_scheduler/src/Helper/ExecRuleHelper.php
+++ b/administrator/components/com_scheduler/src/Helper/ExecRuleHelper.php
@@ -104,7 +104,8 @@ class ExecRuleHelper
             case 'cron-expression':
                 // @todo: testing
                 $cExp     = new CronExpression((string) $this->rule->exp);
-                $nextExec = $cExp->getNextRunDate('now', 0, false, 'UTC');
+                $nextExec = $cExp->getNextRunDate('now', 0, false, Factory::getApplication()->get('offset', 'UTC'));
+                $nextExec->setTimezone(new \DateTimeZone('UTC'));
                 $nextExec = $string ? $this->dateTimeToSql($nextExec) : $nextExec;
                 break;
             default:

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -284,17 +284,17 @@ class TaskModel extends AdminModel
                 $data->execution_rules['exec-time'] = gmdate('H:i');
             }
 
-			if ($data->next_execution) {
-				$data->next_execution = Factory::getDate($data->next_execution);
-				$data->next_execution->setTimezone(new \DateTimeZone($this->app->get('offset', 'UTC')));
-				$data->next_execution = $data->next_execution->toSql(true);
-			}
+            if ($data->next_execution) {
+                $data->next_execution = Factory::getDate($data->next_execution);
+                $data->next_execution->setTimezone(new \DateTimeZone($this->app->get('offset', 'UTC')));
+                $data->next_execution = $data->next_execution->toSql(true);
+            }
 
-			if ($data->last_execution) {
-				$data->last_execution = Factory::getDate($data->last_execution);
-				$data->last_execution->setTimezone(new \DateTimeZone($this->app->get('offset', 'UTC')));
-				$data->last_execution = $data->last_execution->toSql(true);
-			}
+            if ($data->last_execution) {
+                $data->last_execution = Factory::getDate($data->last_execution);
+                $data->last_execution->setTimezone(new \DateTimeZone($this->app->get('offset', 'UTC')));
+                $data->last_execution = $data->last_execution->toSql(true);
+            }
         }
 
         // Let plugins manipulate the data

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -283,6 +283,18 @@ class TaskModel extends AdminModel
                 $data->execution_rules['exec-day']  = gmdate('d');
                 $data->execution_rules['exec-time'] = gmdate('H:i');
             }
+
+			if ($data->next_execution) {
+				$data->next_execution = Factory::getDate($data->next_execution);
+				$data->next_execution->setTimezone(new \DateTimeZone($this->app->get('offset', 'UTC')));
+				$data->next_execution = $data->next_execution->toSql(true);
+			}
+
+			if ($data->last_execution) {
+				$data->last_execution = Factory::getDate($data->last_execution);
+				$data->last_execution->setTimezone(new \DateTimeZone($this->app->get('offset', 'UTC')));
+				$data->last_execution = $data->last_execution->toSql(true);
+			}
         }
 
         // Let plugins manipulate the data


### PR DESCRIPTION
### Summary of Changes
When using Cron expressions in a task, then they are always executed in UTC timezone. This leads to an issue when the cron ob should run on a specific time on the day and the Joomla site is in a timezone where the there are DST changes. This pr calculates the next run date according to the timezone of Joomla and displays the next execution date in the same time when editing the task (it is the same time as in the tasks list then).

### Testing Instructions
- Define a timezone in Joomla, other than UTC
- Create a new sleep task and define a cron expression like  
![image](https://github.com/joomla/joomla-cms/assets/251072/a09a361b-84cd-4514-80ad-bb5006c27673)
- Open the execution history tab

### Actual result BEFORE applying this Pull Request
It shows the UTC time as next execution date.

### Expected result AFTER applying this Pull Request
It shows the correct time as next execution date.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
