### PR TITLE
[6.0] Site Modules Code Style

### DIFF
--- a/modules/mod_articles_archive/tmpl/default.php
+++ b/modules/mod_articles_archive/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 if (!$list) {
     return;

--- a/modules/mod_articles_categories/tmpl/default.php
+++ b/modules/mod_articles_categories/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
 

--- a/modules/mod_articles_categories/tmpl/default_items.php
+++ b/modules/mod_articles_categories/tmpl/default_items.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -21,7 +21,7 @@ $view   = $input->getCmd('view');
 $id     = $input->getInt('id');
 
 foreach ($list as $item) : ?>
-    <li<?php if ($id == $item->id && in_array($view, ['category', 'categories']) && $option == 'com_content') {
+    <li<?php if ($id == $item->id && \in_array($view, ['category', 'categories']) && $option == 'com_content') {
         echo ' class="active"';
        } ?>> <?php $levelup = $item->level - $startLevel - 1; ?>
         <a href="<?php echo Route::_(RouteHelper::getCategoryRoute($item->id, $item->language)); ?>">
@@ -38,7 +38,7 @@ foreach ($list as $item) : ?>
         if (
             $params->get('show_children', 0) && (($params->get('maxlevel', 0) == 0)
             || ($params->get('maxlevel') >= ($item->level - $startLevel)))
-            && count($item->getChildren())
+            && \count($item->getChildren())
         ) : ?>
             <?php echo '<ul>'; ?>
             <?php $temp = $list; ?>

--- a/modules/mod_articles_category/tmpl/default.php
+++ b/modules/mod_articles_category/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Language\Text;

--- a/modules/mod_articles_category/tmpl/default_items.php
+++ b/modules/mod_articles_category/tmpl/default_items.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/modules/mod_articles_latest/tmpl/default.php
+++ b/modules/mod_articles_latest/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 if (!$list) {
     return;

--- a/modules/mod_articles_news/tmpl/_item.php
+++ b/modules/mod_articles_news/tmpl/_item.php
@@ -8,9 +8,10 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
+
 ?>
 <?php if ($params->get('item_title')) : ?>
     <?php $item_heading = $params->get('item_heading', 'h4'); ?>

--- a/modules/mod_articles_news/tmpl/default.php
+++ b/modules/mod_articles_news/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
 

--- a/modules/mod_articles_news/tmpl/horizontal.php
+++ b/modules/mod_articles_news/tmpl/horizontal.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
 

--- a/modules/mod_articles_news/tmpl/vertical.php
+++ b/modules/mod_articles_news/tmpl/vertical.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
 
@@ -22,7 +22,7 @@ if (!$list) {
 
 ?>
 <ul class="mod-articlesnews-vertical newsflash-vert mod-list">
-    <?php for ($i = 0, $n = count($list); $i < $n; $i++) : ?>
+    <?php for ($i = 0, $n = \count($list); $i < $n; $i++) : ?>
         <?php $item = $list[$i]; ?>
         <li class="newsflash-item" itemscope itemtype="https://schema.org/Article">
             <?php require ModuleHelper::getLayoutPath('mod_articles_news', '_item'); ?>

--- a/modules/mod_articles_popular/tmpl/default.php
+++ b/modules/mod_articles_popular/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 if (!isset($list)) {
     if (isset($hitsDisabledMessage)) {

--- a/modules/mod_banners/tmpl/default.php
+++ b/modules/mod_banners/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\MediaHelper;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
+
 ?>
 <div class="mod-banners bannergroup">
 <?php if ($headerText) : ?>
@@ -43,7 +44,7 @@ use Joomla\CMS\Uri\Uri;
                 <?php $height = $item->params->get('height'); ?>
                 <?php $imageAttribs = [
                     'src' => $baseurl . $imageurl,
-                    'alt' => $alt
+                    'alt' => $alt,
                 ];?>
                 <?php if (!empty($width)) : ?>
                     <?php $imageAttribs['width'] = $width; ?>

--- a/modules/mod_breadcrumbs/tmpl/default.php
+++ b/modules/mod_breadcrumbs/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -72,7 +72,7 @@ use Joomla\CMS\WebAsset\WebAssetManager;
         '@context'        => 'https://schema.org',
         '@type'           => 'BreadcrumbList',
         '@id'             => Uri::root() . '#/schema/BreadcrumbList/' . (int) $module->id,
-        'itemListElement' => []
+        'itemListElement' => [],
     ];
 
     // Use an independent counter for positions. E.g. if Heading items in pathway.

--- a/modules/mod_custom/tmpl/default.php
+++ b/modules/mod_custom/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;

--- a/modules/mod_feed/tmpl/default.php
+++ b/modules/mod_feed/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -21,7 +21,7 @@ if (empty($rssurl)) {
     return;
 }
 
-if (!empty($feed) && is_string($feed)) {
+if (!empty($feed) && \is_string($feed)) {
     echo $feed;
 } else {
     $lang      = $app->getLanguage();
@@ -80,7 +80,7 @@ if (!empty($feed) && is_string($feed)) {
     <!-- Show items -->
         <?php if (!empty($feed)) { ?>
         <ul class="newsfeed">
-            <?php for ($i = 0, $max = min(count($feed), $params->get('rssitems', 3)); $i < $max; $i++) { ?>
+            <?php for ($i = 0, $max = min(\count($feed), $params->get('rssitems', 3)); $i < $max; $i++) { ?>
                 <?php
                 $uri  = $feed[$i]->uri || !$feed[$i]->isPermaLink ? trim($feed[$i]->uri) : trim($feed[$i]->guid);
                 $uri  = !$uri || stripos($uri, 'http') !== 0 ? $rssurl : $uri;

--- a/modules/mod_finder/tmpl/default.php
+++ b/modules/mod_finder/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/modules/mod_footer/tmpl/default.php
+++ b/modules/mod_footer/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/modules/mod_languages/tmpl/default.php
+++ b/modules/mod_languages/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\HTML\HTMLHelper;

--- a/modules/mod_login/tmpl/default_logout.php
+++ b/modules/mod_login/tmpl/default_logout.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/modules/mod_menu/tmpl/collapse-default.php
+++ b/modules/mod_menu/tmpl/collapse-default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/modules/mod_menu/tmpl/default.php
+++ b/modules/mod_menu/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
 
@@ -37,14 +37,14 @@ if ($tagId = $params->get('tag_id', '')) {
         $class .= ' current';
     }
 
-    if (in_array($item->id, $path)) {
+    if (\in_array($item->id, $path)) {
         $class .= ' active';
     } elseif ($item->type === 'alias') {
         $aliasToId = $itemParams->get('aliasoptions');
 
-        if (count($path) > 0 && $aliasToId == $path[count($path) - 1]) {
+        if (\count($path) > 0 && $aliasToId == $path[\count($path) - 1]) {
             $class .= ' active';
-        } elseif (in_array($aliasToId, $path)) {
+        } elseif (\in_array($aliasToId, $path)) {
             $class .= ' alias-parent-active';
         }
     }

--- a/modules/mod_menu/tmpl/default_component.php
+++ b/modules/mod_menu/tmpl/default_component.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\Filter\OutputFilter;

--- a/modules/mod_menu/tmpl/default_heading.php
+++ b/modules/mod_menu/tmpl/default_heading.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 

--- a/modules/mod_menu/tmpl/default_separator.php
+++ b/modules/mod_menu/tmpl/default_separator.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 

--- a/modules/mod_menu/tmpl/default_url.php
+++ b/modules/mod_menu/tmpl/default_url.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\Filter\OutputFilter;

--- a/modules/mod_random_image/tmpl/default.php
+++ b/modules/mod_random_image/tmpl/default.php
@@ -8,12 +8,12 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 
-if (!count($images)) {
+if (!\count($images)) {
     echo Text::_('MOD_RANDOM_IMAGE_NO_IMAGES');
 
     return;

--- a/modules/mod_related_items/tmpl/default.php
+++ b/modules/mod_related_items/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/modules/mod_syndicate/tmpl/default.php
+++ b/modules/mod_syndicate/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -19,7 +19,7 @@ $linkText = '<span class="icon-feed m-1" aria-hidden="true"></span>';
 $linkText .= '<span ' . $textClass . '>' . (!empty($text) ? $text : Text::_('MOD_SYNDICATE_DEFAULT_FEED_ENTRIES')) . '</span>';
 
 $attribs = [
-    'class' => 'mod-syndicate syndicate-module'
+    'class' => 'mod-syndicate syndicate-module',
 ];
 
 echo HTMLHelper::_('link', $link, $linkText, $attribs);

--- a/modules/mod_tags_popular/tmpl/cloud.php
+++ b/modules/mod_tags_popular/tmpl/cloud.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
@@ -20,7 +20,7 @@ $maxsize = $params->get('maxsize', 2);
 ?>
 <div class="mod-tagspopular-cloud tagspopular tagscloud">
 <?php
-if (!count($list)) : ?>
+if (!\count($list)) : ?>
     <div class="alert alert-info">
         <span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
         <?php echo Text::_('MOD_TAGS_POPULAR_NO_ITEMS_FOUND'); ?>

--- a/modules/mod_tags_popular/tmpl/default.php
+++ b/modules/mod_tags_popular/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
@@ -16,7 +16,7 @@ use Joomla\Component\Tags\Site\Helper\RouteHelper;
 
 ?>
 <div class="mod-tagspopular tagspopular">
-<?php if (!count($list)) : ?>
+<?php if (!\count($list)) : ?>
     <div class="alert alert-info">
         <span class="icon-info-circle" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('INFO'); ?></span>
         <?php echo Text::_('MOD_TAGS_POPULAR_NO_ITEMS_FOUND'); ?>

--- a/modules/mod_tags_similar/tmpl/default.php
+++ b/modules/mod_tags_similar/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Router\Route;
 

--- a/modules/mod_users_latest/tmpl/default.php
+++ b/modules/mod_users_latest/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 ?>
 <?php if (!empty($names)) : ?>
     <ul class="mod-userslatest latestusers mod-list">

--- a/modules/mod_whosonline/tmpl/default.php
+++ b/modules/mod_whosonline/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 
@@ -21,7 +21,7 @@ use Joomla\CMS\Language\Text;
         <p><?php echo Text::sprintf('MOD_WHOSONLINE_WE_HAVE', $guest, $member); ?></p>
     <?php endif; ?>
 
-    <?php if (($showmode > 0) && count($names)) : ?>
+    <?php if (($showmode > 0) && \count($names)) : ?>
         <?php if ($params->get('filter_groups', 0)) : ?>
             <p><?php echo Text::_('MOD_WHOSONLINE_SAME_GROUP_MESSAGE'); ?></p>
         <?php endif; ?>

--- a/modules/mod_whosonline/tmpl/disabled.php
+++ b/modules/mod_whosonline/tmpl/disabled.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/modules/mod_wrapper/tmpl/default.php
+++ b/modules/mod_wrapper/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 


### PR DESCRIPTION
various files are excluded from the automated checks
    // Ignore template files as PHP CS fixer can't handle them properly
    // https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/3702#issuecomment-396717120

### Summary of Changes
This is a semi-manual review of the site modules to apply
- trailing_comma_in_multiline
- native_function_invocation
- single_line_after_imports


### Testing Instructions
code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
