### PR TITLE
[6.0] Admin modules code style

### DIFF
--- a/administrator/modules/mod_custom/tmpl/default.php
+++ b/administrator/modules/mod_custom/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 ?>
 
 <div class="mod-custom custom">

--- a/administrator/modules/mod_feed/tmpl/default.php
+++ b/administrator/modules/mod_feed/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -21,7 +21,7 @@ if (empty($rssurl)) {
     return;
 }
 
-if (!empty($feed) && is_string($feed)) {
+if (!empty($feed) && \is_string($feed)) {
     echo $feed;
 } else {
     $lang      = $app->getLanguage();
@@ -49,7 +49,7 @@ if (!empty($feed) && is_string($feed)) {
         <?php
 
         // Feed title
-        if (!is_null($feed->title) && $params->get('rsstitle', 1)) : ?>
+        if (!\is_null($feed->title) && $params->get('rsstitle', 1)) : ?>
             <h2 class="<?php echo $direction; ?>">
                 <a href="<?php echo str_replace('&', '&amp;', $rssurl); ?>" target="_blank" rel="noopener noreferrer">
                 <?php echo $feed->title; ?></a>

--- a/administrator/modules/mod_frontend/tmpl/default.php
+++ b/administrator/modules/mod_frontend/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/administrator/modules/mod_guidedtours/tmpl/default.php
+++ b/administrator/modules/mod_guidedtours/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
@@ -37,9 +37,9 @@ $toursCount   = $params->get('tourscount', 7);
 foreach ($tours as $tour) :
     $uri = new Uri($tour->url);
 
-    if (in_array('*', $tour->extensions)) :
+    if (\in_array('*', $tour->extensions)) :
         $starTours[] = $tour;
-    elseif (in_array($extension, $tour->extensions)) :
+    elseif (\in_array($extension, $tour->extensions)) :
         if ($extension === 'com_categories') :
             // Special case for the categories page, where the context is complemented with the extension the categories apply to
             if ($uri->getVar('option', '') === 'com_categories') :
@@ -53,7 +53,7 @@ foreach ($tours as $tour) :
                     $toursCount--;
                 endif;
             else :
-                if (in_array($app->getInput()->get('extension', ''), $tour->extensions)) :
+                if (\in_array($app->getInput()->get('extension', ''), $tour->extensions)) :
                     if ($contextCount > 0) :
                         $contextTours[] = $tour;
                         $contextCount--;
@@ -87,7 +87,7 @@ endforeach;
 
 if ($contextCount > 0) :
     // The '*' tours have lower priority than contextual tours and are added after them, room permitting
-    $contextTours = array_slice(array_merge($contextTours, $starTours), 0, $params->get('contextcount', 7));
+    $contextTours = \array_slice(array_merge($contextTours, $starTours), 0, $params->get('contextcount', 7));
 endif;
 
 $popupId      = 'guidedtours-popup-content' . $module->id;
@@ -111,7 +111,7 @@ $popupOptions = json_encode([
         <span class="icon-angle-down" aria-hidden="true"></span>
     </button>
     <div class="dropdown-menu dropdown-menu-end">
-        <?php if (count($contextTours) > 0) : ?>
+        <?php if (\count($contextTours) > 0) : ?>
             <ul class="list-unstyled m-0">
                 <?php foreach ($contextTours as $tour) : ?>
                     <li>
@@ -124,7 +124,7 @@ $popupOptions = json_encode([
             </ul>
             <hr class="dropdown-divider m-0" role="separator" />
         <?php endif; ?>
-        <?php if (count($listTours) > 0) : ?>
+        <?php if (\count($listTours) > 0) : ?>
             <ul class="list-unstyled m-0">
                 <?php foreach ($listTours as $tour) : ?>
                     <li>

--- a/administrator/modules/mod_latest/tmpl/default.php
+++ b/administrator/modules/mod_latest/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -29,7 +29,7 @@ $moduleId = str_replace(' ', '', $module->title) . $module->id;
         </tr>
     </thead>
     <tbody>
-        <?php if (count($list)) : ?>
+        <?php if (\count($list)) : ?>
             <?php foreach ($list as $i => $item) : ?>
         <tr>
             <th scope="row">

--- a/administrator/modules/mod_latestactions/tmpl/default.php
+++ b/administrator/modules/mod_latestactions/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -23,7 +23,7 @@ use Joomla\CMS\Language\Text;
         </tr>
     </thead>
     <tbody>
-        <?php if (count($list)) : ?>
+        <?php if (\count($list)) : ?>
             <?php foreach ($list as $i => $item) : ?>
         <tr>
             <td>

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/administrator/modules/mod_logged/tmpl/default.php
+++ b/administrator/modules/mod_logged/tmpl/default.php
@@ -12,6 +12,7 @@
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+
 ?>
 <table class="table" id="<?php echo str_replace(' ', '', $module->title) . $module->id; ?>">
     <caption class="visually-hidden"><?php echo $module->title; ?></caption>

--- a/administrator/modules/mod_logged/tmpl/disabled.php
+++ b/administrator/modules/mod_logged/tmpl/disabled.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -120,7 +120,7 @@ Text::script('JHIDEPASSWORD');
             [
                 'target' => '_blank',
                 'rel'    => 'noopener nofollow',
-                'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGIN_CREDENTIALS'))
+                'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGIN_CREDENTIALS')),
             ]
         ); ?>
     </div>

--- a/administrator/modules/mod_loginsupport/tmpl/default.php
+++ b/administrator/modules/mod_loginsupport/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/administrator/modules/mod_loginsupport/tmpl/default.php
+++ b/administrator/modules/mod_loginsupport/tmpl/default.php
@@ -24,7 +24,7 @@ use Joomla\CMS\Language\Text;
                 [
                     'target' => '_blank',
                     'rel'    => 'nofollow noopener',
-                    'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGINSUPPORT_FORUM'))
+                    'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGINSUPPORT_FORUM')),
                 ]
             ); ?>
         </li>
@@ -35,7 +35,7 @@ use Joomla\CMS\Language\Text;
                 [
                     'target' => '_blank',
                     'rel'    => 'nofollow noopener',
-                    'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGINSUPPORT_DOCUMENTATION'))
+                    'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGINSUPPORT_DOCUMENTATION')),
                 ]
             ); ?>
         </li>
@@ -46,7 +46,7 @@ use Joomla\CMS\Language\Text;
                 [
                     'target' => '_blank',
                     'rel'    => 'nofollow noopener',
-                    'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGINSUPPORT_NEWS'))
+                    'title'  => Text::sprintf('JBROWSERTARGET_NEW_TITLE', Text::_('MOD_LOGINSUPPORT_NEWS')),
                 ]
             ); ?>
         </li>

--- a/administrator/modules/mod_menu/tmpl/default.php
+++ b/administrator/modules/mod_menu/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Helper\ModuleHelper;
 use Joomla\CMS\Language\Text;

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/administrator/modules/mod_messages/tmpl/default.php
+++ b/administrator/modules/mod_messages/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;

--- a/administrator/modules/mod_multilangstatus/tmpl/default.php
+++ b/administrator/modules/mod_multilangstatus/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;

--- a/administrator/modules/mod_popular/tmpl/default.php
+++ b/administrator/modules/mod_popular/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -26,7 +26,7 @@ $moduleId = str_replace(' ', '', $module->title) . $module->id;
         </tr>
     </thead>
     <tbody>
-    <?php if (count($list)) : ?>
+    <?php if (\count($list)) : ?>
         <?php foreach ($list as $i => $item) : ?>
             <?php // Calculate popular items ?>
             <?php $hits = (int) $item->hits; ?>

--- a/administrator/modules/mod_post_installation_messages/tmpl/default.php
+++ b/administrator/modules/mod_post_installation_messages/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;

--- a/administrator/modules/mod_privacy_dashboard/tmpl/default.php
+++ b/administrator/modules/mod_privacy_dashboard/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -28,9 +28,9 @@ $activeRequests = 0;
         </tr>
     </thead>
     <tbody>
-        <?php if (count($list)) : ?>
+        <?php if (\count($list)) : ?>
             <?php foreach ($list as $i => $item) : ?>
-                <?php if (in_array($item->status, [0, 1])) : ?>
+                <?php if (\in_array($item->status, [0, 1])) : ?>
                     <?php $activeRequests += $item->count; ?>
                 <?php endif; ?>
                 <?php $totalRequests += $item->count; ?>
@@ -57,7 +57,7 @@ $activeRequests = 0;
         <?php endif; ?>
     </tbody>
 </table>
-<?php if (count($list)) : ?>
+<?php if (\count($list)) : ?>
     <div class="row p-3">
         <div class="col-md-6"><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_TOTAL_REQUESTS', $totalRequests); ?></div>
         <div class="col-md-6"><?php echo Text::plural('COM_PRIVACY_DASHBOARD_BADGE_ACTIVE_REQUESTS', $activeRequests); ?></div>

--- a/administrator/modules/mod_privacy_status/tmpl/default.php
+++ b/administrator/modules/mod_privacy_status/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;

--- a/administrator/modules/mod_quickicon/tmpl/default.php
+++ b/administrator/modules/mod_quickicon/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/administrator/modules/mod_sampledata/tmpl/default.php
+++ b/administrator/modules/mod_sampledata/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/administrator/modules/mod_stats_admin/tmpl/default.php
+++ b/administrator/modules/mod_stats_admin/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 \Joomla\CMS\Factory::getApplication()->getDocument()->addScriptDeclaration('
 (function() {

--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/administrator/modules/mod_title/tmpl/default.php
+++ b/administrator/modules/mod_title/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 ?>
 <?php if (!empty($title)) : ?>
 <div class="d-flex align-items-center">

--- a/administrator/modules/mod_toolbar/tmpl/default.php
+++ b/administrator/modules/mod_toolbar/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 // Echo the toolbar.
 echo $toolbar;

--- a/administrator/modules/mod_user/tmpl/default.php
+++ b/administrator/modules/mod_user/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/administrator/modules/mod_version/tmpl/default.php
+++ b/administrator/modules/mod_version/tmpl/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 


### PR DESCRIPTION
various files are excluded from the automated checks
    // Ignore template files as PHP CS fixer can't handle them properly
    // https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/3702#issuecomment-396717120

### Summary of Changes
This is a semi-manual review of the site modules to apply
- trailing_comma_in_multiline
- native_function_invocation
- single_line_after_imports


### Testing Instructions
code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
