### PR TITLE
[6.0] Layouts codestyle

### DIFF
--- a/layouts/chromes/html5.php
+++ b/layouts/chromes/html5.php
@@ -10,7 +10,7 @@
  * html5 (chosen html5 tag and font header tags)
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\Utilities\ArrayHelper;
 

--- a/layouts/chromes/none.php
+++ b/layouts/chromes/none.php
@@ -8,6 +8,6 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 echo $displayData['module']->content;

--- a/layouts/chromes/outline.php
+++ b/layouts/chromes/outline.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/chromes/table.php
+++ b/layouts/chromes/table.php
@@ -10,7 +10,7 @@
  * Module chrome that wraps the module in a table
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 $module  = $displayData['module'];
 $params  = $displayData['params'];

--- a/layouts/joomla/button/iconclass.php
+++ b/layouts/joomla/button/iconclass.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 

--- a/layouts/joomla/content/associations.php
+++ b/layouts/joomla/content/associations.php
@@ -8,14 +8,14 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 $items = $displayData;
 
 if (!empty($items)) : ?>
     <ul class="item-associations">
         <?php foreach ($items as $id => $item) : ?>
-            <?php if (is_array($item) && isset($item['link'])) : ?>
+            <?php if (\is_array($item) && isset($item['link'])) : ?>
                 <li>
                     <?php echo $item['link']; ?>
                 </li>

--- a/layouts/joomla/content/blog_style_default_item_title.php
+++ b/layouts/joomla/content/blog_style_default_item_title.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/content/categories_default.php
+++ b/layouts/joomla/content/categories_default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;

--- a/layouts/joomla/content/emptystate.php
+++ b/layouts/joomla/content/emptystate.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;

--- a/layouts/joomla/content/emptystate_module.php
+++ b/layouts/joomla/content/emptystate_module.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/content/full_image.php
+++ b/layouts/joomla/content/full_image.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 

--- a/layouts/joomla/content/icons.php
+++ b/layouts/joomla/content/icons.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 

--- a/layouts/joomla/content/icons/create.php
+++ b/layouts/joomla/content/icons/create.php
@@ -9,7 +9,7 @@
  * @deprecated  4.3 will be removed in 6.0
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/content/icons/edit.php
+++ b/layouts/joomla/content/icons/edit.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -20,7 +20,7 @@ $nowDate = strtotime(Factory::getDate());
 $icon = $article->state ? 'edit' : 'eye-slash';
 $currentDate   = Factory::getDate()->format('Y-m-d H:i:s');
 $isUnpublished = ($article->publish_up > $currentDate)
-    || !is_null($article->publish_down) && ($article->publish_down < $currentDate);
+    || !\is_null($article->publish_down) && ($article->publish_down < $currentDate);
 
 if ($isUnpublished) {
     $icon = 'eye-slash';

--- a/layouts/joomla/content/icons/edit_lock.php
+++ b/layouts/joomla/content/icons/edit_lock.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/content/info_block.php
+++ b/layouts/joomla/content/info_block.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/content/info_block/associations.php
+++ b/layouts/joomla/content/info_block/associations.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/content/info_block/author.php
+++ b/layouts/joomla/content/info_block/author.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/content/info_block/category.php
+++ b/layouts/joomla/content/info_block/category.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;

--- a/layouts/joomla/content/info_block/create_date.php
+++ b/layouts/joomla/content/info_block/create_date.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/content/info_block/hits.php
+++ b/layouts/joomla/content/info_block/hits.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/content/info_block/modify_date.php
+++ b/layouts/joomla/content/info_block/modify_date.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/content/info_block/parent_category.php
+++ b/layouts/joomla/content/info_block/parent_category.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;

--- a/layouts/joomla/content/info_block/publish_date.php
+++ b/layouts/joomla/content/info_block/publish_date.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/content/intro_image.php
+++ b/layouts/joomla/content/intro_image.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;

--- a/layouts/joomla/content/language.php
+++ b/layouts/joomla/content/language.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/content/options_default.php
+++ b/layouts/joomla/content/options_default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;

--- a/layouts/joomla/content/readmore.php
+++ b/layouts/joomla/content/readmore.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;

--- a/layouts/joomla/content/tags.php
+++ b/layouts/joomla/content/tags.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Router\Route;
@@ -21,7 +21,7 @@ $authorised = Factory::getUser()->getAuthorisedViewLevels();
 <?php if (!empty($displayData)) : ?>
     <ul class="tags list-inline">
         <?php foreach ($displayData as $i => $tag) : ?>
-            <?php if (in_array($tag->access, $authorised)) : ?>
+            <?php if (\in_array($tag->access, $authorised)) : ?>
                 <?php $tagParams = new Registry($tag->params); ?>
                 <?php $link_class = $tagParams->get('tag_link_class', 'btn-info'); ?>
                 <li class="list-inline-item tag-<?php echo $tag->tag_id; ?> tag-list<?php echo $i; ?>">

--- a/layouts/joomla/content/text_filters.php
+++ b/layouts/joomla/content/text_filters.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/edit/admin_modules.php
+++ b/layouts/joomla/edit/admin_modules.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ModuleHelper;
@@ -43,7 +43,7 @@ $html[] = '<fieldset class="form-vertical">';
 foreach ($fields as $field) {
     foreach ((array) $field as $f) {
         if ($form->getField($f)) {
-            if (in_array($f, $hiddenFields)) {
+            if (\in_array($f, $hiddenFields)) {
                 $form->setFieldAttribute($f, 'type', 'hidden');
             }
 

--- a/layouts/joomla/edit/associations.php
+++ b/layouts/joomla/edit/associations.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/edit/fieldset.php
+++ b/layouts/joomla/edit/fieldset.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 
@@ -28,7 +28,7 @@ $extraFields  = $displayData->get('extra_fields') ? : [];
 if (!empty($displayData->showOptions) || $displayData->get('show_options', 1)) {
     if (isset($extraFields[$name])) {
         foreach ($extraFields[$name] as $f) {
-            if (in_array($f, $ignoreFields)) {
+            if (\in_array($f, $ignoreFields)) {
                 continue;
             }
             if ($form->getField($f)) {

--- a/layouts/joomla/edit/frontediting_modules.php
+++ b/layouts/joomla/edit/frontediting_modules.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;

--- a/layouts/joomla/edit/global.php
+++ b/layouts/joomla/edit/global.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
@@ -60,7 +60,7 @@ $html[] = '<legend class="visually-hidden">' . Text::_('JGLOBAL_FIELDSET_GLOBAL'
 foreach ($fields as $field) {
     foreach ((array) $field as $f) {
         if ($form->getField($f)) {
-            if (in_array($f, $hiddenFields)) {
+            if (\in_array($f, $hiddenFields)) {
                 $form->setFieldAttribute($f, 'type', 'hidden');
             }
 

--- a/layouts/joomla/edit/metadata.php
+++ b/layouts/joomla/edit/metadata.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -45,12 +45,12 @@ if (!$displayData->get('show_options', 1)) {
     // Loop over the fieldsets
     foreach ($fieldSets as $name => $fieldSet) {
         // Check if the fieldset should be ignored
-        if (in_array($name, $ignoreFieldsets, true)) {
+        if (\in_array($name, $ignoreFieldsets, true)) {
             continue;
         }
 
         // If it is a hidden fieldset, render the inputs
-        if (in_array($name, $hiddenFieldsets)) {
+        if (\in_array($name, $hiddenFieldsets)) {
             // Loop over the fields
             foreach ($form->getFieldset($name) as $field) {
                 // Add only the input on the buffer
@@ -81,9 +81,9 @@ foreach ($fieldSets as $name => $fieldSet) {
     // Ensure any fieldsets we don't want to show are skipped (including repeating formfield fieldsets)
     if (
         (isset($fieldSet->repeat) && $fieldSet->repeat === true)
-        || in_array($name, $ignoreFieldsets)
-        || (!empty($configFieldsets) && in_array($name, $configFieldsets, true))
-        || (!empty($hiddenFieldsets) && in_array($name, $hiddenFieldsets, true))
+        || \in_array($name, $ignoreFieldsets)
+        || (!empty($configFieldsets) && \in_array($name, $configFieldsets, true))
+        || (!empty($hiddenFieldsets) && \in_array($name, $hiddenFieldsets, true))
     ) {
         continue;
     }

--- a/layouts/joomla/edit/publishingdata.php
+++ b/layouts/joomla/edit/publishingdata.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 $form = $displayData->getForm();
 
@@ -32,7 +32,7 @@ $hiddenFields = $displayData->get('hidden_fields') ?: [];
 foreach ($fields as $field) {
     foreach ((array) $field as $f) {
         if ($form->getField($f)) {
-            if (in_array($f, $hiddenFields)) {
+            if (\in_array($f, $hiddenFields)) {
                 $form->setFieldAttribute($f, 'type', 'hidden');
             }
 

--- a/layouts/joomla/edit/publishingdata.php
+++ b/layouts/joomla/edit/publishingdata.php
@@ -24,7 +24,7 @@ $fields = $displayData->get('fields') ?: [
     ['modified_by', 'modified_user_id'],
     'version',
     'hits',
-    'id'
+    'id',
 ];
 
 $hiddenFields = $displayData->get('hidden_fields') ?: [];

--- a/layouts/joomla/edit/title_alias.php
+++ b/layouts/joomla/edit/title_alias.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 $form  = $displayData->getForm();
 

--- a/layouts/joomla/editors/buttons.php
+++ b/layouts/joomla/editors/buttons.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/editors/buttons/button.php
+++ b/layouts/joomla/editors/buttons/button.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Uri\Uri;

--- a/layouts/joomla/editors/buttons/modal.php
+++ b/layouts/joomla/editors/buttons/modal.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
@@ -31,7 +31,7 @@ $options  = $button->getOptions();
 
 $confirm = '';
 
-if (is_array($button->get('options')) && isset($options['confirmText']) && isset($options['confirmCallback'])) {
+if (\is_array($button->get('options')) && isset($options['confirmText']) && isset($options['confirmCallback'])) {
     $confirm = '<button type="button" class="btn btn-success" data-bs-dismiss="modal" onclick="' . $options['confirmCallback'] . '">'
         . $options['confirmText'] . ' </button>';
 }
@@ -50,10 +50,10 @@ echo HTMLHelper::_(
     [
         'url'    => $link,
         'title'  => $title,
-        'height' => array_key_exists('height', $options) ? $options['height'] : '400px',
-        'width'  => array_key_exists('width', $options) ? $options['width'] : '800px',
-        'bodyHeight'  => array_key_exists('bodyHeight', $options) ? $options['bodyHeight'] : '70',
-        'modalWidth'  => array_key_exists('modalWidth', $options) ? $options['modalWidth'] : '80',
+        'height' => \array_key_exists('height', $options) ? $options['height'] : '400px',
+        'width'  => \array_key_exists('width', $options) ? $options['width'] : '800px',
+        'bodyHeight'  => \array_key_exists('bodyHeight', $options) ? $options['bodyHeight'] : '70',
+        'modalWidth'  => \array_key_exists('modalWidth', $options) ? $options['modalWidth'] : '80',
         'footer' => $confirm . '<button type="button" class="btn btn-secondary" data-bs-dismiss="modal">'
             . Text::_('JLIB_HTML_BEHAVIOR_CLOSE') . '</button>'
     ]

--- a/layouts/joomla/error/backtrace.php
+++ b/layouts/joomla/error/backtrace.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 

--- a/layouts/joomla/form/field/calendar.php
+++ b/layouts/joomla/form/field/calendar.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -93,7 +93,7 @@ if (strtoupper($value) === 'NOW') {
 $readonly = isset($attributes['readonly']) && $attributes['readonly'] === 'readonly';
 $disabled = isset($attributes['disabled']) && $attributes['disabled'] === 'disabled';
 
-if (is_array($attributes)) {
+if (\is_array($attributes)) {
     $attributes = ArrayHelper::toString($attributes);
 }
 

--- a/layouts/joomla/form/field/checkbox.php
+++ b/layouts/joomla/form/field/checkbox.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Form\Field\CheckboxField;
 

--- a/layouts/joomla/form/field/checkboxes.php
+++ b/layouts/joomla/form/field/checkboxes.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 
@@ -67,7 +67,7 @@ $alt = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
     <?php foreach ($options as $i => $option) : ?>
         <?php
             // Initialize some option attributes.
-            $checked = in_array((string) $option->value, $checkedOptions, true) ? 'checked' : '';
+            $checked = \in_array((string) $option->value, $checkedOptions, true) ? 'checked' : '';
 
             // In case there is no stored value, use the option's default state.
             $checked        = (!$hasValue && $option->checked) ? 'checked' : $checked;

--- a/layouts/joomla/form/field/color/advanced.php
+++ b/layouts/joomla/form/field/color/advanced.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 
@@ -49,14 +49,14 @@ extract($displayData);
  * @var   array    $dataAttributes  Miscellaneous data attributes for eg, data-*.
  */
 
-if ($validate !== 'color' && in_array($format, ['rgb', 'rgba'], true)) {
+if ($validate !== 'color' && \in_array($format, ['rgb', 'rgba'], true)) {
     $alpha = ($format === 'rgba');
     $placeholder = $alpha ? 'rgba(0, 0, 0, 0.5)' : 'rgb(0, 0, 0)';
 } else {
     $placeholder = '#rrggbb';
 }
 
-$inputclass   = ($keywords && ! in_array($format, ['rgb', 'rgba'], true)) ? ' keywords' : ' ' . $format;
+$inputclass   = ($keywords && ! \in_array($format, ['rgb', 'rgba'], true)) ? ' keywords' : ' ' . $format;
 $class        = ' class="form-control ' . trim('minicolors ' . $class) . ($validate === 'color' ? '' : $inputclass) . '"';
 $control      = $control ? ' data-control="' . $control . '"' : '';
 $format       = $format ? ' data-format="' . $format . '"' : '';
@@ -65,7 +65,7 @@ $colors       = $colors ? ' data-colors="' . $colors . '"' : '';
 $validate     = $validate ? ' data-validate="' . $validate . '"' : '';
 $disabled     = $disabled ? ' disabled' : '';
 $readonly     = $readonly ? ' readonly' : '';
-$hint         = strlen($hint) ? ' placeholder="' . $this->escape($hint) . '"' : ' placeholder="' . $placeholder . '"';
+$hint         = \strlen($hint) ? ' placeholder="' . $this->escape($hint) . '"' : ' placeholder="' . $placeholder . '"';
 $onchange     = $onchange ? ' onchange="' . $onchange . '"' : '';
 $required     = $required ? ' required' : '';
 $autocomplete = !empty($autocomplete) ? ' autocomplete="' . $autocomplete . '"' : '';

--- a/layouts/joomla/form/field/color/simple.php
+++ b/layouts/joomla/form/field/color/simple.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/form/field/color/slider.php
+++ b/layouts/joomla/form/field/color/slider.php
@@ -46,7 +46,7 @@ extract($displayData);
  * @var   array   $dataAttributes  Miscellaneous data attributes for eg, data-*.
  */
 
-if ($color === 'none' || is_null($color)) {
+if ($color === 'none' || \is_null($color)) {
     $color = '';
 }
 
@@ -58,7 +58,7 @@ $class        = $class ? ' class="' . $class . '"' : '';
 $default      = $default ? ' data-default="' . $default . '"' : '';
 $disabled     = $disabled ? ' disabled' : '';
 $format       = $format ? ' data-format="' . $format . '"' : '';
-$hint         = strlen($hint) ? ' placeholder="' . $this->escape($hint) . '"' : '';
+$hint         = \strlen($hint) ? ' placeholder="' . $this->escape($hint) . '"' : '';
 $onchange     = $onchange ? ' onchange="' . $onchange . '"' : '';
 $onclick      = $onclick ? ' onclick="' . $onclick . '"' : '';
 $preview      = $preview ? ' data-preview="' . $preview . '"' : '';
@@ -118,7 +118,7 @@ Text::script('JFIELD_COLOR_ERROR_WRONG_FORMAT');
     >
     <span class="form-control-feedback"></span>
 
-    <?php if ($allSliders || in_array('hue', $displayValues)) : ?>
+    <?php if ($allSliders || \in_array('hue', $displayValues)) : ?>
         <label for="hue-slider" class="visually-hidden"><?php echo Text::_('JFIELD_COLOR_LABEL_SLIDER_HUE'); ?></label>
         <input type="range" min="0" max="360" class="form-control color-slider" id="hue-slider" data-type="hue"
             <?php echo
@@ -127,7 +127,7 @@ Text::script('JFIELD_COLOR_ERROR_WRONG_FORMAT');
             ?>
         >
     <?php endif ?>
-    <?php if ($allSliders || in_array('saturation', $displayValues)) : ?>
+    <?php if ($allSliders || \in_array('saturation', $displayValues)) : ?>
         <label for="saturation-slider" class="visually-hidden"><?php echo Text::_('JFIELD_COLOR_LABEL_SLIDER_SATURATION'); ?></label>
         <input type="range" min="0" max="100" class="form-control color-slider" id="saturation-slider" data-type="saturation"
             <?php echo
@@ -136,7 +136,7 @@ Text::script('JFIELD_COLOR_ERROR_WRONG_FORMAT');
             ?>
         >
     <?php endif ?>
-    <?php if ($allSliders || in_array('light', $displayValues)) : ?>
+    <?php if ($allSliders || \in_array('light', $displayValues)) : ?>
         <label for="light-slider" class="visually-hidden"><?php echo Text::_('JFIELD_COLOR_LABEL_SLIDER_LIGHT'); ?></label>
         <input type="range" min="0" max="100" class="form-control color-slider" id="light-slider" data-type="light"
             <?php echo
@@ -145,7 +145,7 @@ Text::script('JFIELD_COLOR_ERROR_WRONG_FORMAT');
             ?>
         >
     <?php endif ?>
-    <?php if ($alpha && ($allSliders || in_array('alpha', $displayValues))) : ?>
+    <?php if ($alpha && ($allSliders || \in_array('alpha', $displayValues))) : ?>
         <label for="alpha-slider" class="visually-hidden"><?php echo Text::_('JFIELD_COLOR_LABEL_SLIDER_ALPHA'); ?></label>
         <input type="range" min="0" max="100" class="form-control color-slider" id="alpha-slider" data-type="alpha"
             <?php echo

--- a/layouts/joomla/form/field/combo.php
+++ b/layouts/joomla/form/field/combo.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/joomla/form/field/contenthistory.php
+++ b/layouts/joomla/form/field/contenthistory.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Router\Route;

--- a/layouts/joomla/form/field/email.php
+++ b/layouts/joomla/form/field/email.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\String\PunycodeHelper;
 
@@ -65,7 +65,7 @@ $attributes = [
     !empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '',
     $multiple ? 'multiple' : '',
     !empty($maxLength) ? 'maxlength="' . $maxLength . '"' : '',
-    strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
+    \strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
     $required ? 'required' : '',
     $autofocus ? 'autofocus' : '',
     $dataAttribute,

--- a/layouts/joomla/form/field/file.php
+++ b/layouts/joomla/form/field/file.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/form/field/groupedlist-fancy-select.php
+++ b/layouts/joomla/form/field/groupedlist-fancy-select.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;

--- a/layouts/joomla/form/field/groupedlist.php
+++ b/layouts/joomla/form/field/groupedlist.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 

--- a/layouts/joomla/form/field/hidden.php
+++ b/layouts/joomla/form/field/hidden.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/joomla/form/field/list-fancy-select.php
+++ b/layouts/joomla/form/field/list-fancy-select.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -76,8 +76,8 @@ if ($readonly) {
     $html[] = HTMLHelper::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $value, $id);
 
     // E.g. form field type tag sends $this->value as array
-    if ($multiple && is_array($value)) {
-        if (!count($value)) {
+    if ($multiple && \is_array($value)) {
+        if (!\count($value)) {
             $value[] = '';
         }
 

--- a/layouts/joomla/form/field/list.php
+++ b/layouts/joomla/form/field/list.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 
@@ -68,8 +68,8 @@ if ($readonly) {
     $html[] = HTMLHelper::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $value, $id);
 
     // E.g. form field type tag sends $this->value as array
-    if ($multiple && is_array($value)) {
-        if (!count($value)) {
+    if ($multiple && \is_array($value)) {
+        if (!\count($value)) {
             $value[] = '';
         }
 

--- a/layouts/joomla/form/field/media.php
+++ b/layouts/joomla/form/field/media.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;

--- a/layouts/joomla/form/field/media/accessiblemedia.php
+++ b/layouts/joomla/form/field/media/accessiblemedia.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/joomla/form/field/meter.php
+++ b/layouts/joomla/form/field/meter.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/joomla/form/field/modal-select.php
+++ b/layouts/joomla/form/field/modal-select.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 

--- a/layouts/joomla/form/field/modal-select/buttons.php
+++ b/layouts/joomla/form/field/modal-select/buttons.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;

--- a/layouts/joomla/form/field/modal-select/extra-buttons.php
+++ b/layouts/joomla/form/field/modal-select/extra-buttons.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 /**
  * The layout allows to add extra control buttons to the field, example "propagate association" by com_content.

--- a/layouts/joomla/form/field/moduleorder.php
+++ b/layouts/joomla/form/field/moduleorder.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 

--- a/layouts/joomla/form/field/number.php
+++ b/layouts/joomla/form/field/number.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 
@@ -51,7 +51,7 @@ $attributes = [
     !empty($description) ? 'aria-describedby="' . ($id ?: $name) . '-desc"' : '',
     $disabled ? 'disabled' : '',
     $readonly ? 'readonly' : '',
-    strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
+    \strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
     !empty($onchange) ? 'onchange="' . $onchange . '"' : '',
     isset($max) ? 'max="' . $max . '"' : '',
     !empty($step) ? 'step="' . $step . '"' : '',

--- a/layouts/joomla/form/field/password.php
+++ b/layouts/joomla/form/field/password.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -87,7 +87,7 @@ $ariaDescribedBy = $rules ? $name . '-rules ' : '';
 $ariaDescribedBy .= !empty($description) ? (($id ?: $name) . '-desc') : '';
 
 $attributes = [
-    strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
+    \strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
     !empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '',
     !empty($class) ? 'class="form-control ' . $class . '"' : 'class="form-control"',
     !empty($ariaDescribedBy) ? 'aria-describedby="' . trim($ariaDescribedBy) . '"' : '',

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 

--- a/layouts/joomla/form/field/radiobasic.php
+++ b/layouts/joomla/form/field/radiobasic.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/form/field/range.php
+++ b/layouts/joomla/form/field/range.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/joomla/form/field/rules.php
+++ b/layouts/joomla/form/field/rules.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Access\Access;
 use Joomla\CMS\Factory;

--- a/layouts/joomla/form/field/subform/default.php
+++ b/layouts/joomla/form/field/subform/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Form\Form;
 

--- a/layouts/joomla/form/field/subform/repeatable-table.php
+++ b/layouts/joomla/form/field/subform/repeatable-table.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;

--- a/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section-byfieldsets.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/form/field/subform/repeatable-table/section.php
+++ b/layouts/joomla/form/field/subform/repeatable-table/section.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/form/field/subform/repeatable.php
+++ b/layouts/joomla/form/field/subform/repeatable.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;

--- a/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
+++ b/layouts/joomla/form/field/subform/repeatable/section-byfieldsets.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/form/field/subform/repeatable/section.php
+++ b/layouts/joomla/form/field/subform/repeatable/section.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/form/field/tag.php
+++ b/layouts/joomla/form/field/tag.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -95,8 +95,8 @@ if ($readonly) {
     $html[] = HTMLHelper::_('select.genericlist', $options, '', trim($attr), 'value', 'text', $value, $id);
 
     // E.g. form field type tag sends $this->value as array
-    if ($multiple && is_array($value)) {
-        if (!count($value)) {
+    if ($multiple && \is_array($value)) {
+        if (!\count($value)) {
             $value[] = '';
         }
 

--- a/layouts/joomla/form/field/tel.php
+++ b/layouts/joomla/form/field/tel.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 
@@ -53,7 +53,7 @@ $attributes = [
     !empty($description) ? 'aria-describedby="' . ($id ?: $name) . '-desc"' : '',
     $disabled ? 'disabled' : '',
     $readonly ? 'readonly' : '',
-    strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
+    \strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
     !empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '',
     $autofocus ? 'autofocus' : '',
     $spellcheck ? '' : 'spellcheck="false"',

--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -83,7 +83,7 @@ $attributes = [
     $readonly ? 'readonly' : '',
     $dataAttribute,
     $list,
-    strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
+    \strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
     $onchange ? ' onchange="' . $onchange . '"' : '',
     !empty($maxLength) ? $maxLength : '',
     $required ? 'required' : '',

--- a/layouts/joomla/form/field/textarea.php
+++ b/layouts/joomla/form/field/textarea.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
@@ -69,7 +69,7 @@ $attributes = [
     $rows ?: '',
     !empty($class) ? 'class="form-control ' . $class . $charcounter . '"' : 'class="form-control' . $charcounter . '"',
     !empty($description) ? 'aria-describedby="' . ($id ?: $name) . '-desc"' : '',
-    strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
+    \strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
     $disabled ? 'disabled' : '',
     $readonly ? 'readonly' : '',
     $onchange ? 'onchange="' . $onchange . '"' : '',

--- a/layouts/joomla/form/field/time.php
+++ b/layouts/joomla/form/field/time.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 /**
  * @var  array $displayData Array with values.
@@ -53,7 +53,7 @@ $attributes = [
     !empty($description) ? 'aria-describedby="' . ($id ?: $name) . '-desc"' : '',
     $disabled ? 'disabled' : '',
     $readonly ? 'readonly' : '',
-    strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
+    \strlen($hint) ? 'placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
     !empty($onchange) ? 'onchange="' . $onchange . '"' : '',
     isset($max) ? 'max="' . $max . '"' : '',
     isset($step) ? 'step="' . $step . '"' : '',

--- a/layouts/joomla/form/field/url.php
+++ b/layouts/joomla/form/field/url.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\String\PunycodeHelper;
 
@@ -54,7 +54,7 @@ $attributes = [
     !empty($description) ? ' aria-describedby="' . ($id ?: $name) . '-desc"' : '',
     $disabled ? ' disabled' : '',
     $readonly ? ' readonly' : '',
-    strlen($hint) ? ' placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
+    \strlen($hint) ? ' placeholder="' . htmlspecialchars($hint, ENT_COMPAT, 'UTF-8') . '"' : '',
     !empty($autocomplete) ? 'autocomplete="' . $autocomplete . '"' : '',
     $autofocus ? ' autofocus' : '',
     $spellcheck ? '' : ' spellcheck="false"',

--- a/layouts/joomla/form/field/user.php
+++ b/layouts/joomla/form/field/user.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/form/renderfield.php
+++ b/layouts/joomla/form/renderfield.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 

--- a/layouts/joomla/form/renderlabel.php
+++ b/layouts/joomla/form/renderlabel.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/joomla/html/batch/access.php
+++ b/layouts/joomla/html/batch/access.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/html/batch/access.php
+++ b/layouts/joomla/html/batch/access.php
@@ -24,6 +24,6 @@ use Joomla\CMS\Language\Text;
         'class="form-select"',
         [
             'title' => Text::_('JLIB_HTML_BATCH_NOCHANGE'),
-            'id'    => 'batch-access'
+            'id'    => 'batch-access',
         ]
     );

--- a/layouts/joomla/html/batch/adminlanguage.php
+++ b/layouts/joomla/html/batch/adminlanguage.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;

--- a/layouts/joomla/html/batch/item.php
+++ b/layouts/joomla/html/batch/item.php
@@ -25,7 +25,7 @@ extract($displayData);
 // Create the copy/move options.
 $options = [
     HTMLHelper::_('select.option', 'c', Text::_('JLIB_HTML_BATCH_COPY')),
-    HTMLHelper::_('select.option', 'm', Text::_('JLIB_HTML_BATCH_MOVE'))
+    HTMLHelper::_('select.option', 'm', Text::_('JLIB_HTML_BATCH_MOVE')),
 ];
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */

--- a/layouts/joomla/html/batch/language.php
+++ b/layouts/joomla/html/batch/language.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/html/batch/tag.php
+++ b/layouts/joomla/html/batch/tag.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/html/batch/user.php
+++ b/layouts/joomla/html/batch/user.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/html/batch/workflowstage.php
+++ b/layouts/joomla/html/batch/workflowstage.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/html/batch/workflowstage.php
+++ b/layouts/joomla/html/batch/workflowstage.php
@@ -25,8 +25,8 @@ $attr = [
     'group.label' => 'text',
     'group.items' => null,
     'list.attr' => [
-        'class' => 'form-select'
-    ]
+        'class' => 'form-select',
+    ],
 ];
 
 $groups = HTMLHelper::_('workflowstage.existing', ['title' => Text::_('JLIB_HTML_BATCH_WORKFLOW_STAGE_NOCHANGE')]);

--- a/layouts/joomla/html/image.php
+++ b/layouts/joomla/html/image.php
@@ -15,7 +15,7 @@
  *                             Eg: src, class, alt, width, height, loading, decoding, style, data-*
  *                             Note: only the alt and src attributes are escaped by default!
  */
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\Utilities\ArrayHelper;

--- a/layouts/joomla/html/treeprefix.php
+++ b/layouts/joomla/html/treeprefix.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\Utilities\ArrayHelper;
 

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -55,7 +55,7 @@ $icon = trim(implode(' ', [$iconPrefix . $icon, $iconFixed, $iconSuffix]));
 if ($html !== false) {
     $iconAttribs = [
         'class'       => $icon,
-        'aria-hidden' => "true"
+        'aria-hidden' => "true",
     ];
 
     if ($tabindex) {

--- a/layouts/joomla/installer/changelog.php
+++ b/layouts/joomla/installer/changelog.php
@@ -10,7 +10,7 @@
 
 use Joomla\CMS\Language\Text;
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 array_walk(
     $displayData,

--- a/layouts/joomla/links/groupclose.php
+++ b/layouts/joomla/links/groupclose.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 ?>
 </ul>

--- a/layouts/joomla/links/groupopen.php
+++ b/layouts/joomla/links/groupopen.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\Filter\OutputFilter;

--- a/layouts/joomla/links/groupsclose.php
+++ b/layouts/joomla/links/groupsclose.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 ?>
 </div>

--- a/layouts/joomla/links/groupseparator.php
+++ b/layouts/joomla/links/groupseparator.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 ?>
 <div class="j-links-separator"></div>

--- a/layouts/joomla/links/groupsopen.php
+++ b/layouts/joomla/links/groupsopen.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 ?>
 <div class="j-links-groups">

--- a/layouts/joomla/links/link.php
+++ b/layouts/joomla/links/link.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\Filter\OutputFilter;
 

--- a/layouts/joomla/pagination/link.php
+++ b/layouts/joomla/pagination/link.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/pagination/links.php
+++ b/layouts/joomla/pagination/links.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -62,7 +62,7 @@ if ($currentPage >= $step) {
                     <?php echo LayoutHelper::render('joomla.pagination.link', $pages['previous']); ?>
                     <?php foreach ($pages['pages'] as $k => $page) : ?>
                         <?php $output = LayoutHelper::render('joomla.pagination.link', $page); ?>
-                        <?php if (in_array($k, range($range * $step - ($step + 1), $range * $step), true)) : ?>
+                        <?php if (\in_array($k, range($range * $step - ($step + 1), $range * $step), true)) : ?>
                             <?php if (($k % $step === 0 || $k === $range * $step - ($step + 1)) && $k !== $currentPage && $k !== $range * $step - $step) : ?>
                                 <?php $output = preg_replace('#(<a.*?>).*?(</a>)#', '$1...$2', $output); ?>
                             <?php endif; ?>

--- a/layouts/joomla/pagination/list.php
+++ b/layouts/joomla/pagination/list.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/quickicons/icon.php
+++ b/layouts/joomla/quickicons/icon.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/searchtools/default.php
+++ b/layouts/joomla/searchtools/default.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -42,7 +42,7 @@ if (isset($data['view']->filterForm) && !empty($data['view']->filterForm)) {
 
     // Checks if the filters button should exist.
     $filters = $data['view']->filterForm->getGroup('filter');
-    $showFilterButton = isset($filters['filter_search']) && count($filters) === 1 ? false : true;
+    $showFilterButton = isset($filters['filter_search']) && \count($filters) === 1 ? false : true;
 
     // Checks if it should show the be hidden.
     $hideActiveFilters = empty($data['view']->activeFilters);

--- a/layouts/joomla/searchtools/default/bar.php
+++ b/layouts/joomla/searchtools/default/bar.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\Registry\Registry;
@@ -18,7 +18,7 @@ $data = $displayData;
 // Receive overridable options
 $data['options'] = !empty($data['options']) ? $data['options'] : [];
 
-if (is_array($data['options'])) {
+if (\is_array($data['options'])) {
     $data['options'] = new Registry($data['options']);
 }
 

--- a/layouts/joomla/searchtools/default/filters.php
+++ b/layouts/joomla/searchtools/default/filters.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Form\FormHelper;

--- a/layouts/joomla/searchtools/default/list.php
+++ b/layouts/joomla/searchtools/default/list.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 $data = $displayData;
 

--- a/layouts/joomla/searchtools/default/noitems.php
+++ b/layouts/joomla/searchtools/default/noitems.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/searchtools/default/selector.php
+++ b/layouts/joomla/searchtools/default/selector.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 $data = $displayData;
 ?>

--- a/layouts/joomla/searchtools/grid/sort.php
+++ b/layouts/joomla/searchtools/grid/sort.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/sidebars/submenu.php
+++ b/layouts/joomla/sidebars/submenu.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\Filter\OutputFilter;

--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -27,7 +27,7 @@ $alert     = [
     CMSApplication::MSG_NOTICE    => 'info',
     CMSApplication::MSG_INFO      => 'info',
     CMSApplication::MSG_DEBUG     => 'info',
-    'message'                     => 'success'
+    'message'                     => 'success',
 ];
 
 // Load JavaScript message titles

--- a/layouts/joomla/system/message.php
+++ b/layouts/joomla/system/message.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Application\CMSApplication;
 use Joomla\CMS\Factory;
@@ -46,7 +46,7 @@ $document->getWebAssetManager()
     ->useStyle('webcomponent.joomla-alert')
     ->useScript('messages');
 
-if (is_array($msgList) && !empty($msgList)) {
+if (\is_array($msgList) && !empty($msgList)) {
     $messages = [];
 
     foreach ($msgList as $type => $msgs) {

--- a/layouts/joomla/tinymce/textarea.php
+++ b/layouts/joomla/tinymce/textarea.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 

--- a/layouts/joomla/tinymce/togglebutton.php
+++ b/layouts/joomla/tinymce/togglebutton.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/toolbar/base.php
+++ b/layouts/joomla/toolbar/base.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData, EXTR_OVERWRITE);
 

--- a/layouts/joomla/toolbar/basic.php
+++ b/layouts/joomla/toolbar/basic.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/toolbar/batch.php
+++ b/layouts/joomla/toolbar/batch.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/joomla/toolbar/containerclose.php
+++ b/layouts/joomla/toolbar/containerclose.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 ?>
 </div>

--- a/layouts/joomla/toolbar/containeropen.php
+++ b/layouts/joomla/toolbar/containeropen.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/toolbar/dropdown.php
+++ b/layouts/joomla/toolbar/dropdown.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/toolbar/iconclass.php
+++ b/layouts/joomla/toolbar/iconclass.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 

--- a/layouts/joomla/toolbar/inlinehelp.php
+++ b/layouts/joomla/toolbar/inlinehelp.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Layout\LayoutHelper;

--- a/layouts/joomla/toolbar/link.php
+++ b/layouts/joomla/toolbar/link.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData, EXTR_OVERWRITE);
 

--- a/layouts/joomla/toolbar/popup.php
+++ b/layouts/joomla/toolbar/popup.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\Utilities\ArrayHelper;

--- a/layouts/joomla/toolbar/separator.php
+++ b/layouts/joomla/toolbar/separator.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData, EXTR_OVERWRITE);
 

--- a/layouts/joomla/toolbar/standard.php
+++ b/layouts/joomla/toolbar/standard.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;

--- a/layouts/joomla/toolbar/title.php
+++ b/layouts/joomla/toolbar/title.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 

--- a/layouts/joomla/toolbar/versions.php
+++ b/layouts/joomla/toolbar/versions.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Session\Session;

--- a/layouts/libraries/html/bootstrap/modal/body.php
+++ b/layouts/libraries/html/bootstrap/modal/body.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/libraries/html/bootstrap/modal/footer.php
+++ b/layouts/libraries/html/bootstrap/modal/footer.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/libraries/html/bootstrap/modal/header.php
+++ b/layouts/libraries/html/bootstrap/modal/header.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 

--- a/layouts/libraries/html/bootstrap/modal/iframe.php
+++ b/layouts/libraries/html/bootstrap/modal/iframe.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\Utilities\ArrayHelper;
 

--- a/layouts/libraries/html/bootstrap/modal/iframe.php
+++ b/layouts/libraries/html/bootstrap/modal/iframe.php
@@ -34,7 +34,7 @@ extract($displayData);
 
 $iframeAttributes = [
     'class' => 'iframe',
-    'src'   => $params['url']
+    'src'   => $params['url'],
 ];
 
 if (isset($params['title'])) {

--- a/layouts/libraries/html/bootstrap/modal/main.php
+++ b/layouts/libraries/html/bootstrap/modal/main.php
@@ -55,7 +55,7 @@ if (!empty($params['modalCss'])) {
 
 $modalAttributes = [
     'tabindex' => '-1',
-    'class'    => 'joomla-modal ' . implode(' ', $modalClasses)
+    'class'    => 'joomla-modal ' . implode(' ', $modalClasses),
 ];
 
 if (isset($params['backdrop'])) {

--- a/layouts/libraries/html/bootstrap/modal/main.php
+++ b/layouts/libraries/html/bootstrap/modal/main.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\Utilities\ArrayHelper;
@@ -59,11 +59,11 @@ $modalAttributes = [
 ];
 
 if (isset($params['backdrop'])) {
-    $modalAttributes['data-bs-backdrop'] = (is_bool($params['backdrop']) ? ($params['backdrop'] ? 'true' : 'false') : $params['backdrop']);
+    $modalAttributes['data-bs-backdrop'] = (\is_bool($params['backdrop']) ? ($params['backdrop'] ? 'true' : 'false') : $params['backdrop']);
 }
 
 if (isset($params['keyboard'])) {
-    $modalAttributes['data-bs-keyboard'] = (is_bool($params['keyboard']) ? ($params['keyboard'] ? 'true' : 'false') : 'true');
+    $modalAttributes['data-bs-keyboard'] = (\is_bool($params['keyboard']) ? ($params['keyboard'] ? 'true' : 'false') : 'true');
 }
 
 if (isset($params['url'])) {

--- a/layouts/libraries/html/bootstrap/tab/addtab.php
+++ b/layouts/libraries/html/bootstrap/tab/addtab.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 $id       = empty($displayData['id']) ? '' : $displayData['id'];
 $active   = empty($displayData['active']) ? '' : $displayData['active'];

--- a/layouts/libraries/html/bootstrap/tab/endtab.php
+++ b/layouts/libraries/html/bootstrap/tab/endtab.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 ?>
 

--- a/layouts/libraries/html/bootstrap/tab/endtabset.php
+++ b/layouts/libraries/html/bootstrap/tab/endtabset.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 ?>
 

--- a/layouts/libraries/html/bootstrap/tab/starttabset.php
+++ b/layouts/libraries/html/bootstrap/tab/starttabset.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 $selector = empty($displayData['selector']) ? '' : $displayData['selector'];
 ?>

--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Document\HtmlDocument;
 use Joomla\CMS\Factory;

--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder/setaccess.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder/setaccess.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/plugins/editors/tinymce/field/tinymcebuilder/setoptions.php
+++ b/layouts/plugins/editors/tinymce/field/tinymcebuilder/setoptions.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/plugins/system/privacyconsent/label.php
+++ b/layouts/plugins/system/privacyconsent/label.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/plugins/system/privacyconsent/message.php
+++ b/layouts/plugins/system/privacyconsent/message.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/plugins/system/webauthn/manage.php
+++ b/layouts/plugins/system/webauthn/manage.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
@@ -62,7 +62,7 @@ if ($displayData['allow_add'] === false) {
 }
 
 // Ensure the GMP or BCmath extension is loaded in PHP - as this is required by third party library
-if ($allow_add && function_exists('gmp_intval') === false && function_exists('bccomp') === false) {
+if ($allow_add && \function_exists('gmp_intval') === false && \function_exists('bccomp') === false) {
     $error = Text::_('PLG_SYSTEM_WEBAUTHN_REQUIRES_GMP');
     $allow_add = false;
 }
@@ -73,7 +73,7 @@ HTMLHelper::_('bootstrap.tooltip', '.plg_system_webauth-has-tooltip');
 ?>
 <div class="plg_system_webauthn" id="plg_system_webauthn-management-interface">
     <?php
-    if (is_string($error) && !empty($error)) : ?>
+    if (\is_string($error) && !empty($error)) : ?>
         <div class="alert alert-danger">
             <?php echo htmlentities($error) ?>
         </div>

--- a/layouts/plugins/user/terms/label.php
+++ b/layouts/plugins/user/terms/label.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;

--- a/layouts/plugins/user/terms/message.php
+++ b/layouts/plugins/user/terms/message.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 extract($displayData);
 

--- a/layouts/plugins/user/token/token.php
+++ b/layouts/plugins/user/token/token.php
@@ -8,7 +8,7 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-defined('_JEXEC') or die;
+\defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;


### PR DESCRIPTION
various files are excluded from the automated checks
    // Ignore template files as PHP CS fixer can't handle them properly
    // https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues/3702#issuecomment-396717120

### Summary of Changes
This is a semi-manual review of the site modules to apply
- trailing_comma_in_multiline
- native_function_invocation


### Testing Instructions
code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
