### PR TITLE
[5.1] PHP Deprecated:  PDO::quote(): Passing null

### DIFF
--- a/libraries/src/Table/Extension.php
+++ b/libraries/src/Table/Extension.php
@@ -107,6 +107,7 @@ class Extension extends Table
         $query = $this->_db->getQuery(true);
 
         foreach ($options as $col => $val) {
+            if ($val === null) continue;
             $query->where($col . ' = ' . $this->_db->quote($val));
         }
 

--- a/libraries/src/Table/Extension.php
+++ b/libraries/src/Table/Extension.php
@@ -107,7 +107,6 @@ class Extension extends Table
         $query = $this->_db->getQuery(true);
 
         foreach ($options as $col => $val) {
-            if ($val === null) continue;
             $query->where($col . ' = ' . $this->_db->quote($val));
         }
 

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -315,7 +315,7 @@ class Updater extends Adapter
                                 'element'   => $current_update->get('element'),
                                 'type'      => $current_update->get('type'),
                                 'client_id' => $current_update->get('client_id'),
-                                'folder'    => $current_update->get('folder'),
+                                'folder'    => $current_update->get('folder', ''),
                             ]
                         );
 

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -305,7 +305,7 @@ class Updater extends Adapter
                                 'element'   => $current_update->get('element'),
                                 'type'      => $current_update->get('type'),
                                 'client_id' => $current_update->get('client_id'),
-                                'folder'    => $current_update->get('folder'),
+                                'folder'    => $current_update->get('folder', ''),
                             ]
                         );
 


### PR DESCRIPTION
Pull Request for Issue 
PHP Deprecated:  PDO::quote(): Passing null
noted while updating from cli

### Summary of Changes
the field folder of #__extensions table is not nullable 

### Testing Instructions
Database Mysql(PDO), Postgresql (PDO)
set error reporting to maximum
go to  Joomla Update and check for update
or
from cli run
`php cli\joomla.php update:extensions:check`
and or
`php cli\joomla.php core:check-updates`


### Actual result BEFORE applying this Pull Request

in the log 
![image](https://github.com/joomla/joomla-cms/assets/181681/efb98d58-15c2-4339-8f96-87261b766215)

from cli

![image](https://github.com/joomla/joomla-cms/assets/181681/436023f9-d398-40fb-b7da-cda658799d79)


### Expected result AFTER applying this Pull Request

no more deprecation

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
