### PR TITLE
[5.2] Deprecate WebApplication::$JComponentTitle

### DIFF
--- a/administrator/modules/mod_title/src/Dispatcher/Dispatcher.php
+++ b/administrator/modules/mod_title/src/Dispatcher/Dispatcher.php
@@ -35,6 +35,7 @@ class Dispatcher extends AbstractModuleDispatcher
         $data = parent::getLayoutData();
 
         // Get the component title div
+        // @deprecated 5.2.0 will be removed in 7.0 as this property is not used anymore see WebApplication
         if (isset($this->getApplication()->JComponentTitle)) {
             $data['title'] = $this->getApplication()->JComponentTitle;
         }

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -49,6 +49,10 @@ abstract class WebApplication extends AbstractWebApplication
      *
      * @var    string
      * @since  4.3.0
+     *
+     * @deprecated 5.2.0 will be removed in 7.0
+     *             Use the Document getTitle() Method
+     *             Example: \Joomla\CMS\Factory::getApplication()->getDocument()->getTitle()
      */
     public $JComponentTitle;
 

--- a/libraries/src/Toolbar/ToolbarHelper.php
+++ b/libraries/src/Toolbar/ToolbarHelper.php
@@ -45,6 +45,7 @@ abstract class ToolbarHelper
         $html   = $layout->render(['title' => $title, 'icon' => $icon]);
 
         $app                  = Factory::getApplication();
+        // @deprecated 5.2.0 will be removed in 7.0 as this property is not used anymore see WebApplication
         $app->JComponentTitle = $html;
         $title                = strip_tags($title) . ' - ' . $app->get('sitename');
 


### PR DESCRIPTION
### Summary of Changes
Deprecate the legacy parameter $JComponentTitle from WebApplication. This should have been done when the variable has been created. Sadly it has been missed. 


### Testing Instructions
No test needed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [X] Pull Request link for manual.joomla.org: [<link>](https://github.com/joomla/Manual/pull/258)
- [ ] No documentation changes for manual.joomla.org needed
