### PR TITLE
[5.1] Fix comment syntax in update SQL scripts "5.1.0-2024-02-24.sql" for adding TUF

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/5.1.0-2024-02-24.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.1.0-2024-02-24.sql
@@ -24,7 +24,7 @@ SELECT ue.`update_site_id`,
   FROM `#__update_sites_extensions` AS ue JOIN `#__extensions` AS e ON (e.`extension_id` = ue.`extension_id`)
  WHERE e.`type`='file' AND e.`element`='joomla';
 
------------------------------------------------------------
+-- --------------------------------------------------------
 -- The following UPDATE statement has been modified to avoid an SQL error
 -- when there is more than 1 update site for the Joomla core.
 -- See https://github.com/joomla/joomla-cms/pull/42988 for details.

--- a/administrator/components/com_admin/sql/updates/postgresql/5.1.0-2024-02-24.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.1.0-2024-02-24.sql
@@ -26,7 +26,7 @@ SELECT ue."update_site_id",
   FROM "#__update_sites_extensions" AS ue JOIN "#__extensions" AS e ON (e."extension_id" = ue."extension_id")
  WHERE e."type"='file' AND e."element"='joomla';
 
------------------------------------------------------------
+-- --------------------------------------------------------
 -- The following UPDATE statement has been modified to avoid an SQL error
 -- when there is more than 1 update site for the Joomla core.
 -- See https://github.com/joomla/joomla-cms/pull/42988 for details.


### PR DESCRIPTION
Pull Request for Issue #43302 .

### Summary of Changes

This pull request (PR) fixes the syntax error in the SQL code comment in the update SQL scripts "5.1.0-2024-02-24.sql" mentioned in the referred issue.

Note that the SQL syntax error will never happen when updating Joomla to 5.1.x as the updater splits the SQL script into the single statements, stripping off any comments (also those with the syntax error), and runs these statements one by one. The error happens only if you copy the content of the script into an SQL client to run the statements "manually", e.g. when trying to fix an update which failed for other reasons.

### Testing Instructions

Code review.

Or if you want to do a real test: Depending on which database type you have available for testing (MySQL/MariaDB or Postgresql), copy the content of the update SQL script "5.1.0-2024-02-24.sql" into an SQL client, e.g. phpMyAdmin for MySQL/MariaDB or phpPgAdmin for PostgreSQL, replace the `#__` by your real table name prefix and run the SQL statement.
- With MySQL/MariaDB use script "administrator/components/com_admin/sql/updates/mysql/5.1.0-2024-02-24.sql".
- With PostgreSQL use script "administrator/components/com_admin/sql/updates/postgresql/5.1.0-2024-02-24.sql".

### Actual result BEFORE applying this Pull Request

See issue #43302 .

### Expected result AFTER applying this Pull Request

No SQL syntax error with that comment.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
