### PR TITLE
[5.1] DarkMode selector

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/5.1.1-2024-04-18.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.1.1-2024-04-18.sql
@@ -1,0 +1,10 @@
+--
+-- Add a default value for the colorScheme in the Atum tenmplate on Joomla update
+-- only when a value is not already set.
+-- New installs will have the default value set in the installation sql.
+--
+
+UPDATE `#__template_styles`
+SET `params` = JSON_SET(`params`, '$.colorScheme', 'os')
+WHERE `template` = 'atum'
+AND JSON_EXTRACT(`params`, '$.colorScheme') IS NULL;

--- a/administrator/components/com_admin/sql/updates/mysql/5.1.1-2024-04-18.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.1.1-2024-04-18.sql
@@ -1,5 +1,5 @@
 --
--- Add a default value for the colorScheme in the Atum tenmplate on Joomla update
+-- Add a default value for the colorScheme in the Atum template on Joomla update
 -- only when a value is not already set.
 -- New installs will have the default value set in the installation sql.
 --

--- a/administrator/components/com_admin/sql/updates/postgresql/5.1.1-2024-04-18.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.1.1-2024-04-18.sql
@@ -1,0 +1,10 @@
+--
+-- Add a default value for the colorScheme in the Atum tenmplate on Joomla update
+-- only when a value is not already set.
+-- New installs will have the default value set in the installation sql.
+--
+
+UPDATE "__template_styles"
+SET "params" = jsonb_set("params", '{colorScheme}', '"os"', true)
+WHERE "template" = 'atum'
+AND NOT ("params" -> 'colorScheme' ? 'os');

--- a/administrator/components/com_admin/sql/updates/postgresql/5.1.1-2024-04-18.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.1.1-2024-04-18.sql
@@ -7,4 +7,4 @@
 UPDATE "#__template_styles"
 SET "params" = jsonb_set("params"::jsonb, '{colorScheme}', '"os"', true)
 WHERE "template" = 'atum'
-AND NOT ("params" -> 'colorScheme' ? 'os');
+AND "params"::jsonb->>'colorScheme' IS NULL;

--- a/administrator/components/com_admin/sql/updates/postgresql/5.1.1-2024-04-18.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.1.1-2024-04-18.sql
@@ -4,7 +4,7 @@
 -- New installs will have the default value set in the installation sql.
 --
 
-UPDATE "__template_styles"
+UPDATE "#__template_styles"
 SET "params" = jsonb_set("params", '{colorScheme}', '"os"', true)
 WHERE "template" = 'atum'
 AND NOT ("params" -> 'colorScheme' ? 'os');

--- a/administrator/components/com_admin/sql/updates/postgresql/5.1.1-2024-04-18.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.1.1-2024-04-18.sql
@@ -5,6 +5,6 @@
 --
 
 UPDATE "#__template_styles"
-SET "params" = jsonb_set("params", '{colorScheme}', '"os"', true)
+SET "params" = jsonb_set("params"::jsonb, '{colorScheme}', '"os"', true)
 WHERE "template" = 'atum'
 AND NOT ("params" -> 'colorScheme' ? 'os');

--- a/administrator/components/com_admin/sql/updates/postgresql/5.1.1-2024-04-18.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.1.1-2024-04-18.sql
@@ -1,5 +1,5 @@
 --
--- Add a default value for the colorScheme in the Atum tenmplate on Joomla update
+-- Add a default value for the colorScheme in the Atum template on Joomla update
 -- only when a value is not already set.
 -- New installs will have the default value set in the installation sql.
 --


### PR DESCRIPTION
On updated versions of Joomla there is no value set for the colorscheme and the only way to enable the colorscheme switch is to op4en the atum template style and then save it.

This PR is (hopefully) sql that will run on the next patch release that will add a default value for the colorScheme so that the switch is always available. Note that if a user has already set a value then nothing is changed.

I dont have a current postgres server so am relying on others to test that carefuly.

Pull Request for Issue #43307 (part).

### Testing Instructions
Update an existing joomla site with the prebuilt package available here https://artifacts.joomla.org/drone/joomla/joomla-cms/5.1-dev/43310/downloads/75557/

### Expected result AFTER applying this Pull Request
If the switcher was NOT available in the  User dropdwn menu then it is now
If the switcher was already available in the  User dropdwn menu thenthere is no change

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
