### PR TITLE
[4.4.4] Update ExtensionAdapter.php due to PHP Warning

### DIFF
--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -107,7 +107,9 @@ class ExtensionAdapter extends UpdateAdapter
                 // Check that the product matches and that the version matches (optionally a regexp)
                 if (
                     $product == $this->currentUpdate->targetplatform['NAME']
-                    && preg_match('/^' . $this->currentUpdate->targetplatform['VERSION'] . '/', JVERSION)
+                    // PHP 8.2.17: Got error 'PHP message: PHP Warning: preg_match(): Compilation failed: missing closing parenthesis at offset 13 in /libraries/src/Updater/Adapter/ExtensionAdapter.php on line 110'
+                    // && preg_match('/^' . $this->currentUpdate->targetplatform['VERSION'] . '/', JVERSION)
+                    && preg_match('/^' . preg_quote($this->currentUpdate->targetplatform['VERSION']) . '/', JVERSION)
                 ) {
                     // Check if PHP version supported via <php_minimum> tag, assume true if tag isn't present
                     if (!isset($this->currentUpdate->php_minimum) || version_compare(PHP_VERSION, $this->currentUpdate->php_minimum, '>=')) {


### PR DESCRIPTION
Joomla v4.4.4
PHP v8.2.17

// **Got error 'PHP message: PHP Warning: preg_match(): Compilation failed: missing closing parenthesis at offset 13 in /libraries/src/Updater/Adapter/ExtensionAdapter.php on line 110'**

### Summary of Changes

Added [preg_quote](https://www.php.net/manual/en/function.preg-quote.php) to the regex pattern of the version check at line 110

### Testing Instructions

Don't know exactly which extension cause this issue, but it happens when the extension update check is triggered from the backend

### Actual result BEFORE applying this Pull Request

the above PHP warning occurs 

### Expected result AFTER applying this Pull Request

The warning is gone

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
