### PR TITLE
[5.1][bug] Media manager misbehaves on files with capitalized extensions

### DIFF
--- a/build/media_source/com_media/js/edit-images.es6.js
+++ b/build/media_source/com_media/js/edit-images.es6.js
@@ -172,7 +172,7 @@ class Edit {
    * Public
    */
   upload(url, stateChangeCallback) {
-    let format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
+    let format = Joomla.MediaManager.Edit.original.extension.toLowerCase() === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension.toLowerCase();
 
     if (!format) {
       // eslint-disable-next-line prefer-destructuring

--- a/build/media_source/plg_media-action_crop/js/crop.es6.js
+++ b/build/media_source/plg_media-action_crop/js/crop.es6.js
@@ -51,7 +51,7 @@ const init = (image) => {
       formElements.cropY.value = Math.round(e.detail.y);
       formElements.cropWidth.value = Math.round(e.detail.width);
       formElements.cropHeight.value = Math.round(e.detail.height);
-      const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
+      const format = Joomla.MediaManager.Edit.original.extension.toLowerCase() === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension.toLowerCase();
       const quality = formElements.cropQuality.value;
 
       // Update the store

--- a/build/media_source/plg_media-action_resize/js/resize.es6.js
+++ b/build/media_source/plg_media-action_resize/js/resize.es6.js
@@ -14,7 +14,7 @@ const resize = (width, height, image) => {
   canvas.getContext('2d').drawImage(image, 0, 0, width, height);
 
   // The format
-  const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension;
+  const format = Joomla.MediaManager.Edit.original.extension.toLowerCase() === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension.toLowerCase();
 
   // The quality
   const quality = formElements.resizeQuality.value;

--- a/build/media_source/plg_media-action_rotate/js/rotate.es6.js
+++ b/build/media_source/plg_media-action_rotate/js/rotate.es6.js
@@ -28,7 +28,7 @@ const rotate = (angle, image) => {
   ctx.drawImage(image, -image.naturalWidth / 2, -image.naturalHeight / 2);
 
   // The format
-  const format = Joomla.MediaManager.Edit.original.extension === 'jpg' ? 'jpeg' : 'jpg';
+  const format = Joomla.MediaManager.Edit.original.extension.toLowerCase() === 'jpg' ? 'jpeg' : Joomla.MediaManager.Edit.original.extension.toLowerCase();
 
   // The quality
   const quality = document.getElementById('jform_rotate_quality').value;

--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -240,6 +240,9 @@ class MediaHelper
             $executables = array_diff($executables, $allowedExecutables);
         }
 
+        // Ensure lowercase extension
+        $filetypes = array_map('strtolower', $filetypes);
+
         $check = array_intersect($filetypes, $executables);
 
         if (!empty($check)) {

--- a/plugins/filesystem/local/src/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/src/Adapter/LocalAdapter.php
@@ -821,7 +821,7 @@ class LocalAdapter implements AdapterInterface
         $helper = new MediaHelper();
 
         // @todo find a better way to check the input, by not writing the file to the disk
-        $tmpFile = Path::clean(\dirname($localPath) . '/' . uniqid() . '.' . File::getExt($name));
+        $tmpFile = Path::clean(\dirname($localPath) . '/' . uniqid() . '.' . strtolower(File::getExt($name)));
 
         if (!File::write($tmpFile, $mediaContent)) {
             throw new \Exception(Text::_('JLIB_MEDIA_ERROR_UPLOAD_INPUT'), 500);


### PR DESCRIPTION
Pull Request for Issue #43315 .

### Summary of Changes

- Fix the logic

### Testing Instructions
#### Note that you have to **copy** the file, Media Manager always normalizes extensions to lowercase!!!

- Copy a file with a capitalized extension
- Try to edit -> rotate -> save

### Actual result BEFORE applying this Pull Request

File is not saved

### Expected result AFTER applying this Pull Request

File is saved

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
