### PR TITLE
[4.4] Fix ordering for files in the template view

### DIFF
--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -443,7 +443,7 @@ class TemplateModel extends FormModel
         uksort($result, function ($a, $b) use ($result) {
             if (\is_string($a)) {
                 if (\is_string($b)) {
-                    return $a <=> $b;
+                    return strnatcmp($a, $b);
                 }
 
                 return -1;
@@ -453,7 +453,7 @@ class TemplateModel extends FormModel
                 return 1;
             }
 
-            return $result[$a]->name <=> $result[$b]->name;
+            return strnatcmp($result[$a]->name, $result[$b]->name);
         });
 
         return !empty($result) ? $result : ['.'];

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -409,43 +409,51 @@ class TemplateModel extends FormModel
     {
         $result = [];
 
+        $prefix = JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator' . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $this->template->element;
+        $mediaPrefix = JPATH_ROOT . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'administrator' . DIRECTORY_SEPARATOR . $this->template->element;
+
+        if ($this->template->client_id === 0) {
+            $prefix = JPATH_ROOT . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $this->template->element;
+            $mediaPrefix = JPATH_ROOT . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'site' . DIRECTORY_SEPARATOR . $this->template->element;
+        }
+
         $dirFiles = scandir($dir);
 
-        foreach ($dirFiles as $key => $value) {
-            if (!in_array($value, ['.', '..', 'node_modules'])) {
-                if (is_dir($dir . $value)) {
-                    $relativePath                                   = str_replace(JPATH_ROOT . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . ($this->template->client_id === 0 ? 'site' : 'administrator') . DIRECTORY_SEPARATOR . $this->template->element, '', $dir . $value);
-                    $relativePath                                   = str_replace(JPATH_ROOT . DIRECTORY_SEPARATOR . ($this->template->client_id === 0 ? '' : 'administrator' . DIRECTORY_SEPARATOR) . 'templates' . DIRECTORY_SEPARATOR . $this->template->element, '', $relativePath);
-                    $result[str_replace('\\', '//', $relativePath)] = $this->getDirectoryTree($dir . $value . '/');
-                } else {
-                    $ext           = pathinfo($dir . $value, PATHINFO_EXTENSION);
-                    $allowedFormat = $this->checkFormat($ext);
+        foreach ($dirFiles as $value) {
+            if (in_array($value, ['.', '..', 'node_modules'])) {
+                continue;
+            }
 
-                    if ($allowedFormat == true) {
-                        $relativePath = str_replace(JPATH_ROOT . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'templates'  . DIRECTORY_SEPARATOR . ($this->template->client_id === 0 ? 'site' : 'administrator') . DIRECTORY_SEPARATOR . $this->template->element, '', $dir . $value);
-                        $relativePath = str_replace(JPATH_ROOT . DIRECTORY_SEPARATOR . ($this->template->client_id === 0 ? '' : 'administrator' . DIRECTORY_SEPARATOR) . 'templates' . DIRECTORY_SEPARATOR . $this->template->element, '', $relativePath);
-                        $result[]     = $this->getFile($relativePath, $value);
-                    }
-                }
+            $relativePath = str_replace([$prefix, $mediaPrefix], '', $dir . $value);
+
+            if (is_dir($dir . $value)) {
+                $result[str_replace('\\', '//', $relativePath)] = $this->getDirectoryTree($dir . $value . '/');
+
+                continue;
+            }
+
+            $ext = pathinfo($dir . $value, PATHINFO_EXTENSION);
+
+            if ($this->checkFormat($ext)) {
+                $result[] = $this->getFile($relativePath, $value);
             }
         }
 
         // Sort directories first, then files alphabetically.
-        uasort($result, function ($a, $b) {
-            if (\is_array($a)) {
-                if (\is_array($b)) {
-                    return key($a) <=> key($b);
+        uksort($result, function ($a, $b) use ($result) {
+            if (\is_string($a)) {
+                if (\is_string($b)) {
+                    return $a <=> $b;
                 }
 
                 return -1;
             }
 
-            if (\is_array($b)) {
-
+            if (\is_string($b)) {
                 return 1;
             }
 
-            return $a->name <=> $b->name;
+            return $result[$a]->name <=> $result[$b]->name;
         });
 
         return !empty($result) ? $result : ['.'];

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -409,11 +409,11 @@ class TemplateModel extends FormModel
     {
         $result = [];
 
-        $prefix = JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator' . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $this->template->element;
+        $prefix      = JPATH_ROOT . DIRECTORY_SEPARATOR . 'administrator' . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $this->template->element;
         $mediaPrefix = JPATH_ROOT . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'administrator' . DIRECTORY_SEPARATOR . $this->template->element;
 
         if ($this->template->client_id === 0) {
-            $prefix = JPATH_ROOT . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $this->template->element;
+            $prefix      = JPATH_ROOT . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . $this->template->element;
             $mediaPrefix = JPATH_ROOT . DIRECTORY_SEPARATOR . 'media' . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'site' . DIRECTORY_SEPARATOR . $this->template->element;
         }
 

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -430,6 +430,24 @@ class TemplateModel extends FormModel
             }
         }
 
+        // Sort directories first, then files alphabetically.
+        uasort($result, function ($a, $b) {
+            if (\is_array($a)) {
+                if (\is_array($b)) {
+                    return key($a) <=> key($b);
+                }
+
+                return -1;
+            }
+
+            if (\is_array($b)) {
+
+                return 1;
+            }
+
+            return $a->name <=> $b->name;
+        });
+
         return !empty($result) ? $result : ['.'];
     }
 

--- a/administrator/components/com_templates/tmpl/template/default_tree.php
+++ b/administrator/components/com_templates/tmpl/template/default_tree.php
@@ -12,7 +12,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Router\Route;
 
-ksort($this->files, SORT_NATURAL);
 ?>
 
 <ul class="directory-tree treeselect">

--- a/administrator/components/com_templates/tmpl/template/default_tree_media.php
+++ b/administrator/components/com_templates/tmpl/template/default_tree_media.php
@@ -17,7 +17,6 @@ if (!count($this->mediaFiles)) {
     return;
 }
 
-ksort($this->mediaFiles, SORT_STRING);
 ?>
 
 <ul class="directory-tree treeselect">


### PR DESCRIPTION
Pull Request for Issue #40605 .

### Summary of Changes
Order is now using the right values for displaying directory structure for templates in the backend.
This could happen on posix filesystems because the natural order is the file creation and not the alphabetical order.

### Testing Instructions
Check if your directories and files are sorted in the corrected order


### Actual result BEFORE applying this Pull Request

The order was only for directories correct


### Expected result AFTER applying this Pull Request

Sorting happens in the model and not longer in the view for directories and files.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed

### Additional
![image](https://github.com/joomla/joomla-cms/assets/1497730/e8911496-e283-4159-83c5-fae55fc2c087)

