### PR TITLE
[6.0] $this: Cleanup of typehints for phpstan

### DIFF
--- a/administrator/components/com_actionlogs/tmpl/actionlogs/default.php
+++ b/administrator/components/com_actionlogs/tmpl/actionlogs/default.php
@@ -15,9 +15,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Actionlogs\Administrator\Helper\ActionlogsHelper;
-use Joomla\Component\Actionlogs\Administrator\View\Actionlogs\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Actionlogs\Administrator\View\Actionlogs\HtmlView $this */
 
 $listOrder  = $this->escape($this->state->get('list.ordering'));
 $listDirn   = $this->escape($this->state->get('list.direction'));

--- a/administrator/components/com_associations/tmpl/association/edit.php
+++ b/administrator/components/com_associations/tmpl/association/edit.php
@@ -13,9 +13,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Associations\Administrator\View\Association\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Associations\Administrator\View\Association\HtmlView $this */
 
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();

--- a/administrator/components/com_guidedtours/tmpl/steps/default.php
+++ b/administrator/components/com_guidedtours/tmpl/steps/default.php
@@ -17,9 +17,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\Component\Guidedtours\Administrator\Extension\GuidedtoursComponent;
-use Joomla\Component\Guidedtours\Administrator\View\Steps\HtmlView;
 
-/** @var  HtmlView  $this */
+/** @var  \Joomla\Component\Guidedtours\Administrator\View\Steps\HtmlView  $this */
 
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();

--- a/administrator/components/com_guidedtours/tmpl/tours/default.php
+++ b/administrator/components/com_guidedtours/tmpl/tours/default.php
@@ -18,9 +18,8 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
-use Joomla\Component\Guidedtours\Administrator\View\Tours\HtmlView;
 
-/** @var  HtmlView  $this */
+/** @var  \Joomla\Component\Guidedtours\Administrator\View\Tours\HtmlView  $this */
 
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();

--- a/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
+++ b/administrator/components/com_joomlaupdate/tmpl/joomlaupdate/preupdatecheck.php
@@ -16,9 +16,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\CMS\Version;
-use Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView $this */
 
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();

--- a/administrator/components/com_joomlaupdate/tmpl/upload/default.php
+++ b/administrator/components/com_joomlaupdate/tmpl/upload/default.php
@@ -14,9 +14,8 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Updater\Update;
 use Joomla\CMS\Utility\Utility;
-use Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Joomlaupdate\Administrator\View\Joomlaupdate\HtmlView $this */
 
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();

--- a/administrator/components/com_scheduler/tmpl/select/default.php
+++ b/administrator/components/com_scheduler/tmpl/select/default.php
@@ -16,9 +16,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Scheduler\Administrator\View\Select\HtmlView;
 
-/** @var  HtmlView  $this */
+/** @var \Joomla\Component\Scheduler\Administrator\View\Select\HtmlView $this */
 
 $app = $this->app;
 

--- a/administrator/components/com_scheduler/tmpl/task/edit.php
+++ b/administrator/components/com_scheduler/tmpl/task/edit.php
@@ -17,9 +17,8 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Scheduler\Administrator\Task\TaskOption;
-use Joomla\Component\Scheduler\Administrator\View\Task\HtmlView;
 
-/** @var  HtmlView $this */
+/** @var \Joomla\Component\Scheduler\Administrator\View\Task\HtmlView $this */
 
 $wa = $this->getDocument()->getWebAssetManager();
 

--- a/administrator/components/com_scheduler/tmpl/tasks/default.php
+++ b/administrator/components/com_scheduler/tmpl/tasks/default.php
@@ -19,9 +19,8 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\Component\Scheduler\Administrator\Task\Status;
-use Joomla\Component\Scheduler\Administrator\View\Tasks\HtmlView;
 
-/** @var  HtmlView  $this*/
+/** @var  \Joomla\Component\Scheduler\Administrator\View\Tasks\HtmlView  $this*/
 
 /** @var \Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();

--- a/administrator/components/com_users/tmpl/captive/select.php
+++ b/administrator/components/com_users/tmpl/captive/select.php
@@ -14,9 +14,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Component\Users\Administrator\View\Captive\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Users\Administrator\View\Captive\HtmlView $this */
 
 $shownMethods = [];
 

--- a/administrator/components/com_users/tmpl/method/backupcodes.php
+++ b/administrator/components/com_users/tmpl/method/backupcodes.php
@@ -15,9 +15,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Users\Administrator\View\Method\HtmlView;
 
-/** @var  HtmlView $this */
+/** @var  \Joomla\Component\Users\Administrator\View\Method\HtmlView $this */
 
 HTMLHelper::_('bootstrap.tooltip', '.hasTooltip');
 

--- a/administrator/components/com_users/tmpl/method/edit.php
+++ b/administrator/components/com_users/tmpl/method/edit.php
@@ -14,10 +14,9 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Users\Administrator\View\Method\HtmlView;
 use Joomla\Utilities\ArrayHelper;
 
-/** @var  HtmlView  $this */
+/** @var  \Joomla\Component\Users\Administrator\View\Method\HtmlView  $this */
 
 $cancelURL = Route::_('index.php?option=com_users&task=methods.display&user_id=' . $this->user->id);
 

--- a/administrator/components/com_users/tmpl/methods/default.php
+++ b/administrator/components/com_users/tmpl/methods/default.php
@@ -14,9 +14,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Users\Administrator\View\Methods\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Users\Administrator\View\Methods\HtmlView $this */
 ?>
 <div id="com-users-methods-list">
     <div id="com-users-methods-reset-container" class="d-flex align-items-center border border-1 rounded-3 p-2">

--- a/administrator/components/com_users/tmpl/methods/firsttime.php
+++ b/administrator/components/com_users/tmpl/methods/firsttime.php
@@ -14,9 +14,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Users\Administrator\View\Methods\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Users\Administrator\View\Methods\HtmlView $this */
 
 $headingLevel = 2;
 ?>

--- a/administrator/components/com_users/tmpl/methods/list.php
+++ b/administrator/components/com_users/tmpl/methods/list.php
@@ -18,9 +18,8 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Users\Administrator\Helper\Mfa as MfaHelper;
 use Joomla\Component\Users\Administrator\Model\MethodsModel;
-use Joomla\Component\Users\Administrator\View\Methods\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Users\Administrator\View\Methods\HtmlView $this */
 
 HTMLHelper::_('bootstrap.tooltip', '.hasTooltip');
 

--- a/administrator/components/com_users/tmpl/user/edit_groups.php
+++ b/administrator/components/com_users/tmpl/user/edit_groups.php
@@ -11,8 +11,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\HTML\HTMLHelper;
-use Joomla\Component\Users\Administrator\View\User\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Users\Administrator\View\User\HtmlView $this */
 
 echo HTMLHelper::_('access.usergroups', 'jform[groups]', $this->groups, true);

--- a/components/com_users/tmpl/captive/select.php
+++ b/components/com_users/tmpl/captive/select.php
@@ -14,9 +14,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Component\Users\Site\View\Captive\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Users\Site\View\Captive\HtmlView $this */
 
 $shownMethods = [];
 

--- a/components/com_users/tmpl/method/backupcodes.php
+++ b/components/com_users/tmpl/method/backupcodes.php
@@ -15,9 +15,8 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Users\Site\View\Method\HtmlView;
 
-/** @var  HtmlView $this */
+/** @var \Joomla\Component\Users\Site\View\Method\HtmlView $this */
 
 HTMLHelper::_('bootstrap.tooltip', '.hasTooltip');
 

--- a/components/com_users/tmpl/method/edit.php
+++ b/components/com_users/tmpl/method/edit.php
@@ -14,10 +14,9 @@ defined('_JEXEC') or die;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Users\Site\View\Method\HtmlView;
 use Joomla\Utilities\ArrayHelper;
 
-/** @var  HtmlView  $this */
+/** @var \Joomla\Component\Users\Site\View\Method\HtmlView $this */
 
 $cancelURL = Route::_('index.php?option=com_users&task=methods.display&user_id=' . $this->user->id);
 

--- a/components/com_users/tmpl/methods/default.php
+++ b/components/com_users/tmpl/methods/default.php
@@ -14,9 +14,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Users\Site\View\Methods\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Users\Site\View\Methods\HtmlView $this */
 ?>
 <div id="com-users-methods-list">
     <?php if (!$this->get('forHMVC', false)) : ?>

--- a/components/com_users/tmpl/methods/firsttime.php
+++ b/components/com_users/tmpl/methods/firsttime.php
@@ -14,9 +14,8 @@ defined('_JEXEC') or die;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Component\Users\Site\View\Methods\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Users\Site\View\Methods\HtmlView $this */
 
 $headingLevel = 2;
 ?>

--- a/components/com_users/tmpl/methods/list.php
+++ b/components/com_users/tmpl/methods/list.php
@@ -17,12 +17,10 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Users\Administrator\Helper\Mfa as MfaHelper;
-use Joomla\Component\Users\Site\Model\MethodsModel;
-use Joomla\Component\Users\Site\View\Methods\HtmlView;
 
-/** @var HtmlView $this */
+/** @var \Joomla\Component\Users\Site\View\Methods\HtmlView $this */
 
-/** @var MethodsModel $model */
+/** @var \Joomla\Component\Users\Site\Model\MethodsModel $model */
 $model = $this->getModel();
 
 $this->getDocument()->getWebAssetManager()->useScript('com_users.two-factor-list');

--- a/plugins/content/pagebreak/tmpl/navigation.php
+++ b/plugins/content/pagebreak/tmpl/navigation.php
@@ -12,12 +12,11 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
-use Joomla\Plugin\Content\PageBreak\Extension\PageBreak;
 
 /**
- * @var PageBreak  $this
- * @var array      $links  Array with keys 'previous' and 'next' with non-SEO links to the previous and next pages
- * @var integer    $page   The page number
+ * @var \Joomla\Plugin\Content\PageBreak\Extension\PageBreak  $this
+ * @var array                                                 $links  Array with keys 'previous' and 'next' with non-SEO links to the previous and next pages
+ * @var integer                                               $page   The page number
  */
 
 $lang = $this->getApplication()->getLanguage();

--- a/plugins/editors/codemirror/layouts/editors/codemirror/codemirror.php
+++ b/plugins/editors/codemirror/layouts/editors/codemirror/codemirror.php
@@ -13,7 +13,6 @@ defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
-use Joomla\CMS\Layout\FileLayout;
 use Joomla\Registry\Registry;
 
 extract($displayData);
@@ -21,15 +20,15 @@ extract($displayData);
 /**
  * Layout variables
  *
- * @var   FileLayout $this
- * @var   object     $options     JS options for editor
- * @var   Registry   $params      Plugin parameters
- * @var   string     $id          The id of the input
- * @var   string     $name        The name of the input
- * @var   integer    $cols        Textarea cols attribute
- * @var   integer    $rows        Textarea rows attribute
- * @var   string     $content     The value
- * @var   string     $buttons     Editor XTD buttons
+ * @var   \Joomla\CMS\Layout\FileLayout $this
+ * @var   object                        $options     JS options for editor
+ * @var   Registry                      $params      Plugin parameters
+ * @var   string                        $id          The id of the input
+ * @var   string                        $name        The name of the input
+ * @var   integer                       $cols        Textarea cols attribute
+ * @var   integer                       $rows        Textarea rows attribute
+ * @var   string                        $content     The value
+ * @var   string                        $buttons     Editor XTD buttons
  */
 
 $option  = ' options="' . $this->escape(json_encode($options)) . '"';


### PR DESCRIPTION
### Summary of Changes
When typehinting $this in our layouts, we use both the full qualified name and a shortened version with an import. phpstan unfortunately does not currently understand the version with the import and thus this unifies this to the long version.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed