### PR TITLE
[5.1] insert media front end

### DIFF
--- a/plugins/editors-xtd/image/src/Extension/Image.php
+++ b/plugins/editors-xtd/image/src/Extension/Image.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Editor\Button\Button;
 use Joomla\CMS\Event\Editor\EditorButtonsSetupEvent;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
+use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -185,6 +186,9 @@ final class Image extends CMSPlugin
             Text::script('JFIELD_MEDIA_DOWNLOAD_FILE');
 
             $link = 'index.php?option=com_media&view=media&tmpl=component&e_name=' . $name . '&asset=' . $asset . '&mediatypes=0,1,2,3' . '&author=' . $author;
+
+            // Correctly route the url to ensure it's correctly using sef modes and subfolders
+            $link = Route::_($link);
 
             return new Button(
                 $this->_name,


### PR DESCRIPTION


Pull Request for Issue ##43344 .

### Summary of Changes
After #42288 edixtor-xtd links to com_media do not work correctly for submenu items.

Correctly route the url to ensure it's correctly using sef modes and subfolders

### Testing Instructions
Edit an article on the front of your site with sef enabled AND with an article that is linked from a submenu. Using the editor-xtd button/link open the media manager to insert an image


### Actual result BEFORE applying this Pull Request
404


### Expected result AFTER applying this Pull Request
works as expected


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
