### PR TITLE
InputFilter fails on cleaning string with HEX entities as string

### DIFF
--- a/libraries/src/Filter/InputFilter.php
+++ b/libraries/src/Filter/InputFilter.php
@@ -454,7 +454,7 @@ class InputFilter extends BaseInputFilter
         $source = preg_replace_callback(
             '/&#x([a-f0-9]+);/mi',
             function ($m) {
-                return mb_convert_encoding(\chr('0x' . $m[1]), 'UTF-8', 'ISO-8859-1');
+                return mb_convert_encoding(\chr(\hexdec($m[1])), 'UTF-8', 'ISO-8859-1');
             },
             $source
         );


### PR DESCRIPTION
### Summary of Changes

`InputFilter::clean($string, 'string')`  fails when decoding the entities with HEX numbers

### Testing Instructions

Execute the code:
```php
$filter = \Joomla\CMS\Filter\InputFilter::getInstance();
var_dump($filter->clean('&#xff;', 'string'));
die;
```

### Actual result BEFORE applying this Pull Request

See error `chr(): Argument #1 ($codepoint) must be of type int, string given`

### Expected result AFTER applying this Pull Request

No errors.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
