### PR TITLE
[6.2] Smart Search: Allow to parse different formats

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Parser.php
+++ b/administrator/components/com_finder/src/Indexer/Parser.php
@@ -79,15 +79,15 @@ abstract class Parser
      */
     public function parse($input)
     {
-        // If the input is less than 2KB we can parse it in one go.
-        if (\strlen($input) <= 2048) {
+        // If the input is less than 32KB we can parse it in one go.
+        if (\strlen($input) <= 32768) {
             return $this->process($input);
         }
 
-        // Input is longer than 2Kb so parse it in chunks of 2Kb or less.
+        // Input is longer than 32Kb so parse it in chunks of 2Kb or less.
         $start  = 0;
         $end    = \strlen($input);
-        $chunk  = 2048;
+        $chunk  = 32768;
         $return = null;
 
         while ($start < $end) {

--- a/administrator/components/com_finder/src/Indexer/Result.php
+++ b/administrator/components/com_finder/src/Indexer/Result.php
@@ -53,6 +53,15 @@ class Result implements \Serializable
     ];
 
     /**
+     * Associative array with keys of properties and the format in which to
+     * parse them to add to the index
+     *
+     * @var    string[]
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $formats = [];
+
+    /**
      * The indexer will use this data to create taxonomy mapping entries for
      * the item so that it can be filtered by type, label, category,
      * or whatever.
@@ -317,6 +326,18 @@ class Result implements \Serializable
     }
 
     /**
+     * Method to get the formats for all properties.
+     *
+     * @return  array  An array of properties with their formats.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getPropertyFormats()
+    {
+        return $this->formats;
+    }
+
+    /**
      * Method to add a processing instruction for an item property.
      *
      * @param   string  $group     The group to associate the property with.
@@ -326,13 +347,16 @@ class Result implements \Serializable
      *
      * @since   2.5
      */
-    public function addInstruction($group, $property)
+    public function addInstruction($group, $property, $format = 'html')
     {
         // Check if the group exists. We can't add instructions for unknown groups.
         // Check if the property exists in the group.
         if (\array_key_exists($group, $this->instructions) && !\in_array($property, $this->instructions[$group], true)) {
             // Add the property to the group.
             $this->instructions[$group][] = $property;
+
+            // Add the format for the property.
+            $this->formats[$property] = $format;
         }
     }
 
@@ -356,6 +380,7 @@ class Result implements \Serializable
             // If the property was found, remove it.
             if ($key !== false) {
                 unset($this->instructions[$group][$key]);
+                unset($this->formats[$property]);
             }
         }
     }


### PR DESCRIPTION
### Summary of Changes
Smart Search has been donated at some point to the project by a commercial company, but I'm pretty sure that the commercial company wasn't the original developer of the system. There are things in the system which feel like it is the child of at least 2 completely different developers, which resulted in inconsistencies which partially haven't been solved even today. One of them is the support for different parsers for the content to index.

The indexer class supports a method parameter to select different parsers for the content, so that you could for example parse plain text, html, RTF documents or basically everything else you can think of. However, this parameter applies to all properties of a Result object, which is a problem when you have HTML content in a description for example and a PDF (or RTF) in another property. (Think about a document manager.)

This PR implements a new parameter to the `Result::addInstruction()` method to select a parser to read the property with. Right now this parameter supports `txt`, `html` and `rtf`, but additional parsers for example for PDF or docx are possible. (Especially for docx it should be considered if this has to be part of Joomla core. I would be happy with just PDF for now.) This PR also fixes an issue where the `memory_table_limit` seems to have been reverted to a wrong value during an upmerge and it raises the chunk size for reading data from 2KiB to 32KiB. While I would even question if 2KiB would have been the right value in 2012 when this was added to Joomla, going to 32KiB today is still playing this VERY safe. However, cutting it up into such small chunks also means that all the rest of the code is run more often than necessary, reducing performance.

The code is backwards compatible and when the `index()` method is called with a `$format` parameter, that parameter takes precedence over the set instructions, expecting this to be legacy code which would be unaware of this new feature.


### Testing Instructions
Please find attached a testing plugin for Smart Search, which adds one entry to the index and reads an RTF file into the system while doing so. You need to get your own RTF sample file. Extract the attached ZIP to your `/plugins/finder` folder and discover the plugin in the backend. Make sure that you have enabled the plugin. Edit `/plugins/finder/test/src/Extension/Test.php` and add your demo RTF file, which you want to index in line 141. It is trying to load the filepath from the root of the site. Then click `Index` in the Smart Search backend. Afterwards you can search for the content of the RTF in the frontend and should get an entry named `Test RTF` when it matches.
[test.zip](https://github.com/joomla/joomla-cms/files/15143530/test.zip)


Documentation will be added soon.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
