### PR TITLE
Fix System test com_privacy consent (#42523)

### DIFF
--- a/tests/System/integration/administrator/components/com_privacy/Consent.cy.js
+++ b/tests/System/integration/administrator/components/com_privacy/Consent.cy.js
@@ -201,6 +201,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.get('tbody > tr > :nth-child(4)').should('contain', 'test user');
     cy.get('table').find('tr').should('have.length', 4);
     cy.get('#list_fullordering').select('Status ascending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
     cy.get('tbody > :nth-child(1) > :nth-child(7)').should('contain', 'invalidated consent user');
     cy.get('tbody > :nth-child(2) > :nth-child(7)').should('contain', 'obsolete consent user');
     cy.get('tbody > :nth-child(3) > :nth-child(7)').should('contain', 'valid consent user');
@@ -218,6 +220,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.get('tbody > tr > :nth-child(4)').should('contain', 'test user');
     cy.get('table').find('tr').should('have.length', 4);
     cy.get('#list_fullordering').select('Status descending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
     cy.get('tbody > :nth-child(1) > :nth-child(7)').should('contain', 'valid consent user');
     cy.get('tbody > :nth-child(2) > :nth-child(7)').should('contain', 'obsolete consent user');
     cy.get('tbody > :nth-child(3) > :nth-child(7)').should('contain', 'invalidated consent user');
@@ -238,6 +242,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.visit('/administrator/index.php?option=com_privacy&view=consents');
     cy.get('table').find('tr').should('have.length', 4);
     cy.get('#list_fullordering').select('Username ascending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
     cy.get('tbody > :nth-child(1) > :nth-child(4)').should('contain', 'a test user');
     cy.get('tbody > :nth-child(2) > :nth-child(4)').should('contain', 'b test user');
     cy.get('tbody > :nth-child(3) > :nth-child(4)').should('contain', 'c test user');
@@ -258,6 +264,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.visit('/administrator/index.php?option=com_privacy&view=consents');
     cy.get('table').find('tr').should('have.length', 4);
     cy.get('#list_fullordering').select('Username descending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
     cy.get('tbody > :nth-child(1) > :nth-child(4)').should('contain', 'c test user');
     cy.get('tbody > :nth-child(2) > :nth-child(4)').should('contain', 'b test user');
     cy.get('tbody > :nth-child(3) > :nth-child(4)').should('contain', 'a test user');
@@ -278,6 +286,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.visit('/administrator/index.php?option=com_privacy&view=consents');
     cy.get('table').find('tr').should('have.length', 4);
     cy.get('#list_fullordering').select('Name descending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
     cy.get('tbody > :nth-child(1) > th').should('contain', 'c test user');
     cy.get('tbody > :nth-child(2) > th').should('contain', 'b test user');
     cy.get('tbody > :nth-child(3) > th').should('contain', 'a test user');
@@ -298,6 +308,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.visit('/administrator/index.php?option=com_privacy&view=consents');
     cy.get('table').find('tr').should('have.length', 4);
     cy.get('#list_fullordering').select('Name ascending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
     cy.get('tbody > :nth-child(1) > th').should('contain', 'a test user');
     cy.get('tbody > :nth-child(2) > th').should('contain', 'b test user');
     cy.get('tbody > :nth-child(3) > th').should('contain', 'c test user');
@@ -319,6 +331,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.get('table').find('tr').should('have.length', 4);
 
     cy.get('#list_fullordering').select('User ID ascending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
 
     const cellData = [];
 
@@ -360,6 +374,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.visit('/administrator/index.php?option=com_privacy&view=consents');
     cy.get('table').find('tr').should('have.length', 4);
     cy.get('#list_fullordering').select('User ID descending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
 
     const cellData = [];
 
@@ -394,6 +410,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.visit('/administrator/index.php?option=com_privacy&view=consents');
     cy.get('table').find('tr').should('have.length', 4);
     cy.get('#list_fullordering').select('Subject ascending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
     cy.get('tbody > :nth-child(1) > :nth-child(6)').should('contain', 'a test subject');
     cy.get('tbody > :nth-child(2) > :nth-child(6)').should('contain', 'b test subject');
     cy.get('tbody > :nth-child(3) > :nth-child(6)').should('contain', 'c test subject');
@@ -410,6 +428,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.visit('/administrator/index.php?option=com_privacy&view=consents');
     cy.get('table').find('tr').should('have.length', 4);
     cy.get('#list_fullordering').select('Subject descending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
     cy.get('tbody > :nth-child(1) > :nth-child(6)').should('contain', 'c test subject');
     cy.get('tbody > :nth-child(2) > :nth-child(6)').should('contain', 'b test subject');
     cy.get('tbody > :nth-child(3) > :nth-child(6)').should('contain', 'a test subject');
@@ -427,6 +447,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.get('table').find('tr').should('have.length', 4);
 
     cy.get('#list_fullordering').select('Consented descending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
 
     const cellData = [];
 
@@ -463,6 +485,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.get('table').find('tr').should('have.length', 4);
 
     cy.get('#list_fullordering').select('Consented ascending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
 
     const cellData = [];
 
@@ -500,6 +524,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.get('tbody > tr > :nth-child(4)').should('contain', 'test user');
     cy.get('table').find('tr').should('have.length', 4);
     cy.get('#list_fullordering').select('ID descending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
 
     const cellData = [];
 
@@ -537,6 +563,8 @@ describe('Test in backend that privacy consent component', () => {
     cy.get('table').find('tr').should('have.length', 4);
 
     cy.get('#list_fullordering').select('ID ascending');
+    // wait for the table to be updated with the new sort order
+    cy.wait(10);
     const cellData = [];
     for (let i = 1; i < 4; i += 1) {
       cy.get(`tbody > :nth-child(${i}) > :nth-child(9)`)


### PR DESCRIPTION
After discussion with Alikon the fix is simple 10 milliseconds waiting time after changing sorting order. The five failures were reproducable in 4.4-dev and fixed and it is expected it works the same way for 5.1.

Pull Request for Issue #42523.

### Summary of Changes
After selecting a new sorting order it is needed to wait for the POST request to be fullfilled.
This is simple possible by waiting 10 milliseconds. 1 millisecond was enough, but to be save,
10 milliseconds are used.


### Testing Instructions
In system test environment with Cypress test e.g. headless:
npm run cypress:run -- --spec tests/System/integration/administrator/components/com_privacy/Consent.cy.js
Please consider this is a racing condition. On drone the test were ?always? successful.
Therefore test first the failure, then patch and test success.

### Actual result BEFORE applying this Pull Request
5 of the 24 tests in the spec failed.



### Expected result AFTER applying this Pull Request
All 24 tests in the spec are successful.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
