### PR TITLE
[5.2] Pin Mysql Version to 8.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -273,7 +273,7 @@ volumes:
 services:
   - name: mysql
     image: mysql:8
-    command: ["--mysql-native-password=ON --default-authentication-plugin=mysql_native_password"]
+    command: ["--mysql-native-password=ON", "--default-authentication-plugin=mysql_native_password"]
     environment:
       MYSQL_USER: joomla_ut
       MYSQL_PASSWORD: joomla_ut
@@ -405,7 +405,6 @@ steps:
       status:
         - failure
 
-
 trigger:
   event:
     - cron
@@ -415,6 +414,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 10a8ddd124694a7a6f6891d06b6a3a40fc16ef5d54038b4a1da9340710294ea0
+hmac: 6b0da38633aea13bdf1ef5e14da9560a714fd37ea7cae561cdc680bc8988d08e
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -273,7 +273,7 @@ volumes:
 services:
   - name: mysql
     image: mysql:8
-    command: ["--default-authentication-plugin=mysql_native_password"]
+    command: ["--mysql-native-password=ON --default-authentication-plugin=mysql_native_password"]
     environment:
       MYSQL_USER: joomla_ut
       MYSQL_PASSWORD: joomla_ut
@@ -415,6 +415,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 90d71e1cf5e5dcdb753ea1da6f8b6e571fc82a47994bd856e83c5f30bdd4a2af
+hmac: 10a8ddd124694a7a6f6891d06b6a3a40fc16ef5d54038b4a1da9340710294ea0
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -273,7 +273,7 @@ volumes:
 services:
   - name: mysql
     image: mysql:8.3.0
-    command: ["--default-auth=mysql_native_password"]
+    command: ["--default-authentication-plugin=mysql_native_password"]
     environment:
       MYSQL_USER: joomla_ut
       MYSQL_PASSWORD: joomla_ut
@@ -414,6 +414,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 3cc50bc3cd80b45a726013509cf62bb076b42ea01da91ceb90cfce329aa57dbb
+hmac: 36617b5838db6f71d0ca77b2b2e8575ba3347e9dbc7457cd6dcd6f764598d3cc
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -273,7 +273,7 @@ volumes:
 services:
   - name: mysql
     image: mysql:8
-    command: ["--mysql-native-password=ON", "--default-authentication-plugin=mysql_native_password"]
+    command: ["--mysql-native-password=ON", "--default-auth=mysql_native_password"]
     environment:
       MYSQL_USER: joomla_ut
       MYSQL_PASSWORD: joomla_ut
@@ -414,6 +414,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 16b7c0f0edf1798cd8f11736655891b5b0faeb3715de7c711592306ca644b0fb
+hmac: 028f0d8619299df32f2c67f2c6111829d194574a7d33d7c603aad86f00ad9607
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -272,7 +272,7 @@ volumes:
 
 services:
   - name: mysql
-    image: mysql:8.3.0
+    image: mysql:8.0.0
     command: ["--default-authentication-plugin=mysql_native_password"]
     environment:
       MYSQL_USER: joomla_ut
@@ -414,6 +414,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 36617b5838db6f71d0ca77b2b2e8575ba3347e9dbc7457cd6dcd6f764598d3cc
+hmac: be5c79feee4a75c18d92a05827afc22ec4198961f098cd3a699bbbd249b09181
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -273,7 +273,7 @@ volumes:
 services:
   - name: mysql
     image: mysql:8
-    command: ["--mysql-native-password=ON", "--default-authentication-plugin=mysql_native_password"]
+    command: ["--mysql-native-password=ON"]
     environment:
       MYSQL_USER: joomla_ut
       MYSQL_PASSWORD: joomla_ut
@@ -414,6 +414,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 16b7c0f0edf1798cd8f11736655891b5b0faeb3715de7c711592306ca644b0fb
+hmac: ac2072ad986413ee162a5b7671222f3d318261f768bc1c764e558e9a1e553915
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -273,7 +273,7 @@ volumes:
 services:
   - name: mysql
     image: mysql:8
-    command: ["--mysql-native-password=ON"]
+    command: ["--mysql-native-password=ON", "--default-authentication-plugin=mysql_native_password"]
     environment:
       MYSQL_USER: joomla_ut
       MYSQL_PASSWORD: joomla_ut
@@ -414,6 +414,6 @@ trigger:
 
 ---
 kind: signature
-hmac: ac2072ad986413ee162a5b7671222f3d318261f768bc1c764e558e9a1e553915
+hmac: 16b7c0f0edf1798cd8f11736655891b5b0faeb3715de7c711592306ca644b0fb
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -414,6 +414,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 6b0da38633aea13bdf1ef5e14da9560a714fd37ea7cae561cdc680bc8988d08e
+hmac: 16b7c0f0edf1798cd8f11736655891b5b0faeb3715de7c711592306ca644b0fb
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -272,7 +272,7 @@ volumes:
 
 services:
   - name: mysql
-    image: mysql:8.0.0
+    image: mysql:8.0
     command: ["--default-authentication-plugin=mysql_native_password"]
     environment:
       MYSQL_USER: joomla_ut
@@ -414,6 +414,6 @@ trigger:
 
 ---
 kind: signature
-hmac: be5c79feee4a75c18d92a05827afc22ec4198961f098cd3a699bbbd249b09181
+hmac: 8f1bbc362aaadc6b7506490a1ff865bc9ccc0aada27104646963e9b44ee22bef
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -272,8 +272,8 @@ volumes:
 
 services:
   - name: mysql
-    image: mysql:8
-    command: ["--mysql-native-password=ON", "--default-auth=mysql_native_password"]
+    image: mysql:8.3.0
+    command: ["--default-auth=mysql_native_password"]
     environment:
       MYSQL_USER: joomla_ut
       MYSQL_PASSWORD: joomla_ut
@@ -414,6 +414,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 028f0d8619299df32f2c67f2c6111829d194574a7d33d7c603aad86f00ad9607
+hmac: 3cc50bc3cd80b45a726013509cf62bb076b42ea01da91ceb90cfce329aa57dbb
 
 ...


### PR DESCRIPTION
### Summary of Changes
~~Allow --mysql-native-password=ON for mysql 8.4.0, the option is disabled by default from 8.4.0~~

Pinned the mysql version to 8.0

### Testing Instructions
Check drone if integration tests are working


### Actual result BEFORE applying this Pull Request
integration tests failing


### Expected result AFTER applying this Pull Request
integration tests are working