### PR TITLE
[5.1] Pin Mysql Version to 8.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -272,7 +272,7 @@ volumes:
 
 services:
   - name: mysql
-    image: mysql:8.0.0
+    image: mysql:8.0
     command: ["--default-authentication-plugin=mysql_native_password"]
     environment:
       MYSQL_USER: joomla_ut
@@ -415,6 +415,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 70d5faea3914f879c0d20e9faff7121efd3f374fe7ed464ab4ef977c70bd35e6
+hmac: 1dd372065e6179c1afc6c4da95e1bf89b3524489488dd2b0ff228f870f111685
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -272,7 +272,7 @@ volumes:
 
 services:
   - name: mysql
-    image: mysql:8.3.0
+    image: mysql:8.0.0
     command: ["--default-authentication-plugin=mysql_native_password"]
     environment:
       MYSQL_USER: joomla_ut
@@ -415,6 +415,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 43fd25d19a626e8b1ea8d255d1ed5ea97730d1f8f89135fab6c8fe9eea6941c3
+hmac: 70d5faea3914f879c0d20e9faff7121efd3f374fe7ed464ab4ef977c70bd35e6
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -272,7 +272,7 @@ volumes:
 
 services:
   - name: mysql
-    image: mysql:8
+    image: mysql:8.3.0
     command: ["--default-authentication-plugin=mysql_native_password"]
     environment:
       MYSQL_USER: joomla_ut
@@ -415,6 +415,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 070b8d44a6bad66956066cf2f6587f8d4726a7d1a5c78a823664458001d90454
+hmac: 43fd25d19a626e8b1ea8d255d1ed5ea97730d1f8f89135fab6c8fe9eea6941c3
 
 ...


### PR DESCRIPTION
### Summary of Changes
~~Allow --mysql-native-password=ON for mysql 8.4.0, the option is disabled by default from 8.4.0~~

Pinned the mysql version to 8.0

### Testing Instructions
Check drone if integration tests are working


### Actual result BEFORE applying this Pull Request
integration tests failing


### Expected result AFTER applying this Pull Request
integration tests are working