### PR TITLE
[5.1] Update deleted files and folders lists in script.php for 5.1.1

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2326,6 +2326,13 @@ class JoomlaInstallerScript
             '/administrator/components/com_admin/sql/updates/postgresql/4.4.4-2024-03-28.sql',
             '/administrator/modules/mod_post_installation_messages/mod_post_installation_messages.php',
             '/media/vendor/punycode/LICENSE-MIT.txt',
+            // From 5.1.0 to 5.1.1
+            '/libraries/vendor/cweagans/composer-patches/LICENSE.md',
+            '/libraries/vendor/cweagans/composer-patches/src/PatchEvent.php',
+            '/libraries/vendor/cweagans/composer-patches/src/PatchEvents.php',
+            '/libraries/vendor/cweagans/composer-patches/src/Patches.php',
+            '/libraries/vendor/cweagans/composer-patches/tests/PatchEventTest.php',
+            '/libraries/vendor/laminas/laminas-diactoros/PATCHES.txt',
         ];
 
         $folders = [
@@ -2585,6 +2592,11 @@ class JoomlaInstallerScript
             '/libraries/src/Event/Router',
             // From 5.1.0-beta2 to 5.1.0-rc1
             '/media/vendor/punycode',
+            // From 5.1.0 to 5.1.1
+            '/libraries/vendor/cweagans/composer-patches/tests',
+            '/libraries/vendor/cweagans/composer-patches/src',
+            '/libraries/vendor/cweagans/composer-patches',
+            '/libraries/vendor/cweagans',
         ];
 
         $status['files_checked']   = $files;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the lists of files and folders to be deleted on update in file `administrator/components/com_admin/script.php` in the 5.1-dev branch in preparation for the upcoming 5.1.1 release.

All entries added to the lists are caused by the different handling of the composer dependency `laminas/laminas-diactoros` on the last 4.4.4 and 5.1.0 releases due to security patches:
- In 4.4.4 we could not update that dependency to a newer version because that version would not support PHP 7.4. Therefore a new composer dependency `cweagans/composer-patches` was added, which patches the older version with the same security fixes as we would get with the latest version. See this commit: https://github.com/joomla/joomla-cms/commit/92f2ffb3c6b2ec321c660f88c207683587fbc0f0
- In 5.1.0 the `laminas/laminas-diactoros` was already up to date. It had been updated with 5.0.0 to version 2.24.0 which includes the security fixes which were patched in 4.4.4.

Therefore the new composer dependency `cweagans/composer-patches` added to 4.4-dev is not needed in 5.1-dev, so this PR here removes it when updating a 4.4.4 or later to 5.1.1 or later, and it removes the patch information `PATCHES.txt` from the folder of the `laminas/laminas-diactoros` dependency which was created by the removed tool.

### Testing Instructions

Code review, or if you want to do a real test:

Update the latest 4.4 nightly build to the latest 5.1 nightly build to get the actual result, and update latest 4.4 nightly build to the patched package created by Drone for this PR to get the expected result.

Here you can find the patched update package or custom update URL created by Drone for this PR: https://artifacts.joomla.org/drone/joomla/joomla-cms/5.1-dev/43461/downloads/76100/

### Actual result BEFORE applying this Pull Request

The files and folders added by this PR to file `administrator/components/com_admin/script.php` are still present after the update.

### Expected result AFTER applying this Pull Request

The files and folders added by this PR to file `administrator/components/com_admin/script.php` have been removed with the update.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
