### PR TITLE
Update tests/README.md

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,6 @@ Javascript tests
 ==========
 The javascript tests test the Joomla-specific Javascript code. For further information on the tests and on how to run them, please check out https://docs.joomla.org/Special:MyLanguage/Running_JavaScript_Tests_for_the_Joomla_CMS
 
-Cypress tests
+System tests
 ==========
-The Cypress tests test the user interface in a real browser and the webservices API of Joomla with the help of cypress.io. For further information on the tests and on how to run them, please check out [tests/System/README.md](cypress/README.md).
+The system tests utilize [Cypress](https://cypress.io) to perform end-to-end tests in a real browser. This includes the Joomla web installation step, testing the user interface, and testing the web services API of Joomla. For further information on the tests and on how to run them, please check out [tests/System/README.md](System/README.md).


### PR DESCRIPTION
### Summary of Changes

- fixed tests/System/README.md broken link 
- renamed Cypress to System tests to have unique naming in documentation
- extended a little bit and linked Cypress.io

### Testing Instructions

- read last past paragraph `System tests` in tests/README.md
- try the two links `Cypress` and `tests/System/README.md`

### Actual result BEFORE applying this Pull Request

- `tests/System/README.md` is broken

### Expected result AFTER applying this Pull Request

- `tests/System/README.md` is working

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed

please upmerge to 5.1-dev, 5.2-dev and 6.0-dev afterwards