### PR TITLE
[5.1] updater contraintchecker stability check early return

### DIFF
--- a/libraries/src/Updater/ConstraintChecker.php
+++ b/libraries/src/Updater/ConstraintChecker.php
@@ -93,6 +93,14 @@ class ConstraintChecker
             return false;
         }
 
+        // Check stability, assume true when not set
+        if (
+            isset($candidate['stability'])
+            && !$this->checkStability($candidate['stability'], $minimumStability)
+        ) {
+            return false;
+        }
+
         $result = true;
 
         // Check php_minimum, assume true when not set
@@ -107,14 +115,6 @@ class ConstraintChecker
         if (
             isset($candidate['supported_databases'])
             && !$this->checkSupportedDatabases($candidate['supported_databases'])
-        ) {
-            $result = false;
-        }
-
-        // Check stability, assume true when not set
-        if (
-            isset($candidate['stability'])
-            && !$this->checkStability($candidate['stability'], $minimumStability)
         ) {
             $result = false;
         }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Check update stability and return before checking database and PHP version to avoid confusing messages about the database or PHP version if stability does not match.

### Testing Instructions

### Actual result BEFORE applying this Pull Request

![image](https://github.com/joomla/joomla-cms/assets/64533137/a131317c-8caa-41ec-bcf5-bfe59c129de9)

### Expected result AFTER applying this Pull Request

No confusing message about database or PHP Version if stability does not match.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
