### PR TITLE
[6.0] Replacing getDbo() with call to container

### DIFF
--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -276,7 +276,7 @@ class ActionlogsHelper
     public static function loadActionLogPluginsLanguage()
     {
         $lang = Factory::getLanguage();
-        $db   =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db   = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Get all (both enabled and disabled) actionlog plugins
         $query = $db->getQuery(true)

--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Router\Route;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\Path;
 use Joomla\String\StringHelper;
 
@@ -275,7 +276,7 @@ class ActionlogsHelper
     public static function loadActionLogPluginsLanguage()
     {
         $lang = Factory::getLanguage();
-        $db   = Factory::getDbo();
+        $db   =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Get all (both enabled and disabled) actionlog plugins
         $query = $db->getQuery(true)

--- a/administrator/components/com_admin/postinstall/languageaccess340.php
+++ b/administrator/components/com_admin/postinstall/languageaccess340.php
@@ -30,7 +30,7 @@ use Joomla\Database\DatabaseInterface;
  */
 function admin_postinstall_languageaccess340_condition()
 {
-    $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+    $db    = Factory::getContainer()->get(DatabaseInterface::class);
     $query = $db->getQuery(true)
         ->select($db->quoteName('access'))
         ->from($db->quoteName('#__languages'))

--- a/administrator/components/com_admin/postinstall/languageaccess340.php
+++ b/administrator/components/com_admin/postinstall/languageaccess340.php
@@ -12,6 +12,7 @@
  */
 
 use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -29,7 +30,7 @@ use Joomla\CMS\Factory;
  */
 function admin_postinstall_languageaccess340_condition()
 {
-    $db    = Factory::getDbo();
+    $db    =  Factory::getContainer()->get(DatabaseInterface::class);
     $query = $db->getQuery(true)
         ->select($db->quoteName('access'))
         ->from($db->quoteName('#__languages'))

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Folder;
@@ -169,7 +170,7 @@ class JoomlaInstallerScript
      */
     protected function clearStatsCache()
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         try {
             // Get the params for the stats plugin
@@ -219,7 +220,7 @@ class JoomlaInstallerScript
      */
     protected function updateDatabase()
     {
-        if (Factory::getDbo()->getServerType() === 'mysql') {
+        if ( Factory::getContainer()->get(DatabaseInterface::class)->getServerType() === 'mysql') {
             $this->updateDatabaseMysql();
         }
     }
@@ -231,7 +232,7 @@ class JoomlaInstallerScript
      */
     protected function updateDatabaseMysql()
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $db->setQuery('SHOW ENGINES');
 
@@ -296,7 +297,7 @@ class JoomlaInstallerScript
             ['type' => 'plugin', 'element' => 'updatenotification', 'folder' => 'system', 'client_id' => 0, 'pre_function' => 'migrateUpdatenotificationPlugin'],
         ];
 
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         foreach ($extensions as $extension) {
             $row = $db->setQuery(
@@ -356,7 +357,7 @@ class JoomlaInstallerScript
      */
     private function migrateCompatPlugin($rowOld)
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $db->setQuery(
             $db->getQuery(true)
@@ -511,7 +512,7 @@ class JoomlaInstallerScript
         $extensions = ExtensionHelper::getCoreExtensions();
 
         // Attempt to refresh manifest caches
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('*')
             ->from('#__extensions');
@@ -2761,7 +2762,7 @@ class JoomlaInstallerScript
      */
     private function migrateDeleteActionlogsConfiguration(): bool
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         try {
             // Get the ActionLogs system plugin's parameters
@@ -2830,7 +2831,7 @@ class JoomlaInstallerScript
      */
     private function migratePrivacyconsentConfiguration(): bool
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         try {
             // Get the PrivacyConsent system plugin's parameters
@@ -2904,7 +2905,7 @@ class JoomlaInstallerScript
      */
     private function migrateTinymceConfiguration(): bool
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         try {
             // Get the TinyMCE editor plugin's parameters

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -170,7 +170,7 @@ class JoomlaInstallerScript
      */
     protected function clearStatsCache()
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         try {
             // Get the params for the stats plugin
@@ -232,7 +232,7 @@ class JoomlaInstallerScript
      */
     protected function updateDatabaseMysql()
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $db->setQuery('SHOW ENGINES');
 
@@ -297,7 +297,7 @@ class JoomlaInstallerScript
             ['type' => 'plugin', 'element' => 'updatenotification', 'folder' => 'system', 'client_id' => 0, 'pre_function' => 'migrateUpdatenotificationPlugin'],
         ];
 
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         foreach ($extensions as $extension) {
             $row = $db->setQuery(
@@ -357,7 +357,7 @@ class JoomlaInstallerScript
      */
     private function migrateCompatPlugin($rowOld)
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $db->setQuery(
             $db->getQuery(true)
@@ -512,7 +512,7 @@ class JoomlaInstallerScript
         $extensions = ExtensionHelper::getCoreExtensions();
 
         // Attempt to refresh manifest caches
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('*')
             ->from('#__extensions');
@@ -2762,7 +2762,7 @@ class JoomlaInstallerScript
      */
     private function migrateDeleteActionlogsConfiguration(): bool
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         try {
             // Get the ActionLogs system plugin's parameters
@@ -2831,7 +2831,7 @@ class JoomlaInstallerScript
      */
     private function migratePrivacyconsentConfiguration(): bool
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         try {
             // Get the PrivacyConsent system plugin's parameters
@@ -2905,7 +2905,7 @@ class JoomlaInstallerScript
      */
     private function migrateTinymceConfiguration(): bool
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         try {
             // Get the TinyMCE editor plugin's parameters

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -220,7 +220,7 @@ class JoomlaInstallerScript
      */
     protected function updateDatabase()
     {
-        if ( Factory::getContainer()->get(DatabaseInterface::class)->getServerType() === 'mysql') {
+        if (Factory::getContainer()->get(DatabaseInterface::class)->getServerType() === 'mysql') {
             $this->updateDatabaseMysql();
         }
     }

--- a/administrator/components/com_associations/src/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/src/Helper/AssociationsHelper.php
@@ -256,7 +256,7 @@ class AssociationsHelper extends ContentHelper
                 $additional  = '';
 
                 if (isset($items[$langCode]['catid'])) {
-                    $db =  Factory::getContainer()->get(DatabaseInterface::class);
+                    $db = Factory::getContainer()->get(DatabaseInterface::class);
 
                     // Get the category name
                     $query = $db->getQuery(true)
@@ -270,7 +270,7 @@ class AssociationsHelper extends ContentHelper
 
                     $additional = '<strong>' . Text::sprintf('JCATEGORY_SPRINTF', $categoryTitle) . '</strong> <br>';
                 } elseif (isset($items[$langCode]['menutype'])) {
-                    $db =  Factory::getContainer()->get(DatabaseInterface::class);
+                    $db = Factory::getContainer()->get(DatabaseInterface::class);
 
                     // Get the menutype name
                     $query = $db->getQuery(true)
@@ -447,7 +447,7 @@ class AssociationsHelper extends ContentHelper
      */
     private static function getEnabledExtensions()
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $query = $db->getQuery(true)
             ->select('*')
@@ -653,7 +653,7 @@ class AssociationsHelper extends ContentHelper
      */
     public static function getLanguagefilterPluginId()
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('extension_id'))
             ->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_associations/src/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/src/Helper/AssociationsHelper.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
@@ -255,7 +256,7 @@ class AssociationsHelper extends ContentHelper
                 $additional  = '';
 
                 if (isset($items[$langCode]['catid'])) {
-                    $db = Factory::getDbo();
+                    $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
                     // Get the category name
                     $query = $db->getQuery(true)
@@ -269,7 +270,7 @@ class AssociationsHelper extends ContentHelper
 
                     $additional = '<strong>' . Text::sprintf('JCATEGORY_SPRINTF', $categoryTitle) . '</strong> <br>';
                 } elseif (isset($items[$langCode]['menutype'])) {
-                    $db = Factory::getDbo();
+                    $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
                     // Get the menutype name
                     $query = $db->getQuery(true)
@@ -446,7 +447,7 @@ class AssociationsHelper extends ContentHelper
      */
     private static function getEnabledExtensions()
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $query = $db->getQuery(true)
             ->select('*')
@@ -652,7 +653,7 @@ class AssociationsHelper extends ContentHelper
      */
     public static function getLanguagefilterPluginId()
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('extension_id'))
             ->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_banners/src/Helper/BannersHelper.php
+++ b/administrator/components/com_banners/src/Helper/BannersHelper.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Table\Table;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -38,7 +39,7 @@ class BannersHelper extends ContentHelper
      */
     public static function updateReset()
     {
-        $db      = Factory::getDbo();
+        $db      =  Factory::getContainer()->get(DatabaseInterface::class);
         $nowDate = Factory::getDate()->toSql();
         $app     = Factory::getApplication();
         $user    = $app->getIdentity();
@@ -147,7 +148,7 @@ class BannersHelper extends ContentHelper
     {
         $options = [];
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [

--- a/administrator/components/com_banners/src/Helper/BannersHelper.php
+++ b/administrator/components/com_banners/src/Helper/BannersHelper.php
@@ -39,7 +39,7 @@ class BannersHelper extends ContentHelper
      */
     public static function updateReset()
     {
-        $db      =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db      = Factory::getContainer()->get(DatabaseInterface::class);
         $nowDate = Factory::getDate()->toSql();
         $app     = Factory::getApplication();
         $user    = $app->getIdentity();
@@ -148,7 +148,7 @@ class BannersHelper extends ContentHelper
     {
         $options = [];
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [

--- a/administrator/components/com_categories/src/Helper/CategoriesHelper.php
+++ b/administrator/components/com_categories/src/Helper/CategoriesHelper.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Categories\Administrator\Helper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Table\Table;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -45,7 +46,7 @@ class CategoriesHelper
             // Include only published categories with user access
             $arrId   = explode(':', $langAssociation->id);
             $assocId = (int) $arrId[0];
-            $db      = Factory::getDbo();
+            $db      =  Factory::getContainer()->get(DatabaseInterface::class);
 
             $query = $db->getQuery(true)
                 ->select($db->quoteName('published'))

--- a/administrator/components/com_categories/src/Helper/CategoriesHelper.php
+++ b/administrator/components/com_categories/src/Helper/CategoriesHelper.php
@@ -46,7 +46,7 @@ class CategoriesHelper
             // Include only published categories with user access
             $arrId   = explode(':', $langAssociation->id);
             $assocId = (int) $arrId[0];
-            $db      =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db      = Factory::getContainer()->get(DatabaseInterface::class);
 
             $query = $db->getQuery(true)
                 ->select($db->quoteName('published'))

--- a/administrator/components/com_categories/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_categories/src/Service/HTML/AdministratorService.php
@@ -52,7 +52,7 @@ class AdministratorService
             $associations = ArrayHelper::toInteger($associations);
 
             // Get the associated categories
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/administrator/components/com_categories/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_categories/src/Service/HTML/AdministratorService.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Categories\Administrator\Helper\CategoriesHelper;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
 
@@ -51,7 +52,7 @@ class AdministratorService
             $associations = ArrayHelper::toInteger($associations);
 
             // Get the associated categories
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/administrator/components/com_config/src/Helper/ConfigHelper.php
+++ b/administrator/components/com_config/src/Helper/ConfigHelper.php
@@ -36,7 +36,7 @@ class ConfigHelper extends ContentHelper
      */
     public static function getAllComponents()
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('element')
             ->from('#__extensions')

--- a/administrator/components/com_config/src/Helper/ConfigHelper.php
+++ b/administrator/components/com_config/src/Helper/ConfigHelper.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Application\ApplicationHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -35,7 +36,7 @@ class ConfigHelper extends ContentHelper
      */
     public static function getAllComponents()
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('element')
             ->from('#__extensions')

--- a/administrator/components/com_contact/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_contact/src/Service/HTML/AdministratorService.php
@@ -52,7 +52,7 @@ class AdministratorService
             }
 
             // Get the associated contact items
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/administrator/components/com_contact/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_contact/src/Service/HTML/AdministratorService.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
 
@@ -51,7 +52,7 @@ class AdministratorService
             }
 
             // Get the associated contact items
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/administrator/components/com_content/src/Helper/ContentHelper.php
+++ b/administrator/components/com_content/src/Helper/ContentHelper.php
@@ -41,7 +41,7 @@ class ContentHelper extends \Joomla\CMS\Helper\ContentHelper
      */
     public static function canDeleteState(int $id): bool
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         $query->select('id')
@@ -91,7 +91,7 @@ class ContentHelper extends \Joomla\CMS\Helper\ContentHelper
             return;
         }
 
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $data = (array) $data;
 

--- a/administrator/components/com_content/src/Helper/ContentHelper.php
+++ b/administrator/components/com_content/src/Helper/ContentHelper.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Table\Category;
 use Joomla\CMS\Workflow\WorkflowServiceInterface;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
@@ -40,7 +41,7 @@ class ContentHelper extends \Joomla\CMS\Helper\ContentHelper
      */
     public static function canDeleteState(int $id): bool
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         $query->select('id')
@@ -90,7 +91,7 @@ class ContentHelper extends \Joomla\CMS\Helper\ContentHelper
             return;
         }
 
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $data = (array) $data;
 

--- a/administrator/components/com_content/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_content/src/Service/HTML/AdministratorService.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -50,7 +51,7 @@ class AdministratorService
             }
 
             // Get the associated menu items
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/administrator/components/com_content/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_content/src/Service/HTML/AdministratorService.php
@@ -51,7 +51,7 @@ class AdministratorService
             }
 
             // Get the associated menu items
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
+++ b/administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Table\ContentHistory;
 use Joomla\CMS\Table\ContentType;
 use Joomla\CMS\Table\Table;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Filesystem\Folder;
 use Joomla\Filesystem\Path;
@@ -190,7 +191,7 @@ class ContenthistoryHelper
         $result = false;
 
         if (isset($lookup->sourceColumn) && isset($lookup->targetTable) && isset($lookup->targetColumn) && isset($lookup->displayColumn)) {
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $value = (int) $value;
             $query = $db->getQuery(true);
             $query->select($db->quoteName($lookup->displayColumn))

--- a/administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
+++ b/administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
@@ -191,7 +191,7 @@ class ContenthistoryHelper
         $result = false;
 
         if (isset($lookup->sourceColumn) && isset($lookup->targetTable) && isset($lookup->targetColumn) && isset($lookup->displayColumn)) {
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $value = (int) $value;
             $query = $db->getQuery(true);
             $query->select($db->quoteName($lookup->displayColumn))

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -591,7 +591,7 @@ class FieldsHelper
             return [];
         }
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         $query->select($db->quoteName('a.category_id'))
@@ -620,7 +620,7 @@ class FieldsHelper
             return [];
         }
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         $query->select($db->quoteName('c.title'))
@@ -643,7 +643,7 @@ class FieldsHelper
      */
     public static function getFieldsPluginId()
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('extension_id'))
             ->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -24,6 +24,7 @@ use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Component\Fields\Administrator\Model\FieldModel;
 use Joomla\Component\Fields\Administrator\Model\FieldsModel;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Event\DispatcherInterface;
 
@@ -590,7 +591,7 @@ class FieldsHelper
             return [];
         }
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         $query->select($db->quoteName('a.category_id'))
@@ -619,7 +620,7 @@ class FieldsHelper
             return [];
         }
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         $query->select($db->quoteName('c.title'))
@@ -642,7 +643,7 @@ class FieldsHelper
      */
     public static function getFieldsPluginId()
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('extension_id'))
             ->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_finder/src/Helper/LanguageHelper.php
+++ b/administrator/components/com_finder/src/Helper/LanguageHelper.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Finder\Administrator\Helper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\LanguageHelper as CMSLanguageHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -124,7 +125,7 @@ class LanguageHelper
         $loaded = true;
 
         // Get array of all the enabled Smart Search plugin names.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select([$db->quoteName('name'), $db->quoteName('element')])
             ->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_finder/src/Helper/LanguageHelper.php
+++ b/administrator/components/com_finder/src/Helper/LanguageHelper.php
@@ -125,7 +125,7 @@ class LanguageHelper
         $loaded = true;
 
         // Get array of all the enabled Smart Search plugin names.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select([$db->quoteName('name'), $db->quoteName('element')])
             ->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_finder/src/Indexer/Helper.php
+++ b/administrator/components/com_finder/src/Indexer/Helper.php
@@ -228,7 +228,7 @@ class Helper
     {
         static $types;
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         // Check if the types are loaded.
@@ -311,7 +311,7 @@ class Helper
      */
     public static function getCommonWords($lang)
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Create the query to load all the common terms for the language.
         $query = $db->getQuery(true)

--- a/administrator/components/com_finder/src/Indexer/Helper.php
+++ b/administrator/components/com_finder/src/Indexer/Helper.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 use Joomla\String\StringHelper;
 
@@ -227,7 +228,7 @@ class Helper
     {
         static $types;
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         // Check if the types are loaded.
@@ -310,7 +311,7 @@ class Helper
      */
     public static function getCommonWords($lang)
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Create the query to load all the common terms for the language.
         $query = $db->getQuery(true)

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -168,7 +168,7 @@ class Indexer
 
             // Load the default configuration options.
             $data->options = ComponentHelper::getParams('com_finder');
-            $db            = Factory::getDbo();
+            $db            =  Factory::getContainer()->get(DatabaseInterface::class);
 
             if ($db->getServerType() == 'mysql') {
                 /**

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -168,7 +168,7 @@ class Indexer
 
             // Load the default configuration options.
             $data->options = ComponentHelper::getParams('com_finder');
-            $db            =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db            = Factory::getContainer()->get(DatabaseInterface::class);
 
             if ($db->getServerType() == 'mysql') {
                 /**

--- a/administrator/components/com_finder/src/Indexer/Taxonomy.php
+++ b/administrator/components/com_finder/src/Indexer/Taxonomy.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Finder\Administrator\Indexer;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Tree\NodeInterface;
 use Joomla\Component\Finder\Administrator\Table\MapTable;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -173,7 +174,7 @@ class Taxonomy
         }
 
         // Check to see if the node is in the table.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('*')
             ->from($db->quoteName('#__finder_taxonomy'))
@@ -275,7 +276,7 @@ class Taxonomy
     public static function addMap($linkId, $nodeId)
     {
         // Insert the map.
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $query = $db->getQuery(true)
             ->select($db->quoteName('link_id'))
@@ -306,7 +307,7 @@ class Taxonomy
      */
     public static function getBranchTitles()
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Set user variables
         $groups = implode(',', Factory::getUser()->getAuthorisedViewLevels());
@@ -338,7 +339,7 @@ class Taxonomy
      */
     public static function getNodeByTitle($branch, $title)
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Set user variables
         $groups = implode(',', Factory::getUser()->getAuthorisedViewLevels());
@@ -375,7 +376,7 @@ class Taxonomy
     public static function removeMaps($linkId)
     {
         // Delete the maps.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->delete($db->quoteName('#__finder_taxonomy_map'))
             ->where($db->quoteName('link_id') . ' = ' . (int) $linkId);
@@ -396,7 +397,7 @@ class Taxonomy
     public static function removeOrphanMaps()
     {
         // Delete all orphaned maps
-        $db     = Factory::getDbo();
+        $db     =  Factory::getContainer()->get(DatabaseInterface::class);
         $query2 = $db->getQuery(true)
             ->select($db->quoteName('link_id'))
             ->from($db->quoteName('#__finder_links'));
@@ -422,7 +423,7 @@ class Taxonomy
     {
         // Delete all orphaned nodes.
         $affectedRows = 0;
-        $db           = Factory::getDbo();
+        $db           =  Factory::getContainer()->get(DatabaseInterface::class);
         $nodeTable    = new MapTable($db);
         $query        = $db->getQuery(true);
 
@@ -458,7 +459,7 @@ class Taxonomy
     public static function getTaxonomy($id = 0)
     {
         if (!\count(self::$taxonomies)) {
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true);
 
             $query->select(['id','parent_id','lft','rgt','level','path','title','alias','state','access','language'])

--- a/administrator/components/com_finder/src/Indexer/Taxonomy.php
+++ b/administrator/components/com_finder/src/Indexer/Taxonomy.php
@@ -174,7 +174,7 @@ class Taxonomy
         }
 
         // Check to see if the node is in the table.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('*')
             ->from($db->quoteName('#__finder_taxonomy'))
@@ -276,7 +276,7 @@ class Taxonomy
     public static function addMap($linkId, $nodeId)
     {
         // Insert the map.
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $query = $db->getQuery(true)
             ->select($db->quoteName('link_id'))
@@ -307,7 +307,7 @@ class Taxonomy
      */
     public static function getBranchTitles()
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Set user variables
         $groups = implode(',', Factory::getUser()->getAuthorisedViewLevels());
@@ -339,7 +339,7 @@ class Taxonomy
      */
     public static function getNodeByTitle($branch, $title)
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Set user variables
         $groups = implode(',', Factory::getUser()->getAuthorisedViewLevels());
@@ -376,7 +376,7 @@ class Taxonomy
     public static function removeMaps($linkId)
     {
         // Delete the maps.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->delete($db->quoteName('#__finder_taxonomy_map'))
             ->where($db->quoteName('link_id') . ' = ' . (int) $linkId);
@@ -397,7 +397,7 @@ class Taxonomy
     public static function removeOrphanMaps()
     {
         // Delete all orphaned maps
-        $db     =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db     = Factory::getContainer()->get(DatabaseInterface::class);
         $query2 = $db->getQuery(true)
             ->select($db->quoteName('link_id'))
             ->from($db->quoteName('#__finder_links'));
@@ -423,7 +423,7 @@ class Taxonomy
     {
         // Delete all orphaned nodes.
         $affectedRows = 0;
-        $db           =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db           = Factory::getContainer()->get(DatabaseInterface::class);
         $nodeTable    = new MapTable($db);
         $query        = $db->getQuery(true);
 
@@ -459,7 +459,7 @@ class Taxonomy
     public static function getTaxonomy($id = 0)
     {
         if (!\count(self::$taxonomies)) {
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true);
 
             $query->select(['id','parent_id','lft','rgt','level','path','title','alias','state','access','language'])

--- a/administrator/components/com_installer/src/Helper/InstallerHelper.php
+++ b/administrator/components/com_installer/src/Helper/InstallerHelper.php
@@ -37,7 +37,7 @@ class InstallerHelper
      */
     public static function getExtensionTypes()
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('DISTINCT ' . $db->quoteName('type'))
             ->from($db->quoteName('#__extensions'));
@@ -63,7 +63,7 @@ class InstallerHelper
     public static function getExtensionGroups()
     {
         $nofolder = '';
-        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db       = Factory::getContainer()->get(DatabaseInterface::class);
         $query    = $db->getQuery(true)
             ->select('DISTINCT ' . $db->quoteName('folder'))
             ->from($db->quoteName('#__extensions'))
@@ -301,7 +301,7 @@ class InstallerHelper
     ): array {
         // Get the database driver. If it fails we cannot report whether the extension supports download keys.
         try {
-            $db =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
         } catch (\Exception $e) {
             return [
                 'supported' => false,
@@ -422,7 +422,7 @@ class InstallerHelper
     protected static function getUpdateSitesInformation(bool $onlyEnabled): array
     {
         try {
-            $db =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
         } catch (\Exception $e) {
             return [];
         }

--- a/administrator/components/com_installer/src/Helper/InstallerHelper.php
+++ b/administrator/components/com_installer/src/Helper/InstallerHelper.php
@@ -37,7 +37,7 @@ class InstallerHelper
      */
     public static function getExtensionTypes()
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('DISTINCT ' . $db->quoteName('type'))
             ->from($db->quoteName('#__extensions'));
@@ -63,7 +63,7 @@ class InstallerHelper
     public static function getExtensionGroups()
     {
         $nofolder = '';
-        $db       = Factory::getDbo();
+        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
         $query    = $db->getQuery(true)
             ->select('DISTINCT ' . $db->quoteName('folder'))
             ->from($db->quoteName('#__extensions'))
@@ -301,7 +301,7 @@ class InstallerHelper
     ): array {
         // Get the database driver. If it fails we cannot report whether the extension supports download keys.
         try {
-            $db = Factory::getDbo();
+            $db =  Factory::getContainer()->get(DatabaseInterface::class);
         } catch (\Exception $e) {
             return [
                 'supported' => false,
@@ -422,7 +422,7 @@ class InstallerHelper
     protected static function getUpdateSitesInformation(bool $onlyEnabled): array
     {
         try {
-            $db = Factory::getDbo();
+            $db =  Factory::getContainer()->get(DatabaseInterface::class);
         } catch (\Exception $e) {
             return [];
         }

--- a/administrator/components/com_languages/src/Helper/MultilangstatusHelper.php
+++ b/administrator/components/com_languages/src/Helper/MultilangstatusHelper.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -35,7 +36,7 @@ abstract class MultilangstatusHelper
     public static function getHomes()
     {
         // Check for multiple Home pages.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('COUNT(*)')
             ->from($db->quoteName('#__menu'))
@@ -60,7 +61,7 @@ abstract class MultilangstatusHelper
     public static function getLangswitchers()
     {
         // Check if switcher is published.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('COUNT(*)')
             ->from($db->quoteName('#__modules'))
@@ -85,7 +86,7 @@ abstract class MultilangstatusHelper
     public static function getContentlangs()
     {
         // Check for published Content Languages.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [
@@ -109,7 +110,7 @@ abstract class MultilangstatusHelper
     public static function getStatus()
     {
         // Check for combined status.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         // Select all fields from the languages table.
@@ -152,7 +153,7 @@ abstract class MultilangstatusHelper
      */
     public static function getContacts()
     {
-        $db        = Factory::getDbo();
+        $db        =  Factory::getContainer()->get(DatabaseInterface::class);
         $languages = \count(LanguageHelper::getLanguages());
 
         // Get the number of contact with all as language
@@ -250,7 +251,7 @@ abstract class MultilangstatusHelper
     public static function getDefaultHomeModule()
     {
         // Find Default Home menutype.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('menutype'))
             ->from($db->quoteName('#__menu'))
@@ -309,7 +310,7 @@ abstract class MultilangstatusHelper
      */
     public static function getModule($moduleName, $instanceTitle = null)
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $query = $db->getQuery(true)
             ->select(

--- a/administrator/components/com_languages/src/Helper/MultilangstatusHelper.php
+++ b/administrator/components/com_languages/src/Helper/MultilangstatusHelper.php
@@ -36,7 +36,7 @@ abstract class MultilangstatusHelper
     public static function getHomes()
     {
         // Check for multiple Home pages.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('COUNT(*)')
             ->from($db->quoteName('#__menu'))
@@ -61,7 +61,7 @@ abstract class MultilangstatusHelper
     public static function getLangswitchers()
     {
         // Check if switcher is published.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('COUNT(*)')
             ->from($db->quoteName('#__modules'))
@@ -86,7 +86,7 @@ abstract class MultilangstatusHelper
     public static function getContentlangs()
     {
         // Check for published Content Languages.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [
@@ -110,7 +110,7 @@ abstract class MultilangstatusHelper
     public static function getStatus()
     {
         // Check for combined status.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         // Select all fields from the languages table.
@@ -153,7 +153,7 @@ abstract class MultilangstatusHelper
      */
     public static function getContacts()
     {
-        $db        =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db        = Factory::getContainer()->get(DatabaseInterface::class);
         $languages = \count(LanguageHelper::getLanguages());
 
         // Get the number of contact with all as language
@@ -251,7 +251,7 @@ abstract class MultilangstatusHelper
     public static function getDefaultHomeModule()
     {
         // Find Default Home menutype.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('menutype'))
             ->from($db->quoteName('#__menu'))
@@ -310,7 +310,7 @@ abstract class MultilangstatusHelper
      */
     public static function getModule($moduleName, $instanceTitle = null)
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $query = $db->getQuery(true)
             ->select(

--- a/administrator/components/com_login/src/Model/LoginModel.php
+++ b/administrator/components/com_login/src/Model/LoginModel.php
@@ -139,7 +139,7 @@ class LoginModel extends BaseDatabaseModel
         $cache = Factory::getCache('com_modules', 'callback');
 
         $loader = function () use ($app, $lang, $module) {
-            $db =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
 
             $query = $db->getQuery(true)
                 ->select(

--- a/administrator/components/com_login/src/Model/LoginModel.php
+++ b/administrator/components/com_login/src/Model/LoginModel.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\BaseDatabaseModel;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Exception\ExecutionFailureException;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -138,7 +139,7 @@ class LoginModel extends BaseDatabaseModel
         $cache = Factory::getCache('com_modules', 'callback');
 
         $loader = function () use ($app, $lang, $module) {
-            $db = Factory::getDbo();
+            $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
             $query = $db->getQuery(true)
                 ->select(

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -105,7 +105,7 @@ class MenusHelper extends ContentHelper
      */
     public static function getMenuTypes($clientId = 0)
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('a.menutype'))
             ->from($db->quoteName('#__menu_types', 'a'));
@@ -141,7 +141,7 @@ class MenusHelper extends ContentHelper
         $hasClientId = $clientId !== null;
         $clientId    = (int) $clientId;
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [
@@ -427,7 +427,7 @@ class MenusHelper extends ContentHelper
      */
     protected static function installPresetItems($node, $menutype)
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $items = $node->getChildren();
 
@@ -696,7 +696,7 @@ class MenusHelper extends ContentHelper
         while ($obj->type == 'alias') {
             $aliasTo = (int) $obj->getParams()->get('aliasoptions');
 
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true);
             $query->select(
                 [
@@ -789,7 +789,7 @@ class MenusHelper extends ContentHelper
                 $lJoin  = (string) $element['sql_leftjoin'];
                 $iJoin  = (string) $element['sql_innerjoin'];
 
-                $db    = Factory::getDbo();
+                $db    =  Factory::getContainer()->get(DatabaseInterface::class);
                 $query = $db->getQuery(true);
                 $query->select($select)->from($from);
 

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -105,7 +105,7 @@ class MenusHelper extends ContentHelper
      */
     public static function getMenuTypes($clientId = 0)
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('a.menutype'))
             ->from($db->quoteName('#__menu_types', 'a'));
@@ -141,7 +141,7 @@ class MenusHelper extends ContentHelper
         $hasClientId = $clientId !== null;
         $clientId    = (int) $clientId;
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [
@@ -427,7 +427,7 @@ class MenusHelper extends ContentHelper
      */
     protected static function installPresetItems($node, $menutype)
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $items = $node->getChildren();
 
@@ -696,7 +696,7 @@ class MenusHelper extends ContentHelper
         while ($obj->type == 'alias') {
             $aliasTo = (int) $obj->getParams()->get('aliasoptions');
 
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true);
             $query->select(
                 [
@@ -789,7 +789,7 @@ class MenusHelper extends ContentHelper
                 $lJoin  = (string) $element['sql_leftjoin'];
                 $iJoin  = (string) $element['sql_innerjoin'];
 
-                $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+                $db    = Factory::getContainer()->get(DatabaseInterface::class);
                 $query = $db->getQuery(true);
                 $query->select($select)->from($from);
 

--- a/administrator/components/com_menus/src/Service/HTML/Menus.php
+++ b/administrator/components/com_menus/src/Service/HTML/Menus.php
@@ -52,7 +52,7 @@ class Menus
         // Get the associations
         if ($associations = MenusHelper::getAssociations($itemid)) {
             // Get the associated menu items
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/administrator/components/com_menus/src/Service/HTML/Menus.php
+++ b/administrator/components/com_menus/src/Service/HTML/Menus.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Menus\Administrator\Helper\MenusHelper;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
@@ -51,7 +52,7 @@ class Menus
         // Get the associations
         if ($associations = MenusHelper::getAssociations($itemid)) {
             // Get the associated menu items
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/administrator/components/com_modules/src/Helper/ModulesHelper.php
+++ b/administrator/components/com_modules/src/Helper/ModulesHelper.php
@@ -70,7 +70,7 @@ abstract class ModulesHelper
      */
     public static function getPositions($clientId, $editPositions = false)
     {
-        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db       = Factory::getContainer()->get(DatabaseInterface::class);
         $clientId = (int) $clientId;
         $query    = $db->getQuery(true)
             ->select('DISTINCT ' . $db->quoteName('position'))
@@ -117,7 +117,7 @@ abstract class ModulesHelper
      */
     public static function getTemplates($clientId = 0, $state = '', $template = '')
     {
-        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db       = Factory::getContainer()->get(DatabaseInterface::class);
         $clientId = (int) $clientId;
 
         // Get the database object and a new query object.
@@ -157,7 +157,7 @@ abstract class ModulesHelper
      */
     public static function getModules($clientId)
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('element AS value, name AS text')
             ->from('#__extensions as e')

--- a/administrator/components/com_modules/src/Helper/ModulesHelper.php
+++ b/administrator/components/com_modules/src/Helper/ModulesHelper.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Modules\Administrator\Helper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
 
@@ -69,7 +70,7 @@ abstract class ModulesHelper
      */
     public static function getPositions($clientId, $editPositions = false)
     {
-        $db       = Factory::getDbo();
+        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
         $clientId = (int) $clientId;
         $query    = $db->getQuery(true)
             ->select('DISTINCT ' . $db->quoteName('position'))
@@ -116,7 +117,7 @@ abstract class ModulesHelper
      */
     public static function getTemplates($clientId = 0, $state = '', $template = '')
     {
-        $db       = Factory::getDbo();
+        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
         $clientId = (int) $clientId;
 
         // Get the database object and a new query object.
@@ -156,7 +157,7 @@ abstract class ModulesHelper
      */
     public static function getModules($clientId)
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('element AS value, name AS text')
             ->from('#__extensions as e')

--- a/administrator/components/com_modules/src/Service/HTML/Modules.php
+++ b/administrator/components/com_modules/src/Service/HTML/Modules.php
@@ -15,6 +15,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\Component\Modules\Administrator\Helper\ModulesHelper;
 use Joomla\Component\Templates\Administrator\Helper\TemplatesHelper;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
 
@@ -229,7 +230,7 @@ class Modules
     public function positionList($clientId = 0)
     {
         $clientId = (int) $clientId;
-        $db       = Factory::getDbo();
+        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
         $query    = $db->getQuery(true)
             ->select('DISTINCT ' . $db->quoteName('position', 'value'))
             ->select($db->quoteName('position', 'text'))

--- a/administrator/components/com_modules/src/Service/HTML/Modules.php
+++ b/administrator/components/com_modules/src/Service/HTML/Modules.php
@@ -230,7 +230,7 @@ class Modules
     public function positionList($clientId = 0)
     {
         $clientId = (int) $clientId;
-        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db       = Factory::getContainer()->get(DatabaseInterface::class);
         $query    = $db->getQuery(true)
             ->select('DISTINCT ' . $db->quoteName('position', 'value'))
             ->select($db->quoteName('position', 'text'))

--- a/administrator/components/com_newsfeeds/src/Helper/NewsfeedsHelper.php
+++ b/administrator/components/com_newsfeeds/src/Helper/NewsfeedsHelper.php
@@ -44,7 +44,7 @@ class NewsfeedsHelper extends ContentHelper
      */
     public static function countItems(&$items)
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $query->select(
             [
@@ -101,7 +101,7 @@ class NewsfeedsHelper extends ContentHelper
      */
     public static function countTagItems(&$items, $extension)
     {
-        $db        =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db        = Factory::getContainer()->get(DatabaseInterface::class);
         $query     = $db->getQuery(true);
         $parts     = explode('.', $extension);
         $section   = null;

--- a/administrator/components/com_newsfeeds/src/Helper/NewsfeedsHelper.php
+++ b/administrator/components/com_newsfeeds/src/Helper/NewsfeedsHelper.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Newsfeeds\Administrator\Helper;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -43,7 +44,7 @@ class NewsfeedsHelper extends ContentHelper
      */
     public static function countItems(&$items)
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $query->select(
             [
@@ -100,7 +101,7 @@ class NewsfeedsHelper extends ContentHelper
      */
     public static function countTagItems(&$items, $extension)
     {
-        $db        = Factory::getDbo();
+        $db        =  Factory::getContainer()->get(DatabaseInterface::class);
         $query     = $db->getQuery(true);
         $parts     = explode('.', $extension);
         $section   = null;

--- a/administrator/components/com_newsfeeds/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_newsfeeds/src/Service/HTML/AdministratorService.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -50,7 +51,7 @@ class AdministratorService
             }
 
             // Get the associated newsfeed items
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true);
             $query
                 ->select(

--- a/administrator/components/com_newsfeeds/src/Service/HTML/AdministratorService.php
+++ b/administrator/components/com_newsfeeds/src/Service/HTML/AdministratorService.php
@@ -51,7 +51,7 @@ class AdministratorService
             }
 
             // Get the associated newsfeed items
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true);
             $query
                 ->select(

--- a/administrator/components/com_plugins/src/Helper/PluginsHelper.php
+++ b/administrator/components/com_plugins/src/Helper/PluginsHelper.php
@@ -52,7 +52,7 @@ class PluginsHelper
      */
     public static function folderOptions()
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('DISTINCT(folder) AS value, folder AS text')
             ->from('#__extensions')
@@ -77,7 +77,7 @@ class PluginsHelper
      */
     public static function elementOptions()
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('DISTINCT(element) AS value, element AS text')
             ->from('#__extensions')

--- a/administrator/components/com_plugins/src/Helper/PluginsHelper.php
+++ b/administrator/components/com_plugins/src/Helper/PluginsHelper.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\Path;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -51,7 +52,7 @@ class PluginsHelper
      */
     public static function folderOptions()
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('DISTINCT(folder) AS value, folder AS text')
             ->from('#__extensions')
@@ -76,7 +77,7 @@ class PluginsHelper
      */
     public static function elementOptions()
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('DISTINCT(element) AS value, element AS text')
             ->from('#__extensions')

--- a/administrator/components/com_privacy/src/Helper/PrivacyHelper.php
+++ b/administrator/components/com_privacy/src/Helper/PrivacyHelper.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Privacy\Administrator\Helper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\Component\Privacy\Administrator\Export\Domain;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -72,7 +73,7 @@ class PrivacyHelper extends ContentHelper
      */
     public static function getPrivacyConsentPluginId()
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('extension_id'))
             ->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_privacy/src/Helper/PrivacyHelper.php
+++ b/administrator/components/com_privacy/src/Helper/PrivacyHelper.php
@@ -73,7 +73,7 @@ class PrivacyHelper extends ContentHelper
      */
     public static function getPrivacyConsentPluginId()
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('extension_id'))
             ->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_redirect/src/Helper/RedirectHelper.php
+++ b/administrator/components/com_redirect/src/Helper/RedirectHelper.php
@@ -63,7 +63,7 @@ class RedirectHelper
      */
     public static function getRedirectPluginId()
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('extension_id'))
             ->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_redirect/src/Helper/RedirectHelper.php
+++ b/administrator/components/com_redirect/src/Helper/RedirectHelper.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Redirect\Administrator\Helper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -62,7 +63,7 @@ class RedirectHelper
      */
     public static function getRedirectPluginId()
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('extension_id'))
             ->from($db->quoteName('#__extensions'))

--- a/administrator/components/com_templates/src/Helper/TemplatesHelper.php
+++ b/administrator/components/com_templates/src/Helper/TemplatesHelper.php
@@ -55,7 +55,7 @@ class TemplatesHelper
     public static function getTemplateOptions($clientId = '*')
     {
         // Build the filter options.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         $query->select($db->quoteName('element', 'value'))

--- a/administrator/components/com_templates/src/Helper/TemplatesHelper.php
+++ b/administrator/components/com_templates/src/Helper/TemplatesHelper.php
@@ -15,6 +15,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Installer\Installer;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Filesystem\Path;
 
@@ -54,7 +55,7 @@ class TemplatesHelper
     public static function getTemplateOptions($clientId = '*')
     {
         // Build the filter options.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         $query->select($db->quoteName('element', 'value'))

--- a/administrator/components/com_users/src/Helper/DebugHelper.php
+++ b/administrator/components/com_users/src/Helper/DebugHelper.php
@@ -38,7 +38,7 @@ class DebugHelper
     public static function getComponents()
     {
         // Initialise variable.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('name AS text, element AS value')
             ->from('#__extensions')

--- a/administrator/components/com_users/src/Helper/DebugHelper.php
+++ b/administrator/components/com_users/src/Helper/DebugHelper.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Access\Access;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -37,7 +38,7 @@ class DebugHelper
     public static function getComponents()
     {
         // Initialise variable.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('name AS text, element AS value')
             ->from('#__extensions')

--- a/administrator/components/com_users/src/Helper/UsersHelper.php
+++ b/administrator/components/com_users/src/Helper/UsersHelper.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Helper\UserGroupsHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -143,7 +144,7 @@ class UsersHelper extends ContentHelper
             return false;
         }
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('title', 'text'))
             ->from($db->quoteName('#__usergroups'))

--- a/administrator/components/com_users/src/Helper/UsersHelper.php
+++ b/administrator/components/com_users/src/Helper/UsersHelper.php
@@ -144,7 +144,7 @@ class UsersHelper extends ContentHelper
             return false;
         }
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('title', 'text'))
             ->from($db->quoteName('#__usergroups'))

--- a/administrator/components/com_users/src/Service/HTML/Users.php
+++ b/administrator/components/com_users/src/Service/HTML/Users.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Filesystem\Path;
 
@@ -298,7 +299,7 @@ class Users
             return static::value($value);
         }
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('title'))
             ->from($db->quoteName('#__template_styles'))
@@ -401,7 +402,7 @@ class Users
             return static::value($value);
         }
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $lang  = Factory::getLanguage();
         $query = $db->getQuery(true)
             ->select($db->quoteName('name'))

--- a/administrator/components/com_users/src/Service/HTML/Users.php
+++ b/administrator/components/com_users/src/Service/HTML/Users.php
@@ -299,7 +299,7 @@ class Users
             return static::value($value);
         }
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('title'))
             ->from($db->quoteName('#__template_styles'))
@@ -402,7 +402,7 @@ class Users
             return static::value($value);
         }
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $lang  = Factory::getLanguage();
         $query = $db->getQuery(true)
             ->select($db->quoteName('name'))

--- a/administrator/components/com_users/src/View/Users/HtmlView.php
+++ b/administrator/components/com_users/src/View/Users/HtmlView.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -107,7 +108,7 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $this->get('FilterForm');
         $this->activeFilters = $this->get('ActiveFilters');
         $this->canDo         = ContentHelper::getActions('com_users');
-        $this->db            = Factory::getDbo();
+        $this->db            =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Check for errors.
         if (\count($errors = $this->get('Errors'))) {

--- a/administrator/components/com_users/src/View/Users/HtmlView.php
+++ b/administrator/components/com_users/src/View/Users/HtmlView.php
@@ -108,7 +108,7 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $this->get('FilterForm');
         $this->activeFilters = $this->get('ActiveFilters');
         $this->canDo         = ContentHelper::getActions('com_users');
-        $this->db            =  Factory::getContainer()->get(DatabaseInterface::class);
+        $this->db            = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Check for errors.
         if (\count($errors = $this->get('Errors'))) {

--- a/administrator/modules/mod_privacy_dashboard/src/Helper/PrivacyDashboardHelper.php
+++ b/administrator/modules/mod_privacy_dashboard/src/Helper/PrivacyDashboardHelper.php
@@ -11,6 +11,7 @@
 namespace Joomla\Module\PrivacyDashboard\Administrator\Helper;
 
 use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Exception\ExecutionFailureException;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -33,7 +34,7 @@ class PrivacyDashboardHelper
      */
     public static function getData()
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [

--- a/administrator/modules/mod_privacy_dashboard/src/Helper/PrivacyDashboardHelper.php
+++ b/administrator/modules/mod_privacy_dashboard/src/Helper/PrivacyDashboardHelper.php
@@ -34,7 +34,7 @@ class PrivacyDashboardHelper
      */
     public static function getData()
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [

--- a/administrator/modules/mod_privacy_status/src/Helper/PrivacyStatusHelper.php
+++ b/administrator/modules/mod_privacy_status/src/Helper/PrivacyStatusHelper.php
@@ -76,7 +76,7 @@ class PrivacyStatusHelper
         ];
         $lang = '';
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [
@@ -120,7 +120,7 @@ class PrivacyStatusHelper
                 $params              = ComponentHelper::getParams('com_languages');
                 $defaultSiteLanguage = $params->get('site');
 
-                $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+                $db    = Factory::getContainer()->get(DatabaseInterface::class);
                 $query = $db->getQuery(true)
                     ->select($db->quoteName('id'))
                     ->from($db->quoteName('#__menu'))
@@ -164,7 +164,7 @@ class PrivacyStatusHelper
         $now    = Factory::getDate()->toSql();
         $period = '-' . $notify;
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $query->select('COUNT(*)')
             ->from($db->quoteName('#__privacy_requests'))

--- a/administrator/modules/mod_privacy_status/src/Helper/PrivacyStatusHelper.php
+++ b/administrator/modules/mod_privacy_status/src/Helper/PrivacyStatusHelper.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -75,7 +76,7 @@ class PrivacyStatusHelper
         ];
         $lang = '';
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [
@@ -119,7 +120,7 @@ class PrivacyStatusHelper
                 $params              = ComponentHelper::getParams('com_languages');
                 $defaultSiteLanguage = $params->get('site');
 
-                $db    = Factory::getDbo();
+                $db    =  Factory::getContainer()->get(DatabaseInterface::class);
                 $query = $db->getQuery(true)
                     ->select($db->quoteName('id'))
                     ->from($db->quoteName('#__menu'))
@@ -163,7 +164,7 @@ class PrivacyStatusHelper
         $now    = Factory::getDate()->toSql();
         $period = '-' . $notify;
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $query->select('COUNT(*)')
             ->from($db->quoteName('#__privacy_requests'))

--- a/components/com_config/src/Model/ModulesModel.php
+++ b/components/com_config/src/Model/ModulesModel.php
@@ -177,7 +177,7 @@ class ModulesModel extends FormModel
      */
     public static function getActivePositions($clientId, $editPositions = false)
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('DISTINCT position')
             ->from($db->quoteName('#__modules'))

--- a/components/com_config/src/Model/ModulesModel.php
+++ b/components/com_config/src/Model/ModulesModel.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\Path;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -176,7 +177,7 @@ class ModulesModel extends FormModel
      */
     public static function getActivePositions($clientId, $editPositions = false)
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('DISTINCT position')
             ->from($db->quoteName('#__modules'))

--- a/components/com_content/src/Helper/AssociationHelper.php
+++ b/components/com_content/src/Helper/AssociationHelper.php
@@ -54,7 +54,7 @@ abstract class AssociationHelper extends CategoryAssociationHelper
             if ($id) {
                 $user      = Factory::getUser();
                 $groups    = implode(',', $user->getAuthorisedViewLevels());
-                $db        =  Factory::getContainer()->get(DatabaseInterface::class);
+                $db        = Factory::getContainer()->get(DatabaseInterface::class);
                 $advClause = [];
 
                 // Filter by user groups

--- a/components/com_content/src/Helper/AssociationHelper.php
+++ b/components/com_content/src/Helper/AssociationHelper.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Language\Associations;
 use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\Component\Categories\Administrator\Helper\CategoryAssociationHelper;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -53,7 +54,7 @@ abstract class AssociationHelper extends CategoryAssociationHelper
             if ($id) {
                 $user      = Factory::getUser();
                 $groups    = implode(',', $user->getAuthorisedViewLevels());
-                $db        = Factory::getDbo();
+                $db        =  Factory::getContainer()->get(DatabaseInterface::class);
                 $advClause = [];
 
                 // Filter by user groups

--- a/components/com_content/src/Helper/QueryHelper.php
+++ b/components/com_content/src/Helper/QueryHelper.php
@@ -71,7 +71,7 @@ class QueryHelper
      */
     public static function orderbySecondary($orderby, $orderDate = 'created', DatabaseInterface $db = null)
     {
-        $db = $db ?:  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = $db ?: Factory::getContainer()->get(DatabaseInterface::class);
 
         $queryDate = self::getQueryDate($orderDate, $db);
 
@@ -172,7 +172,7 @@ class QueryHelper
      */
     public static function getQueryDate($orderDate, DatabaseInterface $db = null)
     {
-        $db = $db ?:  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = $db ?: Factory::getContainer()->get(DatabaseInterface::class);
 
         switch ($orderDate) {
             case 'modified':

--- a/components/com_content/src/Helper/QueryHelper.php
+++ b/components/com_content/src/Helper/QueryHelper.php
@@ -71,7 +71,7 @@ class QueryHelper
      */
     public static function orderbySecondary($orderby, $orderDate = 'created', DatabaseInterface $db = null)
     {
-        $db = $db ?: Factory::getDbo();
+        $db = $db ?:  Factory::getContainer()->get(DatabaseInterface::class);
 
         $queryDate = self::getQueryDate($orderDate, $db);
 
@@ -172,7 +172,7 @@ class QueryHelper
      */
     public static function getQueryDate($orderDate, DatabaseInterface $db = null)
     {
-        $db = $db ?: Factory::getDbo();
+        $db = $db ?:  Factory::getContainer()->get(DatabaseInterface::class);
 
         switch ($orderDate) {
             case 'modified':

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -202,7 +203,7 @@ class HtmlView extends BaseHtmlView
         $this->items      = &$items;
         $this->pagination = &$pagination;
         $this->user       = &$user;
-        $this->db         = Factory::getDbo();
+        $this->db         =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $this->_prepareDocument();
 

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -203,7 +203,7 @@ class HtmlView extends BaseHtmlView
         $this->items      = &$items;
         $this->pagination = &$pagination;
         $this->user       = &$user;
-        $this->db         =  Factory::getContainer()->get(DatabaseInterface::class);
+        $this->db         = Factory::getContainer()->get(DatabaseInterface::class);
 
         $this->_prepareDocument();
 

--- a/components/com_finder/src/Helper/FinderHelper.php
+++ b/components/com_finder/src/Helper/FinderHelper.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Finder\Site\Helper;
 use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\Component\Finder\Administrator\Indexer\Query;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -47,7 +48,7 @@ class FinderHelper
         }
 
         // Initialise our variables
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         // Sanitise the term for the database

--- a/components/com_finder/src/Helper/FinderHelper.php
+++ b/components/com_finder/src/Helper/FinderHelper.php
@@ -48,7 +48,7 @@ class FinderHelper
         }
 
         // Initialise our variables
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         // Sanitise the term for the database

--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -109,7 +109,7 @@ class HtmlView extends BaseHtmlView
         $this->state              = $this->get('State');
         $this->params             = $this->state->get('params');
         $this->mfaConfigurationUI = Mfa::getConfigurationInterface($user);
-        $this->db                 =  Factory::getContainer()->get(DatabaseInterface::class);
+        $this->db                 = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Check for errors.
         if (\count($errors = $this->get('Errors'))) {

--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\User\User;
 use Joomla\Component\Users\Administrator\Helper\Mfa;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -108,7 +109,7 @@ class HtmlView extends BaseHtmlView
         $this->state              = $this->get('State');
         $this->params             = $this->state->get('params');
         $this->mfaConfigurationUI = Mfa::getConfigurationInterface($user);
-        $this->db                 = Factory::getDbo();
+        $this->db                 =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Check for errors.
         if (\count($errors = $this->get('Errors'))) {

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -280,7 +280,7 @@ class Access
         !JDEBUG ?: Profiler::getInstance('Application')->mark('Before Access::preloadPermissions (' . $extensionName . ')');
 
         // Get the database connection object.
-        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db       = Factory::getContainer()->get(DatabaseInterface::class);
         $assetKey = $extensionName . '.%';
 
         // Get a fresh query object.

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\Profiler\Profiler;
 use Joomla\CMS\Table\Asset;
 use Joomla\CMS\User\User;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
 
@@ -279,7 +280,7 @@ class Access
         !JDEBUG ?: Profiler::getInstance('Application')->mark('Before Access::preloadPermissions (' . $extensionName . ')');
 
         // Get the database connection object.
-        $db       = Factory::getDbo();
+        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
         $assetKey = $extensionName . '.%';
 
         // Get a fresh query object.
@@ -345,7 +346,7 @@ class Access
         }
 
         // Get the database connection object.
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Get the asset info for all assets in asset names list.
         $query = $db->getQuery(true)
@@ -566,7 +567,7 @@ class Access
         }
 
         // Get the database connection object.
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Build the database query to get the rules for the asset.
         $query = $db->getQuery(true)
@@ -645,7 +646,7 @@ class Access
         }
 
         // No preload. Return root asset id from Assets.
-        $assets = new Asset(Factory::getDbo());
+        $assets = new Asset( Factory::getContainer()->get(DatabaseInterface::class));
 
         return $assets->getRootId();
     }
@@ -680,7 +681,7 @@ class Access
                     $loaded[$assetKey] = $preloadedAssetsByName[$assetKey];
                 } else {
                     // Else we have to do an extra db query to fetch it from the table fetch it from table.
-                    $table = new Asset(Factory::getDbo());
+                    $table = new Asset( Factory::getContainer()->get(DatabaseInterface::class));
                     $table->load(['name' => $assetKey]);
                     $loaded[$assetKey] = $table->id;
                 }
@@ -717,7 +718,7 @@ class Access
                 $loaded[$assetKey] = self::$preloadedAssets[$assetKey];
             } else {
                 // Else we have to do an extra db query to fetch it from the table fetch it from table.
-                $table = new Asset(Factory::getDbo());
+                $table = new Asset( Factory::getContainer()->get(DatabaseInterface::class));
                 $table->load($assetKey);
                 $loaded[$assetKey] = $table->name;
             }
@@ -797,7 +798,7 @@ class Access
         $groupId = (int) $groupId;
 
         // Fetch the group title from the database
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $query->select($db->quoteName('title'))
             ->from($db->quoteName('#__usergroups'))
@@ -837,7 +838,7 @@ class Access
                 $result = [$guestUsergroup];
             } else {
                 // Registered user and guest if all groups are requested
-                $db = Factory::getDbo();
+                $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
                 // Build the database query to get the rules for the asset.
                 $query = $db->getQuery(true)
@@ -900,7 +901,7 @@ class Access
         $groupId = (int) $groupId;
 
         // Get a database object.
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $test = $recursive ? ' >= ' : ' = ';
 
@@ -941,7 +942,7 @@ class Access
         // Only load the view levels once.
         if (empty(self::$viewLevels)) {
             // Get a database object.
-            $db = Factory::getDbo();
+            $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
             // Build the base query.
             $query = $db->getQuery(true)

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -646,7 +646,7 @@ class Access
         }
 
         // No preload. Return root asset id from Assets.
-        $assets = new Asset( Factory::getContainer()->get(DatabaseInterface::class));
+        $assets = new Asset(Factory::getContainer()->get(DatabaseInterface::class));
 
         return $assets->getRootId();
     }
@@ -681,7 +681,7 @@ class Access
                     $loaded[$assetKey] = $preloadedAssetsByName[$assetKey];
                 } else {
                     // Else we have to do an extra db query to fetch it from the table fetch it from table.
-                    $table = new Asset( Factory::getContainer()->get(DatabaseInterface::class));
+                    $table = new Asset(Factory::getContainer()->get(DatabaseInterface::class));
                     $table->load(['name' => $assetKey]);
                     $loaded[$assetKey] = $table->id;
                 }
@@ -718,7 +718,7 @@ class Access
                 $loaded[$assetKey] = self::$preloadedAssets[$assetKey];
             } else {
                 // Else we have to do an extra db query to fetch it from the table fetch it from table.
-                $table = new Asset( Factory::getContainer()->get(DatabaseInterface::class));
+                $table = new Asset(Factory::getContainer()->get(DatabaseInterface::class));
                 $table->load($assetKey);
                 $loaded[$assetKey] = $table->name;
             }

--- a/libraries/src/Access/Access.php
+++ b/libraries/src/Access/Access.php
@@ -346,7 +346,7 @@ class Access
         }
 
         // Get the database connection object.
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Get the asset info for all assets in asset names list.
         $query = $db->getQuery(true)
@@ -567,7 +567,7 @@ class Access
         }
 
         // Get the database connection object.
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Build the database query to get the rules for the asset.
         $query = $db->getQuery(true)
@@ -798,7 +798,7 @@ class Access
         $groupId = (int) $groupId;
 
         // Fetch the group title from the database
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $query->select($db->quoteName('title'))
             ->from($db->quoteName('#__usergroups'))
@@ -838,7 +838,7 @@ class Access
                 $result = [$guestUsergroup];
             } else {
                 // Registered user and guest if all groups are requested
-                $db =  Factory::getContainer()->get(DatabaseInterface::class);
+                $db = Factory::getContainer()->get(DatabaseInterface::class);
 
                 // Build the database query to get the rules for the asset.
                 $query = $db->getQuery(true)
@@ -901,7 +901,7 @@ class Access
         $groupId = (int) $groupId;
 
         // Get a database object.
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $test = $recursive ? ' >= ' : ' = ';
 
@@ -942,7 +942,7 @@ class Access
         // Only load the view levels once.
         if (empty(self::$viewLevels)) {
             // Get a database object.
-            $db =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
 
             // Build the base query.
             $query = $db->getQuery(true)

--- a/libraries/src/Adapter/Adapter.php
+++ b/libraries/src/Adapter/Adapter.php
@@ -88,7 +88,7 @@ class Adapter
         $this->_classprefix   = $classprefix ?: 'J';
         $this->_adapterfolder = $adapterfolder ?: 'adapters';
 
-        $this->_db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $this->_db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Ensure BC, when removed in 5, then the db must be set with setDatabase explicitly
         if ($this instanceof DatabaseAwareInterface) {

--- a/libraries/src/Adapter/Adapter.php
+++ b/libraries/src/Adapter/Adapter.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Object\LegacyErrorHandlingTrait;
 use Joomla\CMS\Object\LegacyPropertyManagementTrait;
 use Joomla\Database\DatabaseAwareInterface;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -87,7 +88,7 @@ class Adapter
         $this->_classprefix   = $classprefix ?: 'J';
         $this->_adapterfolder = $adapterfolder ?: 'adapters';
 
-        $this->_db = Factory::getDbo();
+        $this->_db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Ensure BC, when removed in 5, then the db must be set with setDatabase explicitly
         if ($this instanceof DatabaseAwareInterface) {

--- a/libraries/src/Adapter/AdapterInstance.php
+++ b/libraries/src/Adapter/AdapterInstance.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Object\LegacyErrorHandlingTrait;
 use Joomla\CMS\Object\LegacyPropertyManagementTrait;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -64,7 +65,7 @@ class AdapterInstance
         $this->parent = $parent;
 
         // Pull in the global dbo in case something happened to it.
-        $this->db = $db ?: Factory::getDbo();
+        $this->db = $db ?:  Factory::getContainer()->get(DatabaseInterface::class);
     }
 
     /**

--- a/libraries/src/Adapter/AdapterInstance.php
+++ b/libraries/src/Adapter/AdapterInstance.php
@@ -65,7 +65,7 @@ class AdapterInstance
         $this->parent = $parent;
 
         // Pull in the global dbo in case something happened to it.
-        $this->db = $db ?:  Factory::getContainer()->get(DatabaseInterface::class);
+        $this->db = $db ?: Factory::getContainer()->get(DatabaseInterface::class);
     }
 
     /**

--- a/libraries/src/Button/PublishedButton.php
+++ b/libraries/src/Button/PublishedButton.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Date\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -59,7 +60,7 @@ class PublishedButton extends ActionButton
             $bakState = $this->getState($value);
             $default  = $this->getState($value) ?? $this->unknownState;
 
-            $nullDate = Factory::getDbo()->getNullDate();
+            $nullDate =  Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
             $nowDate  = Factory::getDate()->toUnix();
 
             $tz = Factory::getUser()->getTimezone();

--- a/libraries/src/Button/PublishedButton.php
+++ b/libraries/src/Button/PublishedButton.php
@@ -60,7 +60,7 @@ class PublishedButton extends ActionButton
             $bakState = $this->getState($value);
             $default  = $this->getState($value) ?? $this->unknownState;
 
-            $nullDate =  Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
+            $nullDate = Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
             $nowDate  = Factory::getDate()->toUnix();
 
             $tz = Factory::getUser()->getTimezone();

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -382,7 +382,7 @@ class ComponentHelper
     protected static function load()
     {
         $loader = function () {
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select($db->quoteName(['extension_id', 'element', 'params', 'enabled'], ['id', 'option', null, null]))
                 ->from($db->quoteName('#__extensions'))

--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Profiler\Profiler;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -381,7 +382,7 @@ class ComponentHelper
     protected static function load()
     {
         $loader = function () {
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select($db->quoteName(['extension_id', 'element', 'params', 'enabled'], ['id', 'option', null, null]))
                 ->from($db->quoteName('#__extensions'))

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\Date;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -425,7 +426,7 @@ class Date extends \DateTime
      * Gets the date as an SQL datetime string.
      *
      * @param   boolean         $local  True to return the date string in the local time zone, false to return it in GMT.
-     * @param   DatabaseDriver  $db     The database driver or null to use Factory::getDbo()
+     * @param   DatabaseDriver  $db     The database driver or null to use  Factory::getContainer()->get(DatabaseInterface::class)
      *
      * @return  string     The date string in SQL datetime format.
      *
@@ -435,7 +436,7 @@ class Date extends \DateTime
     public function toSql($local = false, DatabaseDriver $db = null)
     {
         if ($db === null) {
-            $db = Factory::getDbo();
+            $db =  Factory::getContainer()->get(DatabaseInterface::class);
         }
 
         return $this->format($db->getDateFormat(), $local, false);

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -426,7 +426,7 @@ class Date extends \DateTime
      * Gets the date as an SQL datetime string.
      *
      * @param   boolean         $local  True to return the date string in the local time zone, false to return it in GMT.
-     * @param   DatabaseDriver  $db     The database driver or null to use  Factory::getContainer()->get(DatabaseInterface::class)
+     * @param   DatabaseDriver  $db     The database driver or null to use Factory::getContainer()->get(DatabaseInterface::class)
      *
      * @return  string     The date string in SQL datetime format.
      *
@@ -436,7 +436,7 @@ class Date extends \DateTime
     public function toSql($local = false, DatabaseDriver $db = null)
     {
         if ($db === null) {
-            $db =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
         }
 
         return $this->format($db->getDateFormat(), $local, false);

--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -475,7 +475,7 @@ class ExtensionHelper
         $key = $element . '.' . $type . '.' . $clientId . '.' . $folder;
 
         if (!\array_key_exists($key, self::$loadedExtensions)) {
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select('*')
                 ->from($db->quoteName('#__extensions'))

--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -399,7 +399,7 @@ class ExtensionHelper
             return self::$coreExtensionIds;
         }
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('extension_id'))
             ->from($db->quoteName('#__extensions'));

--- a/libraries/src/Extension/ExtensionHelper.php
+++ b/libraries/src/Extension/ExtensionHelper.php
@@ -10,6 +10,7 @@
 namespace Joomla\CMS\Extension;
 
 use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -398,7 +399,7 @@ class ExtensionHelper
             return self::$coreExtensionIds;
         }
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('extension_id'))
             ->from($db->quoteName('#__extensions'));
@@ -474,7 +475,7 @@ class ExtensionHelper
         $key = $element . '.' . $type . '.' . $clientId . '.' . $folder;
 
         if (!\array_key_exists($key, self::$loadedExtensions)) {
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select('*')
                 ->from($db->quoteName('#__extensions'))

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -132,7 +132,7 @@ abstract class Factory
      * @deprecated  4.3 will be removed in 6.0
      *              Use the database service in the DI container
      *              Example:
-     *           Factory::getContainer()->get(DatabaseInterface::class);
+     *              Factory::getContainer()->get(DatabaseInterface::class);
      */
     public static $database = null;
 
@@ -446,7 +446,7 @@ abstract class Factory
      * @deprecated  4.3 will be removed in 6.0
      *              Use the database service in the DI container
      *              Example:
-     *           Factory::getContainer()->get(DatabaseInterface::class);
+     *              Factory::getContainer()->get(DatabaseInterface::class);
      */
     public static function getDbo()
     {
@@ -641,7 +641,7 @@ abstract class Factory
      * @deprecated  4.3 will be removed in 6.0
      *              Use the database service in the DI container
      *              Example:
-     *           Factory::getContainer()->get(DatabaseInterface::class);
+     *              Factory::getContainer()->get(DatabaseInterface::class);
      */
     protected static function createDbo()
     {

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -132,7 +132,7 @@ abstract class Factory
      * @deprecated  4.3 will be removed in 6.0
      *              Use the database service in the DI container
      *              Example:
-     *             Factory::getContainer()->get(DatabaseInterface::class);
+     *           Factory::getContainer()->get(DatabaseInterface::class);
      */
     public static $database = null;
 
@@ -446,7 +446,7 @@ abstract class Factory
      * @deprecated  4.3 will be removed in 6.0
      *              Use the database service in the DI container
      *              Example:
-     *             Factory::getContainer()->get(DatabaseInterface::class);
+     *           Factory::getContainer()->get(DatabaseInterface::class);
      */
     public static function getDbo()
     {
@@ -641,7 +641,7 @@ abstract class Factory
      * @deprecated  4.3 will be removed in 6.0
      *              Use the database service in the DI container
      *              Example:
-     *             Factory::getContainer()->get(DatabaseInterface::class);
+     *           Factory::getContainer()->get(DatabaseInterface::class);
      */
     protected static function createDbo()
     {

--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -132,7 +132,7 @@ abstract class Factory
      * @deprecated  4.3 will be removed in 6.0
      *              Use the database service in the DI container
      *              Example:
-     *              Factory::getContainer()->get(DatabaseInterface::class);
+     *             Factory::getContainer()->get(DatabaseInterface::class);
      */
     public static $database = null;
 
@@ -446,7 +446,7 @@ abstract class Factory
      * @deprecated  4.3 will be removed in 6.0
      *              Use the database service in the DI container
      *              Example:
-     *              Factory::getContainer()->get(DatabaseInterface::class);
+     *             Factory::getContainer()->get(DatabaseInterface::class);
      */
     public static function getDbo()
     {
@@ -641,7 +641,7 @@ abstract class Factory
      * @deprecated  4.3 will be removed in 6.0
      *              Use the database service in the DI container
      *              Example:
-     *              Factory::getContainer()->get(DatabaseInterface::class);
+     *             Factory::getContainer()->get(DatabaseInterface::class);
      */
     protected static function createDbo()
     {

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -1087,7 +1087,7 @@ abstract class HTMLHelper
         $singleHeader = ($singleHeader) ? "1" : "0";
 
         // Format value when not nulldate ('0000-00-00 00:00:00'), otherwise blank it as it would result in 1970-01-01.
-        if ($value && $value !==  Factory::getContainer()->get(DatabaseInterface::class)->getNullDate() && strtotime($value) !== false) {
+        if ($value && $value !== Factory::getContainer()->get(DatabaseInterface::class)->getNullDate() && strtotime($value) !== false) {
             $tz = date_default_timezone_get();
             date_default_timezone_set('UTC');
 

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Filesystem\Path;
 use Joomla\Utilities\ArrayHelper;
 
@@ -1086,7 +1087,7 @@ abstract class HTMLHelper
         $singleHeader = ($singleHeader) ? "1" : "0";
 
         // Format value when not nulldate ('0000-00-00 00:00:00'), otherwise blank it as it would result in 1970-01-01.
-        if ($value && $value !== Factory::getDbo()->getNullDate() && strtotime($value) !== false) {
+        if ($value && $value !==  Factory::getContainer()->get(DatabaseInterface::class)->getNullDate() && strtotime($value) !== false) {
             $tz = date_default_timezone_get();
             date_default_timezone_set('UTC');
 

--- a/libraries/src/HTML/Helpers/Access.php
+++ b/libraries/src/HTML/Helpers/Access.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Helper\UserGroupsHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -51,7 +52,7 @@ abstract class Access
      */
     public static function level($name, $selected, $attribs = '', $params = true, $id = false)
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [
@@ -244,7 +245,7 @@ abstract class Access
     public static function assetgroups()
     {
         if (empty(static::$asset_groups)) {
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/libraries/src/HTML/Helpers/Access.php
+++ b/libraries/src/HTML/Helpers/Access.php
@@ -52,7 +52,7 @@ abstract class Access
      */
     public static function level($name, $selected, $attribs = '', $params = true, $id = false)
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [
@@ -245,7 +245,7 @@ abstract class Access
     public static function assetgroups()
     {
         if (empty(static::$asset_groups)) {
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/libraries/src/HTML/Helpers/Category.php
+++ b/libraries/src/HTML/Helpers/Category.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\HTML\Helpers;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
 
@@ -51,7 +52,7 @@ abstract class Category
 
         if (!isset(static::$items[$hash])) {
             $config = (array) $config;
-            $db     = Factory::getDbo();
+            $db     =  Factory::getContainer()->get(DatabaseInterface::class);
             $user   = Factory::getUser();
 
             $query = $db->getQuery(true)
@@ -147,7 +148,7 @@ abstract class Category
         if (!isset(static::$items[$hash])) {
             $config = (array) $config;
             $user   = Factory::getUser();
-            $db     = Factory::getDbo();
+            $db     =  Factory::getContainer()->get(DatabaseInterface::class);
             $query  = $db->getQuery(true)
                 ->select(
                     [

--- a/libraries/src/HTML/Helpers/Category.php
+++ b/libraries/src/HTML/Helpers/Category.php
@@ -52,7 +52,7 @@ abstract class Category
 
         if (!isset(static::$items[$hash])) {
             $config = (array) $config;
-            $db     =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db     = Factory::getContainer()->get(DatabaseInterface::class);
             $user   = Factory::getUser();
 
             $query = $db->getQuery(true)
@@ -148,7 +148,7 @@ abstract class Category
         if (!isset(static::$items[$hash])) {
             $config = (array) $config;
             $user   = Factory::getUser();
-            $db     =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db     = Factory::getContainer()->get(DatabaseInterface::class);
             $query  = $db->getQuery(true)
                 ->select(
                     [

--- a/libraries/src/HTML/Helpers/ContentLanguage.php
+++ b/libraries/src/HTML/Helpers/ContentLanguage.php
@@ -48,7 +48,7 @@ abstract class ContentLanguage
     {
         if (empty(static::$items)) {
             // Get the database object and a new query object.
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true);
 
             // Build the query.

--- a/libraries/src/HTML/Helpers/ContentLanguage.php
+++ b/libraries/src/HTML/Helpers/ContentLanguage.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\HTML\Helpers;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -47,7 +48,7 @@ abstract class ContentLanguage
     {
         if (empty(static::$items)) {
             // Get the database object and a new query object.
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true);
 
             // Build the query.

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -207,7 +207,7 @@ abstract class JGrid
 
         // Special state for dates
         if ($publishUp || $publishDown) {
-            $nullDate =  Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
+            $nullDate = Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
             $nowDate  = Factory::getDate()->toUnix();
 
             $tz = Factory::getUser()->getTimezone();

--- a/libraries/src/HTML/Helpers/JGrid.php
+++ b/libraries/src/HTML/Helpers/JGrid.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -206,7 +207,7 @@ abstract class JGrid
 
         // Special state for dates
         if ($publishUp || $publishDown) {
-            $nullDate = Factory::getDbo()->getNullDate();
+            $nullDate =  Factory::getContainer()->get(DatabaseInterface::class)->getNullDate();
             $nowDate  = Factory::getDate()->toUnix();
 
             $tz = Factory::getUser()->getTimezone();

--- a/libraries/src/HTML/Helpers/ListHelper.php
+++ b/libraries/src/HTML/Helpers/ListHelper.php
@@ -92,7 +92,7 @@ abstract class ListHelper
      */
     public static function genericordering($query, $chop = 30)
     {
-        $db      =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db      = Factory::getContainer()->get(DatabaseInterface::class);
         $options = [];
         $db->setQuery($query);
 
@@ -179,7 +179,7 @@ abstract class ListHelper
      */
     public static function users($name, $active, $nouser = 0, $javascript = null, $order = 'name')
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [

--- a/libraries/src/HTML/Helpers/ListHelper.php
+++ b/libraries/src/HTML/Helpers/ListHelper.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\HTML\Helpers;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\DatabaseQuery;
 use Joomla\String\StringHelper;
 
@@ -91,7 +92,7 @@ abstract class ListHelper
      */
     public static function genericordering($query, $chop = 30)
     {
-        $db      = Factory::getDbo();
+        $db      =  Factory::getContainer()->get(DatabaseInterface::class);
         $options = [];
         $db->setQuery($query);
 
@@ -178,7 +179,7 @@ abstract class ListHelper
      */
     public static function users($name, $active, $nouser = 0, $javascript = null, $order = 'name')
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [

--- a/libraries/src/HTML/Helpers/Menu.php
+++ b/libraries/src/HTML/Helpers/Menu.php
@@ -56,7 +56,7 @@ abstract class Menu
         $key = serialize($clientId);
 
         if (!isset(static::$menus[$key])) {
-            $db =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
 
             $query = $db->getQuery(true)
                 ->select(
@@ -105,7 +105,7 @@ abstract class Menu
             $clientId = \array_key_exists('clientid', $config) ? $config['clientid'] : 0;
             $menus    = static::menus($clientId);
 
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [
@@ -245,7 +245,7 @@ abstract class Menu
     public static function ordering(&$row, $id)
     {
         if ($id) {
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [
@@ -291,7 +291,7 @@ abstract class Menu
      */
     public static function linkOptions($all = false, $unassigned = false, $clientId = 0)
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Get a list of the menu items
         $query = $db->getQuery(true)

--- a/libraries/src/HTML/Helpers/Menu.php
+++ b/libraries/src/HTML/Helpers/Menu.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\HTML\Helpers;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -55,7 +56,7 @@ abstract class Menu
         $key = serialize($clientId);
 
         if (!isset(static::$menus[$key])) {
-            $db = Factory::getDbo();
+            $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
             $query = $db->getQuery(true)
                 ->select(
@@ -104,7 +105,7 @@ abstract class Menu
             $clientId = \array_key_exists('clientid', $config) ? $config['clientid'] : 0;
             $menus    = static::menus($clientId);
 
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [
@@ -244,7 +245,7 @@ abstract class Menu
     public static function ordering(&$row, $id)
     {
         if ($id) {
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [
@@ -290,7 +291,7 @@ abstract class Menu
      */
     public static function linkOptions($all = false, $unassigned = false, $clientId = 0)
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Get a list of the menu items
         $query = $db->getQuery(true)

--- a/libraries/src/HTML/Helpers/Tag.php
+++ b/libraries/src/HTML/Helpers/Tag.php
@@ -53,7 +53,7 @@ abstract class Tag
 
         if (!isset(static::$items[$hash])) {
             $config = (array) $config;
-            $db     =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db     = Factory::getContainer()->get(DatabaseInterface::class);
             $query  = $db->getQuery(true)
                 ->select(
                     [
@@ -117,7 +117,7 @@ abstract class Tag
     {
         $hash   = md5(serialize($config));
         $config = (array) $config;
-        $db     =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db     = Factory::getContainer()->get(DatabaseInterface::class);
         $query  = $db->getQuery(true)
             ->select(
                 [

--- a/libraries/src/HTML/Helpers/Tag.php
+++ b/libraries/src/HTML/Helpers/Tag.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
 
@@ -52,7 +53,7 @@ abstract class Tag
 
         if (!isset(static::$items[$hash])) {
             $config = (array) $config;
-            $db     = Factory::getDbo();
+            $db     =  Factory::getContainer()->get(DatabaseInterface::class);
             $query  = $db->getQuery(true)
                 ->select(
                     [
@@ -116,7 +117,7 @@ abstract class Tag
     {
         $hash   = md5(serialize($config));
         $config = (array) $config;
-        $db     = Factory::getDbo();
+        $db     =  Factory::getContainer()->get(DatabaseInterface::class);
         $query  = $db->getQuery(true)
             ->select(
                 [

--- a/libraries/src/HTML/Helpers/User.php
+++ b/libraries/src/HTML/Helpers/User.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Access\Access;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\UserGroupsHelper;
 use Joomla\CMS\HTML\HTMLHelper;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -69,7 +70,7 @@ abstract class User
      */
     public static function userlist()
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [

--- a/libraries/src/HTML/Helpers/User.php
+++ b/libraries/src/HTML/Helpers/User.php
@@ -70,7 +70,7 @@ abstract class User
      */
     public static function userlist()
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [

--- a/libraries/src/HTML/Helpers/WorkflowStage.php
+++ b/libraries/src/HTML/Helpers/WorkflowStage.php
@@ -37,7 +37,7 @@ abstract class WorkflowStage
     public static function existing($options)
     {
         // Get the database object and a new query object.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         // Build the query.

--- a/libraries/src/HTML/Helpers/WorkflowStage.php
+++ b/libraries/src/HTML/Helpers/WorkflowStage.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\HTML\Helpers;
 use Joomla\CMS\Factory;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -36,7 +37,7 @@ abstract class WorkflowStage
     public static function existing($options)
     {
         // Get the database object and a new query object.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         // Build the query.

--- a/libraries/src/Helper/CMSHelper.php
+++ b/libraries/src/Helper/CMSHelper.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\TableInterface;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -78,7 +79,7 @@ class CMSHelper
      */
     public function getLanguageId($langCode)
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('lang_id'))
             ->from($db->quoteName('#__languages'))

--- a/libraries/src/Helper/CMSHelper.php
+++ b/libraries/src/Helper/CMSHelper.php
@@ -79,7 +79,7 @@ class CMSHelper
      */
     public function getLanguageId($langCode)
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('lang_id'))
             ->from($db->quoteName('#__languages'))

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -60,7 +60,7 @@ class ContentHelper
      */
     public static function countRelations(&$items, $config)
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Allow custom state / condition values and custom column names to support custom components
         $counter_names = $config->counter_names ?? [
@@ -244,7 +244,7 @@ class ContentHelper
      */
     public static function getLanguageId($langCode)
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('lang_id'))
             ->from($db->quoteName('#__languages'))

--- a/libraries/src/Helper/ContentHelper.php
+++ b/libraries/src/Helper/ContentHelper.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\View\CanDo;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -59,7 +60,7 @@ class ContentHelper
      */
     public static function countRelations(&$items, $config)
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Allow custom state / condition values and custom column names to support custom components
         $counter_names = $config->counter_names ?? [
@@ -243,7 +244,7 @@ class ContentHelper
      */
     public static function getLanguageId($langCode)
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('lang_id'))
             ->from($db->quoteName('#__languages'))

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Profiler\Profiler;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Filesystem\Path;
 use Joomla\Registry\Registry;
@@ -412,7 +413,7 @@ abstract class ModuleHelper
         // Build a cache ID for the resulting data object
         $cacheId = implode(',', $groups) . '.' . $clientId . '.' . $itemId;
 
-        $db      = Factory::getDbo();
+        $db      =  Factory::getContainer()->get(DatabaseInterface::class);
         $query   = $db->getQuery(true);
         $nowDate = Factory::getDate()->toSql();
 

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -413,7 +413,7 @@ abstract class ModuleHelper
         // Build a cache ID for the resulting data object
         $cacheId = implode(',', $groups) . '.' . $clientId . '.' . $itemId;
 
-        $db      =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db      = Factory::getContainer()->get(DatabaseInterface::class);
         $query   = $db->getQuery(true);
         $nowDate = Factory::getDate()->toSql();
 

--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -179,7 +179,7 @@ class TagsHelper extends CMSHelper
                 // Remove duplicates
                 $aliases = array_values(array_unique($aliases));
 
-                $db = Factory::getDbo();
+                $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
                 $query = $db->getQuery(true)
                     ->select(
@@ -348,7 +348,7 @@ class TagsHelper extends CMSHelper
         $id = (int) $id;
 
         // Initialize some variables.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('m.tag_id'))
             ->from($db->quoteName('#__contentitem_tag_map', 'm'))
@@ -486,7 +486,7 @@ class TagsHelper extends CMSHelper
         $ids = explode(',', $ids);
         $ids = ArrayHelper::toInteger($ids);
 
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Load the tags.
         $query = $db->getQuery(true)
@@ -534,7 +534,7 @@ class TagsHelper extends CMSHelper
         $stateFilter = '0,1'
     ) {
         // Create a new query object.
-        $db       = Factory::getDbo();
+        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
         $query    = $db->getQuery(true);
         $user     = Factory::getUser();
         $nullDate = $db->getNullDate();
@@ -711,7 +711,7 @@ class TagsHelper extends CMSHelper
         if (\is_array($tagIds) && \count($tagIds) > 0) {
             $tagIds = ArrayHelper::toInteger($tagIds);
 
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select($db->quoteName('title'))
                 ->from($db->quoteName('#__tags'))
@@ -773,7 +773,7 @@ class TagsHelper extends CMSHelper
     public static function getTypes($arrayType = 'objectList', $selectTypes = null, $useAlias = true)
     {
         // Initialize some variables.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('*');
 
@@ -911,7 +911,7 @@ class TagsHelper extends CMSHelper
      */
     public static function searchTags($filters = [])
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [
@@ -1021,7 +1021,7 @@ class TagsHelper extends CMSHelper
         $tag_id = (int) $tagId;
 
         // Delete the old tag maps.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->delete($db->quoteName('#__contentitem_tag_map'))
             ->where($db->quoteName('tag_id') . ' = :id')
@@ -1085,7 +1085,7 @@ class TagsHelper extends CMSHelper
     {
         $key   = $table->getKeyName();
         $id    = (int) $table->$key;
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->delete($db->quoteName('#__contentitem_tag_map'))
             ->where(
@@ -1124,7 +1124,7 @@ class TagsHelper extends CMSHelper
         if (\is_array($tagIds) && \count($tagIds) > 0) {
             $tagIds = ArrayHelper::toInteger($tagIds);
 
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select([$db->quoteName('id'), $db->quoteName('title')])
                 ->from($db->quoteName('#__tags'))

--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -179,7 +179,7 @@ class TagsHelper extends CMSHelper
                 // Remove duplicates
                 $aliases = array_values(array_unique($aliases));
 
-                $db =  Factory::getContainer()->get(DatabaseInterface::class);
+                $db = Factory::getContainer()->get(DatabaseInterface::class);
 
                 $query = $db->getQuery(true)
                     ->select(

--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -348,7 +348,7 @@ class TagsHelper extends CMSHelper
         $id = (int) $id;
 
         // Initialize some variables.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('m.tag_id'))
             ->from($db->quoteName('#__contentitem_tag_map', 'm'))
@@ -486,7 +486,7 @@ class TagsHelper extends CMSHelper
         $ids = explode(',', $ids);
         $ids = ArrayHelper::toInteger($ids);
 
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Load the tags.
         $query = $db->getQuery(true)
@@ -534,7 +534,7 @@ class TagsHelper extends CMSHelper
         $stateFilter = '0,1'
     ) {
         // Create a new query object.
-        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db       = Factory::getContainer()->get(DatabaseInterface::class);
         $query    = $db->getQuery(true);
         $user     = Factory::getUser();
         $nullDate = $db->getNullDate();
@@ -711,7 +711,7 @@ class TagsHelper extends CMSHelper
         if (\is_array($tagIds) && \count($tagIds) > 0) {
             $tagIds = ArrayHelper::toInteger($tagIds);
 
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select($db->quoteName('title'))
                 ->from($db->quoteName('#__tags'))
@@ -773,7 +773,7 @@ class TagsHelper extends CMSHelper
     public static function getTypes($arrayType = 'objectList', $selectTypes = null, $useAlias = true)
     {
         // Initialize some variables.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select('*');
 
@@ -911,7 +911,7 @@ class TagsHelper extends CMSHelper
      */
     public static function searchTags($filters = [])
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select(
                 [
@@ -1021,7 +1021,7 @@ class TagsHelper extends CMSHelper
         $tag_id = (int) $tagId;
 
         // Delete the old tag maps.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->delete($db->quoteName('#__contentitem_tag_map'))
             ->where($db->quoteName('tag_id') . ' = :id')
@@ -1085,7 +1085,7 @@ class TagsHelper extends CMSHelper
     {
         $key   = $table->getKeyName();
         $id    = (int) $table->$key;
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->delete($db->quoteName('#__contentitem_tag_map'))
             ->where(
@@ -1124,7 +1124,7 @@ class TagsHelper extends CMSHelper
         if (\is_array($tagIds) && \count($tagIds) > 0) {
             $tagIds = ArrayHelper::toInteger($tagIds);
 
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select([$db->quoteName('id'), $db->quoteName('title')])
                 ->from($db->quoteName('#__tags'))

--- a/libraries/src/Helper/UserGroupsHelper.php
+++ b/libraries/src/Helper/UserGroupsHelper.php
@@ -197,7 +197,7 @@ final class UserGroupsHelper
     public function total()
     {
         if ($this->total === null) {
-            $db =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db = Factory::getContainer()->get(DatabaseInterface::class);
 
             $query = $db->getQuery(true)
                 ->select('COUNT(' . $db->quoteName('id') . ')')
@@ -225,7 +225,7 @@ final class UserGroupsHelper
         // Cast as integer until method is typehinted.
         $id = (int) $id;
 
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $query = $db->getQuery(true)
             ->select('*')
@@ -255,7 +255,7 @@ final class UserGroupsHelper
     {
         $this->groups = [];
 
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $query = $db->getQuery(true)
             ->select('*')

--- a/libraries/src/Helper/UserGroupsHelper.php
+++ b/libraries/src/Helper/UserGroupsHelper.php
@@ -10,6 +10,7 @@
 namespace Joomla\CMS\Helper;
 
 use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -196,7 +197,7 @@ final class UserGroupsHelper
     public function total()
     {
         if ($this->total === null) {
-            $db = Factory::getDbo();
+            $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
             $query = $db->getQuery(true)
                 ->select('COUNT(' . $db->quoteName('id') . ')')
@@ -224,7 +225,7 @@ final class UserGroupsHelper
         // Cast as integer until method is typehinted.
         $id = (int) $id;
 
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $query = $db->getQuery(true)
             ->select('*')
@@ -254,7 +255,7 @@ final class UserGroupsHelper
     {
         $this->groups = [];
 
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $query = $db->getQuery(true)
             ->select('*')

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -259,7 +259,7 @@ class InstallerScript
         // Store the combined new and existing values back as a JSON string
         $paramsString = json_encode($params);
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->update($db->quoteName($this->paramTable))
             ->set('params = :params')
@@ -290,7 +290,7 @@ class InstallerScript
     public function getItemArray($element, $table, $column, $identifier)
     {
         // Get the DB and query objects
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $paramType = is_numeric($identifier) ? ParameterType::INTEGER : ParameterType::STRING;
 

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\Folder;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Filesystem\File;
 use Joomla\Filesystem\Path;
@@ -174,7 +175,7 @@ class InstallerScript
     {
         $extension = $this->extension;
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         // Select the item(s) and retrieve the id
@@ -258,7 +259,7 @@ class InstallerScript
         // Store the combined new and existing values back as a JSON string
         $paramsString = json_encode($params);
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->update($db->quoteName($this->paramTable))
             ->set('params = :params')
@@ -289,7 +290,7 @@ class InstallerScript
     public function getItemArray($element, $table, $column, $identifier)
     {
         // Get the DB and query objects
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $paramType = is_numeric($identifier) ? ParameterType::INTEGER : ParameterType::STRING;
 

--- a/libraries/src/Installer/InstallerScript.php
+++ b/libraries/src/Installer/InstallerScript.php
@@ -175,7 +175,7 @@ class InstallerScript
     {
         $extension = $this->extension;
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
 
         // Select the item(s) and retrieve the id

--- a/libraries/src/Language/Associations.php
+++ b/libraries/src/Language/Associations.php
@@ -66,7 +66,7 @@ class Associations
         if (!isset($multilanguageAssociations[$queryKey])) {
             $multilanguageAssociations[$queryKey] = [];
 
-            $db                 =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db                 = Factory::getContainer()->get(DatabaseInterface::class);
             $query              = $db->getQuery(true);
             $categoriesExtraSql = '';
 

--- a/libraries/src/Language/Associations.php
+++ b/libraries/src/Language/Associations.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Language;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 
@@ -65,7 +66,7 @@ class Associations
         if (!isset($multilanguageAssociations[$queryKey])) {
             $multilanguageAssociations[$queryKey] = [];
 
-            $db                 = Factory::getDbo();
+            $db                 =  Factory::getContainer()->get(DatabaseInterface::class);
             $query              = $db->getQuery(true);
             $categoriesExtraSql = '';
 

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -166,7 +166,7 @@ class LanguageHelper
                 if ($cache->contains('languages')) {
                     $languages = $cache->get('languages');
                 } else {
-                    $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+                    $db    = Factory::getContainer()->get(DatabaseInterface::class);
                     $query = $db->getQuery(true)
                         ->select('*')
                         ->from($db->quoteName('#__languages'))
@@ -376,7 +376,7 @@ class LanguageHelper
             if ($cache->contains('contentlanguages')) {
                 $contentLanguages = $cache->get('contentlanguages');
             } else {
-                $db =  Factory::getContainer()->get(DatabaseInterface::class);
+                $db = Factory::getContainer()->get(DatabaseInterface::class);
 
                 $query = $db->getQuery(true)
                     ->select('*')

--- a/libraries/src/Language/LanguageHelper.php
+++ b/libraries/src/Language/LanguageHelper.php
@@ -166,7 +166,7 @@ class LanguageHelper
                 if ($cache->contains('languages')) {
                     $languages = $cache->get('languages');
                 } else {
-                    $db    = Factory::getDbo();
+                    $db    =  Factory::getContainer()->get(DatabaseInterface::class);
                     $query = $db->getQuery(true)
                         ->select('*')
                         ->from($db->quoteName('#__languages'))
@@ -376,7 +376,7 @@ class LanguageHelper
             if ($cache->contains('contentlanguages')) {
                 $contentLanguages = $cache->get('contentlanguages');
             } else {
-                $db = Factory::getDbo();
+                $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
                 $query = $db->getQuery(true)
                     ->select('*')

--- a/libraries/src/Language/Multilanguage.php
+++ b/libraries/src/Language/Multilanguage.php
@@ -66,7 +66,7 @@ class Multilanguage
         // If already tested, don't test again.
         if (!$tested) {
             // Determine status of language filter plugin.
-            $db    = $db ?:  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = $db ?: Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select($db->quoteName('enabled'))
                 ->from($db->quoteName('#__extensions'))
@@ -102,7 +102,7 @@ class Multilanguage
 
         if (!isset($multilangSiteHomePages)) {
             // Check for Home pages languages.
-            $db    = $db ?:  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = $db ?: Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/libraries/src/Language/Multilanguage.php
+++ b/libraries/src/Language/Multilanguage.php
@@ -66,7 +66,7 @@ class Multilanguage
         // If already tested, don't test again.
         if (!$tested) {
             // Determine status of language filter plugin.
-            $db    = $db ?: Factory::getDbo();
+            $db    = $db ?:  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select($db->quoteName('enabled'))
                 ->from($db->quoteName('#__extensions'))
@@ -102,7 +102,7 @@ class Multilanguage
 
         if (!isset($multilangSiteHomePages)) {
             // Check for Home pages languages.
-            $db    = $db ?: Factory::getDbo();
+            $db    = $db ?:  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     [

--- a/libraries/src/Log/Logger/DatabaseLogger.php
+++ b/libraries/src/Log/Logger/DatabaseLogger.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Log\LogEntry;
 use Joomla\CMS\Log\Logger;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -107,7 +108,7 @@ class DatabaseLogger extends Logger
 
         // If both the database object and driver options are empty we want to use the system database connection.
         if (empty($this->options['db_driver'])) {
-            $this->db       = Factory::getDbo();
+            $this->db       =  Factory::getContainer()->get(DatabaseInterface::class);
             $this->driver   = null;
             $this->host     = null;
             $this->user     = null;

--- a/libraries/src/Log/Logger/DatabaseLogger.php
+++ b/libraries/src/Log/Logger/DatabaseLogger.php
@@ -108,7 +108,7 @@ class DatabaseLogger extends Logger
 
         // If both the database object and driver options are empty we want to use the system database connection.
         if (empty($this->options['db_driver'])) {
-            $this->db       =  Factory::getContainer()->get(DatabaseInterface::class);
+            $this->db       = Factory::getContainer()->get(DatabaseInterface::class);
             $this->driver   = null;
             $this->host     = null;
             $this->user     = null;

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -102,7 +102,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
          *              Database instance is injected through the setter function,
          *              subclasses should not use the db instance in constructor anymore
          */
-        $db = \array_key_exists('dbo', $config) ? $config['dbo'] :  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = \array_key_exists('dbo', $config) ? $config['dbo'] : Factory::getContainer()->get(DatabaseInterface::class);
 
         if ($db) {
             @trigger_error(sprintf('Database is not available in constructor in 6.0.'), E_USER_DEPRECATED);

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -102,7 +102,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
          *              Database instance is injected through the setter function,
          *              subclasses should not use the db instance in constructor anymore
          */
-        $db = \array_key_exists('dbo', $config) ? $config['dbo'] : Factory::getDbo();
+        $db = \array_key_exists('dbo', $config) ? $config['dbo'] :  Factory::getContainer()->get(DatabaseInterface::class);
 
         if ($db) {
             @trigger_error(sprintf('Database is not available in constructor in 6.0.'), E_USER_DEPRECATED);

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -386,7 +386,7 @@ class MailTemplate
      */
     public static function getTemplate($key, $language)
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $query->select('*')
             ->from($db->quoteName('#__mail_templates'))
@@ -419,7 +419,7 @@ class MailTemplate
      */
     public static function createTemplate($key, $subject, $body, $tags, $htmlbody = '')
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $template              = new \stdClass();
         $template->template_id = $key;
@@ -451,7 +451,7 @@ class MailTemplate
      */
     public static function updateTemplate($key, $subject, $body, $tags, $htmlbody = '')
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $template              = new \stdClass();
         $template->template_id = $key;
@@ -477,7 +477,7 @@ class MailTemplate
      */
     public static function deleteTemplate($key)
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $query->delete($db->quoteName('#__mail_templates'))
             ->where($db->quoteName('template_id') . ' = :key')

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Filesystem\File;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Mail\Exception\MailDisabledException;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 use Joomla\Filesystem\Path;
 use Joomla\Registry\Registry;
@@ -385,7 +386,7 @@ class MailTemplate
      */
     public static function getTemplate($key, $language)
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $query->select('*')
             ->from($db->quoteName('#__mail_templates'))
@@ -418,7 +419,7 @@ class MailTemplate
      */
     public static function createTemplate($key, $subject, $body, $tags, $htmlbody = '')
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $template              = new \stdClass();
         $template->template_id = $key;
@@ -450,7 +451,7 @@ class MailTemplate
      */
     public static function updateTemplate($key, $subject, $body, $tags, $htmlbody = '')
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $template              = new \stdClass();
         $template->template_id = $key;
@@ -476,7 +477,7 @@ class MailTemplate
      */
     public static function deleteTemplate($key)
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true);
         $query->delete($db->quoteName('#__mail_templates'))
             ->where($db->quoteName('template_id') . ' = :key')

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -151,7 +151,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
             $dbProperty = $reflection->getProperty('db');
 
             if ($dbProperty->isPrivate() === false && \is_null($this->db)) {
-                $this->db =  Factory::getContainer()->get(DatabaseInterface::class);
+                $this->db = Factory::getContainer()->get(DatabaseInterface::class);
             }
         }
 

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Extension\PluginInterface;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\LanguageAwareInterface;
 use Joomla\CMS\Language\LanguageAwareTrait;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Event\AbstractEvent;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherAwareTrait;
@@ -150,7 +151,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
             $dbProperty = $reflection->getProperty('db');
 
             if ($dbProperty->isPrivate() === false && \is_null($this->db)) {
-                $this->db = Factory::getDbo();
+                $this->db =  Factory::getContainer()->get(DatabaseInterface::class);
             }
         }
 

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -11,6 +11,7 @@ namespace Joomla\CMS\Plugin;
 
 use Joomla\CMS\Cache\Exception\CacheExceptionInterface;
 use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Event\DispatcherAwareInterface;
 use Joomla\Event\DispatcherInterface;
 
@@ -261,7 +262,7 @@ abstract class PluginHelper
         $cache = Factory::getCache('com_plugins', 'callback');
 
         $loader = function () use ($levels) {
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     $db->quoteName(

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -262,7 +262,7 @@ abstract class PluginHelper
         $cache = Factory::getCache('com_plugins', 'callback');
 
         $loader = function () use ($levels) {
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select(
                     $db->quoteName(

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -1390,7 +1390,7 @@ abstract class Table extends \stdClass implements TableInterface, DispatcherAwar
 
         // This last check can only be relied on if tracking session metadata
         if (Factory::getApplication()->get('session_metadata', true)) {
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select('COUNT(userid)')
                 ->from($db->quoteName('#__session'))

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -1390,7 +1390,7 @@ abstract class Table extends \stdClass implements TableInterface, DispatcherAwar
 
         // This last check can only be relied on if tracking session metadata
         if (Factory::getApplication()->get('session_metadata', true)) {
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select('COUNT(userid)')
                 ->from($db->quoteName('#__session'))

--- a/libraries/src/UCM/UCMContent.php
+++ b/libraries/src/UCM/UCMContent.php
@@ -13,6 +13,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Table\TableInterface;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -102,7 +103,7 @@ class UCMContent extends UCMBase
      */
     public function delete($pk, UCMType $type = null)
     {
-        $db   = Factory::getDbo();
+        $db   =  Factory::getContainer()->get(DatabaseInterface::class);
         $type = $type ?: $this->type;
 
         if (!\is_array($pk)) {
@@ -214,7 +215,7 @@ class UCMContent extends UCMBase
      */
     public function getPrimaryKey($typeId, $contentItemId)
     {
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('ucm_id'))
             ->from($db->quoteName('#__ucm_base'))

--- a/libraries/src/UCM/UCMContent.php
+++ b/libraries/src/UCM/UCMContent.php
@@ -103,7 +103,7 @@ class UCMContent extends UCMBase
      */
     public function delete($pk, UCMType $type = null)
     {
-        $db   =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db   = Factory::getContainer()->get(DatabaseInterface::class);
         $type = $type ?: $this->type;
 
         if (!\is_array($pk)) {
@@ -215,7 +215,7 @@ class UCMContent extends UCMBase
      */
     public function getPrimaryKey($typeId, $contentItemId)
     {
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('ucm_id'))
             ->from($db->quoteName('#__ucm_base'))

--- a/libraries/src/UCM/UCMType.php
+++ b/libraries/src/UCM/UCMType.php
@@ -94,7 +94,7 @@ class UCMType implements UCM
      */
     public function __construct($alias = null, DatabaseDriver $database = null, AbstractApplication $application = null)
     {
-        $this->db = $database ?:  Factory::getContainer()->get(DatabaseInterface::class);
+        $this->db = $database ?: Factory::getContainer()->get(DatabaseInterface::class);
         $app      = $application ?: Factory::getApplication();
 
         // Make the best guess we can in the absence of information.

--- a/libraries/src/UCM/UCMType.php
+++ b/libraries/src/UCM/UCMType.php
@@ -12,6 +12,7 @@ namespace Joomla\CMS\UCM;
 use Joomla\Application\AbstractApplication;
 use Joomla\CMS\Factory;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -93,7 +94,7 @@ class UCMType implements UCM
      */
     public function __construct($alias = null, DatabaseDriver $database = null, AbstractApplication $application = null)
     {
-        $this->db = $database ?: Factory::getDbo();
+        $this->db = $database ?:  Factory::getContainer()->get(DatabaseInterface::class);
         $app      = $application ?: Factory::getApplication();
 
         // Make the best guess we can in the absence of information.

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Table\Table;
 use Joomla\CMS\Updater\UpdateAdapter;
 use Joomla\CMS\Updater\Updater;
 use Joomla\CMS\Version;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -134,7 +135,7 @@ class ExtensionAdapter extends UpdateAdapter
 
                     // Check if DB & version is supported via <supported_databases> tag, assume supported if tag isn't present
                     if (isset($this->currentUpdate->supported_databases)) {
-                        $db           = Factory::getDbo();
+                        $db           =  Factory::getContainer()->get(DatabaseInterface::class);
                         $dbType       = strtolower($db->getServerType());
                         $dbVersion    = $db->getVersion();
                         $supportedDbs = $this->currentUpdate->supported_databases;

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -135,7 +135,7 @@ class ExtensionAdapter extends UpdateAdapter
 
                     // Check if DB & version is supported via <supported_databases> tag, assume supported if tag isn't present
                     if (isset($this->currentUpdate->supported_databases)) {
-                        $db           =  Factory::getContainer()->get(DatabaseInterface::class);
+                        $db           = Factory::getContainer()->get(DatabaseInterface::class);
                         $dbType       = strtolower($db->getServerType());
                         $dbVersion    = $db->getVersion();
                         $supportedDbs = $this->currentUpdate->supported_databases;

--- a/libraries/src/Updater/ConstraintChecker.php
+++ b/libraries/src/Updater/ConstraintChecker.php
@@ -196,7 +196,7 @@ class ConstraintChecker
      */
     protected function checkSupportedDatabases(array $supportedDatabases)
     {
-        $db        =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db        = Factory::getContainer()->get(DatabaseInterface::class);
         $dbType    = strtolower($db->getServerType());
         $dbVersion = $db->getVersion();
 

--- a/libraries/src/Updater/ConstraintChecker.php
+++ b/libraries/src/Updater/ConstraintChecker.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Filter\InputFilter;
 use Joomla\CMS\Version;
+use Joomla\Database\DatabaseInterface;
 
 /**
  * ConstraintChecker Class
@@ -195,7 +196,7 @@ class ConstraintChecker
      */
     protected function checkSupportedDatabases(array $supportedDatabases)
     {
-        $db        = Factory::getDbo();
+        $db        =  Factory::getContainer()->get(DatabaseInterface::class);
         $dbType    = strtolower($db->getServerType());
         $dbVersion = $db->getVersion();
 

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -419,7 +419,7 @@ class Update
 
                     // Check if DB & version is supported via <supported_databases> tag, assume supported if tag isn't present
                     if (isset($this->currentUpdate->supported_databases)) {
-                        $db           =  Factory::getContainer()->get(DatabaseInterface::class);
+                        $db           = Factory::getContainer()->get(DatabaseInterface::class);
                         $dbType       = strtolower($db->getServerType());
                         $dbVersion    = $db->getVersion();
                         $supportedDbs = $this->currentUpdate->supported_databases;

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Table\Tuf as TufMetadata;
 use Joomla\CMS\TUF\TufFetcher;
 use Joomla\CMS\Version;
 use Joomla\Database\DatabaseDriver;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -418,7 +419,7 @@ class Update
 
                     // Check if DB & version is supported via <supported_databases> tag, assume supported if tag isn't present
                     if (isset($this->currentUpdate->supported_databases)) {
-                        $db           = Factory::getDbo();
+                        $db           =  Factory::getContainer()->get(DatabaseInterface::class);
                         $dbType       = strtolower($db->getServerType());
                         $dbVersion    = $db->getVersion();
                         $supportedDbs = $this->currentUpdate->supported_databases;

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Object\LegacyErrorHandlingTrait;
 use Joomla\CMS\Object\LegacyPropertyManagementTrait;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 
@@ -427,7 +428,7 @@ class User
     {
         // Brute force method: get all published category rows for the component and check each one
         // @todo: Modify the way permissions are stored in the db to allow for faster implementation and better scaling
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         $subQuery = $db->getQuery(true)
             ->select($db->quoteName(['id', 'asset_id']))

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -428,7 +428,7 @@ class User
     {
         // Brute force method: get all published category rows for the component and check each one
         // @todo: Modify the way permissions are stored in the db to allow for faster implementation and better scaling
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         $subQuery = $db->getQuery(true)
             ->select($db->quoteName(['id', 'asset_id']))

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -25,6 +25,7 @@ use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Session\SessionManager;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\Exception\ExecutionFailureException;
 use Joomla\Database\ParameterType;
 use Joomla\Utilities\ArrayHelper;
@@ -170,7 +171,7 @@ abstract class UserHelper
         // Add the user to the group if necessary.
         if (!\in_array($groupId, $user->groups)) {
             // Check whether the group exists.
-            $db    = Factory::getDbo();
+            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select($db->quoteName('id'))
                 ->from($db->quoteName('#__usergroups'))
@@ -286,7 +287,7 @@ abstract class UserHelper
         $user->groups = $groups;
 
         // Get the titles for the user groups.
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName(['id', 'title']))
             ->from($db->quoteName('#__usergroups'))
@@ -357,7 +358,7 @@ abstract class UserHelper
      */
     public static function activateUser($activation)
     {
-        $db       = Factory::getDbo();
+        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Let's get the id of the user we want to activate
         $query = $db->getQuery(true)
@@ -404,7 +405,7 @@ abstract class UserHelper
     public static function getUserId($username)
     {
         // Initialise some variables
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__users'))
@@ -598,7 +599,7 @@ abstract class UserHelper
             return false;
         }
 
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         try {
             $userId = (int) $userId;

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -171,7 +171,7 @@ abstract class UserHelper
         // Add the user to the group if necessary.
         if (!\in_array($groupId, $user->groups)) {
             // Check whether the group exists.
-            $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+            $db    = Factory::getContainer()->get(DatabaseInterface::class);
             $query = $db->getQuery(true)
                 ->select($db->quoteName('id'))
                 ->from($db->quoteName('#__usergroups'))
@@ -287,7 +287,7 @@ abstract class UserHelper
         $user->groups = $groups;
 
         // Get the titles for the user groups.
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName(['id', 'title']))
             ->from($db->quoteName('#__usergroups'))
@@ -358,7 +358,7 @@ abstract class UserHelper
      */
     public static function activateUser($activation)
     {
-        $db       =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db       = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Let's get the id of the user we want to activate
         $query = $db->getQuery(true)
@@ -405,7 +405,7 @@ abstract class UserHelper
     public static function getUserId($username)
     {
         // Initialise some variables
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName('id'))
             ->from($db->quoteName('#__users'))
@@ -599,7 +599,7 @@ abstract class UserHelper
             return false;
         }
 
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         try {
             $userId = (int) $userId;

--- a/libraries/src/Versioning/Versioning.php
+++ b/libraries/src/Versioning/Versioning.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Table\Table;
 use Joomla\CMS\Workflow\WorkflowServiceInterface;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -40,7 +41,7 @@ class Versioning
      */
     public static function get($typeAlias, $id)
     {
-        $db     = Factory::getDbo();
+        $db     =  Factory::getContainer()->get(DatabaseInterface::class);
         $itemid = $typeAlias . '.' . $id;
         $query  = $db->getQuery(true);
         $query->select($db->quoteName('h.version_note') . ',' . $db->quoteName('h.save_date') . ',' . $db->quoteName('u.name'))
@@ -66,7 +67,7 @@ class Versioning
      */
     public static function delete($typeAlias, $id)
     {
-        $db     = Factory::getDbo();
+        $db     =  Factory::getContainer()->get(DatabaseInterface::class);
         $itemid = $typeAlias . '.' . $id;
         $query  = $db->getQuery(true);
         $query->delete($db->quoteName('#__history'))

--- a/libraries/src/Versioning/Versioning.php
+++ b/libraries/src/Versioning/Versioning.php
@@ -41,7 +41,7 @@ class Versioning
      */
     public static function get($typeAlias, $id)
     {
-        $db     =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db     = Factory::getContainer()->get(DatabaseInterface::class);
         $itemid = $typeAlias . '.' . $id;
         $query  = $db->getQuery(true);
         $query->select($db->quoteName('h.version_note') . ',' . $db->quoteName('h.save_date') . ',' . $db->quoteName('u.name'))
@@ -67,7 +67,7 @@ class Versioning
      */
     public static function delete($typeAlias, $id)
     {
-        $db     =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db     = Factory::getContainer()->get(DatabaseInterface::class);
         $itemid = $typeAlias . '.' . $id;
         $query  = $db->getQuery(true);
         $query->delete($db->quoteName('#__history'))

--- a/modules/mod_whosonline/src/Helper/WhosonlineHelper.php
+++ b/modules/mod_whosonline/src/Helper/WhosonlineHelper.php
@@ -33,7 +33,7 @@ class WhosonlineHelper
      **/
     public static function getOnlineCount()
     {
-        $db =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db = Factory::getContainer()->get(DatabaseInterface::class);
 
         // Calculate number of guests and users
         $result      = [];
@@ -87,7 +87,7 @@ class WhosonlineHelper
     {
         $whereCondition = Factory::getApplication()->get('shared_session', '0') ? 'IS NULL' : '= 0';
 
-        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
+        $db    = Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName(['a.username', 'a.userid', 'a.client_id']))
             ->from($db->quoteName('#__session', 'a'))

--- a/modules/mod_whosonline/src/Helper/WhosonlineHelper.php
+++ b/modules/mod_whosonline/src/Helper/WhosonlineHelper.php
@@ -11,6 +11,7 @@
 namespace Joomla\Module\Whosonline\Site\Helper;
 
 use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -32,7 +33,7 @@ class WhosonlineHelper
      **/
     public static function getOnlineCount()
     {
-        $db = Factory::getDbo();
+        $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
         // Calculate number of guests and users
         $result      = [];
@@ -86,7 +87,7 @@ class WhosonlineHelper
     {
         $whereCondition = Factory::getApplication()->get('shared_session', '0') ? 'IS NULL' : '= 0';
 
-        $db    = Factory::getDbo();
+        $db    =  Factory::getContainer()->get(DatabaseInterface::class);
         $query = $db->getQuery(true)
             ->select($db->quoteName(['a.username', 'a.userid', 'a.client_id']))
             ->from($db->quoteName('#__session', 'a'))

--- a/plugins/fields/sql/tmpl/sql.php
+++ b/plugins/fields/sql/tmpl/sql.php
@@ -20,7 +20,7 @@ if ($value == '') {
     return;
 }
 
-$db    =  Factory::getContainer()->get(DatabaseInterface::class);
+$db    = Factory::getContainer()->get(DatabaseInterface::class);
 $value = (array) $value;
 $query = $db->getQuery(true);
 $sql   = $fieldParams->get('query', '');

--- a/plugins/fields/sql/tmpl/sql.php
+++ b/plugins/fields/sql/tmpl/sql.php
@@ -11,6 +11,7 @@
 defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
 use Joomla\Database\ParameterType;
 
 $value = $field->value;
@@ -19,7 +20,7 @@ if ($value == '') {
     return;
 }
 
-$db    = Factory::getDbo();
+$db    =  Factory::getContainer()->get(DatabaseInterface::class);
 $value = (array) $value;
 $query = $db->getQuery(true);
 $sql   = $fieldParams->get('query', '');

--- a/plugins/system/httpheaders/postinstall/introduction.php
+++ b/plugins/system/httpheaders/postinstall/introduction.php
@@ -9,6 +9,7 @@
  */
 
 use Joomla\CMS\Factory;
+use Joomla\Database\DatabaseInterface;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -37,7 +38,7 @@ function httpheaders_postinstall_condition()
 function httpheaders_postinstall_action()
 {
     // Enable the plugin
-    $db = Factory::getDbo();
+    $db =  Factory::getContainer()->get(DatabaseInterface::class);
 
     $query = $db->getQuery(true)
         ->update($db->quoteName('#__extensions'))

--- a/plugins/system/httpheaders/postinstall/introduction.php
+++ b/plugins/system/httpheaders/postinstall/introduction.php
@@ -38,7 +38,7 @@ function httpheaders_postinstall_condition()
 function httpheaders_postinstall_action()
 {
     // Enable the plugin
-    $db =  Factory::getContainer()->get(DatabaseInterface::class);
+    $db = Factory::getContainer()->get(DatabaseInterface::class);
 
     $query = $db->getQuery(true)
         ->update($db->quoteName('#__extensions'))


### PR DESCRIPTION
### Summary of Changes
The call to `Factory::getDbo()` is deprecated. This PR replaces that with calls to the DI container.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
