### PR TITLE
[5.1] DateTime: Don't convert when there is no user

### DIFF
--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -884,8 +884,10 @@ abstract class HTMLHelper
             // Get a date object based on UTC.
             $date = Factory::getDate($input, 'UTC');
 
-            // Set the correct time zone based on the user configuration.
-            $date->setTimezone($app->getIdentity()->getTimezone());
+            // Set the correct time zone based on the user configuration. CLI doesn't have a user
+            if ($app->getIdentity()) {
+                $date->setTimezone($app->getIdentity()->getTimezone());
+            }
         } elseif ($tz === false) {
             // UTC date converted to server time zone.
             // Get a date object based on UTC.


### PR DESCRIPTION
Pull Request for Issue #43511 .

### Summary of Changes
When you have a custom field set to be indexed in Smart Search and run that indexing process in the CLI, it will fail because the CLI process doesn't have a user object. The failure happens in the HTMLHelper::date() method and this PR simply checks if there is a user object to get the timezone from.


### Testing Instructions
1. Create a custom field of type calendar for your articles and set it to be indexed by Smart Search
2. Run `php cli/joomla.php finder:index` on the command line


### Actual result BEFORE applying this Pull Request
Fatal error in HTMLHelper::date()


### Expected result AFTER applying this Pull Request
Indexing works as expected.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
