### PR TITLE
[5.1] Remove the obsolete view and component metadata.xml manifest file

### DIFF
--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -1118,28 +1118,6 @@ class ItemModel extends AdminModel
                     }
                 }
             }
-
-            // Now check for a view manifest file
-            if (!$formFile) {
-                if (isset($view)) {
-                    $metadataFolders = [
-                        $base . '/view/' . $view,
-                        $base . '/views/' . $view,
-                    ];
-                    $metaPath = Path::find($metadataFolders, 'metadata.xml');
-
-                    if (is_file($path = Path::clean($metaPath))) {
-                        $formFile = $path;
-                    }
-                } elseif ($base) {
-                    // Now check for a component manifest file
-                    $path = Path::clean($base . '/metadata.xml');
-
-                    if (is_file($path)) {
-                        $formFile = $path;
-                    }
-                }
-            }
         }
 
         if ($formFile) {

--- a/administrator/components/com_menus/src/View/Items/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Items/HtmlView.php
@@ -152,28 +152,6 @@ class HtmlView extends BaseHtmlView
                         parse_str($item->link, $vars);
 
                         if (isset($vars['view'])) {
-                            // Attempt to load the view xml file.
-                            $file = JPATH_SITE . '/components/' . $item->componentname . '/views/' . $vars['view'] . '/metadata.xml';
-
-                            if (!is_file($file)) {
-                                $file = JPATH_SITE . '/components/' . $item->componentname . '/view/' . $vars['view'] . '/metadata.xml';
-                            }
-
-                            if (is_file($file) && $xml = simplexml_load_file($file)) {
-                                // Look for the first view node off of the root node.
-                                if ($view = $xml->xpath('view[1]')) {
-                                    // Add view title if present.
-                                    if (!empty($view[0]['title'])) {
-                                        $viewTitle = trim((string) $view[0]['title']);
-
-                                        // Check if the key is valid. Needed due to B/C so we don't show untranslated keys. This check should be removed with Joomla 4.
-                                        if ($lang->hasKey($viewTitle)) {
-                                            $titleParts[] = Text::_($viewTitle);
-                                        }
-                                    }
-                                }
-                            }
-
                             $vars['layout'] = $vars['layout'] ?? 'default';
 
                             // Attempt to load the layout xml file.


### PR DESCRIPTION
### Summary of Changes

This pull request removes the usage of view and component manifest file metadata.xml in com_menus. At this moment there is no usage of view and component metadata.xml in the core as the core only uses layout based manifest file for menu items.

View and component metadata.xml was made optional since 2015: https://github.com/joomla/joomla-cms/pull/7654

Until now I am not aware of any Joomla 3rd extensions that use view and component metadata.xml for menu items. Please correct me if I am wrong.

Removing it to simplify the code base and make the menu item creation faster (in milliseconds maybe).

### Testing Instructions

+ /administrator/index.php?option=com_menus&view=items: should work normally
+ New menu item creation should work normally
+ The menu item types list should work normally (the list opened in modal window)

### Actual result BEFORE applying this Pull Request

### Expected result AFTER applying this Pull Request

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
