### PR TITLE
Check if the identity is available when injecting into the local adapter

### DIFF
--- a/plugins/filesystem/local/src/Extension/Local.php
+++ b/plugins/filesystem/local/src/Extension/Local.php
@@ -133,7 +133,10 @@ final class Local extends CMSPlugin implements ProviderInterface
                 $directoryEntity->thumbs,
                 [200, 200]
             );
-            $adapter->setCurrentUser($this->getApplication()->getIdentity());
+
+            if ($this->getApplication()->getIdentity()) {
+                $adapter->setCurrentUser($this->getApplication()->getIdentity());
+            }
 
             $adapters[$adapter->getAdapterName()] = $adapter;
         }


### PR DESCRIPTION
### Summary of Changes
When the local adapter is loaded through a console application it crashes.

### Testing Instructions
Add the following line to the file /plugins/task/sessiongc/src/Extension/SessionGC.php inside the sessionGC function after line number 104:
`$this->getApplication()->bootComponent('media')->getMVCFactory()->createmodel('Media', 'Administrator')->getProviders();`

Then run the following commend in the console:
`php cli/joomla.php scheduler:run -i 2`

If the session GC task has a different id than 2, adapt the command accordingly.

### Actual result BEFORE applying this Pull Request
The command fails with the current message:
_Joomla\Plugin\Filesystem\Local\Adapter\LocalAdapter::setCurrentUser(): Argument #1 ($currentUser) must be of type Joomla\CMS\User\User, null given, called in /plugins/filesystem/local/src/Extension/Local.php on line 138_

### Expected result AFTER applying this Pull Request
Task runs trough.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
