### PR TITLE
Don't throw an error on Path::clean() if $metaPath isn't found

### DIFF
--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -1128,7 +1128,7 @@ class ItemModel extends AdminModel
                     ];
                     $metaPath = Path::find($metadataFolders, 'metadata.xml');
 
-                    if (is_file($path = Path::clean($metaPath))) {
+                    if ($metaPath !== false && is_file($path = Path::clean($metaPath))) {
                         $formFile = $path;
                     }
                 } elseif ($base) {


### PR DESCRIPTION
Pull Request for Issue #43580 .

### Summary of Changes
Path::find() returns false if the location cannot be found and Path::clean() throws an error if a non-string value is supplied - this makes menu item editing impossible for components that have been uninstalled.


### Testing Instructions
See issue #43580


### Actual result BEFORE applying this Pull Request
You must specify a non-empty path to clean
![image](https://github.com/joomla/joomla-cms/assets/1422378/4c3bf87c-069f-4373-a634-cd6b0f640076)


### Expected result AFTER applying this Pull Request
Menu item editing page opens correctly
![image](https://github.com/joomla/joomla-cms/assets/1422378/bb9a5e55-b77f-4c96-ac8b-b9f6af6d4594)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
