### PR TITLE
[6.0] Set version to 6.0.0-alpha1-dev

### DIFF
--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -2,8 +2,8 @@
 <extension client="administrator" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.2.0</version>
-	<creationDate>2024-05</creationDate>
+	<version>6.0.0</version>
+	<creationDate>2024-06</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/administrator/language/en-GB/langmetadata.xml
+++ b/administrator/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="administrator">
 	<name>English (en-GB)</name>
-	<version>5.2.0</version>
-	<creationDate>2024-05</creationDate>
+	<version>6.0.0</version>
+	<creationDate>2024-06</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,7 +6,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>6.0.0-alpha-dev</version>
+	<version>6.0.0-alpha1-dev</version>
 	<creationDate>2024-06</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,8 +6,8 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>5.2.0-alpha1-dev</version>
-	<creationDate>2024-05</creationDate>
+	<version>6.0.0-alpha-dev</version>
+	<creationDate>2024-06</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 
 	<scriptfile>administrator/components/com_admin/script.php</scriptfile>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,8 +2,8 @@
 <extension type="package" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>5.2.0.1</version>
-	<creationDate>2024-05</creationDate>
+	<version>6.0.0.1</version>
+	<creationDate>2024-06</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/api/language/en-GB/install.xml
+++ b/api/language/en-GB/install.xml
@@ -2,8 +2,8 @@
 <extension client="api" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.2.0</version>
-	<creationDate>2024-05</creationDate>
+	<version>6.0.0</version>
+	<creationDate>2024-06</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/api/language/en-GB/langmetadata.xml
+++ b/api/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="api">
 	<name>English (en-GB)</name>
-	<version>5.2.0</version>
-	<creationDate>2024-05</creationDate>
+	<version>6.0.0</version>
+	<creationDate>2024-06</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/build.xml
+++ b/build.xml
@@ -85,7 +85,7 @@
 			<arg value="--template" />
 			<arg value="joomla" />
 			<arg value="--title" />
-			<arg value="Joomla! CMS 5.2 API" />
+			<arg value="Joomla! CMS 6.0 API" />
 		</exec>
 	</target>
 

--- a/installation/language/en-GB/langmetadata.xml
+++ b/installation/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="installation">
 	<name>English (United Kingdom)</name>
-	<version>5.2.0</version>
-	<creationDate>2024-05</creationDate>
+	<version>6.0.0</version>
+	<creationDate>2024-06</creationDate>
 	<author>Joomla! Project</author>
 	<copyright>(C) 2005 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -2,8 +2,8 @@
 <extension client="site" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.2.0</version>
-	<creationDate>2024-05</creationDate>
+	<version>6.0.0</version>
+	<creationDate>2024-06</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/language/en-GB/langmetadata.xml
+++ b/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="site">
 	<name>English (en-GB)</name>
-	<version>5.2.0</version>
-	<creationDate>2024-05</creationDate>
+	<version>6.0.0</version>
+	<creationDate>2024-06</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -66,7 +66,7 @@ final class Version
      * @var    string
      * @since  3.8.0
      */
-    public const EXTRA_VERSION = 'alpha-dev';
+    public const EXTRA_VERSION = 'alpha1-dev';
 
     /**
      * Development status.
@@ -90,7 +90,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const RELDATE = '28-May-2024';
+    public const RELDATE = '9-June-2024';
 
     /**
      * Release time.
@@ -99,7 +99,7 @@ final class Version
      * @since  3.5
      */
 
-    public const RELTIME = '17:00';
+    public const RELTIME = '09:15';
 
     /**
      * Release timezone.


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) sets the version to "6.0.0-alpha1-dev" using the `build/bump.php` script.

Currently without this PR the version in the "files/joomla.xml" manifest is "5.2.0-alpha1-dev" from the last upmerge.

Therefore you currently cannot use "Upload & Update" for updating a current 5.2-dev build to a current 6.0-dev update package because that would be a downgrade from 5.2.0-alpha2-dev to 5.2.0-alpha1-dev regarding the version in the manifest XML file before the update and in the update package, which is checked by the updater and is rejected.

Furthermore you get an error in the database checker about not matching CMS version because the version in the "libraries/src/Version.php" file was set to "6.0.0-alpha-dev" with PR #42969 , but the manifest was not changed with that PR.

This PR here fixes that.

I had first changed only the version in the manifest file, but I was asked to make a complete version bump by other maintainers.

This PR does not change the code name in the "libraries/src/Version.php" file. That name is still the same as for 5.2.

The 6.0 release managers will have to use `build/bump.php` script again when they have decided for a code name for 6.0.

### Testing Instructions

Code review should be sufficient.

But if you want to make a real test:

Try to update a recent 5.2.0-alpha2-dev nightly build to a recent 6.0 nightly build using the "Upload & Update" button at the bottom of the Joomla Update view.

Result: The update is refused because it would be a downgrade according to the versions from the manifest files of the current installation and the one in the update package.

Now try to update to the update package created by Drone for this PR, also with the "Upload & Update" button.

Result: The captive login is shown, and if you enter the right user name and password the update would be started.

### Actual result BEFORE applying this Pull Request

You can not update a recent 5.2.0-alpha2-dev nightly build to a recent 6.0 nightly build using the "Upload & Update" method because that reports that the update would be a downgrade to 5.2.0-alpha1-dev.

### Expected result AFTER applying this Pull Request

You can update a recent 5.2 nightly build to a 6.0 nightly build.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
