### PR TITLE
[cypress] System Tests fixes #43620, fixes #43622

### DIFF
--- a/tests/System/integration/install/Installation.cy.js
+++ b/tests/System/integration/install/Installation.cy.js
@@ -1,7 +1,5 @@
 describe('Install Joomla', () => {
   it('Install Joomla', () => {
-    cy.exec('rm configuration.php', { failOnNonZeroExit: false });
-
     const config = {
       sitename: Cypress.env('sitename'),
       name: Cypress.env('name'),
@@ -16,6 +14,8 @@ describe('Install Joomla', () => {
       db_prefix: Cypress.env('db_prefix'),
     };
 
+    // If exists, delete PHP configuration file to force a new installation
+    cy.task('deleteFolder', 'configuration.php');
     cy.installJoomla(config);
 
     cy.doAdministratorLogin(config.username, config.password, false);


### PR DESCRIPTION
Pull Request for Issue #43620 and Issue #43622

### Summary of Changes

- fixes issue #43620 - if no 'rm' command is available on Windows
- fixes issue #43622 - if cmsPath is set
- custom task 'deleteFolder' starts relative with cmsPath, can also delete a file and ignores if the file does not exist -> exactly what we need
- once PR is merged i will create the next PR to rename 'deleteFolder' as 'deleteRelativePath' and also 'writeFile' as 'writeRelativeFile' to better represent the functions

### Testing Instructions

tested was #43620 with branch dev-4.4 on macOS 14.5 Sonoma, Windows 11 Pro and Ubuntu 24.04 LTS Noble Numbat
- for Windows: ensured no 'rm' binary is installed (with Laragon simple moved away)
- run two times
  - npx cypress run --spec tests/System/integration/install/Installation.cy.js
  - 2nd time it fails with 
     AssertionError: Timed out retrying after 4000ms: Expected to find element: `#jform_language`, but never found it.
     at Context.installJoomla (webpack://joomla/./node_modules/joomla-cypress/src/joomla.js:10:0)
- implement PR
- run installation step twice without errors
- run complete test suite without errors

tested was #43622 with branch dev-4.4 on macOS 14.5 Sonoma, Windows 11 Pro and Ubuntu 24.04 LTS Noble Numbat 
- set cmsPath: 'my_fs_path' or '/laragon/www/joomla-cms.old' (and baseUrl if needed)
- run two times
  - npx cypress run --spec tests/System/integration/install/Installation.cy.js
  - 2nd time it fails with 
     AssertionError: Timed out retrying after 4000ms: Expected to find element: `#jform_language`, but never found it.
     at Context.installJoomla (webpack://joomla/./node_modules/joomla-cypress/src/joomla.js:10:0)
- implement PR
- run installation step twice without errors
- run complete test suite without errors

tested with branches dev-4.4, dev-5.1, dev-5.2 and dev-6.0 on docker based installation
- merged PR
- run installation step twice without errors
- run complete test suite without errors

### Actual result BEFORE applying this Pull Request

- starting with second run of System Tests installation step:
  - if fails on Windows if no 'rm' binary exists
  - if fails if 'cmsPath' is set != "."   

### Expected result AFTER applying this Pull Request

- second and all following runs of System Tests installation step:
  - works on Windows if no 'rm' binary exists
  - works if 'cmsPath' is set != "."   

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed

### Upmerge
- Please up-merge this PR to dev-5.1, dev-5.2 and dev-6.0 as the fixed issues are the same for those branches.