### PR TITLE
[6.2] fix #43668 PluginAdapter checkExistingExtension does not load plugin

### DIFF
--- a/libraries/src/Installer/Adapter/PluginAdapter.php
+++ b/libraries/src/Installer/Adapter/PluginAdapter.php
@@ -69,6 +69,11 @@ class PluginAdapter extends InstallerAdapter
             $this->currentExtensionId = $this->extension->find(
                 ['type' => $this->type, 'element' => $this->element, 'folder' => $this->group]
             );
+
+            // If it does exist, load it
+            if ($this->currentExtensionId) {
+                $this->extension->load(['type' => $this->type, 'element' => $this->element, 'folder' => $this->group]);
+            }
         } catch (\RuntimeException $e) {
             // Install failed, roll back changes
             throw new \RuntimeException(


### PR DESCRIPTION
Pull Request for Issue #43668 .

### Summary of Changes
Do the same extension load in the checkExistingExtension as for InstallerAdapter


### Testing Instructions
Try to install a plugin as update and get the information of the current installed plugin in the preflight.

For example 

```
public function preflight(string $type, InstallerAdapter $parent): bool
{
    $cache         = new Registry($parent->extension->manifest_cache);
    $this->oldVersion = $cache->get('version');

    return true;
}
```


### Actual result BEFORE applying this Pull Request
`$this->oldVersion = null`


### Expected result AFTER applying this Pull Request
`$this->oldVersion = <the actual currently installed version>`


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
