### PR TITLE
Article: Set required=true for created_by

### DIFF
--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -101,6 +101,7 @@
 			type="user"
 			label="COM_CONTENT_FIELD_CREATED_BY_LABEL"
 			validate="UserId"
+			required="true"
 		/>
 
 		<field


### PR DESCRIPTION
Pull Request for Issue #43674 .

### Summary of Changes
Created_by cannot be null. The "no-user" Button in the user modal is wrong.

### Testing Instructions
Go to the "publishing" tab of an article and try to change the author.


### Actual result BEFORE applying this Pull Request
see  #43674 

### Expected result AFTER applying this Pull Request
No "-- no user --" button is displaed in the users modal. 


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
