### PR TITLE
[5.1] Cypress com_cache joomla dialog fix

### DIFF
--- a/tests/System/integration/administrator/components/com_cache/Default.cy.js
+++ b/tests/System/integration/administrator/components/com_cache/Default.cy.js
@@ -1,0 +1,33 @@
+describe('Test in backend that the cache', () => {
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    cy.visit('/administrator/index.php?option=com_cache&view=cache');
+  });
+
+  it('have a title', () => {
+    cy.get('h1.page-title').should('contain.text', 'Maintenance: Clear Cache');
+  });
+
+  it('can display message', () => {
+    cy.get('div.alert.alert-info').should('contain.text', 'Select the Clear Expired Cache button');
+  });
+
+  it('can display a list of chached items', () => {
+    cy.get('tr.row0').should('contain.text', '_media_version');
+  });
+
+  it('can clear expired cache', () => {
+    cy.get('#toolbar-delete2').click();
+    cy.get('body').then(($body) => {
+      if ($body.find('div.buttons-holder button[data-button-ok]').length > 0) {
+        cy.get('div.buttons-holder button[data-button-ok]').click();
+      }
+    });
+    cy.get('#system-message-container').contains('Expired cached items have been cleared').should('exist');
+  });
+
+  it('can delete all', () => {
+    cy.get('#toolbar-delete1').click();
+    cy.get('#system-message-container').contains('All cache group(s) have been cleared').should('exist');
+  });
+});


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix for Cypress test for com_cache 5.1 for com_cache from 5.1 and upwards like suggested here by @muhme  https://github.com/joomla/joomla-cms/pull/43633#discussion_r1645431142

### Testing Instructions

Review and passing tests

### Actual result BEFORE applying this Pull Request

Tests pass

### Expected result AFTER applying this Pull Request

Tests pass

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
