### PR TITLE
Fix `content-type` header to `application/json`

### DIFF
--- a/libraries/src/Document/JsonDocument.php
+++ b/libraries/src/Document/JsonDocument.php
@@ -12,7 +12,7 @@ namespace Joomla\CMS\Document;
 use Joomla\CMS\Factory as CmsFactory;
 
 // phpcs:disable PSR1.Files.SideEffects
-\defined('JPATH_PLATFORM') or die;
+\defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
@@ -43,16 +43,7 @@ class JsonDocument extends Document
         parent::__construct($options);
 
         // Set mime type
-        if (
-            isset($_SERVER['HTTP_ACCEPT'])
-            && strpos($_SERVER['HTTP_ACCEPT'], 'application/json') === false
-            && strpos($_SERVER['HTTP_ACCEPT'], 'text/html') !== false
-        ) {
-            // Internet Explorer < 10
-            $this->_mime = 'text/plain';
-        } else {
-            $this->_mime = 'application/json';
-        }
+        $this->_mime = 'application/json';
 
         // Set document type
         $this->_type = 'json';
@@ -74,11 +65,6 @@ class JsonDocument extends Document
         $app = CmsFactory::getApplication();
 
         $app->allowCache($cache);
-
-        if ($this->_mime === 'application/json') {
-            // Browser other than Internet Explorer < 10
-            $app->setHeader('Content-Disposition', 'attachment; filename="' . $this->getName() . '.json"', true);
-        }
 
         parent::render($cache, $params);
 


### PR DESCRIPTION
Pull Request for Issue #43641.

### Summary of Changes

`JsonDocument` in Joomla 4.4.5 wrongly sets `text/plain` to all browsers (tested on `Edge`, `Firefox` and `Chrome`). Browsers do not usually send `application/json`, instead they send `*/*` with some lower priority.

#### Note: Joomla 5 already fixed this, so this change needs to be merged to Joomla 4 (maybe Joomla 4.4.6?).

### Testing Instructions
Ping and API endpoint that `extends JsonDocument`. In my case I am returning a normal `json` response instead of a `json:api`.

### Actual result BEFORE applying this Pull Request
Ping an API endpoint like `localhost/api/index.php/v1/example`:
`Content-Type: text/plain; charset=utf-8`

### Expected result AFTER applying this Pull Request
Ping an API endpoint like `localhost/api/index.php/v1/example`:
`Content-Type: application/json; charset=utf-8`

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed