### PR TITLE
[4.4] ESM follow up changes

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6696,6 +6696,9 @@ class JoomlaInstallerScript
             // From 4.4.0-alpha1 to 4.4.0-alpha2
             '/libraries/vendor/jfcherng/php-diff/src/languages/readme.txt',
             '/plugins/editors-xtd/pagebreak/pagebreak.php',
+            // From 4.4.5 to 4.5.6
+            '/cypress.config.mjs',
+            '/cypress.config.dist.mjs',
         ];
 
         $folders = [

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6696,7 +6696,7 @@ class JoomlaInstallerScript
             // From 4.4.0-alpha1 to 4.4.0-alpha2
             '/libraries/vendor/jfcherng/php-diff/src/languages/readme.txt',
             '/plugins/editors-xtd/pagebreak/pagebreak.php',
-            // From 4.4.5 to 4.5.6
+            // From 4.4.5 to 4.4.6
             '/cypress.config.mjs',
             '/cypress.config.dist.mjs',
         ];

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -6696,9 +6696,6 @@ class JoomlaInstallerScript
             // From 4.4.0-alpha1 to 4.4.0-alpha2
             '/libraries/vendor/jfcherng/php-diff/src/languages/readme.txt',
             '/plugins/editors-xtd/pagebreak/pagebreak.php',
-            // From 4.4.5 to 4.4.6
-            '/cypress.config.mjs',
-            '/cypress.config.dist.mjs',
         ];
 
         $folders = [

--- a/build/build.php
+++ b/build/build.php
@@ -399,7 +399,7 @@ $doNotPackage = [
     'composer.json',
     'composer.lock',
     'crowdin.yml',
-    'cypress.config.dist.js',
+    'cypress.config.dist.mjs',
     'package-lock.json',
     'package.json',
     'phpunit-pgsql.xml.dist',


### PR DESCRIPTION
### Summary of Changes

With PR #43676 '[4.4] Move the Cypress Tests to ESM' the Cypress config file is changed to `cypress.config.mjs`. There are places in source code tree with the old file names `*.js`, that are handled by:
1. In the script used to build Joomla distribution archive packages, in the ignore file list, the Cypress config file name has been changed to the new `cypress.config.dist.mjs`.
~~2. In the delete-file-that-should-not-exist list, `cypress.config.mjs`and `cypress.config.dist.mjs` have been added.~~ -> see conversation

:warning: I am not familar with the workflows of creating Joomla distribution archive packages and deleting files that should not exist. If you have any doubts, please leave a comment.

### Testing Instructions

:warning: I have not tested anything. The changes look very small and clear.  But you never know. I therefore ask for your support in testing the two changes.

- building Joomla distribution archive package and check `cypress.config.dist.mjs` is not packed
- ~~Run `deleteUnexistingFiles` from ??? and check old `cypress.config.js` and `cypress.config.dist.js` are deleted; new files `cypress.config.mjs` and `cypress.config.dist.mjs`  are deleted too.~~

### Actual result BEFORE applying this Pull Request

- `cypress.config.dist.mjs` is not ignored in building Joomla distribution archive package
- ~~`cypress.config.mjs` and `cypress.config.dist.mjs` are not deleted on deleting files that should not exist~~

### Expected result AFTER applying this Pull Request

- `cypress.config.dist.mjs` is ignored in building Joomla distribution archive package
- ~~`cypress.config.mjs` and `cypress.config.dist.mjs`, as well as `cypress.config.js` and `cypress.config.dist.js`  are deleted on deleting files that should not exist~~


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
