### PR TITLE
[6.2] allow redis cache storage to delete only cached keys

### DIFF
--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -31,7 +31,7 @@ class RedisStorage extends CacheStorage
      * This constant is used as a prefix for all cache keys to ensure they are easily identifiable
      * and to avoid potential conflicts with other keys in the Redis store.
      *
-     * @since  4.4
+     * @since  __DEPLOY_VERSION__
      */
     protected const CACHE_KEY = '-cache-';
 

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -26,7 +26,7 @@ use Joomla\CMS\Log\Log;
 class RedisStorage extends CacheStorage
 {
     /**
-     * Cache key 
+     * Cache key
      *
      * This constant is used as a prefix for all cache keys to ensure they are easily identifiable
      * and to avoid potential conflicts with other keys in the Redis store.

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -26,6 +26,16 @@ use Joomla\CMS\Log\Log;
 class RedisStorage extends CacheStorage
 {
     /**
+     * Cache key 
+     *
+     * This constant is used as a prefix for all cache keys to ensure they are easily identifiable
+     * and to avoid potential conflicts with other keys in the Redis store.
+     *
+     * @since  4.4
+     */
+    protected const CACHE_KEY = '-cache-';
+
+    /**
      * Redis connection object
      *
      * @var    \Redis
@@ -191,7 +201,7 @@ class RedisStorage extends CacheStorage
             return false;
         }
 
-        $allKeys = static::$_redis->keys('*');
+        $allKeys = static::$_redis->keys('*' . self::CACHE_KEY . '*');
         $data    = [];
         $secret  = $this->_hash;
 
@@ -277,7 +287,7 @@ class RedisStorage extends CacheStorage
             return false;
         }
 
-        $allKeys = static::$_redis->keys('*');
+        $allKeys = static::$_redis->keys('*' . self::CACHE_KEY . '*');
 
         if ($allKeys === false) {
             $allKeys = [];
@@ -286,11 +296,11 @@ class RedisStorage extends CacheStorage
         $secret = $this->_hash;
 
         foreach ($allKeys as $key) {
-            if (strpos($key, $secret . '-cache-' . $group . '-') === 0 && $mode === 'group') {
+            if (strpos($key, $secret . self::CACHE_KEY . $group . '-') === 0 && $mode === 'group') {
                 static::$_redis->del($key);
             }
 
-            if (strpos($key, $secret . '-cache-' . $group . '-') !== 0 && $mode !== 'group') {
+            if (strpos($key, $secret . self::CACHE_KEY . $group . '-') !== 0 && $mode !== 'group') {
                 static::$_redis->del($key);
             }
         }


### PR DESCRIPTION
since the same redis can be used for cache + session (or other stuff) only keys that match the *-cache-* should be used

Pull Request for Issue #43718  

### Summary of Changes
this code would delete ALL keys that aren't in a group regardless of being a cache or not
e.g. deleting keys that handle session or any other stuff
````
            if (strpos($key, $secret . self::CACHE_KEY . $group . '-') !== 0 && $mode !== 'group') {
                static::$_redis->del($key);
````
the code 
`static::$_redis->keys('*' . self::CACHE_KEY . '*');`
instead of 
`static::$_redis->keys('*');`
makes sure redis cache ONLY handles cache keys

### Testing Instructions
1. setup a redis server
2. define that server as a cache_handler + session_handler 
3. use the same server for redis_server_host + session_redis_server_host
4. start caching stuff - and login 
on the first delete of a non group cache - you'll lose all of your sessions 
the easiest way to do that is to connect to redis with 
````
redis-cli -h <host name>
HOST-NAME:PORT>monitor
````
and you'll see after a while these commands:
````
HOST-NAME:PORT>KEYS "*"
HOST-NAME:PORT>DEL <session-id 1>
HOST-NAME:PORT>DEL <session-id 2>
HOST-NAME:PORT>DEL <session-id 3>
....
````


### Actual result BEFORE applying this Pull Request

seeing the 
````
HOST-NAME:PORT>KEYS "*"
HOST-NAME:PORT>DEL <session-id 1>
HOST-NAME:PORT>DEL <session-id 2>
HOST-NAME:PORT>DEL <session-id 3>
....
````

### Expected result AFTER applying this Pull Request
not seeing 
````
HOST-NAME:PORT>KEYS "*"
HOST-NAME:PORT>DEL <session-id 1>
HOST-NAME:PORT>DEL <session-id 2>
HOST-NAME:PORT>DEL <session-id 3>
....
````


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
