### PR TITLE
[5.1] Change redirect url (from headers['Location']) from array to string

### DIFF
--- a/libraries/src/Http/Transport/SocketTransport.php
+++ b/libraries/src/Http/Transport/SocketTransport.php
@@ -131,7 +131,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
 
         // Follow Http redirects
         if ($content->code >= 301 && $content->code < 400 && isset($content->headers['Location'])) {
-            return $this->request($method, new Uri($content->headers['Location']), $data, $headers, $timeout, $userAgent);
+            return $this->request($method, new Uri($content->headers['Location'][0]), $data, $headers, $timeout, $userAgent);
         }
 
         return $content;

--- a/libraries/src/Http/Transport/SocketTransport.php
+++ b/libraries/src/Http/Transport/SocketTransport.php
@@ -130,7 +130,7 @@ class SocketTransport extends AbstractTransport implements TransportInterface
         $content = $this->getResponse($content);
 
         // Follow Http redirects
-        if ($content->code >= 301 && $content->code < 400 && isset($content->headers['Location'])) {
+        if ($content->code >= 301 && $content->code < 400 && isset($content->headers['Location'][0])) {
             return $this->request($method, new Uri($content->headers['Location'][0]), $data, $headers, $timeout, $userAgent);
         }
 


### PR DESCRIPTION
Fixes the error: `parse_url(): Argument #1 ($url) must be of type string, array given`

### Summary of Changes

This PR fixes the same issue that was fixed for the CurlTransport:
https://github.com/joomla/joomla-cms/commit/a4065431e8ddca5caa4ea0eb30b42b4f3aa14ad5

Pull Request for Issue #https://github.com/joomla/joomla-cms/pull/42769.

From the Laminas\Diactoros\MessageTrait::getHeaders() doc

`@return array Returns an associative array of the message's headers. Each key MUST be a header name, and each value MUST be an array of strings.`

PR https://github.com/joomla/joomla-cms/pull/43130/files#diff-eaa7b598c95837c0e0230852d37007e28938d2bfe13048b42462ce106803447fL133 fixes the same issue, but this PR isolates the fix for the above mentioned error.

### Testing Instructions

The same testing Instructions as in https://github.com/joomla/joomla-cms/pull/42769 but instead of 'curl' use 'socket'.

### Actual result BEFORE applying this Pull Request

error: `parse_url(): Argument #1 ($url) must be of type string, array given`

### Expected result AFTER applying this Pull Request

no error

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
