### PR TITLE
[4.4] Fix display of total votes

### DIFF
--- a/plugins/content/vote/tmpl/rating.php
+++ b/plugins/content/vote/tmpl/rating.php
@@ -81,15 +81,15 @@ for ($i = $stars; $i < 5; $i++) {
     <?php if ($rcount) : ?>
     <div class="visually-hidden" itemscope itemtype="https://schema.org/Product">
         <span itemprop="name"><?php echo $row->title; ?></span>
-        <p class="visually-hidden" itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
+        <p itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
             <?php echo Text::sprintf('PLG_VOTE_USER_RATING', '<span itemprop="ratingValue">' . $rating . '</span>', '<span itemprop="bestRating">5</span>'); ?>
             <meta itemprop="ratingCount" content="<?php echo $rcount; ?>">
             <meta itemprop="worstRating" content="1">
         </p>
-        <?php if ($this->params->get('show_total_votes', 0)) : ?>
-            <?php echo Text::sprintf('PLG_VOTE_TOTAL_VOTES', $rcount); ?>
-        <?php endif; ?>
     </div>
+    <?php if ($this->params->get('show_total_votes', 0)) : ?>
+        <?php echo Text::sprintf('PLG_VOTE_TOTAL_VOTES', $rcount); ?>
+    <?php endif; ?>
     <?php endif; ?>
     <ul>
         <?php echo $img; ?>

--- a/plugins/content/vote/tmpl/rating.php
+++ b/plugins/content/vote/tmpl/rating.php
@@ -87,9 +87,9 @@ for ($i = $stars; $i < 5; $i++) {
             <meta itemprop="worstRating" content="1">
         </p>
     </div>
-    <?php if ($this->params->get('show_total_votes', 0)) : ?>
-        <?php echo Text::sprintf('PLG_VOTE_TOTAL_VOTES', $rcount); ?>
-    <?php endif; ?>
+        <?php if ($this->params->get('show_total_votes', 0)) : ?>
+            <?php echo Text::sprintf('PLG_VOTE_TOTAL_VOTES', $rcount); ?>
+        <?php endif; ?>
     <?php endif; ?>
     <ul>
         <?php echo $img; ?>

--- a/plugins/content/vote/tmpl/rating.php
+++ b/plugins/content/vote/tmpl/rating.php
@@ -79,14 +79,14 @@ for ($i = $stars; $i < 5; $i++) {
 ?>
 <div class="content_rating" role="img" aria-label="<?php echo Text::sprintf('PLG_VOTE_STAR_RATING', $rating); ?>">
     <?php if ($rcount) : ?>
-    <div class="visually-hidden" itemscope itemtype="https://schema.org/Product">
-        <span itemprop="name"><?php echo $row->title; ?></span>
-        <p itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
-            <?php echo Text::sprintf('PLG_VOTE_USER_RATING', '<span itemprop="ratingValue">' . $rating . '</span>', '<span itemprop="bestRating">5</span>'); ?>
-            <meta itemprop="ratingCount" content="<?php echo $rcount; ?>">
-            <meta itemprop="worstRating" content="1">
-        </p>
-    </div>
+        <div class="visually-hidden" itemscope itemtype="https://schema.org/Product">
+            <span itemprop="name"><?php echo $row->title; ?></span>
+            <p itemprop="aggregateRating" itemscope itemtype="https://schema.org/AggregateRating">
+                <?php echo Text::sprintf('PLG_VOTE_USER_RATING', '<span itemprop="ratingValue">' . $rating . '</span>', '<span itemprop="bestRating">5</span>'); ?>
+                <meta itemprop="ratingCount" content="<?php echo $rcount; ?>">
+                <meta itemprop="worstRating" content="1">
+            </p>
+        </div>
         <?php if ($this->params->get('show_total_votes', 0)) : ?>
             <?php echo Text::sprintf('PLG_VOTE_TOTAL_VOTES', $rcount); ?>
         <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #43728. Regression of #42934.

### Summary of Changes
Move the number of votes outside of the visually-hidden section so it can be visible.


### Testing Instructions
Enable Voting in Articles component configuration.
Vote for one or more articles.

Edit `Content -Vote` plugin.
Toggle `Number of Votes` to `Show`.


### Actual result BEFORE applying this Pull Request
Total number of votes is not visible.


### Expected result AFTER applying this Pull Request
Total number of votes is visible.


