### PR TITLE
fix PostgreSQL error

### DIFF
--- a/components/com_finder/src/Model/SuggestionsModel.php
+++ b/components/com_finder/src/Model/SuggestionsModel.php
@@ -95,9 +95,7 @@ class SuggestionsModel extends ListModel
         // Select required fields
         $termQuery->select('DISTINCT(t.term)')
             ->from($db->quoteName('#__finder_terms', 't'))
-            ->whereIn('t.term_id', $termIds)
-            ->order('t.links DESC')
-            ->order('t.weight DESC');
+            ->whereIn('t.term_id', $termIds);
 
         // Join mapping table for term <-> link relation
         $mappingTable = $db->quoteName('#__finder_links_terms', 'tm');


### PR DESCRIPTION
for SELECT DISTINCT, ORDER BY expressions must appear in select list

### Summary of Changes

remove order by for distinct select

### Testing Instructions

access com_finder component with query strings: ?task=suggestions.suggest&format=json&tmpl=component&q=eW

### Actual result BEFORE applying this Pull Request

error:
42P10, 7, ERROR:  for SELECT DISTINCT, ORDER BY expressions must appear in select list
LINE 6: ORDER BY t.links DESC,t.weight DESC LIMIT 10
                 ^<br />
<b>Warning</b>:  foreach() argument must be of type array|object, bool given in <b>\components\com_finder\src\Model\SuggestionsModel.php</b> on line <b>54</b><br />
{ "suggestions": [] }

### Expected result AFTER applying this Pull Request

{ "suggestions": [] }

### Link to documentations
- No documentation changes for docs.joomla.org needed
- No documentation changes for manual.joomla.org needed
