### PR TITLE
[4.4] Fix wrong search for id in fields groups

### DIFF
--- a/administrator/components/com_fields/src/Model/GroupsModel.php
+++ b/administrator/components/com_fields/src/Model/GroupsModel.php
@@ -189,7 +189,7 @@ class GroupsModel extends ListModel
             if (stripos($search, 'id:') === 0) {
                 $search = (int) substr($search, 3);
                 $query->where($db->quoteName('a.id') . ' = :search')
-                    ->bind(':id', $search, ParameterType::INTEGER);
+                    ->bind(':search', $search, ParameterType::INTEGER);
             } else {
                 $search = '%' . str_replace(' ', '%', trim($search)) . '%';
                 $query->where($db->quoteName('a.title') . ' LIKE :search')


### PR DESCRIPTION
Pull Request for Issue #43679 .

### Summary of Changes
Fix param in statement


### Testing Instructions
see #43679


### Actual result BEFORE applying this Pull Request
An error has occurred.
0 Cannot use positional argument after named argument


### Expected result AFTER applying this Pull Request
search result is displayed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
