### PR TITLE
[cypress] lint mjs files

### DIFF
--- a/build/.eslintrc
+++ b/build/.eslintrc
@@ -19,7 +19,7 @@
   // Additional global variables your script accesses during execution
   "globals": {
     "Joomla": true,
-    "MediaManager" : true,
+    "MediaManager": true,
     "bootstrap": true
   },
   // Rule overrides
@@ -52,24 +52,24 @@
     ]
   },
   "overrides": [
-	{
-	  "files": ["tests/**/*.js"],
-	  "rules": {
-		"no-undef": ["off"],
-		"import/no-extraneous-dependencies": ["off"]
-	  }
-	},
-	{
-	  "files": ["tests/System/support/index.js"],
-	  "rules": {
-		"no-console": ["off"]
-	  }
-	},
-	{
-	  "files": ["tests/System/support/commands/db.js","tests/System/plugins/index.js"],
-	  "rules": {
-		"no-useless-escape": ["off"]
-	  }
-	}
+    {
+      "files": ["tests/**/*.js", "tests/**/*.mjs"],
+      "rules": {
+        "no-undef": ["off"],
+        "import/no-extraneous-dependencies": ["off"]
+      }
+    },
+    {
+      "files": ["tests/System/support/index.js"],
+      "rules": {
+        "no-console": ["off"]
+      }
+    },
+    {
+      "files": ["tests/System/support/commands/db.mjs"],
+      "rules": {
+        "no-useless-escape": ["off"]
+      }
+    }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "watch": "node build/build.js --watch",
     "watch:com_media": "node build/build.js --watch-com-media",
     "lint:js": "eslint --config build/.eslintrc --ignore-pattern '/media/' --ext .es6.js,.es6,.vue .",
-    "lint:testjs": "eslint --config build/.eslintrc --ext .js tests/System",
+    "lint:testjs": "eslint --config build/.eslintrc --ext .js,.mjs tests/System",
     "lint:css": "stylelint --config build/.stylelintrc.json \"administrator/components/com_media/resources/**/*.scss\" \"administrator/templates/**/*.scss\" \"build/media_source/**/*.scss\" \"templates/**/*.scss\" \"installation/template/**/*.scss\"",
     "install": "node build/build.js --prepare",
     "update": "node build/build.js --copy-assets && node build/build.js --build-pages && node build/build.js --compile-js && node build/build.js --compile-css && node build/build.js --compile-bs && node --env-file=./build/production.env build/build.js --com-media",

--- a/tests/System/plugins/db.mjs
+++ b/tests/System/plugins/db.mjs
@@ -35,7 +35,6 @@ function queryTestDB(joomlaQuery, config) {
 
   // Do we use PostgreSQL?
   if (config.env.db_type === 'pgsql' || config.env.db_type === 'PostgreSQL (PDO)') {
-
     if (postgresConnectionPool === null) {
       // Initialisation on the first call
       postgresConnectionPool = postgres({

--- a/tests/System/plugins/fs.mjs
+++ b/tests/System/plugins/fs.mjs
@@ -1,5 +1,7 @@
-import { chmodSync, existsSync, writeFileSync, mkdirSync, rmSync } from "fs";
-import { dirname, join } from "path";
+import {
+  chmodSync, existsSync, writeFileSync, mkdirSync, rmSync,
+} from 'fs';
+import { dirname, join } from 'path';
 import { umask } from 'node:process';
 
 /**

--- a/tests/System/plugins/index.mjs
+++ b/tests/System/plugins/index.mjs
@@ -1,6 +1,6 @@
-import { getMails, clearEmails, startMailServer } from "./mail.mjs";
-import { writeRelativeFile, deleteRelativePath } from "./fs.mjs";
-import { queryTestDB, deleteInsertedItems } from "./db.mjs";
+import { getMails, clearEmails, startMailServer } from './mail.mjs';
+import { writeRelativeFile, deleteRelativePath } from './fs.mjs';
+import { queryTestDB, deleteInsertedItems } from './db.mjs';
 
 /**
  * Does the setup of the plugins.
@@ -21,4 +21,3 @@ export default function setupPlugins(on, config) {
     startMailServer: () => startMailServer(config),
   });
 }
-


### PR DESCRIPTION
Follow up Pull Request for #43676 .

### Summary of Changes

Some files are renamed from *.js to *.mjs, but the `lint:testjs` command has not been updated to the new file extension

### Testing Instructions

`npm run lint:testjs`

### Actual result BEFORE applying this Pull Request

*.mjs are not tested (eslint) in `javascript-cs`

### Expected result AFTER applying this Pull Request

*.mjs are tested (eslint) in `javascript-cs`
