### PR TITLE
[5.3] Move to ESM

### DIFF
--- a/administrator/components/com_privacy/tmpl/consents/default.php
+++ b/administrator/components/com_privacy/tmpl/consents/default.php
@@ -34,6 +34,7 @@ $stateMsgs  = [
     0 => Text::_('COM_PRIVACY_CONSENTS_STATE_OBSOLETE'),
     1 => Text::_('COM_PRIVACY_CONSENTS_STATE_VALID')
 ];
+$this->getLanguage()->load('plg_system_privacyconsent', JPATH_ADMINISTRATOR);
 
 ?>
 <form action="<?php echo Route::_('index.php?option=com_privacy&view=consents'); ?>" method="post" name="adminForm" id="adminForm">

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -2,7 +2,7 @@
 <extension client="administrator" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.2.0</version>
+	<version>5.2.1</version>
 	<creationDate>2024-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/language/en-GB/langmetadata.xml
+++ b/administrator/language/en-GB/langmetadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="administrator">
 	<name>English (en-GB)</name>
-	<version>5.2.0</version>
+	<version>5.2.1</version>
 	<creationDate>2024-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,7 +6,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>5.2.0-rc5-dev</version>
+	<version>5.2.0</version>
 	<creationDate>2024-10</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,7 +6,7 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>5.2.0</version>
+	<version>5.2.1-dev</version>
 	<creationDate>2024-10</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,7 +2,7 @@
 <extension type="package" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>5.2.0.1</version>
+	<version>5.2.1.1</version>
 	<creationDate>2024-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/api/language/en-GB/install.xml
+++ b/api/language/en-GB/install.xml
@@ -2,7 +2,7 @@
 <extension client="api" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.2.0</version>
+	<version>5.2.1</version>
 	<creationDate>2024-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/api/language/en-GB/langmetadata.xml
+++ b/api/language/en-GB/langmetadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="api">
 	<name>English (en-GB)</name>
-	<version>5.2.0</version>
+	<version>5.2.1</version>
 	<creationDate>2024-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/installation/language/en-GB/langmetadata.xml
+++ b/installation/language/en-GB/langmetadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="installation">
 	<name>English (United Kingdom)</name>
-	<version>5.2.0</version>
+	<version>5.2.1</version>
 	<creationDate>2024-10</creationDate>
 	<author>Joomla! Project</author>
 	<copyright>(C) 2005 Open Source Matters, Inc.</copyright>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -2,7 +2,7 @@
 <extension client="site" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.2.0</version>
+	<version>5.2.1</version>
 	<creationDate>2024-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/language/en-GB/langmetadata.xml
+++ b/language/en-GB/langmetadata.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="site">
 	<name>English (en-GB)</name>
-	<version>5.2.0</version>
+	<version>5.2.1</version>
 	<creationDate>2024-10</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -66,7 +66,7 @@ final class Version
      * @var    string
      * @since  3.8.0
      */
-    public const EXTRA_VERSION = 'rc5-dev';
+    public const EXTRA_VERSION = '';
 
     /**
      * Development status.
@@ -74,7 +74,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const DEV_STATUS = 'Development';
+    public const DEV_STATUS = 'Stable';
 
     /**
      * Code name.
@@ -90,7 +90,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const RELDATE = '9-October-2024';
+    public const RELDATE = '15-October-2024';
 
     /**
      * Release time.
@@ -98,7 +98,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const RELTIME = '20:01';
+    public const RELTIME = '16:00';
 
     /**
      * Release timezone.

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -55,7 +55,7 @@ final class Version
      * @var    integer
      * @since  3.8.0
      */
-    public const PATCH_VERSION = 0;
+    public const PATCH_VERSION = 1;
 
     /**
      * Extra release version info.
@@ -66,7 +66,7 @@ final class Version
      * @var    string
      * @since  3.8.0
      */
-    public const EXTRA_VERSION = '';
+    public const EXTRA_VERSION = 'dev';
 
     /**
      * Development status.
@@ -74,7 +74,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const DEV_STATUS = 'Stable';
+    public const DEV_STATUS = 'Development';
 
     /**
      * Code name.
@@ -98,7 +98,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const RELTIME = '16:00';
+    public const RELTIME = '16:01';
 
     /**
      * Release timezone.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joomla",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joomla",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "Joomla CMS",
   "license": "GPL-2.0-or-later",
   "repository": {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- Move tools and source JS to ESM
- ES6 files have now the extension `.mjs` (used to be `.es6.js`)
- Legacy js files now have a `.js` extension instead of `.es5.js`
- Web Components also have `.mjs` extension (used to be `.w-c.es6.js`)
- The `build/media_source/system/js/joomla-core-loader.mjs` file now includes the required css and the related `build/media_source/system/scss/joomla-core-loader.scss` is deleted

### Testing Instructions

You need Git and NPM to test this

Pull the `4.4-dev` branch and run:
- `npm install`
- `npm run cssversioning`
- `npm run gzip`
- `npm run versioning`
- Store the media folder somewhere outside of the `joomla-cms` folder

Pull this PR `gh pr checkout 43779` and run:
- `npm install`
- `npm run cssversioning`
- `npm run gzip`
- `npm run versioning`
- Store the media folder somewhere outside of the `joomla-cms` folder


Compare the two folders. The only difference should be the missing files: `media/system/css/joomla-core-loader.css`, `media/system/css/joomla-core-loader.min.css`, `media/system/css/joomla-core-loader.min.css.gz`

Check the basic backend functionality 


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed


@Fedik @richard67 could you please test this one (pretty hard for the average tester)?

