### PR TITLE
MFA and Silent Logins

### DIFF
--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
@@ -236,7 +236,7 @@ trait AjaxHandlerLogin
             'onUserLoginFailure',
             [
                 'options' => $options,
-                'subject' => (array) $response
+                'subject' => (array) $response,
             ]
         );
         $dispatcher->dispatch('onUserLoginFailure', $event);

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
@@ -223,7 +223,7 @@ trait AjaxHandlerLogin
                 'onUserAfterLogin',
                 [
                     'options' => $options,
-                    'subject' => (array) $response
+                    'subject' => (array) $response,
                 ]
             );
             $dispatcher->dispatch($event->getName(), $event);

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
@@ -203,7 +203,7 @@ trait AjaxHandlerLogin
             'onUserLogin',
             [
                 'options' => $options,
-                'subject' => (array) $response
+                'subject' => (array) $response,
             ]
         );
         $result         = $dispatcher->dispatch('onUserLogin', $event);


### PR DESCRIPTION
Pull Request for Issue #42308 .

### Summary of Changes

Update `\Joomla\Plugin\System\Webauthn\PluginTraits\AjaxHandlerLogin`. Fix loading user plugins (b/c break). Fix wrong events constructors (missing subject, wrong argument order). Fix triggering events (wrong event name passed).

### Testing Instructions

* Create user with MFA and passkey login
* Users, Manage, Options, Multi-factor Authentication, Multi-factor Authentication after silent login => No.
* Log out
* Log in with passkey

### Actual result BEFORE applying this Pull Request

Joomla! asks for MFA

### Expected result AFTER applying this Pull Request

Joomla does not ask for MFA

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
