### PR TITLE
[4.4] Fix SQL field, get the filter value from the linked filter field

### DIFF
--- a/libraries/src/Form/Field/SqlField.php
+++ b/libraries/src/Form/Field/SqlField.php
@@ -245,11 +245,9 @@ class SqlField extends ListField
                     $escape = $db->quote($db->escape($html_filters[$value]), false);
 
                     $query->where("{$value} = {$escape}");
-                }
-                elseif ($filterFieldValue !== null) {
+                } elseif ($filterFieldValue !== null) {
                     $query->where("{$value} = {$filterFieldValue}");
-                }
-                elseif (!empty($defaults[$value])) {
+                } elseif (!empty($defaults[$value])) {
                     $escape = $db->quote($db->escape($defaults[$value]), false);
 
                     $query->where("{$value} = {$escape}");

--- a/libraries/src/Form/Field/SqlField.php
+++ b/libraries/src/Form/Field/SqlField.php
@@ -246,7 +246,9 @@ class SqlField extends ListField
 
                     $query->where("{$value} = {$escape}");
                 } elseif ($filterFieldValue !== null) {
-                    $query->where("{$value} = {$filterFieldValue}");
+                    $escape = $db->quote($db->escape($filterFieldValue), false);
+
+                    $query->where("{$value} = {$escape}");
                 } elseif (!empty($defaults[$value])) {
                     $escape = $db->quote($db->escape($defaults[$value]), false);
 

--- a/libraries/src/Form/Field/SqlField.php
+++ b/libraries/src/Form/Field/SqlField.php
@@ -233,14 +233,23 @@ class SqlField extends ListField
 
         // Process the filters
         if (\is_array($filters)) {
-            $html_filters = Factory::getApplication()->getUserStateFromRequest($this->context . '.filter', 'filter', [], 'array');
+            // @TODO: Loading the filtering value from the request need to be deprecated.
+            $html_filters = $this->context ? Factory::getApplication()->getUserStateFromRequest($this->context . '.filter', 'filter', [], 'array') : false;
+            $form         = $this->form;
 
             foreach ($filters as $k => $value) {
-                if (!empty($html_filters[$value])) {
+                // Get the filter value from the linked filter field
+                $filterFieldValue = $form->getValue($value, $this->group);
+
+                if ($html_filters && !empty($html_filters[$value])) {
                     $escape = $db->quote($db->escape($html_filters[$value]), false);
 
                     $query->where("{$value} = {$escape}");
-                } elseif (!empty($defaults[$value])) {
+                }
+                elseif ($filterFieldValue !== null) {
+                    $query->where("{$value} = {$filterFieldValue}");
+                }
+                elseif (!empty($defaults[$value])) {
                     $escape = $db->quote($db->escape($defaults[$value]), false);
 
                     $query->where("{$value} = {$escape}");


### PR DESCRIPTION
### Summary of Changes

Due to bug in SQL field the feature ["Linked Fields as Filters"](https://docs.joomla.org/SQL_form_field_type) is broken. 
The PR is fixing this feature, by using the value directly from the form. 
Use of the value from Request should be deprecated in future.

Thanks @robbiejackson for the idea and code. I just copy pasting it in to the PR :)


### Testing Instructions
Add folowing field in to Custom HTML module:
```xml
<field
  name="catid"
  type="sql"
  label="Category"
  sql_select="id, title"
  sql_from="#__categories"
  sql_where="level=1 AND extension='com_content'"
  sql_order="lft"
  key_field="id"
  value_field="title"
  default="2"
  onchange="window['toolbar-apply'].buttonElement.click()"
>
  <option>- Select -</option>
</field>
<field
  name="subcat"
  type="sql"
  label="Article"
  sql_select="id, title"
  sql_from="#__content"
  sql_order="title"
  sql_filter="catid"
  key_field="id"
  value_field="title"
>
  <option>- Select -</option>
</field>
```
Create and save new Custom HTML module, or open existing.
Change the value of "Category" field.
After selecting new value and saving the form, the linked Article field should display only articles from the selected category.


### Actual result BEFORE applying this Pull Request
The Article field shows ALL articles.


### Expected result AFTER applying this Pull Request
The Article field shows only the articles froms the selected category.


### Link to documentations
Please select:
- [x] Documentation link for docs.joomla.org: https://docs.joomla.org/SQL_form_field_type
- [ ] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/278
- [ ] No documentation changes for manual.joomla.org needed
