### PR TITLE
MFA and Silent Logins

### DIFF
--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerLogin.php
@@ -197,10 +197,18 @@ trait AjaxHandlerLogin
         }
 
         // Run the user plugins. They CAN block login by returning boolean false and setting $response->error_message.
-        PluginHelper::importPlugin('user');
-        $eventClassName = self::getEventClassByEventName('onUserLogin');
-        $event          = new $eventClassName('onUserLogin', [(array) $response, $options]);
-        $result         = $this->getApplication()->getDispatcher()->dispatch($event->getName(), $event);
+        $dispatcher = $this->getApplication()->getDispatcher();
+
+        PluginHelper::importPlugin('user', null, true, $dispatcher);
+
+        $event          = new \Joomla\CMS\Event\User\LoginEvent(
+            'onUserLogin',
+            [
+                'options' => $options,
+                'subject' => (array) $response,
+            ]
+        );
+        $result         = $dispatcher->dispatch('onUserLogin', $event);
         $results        = !isset($result['result']) || \is_null($result['result']) ? [] : $result['result'];
 
         // If there is no boolean FALSE result from any plugin the login is successful.
@@ -213,17 +221,27 @@ trait AjaxHandlerLogin
             $options['responseType'] = $response->type;
 
             // The user is successfully logged in. Run the after login events
-            $eventClassName = self::getEventClassByEventName('onUserAfterLogin');
-            $event          = new $eventClassName('onUserAfterLogin', [$options]);
-            $this->getApplication()->getDispatcher()->dispatch($event->getName(), $event);
+            $event          = new \Joomla\CMS\Event\User\AfterLoginEvent(
+                'onUserAfterLogin',
+                [
+                    'options' => $options,
+                    'subject' => (array) $response,
+                ]
+            );
+            $dispatcher->dispatch($event->getName(), $event);
 
             return;
         }
 
         // If we are here the plugins marked a login failure. Trigger the onUserLoginFailure Event.
-        $eventClassName = self::getEventClassByEventName('onUserLoginFailure');
-        $event          = new $eventClassName('onUserLoginFailure', [(array) $response]);
-        $this->getApplication()->getDispatcher()->dispatch($event->getName(), $event);
+        $event          = new \Joomla\CMS\Event\User\LoginFailureEvent(
+            'onUserLoginFailure',
+            [
+                'options' => $options,
+                'subject' => (array) $response,
+            ]
+        );
+        $dispatcher->dispatch('onUserLoginFailure', $event);
 
         // Log the failure
         Log::add($response->error_message, Log::WARNING, 'jerror');


### PR DESCRIPTION
Pull Request for Issue #42308 .

### Summary of Changes

Update `\Joomla\Plugin\System\Webauthn\PluginTraits\AjaxHandlerLogin`. Fix loading user plugins (broken because maybe a b/c break?). Fix wrong events constructors (missing subject, wrong argument order). Fix triggering events (wrong event name passed).

### Testing Instructions

* Create user with MFA and passkey login
* Users, Manage, Options, Multi-factor Authentication, Multi-factor Authentication after silent login => No.
* Log out
* Log in with passkey

### Actual result BEFORE applying this Pull Request

Joomla! asks for MFA

### Expected result AFTER applying this Pull Request

Joomla does not ask for MFA

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
