### PR TITLE
[4.4] Mfa::getConfigurationInterface throws error if called from other component

### DIFF
--- a/administrator/components/com_users/src/Helper/Mfa.php
+++ b/administrator/components/com_users/src/Helper/Mfa.php
@@ -78,7 +78,7 @@ abstract class Mfa
         /** @var CMSApplication $app */
         $app = Factory::getApplication();
 
-        if (!$app->getInput()->getCmd('option', '') === 'com_users') {
+        if ($app->getInput()->getCmd('option', '') !== 'com_users') {
             $app->getLanguage()->load('com_users');
             $app->getDocument()
                 ->getWebAssetManager()


### PR DESCRIPTION
Pull Request for Issue #43812.

### Summary of Changes
Fix syntax error throws error.


### Testing Instructions
Code review

or 

follow instructions #43812
