### PR TITLE
[5.2] Adding phpstan to drone setup

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,6 +38,13 @@ steps:
     commands:
       - ./libraries/vendor/bin/phan
 
+  - name: phpstan
+    image: joomlaprojects/docker-images:php8.2
+    depends_on: [ phpcs ]
+    failure: ignore
+    commands:
+      - ./libraries/vendor/bin/phpstan
+
   - name: npm
     image: node:20-bullseye-slim
     depends_on: [ phpcs ]
@@ -414,6 +421,6 @@ trigger:
 
 ---
 kind: signature
-hmac: bd41423d85abadb875c8fc911f87596ead88b62d26fabf6a283737c5a7b4c5b9
+hmac: ddec56bc5feb60a0a7009d94356b2425e3a3ae112f3f0c89683e1a55f87fa9c2
 
 ...

--- a/build/build.php
+++ b/build/build.php
@@ -73,6 +73,7 @@ function clean_checkout(string $dir)
     system('find . -name psalm.xml.dist | xargs rm -rf -');
     system('find . -name phpcs.xml | xargs rm -rf -');
     system('find . -name phpcs.xml.dist | xargs rm -rf -');
+    system('find . -name phpstan.neon | xargs rm -rf -');
     system('find . -name phpunit.xml | xargs rm -rf -');
     system('find . -name phpunit.*.xml | xargs rm -rf -');
     system('find . -name phpunit.xml.dist | xargs rm -rf -');
@@ -408,6 +409,7 @@ $doNotPackage = [
     'package.json',
     'phpunit-pgsql.xml.dist',
     'phpunit.xml.dist',
+    'phpstan.neon',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.ini',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.sys.ini',
     'plugins/sampledata/testing/testing.php',

--- a/composer.json
+++ b/composer.json
@@ -115,7 +115,9 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
     "joomla/mediawiki": "^3.0",
     "joomla/test": "~3.0",
-    "phan/phan": "^5.4.3"
+    "phan/phan": "^5.4.3",
+    "phpstan/phpstan": "^1.11",
+    "phpstan/phpstan-deprecation-rules": "^1.2"
   },
   "replace": {
     "paragonie/random_compat": "9.99.99",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b25e220b440613ef9279a3625e03eb71",
+    "content-hash": "398727a09c40cf85a82f3c8cdf83e3b4",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -8162,6 +8162,111 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.1"
             },
             "time": "2024-05-31T08:52:43+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.11.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "52d2bbfdcae7f895915629e4694e9497d0f8e28d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/52d2bbfdcae7f895915629e4694e9497d0f8e28d",
+                "reference": "52d2bbfdcae7f895915629e4694e9497d0f8e28d",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-07-06T11:17:41+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
+                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.11"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.0"
+            },
+            "time": "2024-04-20T06:39:48+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-	level: 4
+	level: 0
 	scanDirectories:
 		- libraries/php-encryption
 		- libraries/phpass

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,42 @@
+parameters:
+	level: 4
+	scanDirectories:
+		- libraries/php-encryption
+		- libraries/phpass
+	scanFiles:
+		- globals.php
+		- libraries/loader.php
+		- libraries/namespacemap.php
+	paths:
+		- libraries/src
+		- administrator
+		- components
+		- installation
+		- plugins
+	excludePaths:
+		- administrator/cache
+		- administrator/components/com_joomlaupdate/finalisation.php
+	ignoreErrors:
+		-
+			message: '#Access to protected property [a-zA-Z0-9\\_]+\\HtmlView::\$[a-zA-Z0-9\\_]+.#'
+			paths:
+				- components/*
+				- administrator/components/*
+		-
+			message: '#Call to protected method [a-zA-Z0-9\\_]+\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\.#'
+			paths:
+				- components/*
+				- administrator/components/*
+		-
+			message: '#Call to protected method [a-zA-Z0-9\\_]+\(\) of class Joomla\\CMS\\MVC\\View\\HtmlView\.#'
+			paths:
+				- components/*
+				- administrator/components/*
+		-
+			message: '#Call to protected method [a-zA-Z0-9\\_]+\(\) of class Joomla\\CMS\\.*\.#'
+			paths:
+				- plugins/*
+		-
+			message: '#Call to deprecated method \_\(\) of class Joomla\\CMS\\Language\\Language.*#'
+includes:
+	- libraries/vendor/phpstan/phpstan-deprecation-rules/rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -4,7 +4,6 @@ parameters:
 		- libraries/php-encryption
 		- libraries/phpass
 	scanFiles:
-		- globals.php
 		- libraries/loader.php
 		- libraries/namespacemap.php
 	paths:


### PR DESCRIPTION
### Summary of Changes
This PR adds the phpstan static code analyser to our composer dependencies and to our drone setup. It is configured to ignore a series of false positives and to list all deprecations as well. Its configuration file is excluded from the build script. For now phpstan is only set to scan in level 0. When all reports from that are fixed, we can raise that level gradually. Since phpstan will throw failures for a long time, failures are set to be ignored in drone.

phpstan also allows to register a baseline of errors right now and then throw errors when the result differs from that baseline, but that is something for the future.


### Testing Instructions
See phpstan step in drone and its results.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
