### PR TITLE
[5.1] Fix attachment handling in libraries Mail class

### DIFF
--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -401,19 +401,15 @@ class Mail extends PHPMailer implements MailerInterface
             $result = true;
 
             if (\is_array($path)) {
-                if (!empty($name) && \count($path) != \count($name)) {
+                if (is_array($name) && !empty($name) && \count($path) != \count($name)) {
                     throw new \InvalidArgumentException('The number of attachments must be equal with the number of name');
                 }
 
                 foreach ($path as $key => $file) {
-                    if (!empty($name)) {
-                        $result = parent::addAttachment($file, $name[$key], $encoding, $type);
+                    if (is_array($name)) {
+                        $result = parent::addAttachment($file, $name[$key], $encoding, $type, $disposition);
                     } else {
-                        if (!empty($name)) {
-                            $result = parent::addAttachment($file, $name[$key], $encoding, $type, $disposition);
-                        } else {
-                            $result = parent::addAttachment($file, $name, $encoding, $type, $disposition);
-                        }
+                        $result = parent::addAttachment($file, basename($file), $encoding, $type, $disposition);
                     }
                 }
 
@@ -422,7 +418,7 @@ class Mail extends PHPMailer implements MailerInterface
                     return false;
                 }
             } else {
-                $result = parent::addAttachment($path, $name, $encoding, $type);
+                $result = parent::addAttachment($path, $name, $encoding, $type, $disposition);
             }
 
             // Check for boolean false return if exception handling is disabled

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -406,7 +406,7 @@ class Mail extends PHPMailer implements MailerInterface
                 }
 
                 foreach ($path as $key => $file) {
-                    if (is_array($name)) {
+                    if (isset($name[$key])) {
                         $result = parent::addAttachment($file, $name[$key], $encoding, $type, $disposition);
                     } else {
                         $result = parent::addAttachment($file, basename($file), $encoding, $type, $disposition);

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -401,16 +401,12 @@ class Mail extends PHPMailer implements MailerInterface
             $result = true;
 
             if (\is_array($path)) {
-                if (is_array($name) && !empty($name) && \count($path) != \count($name)) {
+                if (!empty($name) && \is_array($name) && \count($path) != \count($name)) {
                     throw new \InvalidArgumentException('The number of attachments must be equal with the number of name');
                 }
 
                 foreach ($path as $key => $file) {
-                    if (isset($name[$key])) {
-                        $result = parent::addAttachment($file, $name[$key], $encoding, $type, $disposition);
-                    } else {
-                        $result = parent::addAttachment($file, basename($file), $encoding, $type, $disposition);
-                    }
+                    $result = parent::addAttachment($file, isset($name[$key]) ? $name[$key] : '', $encoding, $type, $disposition);
                 }
 
                 // Check for boolean false return if exception handling is disabled


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

It is currently not possible to attach a single attachment with the disposition 'inline' to a mail via the Mail library class.

Above all, this means that it is also not possible to send an image as an inline attachment via the Mail class and then simply refer to it via cid. 

This means that in the e-mails that are sent when they are received on different clients, the download of the images must first be approved by the user before they are visible.

The changes in the Mail class address issues with attachment handling. Specifically:
- Ensured the `addAttachment` method includes the `$disposition` parameter in all cases.
- Simplified the logic for adding attachments by removing redundant checks.
- Added a check to ensure `$name` is an array before comparing its count with `$path`.

### Testing Instructions

Set the option `Mail Format` -> HTML in Global Configuration -> Mail Templates

![grafik](https://github.com/user-attachments/assets/94ea3af5-a68b-4c78-829d-5c29efaea35f)


Add the following lines of code (only!) for testing into the file 'libraries/src/Mail/MailTemplate.php'  line 277

```
$logo = Path::clean(JPATH_ROOT . '/images/banners/white.png');
# Attach the logo as inline attachement
$this->mailer->addAttachment($logo, basename($logo), 'base64', mime_content_type($logo), 'inline');
// We need only the cid for attached logo file inline
$htmlBody .= '<img src="cid:' . htmlspecialchars(basename($logo), ENT_QUOTES) . '" alt="Test inline attachment" style="max-width:80%;height:auto;border:none;text-decoration:none;color:#ffffff;">';
```
![grafik](https://github.com/user-attachments/assets/2a944510-3d79-41aa-aea1-9defb665912d)

Send a test mail under `Global Configuration` -> `Server tab` at the bottom of the page using the `Send Test Mail` button

![grafik](https://github.com/user-attachments/assets/35def84d-cd85-43be-8d7f-17d246e08c60)


### Actual result BEFORE applying this Pull Request

Attachment is inserted but not as an inline attachment and thus the assignment to the image fails.

![grafik](https://github.com/user-attachments/assets/c574698d-b3dc-47dc-a9ef-fc6a9cee9f2f)

![grafik](https://github.com/user-attachments/assets/cf1219f7-913a-48bf-babd-dbffb3775623)

### Expected result AFTER applying this Pull Request

Attachment is inserted as an inline attachment and thus the assignment to the image works.
![grafik](https://github.com/user-attachments/assets/7f17aaa3-98b0-4a3e-b3fb-59752889120f)
![grafik](https://github.com/user-attachments/assets/9de40945-3ab1-45d7-ae0b-5624f9a8c533)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
