### PR TITLE
[5.1] Delete schemaorg item after deleting an item

### DIFF
--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -542,7 +542,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
     /**
      * The delete event.
      *
-     * @param   Ojbject    $event  The event
+     * @param   Object    $event  The event
      *
      * @return  void
      *

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -553,7 +553,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
         $context = $event->getContext();
         $itemId  = $event->getItem()->id;
 
-        $db = $this->getDatabase();
+        $db    = $this->getDatabase();
         $query = $db->getQuery(true);
 
         $query->delete($db->quoteName('#__schemaorg'))

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -61,6 +61,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
             'onContentPrepareData' => 'onContentPrepareData',
             'onContentPrepareForm' => 'onContentPrepareForm',
             'onContentAfterSave'   => 'onContentAfterSave',
+            'onContentAfterDelete' => 'onContentAfterDelete',
         ];
     }
 
@@ -536,5 +537,31 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
         }
 
         return false;
+    }
+
+    /**
+     * The delete event.
+     *
+     * @param   Ojbject    $event  The event
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function onContentAfterDelete(Model\AfterDeleteEvent $event)
+    {
+        $context = $event->getContext();
+        $itemId  = $event->getItem()->id;
+
+        $db = $this->getDatabase();
+        $query = $db->getQuery(true);
+
+        $query->delete($db->quoteName('#__schemaorg'))
+            ->where($db->quoteName('itemId') . '= :itemId')
+            ->bind(':itemId', $itemId, ParameterType::INTEGER)
+            ->where($db->quoteName('context') . '= :context')
+            ->bind(':context', $context, ParameterType::STRING);
+
+        $db->setQuery($query)->execute();
     }
 }

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -205,16 +205,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
         $itemId = (int) $table->id;
 
         if (empty($data['schema']) || empty($data['schema']['schemaType']) || $data['schema']['schemaType'] === 'None') {
-            $query = $db->getQuery(true);
-
-            $query->delete($db->quoteName('#__schemaorg'))
-                ->where($db->quoteName('itemId') . '= :itemId')
-                ->bind(':itemId', $itemId, ParameterType::INTEGER)
-                ->where($db->quoteName('context') . '= :context')
-                ->bind(':context', $context, ParameterType::STRING);
-
-            $db->setQuery($query)->execute();
-
+            $this->deleteSchemaOrg($itemId, $context);
             return;
         }
 
@@ -553,13 +544,28 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
         $context = $event->getContext();
         $itemId  = $event->getItem()->id;
 
+        $this->deleteSchemaOrg($itemId, $context);
+    }
+
+    /**
+     * Delete SchemaOrg record from Database.
+     *
+     * @param   Integer   $itemId
+     * @param   String    $context
+     *
+     * @return  void
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function deleteSchemaOrg($itemId, $context)
+    {
         $db    = $this->getDatabase();
         $query = $db->getQuery(true);
 
         $query->delete($db->quoteName('#__schemaorg'))
             ->where($db->quoteName('itemId') . '= :itemId')
-            ->bind(':itemId', $itemId, ParameterType::INTEGER)
             ->where($db->quoteName('context') . '= :context')
+            ->bind(':itemId', $itemId, ParameterType::INTEGER)
             ->bind(':context', $context, ParameterType::STRING);
 
         $db->setQuery($query)->execute();


### PR DESCRIPTION
Pull Request for Issue #43830 .

### Summary of Changes
Added a onContentAfterDelete event to the schmea org Plugin 


### Testing Instructions
see issue #43830


### Actual result BEFORE applying this Pull Request
The schemaorg entry remains orphaned in the database


### Expected result AFTER applying this Pull Request
The schemaorg entry is deleted with the item


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
