### PR TITLE
[5.2] Feat: Showon for Use Global Option in ListField

### DIFF
--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -150,9 +150,9 @@ class Showon {
             itemval = document.getElementById(originId).value;
             // Check data attribute data-global instead of value in <select> for use global
             if (originField.tagName.toLowerCase() === 'select') {
-              let selectField = document.getElementById(originId);
+              const selectField = document.getElementById(originId);
               if (selectField.options[selectField.selectedIndex].hasAttribute('data-global')) {
-                itemval = selectField.options[selectField.selectedIndex].dataset.global
+                itemval = selectField.options[selectField.selectedIndex].dataset.global;
               }
             }
             // A multi-select <select> $field  will return null when no elements are

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -148,10 +148,10 @@ class Showon {
             // Select lists, text-area etc. Note that multiple-select list returns
             // an Array here s0 we can always treat 'itemval' as an array
             itemval = document.getElementById(originId).value;
-            // Check data attribute data-global insted of value in <select> for use global
+            // Check data attribute data-global instead of value in <select> for use global
             if (originField.tagName.toLowerCase() === 'select') {
               let selectField = document.getElementById(originId);
-              if (selectField.options[selectField.selectedIndex].hasAttribute("data-global")) {
+              if (selectField.options[selectField.selectedIndex].hasAttribute('data-global')) {
                 itemval = selectField.options[selectField.selectedIndex].dataset.global
               }
             }

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -148,6 +148,13 @@ class Showon {
             // Select lists, text-area etc. Note that multiple-select list returns
             // an Array here s0 we can always treat 'itemval' as an array
             itemval = document.getElementById(originId).value;
+            // Check data attribute data-global insted of value in <select> for use global
+            if (originField.tagName.toLowerCase() === 'select') {
+              let selectField = document.getElementById(originId);
+              if (selectField.options[selectField.selectedIndex].hasAttribute("data-global")) {
+                itemval = selectField.options[selectField.selectedIndex].dataset.global
+              }
+            }
             // A multi-select <select> $field  will return null when no elements are
             // selected so we need to define itemval accordingly
             if (itemval === null && originField.tagName.toLowerCase() === 'select') {

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -149,10 +149,11 @@ class Showon {
             // an Array here s0 we can always treat 'itemval' as an array
             itemval = document.getElementById(originId).value;
             // Check data attribute data-global instead of value in <select> for use global
-            if (originField.tagName.toLowerCase() === 'select') {
-              const selectField = document.getElementById(originId);
-              if (selectField.options[selectField.selectedIndex].hasAttribute('data-global')) {
-                itemval = selectField.options[selectField.selectedIndex].dataset.global;
+            if (originField.tagName === 'SELECT') {
+              const selectedOption = document.getElementById(originId).selectedOptions[0];
+
+              if (selectedOption && 'globalValue' in selectedOption.dataset) {
+                itemval = selectedOption.dataset.globalValue;
               }
             }
             // A multi-select <select> $field  will return null when no elements are

--- a/build/media_source/system/js/showon.es6.js
+++ b/build/media_source/system/js/showon.es6.js
@@ -148,7 +148,7 @@ class Showon {
             // Select lists, text-area etc. Note that multiple-select list returns
             // an Array here s0 we can always treat 'itemval' as an array
             itemval = document.getElementById(originId).value;
-            // Check data attribute data-global insted of value in <select> for use global
+            // Check data attribute data-global instead of value in <select> for use global
             if (originField.tagName.toLowerCase() === 'select') {
               let selectField = document.getElementById(originId);
               if (selectField.options[selectField.selectedIndex].hasAttribute("data-global")) {

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -191,7 +191,7 @@ class ListField extends FormField
                 foreach ($options as $option) {
                     if ($option->value === $value) {
                         $value           = $option->text;
-                        $tmp->optionattr = [ 'data-global-value' => $option->value ];
+                        $tmp->optionattr = ['data-global-value' => $option->value];
 
                         break;
                     }

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -190,7 +190,7 @@ class ListField extends FormField
 
                 foreach ($options as $option) {
                     if ($option->value === $value) {
-                        $value = $option->text;
+                        $value           = $option->text;
                         $tmp->optionattr = [ 'data-global' => $option->value ];
 
                         break;

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -191,7 +191,7 @@ class ListField extends FormField
                 foreach ($options as $option) {
                     if ($option->value === $value) {
                         $value           = $option->text;
-                        $tmp->optionattr = [ 'data-global' => $option->value ];
+                        $tmp->optionattr = [ 'data-global-value' => $option->value ];
 
                         break;
                     }

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -188,11 +188,10 @@ class ListField extends FormField
             if (!\is_null($value)) {
                 $value = (string) $value;
 
-                $tmp->optionattr = [ 'data-global' => $option->value ];
-
                 foreach ($options as $option) {
                     if ($option->value === $value) {
                         $value = $option->text;
+                        $tmp->optionattr = [ 'data-global' => $option->value ];
 
                         break;
                     }

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -188,6 +188,8 @@ class ListField extends FormField
             if (!\is_null($value)) {
                 $value = (string) $value;
 
+                $tmp->optionattr = [ 'data-global' => $option->value ];
+
                 foreach ($options as $option) {
                     if ($option->value === $value) {
                         $value = $option->text;


### PR DESCRIPTION
Pull Request for Issue #42381.

### Summary of Changes

At the moment showon fields doesn't work in combination with global options.

The changes introduce a new data-attribute 'data-global' in select option if `useglobal` in ListField is set to true and adds support in showon script.

### Testing Instructions

Run npm `install`

Set Global Configuration -> Contacts: Options -> Tab: Contact Information --> `Show`

Open a contact in edit mode or add a new contact.

Set Contacts: Edit -> Tab: Display -> Contact Information --> `Use Global (Show)`

### Actual result BEFORE applying this Pull Request

Showon will be ignored and the additional fields are not visible.

![grafik](https://github.com/user-attachments/assets/0cc00bb1-b428-4128-b5ce-450c202c1aec)

Additional fields are only available after explicitly setting the option to `show`

![grafik](https://github.com/user-attachments/assets/52925873-16e3-4def-aa80-043327806c63)

### Expected result AFTER applying this Pull Request

Works as expected and the fields are shown also with `Use Global (Show)`

![grafik](https://github.com/user-attachments/assets/5dc248c7-a5cd-472d-b6f2-5749f3fd4606)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
