### PR TITLE
[4.4] Fix missing $db->quoteName in FieldLayoutField

### DIFF
--- a/administrator/components/com_fields/src/Field/FieldLayoutField.php
+++ b/administrator/components/com_fields/src/Field/FieldLayoutField.php
@@ -56,9 +56,9 @@ class FieldLayoutField extends FormField
             // Build the query.
             $query->select('element, name')
                 ->from('#__extensions')
-                ->where($db->quoteName('client_id') . '=' . $db->quote('0'))
-                ->where($db->quoteName('type') . '=' . $db->quote('template'))
-                ->where($db->quoteName('enabled') . '=' . $db->quote('1'));
+                ->where($db->quoteName('client_id') . ' = 0')
+                ->where($db->quoteName('type') . ' = ' . $db->quote('template'))
+                ->where($db->quoteName('enabled') . ' = 1');
 
             // Set the query and load the templates.
             $db->setQuery($query);

--- a/administrator/components/com_fields/src/Field/FieldLayoutField.php
+++ b/administrator/components/com_fields/src/Field/FieldLayoutField.php
@@ -56,9 +56,9 @@ class FieldLayoutField extends FormField
             // Build the query.
             $query->select('element, name')
                 ->from('#__extensions')
-                ->where('client_id = 0')
-                ->where('type = ' . $db->quote('template'))
-                ->where('enabled = 1');
+                ->where($db->quoteName('client_id') . ' = ' . $db->quote('0'))
+                ->where($db->quoteName('type') . '=' . $db->quote('template'))
+                ->where($db->quoteName('enabled') . ' = ' . $db->quote('1'));
 
             // Set the query and load the templates.
             $db->setQuery($query);

--- a/administrator/components/com_fields/src/Field/FieldLayoutField.php
+++ b/administrator/components/com_fields/src/Field/FieldLayoutField.php
@@ -56,9 +56,9 @@ class FieldLayoutField extends FormField
             // Build the query.
             $query->select('element, name')
                 ->from('#__extensions')
-                ->where($db->quoteName('client_id') . ' = ' . $db->quote('0'))
+                ->where($db->quoteName('client_id') . '=' . $db->quote('0'))
                 ->where($db->quoteName('type') . '=' . $db->quote('template'))
-                ->where($db->quoteName('enabled') . ' = ' . $db->quote('1'));
+                ->where($db->quoteName('enabled') . '=' . $db->quote('1'));
 
             // Set the query and load the templates.
             $db->setQuery($query);


### PR DESCRIPTION
Pull Request for Comment https://github.com/joomla/joomla-cms/pull/43829#pullrequestreview-2201148476 .

### Summary of Changes

Add missing $db->quoteName in FieldLayoutField

### Testing Instructions

Create override `com_fields` -> `fields`

![grafik](https://github.com/user-attachments/assets/c1785948-faa7-4afe-bfe5-cbc57e1a54c3)

Rename the layout file e. g. `test.php`

![grafik](https://github.com/user-attachments/assets/68dbabb4-0716-40d3-8f54-aedc618b84ea)

`Content` -> `Fields`-> `New` -> `Tab: Options` -> and scroll to bottom

you should see your new layout override in the Layout Dropdown

### Actual result BEFORE applying this Pull Request

![grafik](https://github.com/user-attachments/assets/69e9021a-f4f5-4a52-9f26-eab9da856a8d)

### Expected result AFTER applying this Pull Request

Nothing should be changed.

![grafik](https://github.com/user-attachments/assets/69e9021a-f4f5-4a52-9f26-eab9da856a8d)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
