### PR TITLE
[5.2] Prefill the alt input field with the file name

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/breadcrumb/breadcrumb.vue
+++ b/administrator/components/com_media/resources/scripts/components/breadcrumb/breadcrumb.vue
@@ -80,6 +80,7 @@ export default {
             cancelable: false,
             detail: {
               type: 'dir',
+              name: destination.name,
               path: destination.path,
             },
           },

--- a/administrator/components/com_media/resources/scripts/components/browser/browser.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/browser.vue
@@ -218,6 +218,7 @@ export default {
               bubbles: true,
               cancelable: false,
               detail: {
+                name: '',
                 path: '',
                 thumb: false,
                 fileType: false,

--- a/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/directory.vue
@@ -58,6 +58,7 @@ export default {
           cancelable: false,
           detail: {
             type: this.item.type,
+            name: this.item.name,
             path: this.item.path,
           },
         }),

--- a/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
+++ b/administrator/components/com_media/resources/scripts/components/browser/items/item.es6.js
@@ -127,6 +127,7 @@ export default {
             cancelable: false,
             detail: {
               type: this.item.type,
+              name: this.item.name,
               path: this.item.path,
               thumb: this.item.thumb,
               fileType: this.item.mime_type ? this.item.mime_type : false,
@@ -145,6 +146,7 @@ export default {
             cancelable: false,
             detail: {
               type: this.item.type,
+              name: this.item.name,
               path: this.item.path,
             },
           }),

--- a/administrator/components/com_media/resources/scripts/components/browser/table/row.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/table/row.vue
@@ -137,8 +137,9 @@ export default {
      */
     onClick(event) {
       const data = {
-        path: this.item.path,
         type: this.item.type,
+        name: this.item.name,
+        path: this.item.path,
         thumb: false,
         fileType: this.item.mime_type ? this.item.mime_type : false,
         extension: this.item.extension ? this.item.extension : false,

--- a/administrator/components/com_media/resources/scripts/components/tree/tree.vue
+++ b/administrator/components/com_media/resources/scripts/components/tree/tree.vue
@@ -90,6 +90,7 @@ export default {
             cancelable: false,
             detail: {
               type: item.type,
+              name: item.name,
               path: item.path,
             },
           },

--- a/administrator/components/com_media/resources/scripts/store/mutations.es6.js
+++ b/administrator/components/com_media/resources/scripts/store/mutations.es6.js
@@ -191,6 +191,7 @@ export default {
         cancelable: false,
         detail: {
           type: selectedFile.type,
+          name: selectedFile.name,
           path: selectedFile.path,
           thumb: selectedFile.thumb,
           fileType: selectedFile.mime_type ? selectedFile.mime_type : false,

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -86,7 +86,7 @@ document.addEventListener('onMediaFileSelected', async (e) => {
       const altField = container.querySelector('#-alt');
       if (altField) {
         // Replace special characters
-        altField.value = Joomla.selectedMediaFile.path.split('/').pop().replace(/_|-/g, ' ');
+        altField.value = Joomla.selectedMediaFile.name.replace(/_|-/g, ' ');
 
         // Remove the file extension
         altField.value = altField.value.split('.').slice(0, -1).join('.');

--- a/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-media-select.w-c.es6.js
@@ -81,6 +81,16 @@ document.addEventListener('onMediaFileSelected', async (e) => {
   height-label="${Joomla.Text._('JFIELD_MEDIA_HEIGHT_LABEL')}"
 ></joomla-field-mediamore>
 `);
+
+      // Set the selected file name as alt attribute without the extension
+      const altField = container.querySelector('#-alt');
+      if (altField) {
+        // Replace special characters
+        altField.value = Joomla.selectedMediaFile.path.split('/').pop().replace(/_|-/g, ' ');
+
+        // Remove the file extension
+        altField.value = altField.value.split('.').slice(0, -1).join('.');
+      }
     }
   }
 });


### PR DESCRIPTION
### Summary of Changes
Often does the filename describe the picture and it would be a good starting point for the alternative text when selecting an image for the description field. This pr prefills the alternative text input field with the filename without underscrore and file extension. 

### Testing Instructions
- Open the article form
- Click on "CMS Content"
- Click on "Media"
- Select an image

### Actual result BEFORE applying this Pull Request
The "Image Description (Alt Text)" input field is empty.

### Expected result AFTER applying this Pull Request
The "Image Description (Alt Text)" input field is has the filename prefilled without -_ characters and the file extension.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
