### PR TITLE
[5.3] Form control fields, new API

### DIFF
--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -136,7 +136,9 @@ class HtmlView extends BaseHtmlView
             }
         } else {
             // In article associations modal we need to remove language filter if forcing a language.
-            if ($forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD')) {
+            $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD');
+
+            if ($forcedLanguage) {
                 // If the language is forced we can't allow to select the language, so transform the language selector filter into a hidden field.
                 $languageXml = new \SimpleXMLElement('<field name="language" type="hidden" default="' . $forcedLanguage . '" />');
                 $this->filterForm->setField($languageXml, 'filter', true);
@@ -144,11 +146,19 @@ class HtmlView extends BaseHtmlView
                 // Also, unset the active language filter so the search tools is not open by default with this filter.
                 unset($this->activeFilters['language']);
             }
+
+            $this->filterForm->addControlField('forcedLanguage', $forcedLanguage);
         }
 
         // If filter by category is active we need to know the extension name to filter the categories
         $extensionName = $this->escape($this->state->get('filter.extension'));
         $this->filterForm->setFieldAttribute('category_id', 'extension', $extensionName, 'filter');
+
+        // Add form control fields
+        $this->filterForm
+            ->addControlField('extension', $this->state->get('filter.extension', ''))
+            ->addControlField('task', '')
+            ->addControlField('boxchecked', '0');
 
         parent::display($tpl);
     }

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -108,10 +108,13 @@ class HtmlView extends BaseHtmlView
             $this->checkTags = true;
         }
 
-        Factory::getApplication()->getInput()->set('hidemainmenu', true);
+        $input          = Factory::getApplication()->getInput();
+        $forcedLanguage = $input->get('forcedLanguage', '', 'cmd');
+
+        $input->set('hidemainmenu', true);
 
         // If we are forcing a language in modal (used for associations).
-        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'cmd')) {
+        if ($this->getLayout() === 'modal' && $forcedLanguage) {
             // Set the language field to the forcedLanguage and disable changing it.
             $this->form->setValue('language', null, $forcedLanguage);
             $this->form->setFieldAttribute('language', 'readonly', 'true');
@@ -122,6 +125,12 @@ class HtmlView extends BaseHtmlView
             // Only allow to select tags with All language or with the forced language.
             $this->form->setFieldAttribute('tags', 'language', '*,' . $forcedLanguage);
         }
+
+        // Add form control fields
+        $this->form
+            ->addControlField('task', '')
+            ->addControlField('return', $input->getBase64('return', ''))
+            ->addControlField('forcedLanguage', $forcedLanguage);
 
         if ($this->getLayout() !== 'modal') {
             $this->addToolbar();

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -282,10 +282,7 @@ if ($saveOrder && !empty($this->items)) {
                     <?php endif; ?>
                 <?php endif; ?>
 
-                <input type="hidden" name="extension" value="<?php echo $extension; ?>">
-                <input type="hidden" name="task" value="">
-                <input type="hidden" name="boxchecked" value="0">
-                <?php echo HTMLHelper::_('form.token'); ?>
+                <?php echo $this->filterForm->renderControlFields(); ?>
             </div>
         </div>
     </div>

--- a/administrator/components/com_categories/tmpl/categories/modal.php
+++ b/administrator/components/com_categories/tmpl/categories/modal.php
@@ -143,11 +143,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 
         <?php endif; ?>
 
-        <input type="hidden" name="extension" value="<?php echo $extension; ?>">
-        <input type="hidden" name="task" value="">
-        <input type="hidden" name="boxchecked" value="0">
-        <input type="hidden" name="forcedLanguage" value="<?php echo $app->getInput()->get('forcedLanguage', '', 'CMD'); ?>">
-        <?php echo HTMLHelper::_('form.token'); ?>
+        <?php echo $this->filterForm->renderControlFields(); ?>
 
     </form>
 </div>

--- a/administrator/components/com_categories/tmpl/category/edit.php
+++ b/administrator/components/com_categories/tmpl/category/edit.php
@@ -123,9 +123,6 @@ $tmpl    = $isModal || $input->get('tmpl', '', 'cmd') === 'component' ? '&tmpl=c
         <?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 
         <?php echo $this->form->getInput('extension'); ?>
-        <input type="hidden" name="task" value="">
-        <input type="hidden" name="return" value="<?php echo $input->getBase64('return'); ?>">
-        <input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">
-        <?php echo HTMLHelper::_('form.token'); ?>
+        <?php echo $this->form->renderControlFields(); ?>
     </div>
 </form>

--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -104,8 +104,11 @@ class HtmlView extends BaseHtmlView
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
+        $input          = Factory::getApplication()->getInput();
+        $forcedLanguage = $input->get('forcedLanguage', '', 'cmd');
+
         // If we are forcing a language in modal (used for associations).
-        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'cmd')) {
+        if ($this->getLayout() === 'modal' && $forcedLanguage) {
             // Set the language field to the forcedLanguage and disable changing it.
             $this->form->setValue('language', null, $forcedLanguage);
             $this->form->setFieldAttribute('language', 'readonly', 'true');
@@ -116,6 +119,12 @@ class HtmlView extends BaseHtmlView
             // Only allow to select tags with All language or with the forced language.
             $this->form->setFieldAttribute('tags', 'language', '*,' . $forcedLanguage);
         }
+
+        // Add form control fields
+        $this->form
+            ->addControlField('task', '')
+            ->addControlField('return', $input->getBase64('return', ''))
+            ->addControlField('forcedLanguage', $forcedLanguage);
 
         if ($this->getLayout() !== 'modal') {
             $this->addToolbar();

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -144,7 +144,9 @@ class HtmlView extends BaseHtmlView
         } else {
             // In article associations modal we need to remove language filter if forcing a language.
             // We also need to change the category filter to show show categories with All or the forced language.
-            if ($forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD')) {
+            $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD');
+
+            if ($forcedLanguage) {
                 // If the language is forced we can't allow to select the language, so transform the language selector filter into a hidden field.
                 $languageXml = new \SimpleXMLElement('<field name="language" type="hidden" default="' . $forcedLanguage . '" />');
                 $this->filterForm->setField($languageXml, 'filter', true);
@@ -155,6 +157,8 @@ class HtmlView extends BaseHtmlView
                 // One last changes needed is to change the category filter to just show categories with All language or with the forced language.
                 $this->filterForm->setFieldAttribute('category_id', 'language', '*,' . $forcedLanguage, 'filter');
             }
+
+            $this->filterForm->addControlField('forcedLanguage', $forcedLanguage);
         }
 
         // Add form control fields

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -157,6 +157,11 @@ class HtmlView extends BaseHtmlView
             }
         }
 
+        // Add form control fields
+        $this->filterForm
+            ->addControlField('task', '')
+            ->addControlField('boxchecked', '0');
+
         parent::display($tpl);
     }
 

--- a/administrator/components/com_content/tmpl/article/edit.php
+++ b/administrator/components/com_content/tmpl/article/edit.php
@@ -179,9 +179,6 @@ $tmpl    = $tmpl ? '&tmpl=' . $tmpl : '';
             <div class="hidden"><?php echo $hidden_fields; ?></div>
         <?php endif; ?>
 
-        <input type="hidden" name="task" value="">
-        <input type="hidden" name="return" value="<?php echo $input->getBase64('return'); ?>">
-        <input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">
-        <?php echo HTMLHelper::_('form.token'); ?>
+        <?php echo $this->form->renderControlFields(); ?>
     </div>
 </form>

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -65,6 +65,8 @@ if ($workflow_enabled) :
 
     $workflow_state    = Factory::getApplication()->bootComponent('com_content')->isFunctionalityUsed('core.state', 'com_content.article');
     $workflow_featured = Factory::getApplication()->bootComponent('com_content')->isFunctionalityUsed('core.featured', 'com_content.article');
+
+    $this->filterForm->addControlField('transition_id', '');
 endif;
 
 $assoc = Associations::isEnabled();
@@ -389,13 +391,7 @@ $assoc = Associations::isEnabled();
                     <?php endif; ?>
                 <?php endif; ?>
 
-                <?php if ($workflow_enabled) : ?>
-                <input type="hidden" name="transition_id" value="">
-                <?php endif; ?>
-
-                <input type="hidden" name="task" value="">
-                <input type="hidden" name="boxchecked" value="0">
-                <?php echo HTMLHelper::_('form.token'); ?>
+                <?php echo $this->filterForm->renderControlFields(); ?>
             </div>
         </div>
     </div>

--- a/administrator/components/com_content/tmpl/articles/modal.php
+++ b/administrator/components/com_content/tmpl/articles/modal.php
@@ -168,10 +168,7 @@ if (!empty($editor)) {
 
         <?php endif; ?>
 
-        <input type="hidden" name="task" value="">
-        <input type="hidden" name="boxchecked" value="0">
-        <input type="hidden" name="forcedLanguage" value="<?php echo $app->getInput()->get('forcedLanguage', '', 'CMD'); ?>">
-        <?php echo HTMLHelper::_('form.token'); ?>
+        <?php echo $this->filterForm->renderControlFields(); ?>
 
     </form>
 </div>

--- a/administrator/components/com_menus/src/View/Item/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Item/HtmlView.php
@@ -108,8 +108,11 @@ class HtmlView extends BaseHtmlView
             return;
         }
 
+        $input          = Factory::getApplication()->getInput();
+        $forcedLanguage = $input->get('forcedLanguage', '', 'cmd');
+
         // If we are forcing a language in modal (used for associations).
-        if ($this->getLayout() === 'modal' && $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'cmd')) {
+        if ($this->getLayout() === 'modal' && $forcedLanguage) {
             // Set the language field to the forcedLanguage and disable changing it.
             $this->form->setValue('language', null, $forcedLanguage);
             $this->form->setFieldAttribute('language', 'readonly', 'true');
@@ -117,6 +120,13 @@ class HtmlView extends BaseHtmlView
             // Only allow to select categories with All language or with the forced language.
             $this->form->setFieldAttribute('parent_id', 'language', '*,' . $forcedLanguage);
         }
+
+        // Add form control fields
+        $this->form
+            ->addControlField('task', '')
+            ->addControlField('forcedLanguage', $forcedLanguage)
+            ->addControlField('menutype', $input->get('menutype', ''))
+            ->addControlField('fieldtype', '', ['id' => 'fieldtype']);
 
         if ($this->getLayout() !== 'modal') {
             $this->addToolbar();

--- a/administrator/components/com_menus/src/View/Items/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Items/HtmlView.php
@@ -266,7 +266,9 @@ class HtmlView extends BaseHtmlView
             }
         } else {
             // In menu associations modal we need to remove language filter if forcing a language.
-            if ($forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD')) {
+            $forcedLanguage = Factory::getApplication()->getInput()->get('forcedLanguage', '', 'CMD');
+
+            if ($forcedLanguage) {
                 // If the language is forced we can't allow to select the language, so transform the language selector filter into a hidden field.
                 $languageXml = new \SimpleXMLElement('<field name="language" type="hidden" default="' . $forcedLanguage . '" />');
                 $this->filterForm->setField($languageXml, 'filter', true);
@@ -274,7 +276,14 @@ class HtmlView extends BaseHtmlView
                 // Also, unset the active language filter so the search tools is not open by default with this filter.
                 unset($this->activeFilters['language']);
             }
+
+            $this->filterForm->addControlField('forcedLanguage', $forcedLanguage);
         }
+
+        // Add form control fields
+        $this->filterForm
+            ->addControlField('task', '')
+            ->addControlField('boxchecked', '0');
 
         // Allow a system plugin to insert dynamic menu types to the list shown in menus:
         $this->getDispatcher()->dispatch('onBeforeRenderMenuItems', new BeforeRenderMenuItemsViewEvent('onBeforeRenderMenuItems', [

--- a/administrator/components/com_menus/src/View/Menu/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menu/HtmlView.php
@@ -79,6 +79,9 @@ class HtmlView extends BaseHtmlView
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
+        // Add form control fields
+        $this->form->addControlField('task', '');
+
         parent::display($tpl);
         $this->addToolbar();
     }

--- a/administrator/components/com_menus/tmpl/item/edit.php
+++ b/administrator/components/com_menus/tmpl/item/edit.php
@@ -170,10 +170,6 @@ if ($clientId === 1) {
         <?php echo HTMLHelper::_('uitab.endTabSet'); ?>
     </div>
 
-    <input type="hidden" name="task" value="">
-    <input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">
-    <input type="hidden" name="menutype" value="<?php echo $input->get('menutype', '', 'cmd'); ?>">
     <?php echo $this->form->getInput('component_id'); ?>
-    <?php echo HTMLHelper::_('form.token'); ?>
-    <input type="hidden" id="fieldtype" name="fieldtype" value="">
+    <?php echo $this->form->renderControlFields(); ?>
 </form>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -275,9 +275,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
                     <?php endif; ?>
                 <?php endif; ?>
 
-                <input type="hidden" name="task" value="">
-                <input type="hidden" name="boxchecked" value="0">
-                <?php echo HTMLHelper::_('form.token'); ?>
+                <?php echo $this->filterForm->renderControlFields();  ?>
             </div>
         </div>
     </div>

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -275,7 +275,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
                     <?php endif; ?>
                 <?php endif; ?>
 
-                <?php echo $this->filterForm->renderControlFields();  ?>
+                <?php echo $this->filterForm->renderControlFields(); ?>
             </div>
         </div>
     </div>

--- a/administrator/components/com_menus/tmpl/menu/edit.php
+++ b/administrator/components/com_menus/tmpl/menu/edit.php
@@ -66,7 +66,6 @@ Text::script('ERROR');
             <?php endif; ?>
 
         <?php echo HTMLHelper::_('uitab.endTabSet'); ?>
-        <input type="hidden" name="task" value="">
-        <?php echo HTMLHelper::_('form.token'); ?>
+        <?php echo $this->form->renderControlFields(); ?>
     </div>
 </form>

--- a/components/com_content/src/View/Form/HtmlView.php
+++ b/components/com_content/src/View/Form/HtmlView.php
@@ -192,6 +192,11 @@ class HtmlView extends BaseHtmlView
             $this->showSaveAsCopy = true;
         }
 
+        // Add form control fields
+        $this->form
+            ->addControlField('task', '')
+            ->addControlField('return', $this->return_page ?? '');
+
         $this->_prepareDocument();
 
         parent::display($tpl);

--- a/components/com_content/tmpl/form/edit.php
+++ b/components/com_content/tmpl/form/edit.php
@@ -151,9 +151,7 @@ if (!$params->exists('show_publishing_options')) {
 
             <?php echo HTMLHelper::_('uitab.endTabSet'); ?>
 
-            <input type="hidden" name="task" value="">
-            <input type="hidden" name="return" value="<?php echo $this->return_page; ?>">
-            <?php echo HTMLHelper::_('form.token'); ?>
+            <?php echo $this->form->renderControlFields(); ?>
         </fieldset>
         <div class="d-grid gap-2 d-sm-block mb-2">
             <button type="button" class="btn btn-primary" data-submit-task="article.apply">

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -86,7 +86,7 @@ class Form implements CurrentUserInterface
     /**
      * List of control fields.
      * Hidden "non-model" fields that need for Controller, like "task", "return", token hash, etc.
-     * Array containing name => value for each field.
+     * Array containing name => [value => value, attributes => []] for each field.
      *
      * @var    array
      * @since  __DEPLOY_VERSION__
@@ -1882,16 +1882,20 @@ class Form implements CurrentUserInterface
     /**
      * Add control field
      *
-     * @param string $name   The name of the input
-     * @param string $value  The value of the input
+     * @param string $name        The name of the input
+     * @param string $value       The value of the input
+     * @param array  $attributes  Optional attributes of the input
      *
      * @return static
      *
      * @since  __DEPLOY_VERSION__
      */
-    public function addControlField(string $name, string $value = ''): static
+    public function addControlField(string $name, string $value = '', array $attributes = []): static
     {
-        $this->controlFields[$name] = $value;
+        $this->controlFields[$name] = [
+            'value'      => $value,
+            'attributes' => $attributes,
+        ];
 
         return $this;
     }
@@ -1907,10 +1911,7 @@ class Form implements CurrentUserInterface
      */
     public function removeControlField(string $name): static
     {
-        if (isset($this->controlFields[$name]))
-        {
-            unset($this->controlFields[$name]);
-        }
+        unset($this->controlFields[$name]);
 
         return $this;
     }
@@ -1939,7 +1940,18 @@ class Form implements CurrentUserInterface
         $html = [];
 
         foreach ($this->controlFields as $n => $v) {
-            $html[] = '<input type="hidden" name="' . htmlspecialchars($n) . '" value="' . htmlspecialchars($v) . '" />';
+            // Check for attributes
+            $attrStr = '';
+
+            if ($v['attributes']) {
+                $attr = [];
+                foreach ($v['attributes'] as $attrName => $attrValue) {
+                    $attr[] = htmlspecialchars($attrName) . '="' . htmlspecialchars($attrValue) . '"';
+                }
+                $attrStr = implode(' ', $attr);
+            }
+
+            $html[] = '<input type="hidden" name="' . htmlspecialchars($n) . '" value="' . htmlspecialchars($v['value']) . '" ' . $attrStr . '/>';
         }
 
         // The Token should be added in any case

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -85,11 +85,11 @@ class Form implements CurrentUserInterface
 
     /**
      * List of control fields.
-     * Array contain Key => Value for each field.
+     * Hidden "non-model" fields that need for Controller, like "task", "return", token hash, etc.
+     * Array containing name => value for each field.
      *
      * @var    array
      * @since  __DEPLOY_VERSION__
-     *
      */
     protected $controlFields = [];
 

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1882,9 +1882,9 @@ class Form implements CurrentUserInterface
     /**
      * Add control field
      *
-     * @param string $name        The name of the input
-     * @param string $value       The value of the input
-     * @param array  $attributes  Optional attributes of the input
+     * @param string    $name        The name of the input
+     * @param string    $value       The value of the input
+     * @param string[]  $attributes  Optional attributes of the input, in format [name => value]
      *
      * @return static
      *

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1951,7 +1951,7 @@ class Form implements CurrentUserInterface
                 $attrStr = implode(' ', $attr);
             }
 
-            $html[] = '<input type="hidden" name="' . htmlspecialchars($n) . '" value="' . htmlspecialchars($v['value']) . '" ' . $attrStr . '/>';
+            $html[] = '<input type="hidden" name="' . htmlspecialchars($n) . '" value="' . htmlspecialchars($v['value']) . '" ' . $attrStr . '>';
         }
 
         // The Token should be added in any case

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -10,6 +10,7 @@
 namespace Joomla\CMS\Form;
 
 use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\User\CurrentUserInterface;
@@ -81,6 +82,16 @@ class Form implements CurrentUserInterface
      * @since  1.7.0
      */
     protected $xml;
+
+    /**
+     * List of control fields.
+     * Array contain Key => Value for each field.
+     *
+     * @var    array
+     * @since  __DEPLOY_VERSION__
+     *
+     */
+    protected $controlFields = [];
 
     /**
      * Form instances.
@@ -1865,5 +1876,75 @@ class Form implements CurrentUserInterface
     public function getFieldXml($name, $group = null)
     {
         return $this->findField($name, $group);
+    }
+
+
+    /**
+     * Add control field
+     *
+     * @param string $name   The name of the input
+     * @param string $value  The value of the input
+     *
+     * @return static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function addControlField(string $name, string $value = ''): static
+    {
+        $this->controlFields[$name] = $value;
+
+        return $this;
+    }
+
+    /**
+     * Remove control field
+     *
+     * @param string $name  The name of the input
+     *
+     * @return static
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function removeControlField(string $name): static
+    {
+        if (isset($this->controlFields[$name]))
+        {
+            unset($this->controlFields[$name]);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Return array of control fields
+     *
+     * @return array
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getControlFields(): array
+    {
+        return $this->controlFields;
+    }
+
+    /**
+     * Render control fields
+     *
+     * @return string
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function renderControlFields(): string
+    {
+        $html = [];
+
+        foreach ($this->controlFields as $n => $v) {
+            $html[] = '<input type="hidden" name="' . htmlspecialchars($n) . '" value="' . htmlspecialchars($v) . '" />';
+        }
+
+        // The Token should be added in any case
+        $html[] = HTMLHelper::_('form.token');
+
+        return implode("\n", $html);
     }
 }


### PR DESCRIPTION
### Summary of Changes

Replace control inputs hardcoded into the form layout with an API which allows to add this fields programaticaly.

**Before PR** (the form layout):
```html
<input type="hidden" name="task" value="">
<input type="hidden" name="return" value="<?php echo $input->getBase64('return'); ?>">
<input type="hidden" name="forcedLanguage" value="<?php echo $input->get('forcedLanguage', '', 'cmd'); ?>">
<?php echo HTMLHelper::_('form.token'); ?>
```
**After PR**:
```php
// In Controller/View
$this->form
  ->addControlField('task', '')
  ->addControlField('return', $input->getBase64('return', ''))
  ->addControlField('forcedLanguage', $forcedLanguage);

// In the form layout
echo $this->form->renderControlFields();
```

For now I have updated following forms:
- [x] Article
- [x] Category 
- [x] Menu

Will update more, when there will be a positive feedbacks.


### Testing Instructions
Code review.
Create/edit Article, Category, Menu item. All should work as before.


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed
- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/322
- [ ] No documentation changes for manual.joomla.org needed
