### PR TITLE
[5.2] Set a fix width for icons on the main menu

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_sidebar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_sidebar.scss
@@ -93,7 +93,9 @@
 
   // All list items
   li {
-
+    > a .fa {
+      width: 1rem;
+    }
     .menu-dashboard,
     .menu-quicktask {
       > a {


### PR DESCRIPTION
### Summary of Changes
Set the width of the main menu icon in backend template to 1rem


### Testing Instructions
Install patched version.
Create a custom backend menu with different sized frontawesome icons
check the menü

### Actual result BEFORE applying this Pull Request
![image](https://github.com/user-attachments/assets/01c284a7-47b7-4623-8857-ac966bac43ba)



### Expected result AFTER applying this Pull Request
![image](https://github.com/user-attachments/assets/c38755d8-a05c-49ae-a511-d696403fa7a0)
