### PR TITLE
[5.1] Fix encoding for a few popup links

### DIFF
--- a/administrator/components/com_finder/tmpl/index/default.php
+++ b/administrator/components/com_finder/tmpl/index/default.php
@@ -43,7 +43,7 @@ if ($this->finderPluginId) {
         Text::_('COM_FINDER_CONTENT_PLUGIN'),
         [
             'class'                 => 'alert-link',
-            'data-joomla-dialog'    => $this->escape(json_encode($popupOptions, JSON_UNESCAPED_SLASHES)),
+            'data-joomla-dialog'    => $this->escape(json_encode($popupOptions, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)),
             'data-checkin-url'      => Route::_('index.php?option=com_plugins&task=plugins.checkin&format=json&cid[]=' . $this->finderPluginId),
             'data-close-on-message' => '',
             'data-reload-on-close'  => '',

--- a/administrator/components/com_finder/tmpl/index/emptystate.php
+++ b/administrator/components/com_finder/tmpl/index/emptystate.php
@@ -47,7 +47,7 @@ if ($this->finderPluginId) {
         Text::_('COM_FINDER_CONTENT_PLUGIN'),
         [
             'class'                 => 'alert-link',
-            'data-joomla-dialog'    => $this->escape(json_encode($popupOptions, JSON_UNESCAPED_SLASHES)),
+            'data-joomla-dialog'    => $this->escape(json_encode($popupOptions, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)),
             'data-checkin-url'      => Route::_('index.php?option=com_plugins&task=plugins.checkin&format=json&cid[]=' . $this->finderPluginId),
             'data-close-on-message' => '',
             'data-reload-on-close'  => '',

--- a/administrator/components/com_redirect/tmpl/links/default.php
+++ b/administrator/components/com_redirect/tmpl/links/default.php
@@ -51,7 +51,7 @@ if ($pluginEnabled && $collectUrlsEnabled) {
         Text::_('COM_REDIRECT_SYSTEM_PLUGIN'),
         [
             'class'                 => 'alert-link',
-            'data-joomla-dialog'    => $this->escape(json_encode($popupOptions, JSON_UNESCAPED_SLASHES)),
+            'data-joomla-dialog'    => $this->escape(json_encode($popupOptions, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)),
             'data-checkin-url'      => Route::_('index.php?option=com_plugins&task=plugins.checkin&format=json&cid[]=' . $redirectPluginId),
             'data-close-on-message' => '',
             'data-reload-on-close'  => '',

--- a/administrator/components/com_redirect/tmpl/links/emptystate.php
+++ b/administrator/components/com_redirect/tmpl/links/emptystate.php
@@ -65,7 +65,7 @@ if ($pluginEnabled && $collectUrlsEnabled) {
         Text::_('COM_REDIRECT_SYSTEM_PLUGIN'),
         [
             'class'                 => 'alert-link',
-            'data-joomla-dialog'    => $this->escape(json_encode($popupOptions, JSON_UNESCAPED_SLASHES)),
+            'data-joomla-dialog'    => $this->escape(json_encode($popupOptions, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)),
             'data-checkin-url'      => Route::_('index.php?option=com_plugins&task=plugins.checkin&format=json&cid[]=' . $redirectPluginId),
             'data-close-on-message' => '',
             'data-reload-on-close'  => '',


### PR DESCRIPTION
Pull Request for Issue #43013 .

### Summary of Changes

Fix encoding for a popup links, for Finder and Redirect plugins.


### Testing Instructions
Please follow #43013

Or add language overide:
```
COM_REDIRECT_EDIT_PLUGIN_SETTINGS="Тест"
COM_FINDER_EDIT_PLUGIN_SETTINGS="Тест"
```

Disable plugins Content - Finder, and System - Redirect.
Visit the Finder index and Redirects overview pages, and click on the link in the message.


### Actual result BEFORE applying this Pull Request
Popup with broken heading


### Expected result AFTER applying this Pull Request
Popup with text `Тест`


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
