### PR TITLE
[4.4] fixing typo

### DIFF
--- a/administrator/components/com_content/src/Field/VotelistField.php
+++ b/administrator/components/com_content/src/Field/VotelistField.php
@@ -37,7 +37,7 @@ class VotelistField extends ListField
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
      * @param   mixed              $value    The form field value to validate.
-     * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+     * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
      *

--- a/administrator/components/com_content/src/Field/VoteradioField.php
+++ b/administrator/components/com_content/src/Field/VoteradioField.php
@@ -37,7 +37,7 @@ class VoteradioField extends RadioField
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
      * @param   mixed              $value    The form field value to validate.
-     * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+     * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
      *

--- a/installation/src/Form/Field/Installation/LanguageField.php
+++ b/installation/src/Form/Field/Installation/LanguageField.php
@@ -38,7 +38,7 @@ class LanguageField extends ListField
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
      * @param   mixed              $value    The form field value to validate.
-     * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+     * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
      *

--- a/libraries/src/Form/Field/TransitionField.php
+++ b/libraries/src/Form/Field/TransitionField.php
@@ -53,7 +53,7 @@ class TransitionField extends GroupedlistField
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
      * @param   mixed              $value    The form field value to validate.
-     * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+     * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
      *

--- a/libraries/src/Form/Field/WorkflowconditionField.php
+++ b/libraries/src/Form/Field/WorkflowconditionField.php
@@ -53,7 +53,7 @@ class WorkflowconditionField extends ListField
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
      * @param   mixed              $value    The form field value to validate.
-     * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+     * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
      *

--- a/libraries/src/Form/Field/WorkflowstageField.php
+++ b/libraries/src/Form/Field/WorkflowstageField.php
@@ -53,7 +53,7 @@ class WorkflowstageField extends GroupedlistField
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
      * @param   mixed              $value    The form field value to validate.
-     * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+     * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
      *

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -616,7 +616,7 @@ abstract class FormField implements DatabaseAwareInterface
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
      * @param   mixed              $value    The form field value to validate.
-     * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+     * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
      *

--- a/libraries/src/Form/FormRule.php
+++ b/libraries/src/Form/FormRule.php
@@ -58,7 +58,7 @@ class FormRule
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
      * @param   mixed              $value    The form field value to validate.
-     * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+     * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
      * @param   ?Registry          $input    An optional Registry object with the entire data set to validate against the entire form.

--- a/libraries/src/Form/Rule/SubformRule.php
+++ b/libraries/src/Form/Rule/SubformRule.php
@@ -30,7 +30,7 @@ class SubformRule extends FormRule
      *
      * @param   \SimpleXMLElement  $element  The SimpleXMLElement object representing the `<field>` tag for the form field object.
      * @param   mixed              $value    The form field value to validate.
-     * @param   string             $group    The field name group control value. This acts as as an array container for the field.
+     * @param   string             $group    The field name group control value. This acts as an array container for the field.
      *                                       For example if the field has name="foo" and the group value is set to "bar" then the
      *                                       full field name would end up being "bar[foo]".
      * @param   ?Registry          $input    An optional Registry object with the entire data set to validate against the entire form.


### PR DESCRIPTION
removal double "as"

Pull Request for Issue # .

### Summary of Changes

removal a double word "as" in the sentence of a Docblock
nothing should change in the code

### Testing Instructions

open editor to see if there is only one "as" instead of two. 

### Actual result BEFORE applying this Pull Request

> This acts as as an array container for the field.


### Expected result AFTER applying this Pull Request

> This acts as an array container for the field.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
