### PR TITLE
[5.1] Fix header translation for modal select field

### DIFF
--- a/layouts/joomla/form/field/modal-select/buttons.php
+++ b/layouts/joomla/form/field/modal-select/buttons.php
@@ -54,17 +54,17 @@ extract($displayData);
 $modalSelect = [
     'popupType'  => 'iframe',
     'src'        => empty($urls['select']) ? '' : Route::_($urls['select'], false),
-    'textHeader' => $modalTitles['select'] ?? Text::_('JSELECT'),
+    'textHeader' => Text::_($modalTitles['select'] ?? 'JSELECT'),
 ];
 $modalNew = [
     'popupType'  => 'iframe',
     'src'        => empty($urls['new']) ? '' : Route::_($urls['new'], false),
-    'textHeader' => $modalTitles['new'] ?? Text::_('JACTION_CREATE'),
+    'textHeader' => Text::_($modalTitles['new'] ?? 'JACTION_CREATE'),
 ];
 $modalEdit = [
     'popupType'  => 'iframe',
     'src'        => empty($urls['edit']) ? '' : Route::_($urls['edit'], false),
-    'textHeader' => $modalTitles['edit'] ?? Text::_('JACTION_EDIT'),
+    'textHeader' => Text::_($modalTitles['edit'] ?? 'JACTION_EDIT'),
 ];
 
 // Decide when the select button always will be visible


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/42918

### Summary of Changes

Fix header translation for modal select field

### Testing Instructions

Add following field XML, somewhere, example in Custom HTML module.
```xml
<field
  type="ModalSelect"
  name="article"
  label="Article"

  select="true"
  titleSelect="JGLOBAL_SELECT_AN_OPTION"
  urlSelect="index.php?option=com_content&amp;view=articles&amp;layout=modal&amp;tmpl=component"
  clear="true"
/>
```

Then edit the form with it, click "select" button.
Check the dialog heading.



### Actual result BEFORE applying this Pull Request
The heading is untranslated language constant.


### Expected result AFTER applying this Pull Request
The heading is translated


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

