### PR TITLE
[4.4] Remove implicit nullable types

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -84,8 +84,8 @@ $config
             'global_namespace_import'                          => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
             // Alpha order imports
             'ordered_imports'                                  => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
-			// Convert implicit nullable type (Foo $bar = null) into explicit (?Foo $bar = null)
-			'nullable_type_declaration_for_default_null_value' => true
+            // Convert implicit nullable type (Foo $bar = null) into explicit (?Foo $bar = null)
+            'nullable_type_declaration_for_default_null_value' => true
         ]
     )
     ->setFinder($finder);

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -67,23 +67,25 @@ $config
     ->setRules(
         [
             // Basic ruleset is PSR 12
-            '@PSR12'                         => true,
+            '@PSR12'                                           => true,
             // Short array syntax
-            'array_syntax'                   => ['syntax' => 'short'],
+            'array_syntax'                                     => ['syntax' => 'short'],
             // Lists should not have a trailing comma like list($foo, $bar,) = ...
-            'no_trailing_comma_in_list_call' => true,
+            'no_trailing_comma_in_list_call'                   => true,
             // Arrays on multiline should have a trailing comma
-            'trailing_comma_in_multiline'    => ['elements' => ['arrays']],
+            'trailing_comma_in_multiline'                      => ['elements' => ['arrays']],
             // Align elements in multiline array and variable declarations on new lines below each other
-            'binary_operator_spaces'         => ['operators' => ['=>' => 'align_single_space_minimal', '=' => 'align']],
+            'binary_operator_spaces'                           => ['operators' => ['=>' => 'align_single_space_minimal', '=' => 'align']],
             // The "No break" comment in switch statements
-            'no_break_comment'               => ['comment_text' => 'No break'],
+            'no_break_comment'                                 => ['comment_text' => 'No break'],
             // Remove unused imports
-            'no_unused_imports'              => true,
+            'no_unused_imports'                                => true,
             // Classes from the global namespace should not be imported
-            'global_namespace_import'        => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
+            'global_namespace_import'                          => ['import_classes' => false, 'import_constants' => false, 'import_functions' => false],
             // Alpha order imports
-            'ordered_imports'                => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+            'ordered_imports'                                  => ['imports_order' => ['class', 'function', 'const'], 'sort_algorithm' => 'alpha'],
+			// Convert implicit nullable type (Foo $bar = null) into explicit (?Foo $bar = null)
+			'nullable_type_declaration_for_default_null_value' => true
         ]
     )
     ->setFinder($finder);

--- a/administrator/components/com_actionlogs/src/Controller/ActionlogsController.php
+++ b/administrator/components/com_actionlogs/src/Controller/ActionlogsController.php
@@ -47,7 +47,7 @@ class ActionlogsController extends AdminController
      *
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_associations/src/Model/AssociationsModel.php
+++ b/administrator/components/com_associations/src/Model/AssociationsModel.php
@@ -39,7 +39,7 @@ class AssociationsModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.7
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_banners/src/Controller/BannersController.php
+++ b/administrator/components/com_banners/src/Controller/BannersController.php
@@ -47,7 +47,7 @@ class BannersController extends AdminController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_banners/src/Extension/BannersComponent.php
+++ b/administrator/components/com_banners/src/Extension/BannersComponent.php
@@ -75,7 +75,7 @@ class BannersComponent extends MVCComponent implements
      *
      * @since   4.0.0
      */
-    protected function getTableNameForSection(string $section = null)
+    protected function getTableNameForSection(?string $section = null)
     {
         return 'banners';
     }

--- a/administrator/components/com_categories/src/Controller/CategoryController.php
+++ b/administrator/components/com_categories/src/Controller/CategoryController.php
@@ -50,7 +50,7 @@ class CategoryController extends FormController
      * @since  1.6
      * @throws \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, CMSApplication $app = null, Input $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_categories/src/Controller/DisplayController.php
+++ b/administrator/components/com_categories/src/Controller/DisplayController.php
@@ -54,7 +54,7 @@ class DisplayController extends BaseController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -47,7 +47,7 @@ class CategoriesModel extends ListModel
      *
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -87,7 +87,7 @@ class CategoryModel extends AdminModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         $extension       = Factory::getApplication()->getInput()->get('extension', 'com_content');
         $this->typeAlias = $extension . '.category';

--- a/administrator/components/com_checkin/src/Model/CheckinModel.php
+++ b/administrator/components/com_checkin/src/Model/CheckinModel.php
@@ -41,7 +41,7 @@ class CheckinModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_config/src/Controller/ApplicationController.php
+++ b/administrator/components/com_config/src/Controller/ApplicationController.php
@@ -42,7 +42,7 @@ class ApplicationController extends BaseController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_config/src/Controller/ComponentController.php
+++ b/administrator/components/com_config/src/Controller/ComponentController.php
@@ -41,7 +41,7 @@ class ComponentController extends FormController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_contact/src/Controller/ContactsController.php
+++ b/administrator/components/com_contact/src/Controller/ContactsController.php
@@ -41,7 +41,7 @@ class ContactsController extends AdminController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_contact/src/Extension/ContactComponent.php
+++ b/administrator/components/com_contact/src/Extension/ContactComponent.php
@@ -134,7 +134,7 @@ class ContactComponent extends MVCComponent implements
      *
      * @since   4.0.0
      */
-    protected function getTableNameForSection(string $section = null)
+    protected function getTableNameForSection(?string $section = null)
     {
         return ($section === 'category' ? 'categories' : 'contact_details');
     }
@@ -148,7 +148,7 @@ class ContactComponent extends MVCComponent implements
      *
      * @since   4.0.0
      */
-    protected function getStateColumnForSection(string $section = null)
+    protected function getStateColumnForSection(?string $section = null)
     {
         return 'published';
     }

--- a/administrator/components/com_content/src/Controller/ArticleController.php
+++ b/administrator/components/com_content/src/Controller/ArticleController.php
@@ -44,7 +44,7 @@ class ArticleController extends FormController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -42,7 +42,7 @@ class ArticlesController extends AdminController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_content/src/Extension/ContentComponent.php
+++ b/administrator/components/com_content/src/Extension/ContentComponent.php
@@ -223,7 +223,7 @@ class ContentComponent extends MVCComponent implements
      *
      * @since   4.0.0
      */
-    protected function getTableNameForSection(string $section = null)
+    protected function getTableNameForSection(?string $section = null)
     {
         return '#__content';
     }

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -103,7 +103,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
      * @since   1.6
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, FormFactoryInterface $formFactory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?FormFactoryInterface $formFactory = null)
     {
         $config['events_map'] = $config['events_map'] ?? [];
 

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -43,7 +43,7 @@ class HistoryModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_fields/src/Controller/FieldController.php
+++ b/administrator/components/com_fields/src/Controller/FieldController.php
@@ -60,7 +60,7 @@ class FieldController extends FormController
      *
      * @since   3.7.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_fields/src/Controller/GroupController.php
+++ b/administrator/components/com_fields/src/Controller/GroupController.php
@@ -58,7 +58,7 @@ class GroupController extends FormController
      *
      * @since   3.7.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_fields/src/Extension/FieldsComponent.php
+++ b/administrator/components/com_fields/src/Extension/FieldsComponent.php
@@ -36,7 +36,7 @@ class FieldsComponent extends MVCComponent implements CategoryServiceInterface
      *
      * @since   4.0.0
      */
-    protected function getTableNameForSection(string $section = null)
+    protected function getTableNameForSection(?string $section = null)
     {
         return 'fields';
     }

--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -107,7 +107,7 @@ class FieldsHelper
         $context,
         $item = null,
         $prepareValue = false,
-        array $valuesToOverride = null,
+        ?array $valuesToOverride = null,
         bool $includeSubformFields = false
     ) {
         if (self::$fieldsCache === null) {

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -91,7 +91,7 @@ class FieldModel extends AdminModel
      * @since   3.7.0
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         parent::__construct($config, $factory);
 

--- a/administrator/components/com_fields/src/Model/FieldsModel.php
+++ b/administrator/components/com_fields/src/Model/FieldsModel.php
@@ -40,7 +40,7 @@ class FieldsModel extends ListModel
      * @since   3.7.0
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_fields/src/Model/GroupsModel.php
+++ b/administrator/components/com_fields/src/Model/GroupsModel.php
@@ -45,7 +45,7 @@ class GroupsModel extends ListModel
      * @since   3.7.0
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_fields/src/Table/FieldTable.php
+++ b/administrator/components/com_fields/src/Table/FieldTable.php
@@ -259,7 +259,7 @@ class FieldTable extends Table
      *
      * @since   3.7.0
      */
-    protected function _getAssetParentId(Table $table = null, $id = null)
+    protected function _getAssetParentId(?Table $table = null, $id = null)
     {
         $contextArray = explode('.', $this->context);
         $component    = $contextArray[0];

--- a/administrator/components/com_fields/src/Table/GroupTable.php
+++ b/administrator/components/com_fields/src/Table/GroupTable.php
@@ -194,7 +194,7 @@ class GroupTable extends Table
      *
      * @since   3.7.0
      */
-    protected function _getAssetParentId(Table $table = null, $id = null)
+    protected function _getAssetParentId(?Table $table = null, $id = null)
     {
         $component = explode('.', $this->context);
         $db        = $this->getDbo();

--- a/administrator/components/com_finder/src/Indexer/Helper.php
+++ b/administrator/components/com_finder/src/Indexer/Helper.php
@@ -403,7 +403,7 @@ class Helper
      *
      * @since   2.5
      */
-    public static function prepareContent($text, $params = null, Result $item = null)
+    public static function prepareContent($text, $params = null, ?Result $item = null)
     {
         static $loaded;
 

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -119,7 +119,7 @@ class Indexer
      *
      * @since  3.8.0
      */
-    public function __construct(DatabaseInterface $db = null)
+    public function __construct(?DatabaseInterface $db = null)
     {
         if ($db === null) {
             @trigger_error(sprintf('Database will be mandatory in 5.0.'), E_USER_DEPRECATED);

--- a/administrator/components/com_finder/src/Indexer/Query.php
+++ b/administrator/components/com_finder/src/Indexer/Query.php
@@ -204,7 +204,7 @@ class Query
      * @since   2.5
      * @throws  \Exception on database error.
      */
-    public function __construct($options, DatabaseInterface $db = null)
+    public function __construct($options, ?DatabaseInterface $db = null)
     {
         if ($db === null) {
             @trigger_error(sprintf('Database will be mandatory in 5.0.'), E_USER_DEPRECATED);

--- a/administrator/components/com_finder/src/Model/FiltersModel.php
+++ b/administrator/components/com_finder/src/Model/FiltersModel.php
@@ -34,7 +34,7 @@ class FiltersModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.7
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_finder/src/Model/IndexModel.php
+++ b/administrator/components/com_finder/src/Model/IndexModel.php
@@ -61,7 +61,7 @@ class IndexModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.7
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_finder/src/Model/MapsModel.php
+++ b/administrator/components/com_finder/src/Model/MapsModel.php
@@ -38,7 +38,7 @@ class MapsModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.7
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_finder/src/Model/SearchesModel.php
+++ b/administrator/components/com_finder/src/Model/SearchesModel.php
@@ -34,7 +34,7 @@ class SearchesModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   4.0.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_installer/src/Controller/ManageController.php
+++ b/administrator/components/com_installer/src/Controller/ManageController.php
@@ -41,7 +41,7 @@ class ManageController extends BaseController
      *
      * @since  1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_installer/src/Controller/UpdatesitesController.php
+++ b/administrator/components/com_installer/src/Controller/UpdatesitesController.php
@@ -49,7 +49,7 @@ class UpdatesitesController extends AdminController
      *
      * @since  1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -69,7 +69,7 @@ class DatabaseModel extends InstallerModel
      * @see     ListModel
      * @since   4.0.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_installer/src/Model/DiscoverModel.php
+++ b/administrator/components/com_installer/src/Model/DiscoverModel.php
@@ -39,7 +39,7 @@ class DiscoverModel extends InstallerModel
      * @see     \Joomla\CMS\MVC\Model\ListModel
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_installer/src/Model/InstallerModel.php
+++ b/administrator/components/com_installer/src/Model/InstallerModel.php
@@ -37,7 +37,7 @@ class InstallerModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\ListModel
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_installer/src/Model/LanguagesModel.php
+++ b/administrator/components/com_installer/src/Model/LanguagesModel.php
@@ -44,7 +44,7 @@ class LanguagesModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\ListModel
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -43,7 +43,7 @@ class ManageModel extends InstallerModel
      * @see     \Joomla\CMS\MVC\Model\ListModel
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -46,7 +46,7 @@ class UpdateModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\ListModel
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_installer/src/Model/UpdatesitesModel.php
+++ b/administrator/components/com_installer/src/Model/UpdatesitesModel.php
@@ -42,7 +42,7 @@ class UpdatesitesModel extends InstallerModel
      * @since   1.6
      * @see     \Joomla\CMS\MVC\Model\ListModel
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -61,7 +61,7 @@ class UpdateModel extends BaseDatabaseModel
      * @since   4.4.0
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         parent::__construct($config, $factory);
 

--- a/administrator/components/com_languages/src/Model/InstalledModel.php
+++ b/administrator/components/com_languages/src/Model/InstalledModel.php
@@ -66,7 +66,7 @@ class InstalledModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_languages/src/Model/LanguageModel.php
+++ b/administrator/components/com_languages/src/Model/LanguageModel.php
@@ -41,7 +41,7 @@ class LanguageModel extends AdminModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         $config = array_merge(
             [

--- a/administrator/components/com_languages/src/Model/LanguagesModel.php
+++ b/administrator/components/com_languages/src/Model/LanguagesModel.php
@@ -37,7 +37,7 @@ class LanguagesModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_languages/src/Model/OverridesModel.php
+++ b/administrator/components/com_languages/src/Model/OverridesModel.php
@@ -37,7 +37,7 @@ class OverridesModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   2.5
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_mails/src/Controller/TemplateController.php
+++ b/administrator/components/com_mails/src/Controller/TemplateController.php
@@ -43,7 +43,7 @@ class TemplateController extends FormController
      * @since   4.0.0
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_media/src/Provider/ProviderManager.php
+++ b/administrator/components/com_media/src/Provider/ProviderManager.php
@@ -69,7 +69,7 @@ class ProviderManager
      *
      * @since   4.0.6
      */
-    public function unregisterProvider(ProviderInterface $provider = null): void
+    public function unregisterProvider(?ProviderInterface $provider = null): void
     {
         if ($provider === null) {
             $this->providers = [];

--- a/administrator/components/com_menus/src/Controller/ItemsController.php
+++ b/administrator/components/com_menus/src/Controller/ItemsController.php
@@ -41,7 +41,7 @@ class ItemsController extends AdminController
      *
      * @since  1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_menus/src/Model/ItemsModel.php
+++ b/administrator/components/com_menus/src/Model/ItemsModel.php
@@ -40,7 +40,7 @@ class ItemsModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_menus/src/Model/MenusModel.php
+++ b/administrator/components/com_menus/src/Model/MenusModel.php
@@ -37,7 +37,7 @@ class MenusModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_messages/src/Model/MessagesModel.php
+++ b/administrator/components/com_messages/src/Model/MessagesModel.php
@@ -35,7 +35,7 @@ class MessagesModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_newsfeeds/src/Extension/NewsfeedsComponent.php
+++ b/administrator/components/com_newsfeeds/src/Extension/NewsfeedsComponent.php
@@ -75,7 +75,7 @@ class NewsfeedsComponent extends MVCComponent implements
      *
      * @since   4.0.0
      */
-    protected function getTableNameForSection(string $section = null)
+    protected function getTableNameForSection(?string $section = null)
     {
         return $section === 'category' ? 'categories' : 'newsfeeds';
     }
@@ -89,7 +89,7 @@ class NewsfeedsComponent extends MVCComponent implements
      *
      * @since   4.0.0
      */
-    protected function getStateColumnForSection(string $section = null)
+    protected function getStateColumnForSection(?string $section = null)
     {
         return 'published';
     }

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedsModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedsModel.php
@@ -38,7 +38,7 @@ class NewsfeedsModel extends ListModel
      * @see    \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_plugins/src/Model/PluginModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginModel.php
@@ -60,7 +60,7 @@ class PluginModel extends AdminModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         $config = array_merge(
             [

--- a/administrator/components/com_plugins/src/Model/PluginsModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginsModel.php
@@ -39,7 +39,7 @@ class PluginsModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_redirect/src/Model/LinksModel.php
+++ b/administrator/components/com_redirect/src/Model/LinksModel.php
@@ -35,7 +35,7 @@ class LinksModel extends ListModel
      *
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -116,7 +116,7 @@ class TaskModel extends AdminModel
      * @since  4.1.0
      * @throws \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, FormFactoryInterface $formFactory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?FormFactoryInterface $formFactory = null)
     {
         $config['events_map'] = $config['events_map'] ?? [];
 

--- a/administrator/components/com_scheduler/src/Model/TasksModel.php
+++ b/administrator/components/com_scheduler/src/Model/TasksModel.php
@@ -46,7 +46,7 @@ class TasksModel extends ListModel
      * @throws  \Exception
      * @see     \JControllerLegacy
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_scheduler/src/Rule/ExecutionRulesRule.php
+++ b/administrator/components/com_scheduler/src/Rule/ExecutionRulesRule.php
@@ -54,7 +54,7 @@ class ExecutionRulesRule extends FormRule
      *
      * @since  4.1.0
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null): bool
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null): bool
     {
         $fieldName = (string) $element['name'];
         $ruleType  = $input->get(self::RULE_TYPE_FIELD);

--- a/administrator/components/com_scheduler/src/Task/Task.php
+++ b/administrator/components/com_scheduler/src/Task/Task.php
@@ -498,7 +498,7 @@ class Task implements LoggerAwareInterface
      *
      * @since 4.1.0
      */
-    protected function set(string $path, $value, string $separator = null)
+    protected function set(string $path, $value, ?string $separator = null)
     {
         return $this->taskRegistry->set($path, $value, $separator);
     }

--- a/administrator/components/com_tags/src/Model/TagsModel.php
+++ b/administrator/components/com_tags/src/Model/TagsModel.php
@@ -38,7 +38,7 @@ class TagsModel extends ListModel
      *
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_templates/src/Controller/TemplateController.php
+++ b/administrator/components/com_templates/src/Controller/TemplateController.php
@@ -44,7 +44,7 @@ class TemplateController extends BaseController
      * @since  1.6
      * @see    BaseController
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -71,7 +71,7 @@ class StyleModel extends AdminModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         $config = array_merge(
             [

--- a/administrator/components/com_templates/src/Model/StylesModel.php
+++ b/administrator/components/com_templates/src/Model/StylesModel.php
@@ -37,7 +37,7 @@ class StylesModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_templates/src/Model/TemplatesModel.php
+++ b/administrator/components/com_templates/src/Model/TemplatesModel.php
@@ -38,7 +38,7 @@ class TemplatesModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_users/src/Controller/CallbackController.php
+++ b/administrator/components/com_users/src/Controller/CallbackController.php
@@ -39,7 +39,7 @@ class CallbackController extends BaseController
      *
      * @since 4.2.0
      */
-    public function __construct(array $config = [], MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
+    public function __construct(array $config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_users/src/Controller/CaptiveController.php
+++ b/administrator/components/com_users/src/Controller/CaptiveController.php
@@ -48,7 +48,7 @@ class CaptiveController extends BaseController implements UserFactoryAwareInterf
      *
      * @since 4.2.0
      */
-    public function __construct(array $config = [], MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
+    public function __construct(array $config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_users/src/Controller/MethodController.php
+++ b/administrator/components/com_users/src/Controller/MethodController.php
@@ -51,7 +51,7 @@ class MethodController extends BaseControllerAlias implements UserFactoryAwareIn
      *
      * @since 4.2.0
      */
-    public function __construct(array $config = [], MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
+    public function __construct(array $config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
     {
         // We have to tell Joomla what is the name of the view, otherwise it defaults to the name of the *component*.
         $config['default_view'] = 'method';

--- a/administrator/components/com_users/src/Controller/MethodsController.php
+++ b/administrator/components/com_users/src/Controller/MethodsController.php
@@ -46,7 +46,7 @@ class MethodsController extends BaseController implements UserFactoryAwareInterf
      *
      * @since 4.2.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
     {
         // We have to tell Joomla what is the name of the view, otherwise it defaults to the name of the *component*.
         $config['default_view'] = 'Methods';

--- a/administrator/components/com_users/src/Controller/UsersController.php
+++ b/administrator/components/com_users/src/Controller/UsersController.php
@@ -48,7 +48,7 @@ class UsersController extends AdminController
      * @see    BaseController
      * @throws \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_users/src/Model/BackupcodesModel.php
+++ b/administrator/components/com_users/src/Model/BackupcodesModel.php
@@ -45,7 +45,7 @@ class BackupcodesModel extends BaseDatabaseModel
      * @throws  \Exception
      * @since 4.2.0
      */
-    public function getBackupCodesRecord(User $user = null): ?MfaTable
+    public function getBackupCodesRecord(?User $user = null): ?MfaTable
     {
         // Make sure I have a user
         if (empty($user)) {
@@ -78,7 +78,7 @@ class BackupcodesModel extends BaseDatabaseModel
      * @throws \Exception
      * @since 4.2.0
      */
-    public function regenerateBackupCodes(User $user = null): void
+    public function regenerateBackupCodes(?User $user = null): void
     {
         // Make sure I have a user
         if (empty($user)) {
@@ -167,7 +167,7 @@ class BackupcodesModel extends BaseDatabaseModel
      * @throws  \Exception
      * @since 4.2.0
      */
-    public function getBackupCodes(User $user = null): ?array
+    public function getBackupCodes(?User $user = null): ?array
     {
         // Make sure I have a user
         if (empty($user)) {

--- a/administrator/components/com_users/src/Model/CaptiveModel.php
+++ b/administrator/components/com_users/src/Model/CaptiveModel.php
@@ -60,7 +60,7 @@ class CaptiveModel extends BaseDatabaseModel
      *
      * @since 4.2.0
      */
-    public function suppressAllModules(CMSApplication $app = null): void
+    public function suppressAllModules(?CMSApplication $app = null): void
     {
         if (is_null($app)) {
             $app = Factory::getApplication();
@@ -80,7 +80,7 @@ class CaptiveModel extends BaseDatabaseModel
      *
      * @since 4.2.0
      */
-    public function getRecords(User $user = null, bool $includeBackupCodes = false): array
+    public function getRecords(?User $user = null, bool $includeBackupCodes = false): array
     {
         if (is_null($user)) {
             $user = $this->getCurrentUser();

--- a/administrator/components/com_users/src/Model/DebuggroupModel.php
+++ b/administrator/components/com_users/src/Model/DebuggroupModel.php
@@ -40,7 +40,7 @@ class DebuggroupModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_users/src/Model/DebuguserModel.php
+++ b/administrator/components/com_users/src/Model/DebuguserModel.php
@@ -39,7 +39,7 @@ class DebuguserModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_users/src/Model/GroupModel.php
+++ b/administrator/components/com_users/src/Model/GroupModel.php
@@ -42,7 +42,7 @@ class GroupModel extends AdminModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         $config = array_merge(
             [

--- a/administrator/components/com_users/src/Model/GroupsModel.php
+++ b/administrator/components/com_users/src/Model/GroupsModel.php
@@ -37,7 +37,7 @@ class GroupsModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_users/src/Model/LevelsModel.php
+++ b/administrator/components/com_users/src/Model/LevelsModel.php
@@ -39,7 +39,7 @@ class LevelsModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_users/src/Model/MethodModel.php
+++ b/administrator/components/com_users/src/Model/MethodModel.php
@@ -126,7 +126,7 @@ class MethodModel extends BaseDatabaseModel
      *
      * @since 4.2.0
      */
-    public function getRecord(User $user = null): MfaTable
+    public function getRecord(?User $user = null): MfaTable
     {
         if (is_null($user)) {
             $user = $this->getCurrentUser();

--- a/administrator/components/com_users/src/Model/NotesModel.php
+++ b/administrator/components/com_users/src/Model/NotesModel.php
@@ -37,7 +37,7 @@ class NotesModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         // Set the list ordering fields.
         if (empty($config['filter_fields'])) {

--- a/administrator/components/com_users/src/Model/UserModel.php
+++ b/administrator/components/com_users/src/Model/UserModel.php
@@ -52,7 +52,7 @@ class UserModel extends AdminModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         $config = array_merge(
             [

--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -49,7 +49,7 @@ class UsersModel extends ListModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/administrator/components/com_users/src/Table/MfaTable.php
+++ b/administrator/components/com_users/src/Table/MfaTable.php
@@ -84,7 +84,7 @@ class MfaTable extends Table implements CurrentUserInterface, UserFactoryAwareIn
      *
      * @since 4.2.0
      */
-    public function __construct(DatabaseDriver $db, DispatcherInterface $dispatcher = null)
+    public function __construct(DatabaseDriver $db, ?DispatcherInterface $dispatcher = null)
     {
         parent::__construct('#__user_mfa', 'id', $db, $dispatcher);
 

--- a/administrator/components/com_workflow/src/Controller/DisplayController.php
+++ b/administrator/components/com_workflow/src/Controller/DisplayController.php
@@ -64,7 +64,7 @@ class DisplayController extends BaseController
      * @since   4.0.0
      * @throws  \InvalidArgumentException when no extension is set
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_workflow/src/Controller/StageController.php
+++ b/administrator/components/com_workflow/src/Controller/StageController.php
@@ -62,7 +62,7 @@ class StageController extends FormController
      * @since   4.0.0
      * @throws  \InvalidArgumentException when no extension or workflow id is set
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_workflow/src/Controller/StagesController.php
+++ b/administrator/components/com_workflow/src/Controller/StagesController.php
@@ -72,7 +72,7 @@ class StagesController extends AdminController
      * @since   4.0.0
      * @throws  \InvalidArgumentException when no extension or workflow id is set
      */
-    public function __construct(array $config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct(array $config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_workflow/src/Controller/TransitionController.php
+++ b/administrator/components/com_workflow/src/Controller/TransitionController.php
@@ -62,7 +62,7 @@ class TransitionController extends FormController
      * @since   4.0.0
      * @throws  \InvalidArgumentException when no extension or workflow id is set
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_workflow/src/Controller/TransitionsController.php
+++ b/administrator/components/com_workflow/src/Controller/TransitionsController.php
@@ -70,7 +70,7 @@ class TransitionsController extends AdminController
      * @since   4.0.0
      * @throws  \InvalidArgumentException when no extension or workflow id is set
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_workflow/src/Controller/WorkflowController.php
+++ b/administrator/components/com_workflow/src/Controller/WorkflowController.php
@@ -56,7 +56,7 @@ class WorkflowController extends FormController
      * @since   4.0.0
      * @throws  \InvalidArgumentException when no extension is set
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_workflow/src/Controller/WorkflowsController.php
+++ b/administrator/components/com_workflow/src/Controller/WorkflowsController.php
@@ -56,7 +56,7 @@ class WorkflowsController extends AdminController
      * @since   4.0.0
      * @throws  \InvalidArgumentException when no extension is set
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/administrator/components/com_workflow/src/Table/StageTable.php
+++ b/administrator/components/com_workflow/src/Table/StageTable.php
@@ -254,7 +254,7 @@ class StageTable extends Table
      *
      * @since  4.0.0
      */
-    protected function _getAssetParentId(Table $table = null, $id = null)
+    protected function _getAssetParentId(?Table $table = null, $id = null)
     {
         $asset = self::getInstance('Asset', 'JTable', ['dbo' => $this->getDbo()]);
 

--- a/administrator/components/com_workflow/src/Table/TransitionTable.php
+++ b/administrator/components/com_workflow/src/Table/TransitionTable.php
@@ -123,7 +123,7 @@ class TransitionTable extends Table
      *
      * @since  4.0.0
      */
-    protected function _getAssetParentId(Table $table = null, $id = null)
+    protected function _getAssetParentId(?Table $table = null, $id = null)
     {
         $asset = self::getInstance('Asset', 'JTable', ['dbo' => $this->getDbo()]);
 

--- a/administrator/components/com_workflow/src/Table/WorkflowTable.php
+++ b/administrator/components/com_workflow/src/Table/WorkflowTable.php
@@ -285,7 +285,7 @@ class WorkflowTable extends Table
      *
      * @since  4.0.0
      */
-    protected function _getAssetParentId(Table $table = null, $id = null)
+    protected function _getAssetParentId(?Table $table = null, $id = null)
     {
         $assetId = null;
 

--- a/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
@@ -50,7 +50,7 @@ class QuickIconHelper
      *
      * @since   1.6
      */
-    public function getButtons(Registry $params, CMSApplication $application = null)
+    public function getButtons(Registry $params, ?CMSApplication $application = null)
     {
         if ($application == null) {
             $application = Factory::getApplication();

--- a/api/components/com_categories/src/View/Categories/JsonapiView.php
+++ b/api/components/com_categories/src/View/Categories/JsonapiView.php
@@ -103,7 +103,7 @@ class JsonapiView extends BaseApiView
      *
      * @since   4.0.0
      */
-    public function displayList(array $items = null)
+    public function displayList(?array $items = null)
     {
         foreach (FieldsHelper::getFields('com_content.categories') as $field) {
             $this->fieldsToRenderList[] = $field->name;

--- a/api/components/com_config/src/View/Application/JsonapiView.php
+++ b/api/components/com_config/src/View/Application/JsonapiView.php
@@ -37,7 +37,7 @@ class JsonapiView extends BaseApiView
      *
      * @since   4.0.0
      */
-    public function displayList(array $items = null)
+    public function displayList(?array $items = null)
     {
         /** @var ApplicationModel $model */
         $model = $this->getModel();

--- a/api/components/com_config/src/View/Component/JsonapiView.php
+++ b/api/components/com_config/src/View/Component/JsonapiView.php
@@ -38,7 +38,7 @@ class JsonapiView extends BaseApiView
      *
      * @since   4.0.0
      */
-    public function displayList(array $items = null)
+    public function displayList(?array $items = null)
     {
         try {
             $component = ComponentHelper::getComponent($this->get('component_name'));

--- a/api/components/com_contact/src/View/Contacts/JsonapiView.php
+++ b/api/components/com_contact/src/View/Contacts/JsonapiView.php
@@ -134,7 +134,7 @@ class JsonapiView extends BaseApiView
      *
      * @since   4.0.0
      */
-    public function displayList(array $items = null)
+    public function displayList(?array $items = null)
     {
         foreach (FieldsHelper::getFields('com_contact.contact') as $field) {
             $this->fieldsToRenderList[] = $field->name;

--- a/api/components/com_content/src/View/Articles/JsonapiView.php
+++ b/api/components/com_content/src/View/Articles/JsonapiView.php
@@ -144,7 +144,7 @@ class JsonapiView extends BaseApiView
      *
      * @since   4.0.0
      */
-    public function displayList(array $items = null)
+    public function displayList(?array $items = null)
     {
         foreach (FieldsHelper::getFields('com_content.article') as $field) {
             $this->fieldsToRenderList[] = $field->name;

--- a/api/components/com_languages/src/View/Overrides/JsonapiView.php
+++ b/api/components/com_languages/src/View/Overrides/JsonapiView.php
@@ -66,7 +66,7 @@ class JsonapiView extends BaseApiView
      *
      * @since   4.0.0
      */
-    public function displayList(array $items = null)
+    public function displayList(?array $items = null)
     {
         /** @var \Joomla\Component\Languages\Administrator\Model\OverridesModel $model */
         $model = $this->getModel();

--- a/api/components/com_languages/src/View/Strings/JsonapiView.php
+++ b/api/components/com_languages/src/View/Strings/JsonapiView.php
@@ -48,7 +48,7 @@ class JsonapiView extends BaseApiView
      *
      * @since   4.0.0
      */
-    public function displayList(array $items = null)
+    public function displayList(?array $items = null)
     {
         /** @var \Joomla\Component\Languages\Administrator\Model\StringsModel $model */
         $model  = $this->getModel();

--- a/api/components/com_users/src/View/Users/JsonapiView.php
+++ b/api/components/com_users/src/View/Users/JsonapiView.php
@@ -75,7 +75,7 @@ class JsonapiView extends BaseApiView
      *
      * @since   4.0.0
      */
-    public function displayList(array $items = null)
+    public function displayList(?array $items = null)
     {
         foreach (FieldsHelper::getFields('com_users.user') as $field) {
             $this->fieldsToRenderList[] = $field->name;

--- a/components/com_config/src/Controller/ConfigController.php
+++ b/components/com_config/src/Controller/ConfigController.php
@@ -39,7 +39,7 @@ class ConfigController extends BaseController
      *
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/components/com_config/src/Controller/ModulesController.php
+++ b/components/com_config/src/Controller/ModulesController.php
@@ -43,7 +43,7 @@ class ModulesController extends BaseController
      *
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/components/com_config/src/Controller/TemplatesController.php
+++ b/components/com_config/src/Controller/TemplatesController.php
@@ -39,7 +39,7 @@ class TemplatesController extends BaseController
      *
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/components/com_contact/src/Controller/DisplayController.php
+++ b/components/com_contact/src/Controller/DisplayController.php
@@ -36,7 +36,7 @@ class DisplayController extends BaseController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         // Contact frontpage Editor contacts proxying.
         $input = Factory::getApplication()->getInput();

--- a/components/com_contact/src/Rule/ContactEmailMessageRule.php
+++ b/components/com_contact/src/Rule/ContactEmailMessageRule.php
@@ -40,7 +40,7 @@ class ContactEmailMessageRule extends FormRule
      *
      * @return  boolean  True if the value is valid, false otherwise.
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $params = ComponentHelper::getParams('com_contact');
         $banned = $params->get('banned_text');

--- a/components/com_contact/src/Rule/ContactEmailRule.php
+++ b/components/com_contact/src/Rule/ContactEmailRule.php
@@ -40,7 +40,7 @@ class ContactEmailRule extends EmailRule
      *
      * @return  boolean  True if the value is valid, false otherwise.
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         if (!parent::test($element, $value, $group, $input, $form)) {
             return false;

--- a/components/com_contact/src/Rule/ContactEmailSubjectRule.php
+++ b/components/com_contact/src/Rule/ContactEmailSubjectRule.php
@@ -40,7 +40,7 @@ class ContactEmailSubjectRule extends FormRule
      *
      * @return  boolean  True if the value is valid, false otherwise
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $params = ComponentHelper::getParams('com_contact');
         $banned = $params->get('banned_subject');

--- a/components/com_content/src/Controller/DisplayController.php
+++ b/components/com_content/src/Controller/DisplayController.php
@@ -37,7 +37,7 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
      *
      * @since   3.0.1
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         $this->input = Factory::getApplication()->getInput();
 

--- a/components/com_content/src/Helper/QueryHelper.php
+++ b/components/com_content/src/Helper/QueryHelper.php
@@ -69,7 +69,7 @@ class QueryHelper
      *
      * @since   1.5
      */
-    public static function orderbySecondary($orderby, $orderDate = 'created', DatabaseInterface $db = null)
+    public static function orderbySecondary($orderby, $orderDate = 'created', ?DatabaseInterface $db = null)
     {
         $db = $db ?: Factory::getDbo();
 
@@ -170,7 +170,7 @@ class QueryHelper
      *
      * @since   1.6
      */
-    public static function getQueryDate($orderDate, DatabaseInterface $db = null)
+    public static function getQueryDate($orderDate, ?DatabaseInterface $db = null)
     {
         $db = $db ?: Factory::getDbo();
 

--- a/components/com_contenthistory/src/Controller/DisplayController.php
+++ b/components/com_contenthistory/src/Controller/DisplayController.php
@@ -34,7 +34,7 @@ class DisplayController extends BaseController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         $config['base_path'] = JPATH_COMPONENT_ADMINISTRATOR;
 

--- a/components/com_fields/src/Controller/DisplayController.php
+++ b/components/com_fields/src/Controller/DisplayController.php
@@ -34,7 +34,7 @@ class DisplayController extends \Joomla\CMS\MVC\Controller\BaseController
      *
      * @since   3.7.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         // Frontpage Editor Fields Button proxying.
         if ($input->get('view') === 'fields' && $input->get('layout') === 'modal') {

--- a/components/com_modules/src/Controller/DisplayController.php
+++ b/components/com_modules/src/Controller/DisplayController.php
@@ -37,7 +37,7 @@ class DisplayController extends BaseController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         $this->input = Factory::getApplication()->getInput();
 

--- a/components/com_newsfeeds/src/Model/CategoryModel.php
+++ b/components/com_newsfeeds/src/Model/CategoryModel.php
@@ -90,7 +90,7 @@ class CategoryModel extends ListModel
      * @see    \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/components/com_tags/src/Model/TagModel.php
+++ b/components/com_tags/src/Model/TagModel.php
@@ -56,7 +56,7 @@ class TagModel extends ListModel
      *
      * @since   1.6
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         if (empty($config['filter_fields'])) {
             $config['filter_fields'] = [

--- a/components/com_users/src/Model/ProfileModel.php
+++ b/components/com_users/src/Model/ProfileModel.php
@@ -52,7 +52,7 @@ class ProfileModel extends FormModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, FormFactoryInterface $formFactory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?FormFactoryInterface $formFactory = null)
     {
         $config = array_merge(
             [

--- a/components/com_users/src/Model/RegistrationModel.php
+++ b/components/com_users/src/Model/RegistrationModel.php
@@ -57,7 +57,7 @@ class RegistrationModel extends FormModel
      * @see     \Joomla\CMS\MVC\Model\BaseDatabaseModel
      * @since   3.2
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, FormFactoryInterface $formFactory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?FormFactoryInterface $formFactory = null)
     {
         $config = array_merge(
             [

--- a/components/com_users/src/Rule/LoginUniqueFieldRule.php
+++ b/components/com_users/src/Rule/LoginUniqueFieldRule.php
@@ -43,7 +43,7 @@ class LoginUniqueFieldRule extends FormRule
      *
      * @since   3.6
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $loginRedirectUrl       = $input['params']->login_redirect_url;
         $loginRedirectMenuitem  = $input['params']->login_redirect_menuitem;

--- a/components/com_users/src/Rule/LogoutUniqueFieldRule.php
+++ b/components/com_users/src/Rule/LogoutUniqueFieldRule.php
@@ -43,7 +43,7 @@ class LogoutUniqueFieldRule extends FormRule
      *
      * @since   3.6
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $logoutRedirectUrl      = $input['params']->logout_redirect_url;
         $logoutRedirectMenuitem = $input['params']->logout_redirect_menuitem;

--- a/installation/src/Application/CliInstallationApplication.php
+++ b/installation/src/Application/CliInstallationApplication.php
@@ -211,7 +211,7 @@ final class CliInstallationApplication extends Application implements CMSApplica
      *
      * @since   4.3.0
      */
-    public function getLocaliseAdmin(DatabaseInterface $db = null)
+    public function getLocaliseAdmin(?DatabaseInterface $db = null)
     {
         $langfiles = [];
 

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -59,7 +59,7 @@ final class InstallationApplication extends CMSApplication
      *
      * @since   3.1
      */
-    public function __construct(Input $input = null, Registry $config = null, WebClient $client = null, Container $container = null)
+    public function __construct(?Input $input = null, ?Registry $config = null, ?WebClient $client = null, ?Container $container = null)
     {
         // Register the application name.
         $this->name = 'installation';
@@ -346,7 +346,7 @@ final class InstallationApplication extends CMSApplication
      *
      * @since   3.1
      */
-    public function getLocaliseAdmin(DatabaseInterface $db = null)
+    public function getLocaliseAdmin(?DatabaseInterface $db = null)
     {
         $langfiles = [];
 
@@ -477,7 +477,7 @@ final class InstallationApplication extends CMSApplication
      *
      * @since   3.2
      */
-    public function loadDocument(Document $document = null)
+    public function loadDocument(?Document $document = null)
     {
         if ($document === null) {
             $lang = $this->getLanguage();

--- a/installation/src/Controller/InstallationController.php
+++ b/installation/src/Controller/InstallationController.php
@@ -37,7 +37,7 @@ class InstallationController extends JSONController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, $app = null, $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, $app = null, $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/installation/src/Form/Rule/UsernameRule.php
+++ b/installation/src/Form/Rule/UsernameRule.php
@@ -38,7 +38,7 @@ class UsernameRule extends FormRule
      *
      * @return  boolean  True if the value is valid, false otherwise.
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $filterInput = InputFilter::getInstance();
 

--- a/installation/src/Model/BaseInstallationModel.php
+++ b/installation/src/Model/BaseInstallationModel.php
@@ -33,7 +33,7 @@ class BaseInstallationModel extends BaseDatabaseModel
      * @since   3.0
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         // @TODO remove me when the base model is db free
         $config['dbo'] = null;

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -68,7 +68,7 @@ class AdministratorApplication extends CMSApplication
      *
      * @since   3.2
      */
-    public function __construct(Input $input = null, Registry $config = null, WebClient $client = null, Container $container = null)
+    public function __construct(?Input $input = null, ?Registry $config = null, ?WebClient $client = null, ?Container $container = null)
     {
         // Register the application name
         $this->name = 'administrator';

--- a/libraries/src/Application/ApiApplication.php
+++ b/libraries/src/Application/ApiApplication.php
@@ -67,7 +67,7 @@ final class ApiApplication extends CMSApplication
      *
      * @since   4.0.0
      */
-    public function __construct(JInputJson $input = null, Registry $config = null, WebClient $client = null, Container $container = null)
+    public function __construct(?JInputJson $input = null, ?Registry $config = null, ?WebClient $client = null, ?Container $container = null)
     {
         // Register the application name
         $this->name = 'api';

--- a/libraries/src/Application/BaseApplication.php
+++ b/libraries/src/Application/BaseApplication.php
@@ -48,7 +48,7 @@ abstract class BaseApplication extends AbstractApplication implements Dispatcher
      *
      * @since   3.0.0
      */
-    public function __construct(Input $input = null, Registry $config = null)
+    public function __construct(?Input $input = null, ?Registry $config = null)
     {
         $this->input  = $input instanceof Input ? $input : new Input();
         $this->config = $config instanceof Registry ? $config : new Registry();

--- a/libraries/src/Application/CLI/CliOutput.php
+++ b/libraries/src/Application/CLI/CliOutput.php
@@ -40,7 +40,7 @@ abstract class CliOutput
      *
      * @since   4.0.0
      */
-    public function __construct(ProcessorInterface $processor = null)
+    public function __construct(?ProcessorInterface $processor = null)
     {
         $this->setProcessor($processor ?: new Output\Processor\ColorProcessor());
     }

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -167,7 +167,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      *
      * @since   3.2
      */
-    public function __construct(Input $input = null, Registry $config = null, WebClient $client = null, Container $container = null)
+    public function __construct(?Input $input = null, ?Registry $config = null, ?WebClient $client = null, ?Container $container = null)
     {
         $container = $container ?: new Container();
         $this->setContainer($container);
@@ -465,7 +465,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      *              Use the application service from the DI container instead
      *              Example: Factory::getContainer()->get($name);
      */
-    public static function getInstance($name = null, $prefix = '\JApplication', Container $container = null)
+    public static function getInstance($name = null, $prefix = '\JApplication', ?Container $container = null)
     {
         if (empty(static::$instances[$name])) {
             // Create a CmsApplication object.

--- a/libraries/src/Application/CMSApplicationInterface.php
+++ b/libraries/src/Application/CMSApplicationInterface.php
@@ -183,5 +183,5 @@ interface CMSApplicationInterface extends ExtensionManagerInterface, Configurati
      *
      * @since   4.0.0
      */
-    public function loadIdentity(User $identity = null);
+    public function loadIdentity(?User $identity = null);
 }

--- a/libraries/src/Application/CliApplication.php
+++ b/libraries/src/Application/CliApplication.php
@@ -114,12 +114,12 @@ abstract class CliApplication extends AbstractApplication implements DispatcherA
      * @since   1.7.0
      */
     public function __construct(
-        Input $input = null,
-        Registry $config = null,
-        CliOutput $output = null,
-        CliInput $cliInput = null,
-        DispatcherInterface $dispatcher = null,
-        Container $container = null
+        ?Input $input = null,
+        ?Registry $config = null,
+        ?CliOutput $output = null,
+        ?CliInput $cliInput = null,
+        ?DispatcherInterface $dispatcher = null,
+        ?Container $container = null
     ) {
         // Close the application if we are not executed from the command line.
         if (!\defined('STDOUT') || !\defined('STDIN') || !isset($_SERVER['argv'])) {

--- a/libraries/src/Application/DaemonApplication.php
+++ b/libraries/src/Application/DaemonApplication.php
@@ -112,7 +112,7 @@ abstract class DaemonApplication extends CliApplication
      *
      * @since   1.7.0
      */
-    public function __construct(Cli $input = null, Registry $config = null, DispatcherInterface $dispatcher = null)
+    public function __construct(?Cli $input = null, ?Registry $config = null, ?DispatcherInterface $dispatcher = null)
     {
         // Verify that the process control extension for PHP is available.
         if (!\defined('SIGHUP')) {

--- a/libraries/src/Application/IdentityAware.php
+++ b/libraries/src/Application/IdentityAware.php
@@ -54,7 +54,7 @@ trait IdentityAware
      *
      * @since   4.0.0
      */
-    public function loadIdentity(User $identity = null)
+    public function loadIdentity(?User $identity = null)
     {
         $this->identity = $identity ?: $this->getUserFactory()->loadUserById(0);
 

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -81,7 +81,7 @@ final class SiteApplication extends CMSApplication
      *
      * @since   3.2
      */
-    public function __construct(Input $input = null, Registry $config = null, WebClient $client = null, Container $container = null)
+    public function __construct(?Input $input = null, ?Registry $config = null, ?WebClient $client = null, ?Container $container = null)
     {
         // Register the application name
         $this->name = 'site';

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -98,7 +98,7 @@ abstract class WebApplication extends AbstractWebApplication
      *
      * @since   1.7.3
      */
-    public function __construct(Input $input = null, Registry $config = null, WebClient $client = null, ResponseInterface $response = null)
+    public function __construct(?Input $input = null, ?Registry $config = null, ?WebClient $client = null, ?ResponseInterface $response = null)
     {
         // Ensure we have a CMS Input object otherwise the DI for \Joomla\CMS\Session\Storage\JoomlaStorage fails
         $input = $input ?: new Input();
@@ -273,7 +273,7 @@ abstract class WebApplication extends AbstractWebApplication
      *
      * @since   1.7.3
      */
-    public function loadDocument(Document $document = null)
+    public function loadDocument(?Document $document = null)
     {
         $this->document = $document ?? Factory::getDocument();
 
@@ -293,7 +293,7 @@ abstract class WebApplication extends AbstractWebApplication
      *
      * @since   1.7.3
      */
-    public function loadLanguage(Language $language = null)
+    public function loadLanguage(?Language $language = null)
     {
         $this->language = $language ?? Factory::getLanguage();
 
@@ -316,7 +316,7 @@ abstract class WebApplication extends AbstractWebApplication
      * @deprecated  4.3 will be removed in 6.0
      *              The session should be injected as a service.
      */
-    public function loadSession(Session $session = null)
+    public function loadSession(?Session $session = null)
     {
         $this->getLogger()->warning(__METHOD__ . '() is deprecated.  Inject the session as a service instead.', ['category' => 'deprecated']);
 

--- a/libraries/src/Authentication/Authentication.php
+++ b/libraries/src/Authentication/Authentication.php
@@ -99,7 +99,7 @@ class Authentication
      *
      * @since   1.7.0
      */
-    public function __construct(string $pluginType = 'authentication', DispatcherInterface $dispatcher = null)
+    public function __construct(string $pluginType = 'authentication', ?DispatcherInterface $dispatcher = null)
     {
         // Set the dispatcher
         if (!\is_object($dispatcher)) {

--- a/libraries/src/Cache/CacheControllerFactoryAwareTrait.php
+++ b/libraries/src/Cache/CacheControllerFactoryAwareTrait.php
@@ -61,7 +61,7 @@ trait CacheControllerFactoryAwareTrait
      *
      * @since   4.2.0
      */
-    public function setCacheControllerFactory(CacheControllerFactoryInterface $cacheControllerFactory = null): void
+    public function setCacheControllerFactory(?CacheControllerFactoryInterface $cacheControllerFactory = null): void
     {
         $this->cacheControllerFactory = $cacheControllerFactory;
     }

--- a/libraries/src/Captcha/Google/HttpBridgePostRequestMethod.php
+++ b/libraries/src/Captcha/Google/HttpBridgePostRequestMethod.php
@@ -49,7 +49,7 @@ final class HttpBridgePostRequestMethod implements RequestMethod
      *
      * @since   3.9.0
      */
-    public function __construct(Http $http = null)
+    public function __construct(?Http $http = null)
     {
         $this->http = $http ?: HttpFactory::getHttp();
     }

--- a/libraries/src/Categories/CategoryServiceTrait.php
+++ b/libraries/src/Categories/CategoryServiceTrait.php
@@ -106,7 +106,7 @@ trait CategoryServiceTrait
      *
      * @since   4.0.0
      */
-    protected function getTableNameForSection(string $section = null)
+    protected function getTableNameForSection(?string $section = null)
     {
         return null;
     }
@@ -120,7 +120,7 @@ trait CategoryServiceTrait
      *
      * @since   4.0.0
      */
-    protected function getStateColumnForSection(string $section = null)
+    protected function getStateColumnForSection(?string $section = null)
     {
         return 'state';
     }

--- a/libraries/src/Component/Exception/MissingComponentException.php
+++ b/libraries/src/Component/Exception/MissingComponentException.php
@@ -31,7 +31,7 @@ class MissingComponentException extends RouteNotFoundException
      *
      * @since   3.7.0
      */
-    public function __construct($message = '', $code = 404, \Exception $previous = null)
+    public function __construct($message = '', $code = 404, ?\Exception $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/libraries/src/Component/Router/RouterFactory.php
+++ b/libraries/src/Component/Router/RouterFactory.php
@@ -61,7 +61,7 @@ class RouterFactory implements RouterFactoryInterface
      *
      * @since   4.0.0
      */
-    public function __construct($namespace, CategoryFactoryInterface $categoryFactory = null, DatabaseInterface $db = null)
+    public function __construct($namespace, ?CategoryFactoryInterface $categoryFactory = null, ?DatabaseInterface $db = null)
     {
         $this->namespace       = $namespace;
         $this->categoryFactory = $categoryFactory;

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -434,7 +434,7 @@ class Date extends \DateTime
      * @link    http://dev.mysql.com/doc/refman/5.0/en/datetime.html
      * @since   2.5.0
      */
-    public function toSql($local = false, DatabaseDriver $db = null)
+    public function toSql($local = false, ?DatabaseDriver $db = null)
     {
         if ($db === null) {
             $db = Factory::getDbo();

--- a/libraries/src/Dispatcher/ComponentDispatcherFactory.php
+++ b/libraries/src/Dispatcher/ComponentDispatcherFactory.php
@@ -66,7 +66,7 @@ class ComponentDispatcherFactory implements ComponentDispatcherFactoryInterface
      *
      * @since   4.0.0
      */
-    public function createDispatcher(CMSApplicationInterface $application, Input $input = null): DispatcherInterface
+    public function createDispatcher(CMSApplicationInterface $application, ?Input $input = null): DispatcherInterface
     {
         $name = ucfirst($application->getName());
 

--- a/libraries/src/Dispatcher/ComponentDispatcherFactoryInterface.php
+++ b/libraries/src/Dispatcher/ComponentDispatcherFactoryInterface.php
@@ -33,5 +33,5 @@ interface ComponentDispatcherFactoryInterface
      *
      * @since   4.0.0
      */
-    public function createDispatcher(CMSApplicationInterface $application, Input $input = null): DispatcherInterface;
+    public function createDispatcher(CMSApplicationInterface $application, ?Input $input = null): DispatcherInterface;
 }

--- a/libraries/src/Dispatcher/ModuleDispatcherFactory.php
+++ b/libraries/src/Dispatcher/ModuleDispatcherFactory.php
@@ -55,7 +55,7 @@ class ModuleDispatcherFactory implements ModuleDispatcherFactoryInterface
      *
      * @since   4.0.0
      */
-    public function createDispatcher(\stdClass $module, CMSApplicationInterface $application, Input $input = null): DispatcherInterface
+    public function createDispatcher(\stdClass $module, CMSApplicationInterface $application, ?Input $input = null): DispatcherInterface
     {
         $name = 'Site';
 

--- a/libraries/src/Dispatcher/ModuleDispatcherFactoryInterface.php
+++ b/libraries/src/Dispatcher/ModuleDispatcherFactoryInterface.php
@@ -34,5 +34,5 @@ interface ModuleDispatcherFactoryInterface
      *
      * @since   4.0.0
      */
-    public function createDispatcher(\stdClass $module, CMSApplicationInterface $application, Input $input = null): DispatcherInterface;
+    public function createDispatcher(\stdClass $module, CMSApplicationInterface $application, ?Input $input = null): DispatcherInterface;
 }

--- a/libraries/src/Document/PreloadManager.php
+++ b/libraries/src/Document/PreloadManager.php
@@ -39,7 +39,7 @@ class PreloadManager implements PreloadManagerInterface
      *
      * @since   4.0.0
      */
-    public function __construct(EvolvableLinkProviderInterface $linkProvider = null)
+    public function __construct(?EvolvableLinkProviderInterface $linkProvider = null)
     {
         $this->linkProvider = $linkProvider ?: new GenericLinkProvider();
     }

--- a/libraries/src/Editor/Editor.php
+++ b/libraries/src/Editor/Editor.php
@@ -78,7 +78,7 @@ class Editor implements DispatcherAwareInterface
      * @param   string               $editor      The editor name
      * @param   DispatcherInterface  $dispatcher  The event dispatcher we're going to use
      */
-    public function __construct($editor = 'none', DispatcherInterface $dispatcher = null)
+    public function __construct($editor = 'none', ?DispatcherInterface $dispatcher = null)
     {
         $this->_name = $editor;
 

--- a/libraries/src/Extension/Module.php
+++ b/libraries/src/Extension/Module.php
@@ -70,7 +70,7 @@ class Module implements ModuleInterface, HelperFactoryInterface
      *
      * @since   4.0.0
      */
-    public function getDispatcher(\stdClass $module, CMSApplicationInterface $application, Input $input = null): DispatcherInterface
+    public function getDispatcher(\stdClass $module, CMSApplicationInterface $application, ?Input $input = null): DispatcherInterface
     {
         $dispatcher = $this->dispatcherFactory->createDispatcher($module, $application, $input);
 

--- a/libraries/src/Extension/ModuleInterface.php
+++ b/libraries/src/Extension/ModuleInterface.php
@@ -35,5 +35,5 @@ interface ModuleInterface
      *
      * @since   4.0.0
      */
-    public function getDispatcher(\stdClass $module, CMSApplicationInterface $application, Input $input = null): DispatcherInterface;
+    public function getDispatcher(\stdClass $module, CMSApplicationInterface $application, ?Input $input = null): DispatcherInterface;
 }

--- a/libraries/src/Feed/FeedParser.php
+++ b/libraries/src/Feed/FeedParser.php
@@ -63,7 +63,7 @@ abstract class FeedParser
      *
      * @since   3.1.4
      */
-    public function __construct(\XMLReader $stream, InputFilter $inputFilter = null)
+    public function __construct(\XMLReader $stream, ?InputFilter $inputFilter = null)
     {
         $this->stream      = $stream;
         $this->inputFilter = $inputFilter ?: InputFilter::getInstance([], [], 1, 1);

--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -386,7 +386,7 @@ class CalendarField extends FormField
      *
      * @since   4.0.0
      */
-    public function filter($value, $group = null, Registry $input = null)
+    public function filter($value, $group = null, ?Registry $input = null)
     {
         // Make sure there is a valid SimpleXMLElement.
         if (!($this->element instanceof \SimpleXMLElement)) {

--- a/libraries/src/Form/Field/SubformField.php
+++ b/libraries/src/Form/Field/SubformField.php
@@ -407,7 +407,7 @@ class SubformField extends FormField
      * @since   4.0.0
      * @throws  \UnexpectedValueException
      */
-    public function filter($value, $group = null, Registry $input = null)
+    public function filter($value, $group = null, ?Registry $input = null)
     {
         // Make sure there is a valid SimpleXMLElement.
         if (!($this->element instanceof \SimpleXMLElement)) {

--- a/libraries/src/Form/Filter/IntarrayFilter.php
+++ b/libraries/src/Form/Filter/IntarrayFilter.php
@@ -40,7 +40,7 @@ class IntarrayFilter implements FormFilterInterface
      *
      * @since   4.0.0
      */
-    public function filter(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function filter(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         if (strtoupper((string) $element['filter']) === 'INT_ARRAY') {
             @trigger_error('`INT_ARRAY` form filter is deprecated and will be removed in 5.0. Use `Intarray` instead', E_USER_DEPRECATED);

--- a/libraries/src/Form/Filter/RawFilter.php
+++ b/libraries/src/Form/Filter/RawFilter.php
@@ -39,7 +39,7 @@ class RawFilter implements FormFilterInterface
      *
      * @since   4.0.0
      */
-    public function filter(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function filter(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         return $value;
     }

--- a/libraries/src/Form/Filter/RulesFilter.php
+++ b/libraries/src/Form/Filter/RulesFilter.php
@@ -39,7 +39,7 @@ class RulesFilter implements FormFilterInterface
      *
      * @since   4.0.0
      */
-    public function filter(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function filter(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $return = [];
 

--- a/libraries/src/Form/Filter/SafehtmlFilter.php
+++ b/libraries/src/Form/Filter/SafehtmlFilter.php
@@ -40,7 +40,7 @@ class SafehtmlFilter implements FormFilterInterface
      *
      * @since   4.0.0
      */
-    public function filter(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function filter(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         return InputFilter::getInstance(
             [],

--- a/libraries/src/Form/Filter/TelFilter.php
+++ b/libraries/src/Form/Filter/TelFilter.php
@@ -39,7 +39,7 @@ class TelFilter implements FormFilterInterface
      *
      * @since   4.0.0
      */
-    public function filter(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function filter(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $value = trim($value);
 

--- a/libraries/src/Form/Filter/UnsetFilter.php
+++ b/libraries/src/Form/Filter/UnsetFilter.php
@@ -39,7 +39,7 @@ class UnsetFilter implements FormFilterInterface
      *
      * @since   4.0.0
      */
-    public function filter(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function filter(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         return null;
     }

--- a/libraries/src/Form/Filter/UrlFilter.php
+++ b/libraries/src/Form/Filter/UrlFilter.php
@@ -42,7 +42,7 @@ class UrlFilter implements FormFilterInterface
      *
      * @since   4.0.0
      */
-    public function filter(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function filter(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         if (empty($value)) {
             return false;

--- a/libraries/src/Form/FormFactoryAwareTrait.php
+++ b/libraries/src/Form/FormFactoryAwareTrait.php
@@ -54,7 +54,7 @@ trait FormFactoryAwareTrait
      *
      * @since   4.0.0
      */
-    public function setFormFactory(FormFactoryInterface $formFactory = null)
+    public function setFormFactory(?FormFactoryInterface $formFactory = null)
     {
         $this->formFactory = $formFactory;
 

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1062,7 +1062,7 @@ abstract class FormField implements DatabaseAwareInterface
      * @since   4.0.0
      * @throws  \UnexpectedValueException
      */
-    public function filter($value, $group = null, Registry $input = null)
+    public function filter($value, $group = null, ?Registry $input = null)
     {
         // Make sure there is a valid SimpleXMLElement.
         if (!($this->element instanceof \SimpleXMLElement)) {
@@ -1142,7 +1142,7 @@ abstract class FormField implements DatabaseAwareInterface
      * @throws  \InvalidArgumentException
      * @throws  \UnexpectedValueException
      */
-    public function validate($value, $group = null, Registry $input = null)
+    public function validate($value, $group = null, ?Registry $input = null)
     {
         // Make sure there is a valid SimpleXMLElement.
         if (!($this->element instanceof \SimpleXMLElement)) {
@@ -1251,7 +1251,7 @@ abstract class FormField implements DatabaseAwareInterface
      *
      * @since   4.0.0
      */
-    public function postProcess($value, $group = null, Registry $input = null)
+    public function postProcess($value, $group = null, ?Registry $input = null)
     {
         return $value;
     }

--- a/libraries/src/Form/FormFilterInterface.php
+++ b/libraries/src/Form/FormFilterInterface.php
@@ -37,5 +37,5 @@ interface FormFilterInterface
      *
      * @since   4.0.0
      */
-    public function filter(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null);
+    public function filter(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null);
 }

--- a/libraries/src/Form/FormRule.php
+++ b/libraries/src/Form/FormRule.php
@@ -69,7 +69,7 @@ class FormRule
      * @since   1.6
      * @throws  \UnexpectedValueException if rule is invalid.
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // Check for a valid regex.
         if (empty($this->regex)) {

--- a/libraries/src/Form/Rule/CalendarRule.php
+++ b/libraries/src/Form/Rule/CalendarRule.php
@@ -41,7 +41,7 @@ class CalendarRule extends FormRule
      *
      * @since   3.7.0
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // If the field is empty and not required, the field is valid.
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');

--- a/libraries/src/Form/Rule/CaptchaRule.php
+++ b/libraries/src/Form/Rule/CaptchaRule.php
@@ -41,7 +41,7 @@ class CaptchaRule extends FormRule
      *
      * @since   2.5
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $app     = Factory::getApplication();
         $default = $app->get('captcha');

--- a/libraries/src/Form/Rule/ColorRule.php
+++ b/libraries/src/Form/Rule/ColorRule.php
@@ -39,7 +39,7 @@ class ColorRule extends FormRule
      *
      * @since   1.7.0
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $value = trim($value);
 

--- a/libraries/src/Form/Rule/CssIdentifierRule.php
+++ b/libraries/src/Form/Rule/CssIdentifierRule.php
@@ -39,7 +39,7 @@ class CssIdentifierRule extends FormRule
      *
      * @since   4.0.0
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // If the field is empty and not required, the field is valid.
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');

--- a/libraries/src/Form/Rule/CssIdentifierSubstringRule.php
+++ b/libraries/src/Form/Rule/CssIdentifierSubstringRule.php
@@ -39,7 +39,7 @@ class CssIdentifierSubstringRule extends FormRule
      *
      * @since   3.10.7
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // If the field is empty and not required, the field is valid.
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');

--- a/libraries/src/Form/Rule/EmailRule.php
+++ b/libraries/src/Form/Rule/EmailRule.php
@@ -58,7 +58,7 @@ class EmailRule extends FormRule implements DatabaseAwareInterface
      * @since   1.7.0
      * @throws  \UnexpectedValueException
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // If the field is empty and not required, the field is valid.
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');

--- a/libraries/src/Form/Rule/EqualsRule.php
+++ b/libraries/src/Form/Rule/EqualsRule.php
@@ -43,7 +43,7 @@ class EqualsRule extends FormRule
      * @throws  \InvalidArgumentException
      * @throws  \UnexpectedValueException
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $field = (string) $element['field'];
 

--- a/libraries/src/Form/Rule/ExistsRule.php
+++ b/libraries/src/Form/Rule/ExistsRule.php
@@ -43,7 +43,7 @@ class ExistsRule extends FormRule implements DatabaseAwareInterface
      *
      * @since   3.9.0
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $value = trim($value);
 

--- a/libraries/src/Form/Rule/FilePathRule.php
+++ b/libraries/src/Form/Rule/FilePathRule.php
@@ -40,7 +40,7 @@ class FilePathRule extends FormRule
      *
      * @since   3.9.21
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $value = trim($value);
 

--- a/libraries/src/Form/Rule/FolderPathExistsRule.php
+++ b/libraries/src/Form/Rule/FolderPathExistsRule.php
@@ -40,7 +40,7 @@ class FolderPathExistsRule extends FilePathRule
      *
      * @since   4.0.0
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         if (!parent::test($element, $value, $group, $input, $form)) {
             return false;

--- a/libraries/src/Form/Rule/NotequalsRule.php
+++ b/libraries/src/Form/Rule/NotequalsRule.php
@@ -43,7 +43,7 @@ class NotequalsRule extends FormRule
      * @throws  \InvalidArgumentException
      * @throws  \UnexpectedValueException
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $field = (string) $element['field'];
 

--- a/libraries/src/Form/Rule/NumberRule.php
+++ b/libraries/src/Form/Rule/NumberRule.php
@@ -39,7 +39,7 @@ class NumberRule extends FormRule
      *
      * @since   3.5
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // Check if the field is required.
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');

--- a/libraries/src/Form/Rule/OptionsRule.php
+++ b/libraries/src/Form/Rule/OptionsRule.php
@@ -40,7 +40,7 @@ class OptionsRule extends FormRule
      *
      * @since   1.7.0
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // Check if the field is required.
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');

--- a/libraries/src/Form/Rule/PasswordRule.php
+++ b/libraries/src/Form/Rule/PasswordRule.php
@@ -46,7 +46,7 @@ class PasswordRule extends FormRule
      * @throws  \InvalidArgumentException
      * @throws  \UnexpectedValueException
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         $meter            = isset($element['strengthmeter']) ? ' meter="0"' : '1';
         $threshold        = isset($element['threshold']) ? (int) $element['threshold'] : 66;

--- a/libraries/src/Form/Rule/RulesRule.php
+++ b/libraries/src/Form/Rule/RulesRule.php
@@ -40,7 +40,7 @@ class RulesRule extends FormRule
      *
      * @since   1.7.0
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // Get the possible field actions and the ones posted to validate them.
         $fieldActions = self::getFieldActions($element);

--- a/libraries/src/Form/Rule/SubformRule.php
+++ b/libraries/src/Form/Rule/SubformRule.php
@@ -40,7 +40,7 @@ class SubformRule extends FormRule
      *
      * @since   3.9.7
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // Get the form field object.
         $field = $form->getField($element['name'], $group);

--- a/libraries/src/Form/Rule/TelRule.php
+++ b/libraries/src/Form/Rule/TelRule.php
@@ -39,7 +39,7 @@ class TelRule extends FormRule
      *
      * @since   1.7.0
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // If the field is empty and not required, the field is valid.
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');

--- a/libraries/src/Form/Rule/TimeRule.php
+++ b/libraries/src/Form/Rule/TimeRule.php
@@ -43,7 +43,7 @@ class TimeRule extends FormRule
      *
      * @throws \Exception
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null): bool
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null): bool
     {
         // Check if the field is required.
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');

--- a/libraries/src/Form/Rule/UrlRule.php
+++ b/libraries/src/Form/Rule/UrlRule.php
@@ -45,7 +45,7 @@ class UrlRule extends FormRule
      * @link    https://www.w3.org/Addressing/URL/url-spec.txt
      * @see     \Joomla\String\StringHelper
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // If the field is empty and not required, the field is valid.
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');

--- a/libraries/src/Form/Rule/UserIdRule.php
+++ b/libraries/src/Form/Rule/UserIdRule.php
@@ -44,7 +44,7 @@ class UserIdRule extends FormRule implements DatabaseAwareInterface
      *
      * @since   4.0.0
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // Check if the field is required.
         $required = ((string) $element['required'] === 'true' || (string) $element['required'] === 'required');

--- a/libraries/src/Form/Rule/UsernameRule.php
+++ b/libraries/src/Form/Rule/UsernameRule.php
@@ -44,7 +44,7 @@ class UsernameRule extends FormRule implements DatabaseAwareInterface
      *
      * @since   1.7.0
      */
-    public function test(\SimpleXMLElement $element, $value, $group = null, Registry $input = null, Form $form = null)
+    public function test(\SimpleXMLElement $element, $value, $group = null, ?Registry $input = null, ?Form $form = null)
     {
         // Get the database object and a new query object.
         $db    = $this->getDatabase();

--- a/libraries/src/HTML/HTMLRegistryAwareTrait.php
+++ b/libraries/src/HTML/HTMLRegistryAwareTrait.php
@@ -54,7 +54,7 @@ trait HTMLRegistryAwareTrait
      *
      * @since   4.0.0
      */
-    public function setRegistry(Registry $registry = null)
+    public function setRegistry(?Registry $registry = null)
     {
         $this->registry = $registry;
     }

--- a/libraries/src/Http/Http.php
+++ b/libraries/src/Http/Http.php
@@ -33,7 +33,7 @@ class Http extends FrameworkHttp
      * @since   1.7.3
      * @throws  \InvalidArgumentException
      */
-    public function __construct($options = [], FrameworkTransportInterface $transport = null)
+    public function __construct($options = [], ?FrameworkTransportInterface $transport = null)
     {
         if (!\is_array($options) && !($options instanceof \ArrayAccess)) {
             throw new \InvalidArgumentException(

--- a/libraries/src/Input/Cli.php
+++ b/libraries/src/Input/Cli.php
@@ -59,7 +59,7 @@ class Cli extends Input
      * @deprecated  4.3 will be removed in 6.0
      *              Use the `joomla/console` package instead
      */
-    public function __construct(array $source = null, array $options = [])
+    public function __construct(?array $source = null, array $options = [])
     {
         if (isset($options['filter'])) {
             $this->filter = $options['filter'];

--- a/libraries/src/Input/Cookie.php
+++ b/libraries/src/Input/Cookie.php
@@ -36,7 +36,7 @@ class Cookie extends Input
      * @deprecated   4.3 will be removed in 6.0.
      *               Use Joomla\Input\Cookie instead
      */
-    public function __construct(array $source = null, array $options = [])
+    public function __construct(?array $source = null, array $options = [])
     {
         if (isset($options['filter'])) {
             $this->filter = $options['filter'];

--- a/libraries/src/Input/Files.php
+++ b/libraries/src/Input/Files.php
@@ -48,7 +48,7 @@ class Files extends Input
      * @deprecated   4.3 will be removed in 6.0.
      *               Use Joomla\Input\Files instead
      */
-    public function __construct(array $source = null, array $options = [])
+    public function __construct(?array $source = null, array $options = [])
     {
         if (isset($options['filter'])) {
             $this->filter = $options['filter'];

--- a/libraries/src/Input/Json.php
+++ b/libraries/src/Input/Json.php
@@ -48,7 +48,7 @@ class Json extends Input
      * @deprecated   4.3 will be removed in 6.0.
      *               Use Joomla\Input\Json instead
      */
-    public function __construct(array $source = null, array $options = [])
+    public function __construct(?array $source = null, array $options = [])
     {
         if (isset($options['filter'])) {
             $this->filter = $options['filter'];

--- a/libraries/src/Installer/InstallerExtension.php
+++ b/libraries/src/Installer/InstallerExtension.php
@@ -113,7 +113,7 @@ class InstallerExtension extends CMSObject
      *
      * @since  3.1
      */
-    public function __construct(\SimpleXMLElement $element = null)
+    public function __construct(?\SimpleXMLElement $element = null)
     {
         if ($element) {
             $this->type = (string) $element->attributes()->type;

--- a/libraries/src/Language/Multilanguage.php
+++ b/libraries/src/Language/Multilanguage.php
@@ -43,7 +43,7 @@ class Multilanguage
      *
      * @since   2.5.4
      */
-    public static function isEnabled(CMSApplication $app = null, DatabaseInterface $db = null)
+    public static function isEnabled(?CMSApplication $app = null, ?DatabaseInterface $db = null)
     {
         // Flag to avoid doing multiple database queries.
         static $tested = false;
@@ -95,7 +95,7 @@ class Multilanguage
      *
      * @since   3.5
      */
-    public static function getSiteHomePages(DatabaseInterface $db = null)
+    public static function getSiteHomePages(?DatabaseInterface $db = null)
     {
         // To avoid doing duplicate database queries.
         static $multilangSiteHomePages = null;

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -69,7 +69,7 @@ class AdminController extends BaseController
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
     {
         parent::__construct($config, $factory, $app, $input);
 

--- a/libraries/src/MVC/Controller/ApiController.php
+++ b/libraries/src/MVC/Controller/ApiController.php
@@ -95,7 +95,7 @@ class ApiController extends BaseController
      * @since   4.0.0
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
     {
         $this->modelState = new CMSObject();
 

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -357,7 +357,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface
      *
      * @since   3.0
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?CMSApplication $app = null, ?Input $input = null)
     {
         $this->methods     = [];
         $this->message     = null;

--- a/libraries/src/MVC/Controller/FormController.php
+++ b/libraries/src/MVC/Controller/FormController.php
@@ -91,10 +91,10 @@ class FormController extends BaseController implements FormFactoryAwareInterface
      */
     public function __construct(
         $config = [],
-        MVCFactoryInterface $factory = null,
+        ?MVCFactoryInterface $factory = null,
         ?CMSApplication $app = null,
         ?Input $input = null,
-        FormFactoryInterface $formFactory = null
+        ?FormFactoryInterface $formFactory = null
     ) {
         parent::__construct($config, $factory, $app, $input);
 

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -200,7 +200,7 @@ abstract class AdminModel extends FormModel
      * @since   1.6
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, FormFactoryInterface $formFactory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?FormFactoryInterface $formFactory = null)
     {
         parent::__construct($config, $factory, $formFactory);
 

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -84,7 +84,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
      * @since   3.0
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         parent::__construct($config);
 
@@ -418,7 +418,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
      *              Use setDatabase() instead
      *              Example: $model->setDatabase($db);
      */
-    public function setDbo(DatabaseInterface $db = null)
+    public function setDbo(?DatabaseInterface $db = null)
     {
         if ($db === null) {
             return;

--- a/libraries/src/MVC/Model/DatabaseAwareTrait.php
+++ b/libraries/src/MVC/Model/DatabaseAwareTrait.php
@@ -72,7 +72,7 @@ trait DatabaseAwareTrait
      *              Use the trait from the database package
      *              Example: \Joomla\Database\DatabaseAwareTrait::setDatabase()
      */
-    public function setDbo(DatabaseInterface $db = null)
+    public function setDbo(?DatabaseInterface $db = null)
     {
         $this->_db = $db;
     }

--- a/libraries/src/MVC/Model/FormModel.php
+++ b/libraries/src/MVC/Model/FormModel.php
@@ -55,7 +55,7 @@ abstract class FormModel extends BaseDatabaseModel implements FormFactoryAwareIn
      * @since   3.6
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null, FormFactoryInterface $formFactory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null, ?FormFactoryInterface $formFactory = null)
     {
         $config['events_map'] = $config['events_map'] ?? [];
 

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -134,7 +134,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
      * @since   1.6
      * @throws  \Exception
      */
-    public function __construct($config = [], MVCFactoryInterface $factory = null)
+    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
     {
         parent::__construct($config, $factory);
 

--- a/libraries/src/MVC/View/JsonApiView.php
+++ b/libraries/src/MVC/View/JsonApiView.php
@@ -110,7 +110,7 @@ abstract class JsonApiView extends JsonView
      *
      * @since   4.0.0
      */
-    public function displayList(array $items = null)
+    public function displayList(?array $items = null)
     {
         /** @var \Joomla\CMS\MVC\Model\ListModel $model */
         $model = $this->getModel();

--- a/libraries/src/Mail/Exception/MailDisabledException.php
+++ b/libraries/src/Mail/Exception/MailDisabledException.php
@@ -54,7 +54,7 @@ final class MailDisabledException extends \RuntimeException
      *
      * @since   4.0.0
      */
-    public function __construct(string $reason, string $message = '', int $code = 0, \Throwable $previous = null)
+    public function __construct(string $reason, string $message = '', int $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
 

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -92,7 +92,7 @@ class MailTemplate
      *
      * @since   4.0.0
      */
-    public function __construct($templateId, $language, Mail $mailer = null)
+    public function __construct($templateId, $language, ?Mail $mailer = null)
     {
         $this->template_id = $templateId;
         $this->language    = $language;

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -121,7 +121,7 @@ class Pagination
      *
      * @since   1.5
      */
-    public function __construct($total, $limitstart, $limit, $prefix = '', CMSApplication $app = null)
+    public function __construct($total, $limitstart, $limit, $prefix = '', ?CMSApplication $app = null)
     {
         // Value/type checking.
         $this->total      = (int) $total;

--- a/libraries/src/Pathway/SitePathway.php
+++ b/libraries/src/Pathway/SitePathway.php
@@ -31,7 +31,7 @@ class SitePathway extends Pathway
      *
      * @since   1.5
      */
-    public function __construct(SiteApplication $app = null)
+    public function __construct(?SiteApplication $app = null)
     {
         $this->pathway = [];
 

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -159,7 +159,7 @@ abstract class PluginHelper
      *
      * @since   1.5
      */
-    public static function importPlugin($type, $plugin = null, $autocreate = true, DispatcherInterface $dispatcher = null)
+    public static function importPlugin($type, $plugin = null, $autocreate = true, ?DispatcherInterface $dispatcher = null)
     {
         static $loaded = [];
 
@@ -216,7 +216,7 @@ abstract class PluginHelper
      *
      * @since   3.2
      */
-    protected static function import($plugin, $autocreate = true, DispatcherInterface $dispatcher = null)
+    protected static function import($plugin, $autocreate = true, ?DispatcherInterface $dispatcher = null)
     {
         static $plugins = [];
 

--- a/libraries/src/Router/Exception/RouteNotFoundException.php
+++ b/libraries/src/Router/Exception/RouteNotFoundException.php
@@ -29,7 +29,7 @@ class RouteNotFoundException extends \InvalidArgumentException
      *
      * @since   3.8.0
      */
-    public function __construct($message = '', $code = 404, \Exception $previous = null)
+    public function __construct($message = '', $code = 404, ?\Exception $previous = null)
     {
         if (empty($message)) {
             $message = 'URL was not found';

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -62,7 +62,7 @@ class SiteRouter extends Router
      *
      * @since   3.4
      */
-    public function __construct(CMSApplication $app = null, AbstractMenu $menu = null)
+    public function __construct(?CMSApplication $app = null, ?AbstractMenu $menu = null)
     {
         $this->app  = $app ?: Factory::getContainer()->get(SiteApplication::class);
         $this->menu = $menu ?: $this->app->getMenu();

--- a/libraries/src/Serializer/JoomlaSerializer.php
+++ b/libraries/src/Serializer/JoomlaSerializer.php
@@ -49,7 +49,7 @@ class JoomlaSerializer extends AbstractSerializer
      *
      * @since   4.0.0
      */
-    public function getAttributes($post, array $fields = null)
+    public function getAttributes($post, ?array $fields = null)
     {
         if (!($post instanceof \stdClass) && !(\is_array($post)) && !($post instanceof CMSObject)) {
             $message = sprintf(

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -40,7 +40,7 @@ class Session extends BaseSession
      *
      * @since   1.0
      */
-    public function __construct(StorageInterface $store = null, DispatcherInterface $dispatcher = null, array $options = [])
+    public function __construct(?StorageInterface $store = null, ?DispatcherInterface $dispatcher = null, array $options = [])
     {
         // Extra hash the name of the session for b/c with Joomla 3.x or the session is never found.
         if (isset($options['name'])) {

--- a/libraries/src/Session/Storage/JoomlaStorage.php
+++ b/libraries/src/Session/Storage/JoomlaStorage.php
@@ -58,7 +58,7 @@ class JoomlaStorage extends NativeStorage
      *
      * @since   4.0.0
      */
-    public function __construct(Input $input, \SessionHandlerInterface $handler = null, array $options = [])
+    public function __construct(Input $input, ?\SessionHandlerInterface $handler = null, array $options = [])
     {
         // Disable transparent sid support and default use cookies
         $options += [

--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -98,7 +98,7 @@ class Category extends Nested implements VersionableTableInterface, TaggableTabl
      *
      * @since   1.6
      */
-    protected function _getAssetParentId(Table $table = null, $id = null)
+    protected function _getAssetParentId(?Table $table = null, $id = null)
     {
         $assetId = null;
 

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -97,7 +97,7 @@ class Content extends Table implements VersionableTableInterface, TaggableTableI
      *
      * @since   1.6
      */
-    protected function _getAssetParentId(Table $table = null, $id = null)
+    protected function _getAssetParentId(?Table $table = null, $id = null)
     {
         $assetId = null;
 

--- a/libraries/src/Table/Language.php
+++ b/libraries/src/Table/Language.php
@@ -138,7 +138,7 @@ class Language extends Table
      *
      * @since   3.8.0
      */
-    protected function _getAssetParentId(Table $table = null, $id = null)
+    protected function _getAssetParentId(?Table $table = null, $id = null)
     {
         $assetId = null;
         $asset   = Table::getInstance('asset');

--- a/libraries/src/Table/MenuType.php
+++ b/libraries/src/Table/MenuType.php
@@ -302,7 +302,7 @@ class MenuType extends Table
      *
      * @since   3.6
      */
-    protected function _getAssetParentId(Table $table = null, $id = null)
+    protected function _getAssetParentId(?Table $table = null, $id = null)
     {
         $assetId = null;
         $asset   = Table::getInstance('asset');

--- a/libraries/src/Table/Module.php
+++ b/libraries/src/Table/Module.php
@@ -86,7 +86,7 @@ class Module extends Table
      *
      * @since   3.2
      */
-    protected function _getAssetParentId(Table $table = null, $id = null)
+    protected function _getAssetParentId(?Table $table = null, $id = null)
     {
         $assetId = null;
 

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -162,7 +162,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
      *
      * @since   1.7.0
      */
-    public function __construct($table, $key, DatabaseDriver $db, DispatcherInterface $dispatcher = null)
+    public function __construct($table, $key, DatabaseDriver $db, ?DispatcherInterface $dispatcher = null)
     {
         parent::__construct();
 
@@ -405,7 +405,7 @@ abstract class Table extends CMSObject implements TableInterface, DispatcherAwar
      *
      * @since   1.7.0
      */
-    protected function _getAssetParentId(Table $table = null, $id = null)
+    protected function _getAssetParentId(?Table $table = null, $id = null)
     {
         // For simple cases, parent to the asset root.
         /** @var Asset $assets */

--- a/libraries/src/Tag/TagServiceTrait.php
+++ b/libraries/src/Tag/TagServiceTrait.php
@@ -57,7 +57,7 @@ trait TagServiceTrait
      *
      * @since   4.0.0
      */
-    protected function getTableNameForSection(string $section = null)
+    protected function getTableNameForSection(?string $section = null)
     {
         return null;
     }
@@ -71,7 +71,7 @@ trait TagServiceTrait
      *
      * @since   4.0.0
      */
-    protected function getStateColumnForSection(string $section = null)
+    protected function getStateColumnForSection(?string $section = null)
     {
         return 'state';
     }

--- a/libraries/src/Toolbar/Toolbar.php
+++ b/libraries/src/Toolbar/Toolbar.php
@@ -96,7 +96,7 @@ class Toolbar
      *
      * @since   1.5
      */
-    public function __construct($name = 'toolbar', ToolbarFactoryInterface $factory = null)
+    public function __construct($name = 'toolbar', ?ToolbarFactoryInterface $factory = null)
     {
         $this->_name = $name;
 

--- a/libraries/src/UCM/UCMBase.php
+++ b/libraries/src/UCM/UCMBase.php
@@ -49,7 +49,7 @@ class UCMBase implements UCM
      *
      * @since   3.1
      */
-    public function __construct($alias = null, UCMType $type = null)
+    public function __construct($alias = null, ?UCMType $type = null)
     {
         // Setup dependencies.
         $input       = Factory::getApplication()->getInput();
@@ -70,7 +70,7 @@ class UCMBase implements UCM
      * @since   3.1
      * @throws  \Exception
      */
-    protected function store($data, TableInterface $table = null, $primaryKey = null)
+    protected function store($data, ?TableInterface $table = null, $primaryKey = null)
     {
         if (!$table) {
             $table = Table::getInstance('Ucm');
@@ -124,7 +124,7 @@ class UCMBase implements UCM
      *
      * @since   3.1
      */
-    public function mapBase($original, UCMType $type = null)
+    public function mapBase($original, ?UCMType $type = null)
     {
         $type = $type ?: $this->type;
 

--- a/libraries/src/UCM/UCMContent.php
+++ b/libraries/src/UCM/UCMContent.php
@@ -51,7 +51,7 @@ class UCMContent extends UCMBase
      *
      * @since   3.1
      */
-    public function __construct(TableInterface $table = null, $alias = null, UCMType $type = null)
+    public function __construct(?TableInterface $table = null, $alias = null, ?UCMType $type = null)
     {
         parent::__construct($alias, $type);
 
@@ -73,7 +73,7 @@ class UCMContent extends UCMBase
      *
      * @since   3.1
      */
-    public function save($original = null, UCMType $type = null)
+    public function save($original = null, ?UCMType $type = null)
     {
         $type    = $type ?: $this->type;
         $ucmData = $original ? $this->mapData($original, $type) : $this->ucmData;
@@ -100,7 +100,7 @@ class UCMContent extends UCMBase
      *
      * @since   3.1
      */
-    public function delete($pk, UCMType $type = null)
+    public function delete($pk, ?UCMType $type = null)
     {
         $db   = Factory::getDbo();
         $type = $type ?: $this->type;
@@ -131,7 +131,7 @@ class UCMContent extends UCMBase
      *
      * @since   3.1
      */
-    public function mapData($original, UCMType $type = null)
+    public function mapData($original, ?UCMType $type = null)
     {
         $contentType = $type ?: $this->type;
 
@@ -180,7 +180,7 @@ class UCMContent extends UCMBase
      *
      * @since   3.1
      */
-    protected function store($data, TableInterface $table = null, $primaryKey = null)
+    protected function store($data, ?TableInterface $table = null, $primaryKey = null)
     {
         $table = $table ?: Table::getInstance('Corecontent');
 

--- a/libraries/src/UCM/UCMType.php
+++ b/libraries/src/UCM/UCMType.php
@@ -91,7 +91,7 @@ class UCMType implements UCM
      *
      * @since   3.1
      */
-    public function __construct($alias = null, DatabaseDriver $database = null, AbstractApplication $application = null)
+    public function __construct($alias = null, ?DatabaseDriver $database = null, ?AbstractApplication $application = null)
     {
         $this->db = $database ?: Factory::getDbo();
         $app      = $application ?: Factory::getApplication();

--- a/libraries/src/WebAsset/AssetItem/LangActiveAssetItem.php
+++ b/libraries/src/WebAsset/AssetItem/LangActiveAssetItem.php
@@ -37,7 +37,7 @@ class LangActiveAssetItem extends WebAssetItem
      */
     public function __construct(
         string $name,
-        string $uri = null,
+        ?string $uri = null,
         array $options = [],
         array $attributes = [],
         array $dependencies = []

--- a/libraries/src/WebAsset/WebAssetItem.php
+++ b/libraries/src/WebAsset/WebAssetItem.php
@@ -87,7 +87,7 @@ class WebAssetItem implements WebAssetItemInterface
      */
     public function __construct(
         string $name,
-        string $uri = null,
+        ?string $uri = null,
         array $options = [],
         array $attributes = [],
         array $dependencies = []

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -731,7 +731,7 @@ class WebAssetManager implements WebAssetManagerInterface
      *
      * @since  4.0.0
      */
-    protected function enableDependencies(string $type = null, WebAssetItem $asset = null): self
+    protected function enableDependencies(?string $type = null, ?WebAssetItem $asset = null): self
     {
         if ($type === 'preset') {
             // Preset items already was enabled by usePresetItems()
@@ -956,8 +956,8 @@ class WebAssetManager implements WebAssetManagerInterface
         string $type,
         WebAssetItem $asset,
         $recursively = false,
-        string $recursionType = null,
-        WebAssetItem $recursionRoot = null
+        ?string $recursionType = null,
+        ?WebAssetItem $recursionRoot = null
     ): array {
         $assets        = [];
         $recursionRoot = $recursionRoot ?? $asset;

--- a/libraries/src/WebAsset/WebAssetRegistry.php
+++ b/libraries/src/WebAsset/WebAssetRegistry.php
@@ -233,7 +233,7 @@ class WebAssetRegistry implements WebAssetRegistryInterface, DispatcherAwareInte
      */
     public function createAsset(
         string $name,
-        string $uri = null,
+        ?string $uri = null,
         array $options = [],
         array $attributes = [],
         array $dependencies = []

--- a/libraries/src/Workflow/WorkflowPluginTrait.php
+++ b/libraries/src/Workflow/WorkflowPluginTrait.php
@@ -66,7 +66,7 @@ trait WorkflowPluginTrait
      *
      * @since   4.0.0
      */
-    protected function getWorkflow(int $workflowId = null)
+    protected function getWorkflow(?int $workflowId = null)
     {
         $app        = $this->getApplication() ?? $this->app;
         $workflowId = !empty($workflowId) ? $workflowId : $app->getInput()->getInt('workflow_id');

--- a/plugins/privacy/actionlogs/src/Extension/Actionlogs.php
+++ b/plugins/privacy/actionlogs/src/Extension/Actionlogs.php
@@ -37,7 +37,7 @@ final class Actionlogs extends PrivacyPlugin
      *
      * @since   3.9.0
      */
-    public function onPrivacyExportRequest(RequestTable $request, User $user = null)
+    public function onPrivacyExportRequest(RequestTable $request, ?User $user = null)
     {
         if (!$user) {
             return [];

--- a/plugins/privacy/consents/src/Extension/Consents.php
+++ b/plugins/privacy/consents/src/Extension/Consents.php
@@ -38,7 +38,7 @@ final class Consents extends PrivacyPlugin
      *
      * @since   3.9.0
      */
-    public function onPrivacyExportRequest(RequestTable $request, User $user = null)
+    public function onPrivacyExportRequest(RequestTable $request, ?User $user = null)
     {
         if (!$user) {
             return [];

--- a/plugins/privacy/contact/src/Extension/Contact.php
+++ b/plugins/privacy/contact/src/Extension/Contact.php
@@ -40,7 +40,7 @@ final class Contact extends PrivacyPlugin
      *
      * @since   3.9.0
      */
-    public function onPrivacyExportRequest(RequestTable $request, User $user = null)
+    public function onPrivacyExportRequest(RequestTable $request, ?User $user = null)
     {
         if (!$user && !$request->email) {
             return [];

--- a/plugins/privacy/content/src/Extension/Content.php
+++ b/plugins/privacy/content/src/Extension/Content.php
@@ -39,7 +39,7 @@ final class Content extends PrivacyPlugin
      *
      * @since   3.9.0
      */
-    public function onPrivacyExportRequest(RequestTable $request, User $user = null)
+    public function onPrivacyExportRequest(RequestTable $request, ?User $user = null)
     {
         if (!$user) {
             return [];

--- a/plugins/privacy/message/src/Extension/Message.php
+++ b/plugins/privacy/message/src/Extension/Message.php
@@ -38,7 +38,7 @@ final class Message extends PrivacyPlugin
      *
      * @since   3.9.0
      */
-    public function onPrivacyExportRequest(RequestTable $request, User $user = null)
+    public function onPrivacyExportRequest(RequestTable $request, ?User $user = null)
     {
         if (!$user) {
             return [];

--- a/plugins/privacy/user/src/Extension/UserPlugin.php
+++ b/plugins/privacy/user/src/Extension/UserPlugin.php
@@ -43,7 +43,7 @@ final class UserPlugin extends PrivacyPlugin
      *
      * @since   3.9.0
      */
-    public function onPrivacyCanRemoveData(RequestTable $request, User $user = null)
+    public function onPrivacyCanRemoveData(RequestTable $request, ?User $user = null)
     {
         $status = new Status();
 
@@ -76,7 +76,7 @@ final class UserPlugin extends PrivacyPlugin
      *
      * @since   3.9.0
      */
-    public function onPrivacyExportRequest(RequestTable $request, User $user = null)
+    public function onPrivacyExportRequest(RequestTable $request, ?User $user = null)
     {
         if (!$user) {
             return [];
@@ -107,7 +107,7 @@ final class UserPlugin extends PrivacyPlugin
      *
      * @since   3.9.0
      */
-    public function onPrivacyRemoveData(RequestTable $request, User $user = null)
+    public function onPrivacyRemoveData(RequestTable $request, ?User $user = null)
     {
         // This plugin only processes data for registered user accounts
         if (!$user) {

--- a/plugins/system/webauthn/src/Authentication.php
+++ b/plugins/system/webauthn/src/Authentication.php
@@ -96,9 +96,9 @@ final class Authentication
      * @since   4.2.0
      */
     public function __construct(
-        ApplicationInterface $app = null,
-        SessionInterface $session = null,
-        PublicKeyCredentialSourceRepository $credRepo = null,
+        ?ApplicationInterface $app = null,
+        ?SessionInterface $session = null,
+        ?PublicKeyCredentialSourceRepository $credRepo = null,
         ?MetadataStatementRepository $mdsRepo = null
     ) {
         $this->app                   = $app;

--- a/plugins/system/webauthn/src/CredentialRepository.php
+++ b/plugins/system/webauthn/src/CredentialRepository.php
@@ -44,7 +44,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
      *
      * @since   4.2.0
      */
-    public function __construct(DatabaseInterface $db = null)
+    public function __construct(?DatabaseInterface $db = null)
     {
         $this->setDatabase($db);
     }

--- a/plugins/system/webauthn/src/Extension/Webauthn.php
+++ b/plugins/system/webauthn/src/Extension/Webauthn.php
@@ -113,7 +113,7 @@ final class Webauthn extends CMSPlugin implements SubscriberInterface
      *
      * @since  4.0.0
      */
-    public function __construct(&$subject, array $config = [], Authentication $authHelper = null)
+    public function __construct(&$subject, array $config = [], ?Authentication $authHelper = null)
     {
         parent::__construct($subject, $config);
 

--- a/tests/Unit/Libraries/Cms/Mail/MailerFactoryAwareTraitTest.php
+++ b/tests/Unit/Libraries/Cms/Mail/MailerFactoryAwareTraitTest.php
@@ -35,7 +35,7 @@ class MailerFactoryAwareTraitTest extends UnitTestCase
     public function testGetSetMailerFactory()
     {
         $mailerFactory = new class () implements MailerFactoryInterface {
-            public function createMailer(Registry $configuration = null): MailerInterface
+            public function createMailer(?Registry $configuration = null): MailerInterface
             {
                 return new class () implements MailerInterface {
                     public function send()

--- a/tests/Unit/Libraries/Cms/Plugin/CMSPluginTest.php
+++ b/tests/Unit/Libraries/Cms/Plugin/CMSPluginTest.php
@@ -378,7 +378,7 @@ class CMSPluginTest extends UnitTestCase
         $dispatcher = new Dispatcher();
 
         $plugin = new class ($dispatcher, []) extends CMSPlugin {
-            public function onTest(\stdClass $event = null)
+            public function onTest(?\stdClass $event = null)
             {
             }
         };

--- a/tests/Unit/Plugin/Authentication/Ldap/LdapPluginTest.php
+++ b/tests/Unit/Plugin/Authentication/Ldap/LdapPluginTest.php
@@ -333,7 +333,7 @@ class LdapPluginTest extends UnitTestCase
                         $this->hasEntry  = $hasEntry;
                     }
 
-                    public function bind(string $dn = null, string $password = null)
+                    public function bind(?string $dn = null, ?string $password = null)
                     {
                         if ($this->failBind) {
                             throw new LdapException();


### PR DESCRIPTION
### Summary of Changes
In [PHP 8.4 will implicit nullable types being deprecated](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types). This pr changes that syntax in core by adding the new rule [nullable_type_declaration_for_default_null_value](https://cs.symfony.com/doc/rules/function_notation/nullable_type_declaration_for_default_null_value.html) to our CS fixer definition.