### PR TITLE
Fix for a radio switch/buttons layout in subform field type

### DIFF
--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -66,6 +66,8 @@ if (!empty($autofocus)) {
 
 if ($required) {
     $attribs[] = 'class="required radio"';
+} else {
+    $attribs[] = 'class="radio"';
 }
 
 if ($readonly || $disabled) {

--- a/layouts/joomla/form/field/radio/switcher.php
+++ b/layouts/joomla/form/field/radio/switcher.php
@@ -62,7 +62,7 @@ Factory::getApplication()->getDocument()->getWebAssetManager()->useStyle('switch
  */
 $input = '<input type="radio" id="%1$s" name="%2$s" value="%3$s" %4$s>';
 
-$attr = 'id="' . $id . '"';
+$attr = 'id="' . $id . '" class="radio"';
 $attr .= $onchange ? ' onchange="' . $onchange . '"' : '';
 $attr .= $dataAttribute;
 


### PR DESCRIPTION
Change made last month in a `subform` field broke subform support when there is a `joomla.form.field.radio.switcher`  (and most likely `joomla.form.field.radio.buttons`) layout set on the field. The result is Uncaught TypeError like this
![obraz](https://github.com/user-attachments/assets/ca5ebf0f-0a9d-493c-a28c-2258db42622f)
 In short, the script is looking for a `radio` class in element parents. Where the script itself works fine, the `switcher` and `buttons` layout for the radio field lacks the `radio` class on a fieldset.


### Summary of Changes
Added `radio` class to `joomla.form.field.radio.switcher` and `joomla.form.field.radio.buttons` layouts.


### Testing Instructions
Add this field XML to any of the core modules like (eg `mod_banners`) and try to add new row in this field:
```xml
<field name="fields" type="subform"
       multiple="true"
       label="Fields"
>
    <form>
        <field name="checkboxes" 
               type="checkboxes" 
               label="Checkboxes"
        >
            <option value="0">JNO</option>
            <option value="1">JYES</option>
        </field>
        <field name="radio" 
               type="radio"
               label="Radio"
               layout="joomla.form.field.radio.switcher"
        >
            <option value="0">JNO</option>
            <option value="1">JYES</option>
        </field>
    </form>
</field>
```


### Actual result BEFORE applying this Pull Request
`Uncaught TypeError: can't access property "nodeName", b is null`


### Expected result AFTER applying this Pull Request
New row in a subform is added


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
