### PR TITLE
[4.0] close collapse when opening a dropdown

### DIFF
--- a/build/media_source/templates/administrator/atum/js/template.es6.js
+++ b/build/media_source/templates/administrator/atum/js/template.es6.js
@@ -242,3 +242,20 @@ window.addEventListener('joomla:menu-toggle', (event) => {
     changeLogo(event.detail);
   }
 });
+
+// Get all buttons with data-bs-toggle attributes
+const collapseButtons = document.querySelectorAll('[data-bs-toggle="collapse"]');
+const dropdownButtons = document.querySelectorAll('[data-bs-toggle="dropdown"]');
+
+// Add event listeners to dropdown buttons
+dropdownButtons.forEach(button => {
+  button.addEventListener('click', function () {
+    collapseButtons.forEach(cb => {
+      const target = document.querySelector(cb.getAttribute('data-bs-target'));
+      const collapseMenu = bootstrap.Collapse.getInstance(target) || new bootstrap.Collapse(target, {
+        toggle: false
+      });
+      collapseMenu.hide();
+    });
+  });
+});

--- a/build/media_source/templates/administrator/atum/js/template.es6.js
+++ b/build/media_source/templates/administrator/atum/js/template.es6.js
@@ -246,7 +246,7 @@ window.addEventListener('joomla:menu-toggle', (event) => {
 /**
  * Close any open data-bs-toggle="collapse" when opening a data-bs-toggle="dropdown"
  *
- * since 4.4
+ * @since 4.4
  */
 document.querySelectorAll('[data-bs-toggle="dropdown"]').forEach((button) => {
   button.addEventListener('click', () => {

--- a/build/media_source/templates/administrator/atum/js/template.es6.js
+++ b/build/media_source/templates/administrator/atum/js/template.es6.js
@@ -243,17 +243,17 @@ window.addEventListener('joomla:menu-toggle', (event) => {
   }
 });
 
-// Get all buttons with data-bs-toggle attributes
-const collapseButtons = document.querySelectorAll('[data-bs-toggle="collapse"]');
-const dropdownButtons = document.querySelectorAll('[data-bs-toggle="dropdown"]');
-
-// Add event listeners to dropdown buttons
-dropdownButtons.forEach(button => {
-  button.addEventListener('click', function () {
-    collapseButtons.forEach(cb => {
+/**
+ * Close any open data-bs-toggle="collapse" when opening a data-bs-toggle="dropdown"
+ *
+ * since 4.4
+ */
+document.querySelectorAll('[data-bs-toggle="dropdown"]').forEach((button) => {
+  button.addEventListener('click', () => {
+    document.querySelectorAll('[data-bs-toggle="collapse"]').forEach((cb) => {
       const target = document.querySelector(cb.getAttribute('data-bs-target'));
       const collapseMenu = bootstrap.Collapse.getInstance(target) || new bootstrap.Collapse(target, {
-        toggle: false
+        toggle: false,
       });
       collapseMenu.hide();
     });

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_header.scss
@@ -204,6 +204,10 @@
     .fas {
       font-size: 1.5rem;
     }
+
+    > * {
+      pointer-events: none;
+    }
   }
 
   .container-search {

--- a/build/media_source/templates/site/cassiopeia/scss/blocks/_toolbar.scss
+++ b/build/media_source/templates/site/cassiopeia/scss/blocks/_toolbar.scss
@@ -119,6 +119,10 @@
     &.btn {
       padding-inline-end: 0;
     }
+
+    > * {
+      pointer-events: none;
+    }
   }
 
   .btn-group:not(:last-child) > .dropdown-toggle-split {


### PR DESCRIPTION
Pull Request for Issue #28952 .

### Summary of Changes

This PR will add some javascript.
When you click on a dropdown element (data-bs-toggle="dropdown") , all open collapse elements (data-bs-toggle="collapse") will close


### Testing Instructions

- Joomla 4.4-dev with demo data
- resize viewport to mobile
- toggle any of the three buttons in the footer to open / close the element
- see the issue as shown in the first screencapture movie
- run `npm ci` to compile both css and js
- toggle any of the three buttons in the footer to open / close the element
- see the issue as shown in the second screencapture movie

### Actual result BEFORE applying this Pull Request

https://github.com/user-attachments/assets/7a45ec99-4f5a-42a7-8566-28d03ba597e2



### Expected result AFTER applying this Pull Request


https://github.com/user-attachments/assets/d605acff-d038-4c2f-bb4c-6bf7e9b26447



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
