### PR TITLE
[5.x] Update joomla-cypress 1.1.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -81,7 +81,7 @@
         "fs-extra": "^10.1.0",
         "ini": "^2.0.0",
         "jasmine-core": "^3.99.1",
-        "joomla-cypress": "^1.0.3",
+        "joomla-cypress": "^1.1.1",
         "lightningcss": "^1.24.1",
         "mysql": "^2.18.1",
         "postcss-scss": "^4.0.9",
@@ -4186,13 +4186,13 @@
       "integrity": "sha512-GAj5FOq0Hd+RsCGVJxZuKaIDXDf3h6GQoNEjFgbLLI/trgtavwUbSnZ5pVfg27DVCaWjIohryS0JFwIJyT2cMg=="
     },
     "node_modules/cypress": {
-      "version": "13.7.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.7.0.tgz",
-      "integrity": "sha512-UimjRSJJYdTlvkChcdcfywKJ6tUYuwYuk/n1uMMglrvi+ZthNhoRYcxnWgTqUtkl17fXrPAsD5XT2rcQYN1xKA==",
+      "version": "13.13.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.13.2.tgz",
+      "integrity": "sha512-PvJQU33933NvS1StfzEb8/mu2kMy4dABwCF+yd5Bi7Qly1HOVf+Bufrygee/tlmty/6j5lX+KIi8j9Q3JUMbhA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^3.0.0",
+        "@cypress/request": "^3.0.1",
         "@cypress/xvfb": "^1.2.4",
         "@types/sinonjs__fake-timers": "8.1.1",
         "@types/sizzle": "^2.3.2",
@@ -4231,7 +4231,7 @@
         "request-progress": "^3.0.0",
         "semver": "^7.5.3",
         "supports-color": "^8.1.1",
-        "tmp": "~0.2.1",
+        "tmp": "~0.2.3",
         "untildify": "^4.0.0",
         "yauzl": "^2.10.0"
       },
@@ -4240,6 +4240,18 @@
       },
       "engines": {
         "node": "^16.0.0 || ^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/cypress-file-upload": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
+      "integrity": "sha512-+8VzNabRk3zG6x8f8BWArF/xA/W0VK4IZNx3MV0jFWrJS/qKn8eHfa5nU73P9fOQAgwHFJx7zjg4lwOnljMO8g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8.2.1"
+      },
+      "peerDependencies": {
+        "cypress": ">3.0.0"
       }
     },
     "node_modules/cypress/node_modules/ansi-styles": {
@@ -6716,10 +6728,14 @@
       "dev": true
     },
     "node_modules/joomla-cypress": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/joomla-cypress/-/joomla-cypress-1.0.3.tgz",
-      "integrity": "sha512-lHNGgBS79Z32HedbqqIiezcz5oRJGPngEh9Z8Sh6i1RytOHbMU0PmNxZvuTkS8y8/RGfSgZdlf71UtJ45OLnAg==",
-      "dev": true
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/joomla-cypress/-/joomla-cypress-1.1.1.tgz",
+      "integrity": "sha512-F+suvN5CULRmUeJmkOW4pbIhtJQnuer2C7HoLGbjGF6KbHiHTbhtoDe0cY5qFfE7K+2+CRunKUzUU+cU/gchWw==",
+      "dev": true,
+      "dependencies": {
+        "cypress": "^13.13.2",
+        "cypress-file-upload": "^5.0.8"
+      }
     },
     "node_modules/joomla-ui-custom-elements": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "fs-extra": "^10.1.0",
     "ini": "^2.0.0",
     "jasmine-core": "^3.99.1",
-    "joomla-cypress": "^1.0.3",
+    "joomla-cypress": "^1.1.1",
     "lightningcss": "^1.24.1",
     "mysql": "^2.18.1",
     "postcss-scss": "^4.0.9",

--- a/tests/System/README.md
+++ b/tests/System/README.md
@@ -122,10 +122,6 @@ SMTP configuration.
 
 The used npm package "Helpers for using Cypress with Joomla for testing" **[joomala-cypress](https://github.com/joomla-projects/joomla-cypress/)** helps in writing the Cypress tests for Joomla in extending the Cypress API with custom commands.
 
-> [!IMPORTANT]
-> Some `joomala-cypress` commands are overwritten by the System Tests,
-> see [tests/System/support/commands.js](/tests/System/support/commands.js).
-
 The **[smtp-tester](https://www.npmjs.com/package/smtp-tester)** npm package creates an SMTP server that listens
 on the `smtp_port` specified in `cypress.config.mjs` during test runtime.
 This server accepts connections, receives emails, and provides the capability to check the received emails during the test.


### PR DESCRIPTION
### Summary of Changes

The goal is to use the NPM joomla-cypress version 1.1.1 for all four active joomla-cms branches. Actual 4.4-dev uses 0.0.16 and 5.1-dev, 5.2-dev and 6.0-dev are using 1.0.3.

For 4.4-dev there is already PR https://github.com/joomla/joomla-cms/pull/43722

This PR is for branches 5.1-dev and 5.2-dev (see at the end).

Change:
* The joomla-cypress version is set to ^1.1.1, so - among other things - PHP warnings are speaking (tell you what was going wrong) and ready for 5.2 guided tours new 'Skip Tour'
* The note about overwritten commands in tests/System/README.md is deleted, it was only valid for 4.4-dev

Successfully pretested with all System Tests passed:
* on Intel macOS 14.5 Sonoma with PHP 8.3.9

⚠️ Only NPM package `joomla-cypress` was updated, BUT there are more changes in package-lock.json. ⚠️
* Reason is dependend packages like `cypress` and `cypress-file-upload`
  
### Testing Instructions

* Install (in using `npm ci`) and run [System Tests](https://github.com/joomla/joomla-cms/tree/4.4-dev/tests/System/README.md) w/o errors
* Check version is 1.1.1 in `node_modules/joomla-cypress/package.json`
* Check that the additional updates in the `package-lock.json` file had no effect.

### Actual result BEFORE applying this Pull Request

* System Tests is using joomla-cypress version 1.0.3
* System Tests suite is running without errors

### Expected result AFTER applying this Pull Request

* System Tests is using joomla-cypress version 1.1.1
* System Tests suite is running without errors

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed

### Up-Merging 5.2-dev

For [5.2] Guided Tours https://github.com/joomla/joomla-cms/pull/43814 `joomla-cypress` 1.1.1 is required to handle new 'Skip Tour' with Cypress custom command `cancelTour`.

@laoneo This PR was successfully pretested on 5.2-dev branch with all System Tests passed:
* on Intel macOS 14.5 Sonoma with PHP 8.3.9 

⚠️ Only NPM package `joomla-cypress` was updated, BUT there are more changes in package-lock.json. ⚠️
* Reasons are
  * Dependend packages like `cypress` and `cypress-file-upload`
  * `package.json` and `package-lock.json` were not in-sync. For example in `package.json` the version is stated as '5.2.0' and in `package-lock.json` as '5.1.2'.

### Up-Merging 6.0-dev

Was not tested and needs first https://github.com/joomla/joomla-cms/pull/43642 to be merged.