### PR TITLE
[4.4] Incorrect file size validation in media manager

### DIFF
--- a/administrator/components/com_media/src/Controller/ApiController.php
+++ b/administrator/components/com_media/src/Controller/ApiController.php
@@ -346,7 +346,8 @@ class ApiController extends BaseController
         $helper              = new MediaHelper();
         $contentLength       = $this->input->server->getInt('CONTENT_LENGTH');
         $params              = ComponentHelper::getParams('com_media');
-        $paramsUploadMaxsize = $params->get('upload_maxsize', 0) * 1024 * 1024;
+        // As the Base64 version of a string or file is approximately a third larger than its source adjust the calulation by a factor of 1.33
+        $paramsUploadMaxsize = $params->get('upload_maxsize', 0) * 1024 * 1024 * 1.33;
         $uploadMaxFilesize   = $helper->toBytes(ini_get('upload_max_filesize'));
         $postMaxSize         = $helper->toBytes(ini_get('post_max_size'));
         $memoryLimit         = $helper->toBytes(ini_get('memory_limit'));


### PR DESCRIPTION
PR for #43387

the Base64 version of a string or file is typically roughly a third larger than its source so this adds a 1.33 factor to the size calculation

See #43387 and https://developer.mozilla.org/en-US/docs/Glossary/Base64#encoded_size_increase for more information

## Test instructions
- media manager set to 4mb
Try to upload a file just below 4mb in size

## Before
Image is rejected as too large

## After
Image is accepted


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
