### PR TITLE
[6.0] Replace GMT with UTC

### DIFF
--- a/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
@@ -210,7 +210,7 @@ class ActionlogsModel extends ListModel
                 $dStart->setTime(0, 0, 0);
 
                 // Now change the timezone back to UTC.
-                $tz = new \DateTimeZone('GMT');
+                $tz = new \DateTimeZone('UTC');
                 $dStart->setTimezone($tz);
                 break;
         }

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -554,7 +554,7 @@ class TaskModel extends AdminModel
             $basisDayOfMonth           = $data['execution_rules']['exec-day'];
             [$basisHour, $basisMinute] = explode(':', $data['execution_rules']['exec-time']);
 
-            $data['last_execution'] = Factory::getDate('now', 'GMT')->format('Y-m')
+            $data['last_execution'] = Factory::getDate('now', 'UTC')->format('Y-m')
                 . "-$basisDayOfMonth $basisHour:$basisMinute:00";
         } else {
             $data['last_execution'] = $this->getItem($id)->last_execution;

--- a/administrator/components/com_scheduler/src/Model/TasksModel.php
+++ b/administrator/components/com_scheduler/src/Model/TasksModel.php
@@ -251,7 +251,7 @@ class TasksModel extends ListModel
         $due = $this->getState('filter.due');
 
         if (is_numeric($due) && $due != 0) {
-            $now      = Factory::getDate('now', 'GMT')->toSql();
+            $now      = Factory::getDate('now', 'UTC')->toSql();
             $operator = $due == 1 ? ' <= ' : ' > ';
             $filterCount++;
             $query->where($db->quoteName('a.next_execution') . $operator . ':now')
@@ -268,7 +268,7 @@ class TasksModel extends ListModel
         $locked = $this->getState('filter.locked');
 
         if (is_numeric($locked) && $locked != 0) {
-            $now              = Factory::getDate('now', 'GMT');
+            $now              = Factory::getDate('now', 'UTC');
             $timeout          = ComponentHelper::getParams('com_scheduler')->get('timeout', 300);
             $timeout          = new \DateInterval(sprintf('PT%dS', $timeout));
             $timeoutThreshold = (clone $now)->sub($timeout)->toSql();

--- a/administrator/components/com_scheduler/src/Task/Task.php
+++ b/administrator/components/com_scheduler/src/Task/Task.php
@@ -307,7 +307,7 @@ class Task implements LoggerAwareInterface
         $db    = $this->db;
         $query = $db->getQuery(true);
         $id    = $this->get('id');
-        $now   = Factory::getDate('now', 'GMT');
+        $now   = Factory::getDate('now', 'UTC');
 
         $timeout          = ComponentHelper::getParams('com_scheduler')->get('timeout', 300);
         $timeout          = new \DateInterval(sprintf('PT%dS', $timeout));

--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -567,7 +567,7 @@ class UsersModel extends ListModel
                 $dStart->setTime(0, 0, 0);
 
                 // Now change the timezone back to UTC.
-                $tz = new \DateTimeZone('GMT');
+                $tz = new \DateTimeZone('UTC');
                 $dStart->setTimezone($tz);
                 break;
             case 'never':

--- a/build/bump.php
+++ b/build/bump.php
@@ -162,7 +162,7 @@ $version = [
     'build'      => '',
     'reldate'    => $date->format('j-F-Y'),
     'reltime'    => $date->format('H:i'),
-    'reltz'      => 'GMT',
+    'reltz'      => 'UTC',
     'credate'    => $date->format('Y-m'),
 ];
 

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -100,7 +100,7 @@ class Date extends \DateTime
         // Create the base GMT and server time zone objects.
         if (empty(self::$gmt) || empty(self::$stz)) {
             // @TODO: This code block stays here only for B/C, can be removed in 5.0
-            self::$gmt = new \DateTimeZone('GMT');
+            self::$gmt = new \DateTimeZone('UTC');
             self::$stz = new \DateTimeZone(@date_default_timezone_get());
         }
 

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -542,7 +542,7 @@ class User
      */
     public function getTimezone()
     {
-        $timezone = $this->getParam('timezone', Factory::getApplication()->get('offset', 'GMT'));
+        $timezone = $this->getParam('timezone', Factory::getApplication()->get('offset', 'UTC'));
 
         return new \DateTimeZone($timezone);
     }

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -107,7 +107,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const RELTZ = 'GMT';
+    public const RELTZ = 'UTC';
 
     /**
      * Copyright Notice.

--- a/plugins/system/webauthn/src/CredentialRepository.php
+++ b/plugins/system/webauthn/src/CredentialRepository.php
@@ -622,7 +622,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
             try {
                 $tzDefault = Factory::getApplication()->get('offset');
             } catch (\Exception $e) {
-                $tzDefault = 'GMT';
+                $tzDefault = 'UTC';
             }
 
             $user = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($userId ?? 0);


### PR DESCRIPTION
### Summary of Changes
Unifies the code base to use UTC instead of GMT as we offer only UTC as timezone in the options.

Code review as both timezones should be the same.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/296
- [ ] No documentation changes for manual.joomla.org needed
