### PR TITLE
Revert "[5.2] Remove legacy code for filtering state in backend model…

### DIFF
--- a/administrator/components/com_associations/src/Model/AssociationsModel.php
+++ b/administrator/components/com_associations/src/Model/AssociationsModel.php
@@ -101,6 +101,13 @@ class AssociationsModel extends ListModel
         $this->setState('itemtype', $this->getUserStateFromRequest($this->context . '.itemtype', 'itemtype', '', 'string'));
         $this->setState('language', $this->getUserStateFromRequest($this->context . '.language', 'language', '', 'string'));
 
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+        $this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'cmd'));
+        $this->setState('filter.category_id', $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id', '', 'cmd'));
+        $this->setState('filter.menutype', $this->getUserStateFromRequest($this->context . '.filter.menutype', 'filter_menutype', '', 'string'));
+        $this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'string'));
+        $this->setState('filter.level', $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level', '', 'cmd'));
+
         // List state information.
         parent::populateState($ordering, $direction);
 

--- a/administrator/components/com_cache/src/Model/CacheModel.php
+++ b/administrator/components/com_cache/src/Model/CacheModel.php
@@ -88,6 +88,9 @@ class CacheModel extends ListModel
      */
     protected function populateState($ordering = 'group', $direction = 'asc')
     {
+        // Load the filter state.
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+
         parent::populateState($ordering, $direction);
     }
 

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -141,6 +141,43 @@ class ArticlesModel extends ListModel
             $this->context .= '.' . $forcedLanguage;
         }
 
+        $search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
+        $this->setState('filter.search', $search);
+
+        $featured = $this->getUserStateFromRequest($this->context . '.filter.featured', 'filter_featured', '');
+        $this->setState('filter.featured', $featured);
+
+        $published = $this->getUserStateFromRequest($this->context . '.filter.published', 'filter_published', '');
+        $this->setState('filter.published', $published);
+
+        $level = $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level');
+        $this->setState('filter.level', $level);
+
+        $language = $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '');
+        $this->setState('filter.language', $language);
+
+        $formSubmitted = $input->post->get('form_submitted');
+
+        // Gets the value of a user state variable and sets it in the session
+        $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access');
+        $this->getUserStateFromRequest($this->context . '.filter.author_id', 'filter_author_id');
+        $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id');
+        $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '');
+
+        if ($formSubmitted) {
+            $access = $input->post->get('access');
+            $this->setState('filter.access', $access);
+
+            $authorId = $input->post->get('author_id');
+            $this->setState('filter.author_id', $authorId);
+
+            $categoryId = $input->post->get('category_id');
+            $this->setState('filter.category_id', $categoryId);
+
+            $tag = $input->post->get('tag');
+            $this->setState('filter.tag', $tag);
+        }
+
         // List state information.
         parent::populateState($ordering, $direction);
 

--- a/administrator/components/com_finder/src/Model/FiltersModel.php
+++ b/administrator/components/com_finder/src/Model/FiltersModel.php
@@ -128,6 +128,10 @@ class FiltersModel extends ListModel
      */
     protected function populateState($ordering = 'a.title', $direction = 'asc')
     {
+        // Load the filter state.
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+        $this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'cmd'));
+
         // Load the parameters.
         $params = ComponentHelper::getParams('com_finder');
         $this->setState('params', $params);

--- a/administrator/components/com_finder/src/Model/IndexModel.php
+++ b/administrator/components/com_finder/src/Model/IndexModel.php
@@ -394,6 +394,13 @@ class IndexModel extends ListModel
      */
     protected function populateState($ordering = 'l.title', $direction = 'asc')
     {
+        // Load the filter state.
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+        $this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'cmd'));
+        $this->setState('filter.type', $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', '', 'cmd'));
+        $this->setState('filter.content_map', $this->getUserStateFromRequest($this->context . '.filter.content_map', 'filter_content_map', '', 'cmd'));
+        $this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', ''));
+
         // Load the parameters.
         $params = ComponentHelper::getParams('com_finder');
         $this->setState('params', $params);

--- a/administrator/components/com_finder/src/Model/MapsModel.php
+++ b/administrator/components/com_finder/src/Model/MapsModel.php
@@ -289,6 +289,12 @@ class MapsModel extends ListModel
      */
     protected function populateState($ordering = 'branch_title, a.lft', $direction = 'ASC')
     {
+        // Load the filter state.
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+        $this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'cmd'));
+        $this->setState('filter.branch', $this->getUserStateFromRequest($this->context . '.filter.branch', 'filter_branch', '', 'cmd'));
+        $this->setState('filter.level', $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level', '', 'cmd'));
+
         // Load the parameters.
         $params = ComponentHelper::getParams('com_finder');
         $this->setState('params', $params);

--- a/administrator/components/com_guidedtours/src/Model/ToursModel.php
+++ b/administrator/components/com_guidedtours/src/Model/ToursModel.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Component\Guidedtours\Administrator\Model;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\Model\ListModel;
 use Joomla\Component\Guidedtours\Administrator\Helper\GuidedtoursHelper;
@@ -77,6 +78,11 @@ class ToursModel extends ListModel
      */
     protected function populateState($ordering = 'a.ordering', $direction = 'ASC')
     {
+        $app       = Factory::getApplication();
+        $extension = $app->getUserStateFromRequest($this->context . '.filter.extension', 'extension', null, 'cmd');
+
+        $this->setState('filter.extension', $extension);
+
         parent::populateState($ordering, $direction);
     }
 

--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -256,6 +256,11 @@ class DatabaseModel extends InstallerModel
      */
     protected function populateState($ordering = 'name', $direction = 'asc')
     {
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+        $this->setState('filter.client_id', $this->getUserStateFromRequest($this->context . '.filter.client_id', 'filter_client_id', null, 'int'));
+        $this->setState('filter.type', $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', '', 'string'));
+        $this->setState('filter.folder', $this->getUserStateFromRequest($this->context . '.filter.folder', 'filter_folder', '', 'string'));
+
         parent::populateState($ordering, $direction);
     }
 

--- a/administrator/components/com_installer/src/Model/DiscoverModel.php
+++ b/administrator/components/com_installer/src/Model/DiscoverModel.php
@@ -71,6 +71,12 @@ class DiscoverModel extends InstallerModel
     {
         $app = Factory::getApplication();
 
+        // Load the filter state.
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+        $this->setState('filter.client_id', $this->getUserStateFromRequest($this->context . '.filter.client_id', 'filter_client_id', null, 'int'));
+        $this->setState('filter.type', $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', '', 'string'));
+        $this->setState('filter.folder', $this->getUserStateFromRequest($this->context . '.filter.folder', 'filter_folder', '', 'string'));
+
         $this->setState('message', $app->getUserState('com_installer.message'));
         $this->setState('extension_message', $app->getUserState('com_installer.extension_message'));
 

--- a/administrator/components/com_installer/src/Model/InstallerModel.php
+++ b/administrator/components/com_installer/src/Model/InstallerModel.php
@@ -70,7 +70,7 @@ class InstallerModel extends ListModel
         $listDirn  = $this->getState('list.direction', 'asc');
 
         // Replace slashes so preg_match will work
-        $search = $this->getState('filter.search', '');
+        $search = $this->getState('filter.search');
         $search = str_replace('/', ' ', $search);
         $db     = $this->getDatabase();
 

--- a/administrator/components/com_installer/src/Model/LanguagesModel.php
+++ b/administrator/components/com_installer/src/Model/LanguagesModel.php
@@ -245,6 +245,8 @@ class LanguagesModel extends ListModel
      */
     protected function populateState($ordering = 'name', $direction = 'asc')
     {
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+
         $this->setState('extension_message', Factory::getApplication()->getUserState('com_installer.extension_message'));
 
         parent::populateState($ordering, $direction);

--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -82,6 +82,15 @@ class ManageModel extends InstallerModel
     {
         $app = Factory::getApplication();
 
+        // Load the filter state.
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+        $this->setState('filter.client_id', $this->getUserStateFromRequest($this->context . '.filter.client_id', 'filter_client_id', null, 'int'));
+        $this->setState('filter.package_id', $this->getUserStateFromRequest($this->context . '.filter.package_id', 'filter_package_id', null, 'int'));
+        $this->setState('filter.status', $this->getUserStateFromRequest($this->context . '.filter.status', 'filter_status', '', 'string'));
+        $this->setState('filter.type', $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', '', 'string'));
+        $this->setState('filter.folder', $this->getUserStateFromRequest($this->context . '.filter.folder', 'filter_folder', '', 'string'));
+        $this->setState('filter.core', $this->getUserStateFromRequest($this->context . '.filter.core', 'filter_core', '', 'string'));
+
         $this->setState('message', $app->getUserState('com_installer.message'));
         $this->setState('extension_message', $app->getUserState('com_installer.extension_message'));
         $app->setUserState('com_installer.message', '');

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -75,6 +75,11 @@ class UpdateModel extends ListModel
      */
     protected function populateState($ordering = 'u.name', $direction = 'asc')
     {
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+        $this->setState('filter.client_id', $this->getUserStateFromRequest($this->context . '.filter.client_id', 'filter_client_id', null, 'int'));
+        $this->setState('filter.type', $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', '', 'string'));
+        $this->setState('filter.folder', $this->getUserStateFromRequest($this->context . '.filter.folder', 'filter_folder', '', 'string'));
+
         $app = Factory::getApplication();
         $this->setState('message', $app->getUserState('com_installer.message'));
         $this->setState('extension_message', $app->getUserState('com_installer.extension_message'));

--- a/administrator/components/com_installer/src/Model/UpdatesitesModel.php
+++ b/administrator/components/com_installer/src/Model/UpdatesitesModel.php
@@ -466,6 +466,40 @@ class UpdatesitesModel extends InstallerModel
      */
     protected function populateState($ordering = 'name', $direction = 'asc')
     {
+        // Load the filter state.
+        $stateKeys = [
+            'search'    => 'string',
+            'client_id' => 'int',
+            'enabled'   => 'string',
+            'type'      => 'string',
+            'folder'    => 'string',
+            'supported' => 'int',
+        ];
+
+        foreach ($stateKeys as $key => $filterType) {
+            $stateKey = 'filter.' . $key;
+
+            switch ($filterType) {
+                case 'int':
+                case 'bool':
+                    $default = null;
+                    break;
+
+                default:
+                    $default = '';
+                    break;
+            }
+
+            $stateValue = $this->getUserStateFromRequest(
+                $this->context . '.' . $stateKey,
+                'filter_' . $key,
+                $default,
+                $filterType
+            );
+
+            $this->setState($stateKey, $stateValue);
+        }
+
         parent::populateState($ordering, $direction);
     }
 

--- a/administrator/components/com_languages/src/Model/InstalledModel.php
+++ b/administrator/components/com_languages/src/Model/InstalledModel.php
@@ -101,6 +101,9 @@ class InstalledModel extends ListModel
      */
     protected function populateState($ordering = 'name', $direction = 'asc')
     {
+        // Load the filter state.
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+
         // Special case for client id.
         $clientId = (int) $this->getUserStateFromRequest($this->context . '.client_id', 'client_id', 0, 'int');
         $clientId = (!\in_array($clientId, [0, 1])) ? 0 : $clientId;

--- a/administrator/components/com_languages/src/Model/OverridesModel.php
+++ b/administrator/components/com_languages/src/Model/OverridesModel.php
@@ -165,7 +165,13 @@ class OverridesModel extends ListModel
         $client          = substr($language_client, -1);
         $language        = substr($language_client, 0, -1);
 
+        // Sets the search filter.
+        $search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
+        $this->setState('filter.search', $search);
+
         $this->setState('language_client', $language . $client);
+        $this->setState('filter.client', $client ? 'administrator' : 'site');
+        $this->setState('filter.language', $language);
 
         // Add the 'language_client' value to the session to display a message if none selected
         $app->setUserState('com_languages.overrides.language_client', $language . $client);

--- a/administrator/components/com_menus/src/Model/ItemsModel.php
+++ b/administrator/components/com_menus/src/Model/ItemsModel.php
@@ -103,6 +103,21 @@ class ItemsModel extends ListModel
             $this->context .= '.' . $forcedLanguage;
         }
 
+        $search = $this->getUserStateFromRequest($this->context . '.search', 'filter_search');
+        $this->setState('filter.search', $search);
+
+        $published = $this->getUserStateFromRequest($this->context . '.published', 'filter_published', '');
+        $this->setState('filter.published', $published);
+
+        $access = $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access');
+        $this->setState('filter.access', $access);
+
+        $parentId = $this->getUserStateFromRequest($this->context . '.filter.parent_id', 'filter_parent_id');
+        $this->setState('filter.parent_id', $parentId);
+
+        $level = $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level');
+        $this->setState('filter.level', $level);
+
         // Watch changes in client_id and menutype and keep sync whenever needed.
         $currentClientId = $app->getUserState($this->context . '.client_id', 0);
         $clientId        = $app->getInput()->getInt('client_id', $currentClientId);

--- a/administrator/components/com_menus/src/Model/MenusModel.php
+++ b/administrator/components/com_menus/src/Model/MenusModel.php
@@ -213,6 +213,9 @@ class MenusModel extends ListModel
      */
     protected function populateState($ordering = 'a.ordering', $direction = 'asc')
     {
+        $search   = $this->getUserStateFromRequest($this->context . '.search', 'filter_search');
+        $this->setState('filter.search', $search);
+
         $clientId = (int) $this->getUserStateFromRequest($this->context . '.client_id', 'client_id', 0, 'int');
         $this->setState('client_id', $clientId);
 

--- a/administrator/components/com_modules/src/Model/ModulesModel.php
+++ b/administrator/components/com_modules/src/Model/ModulesModel.php
@@ -92,10 +92,21 @@ class ModulesModel extends ListModel
         // Make context client aware
         $this->context .= '.' . $app->getInput()->get->getInt('client_id', 0);
 
+        // Load the filter state.
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+        $this->setState('filter.position', $this->getUserStateFromRequest($this->context . '.filter.position', 'filter_position', '', 'string'));
+        $this->setState('filter.module', $this->getUserStateFromRequest($this->context . '.filter.module', 'filter_module', '', 'string'));
+        $this->setState('filter.menuitem', $this->getUserStateFromRequest($this->context . '.filter.menuitem', 'filter_menuitem', '', 'cmd'));
+        $this->setState('filter.access', $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access', '', 'cmd'));
+
         // If in modal layout on the frontend, state and language are always forced.
         if ($app->isClient('site') && $layout === 'modal') {
             $this->setState('filter.language', 'current');
             $this->setState('filter.state', 1);
+        } else {
+            // If in backend (modal or not) we get the same fields from the user request.
+            $this->setState('filter.language', $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '', 'string'));
+            $this->setState('filter.state', $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'string'));
         }
 
         // Special case for the client id.

--- a/administrator/components/com_modules/src/Model/PositionsModel.php
+++ b/administrator/components/com_modules/src/Model/PositionsModel.php
@@ -63,6 +63,19 @@ class PositionsModel extends ListModel
      */
     protected function populateState($ordering = 'ordering', $direction = 'asc')
     {
+        // Load the filter state.
+        $search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
+        $this->setState('filter.search', $search);
+
+        $state = $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state', '', 'string');
+        $this->setState('filter.state', $state);
+
+        $template = $this->getUserStateFromRequest($this->context . '.filter.template', 'filter_template', '', 'string');
+        $this->setState('filter.template', $template);
+
+        $type = $this->getUserStateFromRequest($this->context . '.filter.type', 'filter_type', '', 'string');
+        $this->setState('filter.type', $type);
+
         // Special case for the client id.
         $clientId = (int) $this->getUserStateFromRequest($this->context . '.client_id', 'client_id', 0, 'int');
         $clientId = (!\in_array((int) $clientId, [0, 1])) ? 0 : (int) $clientId;

--- a/administrator/components/com_privacy/src/Model/ConsentsModel.php
+++ b/administrator/components/com_privacy/src/Model/ConsentsModel.php
@@ -158,6 +158,22 @@ class ConsentsModel extends ListModel
      */
     protected function populateState($ordering = 'a.id', $direction = 'desc')
     {
+        // Load the filter state.
+        $this->setState(
+            'filter.search',
+            $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search')
+        );
+
+        $this->setState(
+            'filter.subject',
+            $this->getUserStateFromRequest($this->context . '.filter.subject', 'filter_subject')
+        );
+
+        $this->setState(
+            'filter.state',
+            $this->getUserStateFromRequest($this->context . '.filter.state', 'filter_state')
+        );
+
         // Load the parameters.
         $this->setState('params', ComponentHelper::getParams('com_privacy'));
 

--- a/administrator/components/com_privacy/src/Model/RequestsModel.php
+++ b/administrator/components/com_privacy/src/Model/RequestsModel.php
@@ -146,6 +146,22 @@ class RequestsModel extends ListModel
      */
     protected function populateState($ordering = 'a.id', $direction = 'desc')
     {
+        // Load the filter state.
+        $this->setState(
+            'filter.search',
+            $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search')
+        );
+
+        $this->setState(
+            'filter.status',
+            $this->getUserStateFromRequest($this->context . '.filter.status', 'filter_status', '', 'int')
+        );
+
+        $this->setState(
+            'filter.request_type',
+            $this->getUserStateFromRequest($this->context . '.filter.request_type', 'filter_request_type', '', 'string')
+        );
+
         // Load the parameters.
         $this->setState('params', ComponentHelper::getParams('com_privacy'));
 

--- a/administrator/components/com_templates/src/Model/StylesModel.php
+++ b/administrator/components/com_templates/src/Model/StylesModel.php
@@ -70,6 +70,11 @@ class StylesModel extends ListModel
         $app = Factory::getApplication();
 
         if (!$app->isClient('api')) {
+            // Load the filter state.
+            $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+            $this->setState('filter.template', $this->getUserStateFromRequest($this->context . '.filter.template', 'filter_template', '', 'string'));
+            $this->setState('filter.menuitem', $this->getUserStateFromRequest($this->context . '.filter.menuitem', 'filter_menuitem', '', 'cmd'));
+
             // Special case for the client id.
             $clientId = (int) $this->getUserStateFromRequest($this->context . '.client_id', 'client_id', 0, 'int');
             $clientId = !\in_array($clientId, [0, 1]) ? 0 : $clientId;

--- a/administrator/components/com_templates/src/Model/TemplatesModel.php
+++ b/administrator/components/com_templates/src/Model/TemplatesModel.php
@@ -206,6 +206,9 @@ class TemplatesModel extends ListModel
      */
     protected function populateState($ordering = 'a.element', $direction = 'asc')
     {
+        // Load the filter state.
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
+
         // Special case for the client id.
         $clientId = (int) $this->getUserStateFromRequest($this->context . '.client_id', 'client_id', 0, 'int');
         $clientId = (!\in_array($clientId, [0, 1])) ? 0 : $clientId;

--- a/administrator/components/com_users/src/Model/DebuggroupModel.php
+++ b/administrator/components/com_users/src/Model/DebuggroupModel.php
@@ -119,6 +119,7 @@ class DebuggroupModel extends ListModel
         }
 
         // Load the filter state.
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
         $this->setState('group_id', $this->getUserStateFromRequest($this->context . '.group_id', 'group_id', 0, 'int', false));
 
         $levelStart = $this->getUserStateFromRequest($this->context . '.filter.level_start', 'filter_level_start', '', 'cmd');

--- a/administrator/components/com_users/src/Model/DebuguserModel.php
+++ b/administrator/components/com_users/src/Model/DebuguserModel.php
@@ -125,6 +125,7 @@ class DebuguserModel extends ListModel implements UserFactoryAwareInterface
         }
 
         // Load the filter state.
+        $this->setState('filter.search', $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search', '', 'string'));
         $this->setState('user_id', $this->getUserStateFromRequest($this->context . '.user_id', 'user_id', 0, 'int', false));
 
         $levelStart = $this->getUserStateFromRequest($this->context . '.filter.level_start', 'filter_level_start', '', 'cmd');


### PR DESCRIPTION


### Summary of Changes

This reverts (#43230)

Clearly the code is used and cannot simply be removed as was done in the original pr


### Testing Instructions
This is for 5.2 only
Clear all session storage, cookies etc
Log in to the admin and go to the system page

### Actual result BEFORE applying this Pull Request
Language Overrides - error undefined constant
Update Sites - no results


### Expected result AFTER applying this Pull Request
All works as expected


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
