### PR TITLE
[5.2] PHPStan integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -38,6 +38,13 @@ steps:
     commands:
       - ./libraries/vendor/bin/phan
 
+  - name: phpstan
+    image: joomlaprojects/docker-images:php8.2
+    depends_on: [ phpcs ]
+    failure: ignore
+    commands:
+      - ./libraries/vendor/bin/phpstan
+
   - name: npm
     image: node:20-bullseye-slim
     depends_on: [ phpcs ]
@@ -430,6 +437,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 66d331abed02e76707b26cbf12fef3ec4506858cc748acdb5aee2c256e92ba4f
+hmac: 74b2bf309c95831161344b6812bfe6f5140e4438c4db679af08213373109d316
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,13 +31,6 @@ steps:
       - ./libraries/vendor/bin/phpcs --extensions=php -p --standard=ruleset.xml .
       - echo $(date)
 
-  - name: phan
-    image: joomlaprojects/docker-images:php8.1-ast
-    depends_on: [ phpcs ]
-    failure: ignore
-    commands:
-      - ./libraries/vendor/bin/phan
-
   - name: phpstan
     image: joomlaprojects/docker-images:php8.2
     depends_on: [ phpcs ]
@@ -437,6 +430,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 74b2bf309c95831161344b6812bfe6f5140e4438c4db679af08213373109d316
+hmac: 903759c59028cc757ba3faef044e3b9122d00f99ea0367caadceb710cb88030f
 
 ...

--- a/build/build.php
+++ b/build/build.php
@@ -73,6 +73,7 @@ function clean_checkout(string $dir)
     system('find . -name psalm.xml.dist | xargs rm -rf -');
     system('find . -name phpcs.xml | xargs rm -rf -');
     system('find . -name phpcs.xml.dist | xargs rm -rf -');
+    system('find . -name phpstan.neon | xargs rm -rf -');
     system('find . -name phpunit.xml | xargs rm -rf -');
     system('find . -name phpunit.*.xml | xargs rm -rf -');
     system('find . -name phpunit.xml.dist | xargs rm -rf -');
@@ -407,6 +408,7 @@ $doNotPackage = [
     'package-lock.json',
     'package.json',
     'phpunit-pgsql.xml.dist',
+    'phpstan.neon',
     'phpunit.xml.dist',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.ini',
     'plugins/sampledata/testing/language/en-GB/en-GB.plg_sampledata_testing.sys.ini',

--- a/build/phpstan/joomla-bootstrap.php
+++ b/build/phpstan/joomla-bootstrap.php
@@ -1,0 +1,30 @@
+<?php
+
+/**
+ * @package    Joomla.Build
+ *
+ * @copyright  (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @phpcs:disable PSR1.Classes.ClassDeclaration.MissingNamespace
+ */
+
+\define('_JEXEC', 1);
+\define('JPATH_PLATFORM', 1);
+\define('JPATH_BASE', \dirname(__DIR__, 2));
+
+
+// Load the Joomla class loader
+require_once JPATH_BASE . '/includes/defines.php';
+
+require_once JPATH_LIBRARIES . '/loader.php';
+JLoader::setup();
+require_once JPATH_LIBRARIES . '/vendor/autoload.php';
+
+// Rector crashes as it is inside a phar
+//require_once JPATH_BASE . '/libraries/bootstrap.php';
+
+// Load the extension namespaces
+JLoader::register('JNamespacePsr4Map', JPATH_LIBRARIES . '/namespacemap.php');
+$map = new JNamespacePsr4Map();
+$map->load();

--- a/build/phpstan/joomla-bootstrap.php
+++ b/build/phpstan/joomla-bootstrap.php
@@ -13,16 +13,13 @@
 \define('JPATH_PLATFORM', 1);
 \define('JPATH_BASE', \dirname(__DIR__, 2));
 
-
-// Load the Joomla class loader
+// Load the Joomla environment
 require_once JPATH_BASE . '/includes/defines.php';
 
+// Load the Joomla class loader
 require_once JPATH_LIBRARIES . '/loader.php';
 JLoader::setup();
 require_once JPATH_LIBRARIES . '/vendor/autoload.php';
-
-// Rector crashes as it is inside a phar
-//require_once JPATH_BASE . '/libraries/bootstrap.php';
 
 // Load the extension namespaces
 JLoader::register('JNamespacePsr4Map', JPATH_LIBRARIES . '/namespacemap.php');

--- a/build/phpstan/phpstan.neon
+++ b/build/phpstan/phpstan.neon
@@ -1,0 +1,48 @@
+parameters:
+	bootstrapFiles:
+		- joomla-bootstrap.php
+	stubFiles:
+		- stubs/AdminModel.stub
+		- stubs/Language.stub
+		- stubs/CMSApplication.stub
+	universalObjectCratesClasses:
+		- Joomla\CMS\Object\CMSObject
+		- Joomla\CMS\Table\Table
+		- Joomla\Component\Finder\Administrator\Indexer\Result
+	earlyTerminatingMethodCalls:
+		Joomla\CMS\Application\CMSApplicationInterface:
+			- close
+
+services:
+	-
+		class: Joomla\PHPStan\DynamicReturnType\DIContainer
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: Joomla\PHPStan\DynamicReturnType\ExtensionManagerInterface
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: Joomla\PHPStan\DynamicReturnType\ModelBootComponent
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: Joomla\PHPStan\DynamicReturnType\MVCFactoryInterfaceInterface
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: Joomla\PHPStan\DynamicReturnType\ControllerLoader
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: Joomla\PHPStan\DynamicReturnType\ViewModelLoader
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: Joomla\PHPStan\DynamicReturnType\ModelTableLoader
+		tags:
+			- phpstan.broker.dynamicMethodReturnTypeExtension
+	-
+		class: Joomla\PHPStan\Reflection\FormField
+		tags:
+			- phpstan.broker.propertiesClassReflectionExtension

--- a/build/phpstan/src/DynamicReturnType/ControllerLoader.php
+++ b/build/phpstan/src/DynamicReturnType/ControllerLoader.php
@@ -66,7 +66,7 @@ class ControllerLoader extends NamespaceBased
             }
         }
 
-        // Search in all namespaces, eg. when a admin model is loaded on site
+        // Search in all namespaces, eg. when an admin model is loaded on site
         foreach ($this->getNamespaces() as $ns => $path) {
             foreach (['Model', 'View'] as $type) {
                 if (($methodReflection->getName() !== 'create' . $type && $methodReflection->getName() !== 'get' . $type)

--- a/build/phpstan/src/DynamicReturnType/ControllerLoader.php
+++ b/build/phpstan/src/DynamicReturnType/ControllerLoader.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * @package     Joomla.Build
+ * @subpackage  phpstan
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\PHPStan\DynamicReturnType;
+
+use Joomla\CMS\MVC\Controller\BaseController;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class ControllerLoader extends NamespaceBased
+{
+    public function getClass(): string
+    {
+        return BaseController::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return \in_array($methodReflection->getName(), ['getModel', 'createModel', 'getView', 'createView']);
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        $name   = '';
+        $prefix = '';
+
+        if (\count($methodCall->getArgs()) === 0) {
+            $name = str_replace('Controller', '', $scope->getClassReflection()->getNativeReflection()->getShortName());
+        }
+
+        if (\count($methodCall->getArgs()) < 2) {
+            $prefix = strpos($scope->getNamespace(), 'Site') ? 'Site' : 'Administrator';
+        }
+
+        if (\count($methodCall->getArgs()) > 0) {
+            $name = str_replace("'", '', $methodCall->getArgs()[0]->value->getAttribute('rawValue'));
+        }
+
+        if (\count($methodCall->getArgs()) > 1) {
+            $prefix = str_replace("'", '', $methodCall->getArgs()[1]->value->getAttribute('rawValue'));
+        }
+
+        if (!$name || !$prefix) {
+            return null;
+        }
+
+        // Search in namespaces which belong to the defined prefix
+        foreach ($this->findNamespaces($prefix) as $ns => $path) {
+            foreach (['Model', 'View'] as $type) {
+                if (($methodReflection->getName() !== 'create' . $type && $methodReflection->getName() !== 'get' . $type)
+                    || !class_exists($ns . $type . '\\' . $name . $type)) {
+                    continue;
+                }
+
+                return new ObjectType($ns . $type . '\\' . $name . $type);
+            }
+        }
+
+        // Search in all namespaces, eg. when a admin model is loaded on site
+        foreach ($this->getNamespaces() as $ns => $path) {
+            foreach (['Model', 'View'] as $type) {
+                if (($methodReflection->getName() !== 'create' . $type && $methodReflection->getName() !== 'get' . $type)
+                    || !class_exists($ns . $type . '\\' . $name . $type)) {
+                    continue;
+                }
+
+                return new ObjectType($ns . $type . '\\' . $name . $type);
+            }
+        }
+
+        return null;
+    }
+}

--- a/build/phpstan/src/DynamicReturnType/DIContainer.php
+++ b/build/phpstan/src/DynamicReturnType/DIContainer.php
@@ -1,0 +1,43 @@
+<?php
+
+/**
+ * @package     Joomla.Build
+ * @subpackage  phpstan
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\PHPStan\DynamicReturnType;
+
+use Joomla\DI\Container;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class DIContainer implements DynamicMethodReturnTypeExtension
+{
+    public function getClass(): string
+    {
+        return Container::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'get';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        if (\count($methodCall->getArgs()) === 0) {
+            return null;
+        }
+
+        $arg = $methodCall->getArgs()[0]->value;
+
+        return new ObjectType($scope->getType($arg)->getValue());
+    }
+}

--- a/build/phpstan/src/DynamicReturnType/DIContainer.php
+++ b/build/phpstan/src/DynamicReturnType/DIContainer.php
@@ -38,9 +38,11 @@ class DIContainer implements DynamicMethodReturnTypeExtension
 
         $arg  = $methodCall->getArgs()[0]->value;
         $type = $scope->getType($arg);
-        if(!method_exists($type, 'getValue')) {
+
+        if (!method_exists($type, 'getValue')) {
             return null;
         }
+
         return new ObjectType($type->getValue());
     }
 }

--- a/build/phpstan/src/DynamicReturnType/DIContainer.php
+++ b/build/phpstan/src/DynamicReturnType/DIContainer.php
@@ -36,8 +36,11 @@ class DIContainer implements DynamicMethodReturnTypeExtension
             return null;
         }
 
-        $arg = $methodCall->getArgs()[0]->value;
-
-        return new ObjectType($scope->getType($arg)->getValue());
+        $arg  = $methodCall->getArgs()[0]->value;
+        $type = $scope->getType($arg);
+        if(!method_exists($type, 'getValue')) {
+            return null;
+        }
+        return new ObjectType($type->getValue());
     }
 }

--- a/build/phpstan/src/DynamicReturnType/ExtensionManagerInterface.php
+++ b/build/phpstan/src/DynamicReturnType/ExtensionManagerInterface.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @package     Joomla.Build
+ * @subpackage  phpstan
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\PHPStan\DynamicReturnType;
+
+use Joomla\CMS\Extension\ExtensionManagerInterface as CMSExtensionManagerInterface;
+use Joomla\CMS\Extension\MVCComponent;
+use Joomla\CMS\Plugin\CMSPlugin;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class ExtensionManagerInterface extends NamespaceBased
+{
+    public function getClass(): string
+    {
+        return CMSExtensionManagerInterface::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return \in_array($methodReflection->getName(), ['bootComponent', 'bootPlugin']);
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        if (\count($methodCall->getArgs()) === 0) {
+            return null;
+        }
+
+        $name = str_replace(["'", 'com_'], ['', ''], $methodCall->getArgs()[0]->value->getAttribute('rawValue'));
+        $type = \count($methodCall->getArgs()) > 1 ? str_replace("'", '', $methodCall->getArgs()[1]->value->getAttribute('rawValue')) : '';
+
+        // Component class
+        if (!$type && $namespace = $this->findNamespace('\\Component\\' . $name . '\\Administrator')) {
+            $class = $namespace . 'Extension\\' . ucfirst($name) . 'Component';
+            if (!class_exists($class)) {
+                // Try to determine the real name
+                $class = $namespace . 'Extension\\' . substr($namespace, strpos($namespace, 'Component\\') + 10, \strlen($name)) . 'Component';
+            }
+
+            if (!class_exists($class)) {
+                $class = MVCComponent::class;
+            }
+
+            return new ObjectType($class);
+        }
+
+        // Plugin class
+        if ($type && $namespace = $this->findNamespace('\\Plugin\\' . $type . '\\' . $name)) {
+            $class = $namespace . 'Extension\\' . $name;
+            if (!class_exists($class)) {
+                $class = CMSPlugin::class;
+            }
+
+            return new ObjectType($class);
+        }
+
+        return null;
+    }
+}

--- a/build/phpstan/src/DynamicReturnType/MVCFactoryInterfaceInterface.php
+++ b/build/phpstan/src/DynamicReturnType/MVCFactoryInterfaceInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * @package     Joomla.Build
+ * @subpackage  phpstan
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\PHPStan\DynamicReturnType;
+
+use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class MVCFactoryInterfaceInterface extends NamespaceBased
+{
+    public function getClass(): string
+    {
+        return MVCFactoryInterface::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return \in_array($methodReflection->getName(), ['createController', 'createModel', 'createView', 'createTable']);
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        if (\count($methodCall->getArgs()) === 0) {
+            return null;
+        }
+
+        $name   = str_replace("'", '', $methodCall->getArgs()[0]->value->getAttribute('rawValue'));
+        $prefix = str_replace("'", '', $methodCall->getArgs()[1]->value->getAttribute('rawValue'));
+
+        foreach ($this->findNamespaces($prefix) as $ns => $path) {
+            foreach (['Controller', 'Model', 'View', 'Table'] as $type) {
+                if ($methodReflection->getName() !== 'create' . $type || !class_exists($ns . $type . '\\' . $name . $type)) {
+                    continue;
+                }
+
+                return new ObjectType($ns . $type . '\\' . $name . $type);
+            }
+        }
+
+        return null;
+    }
+}

--- a/build/phpstan/src/DynamicReturnType/ModelBootComponent.php
+++ b/build/phpstan/src/DynamicReturnType/ModelBootComponent.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * @package     Joomla.Build
+ * @subpackage  phpstan
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\PHPStan\DynamicReturnType;
+
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class ModelBootComponent extends NamespaceBased
+{
+    public function getClass(): string
+    {
+        return BaseDatabaseModel::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'bootComponent';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        if (\count($methodCall->getArgs()) === 0) {
+            return null;
+        }
+
+        $name = str_replace("'", '', $methodCall->getArgs()[0]->value->getAttribute('rawValue'));
+
+        if ($namespace = $this->findNamespace('\\Component\\' . $name . '\\Administrator')) {
+            return new ObjectType($namespace . 'Extension\\' . $name . 'Component');
+        }
+
+        return null;
+    }
+}

--- a/build/phpstan/src/DynamicReturnType/ModelTableLoader.php
+++ b/build/phpstan/src/DynamicReturnType/ModelTableLoader.php
@@ -1,0 +1,70 @@
+<?php
+
+/**
+ * @package     Joomla.Build
+ * @subpackage  phpstan
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\PHPStan\DynamicReturnType;
+
+use Joomla\CMS\MVC\Model\BaseDatabaseModel;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class ModelTableLoader extends NamespaceBased
+{
+    public function getClass(): string
+    {
+        return BaseDatabaseModel::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'getTable';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        $name   = '';
+        $prefix = '';
+
+        if (\count($methodCall->getArgs()) === 0) {
+            $name = end(explode('\\', $scope->getClassReflection()->getNativeReflection()->getShortName()));
+
+            // Some models have form as part of their name
+            $name = str_replace(['Model', 'form'], ['', ''], $name);
+        }
+
+        if (\count($methodCall->getArgs()) < 2) {
+            $prefix = 'Administrator';
+        }
+
+        if (\count($methodCall->getArgs()) > 0) {
+            $name = str_replace("'", '', $methodCall->getArgs()[0]->value->getAttribute('rawValue'));
+        }
+
+        if (\count($methodCall->getArgs()) > 1) {
+            $prefix = str_replace("'", '', $methodCall->getArgs()[1]->value->getAttribute('rawValue'));
+        }
+
+        if (!$name || !$prefix) {
+            return null;
+        }
+
+        foreach ($this->findNamespaces($prefix) as $ns => $path) {
+            if (!class_exists($ns . 'Table\\' . $name . 'Table')) {
+                continue;
+            }
+
+            return new ObjectType($ns . 'Table\\' . $name . 'Table');
+        }
+
+        return null;
+    }
+}

--- a/build/phpstan/src/DynamicReturnType/NamespaceBased.php
+++ b/build/phpstan/src/DynamicReturnType/NamespaceBased.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @package     Joomla.Build
+ * @subpackage  phpstan
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\PHPStan\DynamicReturnType;
+
+use PHPStan\Type\DynamicMethodReturnTypeExtension;
+
+abstract class NamespaceBased implements DynamicMethodReturnTypeExtension
+{
+    private array $namespaces = [];
+
+    /**
+     * Returns a list of namespaces.
+     */
+    protected function getNamespaces(): array
+    {
+        if (!$this->namespaces) {
+            $this->namespaces = require \dirname(__DIR__, 4) . '/administrator/cache/autoload_psr4.php';
+        }
+
+        return $this->namespaces;
+    }
+
+    /**
+     * Searches namespaces for the given name case insensitive.
+     */
+    protected function findNamespaces(string $name): array
+    {
+        $result = [];
+
+        foreach ($this->getNamespaces() as $ns => $path) {
+            if (!stripos($ns, $name)) {
+                continue;
+            }
+
+            $result[$ns] = $path;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Searches a namespace for the given name case insensitive.
+     */
+    protected function findNamespace(string $name): string
+    {
+        foreach ($this->getNamespaces() as $ns => $path) {
+            if (!stripos($ns, $name)) {
+                continue;
+            }
+
+            return $ns;
+        }
+
+        return '';
+    }
+}

--- a/build/phpstan/src/DynamicReturnType/ViewModelLoader.php
+++ b/build/phpstan/src/DynamicReturnType/ViewModelLoader.php
@@ -63,7 +63,7 @@ class ViewModelLoader extends NamespaceBased
             return new ObjectType($ns . 'Model\\' . $name . 'Model');
         }
 
-        // Search in all namespaces, eg. when a admin model is loaded on site
+        // Search in all namespaces, eg. when an admin model is loaded on site
         foreach ($this->getNamespaces() as $ns => $path) {
             if (!class_exists($ns . 'Model\\' . $name . 'Model')) {
                 continue;

--- a/build/phpstan/src/DynamicReturnType/ViewModelLoader.php
+++ b/build/phpstan/src/DynamicReturnType/ViewModelLoader.php
@@ -1,0 +1,77 @@
+<?php
+
+/**
+ * @package     Joomla.Build
+ * @subpackage  phpstan
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\PHPStan\DynamicReturnType;
+
+use Joomla\CMS\MVC\View\AbstractView;
+use PhpParser\Node\Expr\MethodCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+
+class ViewModelLoader extends NamespaceBased
+{
+    public function getClass(): string
+    {
+        return AbstractView::class;
+    }
+
+    public function isMethodSupported(MethodReflection $methodReflection): bool
+    {
+        return $methodReflection->getName() === 'getModel';
+    }
+
+    public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): ?Type
+    {
+        $name   = '';
+        $prefix = '';
+
+        if (\count($methodCall->getArgs()) === 0) {
+            $name = end(explode('\\', $scope->getNamespace()));
+        }
+
+        if (\count($methodCall->getArgs()) < 2) {
+            $prefix = strpos($scope->getNamespace(), 'Site') ? 'Site' : 'Administrator';
+        }
+
+        if (\count($methodCall->getArgs()) > 0) {
+            $name = str_replace("'", '', $methodCall->getArgs()[0]->value->getAttribute('rawValue'));
+        }
+
+        if (\count($methodCall->getArgs()) > 1) {
+            $prefix = str_replace("'", '', $methodCall->getArgs()[1]->value->getAttribute('rawValue'));
+        }
+
+        if (!$name || !$prefix) {
+            return null;
+        }
+
+        // Search in namespaces which belong to the defined prefix
+        foreach ($this->findNamespaces($prefix) as $ns => $path) {
+            if (!class_exists($ns . 'Model\\' . $name . 'Model')) {
+                continue;
+            }
+
+            return new ObjectType($ns . 'Model\\' . $name . 'Model');
+        }
+
+        // Search in all namespaces, eg. when a admin model is loaded on site
+        foreach ($this->getNamespaces() as $ns => $path) {
+            if (!class_exists($ns . 'Model\\' . $name . 'Model')) {
+                continue;
+            }
+
+            return new ObjectType($ns . 'Model\\' . $name . 'Model');
+        }
+
+        return null;
+    }
+}

--- a/build/phpstan/src/Reflection/FormField.php
+++ b/build/phpstan/src/Reflection/FormField.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @package     Joomla.Build
+ * @subpackage  phpstan
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\PHPStan\Reflection;
+
+use Joomla\CMS\Form\FormField as CMSFormField;
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertiesClassReflectionExtension;
+use PHPStan\Reflection\PropertyReflection;
+
+class FormField implements PropertiesClassReflectionExtension
+{
+    public function hasProperty(ClassReflection $classReflection, string $propertyName): bool
+    {
+        if (!$classReflection->is(CMSFormField::class)) {
+            return false;
+        }
+
+        return $classReflection->hasNativeProperty($propertyName);
+    }
+
+    public function getProperty(ClassReflection $classReflection, string $propertyName): PropertyReflection
+    {
+        return new FormFieldProperty($classReflection, $propertyName);
+    }
+}

--- a/build/phpstan/src/Reflection/FormFieldProperty.php
+++ b/build/phpstan/src/Reflection/FormFieldProperty.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @package     Joomla.Build
+ * @subpackage  phpstan
+ *
+ * @copyright   (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\PHPStan\Reflection;
+
+use PHPStan\Reflection\ClassReflection;
+use PHPStan\Reflection\PropertyReflection;
+use PHPStan\TrinaryLogic;
+use PHPStan\Type\Type;
+
+class FormFieldProperty implements PropertyReflection
+{
+    public function __construct(
+        private ClassReflection $classReflection,
+        private string $propertyName
+    ) {
+    }
+
+    public function getDeclaringClass(): ClassReflection
+    {
+        return $this->classReflection;
+    }
+
+    public function isStatic(): bool
+    {
+        return false;
+    }
+
+    public function isPrivate(): bool
+    {
+        return false;
+    }
+
+    public function isPublic(): bool
+    {
+        return true;
+    }
+
+    public function getDocComment(): ?string
+    {
+        return '';
+    }
+
+    public function getReadableType(): Type
+    {
+        return $this->classReflection->getNativeProperty($this->propertyName)->getReadableType();
+    }
+
+    public function getWritableType(): Type
+    {
+        return $this->classReflection->getNativeProperty($this->propertyName)->getWritableType();
+    }
+
+    public function canChangeTypeAfterAssignment(): bool
+    {
+        return true;
+    }
+
+    public function isReadable(): bool
+    {
+        return true;
+    }
+
+    public function isWritable(): bool
+    {
+        return true;
+    }
+
+    public function isInternal(): TrinaryLogic
+    {
+        return $this->classReflection->getNativeProperty($this->propertyName)->isInternal();
+    }
+
+    public function isDeprecated(): TrinaryLogic
+    {
+        return $this->classReflection->getNativeProperty($this->propertyName)->isDeprecated();
+    }
+
+    public function getDeprecatedDescription(): ?string
+    {
+        return '';
+    }
+}

--- a/build/phpstan/stubs/AdminModel.stub
+++ b/build/phpstan/stubs/AdminModel.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace Joomla\CMS\MVC\Model;
+
+class AdminModel
+{
+	/**
+	 * @param   mixed  $pk
+	 *
+	 * @return \stdClass|false
+     */
+    public function getItem($pk);
+}

--- a/build/phpstan/stubs/CMSApplication.stub
+++ b/build/phpstan/stubs/CMSApplication.stub
@@ -1,0 +1,13 @@
+<?php
+
+namespace Joomla\CMS\Application;
+
+class CMSApplication
+{
+	/**
+     * @param   boolean  $params  True to return the template parameters
+     *
+     * @return  ($params is false ? string : \stdClass)
+     */
+    public function getTemplate($params = false);
+}

--- a/build/phpstan/stubs/Language.stub
+++ b/build/phpstan/stubs/Language.stub
@@ -1,0 +1,16 @@
+<?php
+
+namespace Joomla\CMS\Language;
+
+class Language
+{
+	/**
+	 * As the framework package has the _ function deprecated and the CMS one not, PHPStan will report it as deprecated.
+	 * We revert that.
+	 *
+     * @not-deprecated
+	 *
+	 * @return string
+     */
+    public function _();
+}

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Joomla\\Tests\\": "tests"
+      "Joomla\\Tests\\": "tests",
+      "Joomla\\PHPStan\\": "build/phpstan/src"
     }
   },
   "require": {
@@ -115,7 +116,9 @@
     "dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
     "joomla/mediawiki": "^3.0",
     "joomla/test": "~3.0",
-    "phan/phan": "^5.4.3"
+    "phan/phan": "^5.4.3",
+    "phpstan/phpstan": "^1.11.10",
+    "phpstan/phpstan-deprecation-rules": "^1.2.0"
   },
   "replace": {
     "paragonie/random_compat": "9.99.99",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b25e220b440613ef9279a3625e03eb71",
+    "content-hash": "def311e0931f49c024ac61673999cfea",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -8162,6 +8162,111 @@
                 "source": "https://github.com/phpstan/phpdoc-parser/tree/1.29.1"
             },
             "time": "2024-05-31T08:52:43+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.11.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "640410b32995914bde3eed26fa89552f9c2c082f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/640410b32995914bde3eed26fa89552f9c2c082f",
+                "reference": "640410b32995914bde3eed26fa89552f9c2c082f",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "keywords": [
+                "dev",
+                "static analysis"
+            ],
+            "support": {
+                "docs": "https://phpstan.org/user-guide/getting-started",
+                "forum": "https://github.com/phpstan/phpstan/discussions",
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "security": "https://github.com/phpstan/phpstan/security/policy",
+                "source": "https://github.com/phpstan/phpstan-src"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-08T09:02:50+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-deprecation-rules",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-deprecation-rules.git",
+                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-deprecation-rules/zipball/fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
+                "reference": "fa8cce7720fa782899a0aa97b6a41225d1bb7b26",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpstan/phpstan": "^1.11"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan rules for detecting usage of deprecated classes, methods, properties, constants and traits.",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-deprecation-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-deprecation-rules/tree/1.2.0"
+            },
+            "time": "2024-04-20T06:39:48+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,6 +6,7 @@ includes:
 parameters:
 	level: 0
 	phpVersion: 80100
+	reportUnmatchedIgnoredErrors: false
 	scanDirectories:
 		- libraries/php-encryption
 		- libraries/phpass

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,45 @@
+
+includes:
+	- libraries/vendor/phpstan/phpstan-deprecation-rules/rules.neon
+	- build/phpstan/phpstan.neon
+
+parameters:
+	level: 0
+	phpVersion: 80100
+	scanDirectories:
+		- libraries/php-encryption
+		- libraries/phpass
+	scanFiles:
+		- libraries/loader.php
+		- libraries/namespacemap.php
+	paths:
+		- libraries/src
+		- administrator
+		- components
+		- installation
+		- plugins
+	excludePaths:
+		- administrator/cache
+		- administrator/components/com_joomlaupdate/finalisation.php
+	ignoreErrors:
+		-
+			message: '#Access to protected property [a-zA-Z0-9\\_]+\\HtmlView::\$[a-zA-Z0-9\\_]+.#'
+			paths:
+				- components/*
+				- administrator/components/*
+		-
+			message: '#Call to protected method [a-zA-Z0-9\\_]+\(\) of class Joomla\\CMS\\MVC\\View\\AbstractView\.#'
+			paths:
+				- components/*
+				- administrator/components/*
+		-
+			message: '#Call to protected method [a-zA-Z0-9\\_]+\(\) of class Joomla\\CMS\\MVC\\View\\HtmlView\.#'
+			paths:
+				- components/*
+				- administrator/components/*
+		-
+			message: '#Call to protected method [a-zA-Z0-9\\_]+\(\) of class Joomla\\CMS\\.*\.#'
+			paths:
+				- plugins/*
+		-
+			message: '#Call to deprecated method \_\(\) of class Joomla\\CMS\\Language\\Language.*#'


### PR DESCRIPTION
Pull Request for pr #43819.

### Summary of Changes
Integrates PHPStan into core. It uses the CMS setup from #43819 and the stubs, reflection and dynamic return types from the [DPDocker code analyze task](https://github.com/Digital-Peak/DPDocker/blob/main/code/config/phpstan.neon). The later can be used by extension developers in a similar way how the CMS is using it by including the build/phpstan/phpstan.neon into the main phpstan.neon of their extension.

### Testing Instructions
Is all for system tests only, but if you want to check it out locally, do a `composer install` of the branch and then `libraries/vendor/bin/phpstan` on the command line.
