### PR TITLE
[5.2] Partial revert of #43230

### DIFF
--- a/administrator/components/com_installer/src/Model/UpdatesitesModel.php
+++ b/administrator/components/com_installer/src/Model/UpdatesitesModel.php
@@ -554,7 +554,7 @@ class UpdatesitesModel extends InstallerModel
 
         // Process select filters.
         $supported = $this->getState('filter.supported');
-        $enabled   = $this->getState('filter.enabled');
+        $enabled   = $this->getState('filter.enabled', '');
         $type      = $this->getState('filter.type');
         $clientId  = $this->getState('filter.client_id');
         $folder    = $this->getState('filter.folder');

--- a/administrator/components/com_languages/src/Model/OverridesModel.php
+++ b/administrator/components/com_languages/src/Model/OverridesModel.php
@@ -165,7 +165,13 @@ class OverridesModel extends ListModel
         $client          = substr($language_client, -1);
         $language        = substr($language_client, 0, -1);
 
+        // Sets the search filter.
+        $search = $this->getUserStateFromRequest($this->context . '.filter.search', 'filter_search');
+        $this->setState('filter.search', $search);
+
         $this->setState('language_client', $language . $client);
+        $this->setState('filter.client', $client ? 'administrator' : 'site');
+        $this->setState('filter.language', $language);
 
         // Add the 'language_client' value to the session to display a message if none selected
         $app->setUserState('com_languages.overrides.language_client', $language . $client);


### PR DESCRIPTION
### Summary of Changes
#43230 broke the Language Overrides list view and the list view for updatesites. This PR fixes that again.


### Testing Instructions
1. Install a clean 5.2-dev Joomla installation
2. Go to the list of language overrides
3. Go to the list of updatesites


### Actual result BEFORE applying this Pull Request
Language overrides throws a hard error, updatesites doesn't show any updatesites.


### Expected result AFTER applying this Pull Request
Language overrides works as expected, updatesites shows a list of updatesites.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
