### PR TITLE
[5.2] Update deleted files list in script.php for 5.2.0-beta1

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2340,6 +2340,23 @@ class JoomlaInstallerScript
             '/libraries/vendor/maximebf/debugbar/src/DebugBar/Resources/vendor/font-awesome/fonts/fontawesome-webfont.ttf',
             '/libraries/vendor/maximebf/debugbar/src/DebugBar/Resources/vendor/font-awesome/fonts/fontawesome-webfont.woff',
             '/libraries/vendor/maximebf/debugbar/src/DebugBar/Resources/vendor/font-awesome/fonts/fontawesome-webfont.woff2',
+            // From 5.2.0-alpha3 to 5.2.0-beta1
+            '/libraries/vendor/joomla/application/rector.php',
+            '/libraries/vendor/joomla/console/.drone.jsonnet',
+            '/libraries/vendor/joomla/console/.drone.yml',
+            '/libraries/vendor/joomla/database/.drone.jsonnet',
+            '/libraries/vendor/joomla/database/.drone.yml',
+            '/libraries/vendor/joomla/database/phpunit.appveyor_sql2012sp1.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.appveyor_sql2014.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.appveyor_sql2017.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.mariadb.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.mysql.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.mysqli.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.pgsql.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.sqlite.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.sqlsrv.xml.dist',
+            '/libraries/vendor/joomla/session/.drone.jsonnet',
+            '/libraries/vendor/joomla/session/.drone.yml',
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in file `administrator/components/com_admin/script.php` in the 5.2-dev branch in preparation for the next 5.2.0-beta1 release.

All files added by this PR are deleted due to the update the joomla framework composer dependencies, where developer-only files are not shipped anymore.

Code review, or if you want to do a real test:

Update a 5.2.0-alpha3 to a current 5.2-dev build which contains the changes from the merged PR #43939 to get the actual result, and update a 5.2.0-alpha3 to the patched package created by Drone for this PR to get the expected result.

To create a current 5.2-dev build, open a Linux or WSL shell, change to the base folder of your git clone, checkout the 5.2-dev branch of the CMS repo or update your 5.2-dev branch to that (upstream) and then run:
```
php ./build/build.php --remote=HEAD --exclude-gzip --exclude-zstd
```

And here you can find the patched update package or custom update URL created by Drone for this PR: https://artifacts.joomla.org/drone/joomla/joomla-cms/5.2-dev/43942/downloads/78194/Joomla_5.2.0-alpha4-dev+pr.43942-Development-Update_Package.zip

### Actual result BEFORE applying this Pull Request

The files added by this PR to file `administrator/components/com_admin/script.php` are still present after the update.

### Expected result AFTER applying this Pull Request

The files added by this PR to file `administrator/components/com_admin/script.php` have been removed with the update.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
