### PR TITLE
[5.1] Update deleted files list in script.php for 5.1.3

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2333,6 +2333,23 @@ class JoomlaInstallerScript
             '/libraries/vendor/cweagans/composer-patches/src/Patches.php',
             '/libraries/vendor/cweagans/composer-patches/tests/PatchEventTest.php',
             '/libraries/vendor/laminas/laminas-diactoros/PATCHES.txt',
+            // From 5.1.2 to 5.1.3
+            '/libraries/vendor/joomla/application/rector.php',
+            '/libraries/vendor/joomla/console/.drone.jsonnet',
+            '/libraries/vendor/joomla/console/.drone.yml',
+            '/libraries/vendor/joomla/database/.drone.jsonnet',
+            '/libraries/vendor/joomla/database/.drone.yml',
+            '/libraries/vendor/joomla/database/phpunit.appveyor_sql2012sp1.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.appveyor_sql2014.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.appveyor_sql2017.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.mariadb.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.mysql.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.mysqli.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.pgsql.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.sqlite.xml.dist',
+            '/libraries/vendor/joomla/database/phpunit.sqlsrv.xml.dist',
+            '/libraries/vendor/joomla/session/.drone.jsonnet',
+            '/libraries/vendor/joomla/session/.drone.yml',
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in file `administrator/components/com_admin/script.php` in the 5.1-dev branch in preparation for the next 5.1.3 release.

All files added by this PR are deleted due to the update the joomla framework composer dependencies, where developer-only files are not shipped anymore.

Code review, or if you want to do a real test:

Update a 5.1.2 to a current 5.1-dev build which contains the changes from the merged PR #43943 to get the actual result, and update a 5.1.2 to the patched package created by Drone for this PR to get the expected result.

To create a current 5.1-dev build, open a Linux or WSL shell, change to the base folder of your git clone, checkout the 5.1-dev branch of the CMS repo or update your 5.1-dev branch to that (upstream) and then run:
```
php ./build/build.php --remote=HEAD --exclude-gzip --exclude-zstd
```

And here you can find the patched update package or custom update URL created by Drone for this PR: https://artifacts.joomla.org/drone/joomla/joomla-cms/5.1-dev/43944/downloads/78199/Joomla_5.1.3-rc2-dev+pr.43944-Development-Update_Package.zip

### Actual result BEFORE applying this Pull Request

The files added by this PR to file `administrator/components/com_admin/script.php` are still present after the update.

### Expected result AFTER applying this Pull Request

The files added by this PR to file `administrator/components/com_admin/script.php` have been removed with the update.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
