### PR TITLE
Feature/4 4 docblock typo

### DIFF
--- a/libraries/src/Factory.php
+++ b/libraries/src/Factory.php
@@ -178,7 +178,7 @@ abstract class Factory
      * @deprecated  4.3 will be removed in 6.0
      *              Use the configuration object within the application
      *              Example:
-     *              Factory::getApplication->getConfig();
+     *              Factory::getApplication()->getConfig();
      */
     public static function getConfig($file = null, $type = 'PHP', $namespace = '')
     {
@@ -556,7 +556,7 @@ abstract class Factory
      *
      * @deprecated  4.0 will be removed in 6.0
      *              Use the configuration object within the application.
-     *              Example: Factory::getApplication->getConfig();
+     *              Example: Factory::getApplication()->getConfig();
      */
     protected static function createConfig($file, $type = 'PHP', $namespace = '')
     {

--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -62,7 +62,7 @@ trait LegacyModelLoaderTrait
      *
      * @deprecated  4.3 will be removed in 6.0
      *              Will be removed without replacement. Get the model through the MVCFactory instead
-     *              Example: Factory::getApplication->bootComponent('com_xxx')->getMVCFactory()->createModel($type, $prefix, $config);
+     *              Example: Factory::getApplication()->bootComponent('com_xxx')->getMVCFactory()->createModel($type, $prefix, $config);
      */
     public static function getInstance($type, $prefix = '', $config = [])
     {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This PR without any issue will fix some typos in DocBlock
When DocBlock states that some code is deprecated and comes with an alternative it would be nice if the alternative is free from typos.

### Testing Instructions

open mentioned files
look for the docblock of the changed lines
apply pr
and see changes in docblock.

this PR will not change any functionality of Joomla.
Just fixing typo in DocBlock


### Actual result BEFORE applying this Pull Request

```
     * @deprecated  4.0 will be removed in 6.0
     *              Use the configuration object within the application.
     *              Example: Factory::getApplication->getConfig();
     */
```


### Expected result AFTER applying this Pull Request

```
     * @deprecated  4.0 will be removed in 6.0
     *              Use the configuration object within the application.
     *              Example: Factory::getApplication()->getConfig();
     */
```


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
