### PR TITLE
[4.x] Fix paginated page links for com_finder and com_content archive

### DIFF
--- a/components/com_content/src/View/Archive/HtmlView.php
+++ b/components/com_content/src/View/Archive/HtmlView.php
@@ -220,6 +220,7 @@ class HtmlView extends BaseHtmlView
         $this->pagination = &$pagination;
         $this->pagination->setAdditionalUrlParam('month', $state->get('filter.month'));
         $this->pagination->setAdditionalUrlParam('year', $state->get('filter.year'));
+        $this->pagination->setAdditionalUrlParam('filter-search', $state->get('list.filter'));
         $this->pagination->setAdditionalUrlParam('catid', $app->input->get('catid', [], 'array'));
 
         $this->_prepareDocument();

--- a/components/com_content/src/View/Archive/HtmlView.php
+++ b/components/com_content/src/View/Archive/HtmlView.php
@@ -115,6 +115,7 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        $app        = Factory::getApplication();
         $user       = $this->getCurrentUser();
         $state      = $this->get('State');
         $items      = $this->get('Items');
@@ -219,6 +220,7 @@ class HtmlView extends BaseHtmlView
         $this->pagination = &$pagination;
         $this->pagination->setAdditionalUrlParam('month', $state->get('filter.month'));
         $this->pagination->setAdditionalUrlParam('year', $state->get('filter.year'));
+        $this->pagination->setAdditionalUrlParam('catid', $app->input->get('catid', [], 'array'));
 
         $this->_prepareDocument();
 

--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -155,14 +155,14 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
 
         // Add additional parameters
         $queryParameterList = [
-            "f"  => "int",
-            "t"  => "array",
-            "q"  => "string",
-            "l"  => "cmd",
-            "d1" => "string",
-            "d2" => "string",
-            "w1" => "string",
-            "w2" => "string",
+            'f'  => 'int',
+            't'  => 'array',
+            'q'  => 'string',
+            'l'  => 'cmd',
+            'd1' => 'string',
+            'd2' => 'string',
+            'w1' => 'string',
+            'w2' => 'string',
         ];
 
         foreach ($queryParameterList as $parameter => $filter) {

--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -153,6 +153,28 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
         // Flag indicates to not add limitstart=0 to URL
         $this->pagination->hideEmptyLimitstart = true;
 
+        // Add additional parameters
+        $queryParameterList = [
+            "f" => "int",
+            "t" => "array",
+            "q" => "string",
+            "l" => "cmd",
+            "d1" => "string",
+            "d2" => "string",
+            "w1" => "string",
+            "w2" => "string"
+        ];
+
+        foreach ($queryParameterList as $parameter => $filter) {
+            $value = $app->input->get($parameter, null, $filter);
+
+            if (is_null($value)) {
+                continue;
+            }
+
+            $this->pagination->setAdditionalUrlParam($parameter, $value);
+        }
+
         // Check for errors.
         if (count($errors = $this->get('Errors'))) {
             throw new GenericDataException(implode("\n", $errors), 500);

--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -155,14 +155,14 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
 
         // Add additional parameters
         $queryParameterList = [
-            "f" => "int",
-            "t" => "array",
-            "q" => "string",
-            "l" => "cmd",
+            "f"  => "int",
+            "t"  => "array",
+            "q"  => "string",
+            "l"  => "cmd",
             "d1" => "string",
             "d2" => "string",
             "w1" => "string",
-            "w2" => "string"
+            "w2" => "string",
         ];
 
         foreach ($queryParameterList as $parameter => $filter) {

--- a/libraries/src/Cache/Cache.php
+++ b/libraries/src/Cache/Cache.php
@@ -687,7 +687,7 @@ class Cache
             'view'   => 'WORD',
             'layout' => 'WORD',
             'tpl'    => 'CMD',
-            'id'     => 'INT',
+            'id'     => 'STRING',
         ];
 
         // Use platform defaults if parameter doesn't already exist.

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -675,7 +675,7 @@ class Pagination
             'templateStyle' => 'INT',
             'tmpl'          => 'CMD',
             'tpl'           => 'CMD',
-            'id'            => 'INT',
+            'id'            => 'STRING',
             'Itemid'        => 'INT',
         ];
 

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -665,21 +665,27 @@ class Pagination
 
         // Platform defaults
         $defaultUrlParams = [
-            'format' => 'WORD',
-            'option' => 'WORD',
-            'view'   => 'WORD',
-            'layout' => 'WORD',
-            'tpl'    => 'CMD',
-            'id'     => 'INT',
-            'Itemid' => 'INT',
+            'format'        => 'WORD',
+            'option'        => 'WORD',
+            'controller'    => 'WORD',
+            'view'          => 'WORD',
+            'layout'        => 'STRING',
+            'task'          => 'CMD',
+            'template'      => 'CMD',
+            'templateStyle' => 'INT',
+            'tmpl'          => 'CMD',
+            'tpl'           => 'CMD',
+            'id'            => 'INT',
+            'Itemid'        => 'INT',
         ];
 
         // Prepare the routes
         $params = [];
+        $input = $this->app->getInput();
 
         // Use platform defaults if parameter doesn't already exist.
         foreach ($defaultUrlParams as $param => $filter) {
-            $value = $this->app->input->get($param, null, $filter);
+            $value = $input->get($param, null, $filter);
 
             if ($value === null) {
                 continue;

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -681,7 +681,7 @@ class Pagination
 
         // Prepare the routes
         $params = [];
-        $input = $this->app->getInput();
+        $input  = $this->app->getInput();
 
         // Use platform defaults if parameter doesn't already exist.
         foreach ($defaultUrlParams as $param => $filter) {


### PR DESCRIPTION
### Summary of Changes
The 4.4.7 and 5.1.3 security release broke the pagination in com_finder (thanks Phil for reporting) and the com_content archive view.


### Testing Instructions
Create a test site with a sufficient amount of articles to get a paginated result for the com_finder search results. Click on the pagination links.

Furthermore create an archive view with a sufficient amount of articles that filters for a specific category.


### Actual result BEFORE applying this Pull Request
* finder: Search parameters and search word are lost.
* archive: catid parameter is lost

### Expected result AFTER applying this Pull Request
* finder: Search parameters and search word are appended to the URL.
* archive: catid parameter is appended

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
