### PR TITLE
[4.4] Pagination fixes part 2

### DIFF
--- a/components/com_content/src/View/Archive/HtmlView.php
+++ b/components/com_content/src/View/Archive/HtmlView.php
@@ -221,7 +221,7 @@ class HtmlView extends BaseHtmlView
         $this->pagination->setAdditionalUrlParam('month', $state->get('filter.month'));
         $this->pagination->setAdditionalUrlParam('year', $state->get('filter.year'));
         $this->pagination->setAdditionalUrlParam('filter-search', $state->get('list.filter'));
-        $this->pagination->setAdditionalUrlParam('catid', $app->input->get('catid', [], 'array'));
+        $this->pagination->setAdditionalUrlParam('catid', $app->getInput()->get->get('catid', [], 'array'));
 
         $this->_prepareDocument();
 

--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -165,7 +165,7 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
             'd2' => 'string',
             'w1' => 'string',
             'w2' => 'string',
-            'o' => 'word',
+            'o'  => 'word',
             'od' => 'word',
         ];
 

--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -153,6 +153,8 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
         // Flag indicates to not add limitstart=0 to URL
         $this->pagination->hideEmptyLimitstart = true;
 
+        $input = $app->getInput()->get;
+
         // Add additional parameters
         $queryParameterList = [
             'f'  => 'int',
@@ -163,10 +165,12 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
             'd2' => 'string',
             'w1' => 'string',
             'w2' => 'string',
+            'o' => 'word',
+            'od' => 'word',
         ];
 
         foreach ($queryParameterList as $parameter => $filter) {
-            $value = $app->input->get($parameter, null, $filter);
+            $value = $input->get($parameter, null, $filter);
 
             if (is_null($value)) {
                 continue;

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -681,7 +681,7 @@ class Pagination
 
         // Prepare the routes
         $params = [];
-        $input  = $this->app->getInput()->get;
+        $input  = $this->app->getInput();
 
         // Use platform defaults if parameter doesn't already exist.
         foreach ($defaultUrlParams as $param => $filter) {

--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -681,7 +681,7 @@ class Pagination
 
         // Prepare the routes
         $params = [];
-        $input  = $this->app->getInput();
+        $input  = $this->app->getInput()->get;
 
         // Use platform defaults if parameter doesn't already exist.
         foreach ($defaultUrlParams as $param => $filter) {


### PR DESCRIPTION
### Summary of Changes
The 4.4.7 and 5.1.3 security release broke the pagination in com_finder  and the com_content archive view. Furthermore, parameters were read from $_REQUEST and not from $_GET.


### Testing Instructions
Enable the "Show Sort Fields" setting in the Smart Search menu item (under Advanced).
Then use the ordering fields to change the order, in a result set that has several pages and try to change page.


### Actual result BEFORE applying this Pull Request
* The ordering field and direction are vanished.

### Expected result AFTER applying this Pull Request
* The ordering field and direction are kept.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
