### PR TITLE
[cypress] Add db_port in Installation.cy.js

### DIFF
--- a/tests/System/integration/install/Installation.cy.js
+++ b/tests/System/integration/install/Installation.cy.js
@@ -8,6 +8,7 @@ describe('Install Joomla', () => {
       email: Cypress.env('email'),
       db_type: Cypress.env('db_type'),
       db_host: Cypress.env('db_host'),
+      db_port: Cypress.env('db_port'),
       db_user: Cypress.env('db_user'),
       db_password: Cypress.env('db_password'),
       db_name: Cypress.env('db_name'),


### PR DESCRIPTION
Pull Request as a puzzle piece of Issue #43902

### Summary of Changes

In the installation step of the system tests, support for the configuration of the database port is added.

### Testing Instructions

The only isolated test that can be carried out for this change is that it does no harm.

You could see this PR is already used as *hack* in [Joomla Branches Tester](https://github.com/muhme/joomla-branches-tester). There you can see it working in `scripts/cypress.sh 44 local` and running the `Installation.cy.js` step. Without the change (you have to comment-out the change in `tests/System/integration/install/Installation.cy.js` the Joomla Web Installer fails with:
```
Could not connect to the database. Connector returned error message: No such file or directory
```

### Actual result BEFORE applying this Pull Request

The System Tests installation step cannot set the database port.

### Expected result AFTER applying this Pull Request

The System Tests installation step can set the database port.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
