### PR TITLE
Change 'option' filter in Pagination.php from WORD to CMD

### DIFF
--- a/libraries/src/Pagination/Pagination.php
+++ b/libraries/src/Pagination/Pagination.php
@@ -666,7 +666,7 @@ class Pagination
         // Platform defaults
         $defaultUrlParams = [
             'format' => 'WORD',
-            'option' => 'WORD',
+            'option' => 'CMD',
             'view'   => 'WORD',
             'layout' => 'WORD',
             'tpl'    => 'CMD',


### PR DESCRIPTION
Changed the default 'option' parameter value from 'WORD' to 'CMD'.

### Summary of Changes
This modification ensures that components with numbers in their names (e.g., com_example123) are correctly recognized and processed by the Joomla pagination system. Previously, the WORD filter would strip out numeric characters, causing issues when routing to components with numeric names.


### Testing Instructions
Create a component with numbers in its name (e.g., com_example123).
Implement pagination in the component.
Navigate through the paginated views of the component.
Verify the URL includes the full name of the component, including numbers, when you move through pages.
Confirm the component functions correctly and that the pagination operates as expected without errors.


### Actual result BEFORE applying this Pull Request
URLs for paginated pages would strip numbers from the option parameter, leading to incorrect routing.
Components with numbers in their names could not be correctly identified by the system, causing potential 404 errors.


### Expected result AFTER applying this Pull Request
URLs for paginated pages will correctly retain numbers in the option parameter.
Components with numeric characters in their names will be properly recognized and routed, ensuring they function as expected without issues.


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed

- [x] No documentation changes for manual.joomla.org needed
