### PR TITLE
[4.4] new dates for supported php versions

### DIFF
--- a/plugins/quickicon/phpversioncheck/src/Extension/PhpVersionCheck.php
+++ b/plugins/quickicon/phpversioncheck/src/Extension/PhpVersionCheck.php
@@ -137,15 +137,15 @@ final class PhpVersionCheck extends CMSPlugin implements SubscriberInterface
             ],
             '8.1' => [
                 'security' => '2023-11-25',
-                'eos'      => '2024-11-25',
+                'eos'      => '2025-12-31',
             ],
             '8.2' => [
-                'security' => '2024-12-08',
-                'eos'      => '2025-12-08',
+                'security' => '2024-12-31',
+                'eos'      => '2026-12-31',
             ],
             '8.3' => [
-                'security' => '2025-11-23',
-                'eos'      => '2026-11-23',
+                'security' => '2025-12-31',
+                'eos'      => '2027-12-31',
             ],
         ];
 


### PR DESCRIPTION
### Summary of Changes

Since 25 August 2024, the following text has been output in the backend when using PHP 8.1:

`Your PHP version, 8.1.x, is only receiving security fixes from the PHP project at this time. This means your PHP version will soon no longer be supported. We recommend planning to upgrade to a newer PHP version before it reaches end of support on 2024-11-25. Joomla will be faster and more secure if you upgrade to a newer PHP version. Please contact your host for upgrade instructions.`

A value from https://github.com/joomla/joomla-cms/blob/9c9dd251450d7f87dd44cee45f1c22255c86c7dc/plugins/quickicon/phpversioncheck/src/Extension/PhpVersionCheck.php#L140 is used for the date.
Unfortunately, this value is out of date and will be corrected with this PR in accordance with https://www.php.net/supported-versions.php.

### Testing Instructions

Use Joomla! 4.4 with PHP 8.1.x

### Actual result BEFORE applying this Pull Request

The above message should be displayed.

### Expected result AFTER applying this Pull Request

The above message should no longer be displayed.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
