### PR TITLE
[4.x] Fix default language value for taxonomy rows

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Result.php
+++ b/administrator/components/com_finder/src/Indexer/Result.php
@@ -427,7 +427,7 @@ class Result implements \Serializable
      *
      * @since   4.0.0
      */
-    public function addNestedTaxonomy($branch, ImmutableNodeInterface $contentNode, $state = 1, $access = 1, $language = '')
+    public function addNestedTaxonomy($branch, ImmutableNodeInterface $contentNode, $state = 1, $access = 1, $language = '*')
     {
         // We can't add taxonomies with empty titles
         if (!trim($contentNode->title)) {

--- a/administrator/components/com_finder/src/Indexer/Result.php
+++ b/administrator/components/com_finder/src/Indexer/Result.php
@@ -392,7 +392,7 @@ class Result implements \Serializable
      *
      * @since   2.5
      */
-    public function addTaxonomy($branch, $title, $state = 1, $access = 1, $language = '')
+    public function addTaxonomy($branch, $title, $state = 1, $access = 1, $language = '*')
     {
         // We can't add taxonomies with empty titles
         if (!trim($title)) {

--- a/administrator/components/com_finder/src/Indexer/Taxonomy.php
+++ b/administrator/components/com_finder/src/Indexer/Taxonomy.php
@@ -68,7 +68,7 @@ class Taxonomy
         $node->state     = $state;
         $node->access    = $access;
         $node->parent_id = 1;
-        $node->language  = '';
+        $node->language  = '*';
 
         return self::storeNode($node, 1);
     }
@@ -87,7 +87,7 @@ class Taxonomy
      * @since   2.5
      * @throws  \RuntimeException on database error.
      */
-    public static function addNode($branch, $title, $state = 1, $access = 1, $language = '')
+    public static function addNode($branch, $title, $state = 1, $access = 1, $language = '*')
     {
         // Get the branch id, insert it if it does not exist.
         $branchId = static::addBranch($branch);
@@ -116,7 +116,7 @@ class Taxonomy
      *
      * @since   4.0.0
      */
-    public static function addNestedNode($branch, NodeInterface $node, $state = 1, $access = 1, $language = '', $branchId = null)
+    public static function addNestedNode($branch, NodeInterface $node, $state = 1, $access = 1, $language = '*', $branchId = null)
     {
         if (!$branchId) {
             // Get the branch id, insert it if it does not exist.


### PR DESCRIPTION
### Summary of Changes
So far com_finder taxonomy rows had an empty string as default parameter for the language column. Taxonomy rows with that empty string became unselectable one the multilanguage feature was enabled, as the language filter only filtered for the current language and the * character, see:
https://github.com/joomla/joomla-cms/blob/4.4-dev/administrator/components/com_finder/src/Service/HTML/Filter.php#L306


### Testing Instructions
* Run the finder indexer, view the #__finder_taxonomy table and check the taxonomy column values. 
* Apply the patch. 
* Reindex
* Check the DB table again


### Actual result BEFORE applying this Pull Request
Rows with empty string.


### Expected result AFTER applying this Pull Request
Rows with empty strings are now using * as value


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
