### PR TITLE
[5.3] Remove calls to JLoader::register() from core code

### DIFF
--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -248,7 +248,9 @@ class ActionlogsHelper
             $prefix = ucfirst(str_replace('com_', '', $component));
             $cName  = $prefix . 'Helper';
 
-            \JLoader::register($cName, $file);
+            if (!class_exists($cName)) {
+                require_once $file;
+            }
 
             if (class_exists($cName) && \is_callable([$cName, 'getContentTypeLink'])) {
                 return $cName::getContentTypeLink($contentType, $id, $object);

--- a/administrator/components/com_categories/src/Model/CategoriesModel.php
+++ b/administrator/components/com_categories/src/Model/CategoriesModel.php
@@ -437,7 +437,10 @@ class CategoriesModel extends ListModel
         }
 
         $hname = $cname . 'HelperAssociation';
-        \JLoader::register($hname, JPATH_SITE . '/components/' . $component . '/helpers/association.php');
+
+        if (!class_exists($hname)) {
+            require_once JPATH_SITE . '/components/' . $component . '/helpers/association.php';
+        }
 
         $this->hasAssociation = class_exists($hname) && !empty($hname::$category_association);
 

--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -440,7 +440,9 @@ class CategoryModel extends AdminModel
             if (file_exists($path)) {
                 $cName = ucfirst($eName) . ucfirst($section) . 'HelperCategory';
 
-                \JLoader::register($cName, $path);
+                if (!class_exists($cName)) {
+                    require_once $path;
+                }
 
                 if (class_exists($cName) && \is_callable([$cName, 'onPrepareForm'])) {
                     $lang->load($component, JPATH_BASE, null, false, false)
@@ -1302,7 +1304,10 @@ class CategoryModel extends AdminModel
         }
 
         $hname = $cname . 'HelperAssociation';
-        \JLoader::register($hname, JPATH_SITE . '/components/' . $component . '/helpers/association.php');
+
+        if (!class_exists($hname)) {
+            require_once JPATH_SITE . '/components/' . $component . '/helpers/association.php';
+        }
 
         $this->hasAssociation = class_exists($hname) && !empty($hname::$category_association);
 

--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -24,7 +24,9 @@ use Joomla\Database\ParameterType;
 use Joomla\Database\QueryInterface;
 use Joomla\Registry\Registry;
 
-\JLoader::register('JoomlaInstallerScript', JPATH_ADMINISTRATOR . '/components/com_admin/script.php');
+if (!class_exists('JoomlaInstallerScript')) {
+    require_once JPATH_ADMINISTRATOR . '/components/com_admin/script.php';
+}
 
 /**
  * Installer Database Model

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -689,7 +689,9 @@ ENDDATA;
         $installer->setPath('extension_root', JPATH_ROOT);
 
         // Run the script file.
-        \JLoader::register('JoomlaInstallerScript', JPATH_ADMINISTRATOR . '/components/com_admin/script.php');
+        if (!class_exists('JoomlaInstallerScript')) {
+            require_once JPATH_ADMINISTRATOR . '/components/com_admin/script.php';
+        }
 
         $msg           = '';
         $manifestClass = new \JoomlaInstallerScript();

--- a/components/com_ajax/ajax.php
+++ b/components/com_ajax/ajax.php
@@ -90,7 +90,9 @@ if (!$format) {
         }
 
         if ($results === null && is_file($helperFile)) {
-            JLoader::register($class, $helperFile);
+            if (!class_exists($class)) {
+                require_once $helperFile;
+            }
 
             if (method_exists($class, $method . 'Ajax')) {
                 // Load language file for module
@@ -175,7 +177,9 @@ if (!$format) {
         $method = $input->get('method') ?: 'get';
 
         if (is_file($helperFile)) {
-            JLoader::register($class, $helperFile);
+            if (!class_exists($class)) {
+                require_once $helperFile;
+            }
 
             if (method_exists($class, $method . 'Ajax')) {
                 // Load language file for template

--- a/components/com_tags/src/Helper/RouteHelper.php
+++ b/components/com_tags/src/Helper/RouteHelper.php
@@ -54,9 +54,12 @@ class RouteHelper extends CMSRouteHelper
         $explodedRouter = explode('::', $routerName);
 
         if (file_exists($routerFile = JPATH_BASE . '/components/' . $explodedAlias[0] . '/helpers/route.php')) {
-            \JLoader::register($explodedRouter[0], $routerFile);
             $routerClass  = $explodedRouter[0];
             $routerMethod = $explodedRouter[1];
+
+            if (!class_exists($routerClass)) {
+                require_once $routerFile;
+            }
 
             if (class_exists($routerClass) && method_exists($routerClass, $routerMethod)) {
                 if ($routerMethod === 'getCategoryRoute') {

--- a/libraries/src/Application/ExtensionNamespaceMapper.php
+++ b/libraries/src/Application/ExtensionNamespaceMapper.php
@@ -29,7 +29,9 @@ trait ExtensionNamespaceMapper
      */
     public function createExtensionNamespaceMap()
     {
-        \JLoader::register('JNamespacePsr4Map', JPATH_LIBRARIES . '/namespacemap.php');
+        if (!class_exists('JNamespacePsr4Map')) {
+            require_once JPATH_LIBRARIES . '/namespacemap.php';
+        }
         $extensionPsr4Loader = new \JNamespacePsr4Map();
         $extensionPsr4Loader->load();
     }

--- a/libraries/src/Cache/CacheStorage.php
+++ b/libraries/src/Cache/CacheStorage.php
@@ -165,7 +165,7 @@ class CacheStorage
                 throw new UnsupportedCacheException(sprintf('Unable to load Cache Storage: %s', $handler));
             }
 
-            \JLoader::register($class, $path);
+            require_once $path;
 
             // The class should now be loaded
             if (!class_exists($class)) {

--- a/libraries/src/Console/RemoveOldFilesCommand.php
+++ b/libraries/src/Console/RemoveOldFilesCommand.php
@@ -54,7 +54,9 @@ class RemoveOldFilesCommand extends AbstractCommand
         $symfonyStyle->title('Removing Unneeded Files & Folders' . ($dryRun ? ' - Dry Run' : ''));
 
         // We need the update script
-        \JLoader::register('JoomlaInstallerScript', JPATH_ADMINISTRATOR . '/components/com_admin/script.php');
+        if (!class_exists('JoomlaInstallerScript')) {
+            require_once JPATH_ADMINISTRATOR . '/components/com_admin/script.php';
+        }
 
         $status = (new \JoomlaInstallerScript())->deleteUnexistingFiles($dryRun, true);
 

--- a/libraries/src/Extension/LegacyComponent.php
+++ b/libraries/src/Extension/LegacyComponent.php
@@ -271,7 +271,7 @@ class LegacyComponent implements
             return false;
         }
 
-        \JLoader::register($className, $file);
+        require_once $file;
 
         if (!class_exists($className)) {
             return false;

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -159,7 +159,7 @@ abstract class HTMLHelper
                 throw new \InvalidArgumentException(sprintf('%s %s not found.', $prefix, $file), 500);
             }
 
-            \JLoader::register($className, $path);
+            require_once $path;
 
             if (!class_exists($className)) {
                 if ($prefix !== 'Joomla\\CMS\\HTML\\HTMLHelper') {
@@ -168,8 +168,6 @@ abstract class HTMLHelper
 
                 // @deprecated with 5.0 remove with 6.0 or 7.0 (depends on other relevant code)
                 $className = 'JHtml' . ucfirst($file);
-
-                \JLoader::register($className, $path);
 
                 if (!class_exists($className)) {
                     throw new \InvalidArgumentException(sprintf('%s not found.', $className), 500);

--- a/libraries/src/Installer/Installer.php
+++ b/libraries/src/Installer/Installer.php
@@ -2384,7 +2384,7 @@ class Installer extends Adapter implements DatabaseAwareInterface
             // Core adapters should autoload based on classname, keep this fallback just in case
             if (!class_exists($class)) {
                 // Try to load the adapter object
-                \JLoader::register($class, $this->_basepath . '/' . $this->_adapterfolder . '/' . $fileName);
+                require_once $this->_basepath . '/' . $this->_adapterfolder . '/' . $fileName;
 
                 if (!class_exists($class)) {
                     // Skip to next one

--- a/libraries/src/Installer/InstallerAdapter.php
+++ b/libraries/src/Installer/InstallerAdapter.php
@@ -980,7 +980,9 @@ abstract class InstallerAdapter implements ContainerAwareInterface, DatabaseAwar
 
             $classname = $this->getScriptClassName();
 
-            \JLoader::register($classname, $manifestScriptFile);
+            if (!class_exists($classname) && is_file($manifestScriptFile)) {
+                require_once $manifestScriptFile;
+            }
 
             if (!class_exists($classname)) {
                 return;

--- a/libraries/src/MVC/Factory/LegacyFactory.php
+++ b/libraries/src/MVC/Factory/LegacyFactory.php
@@ -101,7 +101,7 @@ class LegacyFactory implements MVCFactoryInterface
                 return null;
             }
 
-            \JLoader::register($viewClass, $path);
+            require_once $path;
 
             if (!class_exists($viewClass)) {
                 throw new \Exception(Text::sprintf('JLIB_APPLICATION_ERROR_VIEW_CLASS_NOT_FOUND', $viewClass, $path), 500);

--- a/libraries/src/MVC/View/ListView.php
+++ b/libraries/src/MVC/View/ListView.php
@@ -178,7 +178,9 @@ class ListView extends HtmlView
         $helperClass   = ucfirst($componentName . 'Helper');
 
         // Include the component helpers.
-        \JLoader::register($helperClass, JPATH_COMPONENT . '/helpers/' . $componentName . '.php');
+        if (!class_exists($helperClass) && is_file(JPATH_COMPONENT . '/helpers/' . $componentName . '.php')) {
+            require_once JPATH_COMPONENT . '/helpers/' . $componentName . '.php';
+        }
 
         if ($this->getLayout() !== 'modal') {
             if (\is_callable($helperClass . '::addSubmenu')) {

--- a/libraries/src/Service/Provider/Config.php
+++ b/libraries/src/Service/Provider/Config.php
@@ -43,7 +43,9 @@ class Config implements ServiceProviderInterface
                         return new Registry();
                     }
 
-                    \JLoader::register('JConfig', JPATH_CONFIGURATION . '/configuration.php');
+                    if (!class_exists('JConfig')) {
+                        require_once JPATH_CONFIGURATION . '/configuration.php';
+                    }
 
                     if (!class_exists('JConfig')) {
                         throw new \RuntimeException('Configuration class does not exist.');

--- a/plugins/finder/categories/src/Extension/Categories.php
+++ b/plugins/finder/categories/src/Extension/Categories.php
@@ -333,7 +333,9 @@ final class Categories extends Adapter implements SubscriberInterface
         $class = $extension . 'HelperRoute';
 
         // Need to import component route helpers dynamically, hence the reason it's handled here.
-        \JLoader::register($class, JPATH_SITE . '/components/' . $extension_element . '/helpers/route.php');
+        if (!class_exists($class)) {
+            require_once JPATH_SITE . '/components/' . $extension_element . '/helpers/route.php';
+        }
 
         if (class_exists($class) && method_exists($class, 'getCategoryRoute')) {
             $item->route = $class::getCategoryRoute($item->id, $item->language);

--- a/plugins/system/languagefilter/src/Extension/LanguageFilter.php
+++ b/plugins/system/languagefilter/src/Extension/LanguageFilter.php
@@ -769,7 +769,10 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
                 $cassociations = $component->getAssociationsExtension()->getAssociationsForItem();
             } else {
                 $cName = ucfirst(substr($option, 4)) . 'HelperAssociation';
-                \JLoader::register($cName, Path::clean(JPATH_SITE . '/components/' . $option . '/helpers/association.php'));
+
+                if (!class_exists($cName)) {
+                    require_once Path::clean(JPATH_SITE . '/components/' . $option . '/helpers/association.php');
+                }
 
                 if (class_exists($cName) && \is_callable([$cName, 'getAssociations'])) {
                     $cassociations = \call_user_func([$cName, 'getAssociations']);


### PR DESCRIPTION
### Summary of Changes
`JLoader::register()` is deprecated. This PR removes all calls to it from our codebase.


### Testing Instructions
Codereview.



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
