### PR TITLE
[4.4]Articles News : fix trigger event context

### DIFF
--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -172,7 +172,7 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
                 if ($featured) {
                     $context = 'com_content.featured';
                 }
-                
+
                 $app->triggerEvent('onContentPrepare', [$context, &$item, &$params, 0]);
 
                 $results                 = $app->triggerEvent('onContentAfterTitle', [$context, &$item, &$params, 0]);

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -167,15 +167,21 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
 
             if ($triggerEvents) {
                 $item->text = '';
-                $app->triggerEvent('onContentPrepare', ['com_content.article', &$item, &$params, 0]);
+                $context = 'com_content.category';
 
-                $results                 = $app->triggerEvent('onContentAfterTitle', ['com_content.article', &$item, &$params, 0]);
+               if ($featured) {
+                    $context = 'com_content.featured';
+                }
+                
+                $app->triggerEvent('onContentPrepare', [$context, &$item, &$params, 0]);
+
+                $results                 = $app->triggerEvent('onContentAfterTitle', [$context, &$item, &$params, 0]);
                 $item->afterDisplayTitle = trim(implode("\n", $results));
 
-                $results                    = $app->triggerEvent('onContentBeforeDisplay', ['com_content.article', &$item, &$params, 0]);
+                $results                    = $app->triggerEvent('onContentBeforeDisplay', [$context, &$item, &$params, 0]);
                 $item->beforeDisplayContent = trim(implode("\n", $results));
 
-                $results                   = $app->triggerEvent('onContentAfterDisplay', ['com_content.article', &$item, &$params, 0]);
+                $results                   = $app->triggerEvent('onContentAfterDisplay', [$context, &$item, &$params, 0]);
                 $item->afterDisplayContent = trim(implode("\n", $results));
             } else {
                 $item->afterDisplayTitle    = '';

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -167,9 +167,9 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
 
             if ($triggerEvents) {
                 $item->text = '';
-                $context = 'com_content.category';
+                $context    = 'com_content.category';
 
-               if ($featured) {
+                if ($featured) {
                     $context = 'com_content.featured';
                 }
                 


### PR DESCRIPTION
Articles News module uses com_content.article context to call content plugin when it should call com_content.featured or com_content.category context depending on module's parameters.

### Summary of Changes

Articles News module should behave like a blog view or a featured articles view as it displays categories articles, featured or not. Specific plugins working on blog view/featured view don't work.

This behaviour is conform with com_content/srv/View/Featured/HtmlView.php (line 159 and below)  and com_content/srv/View/Category/HtmlView.php (line 108 and below) use of triggerEvent commands 

### Testing Instructions

Set Trigger Plugin Events parameter in Articles News module.

### Actual result BEFORE applying this Pull Request

Articles News module calls content plugin with com_content.article context

### Expected result AFTER applying this Pull Request

Articles News module calls content plugin with com_content.featured or com_content.category context depending on its parameters

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
