### PR TITLE
[5.2] Smart Search: Refactor Queries when filling terms

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -500,7 +500,7 @@ class Indexer
             ' JOIN ' . $db->quoteName('#__finder_tokens') . ' AS t2 ON t2.term = t1.term AND t2.language = t1.language' .
             ' LEFT JOIN ' . $db->quoteName('#__finder_terms') . ' AS t ON t.term = t1.term AND t.language = t1.language' .
             ' WHERE t2.context = %d' .
-            ' GROUP BY t1.term, t.term_id, t1.term, t1.stem, t1.common, t1.phrase, t1.weight, t1.context, t1.language' .
+            ' GROUP BY t1.term, t1.language, t.term_id, t1.term, t1.stem, t1.common, t1.phrase, t1.weight, t1.context' .
             ' ORDER BY t1.term DESC';
 
         // Iterate through the contexts and aggregate the tokens per context.
@@ -532,7 +532,7 @@ class Indexer
             ' SELECT ta.term, ta.stem, ta.common, ta.phrase, ta.term_weight, SOUNDEX(ta.term), ta.language' .
             ' FROM ' . $db->quoteName('#__finder_tokens_aggregate') . ' AS ta' .
             ' WHERE ta.term_id = 0' .
-            ' GROUP BY ta.term, ta.stem, ta.common, ta.phrase, ta.term_weight, SOUNDEX(ta.term), ta.language'
+            ' GROUP BY ta.term, ta.language, ta.stem, ta.common, ta.phrase, ta.term_weight, SOUNDEX(ta.term)'
         );
         $db->execute();
 


### PR DESCRIPTION
### Summary of Changes
Smart Search in certain conditions fails the indexing process with a violation of the unique index on #__finder_terms. This is because of these wrong and overly complex queries. I actually can't explain why this is the case right now... I will investigate this further.


### Testing Instructions
I also don't have instructions on how to reliably recreate this right now.


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
