### PR TITLE
[4.4] Fix workflow transition task name in featured articles layout

### DIFF
--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -201,7 +201,7 @@ $assoc = Associations::isEnabled();
                                     'title' => Text::_($item->stage_title),
                                     'tip_content' => Text::sprintf('JWORKFLOW', Text::_($item->workflow_title)),
                                     'id' => 'workflow-' . $item->id,
-                                    'task' => 'articles.runTransitions'
+                                    'task' => 'articles.runTransition'
                                     ];
 
                                     echo (new TransitionButton($options))


### PR DESCRIPTION
### Summary of Changes
The workflow transition form in the featured articles view is using the wrong task name, therefore transitions are performed.


### Testing Instructions
Configure a site with workflows, perform a transition for an article in the "feature articles" list view in the backend using the button in the column.


### Actual result BEFORE applying this Pull Request
Transition not exectued


### Expected result AFTER applying this Pull Request
Transition executed.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x ] No documentation changes for manual.joomla.org needed
