### PR TITLE
[4.4] Fix start=0 in the pagination

### DIFF
--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -481,10 +481,11 @@ class SiteRouter extends Router
     {
         $limitstart = $uri->getVar('limitstart');
 
-        if ($limitstart !== null) {
-            $uri->setVar('start', (int) $uri->getVar('limitstart'));
-            $uri->delVar('limitstart');
+        if ($limitstart !== null && $limitstart !== '') {
+            $uri->setVar('start', (int) $limitstart);
         }
+
+        $uri->delVar('limitstart');
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue https://github.com/joomla/joomla-cms/issues/44049 .

### Summary of Changes

Fix removing of `start=0` from pagination for the first page.


### Testing Instructions

Visit Category Blog or another list view with pagination.
Visit second page, and check the link for first page.


### Actual result BEFORE applying this Pull Request
Link contain `start=0`


### Expected result AFTER applying this Pull Request
Link without `start=0`


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
