### PR TITLE
[5.2] Delete chromedriver binary from debugbar upon build

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -148,6 +148,9 @@ function clean_checkout(string $dir)
     system('rm -rf libraries/vendor/joomla/*/Tests');
     system('rm -rf libraries/vendor/joomla/*/ruleset.xml');
 
+    // maximebf/debugbar
+    system('rm -f libraries/vendor/maximebf/debugbar/chromedriver');
+
     // testing sampledata
     system('rm -rf plugins/sampledata/testing');
     system('rm -rf images/sampledata/parks');


### PR DESCRIPTION
### Summary of Changes
Our dependency maximebf/debugbar currently ships with a 20MB binary of the selenium chromedriver. A ticket has been opened for the maintainer to remove that: https://github.com/maximebf/php-debugbar/issues/683
Until a new release is made which doesn't contain this anymore, we are deleting this manually when building the release.

### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
