### PR TITLE
[4.4][Performance] Fix duplicated DB queries for ActionLog language loading

### DIFF
--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -268,6 +268,12 @@ class ActionlogsHelper
      */
     public static function loadActionLogPluginsLanguage()
     {
+        static $loaded;
+        if ($loaded) {
+            return;
+        }
+        $loaded = true;
+
         $lang = Factory::getLanguage();
         $db   = Factory::getDbo();
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix duplicated DB queries for ActionLog language loading


### Testing Instructions

Visit Home Dashboard with "Latest Actions" module enabled (with few actions in it).
Enable debug and debug Query in the debug plugin.
Check amount of DB queries in debug panel.



### Actual result BEFORE applying this Pull Request
In my test was 41 


### Expected result AFTER applying this Pull Request
In my test was 36 (5 less, depend how many latest actions in the module)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
