### PR TITLE
[5.3] PoC for b/c error handling

### DIFF
--- a/administrator/components/com_content/src/Controller/ArticlesController.php
+++ b/administrator/components/com_content/src/Controller/ArticlesController.php
@@ -101,10 +101,13 @@ class ArticlesController extends AdminController
         // Get the model.
         /** @var \Joomla\Component\Content\Administrator\Model\ArticleModel $model */
         $model = $this->getModel();
+        $model->setUseExceptions(true);
 
         // Publish the items.
-        if (!$model->featured($ids, $value)) {
-            $this->setRedirect(Route::_($redirectUrl, false), $model->getError(), 'error');
+        try {
+            $model->featured($ids, $value);
+        } catch (\Exception $e) {
+            $this->setRedirect(Route::_($redirectUrl, false), $e->getMessage(), 'error');
 
             return;
         }

--- a/administrator/components/com_content/src/Controller/FeaturedController.php
+++ b/administrator/components/com_content/src/Controller/FeaturedController.php
@@ -60,10 +60,13 @@ class FeaturedController extends ArticlesController
         } else {
             /** @var \Joomla\Component\Content\Administrator\Model\FeatureModel $model */
             $model = $this->getModel();
+            $model->setUseExceptions(true);
 
             // Remove the items.
-            if (!$model->featured($ids, 0)) {
-                $this->app->enqueueMessage($model->getError(), 'error');
+            try {
+                $model->featured($ids, 0);
+            } catch (\Exception $e) {
+                $this->app->enqueueMessage($e->getMessage(), 'error');
             }
         }
 

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -833,9 +833,13 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
         }
 
         if (empty($pks)) {
-            $this->setError(Text::_('COM_CONTENT_NO_ITEM_SELECTED'));
+            if (!$this->shouldUseExceptions()) {
+                $this->setError(Text::_('COM_CONTENT_NO_ITEM_SELECTED'));
 
-            return false;
+                return false;
+            }
+
+            throw new \Exception(Text::_('COM_CONTENT_NO_ITEM_SELECTED'));
         }
 
         $table = $this->getTable('Featured', 'Administrator');
@@ -856,9 +860,13 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
         );
 
         if ($eventResult->getArgument('abort', false)) {
-            $this->setError(Text::_($eventResult->getArgument('abortReason')));
+            if (!$this->shouldUseExceptions()) {
+                $this->setError(Text::_($eventResult->getArgument('abortReason')));
 
-            return false;
+                return false;
+            }
+
+            throw new \Exception(Text::_($eventResult->getArgument('abortReason')));
         }
 
         try {
@@ -938,9 +946,13 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
                 }
             }
         } catch (\Exception $e) {
-            $this->setError($e->getMessage());
+            if (!$this->shouldUseExceptions()) {
+                $this->setError($e->getMessage());
 
-            return false;
+                return false;
+            }
+
+            throw $e;
         }
 
         $table->reorder();

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -596,9 +596,13 @@ class ArticlesModel extends ListModel
                 $this->cache[$store] = $transitions;
             }
         } catch (\RuntimeException $e) {
-            $this->setError($e->getMessage());
+            if (!$this->shouldUseExceptions()) {
+                $this->setError($e->getMessage());
 
-            return false;
+                return false;
+            }
+
+            throw $e;
         }
 
         return $this->cache[$store];

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -108,27 +108,29 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
-        $this->vote          = PluginHelper::isEnabled('content', 'vote');
-        $this->hits          = ComponentHelper::getParams('com_content')->get('record_hits', 1) == 1;
+        $model = $this->getModel();
+        $model->setUseExceptions(true);
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
-            $this->setLayout('emptystate');
-        }
+        try {
+            $this->items         = $this->get('Items');
+            $this->pagination    = $this->get('Pagination');
+            $this->state         = $this->get('State');
+            $this->filterForm    = $this->get('FilterForm');
+            $this->activeFilters = $this->get('ActiveFilters');
+            $this->vote          = PluginHelper::isEnabled('content', 'vote');
+            $this->hits          = ComponentHelper::getParams('com_content')->get('record_hits', 1) == 1;
 
-        if (ComponentHelper::getParams('com_content')->get('workflow_enabled')) {
-            PluginHelper::importPlugin('workflow');
+            if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+                $this->setLayout('emptystate');
+            }
 
-            $this->transitions = $this->get('Transitions');
-        }
+            if (ComponentHelper::getParams('com_content')->get('workflow_enabled')) {
+                PluginHelper::importPlugin('workflow');
 
-        // Check for errors.
-        if (\count($errors = $this->get('Errors')) || $this->transitions === false) {
-            throw new GenericDataException(implode("\n", $errors), 500);
+                $this->transitions = $this->get('Transitions');
+            }
+        } catch (\Exception $e) {
+            throw new GenericDataException($e->getMessage(), 500, $e);
         }
 
         // We don't need toolbar in the modal window.

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
+use Joomla\Component\Content\Administrator\Model\ArticlesModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -108,15 +109,16 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var ArticlesModel $model */
         $model = $this->getModel();
         $model->setUseExceptions(true);
 
         try {
-            $this->items         = $this->get('Items');
-            $this->pagination    = $this->get('Pagination');
-            $this->state         = $this->get('State');
-            $this->filterForm    = $this->get('FilterForm');
-            $this->activeFilters = $this->get('ActiveFilters');
+            $this->items         = $model->getItems();
+            $this->pagination    = $model->getPagination();
+            $this->state         = $model->getState();
+            $this->filterForm    = $model->getFilterForm();
+            $this->activeFilters = $model->getActiveFilters();
             $this->vote          = PluginHelper::isEnabled('content', 'vote');
             $this->hits          = ComponentHelper::getParams('com_content')->get('record_hits', 1) == 1;
 
@@ -127,7 +129,7 @@ class HtmlView extends BaseHtmlView
             if (ComponentHelper::getParams('com_content')->get('workflow_enabled')) {
                 PluginHelper::importPlugin('workflow');
 
-                $this->transitions = $this->get('Transitions');
+                $this->transitions = $model->getTransitions();
             }
         } catch (\Exception $e) {
             throw new GenericDataException($e->getMessage(), 500, $e);

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -360,9 +360,13 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
             // Load the total and add the total to the internal cache.
             $this->cache[$store] = (int) $this->_getListCount($this->_getListQuery());
         } catch (\RuntimeException $e) {
-            $this->setError($e->getMessage());
+            if (!$this->shouldUseExceptions()) {
+                $this->setError($e->getMessage());
 
-            return false;
+                return false;
+            }
+
+            throw $e;
         }
 
         return $this->cache[$store];

--- a/libraries/src/Object/LegacyErrorHandlingTrait.php
+++ b/libraries/src/Object/LegacyErrorHandlingTrait.php
@@ -37,6 +37,15 @@ trait LegacyErrorHandlingTrait
     // phpcs:enable PSR2.Classes.PropertyDeclaration
 
     /**
+     * Use exceptions rather than getError/setError. This will default to true in Joomla 6 and removed in Joomla 7.
+     *
+     * @var          boolean
+     * @since        __DEPLOY_VERSION__
+     * @deprecated   7.0
+     */
+    private bool $useExceptions = false;
+
+    /**
      * Get the most recent error message.
      *
      * @param   integer  $i         Option error index.
@@ -103,5 +112,33 @@ trait LegacyErrorHandlingTrait
     public function setError($error)
     {
         $this->_errors[] = $error;
+    }
+
+    /**
+     * If true then subclasses should throw exceptions rather than use getError and setError.
+     *
+     * @return  boolean
+     *
+     * @since        __DEPLOY_VERSION__
+     * @deprecated   7.0
+     */
+    public function shouldUseExceptions(): bool
+    {
+        return $this->useExceptions;
+    }
+
+    /**
+     * If true then subclasses should throw exceptions rather than use getError and setError.
+     *
+     * @param   boolean   $value  The value to set for the field.
+     *
+     * @return  void
+     *
+     * @since        __DEPLOY_VERSION__
+     * @deprecated   7.0
+     */
+    public function setUseExceptions(bool $value): void
+    {
+        $this->useExceptions = $value;
     }
 }


### PR DESCRIPTION
### Summary of Changes
This is an attempt to implement an error handling which is backwards compatible to switch between legacy set/getError and throwing exceptions. Yes, this will mean a lot of code duplication due to setting the flag and when throwing an error, we have to have the code for both methods. The background is, that at some point we have to refactor the code to finally only use exceptions and in order to make this as simple as possible, I want this to be prepare in such a way that we only have to delete the old code and be done with it instead of having to again check each line of code and fixing it the right way. The moment we want to delete all of this, we can check for `$obj->setUseExceptions(true)` and delete that line and then look for the block with `$this->shouldUseExceptions()` and delete that. 


### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
