### PR TITLE
[5.2] [Guided Tours] Fix content and footer padding

### DIFF
--- a/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
+++ b/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
@@ -26,6 +26,7 @@
   border: 1px solid var(--border-color-translucent);
   border-radius: .3rem;
   box-shadow: var(--modal-joomla-dialog-box-shadow);
+  padding-bottom: 1rem;
 }
 
 .shepherd-content img {
@@ -69,7 +70,7 @@
 .shepherd-footer {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  padding: 1rem;
+  padding: 1rem 1rem 0;
 }
 
 .shepherd-button-primary {

--- a/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
+++ b/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
@@ -25,8 +25,8 @@
 .shepherd-content {
   border: 1px solid var(--border-color-translucent);
   border-radius: .3rem;
-  box-shadow: var(--modal-joomla-dialog-box-shadow);
   padding: 0 0 1rem;
+  box-shadow: var(--modal-joomla-dialog-box-shadow);
 }
 
 .shepherd-content img {

--- a/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
+++ b/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
@@ -26,7 +26,7 @@
   border: 1px solid var(--border-color-translucent);
   border-radius: .3rem;
   box-shadow: var(--modal-joomla-dialog-box-shadow);
-  padding-bottom: 1rem;
+  padding: 0 0 1rem;
 }
 
 .shepherd-content img {

--- a/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
+++ b/build/media_source/plg_system_guidedtours/scss/guidedtours.scss
@@ -23,9 +23,9 @@
 }
 
 .shepherd-content {
+  padding: 0 0 1rem;
   border: 1px solid var(--border-color-translucent);
   border-radius: .3rem;
-  padding: 0 0 1rem;
   box-shadow: var(--modal-joomla-dialog-box-shadow);
 }
 


### PR DESCRIPTION
Pull Request for Issue #44096.

### Summary of Changes

When footer buttons are missing, the step content has no bottom padding.

### Testing Instructions

There is no core tour that can show this behavior.

Create a new tour (with relative URL: administrator/index.php, Component selector: 'Home dashboard').

Create the following steps for the tour:

Step 1:
Position: Bottom
Target: .quickicon a[href*=com_config]
Type: Interactive
Interactive type: Form submit

Step 2:
Position: Bottom
Target: #toolbar-save
Type: Interactive
Interactive type: Form submit

Step 3:
Position: Center
Type: Next

It does not matter what you enter in titles and descriptions.

Run the tour.

Run other tours and make sure bottom padding is correct in the other tour(s) you run.

### Actual result BEFORE applying this Pull Request

No padding at the bottom of the popup in step 3.

![image](https://github.com/user-attachments/assets/5dc4bf67-f6d6-46f8-8ff4-25137824e451)

### Expected result AFTER applying this Pull Request

Padding at the bottom of the popup in step 3.

![image](https://github.com/user-attachments/assets/57446682-322f-4fcb-9053-16f4ffae5d42)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
