### PR TITLE
[5.2] [Guided Tours] The 'Welcome' tour contains unescaped quotes in a language string

### DIFF
--- a/administrator/language/en-GB/guidedtours.joomla_welcome.ini
+++ b/administrator/language/en-GB/guidedtours.joomla_welcome.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 COM_GUIDEDTOURS_TOUR_WELCOMETOJOOMLA_TITLE="Welcome to Joomla!"
-COM_GUIDEDTOURS_TOUR_WELCOMETOJOOMLA_DESCRIPTION="<p>This tour will give you a quick overview of how to get started with Joomla!</p><p>You are in the Joomla Administrator area, also known as the "<strong>Backend</strong>".<br>This is where you set up and manage your entire Joomla Site.</p><p><strong>Want to learn more?</strong></p><p>Let's start the tour and build your site with the power of Joomla!</p>"
+COM_GUIDEDTOURS_TOUR_WELCOMETOJOOMLA_DESCRIPTION="<p>This tour will give you a quick overview of how to get started with Joomla!</p><p>You are in the Joomla Administrator area, also known as the '<strong>Backend</strong>'.<br>This is where you set up and manage your entire Joomla Site.</p><p><strong>Want to learn more?</strong></p><p>Let's start the tour and build your site with the power of Joomla!</p>"


### PR DESCRIPTION
### Summary of Changes

The 'Welcome' tour has unescaped quotes in a string. 

### Testing Instructions

Install a fresh instance of this PR.

### Actual result BEFORE applying this Pull Request

The 'Welcome' tour runs properly.

### Expected result AFTER applying this Pull Request

The 'Welcome' tour runs properly.
You should see:

![image](https://github.com/user-attachments/assets/115e0508-a225-4571-bb59-3224655080a5)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
