### PR TITLE
[4.4] [Guided Tours] The categories tour is not visible to Managers

### DIFF
--- a/administrator/modules/mod_guidedtours/src/Helper/GuidedToursHelper.php
+++ b/administrator/modules/mod_guidedtours/src/Helper/GuidedToursHelper.php
@@ -59,6 +59,9 @@ class GuidedToursHelper
             $uri = new Uri($item->url);
 
             if ($extension = $uri->getVar('option')) {
+                if ($extension == 'com_categories') {
+                    $extension = $uri->getVar('extension');
+                }
                 if (!$user->authorise('core.manage', $extension)) {
                     unset($items[$key]);
                 }

--- a/administrator/modules/mod_guidedtours/src/Helper/GuidedToursHelper.php
+++ b/administrator/modules/mod_guidedtours/src/Helper/GuidedToursHelper.php
@@ -59,7 +59,7 @@ class GuidedToursHelper
             $uri = new Uri($item->url);
 
             if ($extension = $uri->getVar('option')) {
-                if ($extension == 'com_categories') {
+                if ($extension === 'com_categories') {
                     $extension = $uri->getVar('extension');
                 }
                 if (!$user->authorise('core.manage', $extension)) {


### PR DESCRIPTION
Pull Request for Issue #44089.

### Summary of Changes

When the tour is a category, the authorization to run should come from the extension associated with those categories.

### Testing Instructions

Create a user with Manager privileges.
Login as that user.

### Actual result BEFORE applying this Pull Request

The tour 'How to create a category' does not show in the list of tours (in the modal).

### Expected result AFTER applying this Pull Request

The tour 'How to create a category' shows in the list of tours (in the modal).

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
