### PR TITLE
[4.4] Quickicon for article categories fails with error permissions on + (add)

### DIFF
--- a/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
+++ b/administrator/modules/mod_quickicon/src/Helper/QuickIconHelper.php
@@ -137,7 +137,7 @@ class QuickIconHelper
                 $tmp = [
                     'image'   => 'icon-folder-open',
                     'link'    => Route::_('index.php?option=com_categories&view=categories&extension=com_content'),
-                    'linkadd' => Route::_('index.php?option=com_categories&task=category.add'),
+                    'linkadd' => Route::_('index.php?option=com_categories&task=category.add&extension=com_content'),
                     'name'    => 'MOD_QUICKICON_CATEGORY_MANAGER',
                     'access'  => ['core.manage', 'com_content', 'core.create', 'com_content'],
                     'group'   => 'MOD_QUICKICON_SITE',


### PR DESCRIPTION
Found out while looking at Issue #44089 .

### Summary of Changes

The quickicon + task is missing com_content.

### Testing Instructions

Create a user and assign it to the Manager group.
Login as that user.

Go to the Articles Categories quick icon. Click on +.

![image](https://github.com/user-attachments/assets/5a993037-570d-4f42-88e7-857dcf2579e9)

### Actual result BEFORE applying this Pull Request

Permissions error.

![image](https://github.com/user-attachments/assets/89ea9a44-f0fe-4065-86b6-6140722a0e98)


### Expected result AFTER applying this Pull Request

No error, you can add a category.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
