### PR TITLE
[5.3] Refactoring views to directly call models (com_actionlogs to com_finder)

### DIFF
--- a/administrator/components/com_associations/src/View/Associations/HtmlView.php
+++ b/administrator/components/com_associations/src/View/Associations/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Associations\Administrator\Helper\AssociationsHelper;
+use Joomla\Component\Associations\Administrator\Model\AssociationsModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -126,9 +127,12 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var AssociationsModel $model */
+        $model = $this->getModel();
+
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         if (!Associations::isEnabled()) {
             $link = Route::_('index.php?option=com_plugins&task=plugin.edit&extension_id=' . AssociationsHelper::getLanguagefilterPluginId());
@@ -211,8 +215,8 @@ class HtmlView extends BaseHtmlView
                     }
                 }
 
-                $this->items      = $this->get('Items');
-                $this->pagination = $this->get('Pagination');
+                $this->items      = $model->getItems();
+                $this->pagination = $model->getPagination();
 
                 $linkParameters = [
                     'layout'   => 'edit',
@@ -225,7 +229,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new \Exception(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_banners/src/View/Banner/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Banner/HtmlView.php
@@ -76,7 +76,7 @@ class HtmlView extends BaseHtmlView
         $this->state = $model->getState();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_banners/src/View/Banners/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Banners/HtmlView.php
@@ -110,12 +110,12 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_banners/src/View/Client/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Client/HtmlView.php
@@ -85,7 +85,7 @@ class HtmlView extends BaseHtmlView
         $this->canDo = ContentHelper::getActions('com_banners');
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_banners/src/View/Clients/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Clients/HtmlView.php
@@ -99,12 +99,12 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_banners/src/View/Download/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Download/HtmlView.php
@@ -52,7 +52,7 @@ class HtmlView extends BaseHtmlView
         $this->form = $model->getForm();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_banners/src/View/Tracks/HtmlView.php
+++ b/administrator/components/com_banners/src/View/Tracks/HtmlView.php
@@ -99,12 +99,12 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_banners/src/View/Tracks/RawView.php
+++ b/administrator/components/com_banners/src/View/Tracks/RawView.php
@@ -48,7 +48,7 @@ class RawView extends BaseHtmlView
         $content  = $model->getContent();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_cache/src/View/Cache/HtmlView.php
+++ b/administrator/components/com_cache/src/View/Cache/HtmlView.php
@@ -100,7 +100,7 @@ class HtmlView extends BaseHtmlView
         $this->activeFilters = $model->getActiveFilters();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -20,6 +20,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Categories\Administrator\Model\CategoriesModel;
 use Joomla\Filesystem\Path;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -102,20 +103,23 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state         = $this->get('State');
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
+        /** @var CategoriesModel $model */
+        $model = $this->getModel();
+
+        $this->state         = $model->getState();
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
         $this->assoc         = $this->get('Assoc');
         $this->filterForm    = $this->get('FilterForm');
         $this->activeFilters = $this->get('ActiveFilters');
 
         // Written this way because we only want to call IsEmptyState if no items, to prevent always calling it when not needed.
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_categories/src/View/Categories/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Categories/HtmlView.php
@@ -109,9 +109,9 @@ class HtmlView extends BaseHtmlView
         $this->state         = $model->getState();
         $this->items         = $model->getItems();
         $this->pagination    = $model->getPagination();
-        $this->assoc         = $this->get('Assoc');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        $this->assoc         = $model->getAssoc();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         // Written this way because we only want to call IsEmptyState if no items, to prevent always calling it when not needed.
         if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {

--- a/administrator/components/com_categories/src/View/Category/HtmlView.php
+++ b/administrator/components/com_categories/src/View/Category/HtmlView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Associations\Administrator\Helper\AssociationsHelper;
+use Joomla\Component\Categories\Administrator\Model\CategoryModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -94,12 +95,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->form  = $this->get('Form');
-        $this->item  = $this->get('Item');
-        $this->state = $this->get('State');
+        /** @var CategoryModel $model */
+        $model = $this->getModel();
+
+        $this->form  = $model->getForm();
+        $this->item  = $model->getItem();
+        $this->state = $model->getState();
         $section     = $this->state->get('category.section') ? $this->state->get('category.section') . '.' : '';
         $this->canDo = ContentHelper::getActions($this->state->get('category.component'), $section . 'category', $this->item->id);
-        $this->assoc = $this->get('Assoc');
+        $this->assoc = $model->getAssoc();
 
         if ($this->getLayout() === 'modalreturn') {
             parent::display($tpl);
@@ -108,7 +112,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_checkin/src/View/Checkin/HtmlView.php
+++ b/administrator/components/com_checkin/src/View/Checkin/HtmlView.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Checkin\Administrator\Model\CheckinModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -90,12 +91,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->total         = $this->get('Total');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var CheckinModel $model */
+        $model = $this->getModel();
+
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->total         = $model->getTotal();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         if (!\count($this->items)) {
             $this->isEmptyState = true;
@@ -103,7 +107,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_config/src/View/Application/HtmlView.php
+++ b/administrator/components/com_config/src/View/Application/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Config\Administrator\Helper\ConfigHelper;
+use Joomla\Component\Config\Administrator\Model\ApplicationModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -93,10 +94,13 @@ class HtmlView extends BaseHtmlView
     public function display($tpl = null)
     {
         try {
+            /** @var ApplicationModel $model */
+            $model = $this->getModel();
+
             // Load Form and Data
-            $form = $this->get('form');
-            $data = $this->get('data');
-            $user = $this->getCurrentUser();
+            $this->form = $model->getForm();
+            $this->data = $model->getData();
+            $this->user = $this->getCurrentUser();
         } catch (\Exception $e) {
             Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 
@@ -104,24 +108,20 @@ class HtmlView extends BaseHtmlView
         }
 
         // Bind data
-        if ($form && $data) {
-            $form->bind($data);
+        if ($this->form && $this->data) {
+            $this->form->bind($this->data);
         }
 
         // Get the params for com_users.
-        $usersParams = ComponentHelper::getParams('com_users');
+        $this->usersParams = ComponentHelper::getParams('com_users');
 
         // Get the params for com_media.
-        $mediaParams = ComponentHelper::getParams('com_media');
+        $this->mediaParams = ComponentHelper::getParams('com_media');
 
-        $this->form        = &$form;
-        $this->data        = &$data;
-        $this->usersParams = &$usersParams;
-        $this->mediaParams = &$mediaParams;
         $this->components  = ConfigHelper::getComponentsWithConfig();
         ConfigHelper::loadLanguageForComponents($this->components);
 
-        $this->userIsSuperAdmin = $user->authorise('core.admin');
+        $this->userIsSuperAdmin = $this->user->authorise('core.admin');
 
         $this->addToolbar();
 

--- a/administrator/components/com_config/src/View/Component/HtmlView.php
+++ b/administrator/components/com_config/src/View/Component/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Config\Administrator\Helper\ConfigHelper;
+use Joomla\Component\Config\Administrator\Model\ComponentModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -91,13 +92,16 @@ class HtmlView extends BaseHtmlView
     public function display($tpl = null)
     {
         try {
-            $this->component = $this->get('component');
+            /** @var ComponentModel $model */
+            $model = $this->getModel();
+
+            $this->component = $model->getComponent();
 
             if (!$this->component->enabled) {
                 return;
             }
 
-            $this->form = $this->get('Form');
+            $this->form = $model->getForm();
             $user       = $this->getCurrentUser();
         } catch (\Exception $e) {
             Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');

--- a/administrator/components/com_contact/src/View/Contact/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contact/HtmlView.php
@@ -19,6 +19,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Contact\Administrator\Model\ContactModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -70,10 +71,13 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var ContactModel $model */
+        $model = $this->getModel();
+
         // Initialise variables.
-        $this->form  = $this->get('Form');
-        $this->item  = $this->get('Item');
-        $this->state = $this->get('State');
+        $this->form  = $model->getForm();
+        $this->item  = $model->getItem();
+        $this->state = $model->getState();
 
         if ($this->getLayout() === 'modalreturn') {
             parent::display($tpl);
@@ -82,7 +86,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_contact/src/View/Contacts/HtmlView.php
+++ b/administrator/components/com_contact/src/View/Contacts/HtmlView.php
@@ -18,6 +18,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Contact\Administrator\Model\ContactsModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -83,18 +84,21 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var ContactsModel $model */
+        $model = $this->getModel();
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
+
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_content/src/View/Article/HtmlView.php
+++ b/administrator/components/com_content/src/View/Article/HtmlView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Content\Administrator\Model\ArticleModel;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -97,9 +98,12 @@ class HtmlView extends BaseHtmlView
             return;
         }
 
-        $this->form  = $this->get('Form');
-        $this->item  = $this->get('Item');
-        $this->state = $this->get('State');
+        /** @var ArticleModel $model */
+        $model = $this->getModel();
+
+        $this->form  = $model->getForm();
+        $this->item  = $model->getItem();
+        $this->state = $model->getState();
         $this->canDo = ContentHelper::getActions('com_content', 'article', $this->item->id);
 
         if ($this->getLayout() === 'modalreturn') {
@@ -109,7 +113,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -127,7 +127,7 @@ class HtmlView extends BaseHtmlView
         if (ComponentHelper::getParams('com_content')->get('workflow_enabled')) {
             PluginHelper::importPlugin('workflow');
 
-            $this->transitions = $this->get('Transitions');
+            $this->transitions = $model->getTransitions();
         }
 
         // Check for errors.

--- a/administrator/components/com_content/src/View/Articles/HtmlView.php
+++ b/administrator/components/com_content/src/View/Articles/HtmlView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
+use Joomla\Component\Content\Administrator\Model\ArticlesModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -108,15 +109,18 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var ArticlesModel $model */
+        $model = $this->getModel();
+
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
         $this->vote          = PluginHelper::isEnabled('content', 'vote');
         $this->hits          = ComponentHelper::getParams('com_content')->get('record_hits', 1) == 1;
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
@@ -127,7 +131,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors')) || $this->transitions === false) {
+        if (\count($errors = $model->getErrors()) || $this->transitions === false) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_content/src/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/src/View/Featured/HtmlView.php
@@ -110,7 +110,7 @@ class HtmlView extends BaseHtmlView
         if (ComponentHelper::getParams('com_content')->get('workflow_enabled')) {
             PluginHelper::importPlugin('workflow');
 
-            $this->transitions = $this->get('Transitions');
+            $this->transitions = $model->getTransitions();
         }
 
         // Check for errors.

--- a/administrator/components/com_content/src/View/Featured/HtmlView.php
+++ b/administrator/components/com_content/src/View/Featured/HtmlView.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Content\Administrator\Extension\ContentComponent;
 use Joomla\Component\Content\Administrator\Helper\ContentHelper;
+use Joomla\Component\Content\Administrator\Model\FeaturedModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -91,15 +92,18 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var FeaturedModel $model */
+        $model = $this->getModel();
+
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
         $this->vote          = PluginHelper::isEnabled('content', 'vote');
         $this->hits          = ComponentHelper::getParams('com_content')->get('record_hits', 1);
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
@@ -110,7 +114,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_contenthistory/src/View/Compare/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/Compare/HtmlView.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Contenthistory\Administrator\View\Compare;
 
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Contenthistory\Administrator\Model\CompareModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -49,11 +50,14 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state = $this->get('State');
-        $this->items = $this->get('Items');
+        /** @var CompareModel $model */
+        $model = $this->getModel();
+
+        $this->state = $model->getState();
+        $this->items = $model->getItems();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_contenthistory/src/View/History/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/History/HtmlView.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Session\Session;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarFactoryInterface;
+use Joomla\Component\Contenthistory\Administrator\Model\HistoryModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -70,12 +71,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state      = $this->get('State');
-        $this->items      = $this->get('Items');
-        $this->pagination = $this->get('Pagination');
+        /** @var HistoryModel $model */
+        $model = $this->getModel();
+
+        $this->state      = $model->getState();
+        $this->items      = $model->getItems();
+        $this->pagination = $model->getPagination();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_contenthistory/src/View/Preview/HtmlView.php
+++ b/administrator/components/com_contenthistory/src/View/Preview/HtmlView.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Contenthistory\Administrator\View\Preview;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Contenthistory\Administrator\Model\PreviewModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -50,8 +51,11 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state = $this->get('State');
-        $this->item  = $this->get('Item');
+        /** @var PreviewModel $model */
+        $model = $this->getModel();
+
+        $this->state = $model->getState();
+        $this->item  = $model->getItem();
 
         if (false === $this->item) {
             $this->getLanguage()->load('com_content', JPATH_SITE, null, true);
@@ -60,7 +64,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_fields/src/View/Field/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Field/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Fields\Administrator\Model\FieldModel;
 use Joomla\Filesystem\Path;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -64,14 +65,17 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->form  = $this->get('Form');
-        $this->item  = $this->get('Item');
-        $this->state = $this->get('State');
+        /** @var FieldModel $model */
+        $model = $this->getModel();
+
+        $this->form  = $model->getForm();
+        $this->item  = $model->getItem();
+        $this->state = $model->getState();
 
         $this->canDo = ContentHelper::getActions($this->state->get('field.component'), 'field', $this->item->id);
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_fields/src/View/Fields/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Fields/HtmlView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+use Joomla\Component\Fields\Administrator\Model\FieldsModel;
 use Joomla\Filesystem\Path;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -82,14 +83,17 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state         = $this->get('State');
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var FieldsModel $model */
+        $model = $this->getModel();
+
+        $this->state         = $model->getState();
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_fields/src/View/Group/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Group/HtmlView.php
@@ -18,6 +18,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+use Joomla\Component\Fields\Administrator\Model\GroupModel;
 use Joomla\Filesystem\Path;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -72,9 +73,12 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->form  = $this->get('Form');
-        $this->item  = $this->get('Item');
-        $this->state = $this->get('State');
+        /** @var GroupModel $model */
+        $model = $this->getModel();
+
+        $this->form  = $model->getForm();
+        $this->item  = $model->getItem();
+        $this->state = $model->getState();
 
         $component = '';
         $parts     = FieldsHelper::extract($this->state->get('filter.context'));
@@ -86,7 +90,7 @@ class HtmlView extends BaseHtmlView
         $this->canDo = ContentHelper::getActions($component, 'fieldgroup', $this->item->id);
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_fields/src/View/Groups/HtmlView.php
+++ b/administrator/components/com_fields/src/View/Groups/HtmlView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Fields\Administrator\Helper\FieldsHelper;
+use Joomla\Component\Fields\Administrator\Model\GroupsModel;
 use Joomla\Filesystem\Path;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -82,14 +83,17 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state         = $this->get('State');
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var GroupsModel $model */
+        $model = $this->getModel();
+
+        $this->state         = $model->getState();
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_fields/tmpl/fields/default_batch_body.php
+++ b/administrator/components/com_fields/tmpl/fields/default_batch_body.php
@@ -17,6 +17,9 @@ use Joomla\CMS\Layout\LayoutHelper;
 
 /** @var \Joomla\Component\Fields\Administrator\View\Fields\HtmlView $this */
 
+/** @var \Joomla\Component\Fields\Administrator\Model\FieldsModel $model */
+$model = $this->getModel();
+
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('com_fields.admin-fields-batch');
@@ -55,7 +58,7 @@ $context = $this->escape($this->state->get('filter.context'));
                     <select name="batch[group_id]" class="form-select" id="batch-group-id">
                         <option value=""><?php echo Text::_('JLIB_HTML_BATCH_NO_CATEGORY'); ?></option>
                         <option value="nogroup"><?php echo Text::_('COM_FIELDS_BATCH_GROUP_OPTION_NONE'); ?></option>
-                        <?php echo HTMLHelper::_('select.options', $this->get('Groups'), 'value', 'text'); ?>
+                        <?php echo HTMLHelper::_('select.options', $model->getGroups(), 'value', 'text'); ?>
                     </select>
                 </div>
                 <div id="batch-copy-move">

--- a/administrator/components/com_finder/src/View/Filter/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Filter/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Finder\Administrator\Model\FilterModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -94,15 +95,18 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var FilterModel $model */
+        $model = $this->getModel();
+
         // Load the view data.
-        $this->filter = $this->get('Filter');
-        $this->item   = $this->get('Item');
-        $this->form   = $this->get('Form');
-        $this->state  = $this->get('State');
-        $this->total  = $this->get('Total');
+        $this->filter = $model->getFilter();
+        $this->item   = $model->getItem();
+        $this->form   = $model->getForm();
+        $this->state  = $model->getState();
+        $this->total  = $model->getTotal();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_finder/src/View/Filters/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Filters/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Finder\Administrator\Model\FiltersModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -100,20 +101,23 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        // Load the view data.
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->total         = $this->get('Total');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var FiltersModel $model */
+        $model = $this->getModel();
 
-        if (\count($this->items) === 0 && $this->isEmptyState = $this->get('IsEmptyState')) {
+        // Load the view data.
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->total         = $model->getTotal();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
+
+        if (\count($this->items) === 0 && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_finder/src/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Index/HtmlView.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Finder\Administrator\Helper\FinderHelper;
 use Joomla\Component\Finder\Administrator\Helper\LanguageHelper;
+use Joomla\Component\Finder\Administrator\Model\IndexModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -125,15 +126,18 @@ class HtmlView extends BaseHtmlView
         // Load plugin language files.
         LanguageHelper::loadPluginLanguage();
 
-        $this->items         = $this->get('Items');
-        $this->total         = $this->get('Total');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->pluginState   = $this->get('pluginState');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var IndexModel $model */
+        $model = $this->getModel();
 
-        if ($this->get('TotalIndexed') === 0 && $this->isEmptyState = $this->get('IsEmptyState')) {
+        $this->items         = $model->getItems();
+        $this->total         = $model->getTotal();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->pluginState   = $model->getPluginState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
+
+        if ($this->get('TotalIndexed') === 0 && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
@@ -144,7 +148,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_finder/src/View/Index/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Index/HtmlView.php
@@ -137,7 +137,7 @@ class HtmlView extends BaseHtmlView
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
-        if ($this->get('TotalIndexed') === 0 && $this->isEmptyState = $model->getIsEmptyState()) {
+        if ($model->getTotalIndexed() === 0 && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 

--- a/administrator/components/com_finder/src/View/Indexer/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Indexer/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Finder\Administrator\Model\IndexerModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -47,7 +48,9 @@ class HtmlView extends BaseHtmlView
     public function display($tpl = null)
     {
         if ($this->getLayout() == 'debug') {
-            $this->form = $this->get('Form');
+            /** @var IndexerModel $model */
+            $model      = $this->getModel();
+            $this->form = $model->getForm();
             $this->addToolbar();
         }
 

--- a/administrator/components/com_finder/src/View/Item/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Item/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Finder\Administrator\Model\ItemModel;
 
 /**
  * Index view class for Finder.
@@ -61,9 +62,12 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->item       = $this->get('Item');
-        $this->terms      = $this->get('Terms');
-        $this->taxonomies = $this->get('Taxonomies');
+        /** @var ItemModel $model */
+        $model = $this->getModel();
+
+        $this->item       = $model->getItem();
+        $this->terms      = $model->getTerms();
+        $this->taxonomies = $model->getTaxonomies();
 
         // Configure the toolbar.
         $this->addToolbar();

--- a/administrator/components/com_finder/src/View/Maps/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Maps/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Finder\Administrator\Helper\LanguageHelper;
+use Joomla\Component\Finder\Administrator\Model\MapsModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -104,20 +105,23 @@ class HtmlView extends BaseHtmlView
         // Load plugin language files.
         LanguageHelper::loadPluginLanguage();
 
-        // Load the view data.
-        $this->items         = $this->get('Items');
-        $this->total         = $this->get('Total');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var MapsModel $model */
+        $model = $this->getModel();
 
-        if ($this->total === 0 && $this->isEmptyState = $this->get('isEmptyState')) {
+        // Load the view data.
+        $this->items         = $model->getItems();
+        $this->total         = $model->getTotal();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
+
+        if ($this->total === 0 && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_finder/src/View/Searches/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Searches/HtmlView.php
@@ -19,6 +19,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Component\Finder\Administrator\Model\SearchesModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -102,24 +103,27 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var SearchesModel $model */
+        $model = $this->getModel();
+
         $app                 = Factory::getApplication();
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
         $this->enabled       = $this->state->params->get('gather_search_statistics', 0);
         $this->canDo         = ContentHelper::getActions('com_finder');
         $uri                 = Uri::getInstance();
         $link                = 'index.php?option=com_config&view=component&component=com_finder&return=' . base64_encode($uri);
         $output              = HTMLHelper::_('link', Route::_($link), Text::_('JOPTIONS'));
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_finder/src/View/Statistics/HtmlView.php
+++ b/administrator/components/com_finder/src/View/Statistics/HtmlView.php
@@ -12,6 +12,7 @@ namespace Joomla\Component\Finder\Administrator\View\Statistics;
 
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Finder\Administrator\Model\StatisticsModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -44,11 +45,14 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var StatisticsModel $model */
+        $model = $this->getModel();
+
         // Load the view data.
-        $this->data = $this->get('Data');
+        $this->data = $model->getData();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 


### PR DESCRIPTION
### Summary of Changes
This PR refactors the views to get the model object and then directly call the methods of the model instead of going through the `View::get()` indirection. This refactors the views of the backend components from com_actionlogs to com_finder.


### Testing Instructions
Everything should work the same.



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
