### PR TITLE
[5.2] Add active class to active item in mod_ articles

### DIFF
--- a/modules/mod_articles/tmpl/default_items.php
+++ b/modules/mod_articles/tmpl/default_items.php
@@ -25,7 +25,7 @@ if ($params->get('articles_layout') == 1) {
         $displayInfo = $item->displayHits || $item->displayAuthorName || $item->displayCategoryTitle || $item->displayDate;
         ?>
         <li>
-            <article class="mod-articles-item<?php echo $item->active ? ' ' . $item->active : ''; ?>" itemscope itemtype="https://schema.org/Article">
+            <article class="mod-articles-item" itemscope itemtype="https://schema.org/Article">
 
                 <?php if ($params->get('item_title') || $displayInfo || $params->get('show_tags') || $params->get('show_introtext') || $params->get('show_readmore')) : ?>
                     <div class="mod-articles-item-content">

--- a/modules/mod_articles/tmpl/default_items.php
+++ b/modules/mod_articles/tmpl/default_items.php
@@ -25,7 +25,7 @@ if ($params->get('articles_layout') == 1) {
         $displayInfo = $item->displayHits || $item->displayAuthorName || $item->displayCategoryTitle || $item->displayDate;
         ?>
         <li>
-            <article class="mod-articles-item" itemscope itemtype="https://schema.org/Article">
+            <article class="mod-articles-item<?php echo $item->active ? ' ' . $item->active : ''; ?>" itemscope itemtype="https://schema.org/Article">
 
                 <?php if ($params->get('item_title') || $displayInfo || $params->get('show_tags') || $params->get('show_introtext') || $params->get('show_readmore')) : ?>
                     <div class="mod-articles-item-content">

--- a/modules/mod_articles/tmpl/default_titles.php
+++ b/modules/mod_articles/tmpl/default_titles.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 <ul class="mod-articles mod-list">
     <?php foreach ($items as $item) : ?>
         <li itemscope itemtype="https://schema.org/Article">
-            <a href="<?php echo $item->link; ?>" itemprop="url">
+            <a <?php echo $item->active ? ' class="' . $item->active . '"' : ''; ?>href="<?php echo $item->link; ?>" itemprop="url">
                 <span itemprop="name">
                     <?php echo $item->title; ?>
                 </span>

--- a/modules/mod_articles/tmpl/default_titles.php
+++ b/modules/mod_articles/tmpl/default_titles.php
@@ -14,7 +14,7 @@ defined('_JEXEC') or die;
 <ul class="mod-articles mod-list">
     <?php foreach ($items as $item) : ?>
         <li itemscope itemtype="https://schema.org/Article">
-            <a <?php echo $item->active ? ' class="' . $item->active . '"' : ''; ?>href="<?php echo $item->link; ?>" itemprop="url">
+            <a <?php echo $item->active ? 'class="' . $item->active . '" ' : ''; ?>href="<?php echo $item->link; ?>" itemprop="url">
                 <span itemprop="name">
                     <?php echo $item->title; ?>
                 </span>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The new mod_articles module has no active class for the active item like there was in mod_articles_category. This PR adds this functionality. 

### Testing Instructions
1. Create a list of articles with the module active on all pages.
2. Open the inspector in the browser.
3. With the Title Only (lists) option selected, see if the link to the current article has an active class.
![image](https://github.com/user-attachments/assets/f391d95b-2490-46a3-a30d-14dc344524b0)

### Actual result BEFORE applying this Pull Request
No active class

### Expected result AFTER applying this Pull Request
Has an active class

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
