### PR TITLE
Fix showon for Trigger Plugin Events in mod_articles

### DIFF
--- a/modules/mod_articles/mod_articles.xml
+++ b/modules/mod_articles/mod_articles.xml
@@ -378,6 +378,7 @@
 					layout="joomla.form.field.radio.switcher"
 					default="0"
 					filter="integer"
+					showon="title_only:0"
 					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
When the option Title Only (lists) is selected in mod_articles, the option Trigger Plugin Events is visible. This is the wrong behavior and this PR fixes the issue.

### Testing Instructions
See if the option Trigger Plugin Events is hidden when Title Only (lists) is selected.

### Actual result BEFORE applying this Pull Request
![image](https://github.com/user-attachments/assets/9ec5ddfe-b217-443f-9874-765c645cdd00)

### Expected result AFTER applying this Pull Request
![image](https://github.com/user-attachments/assets/ab6bd174-96db-4717-adf2-9fafe699b8e9)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
