### PR TITLE
[5.2] Update NPM developer dependency "rollup" from 2.79.1 to 2.79.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9544,9 +9544,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/rollup": {
-      "version": "2.79.1",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
-      "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "version": "2.79.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.2.tgz",
+      "integrity": "sha512-fS6iqSPZDs3dr/y7Od6y5nha8dW1YnbgtsyotCVvoFGKbERG++CVRFv1meyGDE1SNItQA8BrnCw7ScdAhRJ3XQ==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "postgres": "^3.4.4",
         "recursive-readdir": "^2.2.3",
         "rimraf": "^3.0.2",
-        "rollup": "^2.79.1",
+        "rollup": "^2.79.2",
         "rollup-plugin-vue": "^6.0.0",
         "rtlcss": "^3.5.0",
         "sass-embedded": "^1.79.3",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,7 @@
     "postgres": "^3.4.4",
     "recursive-readdir": "^2.2.3",
     "rimraf": "^3.0.2",
-    "rollup": "^2.79.1",
+    "rollup": "^2.79.2",
     "rollup-plugin-vue": "^6.0.0",
     "rtlcss": "^3.5.0",
     "sass-embedded": "^1.79.3",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the NPM developer dependency "rollup" from 2.79.1 to 2.79.2 .

### Testing Instructions

Check e.g. in Drone if npm and the upload package build still succeed.

### Actual result BEFORE applying this Pull Request

Works, node_modules/rollup has version 2.79.1.

### Expected result AFTER applying this Pull Request

Works, node_modules/rollup has version 2.79.2.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
