### PR TITLE
[5.2] Fix saving edited images in media manager

### DIFF
--- a/administrator/components/com_media/src/Controller/ApiController.php
+++ b/administrator/components/com_media/src/Controller/ApiController.php
@@ -270,7 +270,7 @@ class ApiController extends BaseController
         $move         = $content->get('move', true);
 
         if ($mediaContent != null) {
-            $this->checkContent();
+            $this->checkFileSize(\strlen($mediaContent));
 
             $this->getModel()->updateFile($adapter, $name, str_replace($name, '', $path), $mediaContent);
         }


### PR DESCRIPTION
### Summary of Changes
When editing an image and trying to save it in 5.2-dev, the save button returns an error instead of saving the image. This PR fixes that.


### Testing Instructions
Go to the media manager and edit an image. Rotate the image for example and open the developer tools. Click the Save button at the top.


### Actual result BEFORE applying this Pull Request
See an error in the browser developer tools and the image isn't saved.


### Expected result AFTER applying this Pull Request
The image is properly saved.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
