### PR TITLE
[5.3] Refactoring AbstractView::getName()

### DIFF
--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -221,10 +221,10 @@ abstract class AbstractView implements ViewInterface, DispatcherAwareInterface, 
     public function getName()
     {
         if (empty($this->_name)) {
-            $className = get_class($this);
+            $className = \get_class($this);
             $elements  = explode('\\', $className);
 
-            if (count($elements) > 1) {
+            if (\count($elements) > 1) {
                 array_pop($elements);
                 $this->_name = strtolower(array_pop($elements));
             } else {

--- a/libraries/src/MVC/View/AbstractView.php
+++ b/libraries/src/MVC/View/AbstractView.php
@@ -221,20 +221,17 @@ abstract class AbstractView implements ViewInterface, DispatcherAwareInterface, 
     public function getName()
     {
         if (empty($this->_name)) {
-            $reflection = new \ReflectionClass($this);
+            $className = get_class($this);
+            $elements  = explode('\\', $className);
 
-            if ($viewNamespace = $reflection->getNamespaceName()) {
-                $pos = strrpos($viewNamespace, '\\');
-
-                if ($pos !== false) {
-                    $this->_name = strtolower(substr($viewNamespace, $pos + 1));
-                }
+            if (count($elements) > 1) {
+                array_pop($elements);
+                $this->_name = strtolower(array_pop($elements));
             } else {
-                $className = \get_class($this);
-                $viewPos   = strpos($className, 'View');
+                $viewPos   = strpos($elements[0], 'View');
 
                 if ($viewPos != false) {
-                    $this->_name = strtolower(substr($className, $viewPos + 4));
+                    $this->_name = strtolower(substr($elements[0], $viewPos + 4));
                 }
             }
 


### PR DESCRIPTION
### Summary of Changes
While reviewing the AbstractView class, I stumbled upon the use of the reflection class in the getName() method of AbstractView. This PR refactors the method to not use reflection.


### Testing Instructions
Codereview


### Actual result BEFORE applying this Pull Request
Everything should work identical to before.


### Expected result AFTER applying this Pull Request
Everything should work identical to before.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
