### PR TITLE
[5.3] Refactoring views to directly call models (com_plugins to com_workflow)

### DIFF
--- a/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
@@ -124,7 +124,9 @@ class HtmlView extends BaseHtmlView
         // Get the help information for the plugin item.
         $lang = $this->getLanguage();
 
-        $help = $this->get('Help');
+        /** @var PluginModel $model */
+        $model = $this->getModel();
+        $help  = $model->getHelp();
 
         if ($help->url && $lang->hasKey($help->url)) {
             $debug = $lang->setDebug(false);

--- a/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugin/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Plugins\Administrator\Model\PluginModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -67,9 +68,12 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state = $this->get('State');
-        $this->item  = $this->get('Item');
-        $this->form  = $this->get('Form');
+        /** @var PluginModel $model */
+        $model = $this->getModel();
+
+        $this->state = $model->getState();
+        $this->item  = $model->getItem();
+        $this->form  = $model->getForm();
 
         if ($this->getLayout() === 'modalreturn') {
             parent::display($tpl);
@@ -78,7 +82,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_plugins/src/View/Plugins/HtmlView.php
+++ b/administrator/components/com_plugins/src/View/Plugins/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Plugins\Administrator\Model\PluginsModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -73,14 +74,17 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var PluginsModel $model */
+        $model = $this->getModel();
+
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_privacy/src/View/Capabilities/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Capabilities/HtmlView.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Privacy\Administrator\Model\CapabilitiesModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -55,12 +56,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var CapabilitiesModel $model */
+        $model = $this->getModel();
+
         // Initialise variables
-        $this->capabilities = $this->get('Capabilities');
-        $this->state        = $this->get('State');
+        $this->capabilities = $model->getCapabilities();
+        $this->state        = $model->getState();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new Genericdataexception(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_privacy/src/View/Consents/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Consents/HtmlView.php
@@ -93,19 +93,20 @@ class HtmlView extends BaseHtmlView
     public function display($tpl = null)
     {
         /** @var ConsentsModel $model */
-        $model               = $this->getModel();
+        $model = $this->getModel();
+
         $this->items         = $model->getItems();
         $this->pagination    = $model->getPagination();
         $this->state         = $model->getState();
         $this->filterForm    = $model->getFilterForm();
         $this->activeFilters = $model->getActiveFilters();
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new Genericdataexception(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_privacy/src/View/Export/XmlView.php
+++ b/administrator/components/com_privacy/src/View/Export/XmlView.php
@@ -46,7 +46,7 @@ class XmlView extends AbstractView
         $exportData = $model->collectDataForExportRequest();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_privacy/src/View/Request/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Request/HtmlView.php
@@ -96,11 +96,11 @@ class HtmlView extends BaseHtmlView
 
         // Variables only required for the edit layout
         if ($this->getLayout() === 'edit') {
-            $this->form = $this->get('Form');
+            $this->form = $model->getForm();
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_privacy/src/View/Requests/HtmlView.php
+++ b/administrator/components/com_privacy/src/View/Requests/HtmlView.php
@@ -112,12 +112,12 @@ class HtmlView extends BaseHtmlView
         $this->urgentRequestAge = (int) ComponentHelper::getParams('com_privacy')->get('notify', 14);
         $this->sendMailEnabled  = (bool) Factory::getApplication()->get('mailonline', 1);
 
-        if (!\count($this->items) && $this->get('IsEmptyState')) {
+        if (!\count($this->items) && $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new Genericdataexception(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_redirect/src/View/Link/HtmlView.php
+++ b/administrator/components/com_redirect/src/View/Link/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Redirect\Administrator\Model\LinkModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -61,12 +62,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->form  = $this->get('Form');
-        $this->item  = $this->get('Item');
-        $this->state = $this->get('State');
+        /** @var LinkModel $model */
+        $model = $this->getModel();
+
+        $this->form  = $model->getForm();
+        $this->item  = $model->getItem();
+        $this->state = $model->getState();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_redirect/src/View/Links/HtmlView.php
+++ b/administrator/components/com_redirect/src/View/Links/HtmlView.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Redirect\Administrator\Helper\RedirectHelper;
+use Joomla\Component\Redirect\Administrator\Model\LinksModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -118,20 +119,23 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var LinksModel $model */
+        $model = $this->getModel();
+
         // Set variables
-        $this->items                = $this->get('Items');
-        $this->pagination           = $this->get('Pagination');
-        $this->state                = $this->get('State');
-        $this->filterForm           = $this->get('FilterForm');
-        $this->activeFilters        = $this->get('ActiveFilters');
+        $this->items                = $model->getItems();
+        $this->pagination           = $model->getPagination();
+        $this->state                = $model->getState();
+        $this->filterForm           = $model->getFilterForm();
+        $this->activeFilters        = $model->getActiveFilters();
         $this->params               = ComponentHelper::getParams('com_redirect');
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
@@ -153,7 +157,7 @@ class HtmlView extends BaseHtmlView
      */
     protected function addToolbar()
     {
-        $state   = $this->get('State');
+        $state   = $this->state;
         $canDo   = ContentHelper::getActions('com_redirect');
         $toolbar = $this->getDocument()->getToolbar();
 

--- a/administrator/components/com_scheduler/src/View/Select/HtmlView.php
+++ b/administrator/components/com_scheduler/src/View/Select/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Scheduler\Administrator\Model\SelectModel;
 use Joomla\Component\Scheduler\Administrator\Task\TaskOption;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -85,11 +86,14 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null): void
     {
-        $this->state     = $this->get('State');
-        $this->items     = $this->get('Items');
+        /** @var SelectModel $model */
+        $model = $this->getModel();
+
+        $this->state     = $model->getState();
+        $this->items     = $model->getItems();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_scheduler/src/View/Task/HtmlView.php
+++ b/administrator/components/com_scheduler/src/View/Task/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Helper\ContentHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Scheduler\Administrator\Model\TaskModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -109,12 +110,12 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null): void
     {
-        /*
-         * Will call the getForm() method of TaskModel
-         */
-        $this->form  = $this->get('Form');
-        $this->item  = $this->get('Item');
-        $this->state = $this->get('State');
+        /** @var TaskModel $model */
+        $model = $this->getModel();
+
+        $this->form  = $model->getForm();
+        $this->item  = $model->getItem();
+        $this->state = $model->getState();
         $this->canDo = ContentHelper::getActions('com_scheduler', 'task', $this->item->id);
 
         $this->addToolbar();

--- a/administrator/components/com_scheduler/src/View/Tasks/HtmlView.php
+++ b/administrator/components/com_scheduler/src/View/Tasks/HtmlView.php
@@ -18,6 +18,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Pagination\Pagination;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Scheduler\Administrator\Model\TasksModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -91,19 +92,22 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null): void
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
-        $this->hasDueTasks   = $this->get('hasDueTasks');
+        /** @var TasksModel $model */
+        $model = $this->getModel();
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
+        $this->hasDueTasks   = $model->getHasDueTasks();
+
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('empty_state');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_tags/src/View/Tag/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tag/HtmlView.php
@@ -18,6 +18,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Tags\Administrator\Model\TagModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -85,12 +86,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->form  = $this->get('Form');
-        $this->item  = $this->get('Item');
-        $this->state = $this->get('State');
+        /** @var TagModel $model */
+        $model = $this->getModel();
+
+        $this->form  = $model->getForm();
+        $this->item  = $model->getItem();
+        $this->state = $model->getState();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_tags/src/View/Tags/HtmlView.php
+++ b/administrator/components/com_tags/src/View/Tags/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Tags\Administrator\Model\TagsModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -94,18 +95,21 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var TagsModel $model */
+        $model = $this->getModel();
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
+
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_templates/src/View/Style/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Style/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Templates\Administrator\Model\StyleModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -79,13 +80,16 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->item  = $this->get('Item');
-        $this->state = $this->get('State');
-        $this->form  = $this->get('Form');
+        /** @var StyleModel $model */
+        $model = $this->getModel();
+
+        $this->item  = $model->getItem();
+        $this->state = $model->getState();
+        $this->form  = $model->getForm();
         $this->canDo = ContentHelper::getActions('com_templates');
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_templates/src/View/Style/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Style/HtmlView.php
@@ -150,7 +150,10 @@ class HtmlView extends BaseHtmlView
 
         // Get the help information for the template item.
         $lang = $this->getLanguage();
-        $help = $this->get('Help');
+
+        /** @var StyleModel $model */
+        $model = $this->getModel();
+        $help  = $model->getHelp();
 
         if ($lang->hasKey($help->url)) {
             $debug = $lang->setDebug(false);

--- a/administrator/components/com_templates/src/View/Style/JsonView.php
+++ b/administrator/components/com_templates/src/View/Style/JsonView.php
@@ -13,7 +13,6 @@ namespace Joomla\Component\Templates\Administrator\View\Style;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\Component\Templates\Administrator\Model\StyleModel;
-use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;

--- a/administrator/components/com_templates/src/View/Style/JsonView.php
+++ b/administrator/components/com_templates/src/View/Style/JsonView.php
@@ -12,6 +12,8 @@ namespace Joomla\Component\Templates\Administrator\View\Style;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Templates\Administrator\Model\StyleModel;
+use Joomla\Utilities\ArrayHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -56,8 +58,11 @@ class JsonView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var StyleModel $model */
+        $model = $this->getModel();
+
         try {
-            $this->item = $this->get('Item');
+            $this->item = $model->getItem();
         } catch (\Exception $e) {
             $app = Factory::getApplication();
             $app->enqueueMessage($e->getMessage(), 'error');
@@ -65,7 +70,7 @@ class JsonView extends BaseHtmlView
             return false;
         }
 
-        $paramsList = $this->item->getProperties();
+        $paramsList = (array) $this->item;
 
         unset($paramsList['xml']);
 

--- a/administrator/components/com_templates/src/View/Styles/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Styles/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Templates\Administrator\Model\StylesModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -83,12 +84,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->total         = $this->get('Total');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var StylesModel $model */
+        $model = $this->getModel();
+
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->total         = $model->getTotal();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
         $this->preview       = ComponentHelper::getParams('com_templates')->get('template_positions_display');
 
         // Remove the menu item filter for administrator styles.
@@ -98,7 +102,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
@@ -117,7 +121,7 @@ class HtmlView extends BaseHtmlView
     protected function addToolbar()
     {
         $canDo    = ContentHelper::getActions('com_templates');
-        $clientId = (int) $this->get('State')->get('client_id');
+        $clientId = (int) $this->state->get('client_id');
         $toolbar  = $this->getDocument()->getToolbar();
 
         // Add a shortcut to the templates list view.

--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\CMS\Uri\Uri;
+use Joomla\Component\Templates\Administrator\Model\TemplateModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -157,19 +158,22 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var TemplateModel $model */
+        $model = $this->getModel();
+
         $app               = Factory::getApplication();
         $this->file        = $app->getInput()->get('file', '');
         $this->fileName    = InputFilter::getInstance()->clean(base64_decode($this->file), 'string');
         $explodeArray      = explode('.', $this->fileName);
         $ext               = end($explodeArray);
-        $this->files       = $this->get('Files');
-        $this->mediaFiles  = $this->get('MediaFiles');
-        $this->state       = $this->get('State');
-        $this->template    = $this->get('Template');
-        $this->preview     = $this->get('Preview');
+        $this->files       = $model->getFiles();
+        $this->mediaFiles  = $model->getMediaFiles();
+        $this->state       = $model->getState();
+        $this->template    = $model->getTemplate();
+        $this->preview     = $model->getPreview();
         $this->pluginState = PluginHelper::isEnabled('installer', 'override');
-        $this->updatedList = $this->get('UpdatedList');
-        $this->styles      = $this->get('AllTemplateStyles');
+        $this->updatedList = $model->getUpdatedList();
+        $this->styles      = $model->getAllTemplateStyles();
         $this->stylesHTML  = '';
 
         $params       = ComponentHelper::getParams('com_templates');
@@ -179,33 +183,33 @@ class HtmlView extends BaseHtmlView
         $archiveTypes = explode(',', $params->get('compressed_formats', 'zip'));
 
         if (\in_array($ext, $sourceTypes)) {
-            $this->form   = $this->get('Form');
+            $this->form   = $model->getForm();
             $this->form->setFieldAttribute('source', 'syntax', $ext);
-            $this->source = $this->get('Source');
+            $this->source = $model->getSource();
             $this->type   = 'file';
         } elseif (\in_array($ext, $imageTypes)) {
             try {
-                $this->image = $this->get('Image');
+                $this->image = $model->getImage();
                 $this->type  = 'image';
             } catch (\RuntimeException $exception) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_GD_EXTENSION_NOT_AVAILABLE'));
                 $this->type = 'home';
             }
         } elseif (\in_array($ext, $fontTypes)) {
-            $this->font = $this->get('Font');
+            $this->font = $model->getFont();
             $this->type = 'font';
         } elseif (\in_array($ext, $archiveTypes)) {
-            $this->archive = $this->get('Archive');
+            $this->archive = $model->getArchive();
             $this->type    = 'archive';
         } else {
             $this->type = 'home';
         }
 
-        $this->overridesList = $this->get('OverridesList');
+        $this->overridesList = $model->getOverridesList();
         $this->id            = $this->state->get('extension.id');
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             $app->enqueueMessage(implode("\n", $errors));
 
             return false;

--- a/administrator/components/com_templates/src/View/Templates/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Templates/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Templates\Administrator\Model\TemplatesModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -104,18 +105,21 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->total         = $this->get('Total');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var TemplatesModel $model */
+        $model = $this->getModel();
+
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->total         = $model->getTotal();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
         $this->preview       = ComponentHelper::getParams('com_templates')->get('template_positions_display');
         $this->file          = base64_encode('home');
         $this->pluginState   = PluginHelper::isEnabled('installer', 'override');
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
@@ -134,7 +138,7 @@ class HtmlView extends BaseHtmlView
     protected function addToolbar()
     {
         $canDo    = ContentHelper::getActions('com_templates');
-        $clientId = (int) $this->get('State')->get('client_id');
+        $clientId = (int) $this->state->get('client_id');
         $toolbar  = $this->getDocument()->getToolbar();
 
         // Add a shortcut to the styles list view.

--- a/administrator/components/com_users/src/View/Captive/HtmlView.php
+++ b/administrator/components/com_users/src/View/Captive/HtmlView.php
@@ -118,8 +118,8 @@ class HtmlView extends BaseHtmlView
 
         // Load data from the model
         $this->isAdmin    = $app->isClient('administrator');
-        $this->records    = $this->get('records');
-        $this->record     = $this->get('record');
+        $this->records    = $model->getRecords();
+        $this->record     = $model->getRecord();
         $this->mfaMethods = MfaHelper::getMfaMethods();
 
         if (!empty($this->records)) {
@@ -182,7 +182,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Which title should I use for the page?
-        $this->title = $this->get('PageTitle');
+        $this->title = $model->getPageTitle();
 
         // Back-end: always show a title in the 'title' module position, not in the page body
         if ($this->isAdmin) {

--- a/administrator/components/com_users/src/View/Debuggroup/HtmlView.php
+++ b/administrator/components/com_users/src/View/Debuggroup/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Users\Administrator\Model\DebuggroupModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -95,16 +96,19 @@ class HtmlView extends BaseHtmlView
             throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
         }
 
-        $this->actions       = $this->get('DebugActions');
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->group         = $this->get('Group');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var DebuggroupModel $model */
+        $model = $this->getModel();
+
+        $this->actions       = $model->getDebugActions();
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->group         = $model->getGroup();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_users/src/View/Debuguser/HtmlView.php
+++ b/administrator/components/com_users/src/View/Debuguser/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\CMS\User\User;
+use Joomla\Component\Users\Administrator\Model\DebuguserModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -95,16 +96,19 @@ class HtmlView extends BaseHtmlView
             throw new NotAllowed(Text::_('JERROR_ALERTNOAUTHOR'), 403);
         }
 
-        $this->actions       = $this->get('DebugActions');
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->user          = $this->get('User');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var DebuguserModel $model */
+        $model = $this->getModel();
+
+        $this->actions       = $model->getDebugActions();
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->user          = $model->getUser();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_users/src/View/Group/HtmlView.php
+++ b/administrator/components/com_users/src/View/Group/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Users\Administrator\Model\GroupModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -70,12 +71,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state = $this->get('State');
-        $this->item  = $this->get('Item');
-        $this->form  = $this->get('Form');
+        /** @var GroupModel $model */
+        $model = $this->getModel();
+
+        $this->state = $model->getState();
+        $this->item  = $model->getItem();
+        $this->form  = $model->getForm();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_users/src/View/Groups/HtmlView.php
+++ b/administrator/components/com_users/src/View/Groups/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Users\Administrator\Model\GroupsModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -77,14 +78,17 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var GroupsModel $model */
+        $model = $this->getModel();
+
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_users/src/View/Level/HtmlView.php
+++ b/administrator/components/com_users/src/View/Level/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Users\Administrator\Model\LevelModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -61,12 +62,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->form  = $this->get('Form');
-        $this->item  = $this->get('Item');
-        $this->state = $this->get('State');
+        /** @var LevelModel $model */
+        $model = $this->getModel();
+
+        $this->form  = $model->getForm();
+        $this->item  = $model->getItem();
+        $this->state = $model->getState();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_users/src/View/Levels/HtmlView.php
+++ b/administrator/components/com_users/src/View/Levels/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Users\Administrator\Model\LevelsModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -77,14 +78,17 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var LevelsModel $model */
+        $model = $this->getModel();
+
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_users/src/View/Mail/HtmlView.php
+++ b/administrator/components/com_users/src/View/Mail/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Users\Administrator\Model\MailModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -50,8 +51,11 @@ class HtmlView extends BaseHtmlView
             Factory::getApplication()->redirect(Route::_('index.php', false));
         }
 
+        /** @var MailModel $model */
+        $model = $this->getModel();
+
         // Get data from the model
-        $this->form = $this->get('Form');
+        $this->form = $model->getForm();
 
         $this->addToolbar();
         parent::display($tpl);

--- a/administrator/components/com_users/src/View/Note/HtmlView.php
+++ b/administrator/components/com_users/src/View/Note/HtmlView.php
@@ -18,6 +18,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Users\Administrator\Model\NoteModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -67,13 +68,16 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var NoteModel $model */
+        $model = $this->getModel();
+
         // Initialise view variables.
-        $this->state = $this->get('State');
-        $this->item  = $this->get('Item');
-        $this->form  = $this->get('Form');
+        $this->state = $model->getState();
+        $this->item  = $model->getItem();
+        $this->form  = $model->getForm();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_users/src/View/Notes/HtmlView.php
+++ b/administrator/components/com_users/src/View/Notes/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\CMS\User\User;
+use Joomla\Component\Users\Administrator\Model\NotesModel;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -98,20 +99,23 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        // Initialise view variables.
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->user          = $this->get('User');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var NotesModel $model */
+        $model = $this->getModel();
 
-        if (!\count($this->items) && $this->isEmptyState = $this->get('IsEmptyState')) {
+        // Initialise view variables.
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->user          = $model->getUser();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
+
+        if (!\count($this->items) && $this->isEmptyState = $model->getIsEmptyState()) {
             $this->setLayout('emptystate');
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_users/src/View/User/HtmlView.php
+++ b/administrator/components/com_users/src/View/User/HtmlView.php
@@ -121,8 +121,8 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
         $user = $this->getCurrentUser();
 
         if ((int) $user->id != (int) $this->item->id || $user->authorise('core.admin')) {
-            $this->grouplist = $this->get('Groups');
-            $this->groups    = $this->get('AssignedGroups');
+            $this->grouplist = $model->getGroups();
+            $this->groups    = $model->getAssignedGroups();
         }
 
         $this->form->setValue('password', null);

--- a/administrator/components/com_users/src/View/User/HtmlView.php
+++ b/administrator/components/com_users/src/View/User/HtmlView.php
@@ -20,6 +20,7 @@ use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\CMS\User\UserFactoryAwareInterface;
 use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Component\Users\Administrator\Helper\Mfa;
+use Joomla\Component\Users\Administrator\Model\UserModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -98,18 +99,21 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
      */
     public function display($tpl = null)
     {
+        /** @var UserModel $model */
+        $model = $this->getModel();
+
         // If no item found, dont show the edit screen, redirect with message
-        if (false === $this->item = $this->get('Item')) {
+        if (false === $this->item = $model->getItem()) {
             $app = Factory::getApplication();
             $app->enqueueMessage(Text::_('JLIB_APPLICATION_ERROR_NOT_EXIST'), 'error');
             $app->redirect('index.php?option=com_users&view=users');
         }
 
-        $this->form  = $this->get('Form');
-        $this->state = $this->get('State');
+        $this->form  = $model->getForm();
+        $this->state = $model->getState();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_users/src/View/Users/HtmlView.php
+++ b/administrator/components/com_users/src/View/Users/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Users\Administrator\Model\UsersModel;
 use Joomla\Database\DatabaseDriver;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -100,16 +101,19 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->items         = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->state         = $this->get('State');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
+        /** @var UsersModel $model */
+        $model = $this->getModel();
+
+        $this->items         = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->state         = $model->getState();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
         $this->canDo         = ContentHelper::getActions('com_users');
         $this->db            = Factory::getDbo();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_workflow/src/View/Stage/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Stage/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Workflow\Administrator\Helper\StageHelper;
+use Joomla\Component\Workflow\Administrator\Model\StageModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -81,13 +82,16 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var StageModel $model */
+        $model = $this->getModel();
+
         // Get the Data
-        $this->state      = $this->get('State');
-        $this->form       = $this->get('Form');
-        $this->item       = $this->get('Item');
+        $this->state = $model->getState();
+        $this->form  = $model->getForm();
+        $this->item  = $model->getItem();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_workflow/src/View/Stages/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Stages/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Workflow\Administrator\Model\StagesModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -129,15 +130,18 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state         = $this->get('State');
-        $this->stages        = $this->get('Items');
-        $this->pagination    = $this->get('Pagination');
-        $this->filterForm    = $this->get('FilterForm');
-        $this->activeFilters = $this->get('ActiveFilters');
-        $this->workflow      = $this->get('Workflow');
+        /** @var StagesModel $model */
+        $model = $this->getModel();
+
+        $this->state         = $model->getState();
+        $this->stages        = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
+        $this->workflow      = $model->getWorkflow();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_workflow/src/View/Transition/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Transition/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Workflow\Administrator\Helper\StageHelper;
+use Joomla\Component\Workflow\Administrator\Model\TransitionModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -117,13 +118,15 @@ class HtmlView extends BaseHtmlView
         $this->app   = Factory::getApplication();
         $this->input = $this->app->getInput();
 
-        // Get the Data
-        $this->state      = $this->get('State');
-        $this->form       = $this->get('Form');
-        $this->item       = $this->get('Item');
+        /** @var TransitionModel $model */
+        $model = $this->getModel();
+
+        $this->state      = $model->getState();
+        $this->form       = $model->getForm();
+        $this->item       = $model->getItem();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_workflow/src/View/Transitions/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Transitions/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Workflow\Administrator\Model\TransitionsModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -122,15 +123,18 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state            = $this->get('State');
-        $this->transitions      = $this->get('Items');
-        $this->pagination       = $this->get('Pagination');
-        $this->filterForm       = $this->get('FilterForm');
-        $this->activeFilters    = $this->get('ActiveFilters');
-        $this->workflow         = $this->get('Workflow');
+        /** @var TransitionsModel $model */
+        $model = $this->getModel();
+
+        $this->state         = $model->getState();
+        $this->transitions   = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
+        $this->workflow      = $model->getWorkflow();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_workflow/src/View/Workflow/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Workflow/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Toolbar;
 use Joomla\CMS\Toolbar\ToolbarHelper;
 use Joomla\Component\Workflow\Administrator\Helper\WorkflowHelper;
+use Joomla\Component\Workflow\Administrator\Model\WorkflowModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -86,13 +87,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        // Get the Data
-        $this->state      = $this->get('State');
-        $this->form       = $this->get('Form');
-        $this->item       = $this->get('Item');
+        /** @var WorkflowModel $model */
+        $model = $this->getModel();
+
+        $this->state      = $model->getState();
+        $this->form       = $model->getForm();
+        $this->item       = $model->getItem();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/administrator/components/com_workflow/src/View/Workflows/HtmlView.php
+++ b/administrator/components/com_workflow/src/View/Workflows/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Toolbar\Button\DropdownButton;
 use Joomla\CMS\Toolbar\ToolbarHelper;
+use Joomla\Component\Workflow\Administrator\Model\WorkflowsModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -103,14 +104,17 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        $this->state            = $this->get('State');
-        $this->workflows        = $this->get('Items');
-        $this->pagination       = $this->get('Pagination');
-        $this->filterForm       = $this->get('FilterForm');
-        $this->activeFilters    = $this->get('ActiveFilters');
+        /** @var WorkflowsModel $model */
+        $model = $this->getModel();
+
+        $this->state         = $model->getState();
+        $this->workflows     = $model->getItems();
+        $this->pagination    = $model->getPagination();
+        $this->filterForm    = $model->getFilterForm();
+        $this->activeFilters = $model->getActiveFilters();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 


### PR DESCRIPTION
### Summary of Changes
This PR refactors the views to get the model object and then directly call the methods of the model instead of going through the `View::get()` indirection. This refactors the views of the backend components from com_plugins to com_workflow.


### Testing Instructions
Everything should work the same.



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
