### PR TITLE
[5.3] Refactoring views to directly call models (frontend)

### DIFF
--- a/components/com_config/src/View/Modules/HtmlView.php
+++ b/components/com_config/src/View/Modules/HtmlView.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Config\Site\Model\ModulesModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -71,9 +72,10 @@ class HtmlView extends BaseHtmlView
         // Need to add module name to the state of model
         $model->getState()->set('module.name', $moduleData['module']);
 
-        /** @var Form form */
-        $this->form      = $this->get('form');
-        $this->positions = $this->get('positions');
+        /** @var ModulesModel $model */
+        $model           = $this->getModel();
+        $this->form      = $model->getForm();
+        $this->positions = $model->getPositions();
         $this->item      = $moduleData;
 
         if ($this->form) {

--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -21,6 +21,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\User\UserFactoryAwareInterface;
 use Joomla\CMS\User\UserFactoryAwareTrait;
 use Joomla\Component\Contact\Site\Helper\RouteHelper;
+use Joomla\Component\Contact\Site\Model\ContactModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -136,11 +137,13 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
      */
     public function display($tpl = null)
     {
+        /** @var ContactModel $model */
+        $model      = $this->getModel();
         $app        = Factory::getApplication();
         $user       = $this->getCurrentUser();
-        $state      = $this->get('State');
-        $item       = $this->get('Item');
-        $this->form = $this->get('Form');
+        $state      = $model->getState();
+        $item       = $model->getItem();
+        $this->form = $model->getForm();
         $params     = $state->get('params');
         $contacts   = [];
 
@@ -193,7 +196,7 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_contact/src/View/Contact/VcfView.php
+++ b/components/com_contact/src/View/Contact/VcfView.php
@@ -13,6 +13,7 @@ namespace Joomla\Component\Contact\Site\View\Contact;
 use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\View\AbstractView;
 use Joomla\CMS\MVC\View\GenericDataException;
+use Joomla\Component\Contact\Site\Model\ContactModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -43,11 +44,12 @@ class VcfView extends AbstractView
      */
     public function display($tpl = null)
     {
-        // Get model data.
-        $item = $this->get('Item');
+        /** @var ContactModel $model */
+        $model = $this->getModel();
+        $item  = $model->getItem();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_contact/src/View/Featured/HtmlView.php
+++ b/components/com_contact/src/View/Featured/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\Mail\MailHelper;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Contact\Site\Model\FeaturedModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -87,19 +88,20 @@ class HtmlView extends BaseHtmlView
         $app    = Factory::getApplication();
         $params = $app->getParams();
 
-        // Get some data from the models
-        $state      = $this->get('State');
-        $items      = $this->get('Items');
+        /** @var FeaturedModel $model */
+        $model      = $this->getModel();
+        $state      = $model->getState();
+        $items      = $model->getItems();
         $category   = $this->get('Category');
         $children   = $this->get('Children');
         $parent     = $this->get('Parent');
-        $pagination = $this->get('Pagination');
+        $pagination = $model->getPagination();
 
         // Flag indicates to not add limitstart=0 to URL
         $pagination->hideEmptyLimitstart = true;
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_contact/src/View/Form/HtmlView.php
+++ b/components/com_contact/src/View/Form/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\Component\Contact\Administrator\Helper\ContactHelper;
+use Joomla\Component\Contact\Site\Model\FormModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -79,11 +80,12 @@ class HtmlView extends BaseHtmlView
         $user = $this->getCurrentUser();
         $app  = Factory::getApplication();
 
-        // Get model data.
-        $this->state       = $this->get('State');
-        $this->item        = $this->get('Item');
-        $this->form        = $this->get('Form');
-        $this->return_page = $this->get('ReturnPage');
+        /** @var FormModel $model */
+        $model             = $this->getModel();
+        $this->state       = $model->getState();
+        $this->item        = $model->getItem();
+        $this->form        = $model->getForm();
+        $this->return_page = $model->getReturnPage();
 
         if (empty($this->item->id)) {
             $authorised = $user->authorise('core.create', 'com_contact') || \count($user->getAuthorisedCategories('com_contact', 'core.create'));
@@ -107,7 +109,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             $app->enqueueMessage(implode("\n", $errors), 'error');
 
             return false;

--- a/components/com_content/src/View/Archive/HtmlView.php
+++ b/components/com_content/src/View/Archive/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Component\Content\Site\Model\ArchiveModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -115,13 +116,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
+        /** @var ArchiveModel $model */
+        $model      = $this->getModel();
         $app        = Factory::getApplication();
         $user       = $this->getCurrentUser();
-        $state      = $this->get('State');
-        $items      = $this->get('Items');
-        $pagination = $this->get('Pagination');
+        $state      = $model->getState();
+        $items      = $model->getItems();
+        $pagination = $model->getPagination();
 
-        if ($errors = $this->getModel()->getErrors()) {
+        if ($errors = $model->getErrors()) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_content/src/View/Article/HtmlView.php
+++ b/components/com_content/src/View/Article/HtmlView.php
@@ -24,6 +24,7 @@ use Joomla\CMS\Router\Route;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Content\Site\Helper\AssociationHelper;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
+use Joomla\Component\Content\Site\Model\ArticleModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -107,13 +108,15 @@ class HtmlView extends BaseHtmlView
         $app  = Factory::getApplication();
         $user = $this->getCurrentUser();
 
-        $this->item  = $this->get('Item');
+        /** @var ArticleModel $model */
+        $model       = $this->getModel();
+        $this->item  = $model->getItem();
         $this->print = $app->getInput()->getBool('print', false);
-        $this->state = $this->get('State');
+        $this->state = $model->getState();
         $this->user  = $user;
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_content/src/View/Featured/FeedView.php
+++ b/components/com_content/src/View/Featured/FeedView.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\AbstractView;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Content\Site\Helper\RouteHelper;
+use Joomla\Component\Content\Site\Model\FeaturedModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -55,7 +56,10 @@ class FeedView extends AbstractView
         // Get some data from the model
         $app->getInput()->set('limit', $app->get('feed_limit'));
         $categories = Categories::getInstance('Content');
-        $rows       = $this->get('Items');
+
+        /** @var FeaturedModel $model */
+        $model = $this->getModel();
+        $rows  = $model->getItems();
 
         foreach ($rows as $row) {
             // Strip html from feed item title

--- a/components/com_content/src/View/Featured/HtmlView.php
+++ b/components/com_content/src/View/Featured/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
+use Joomla\Component\Content\Site\Model\FeaturedModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -117,20 +118,22 @@ class HtmlView extends BaseHtmlView
     {
         $user = $this->getCurrentUser();
 
-        $state      = $this->get('State');
-        $items      = $this->get('Items');
-        $pagination = $this->get('Pagination');
+        /** @var FeaturedModel $model */
+        $model      = $this->getModel();
+        $state      = $model->getState();
+        $items      = $model->getItems();
+        $pagination = $model->getPagination();
 
         // Flag indicates to not add limitstart=0 to URL
         $pagination->hideEmptyLimitstart = true;
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
         /** @var \Joomla\Registry\Registry $params */
-        $params = &$state->params;
+        $params = $state->params;
 
         // PREPARE THE DATA
 

--- a/components/com_content/src/View/Form/HtmlView.php
+++ b/components/com_content/src/View/Form/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Component\Content\Site\Model\FormModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -113,11 +114,12 @@ class HtmlView extends BaseHtmlView
         $app  = Factory::getApplication();
         $user = $app->getIdentity();
 
-        // Get model data.
-        $this->state       = $this->get('State');
-        $this->item        = $this->get('Item');
-        $this->form        = $this->get('Form');
-        $this->return_page = $this->get('ReturnPage');
+        /** @var FormModel $model */
+        $model             = $this->getModel();
+        $this->state       = $model->getState();
+        $this->item        = $model->getItem();
+        $this->form        = $model->getForm();
+        $this->return_page = $model->getReturnPage();
 
         if (empty($this->item->id)) {
             $catid = $this->state->params->get('catid');
@@ -153,7 +155,7 @@ class HtmlView extends BaseHtmlView
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_finder/src/View/Search/FeedView.php
+++ b/components/com_finder/src/View/Search/FeedView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
+use Joomla\Component\Finder\Site\Model\SearchModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -45,12 +46,12 @@ class FeedView extends BaseHtmlView
         // Adjust the list limit to the feed limit.
         $app->getInput()->set('limit', $app->get('feed_limit'));
 
-        // Get view data.
-        $state   = $this->get('State');
+        /** @var SearchModel $model */
+        $model   = $this->getModel();
+        $state   = $model->getState();
         $params  = $state->get('params');
-        $query   = $this->get('Query');
-        $results = $this->get('Items');
-        $total   = $this->get('Total');
+        $query   = $model->getQuery();
+        $results = $model->getItems();
 
         // If the feed has been disabled, we want to bail out here
         if ($params->get('show_feed_link', 1) == 0) {

--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -25,6 +25,7 @@ use Joomla\CMS\Router\SiteRouterAwareTrait;
 use Joomla\CMS\Uri\Uri;
 use Joomla\Component\Finder\Administrator\Indexer\Query;
 use Joomla\Component\Finder\Site\Helper\FinderHelper;
+use Joomla\Component\Finder\Site\Model\SearchModel;
 use Joomla\Filesystem\Path;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -138,17 +139,20 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
         $app          = Factory::getApplication();
         $this->params = $app->getParams();
 
+        /** @var SearchModel $model */
+        $model = $this->getModel();
+
         // Get view data.
-        $this->state = $this->get('State');
-        $this->query = $this->get('Query');
+        $this->state = $model->getState();
+        $this->query = $model->getQuery();
         \JDEBUG ? Profiler::getInstance('Application')->mark('afterFinderQuery') : null;
-        $this->results = $this->get('Items');
+        $this->results = $model->getItems();
         \JDEBUG ? Profiler::getInstance('Application')->mark('afterFinderResults') : null;
-        $this->sortOrderFields = $this->get('sortOrderFields');
+        $this->sortOrderFields = $model->getSortOrderFields();
         \JDEBUG ? Profiler::getInstance('Application')->mark('afterFinderSortOrderFields') : null;
-        $this->total = $this->get('Total');
+        $this->total = $model->getTotal();
         \JDEBUG ? Profiler::getInstance('Application')->mark('afterFinderTotal') : null;
-        $this->pagination = $this->get('Pagination');
+        $this->pagination = $model->getPagination();
         \JDEBUG ? Profiler::getInstance('Application')->mark('afterFinderPagination') : null;
 
         // Flag indicates to not add limitstart=0 to URL
@@ -181,7 +185,7 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
         }
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\Component\Newsfeeds\Site\Helper\RouteHelper;
+use Joomla\Component\Newsfeeds\Site\Model\NewsfeedModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -101,13 +102,14 @@ class HtmlView extends BaseHtmlView
         // Get view related request variables.
         $print = $app->getInput()->getBool('print');
 
-        // Get model data.
-        $state = $this->get('State');
-        $item  = $this->get('Item');
+        /** @var NewsfeedModel $model */
+        $model = $this->getModel();
+        $state = $model->getState();
+        $item  = $model->getItem();
 
         // Check for errors.
         // @TODO: Maybe this could go into ComponentHelper::raiseErrors($this->get('Errors'))
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_privacy/src/View/Confirm/HtmlView.php
+++ b/components/com_privacy/src/View/Confirm/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Privacy\Site\Model\ConfirmModel;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -73,13 +74,14 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        // Initialise variables.
-        $this->form   = $this->get('Form');
-        $this->state  = $this->get('State');
+        /** @var ConfirmModel $model */
+        $model        = $this->getModel();
+        $this->form   = $model->getForm();
+        $this->state  = $model->getState();
         $this->params = $this->state->params;
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_privacy/src/View/Remind/HtmlView.php
+++ b/components/com_privacy/src/View/Remind/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Privacy\Site\Model\RemindModel;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -73,13 +74,14 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        // Initialise variables.
-        $this->form   = $this->get('Form');
-        $this->state  = $this->get('State');
+        /** @var RemindModel $model */
+        $model        = $this->getModel();
+        $this->form   = $model->getForm();
+        $this->state  = $model->getState();
         $this->params = $this->state->params;
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_privacy/src/View/Request/HtmlView.php
+++ b/components/com_privacy/src/View/Request/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Privacy\Site\Model\RequestModel;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -81,14 +82,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        // Initialise variables.
-        $this->form            = $this->get('Form');
-        $this->state           = $this->get('State');
+        /** @var RequestModel $model */
+        $model                 = $this->getModel();
+        $this->form            = $model->getForm();
+        $this->state           = $model->getState();
         $this->params          = $this->state->params;
         $this->sendMailEnabled = (bool) Factory::getApplication()->get('mailonline', 1);
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_tags/src/View/Tag/FeedView.php
+++ b/components/com_tags/src/View/Tag/FeedView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
+use Joomla\Component\Tags\Site\Model\TagModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -73,8 +74,9 @@ class FeedView extends BaseHtmlView
             $this->getDocument()->editorEmail = $siteEmail;
         }
 
-        // Get some data from the model
-        $items    = $this->get('Items');
+        /** @var TagModel $model */
+        $model = $this->getModel();
+        $items = $model->getItems();
 
         if ($items !== false) {
             foreach ($items as $item) {

--- a/components/com_tags/src/View/Tag/HtmlView.php
+++ b/components/com_tags/src/View/Tag/HtmlView.php
@@ -17,6 +17,7 @@ use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\User\User;
+use Joomla\Component\Tags\Site\Model\TagModel;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -133,19 +134,22 @@ class HtmlView extends BaseHtmlView
     {
         $app    = Factory::getApplication();
 
+        /** @var TagModel $model */
+        $model = $this->getModel();
+
         // Get some data from the models
-        $this->state      = $this->get('State');
-        $this->items      = $this->get('Items');
-        $this->item       = $this->get('Item');
+        $this->state      = $model->getState();
+        $this->items      = $model->getItems();
+        $this->item       = $model->getItem();
         $this->children   = $this->get('Children');
         $this->parent     = $this->get('Parent');
-        $this->pagination = $this->get('Pagination');
+        $this->pagination = $model->getPagination();
         $this->user       = $this->getCurrentUser();
 
         // Flag indicates to not add limitstart=0 to URL
         $this->pagination->hideEmptyLimitstart = true;
 
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_tags/src/View/Tags/FeedView.php
+++ b/components/com_tags/src/View/Tags/FeedView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
+use Joomla\Component\Tags\Site\Model\TagsModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -56,8 +57,9 @@ class FeedView extends BaseHtmlView
             $this->getDocument()->editorEmail = $siteEmail;
         }
 
-        // Get some data from the model
-        $items = $this->get('Items');
+        /** @var TagsModel $model */
+        $model = $this->getModel();
+        $items = $model->getItems();
 
         foreach ($items as $item) {
             // Strip HTML from feed item title

--- a/components/com_tags/src/View/Tags/HtmlView.php
+++ b/components/com_tags/src/View/Tags/HtmlView.php
@@ -15,6 +15,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
+use Joomla\Component\Tags\Site\Model\TagsModel;
 use Joomla\Registry\Registry;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -86,14 +87,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        // Get some data from the models
-        $this->state      = $this->get('State');
-        $this->items      = $this->get('Items');
-        $this->pagination = $this->get('Pagination');
+        /** @var TagsModel $model */
+        $model            = $this->getModel();
+        $this->state      = $model->getState();
+        $this->items      = $model->getItems();
+        $this->pagination = $model->getPagination();
         $this->params     = $this->state->get('params');
         $this->user       = $this->getCurrentUser();
 
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_users/src/View/Login/HtmlView.php
+++ b/components/com_users/src/View/Login/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\User\User;
+use Joomla\Component\Users\Site\Model\LoginModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -95,14 +96,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        // Get the view data.
+        /** @var LoginModel $model */
+        $model        = $this->getModel();
         $this->user   = $this->getCurrentUser();
-        $this->form   = $this->get('Form');
-        $this->state  = $this->get('State');
+        $this->form   = $model->getForm();
+        $this->state  = $model->getState();
         $this->params = $this->state->get('params');
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -19,6 +19,7 @@ use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\User\User;
 use Joomla\Component\Users\Administrator\Helper\Mfa;
+use Joomla\Component\Users\Site\Model\ProfileModel;
 use Joomla\Database\DatabaseDriver;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -102,16 +103,17 @@ class HtmlView extends BaseHtmlView
     {
         $user = $this->getCurrentUser();
 
-        // Get the view data.
-        $this->data               = $this->get('Data');
-        $this->form               = $this->getModel()->getForm(new CMSObject(['id' => $user->id]));
-        $this->state              = $this->get('State');
+        /** @var ProfileModel $model */
+        $model                    = $this->getModel();
+        $this->data               = $model->getData();
+        $this->form               = $model->getForm();
+        $this->state              = $model->getState();
         $this->params             = $this->state->get('params');
         $this->mfaConfigurationUI = Mfa::getConfigurationInterface($user);
         $this->db                 = Factory::getDbo();
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_users/src/View/Profile/HtmlView.php
+++ b/components/com_users/src/View/Profile/HtmlView.php
@@ -14,7 +14,6 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
-use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\User\User;

--- a/components/com_users/src/View/Registration/HtmlView.php
+++ b/components/com_users/src/View/Registration/HtmlView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Plugin\PluginHelper;
+use Joomla\Component\Users\Site\Model\RegistrationModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -92,14 +93,15 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        // Get the view data.
-        $this->form   = $this->get('Form');
-        $this->data   = $this->get('Data');
-        $this->state  = $this->get('State');
+        /** @var RegistrationModel $model */
+        $model        = $this->getModel();
+        $this->form   = $model->getForm();
+        $this->data   = $model->getData();
+        $this->state  = $model->getState();
         $this->params = $this->state->get('params');
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_users/src/View/Remind/HtmlView.php
+++ b/components/com_users/src/View/Remind/HtmlView.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Users\Site\Model\RemindModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -67,13 +68,14 @@ class HtmlView extends BaseHtmlView
      */
     public function display($tpl = null)
     {
-        // Get the view data.
-        $this->form   = $this->get('Form');
-        $this->state  = $this->get('State');
+        /** @var RemindModel $model */
+        $model        = $this->getModel();
+        $this->form   = $model->getForm();
+        $this->state  = $model->getState();
         $this->params = $this->state->params;
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 

--- a/components/com_users/src/View/Reset/HtmlView.php
+++ b/components/com_users/src/View/Reset/HtmlView.php
@@ -14,6 +14,7 @@ use Joomla\CMS\Factory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+use Joomla\Component\Users\Site\Model\ResetModel;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
@@ -69,24 +70,27 @@ class HtmlView extends BaseHtmlView
         // This name will be used to get the model
         $name = $this->getLayout();
 
+        /** @var ResetModel $model */
+        $model = $this->getModel();
+
         // Check that the name is valid - has an associated model.
         if (!\in_array($name, ['confirm', 'complete'])) {
             $name = 'default';
         }
 
         if ('default' === $name) {
-            $formname = 'Form';
-        } else {
-            $formname = ucfirst($this->_name) . ucfirst($name) . 'Form';
+            $this->form = $model->getForm();
+        } elseif ($name === 'confirm') {
+            $this->form = $model->getResetConfirmForm();
+        } elseif ($name === 'complete') {
+            $this->form = $model->getResetCompleteForm();
         }
 
-        // Get the view data.
-        $this->form   = $this->get($formname);
-        $this->state  = $this->get('State');
+        $this->state  = $model->getState();
         $this->params = $this->state->params;
 
         // Check for errors.
-        if (\count($errors = $this->get('Errors'))) {
+        if (\count($errors = $model->getErrors())) {
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 


### PR DESCRIPTION
### Summary of Changes
This PR refactors the views to get the model object and then directly call the methods of the model instead of going through the `View::get()` indirection. This refactors the views of all frontend components.


### Testing Instructions
Everything should work the same.



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
