### PR TITLE
[5.2] Articles module : setting Introtext Limit destroys article html formats

### DIFF
--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -368,7 +368,7 @@ class ArticlesHelper implements DatabaseAwareInterface
                 }
 
                 if ($introtext_limit != 0) {
-                    $item->displayIntrotext = SpecialStringHelper::truncate($item->introtext, $introtext_limit, true, false);
+                    $item->displayIntrotext = SpecialStringHelper::truncateComplex($item->displayIntrotext, $introtext_limit, true);
                 }
             }
 


### PR DESCRIPTION
In articles module, if introtext limit is set to a non zero value, all html tags (ul, li, hx,...) are removed.

### Summary of Changes

In mod_articles/src/Helper/ArticlesHelper.php, line 371, replacing truncate by truncateComplex preserves as much HTML code as possible.

Note : in current version, line 371 contains a bug, it performs a truncate with introtext when it should be displayIntrotext

### Testing Instructions
Create one article with some html like text formatting, ul, li, .... in its first 100 characters.
Create an Articles module so that it will display your article and set introtext limit to 100.

### Actual result BEFORE applying this Pull Request
In articles modules, articles are displayed as plain text.

### Expected result AFTER applying this Pull Request
In articles modules, articles are displayed with as much HTML as possible.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
