### PR TITLE
[5.2-RC] mod_articles : show introtext not working

### DIFF
--- a/modules/mod_articles/tmpl/default_items.php
+++ b/modules/mod_articles/tmpl/default_items.php
@@ -104,7 +104,7 @@ if ($params->get('articles_layout') == 1) {
                         <?php echo $item->event->beforeDisplayContent; ?>
 
                         <?php if ($params->get('show_introtext', 1)) : ?>
-                            <?php echo $item->introtext; ?>
+                            <?php echo $item->displayIntrotext; ?>
                         <?php endif; ?>
 
                         <?php echo $item->event->afterDisplayContent; ?>


### PR DESCRIPTION
Mod_Articles : if show introtext parameter is set with an introtext limit greater than 0, a wrong value is displayed in the module.

### Summary of Changes

In ArticlesHelper.php, show_introtext fills up displayIntrotext field (lines 362 to 373), but default_items.php displays introtext field (line 107).

### Testing Instructions

In Articles module, set IntroText parameter to Show and set IntroText Limit to any non-zero value.

### Actual result BEFORE applying this Pull Request

Articles module shows full article

### Expected result AFTER applying this Pull Request

Articles module shows truncated articles to the defined limit.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
