### PR TITLE
[5.2] Articles module: Truncate text (introtext and read more title)

### DIFF
--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -16,7 +16,6 @@ use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Date\Date;
 use Joomla\CMS\Event\Content;
 use Joomla\CMS\Factory;
-use Joomla\CMS\HTML\Helpers\StringHelper as SpecialStringHelper;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
@@ -368,7 +367,7 @@ class ArticlesHelper implements DatabaseAwareInterface
                 }
 
                 if ($introtext_limit != 0) {
-                    $item->displayIntrotext = SpecialStringHelper::truncate($item->introtext, $introtext_limit, true, false);
+                    $item->displayIntrotext = HTMLHelper::_('string.truncateComplex', $item->displayIntrotext, $introtext_limit);
                 }
             }
 

--- a/modules/mod_articles/tmpl/default_items.php
+++ b/modules/mod_articles/tmpl/default_items.php
@@ -104,12 +104,12 @@ if ($params->get('articles_layout') == 1) {
                         <?php echo $item->event->beforeDisplayContent; ?>
 
                         <?php if ($params->get('show_introtext', 1)) : ?>
-                            <?php echo $item->introtext; ?>
+                            <?php echo $item->displayIntrotext; ?>
                         <?php endif; ?>
 
                         <?php echo $item->event->afterDisplayContent; ?>
 
-                        <?php if (isset($item->link) && $item->readmore != 0 && $params->get('show_readmore')) : ?>
+                        <?php if ($params->get('show_readmore')) : ?>
                             <?php if ($params->get('show_readmore_title', '') !== '') : ?>
                                 <?php $item->params->set('show_readmore_title', $params->get('show_readmore_title')); ?>
                                 <?php $item->params->set('readmore_limit', $params->get('readmore_limit')); ?>


### PR DESCRIPTION
This Pull Request tries to solve several issues #44183, #44185, corrects wrong introduced parameters for the read more button #44136 and replaces other PRs #44179, #44175

### Summary of Changes
Replaced the truncate method with `string.truncateComplex` . The intro text preserves now html tags (e.g. formatting like `strong` or links) and the number of characters is almost correct (the truncate method doesn't cut words, so the number of characters can be more or less depending on the length of the words and the position of a space). The ellipsis are on a new line, I don't like it, but that is the way the method is defined and it is not in the scope of this PR to change the truncate method.
The PR #44136 introduced some additional parameters on the read more button. These are not necessary and interferes with the parameter of the module (e.g. don't displaying the read more button although the parameter is set to show).

### Testing Instructions

Create several articles with and without formatting (e.g. strong) and / or links in the intro text. Create a module to display the articles and play with the parameters Introtext, Introtext Limit, "Read More" Link, Read More with Title, Read More Limit

### Actual result BEFORE applying this Pull Request
Please look at all linked issues and pull requests.

### Expected result AFTER applying this Pull Request
![grafik](https://github.com/user-attachments/assets/52783587-2d90-4cca-a03a-36c03bdba527)
![grafik](https://github.com/user-attachments/assets/f27da960-cdfd-4ab0-8882-56113c72a600)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
