### PR TITLE
[5.2][GuidedTours] replace deprecated access of input property

### DIFF
--- a/administrator/components/com_guidedtours/src/Controller/AjaxController.php
+++ b/administrator/components/com_guidedtours/src/Controller/AjaxController.php
@@ -37,9 +37,9 @@ class AjaxController extends BaseController
     {
         $user = $this->app->getIdentity();
 
-        $tourId     = $this->app->input->getInt('tid', 0);
-        $stepNumber = $this->app->input->getInt('sid', 0);
-        $context    = $this->app->input->getString('context', '');
+        $tourId     = $this->app->getInput()->getInt('tid', 0);
+        $stepNumber = $this->app->getInput()->getInt('sid', 0);
+        $context    = $this->app->getInput()->getString('context', '');
 
         if ($user == null || $user->id <= 0) {
             echo new JsonResponse(['success' => false, 'tourId' => $tourId], Text::_('COM_GUIDEDTOURS_USERSTATE_CONNECTEDONLY'), true);


### PR DESCRIPTION
### Summary of Changes

#43814 use deprecated code
https://github.com/joomla-framework/application/blob/dd055642fbe8d7b919a6c6c345a0d016b0981e65/src/AbstractWebApplication.php#L229-L238

See also #39029 for information

### Testing Instructions

- use guided tours
- code review

### Actual result BEFORE applying this Pull Request

Use of deprecated access to the application's input property

### Expected result AFTER applying this Pull Request

Application->getInput() instead of Application->input (no deprecation warning)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
