### PR TITLE
[4.4] Fix the actions menu in the admin isn't working on mobile

### DIFF
--- a/build/media_source/templates/administrator/atum/js/template.es6.js
+++ b/build/media_source/templates/administrator/atum/js/template.es6.js
@@ -252,6 +252,9 @@ document.querySelectorAll('[data-bs-toggle="dropdown"]').forEach((button) => {
   button.addEventListener('click', () => {
     document.querySelectorAll('[data-bs-toggle="collapse"]').forEach((cb) => {
       const target = document.querySelector(cb.getAttribute('data-bs-target'));
+      if (target.contains(button)) {
+        return;
+      }
       const collapseMenu = bootstrap.Collapse.getInstance(target) || new bootstrap.Collapse(target, {
         toggle: false,
       });


### PR DESCRIPTION
Pull Request for Issue #44198 .

### Summary of Changes

Fix the actions menu in the admin isn't working on mobile

### Testing Instructions

Select one or more articles / users from the list. Then click in the top right corner to open the menu and click on 'Actions'.

### Actual result BEFORE applying this Pull Request

The whole menu is closed.

### Expected result AFTER applying this Pull Request

Open the submenu to give you a choice

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
