### PR TITLE
[5.2] Articles Module: Display not only titles by default

### DIFF
--- a/modules/mod_articles/mod_articles.xml
+++ b/modules/mod_articles/mod_articles.xml
@@ -181,7 +181,7 @@
 					type="radio"
 					label="MOD_ARTICLES_FIELD_TITLEONLY_LABEL"
 					layout="joomla.form.field.radio.switcher"
-					default="1"
+					default="0"
 					filter="integer"
 					>
 					<option value="0">JNO</option>

--- a/modules/mod_articles/tmpl/default.php
+++ b/modules/mod_articles/tmpl/default.php
@@ -33,7 +33,7 @@ if ((bool) $module->showtitle) {
     }
 }
 
-$layoutSuffix = $params->get('title_only', 1) ? '_titles' : '_items';
+$layoutSuffix = $params->get('title_only', 0) ? '_titles' : '_items';
 
 ?>
 <?php if ($grouped) : ?>


### PR DESCRIPTION
### Summary of Changes
The Articles module right now is set to only display titles by default and then hides all other options. This is confusing and this PR switches that behavior around. 


### Testing Instructions
Create a new Articles module instance.


### Actual result BEFORE applying this Pull Request
You only see the option "Show titles only" being set to "Yes". Rest is hidden.


### Expected result AFTER applying this Pull Request
Option "Show titles only" is set to "No" by default and all other options are displayed.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
