### PR TITLE
[5.2] SEF: Don't remove trailingslash on hp in a subdir

### DIFF
--- a/plugins/system/sef/src/Extension/Sef.php
+++ b/plugins/system/sef/src/Extension/Sef.php
@@ -364,7 +364,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
     {
         $path = $uri->getPath();
 
-        if ($path != '/' && str_ends_with($path, '/')) {
+        if ($path != Uri::base(true) . '/' && str_ends_with($path, '/')) {
             $uri->setPath(substr($path, 0, -1));
         }
     }


### PR DESCRIPTION
### Summary of Changes
When running an installation in a subdirectory with strict routing enabled, the last slash is removed and a redirect is executed, breaking for example the login. This PR fixes that. A big thanks goes to @LadySolveig, who reported this. 


### Testing Instructions
Install a Joomla 5.2.0 or use an updated site in a subdirectory. In case of an updated site, enable strict routing in the SEF system plugin. Make sure that the site is using URL rewriting. Login on the frontend.


### Actual result BEFORE applying this Pull Request
Login doesn't work.


### Expected result AFTER applying this Pull Request
Login works.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
