### PR TITLE
[5.2] Fix contact state filter for administrator

### DIFF
--- a/components/com_contact/src/Model/CategoryModel.php
+++ b/components/com_contact/src/Model/CategoryModel.php
@@ -196,7 +196,7 @@ class CategoryModel extends ListModel
             $query->where($db->quoteName('a.published') . ' = :published');
             $query->bind(':published', $state, ParameterType::INTEGER);
         } else {
-            $query->whereIn($db->quoteName('c.published'), [0,1,2]);
+            $query->whereIn($db->quoteName('a.published'), [0,1,2]);
         }
 
         // Filter by start and end dates.


### PR DESCRIPTION
There was a bug in state filtering of **CategoryModel** that lead to administrators seeing trashed items in the front-end. 

### Summary of Changes
Changed the state filter to filter the contact items.


### Testing Instructions
- Create 2 contacts: **contact A** and **contact B** to **Uncategorized**
- Move **contact B** to Trash
- Create a front-end menu item of type **List Contacts in a Category** and select **Uncategorized**
- Visit front-end logged in as a **Super Administrator** and click the menu item created in previous step


### Actual result BEFORE applying this Pull Request
Both contacts visible


### Expected result AFTER applying this Pull Request
Only contact A should be visible


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
