### PR TITLE
[5.2RC3] fix to exclude current article even in include mode

### DIFF
--- a/modules/mod_articles/mod_articles.xml
+++ b/modules/mod_articles/mod_articles.xml
@@ -112,7 +112,7 @@
 					layout="joomla.form.field.radio.switcher"
 					default="1"
 					filter="integer"
-				>
+					>
 					<option value="0">JNO</option>
 					<option value="1">JYES</option>
 				</field>
@@ -123,7 +123,7 @@
 					label="MOD_ARTICLES_FIELD_EX_OR_INCLUDE_LABEL"
 					default="0"
 					filter="integer"
-				>
+					>
 					<option value="0">MOD_ARTICLES_OPTION_EXCLUDE_VALUE</option>
 					<option value="1">MOD_ARTICLES_OPTION_INCLUDE_VALUE</option>
 				</field>

--- a/modules/mod_articles/mod_articles.xml
+++ b/modules/mod_articles/mod_articles.xml
@@ -106,6 +106,18 @@
 				/>
 
 				<field
+					name="exclude_current"
+					type="radio"
+					label="MOD_ARTICLES_FIELD_EXCLUDE_CURRENT_LABEL"
+					layout="joomla.form.field.radio.switcher"
+					default="1"
+					filter="integer"
+				>
+					<option value="0">JNO</option>
+					<option value="1">JYES</option>
+				</field>
+
+				<field
 					name="ex_or_include_articles"
 					type="list"
 					label="MOD_ARTICLES_FIELD_EX_OR_INCLUDE_LABEL"
@@ -115,20 +127,6 @@
 					<option value="0">MOD_ARTICLES_OPTION_EXCLUDE_VALUE</option>
 					<option value="1">MOD_ARTICLES_OPTION_INCLUDE_VALUE</option>
 				</field>
-
-				<field
-					name="exclude_current"
-					type="radio"
-					label="MOD_ARTICLES_FIELD_EXCLUDE_CURRENT_LABEL"
-					layout="joomla.form.field.radio.switcher"
-					default="1"
-					filter="integer"
-					showon="ex_or_include_articles:0"
-					>
-					<option value="0">JNO</option>
-					<option value="1">JYES</option>
-				</field>
-
 
 				<field
 					name="excluded_articles"

--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -258,7 +258,7 @@ class ArticlesHelper implements DatabaseAwareInterface
             && (int) $article['id'] === $currentArticleId
             && empty($articlesList)
         ) {
-            $filterInclude = false;
+            $filterInclude  = false;
             $articlesList[] = $currentArticleId;
         }
 

--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -216,6 +216,7 @@ class ArticlesHelper implements DatabaseAwareInterface
         $ex_or_include_articles = $params->get('ex_or_include_articles', 0);
         $filterInclude          = true;
         $articlesList           = [];
+        $currentArticleId       = $input->get('id', 0, 'UINT');
 
         $articlesListToProcess = $params->get('included_articles', '');
 
@@ -227,13 +228,22 @@ class ArticlesHelper implements DatabaseAwareInterface
                 && $input->get('option') === 'com_content'
                 && $input->get('view') === 'article'
             ) {
-                $articlesList[] = $input->get('id', 0, 'UINT');
+                $articlesList[] = $currentArticleId;
             }
 
             $articlesListToProcess = $params->get('excluded_articles', '');
         }
 
         foreach (ArrayHelper::fromObject($articlesListToProcess) as $article) {
+            if (
+                $ex_or_include_articles === 1
+                && $params->get('exclude_current', 1) === 1
+                && $input->get('option') === 'com_content'
+                && (int) $article['id'] === $currentArticleId
+            ) {
+                continue;
+            }
+
             $articlesList[] = (int) $article['id'];
         }
 

--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -239,6 +239,7 @@ class ArticlesHelper implements DatabaseAwareInterface
                 $ex_or_include_articles === 1
                 && $params->get('exclude_current', 1) === 1
                 && $input->get('option') === 'com_content'
+                && $input->get('view') === 'article'
                 && (int) $article['id'] === $currentArticleId
             ) {
                 continue;

--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -255,7 +255,6 @@ class ArticlesHelper implements DatabaseAwareInterface
             && $params->get('exclude_current', 1) === 1
             && $input->get('option') === 'com_content'
             && $input->get('view') === 'article'
-            && (int) $article['id'] === $currentArticleId
             && empty($articlesList)
         ) {
             $filterInclude  = false;

--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -248,6 +248,20 @@ class ArticlesHelper implements DatabaseAwareInterface
             $articlesList[] = (int) $article['id'];
         }
 
+        // Edge case when the user select include mode but didn't add an article,
+        // we might have to exclude the current article
+        if (
+            $ex_or_include_articles === 1
+            && $params->get('exclude_current', 1) === 1
+            && $input->get('option') === 'com_content'
+            && $input->get('view') === 'article'
+            && (int) $article['id'] === $currentArticleId
+            && empty($articlesList)
+        ) {
+            $filterInclude = false;
+            $articlesList[] = $currentArticleId;
+        }
+
         if (!empty($articlesList)) {
             $articles->setState('filter.article_id', $articlesList);
             $articles->setState('filter.article_id.include', $filterInclude);

--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -218,16 +218,17 @@ class ArticlesHelper implements DatabaseAwareInterface
         $articlesList           = [];
         $currentArticleId       = $input->get('id', 0, 'UINT');
 
+        $isArticleAndShouldExcluded = $params->get('exclude_current', 1) === 1
+            && $input->get('option') === 'com_content'
+            && $input->get('view') === 'article';
+
+
         $articlesListToProcess = $params->get('included_articles', '');
 
         if ($ex_or_include_articles === 0) {
             $filterInclude = false;
 
-            if (
-                $params->get('exclude_current', 1) === 1
-                && $input->get('option') === 'com_content'
-                && $input->get('view') === 'article'
-            ) {
+            if ($isArticleAndShouldExcluded) {
                 $articlesList[] = $currentArticleId;
             }
 
@@ -237,9 +238,7 @@ class ArticlesHelper implements DatabaseAwareInterface
         foreach (ArrayHelper::fromObject($articlesListToProcess) as $article) {
             if (
                 $ex_or_include_articles === 1
-                && $params->get('exclude_current', 1) === 1
-                && $input->get('option') === 'com_content'
-                && $input->get('view') === 'article'
+                && $isArticleAndShouldExcluded
                 && (int) $article['id'] === $currentArticleId
             ) {
                 continue;
@@ -252,9 +251,7 @@ class ArticlesHelper implements DatabaseAwareInterface
         // we might have to exclude the current article
         if (
             $ex_or_include_articles === 1
-            && $params->get('exclude_current', 1) === 1
-            && $input->get('option') === 'com_content'
-            && $input->get('view') === 'article'
+            && $isArticleAndShouldExcluded
             && empty($articlesList)
         ) {
             $filterInclude  = false;

--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -222,7 +222,6 @@ class ArticlesHelper implements DatabaseAwareInterface
             && $input->get('option') === 'com_content'
             && $input->get('view') === 'article';
 
-
         $articlesListToProcess = $params->get('included_articles', '');
 
         if ($ex_or_include_articles === 0) {


### PR DESCRIPTION
### Summary of Changes
With this change we can also use the exclude current article when we chose include article ids


### Testing Instructions
Try to exclude some articles and include some articles. Check if the module show the expected articles. You should be able to use the exclude current article and include article at the same time. To test you have to add articles to the list of included articles and navigate to one of the included articles.

### Expected result AFTER applying this Pull Request
Module shows the expected articles