### PR TITLE
[5.2] Debug plugin Remove unused code

### DIFF
--- a/build/media_source/plg_system_debug/widgets/info/widget.es5.js
+++ b/build/media_source/plg_system_debug/widgets/info/widget.es5.js
@@ -12,19 +12,6 @@
                 this.$el.empty()
                 var tr
 
-                /*
-                // @todo enable Info link
-                var link = $('<a />')
-                    .text('Info')
-                    .attr('href', 'index.php?option=com_content&view=debug&id=' + data.requestId)
-                    .attr('target', '_blank');
-
-                tr = $('<tr />')
-                    .append($('<td />').text('Info'))
-                    .append($('<td />').append(link));
-                this.$el.append(tr);
-                */
-
                 tr = $('<tr />')
                     .append($('<td />').text('Joomla! Version'))
                     .append($('<td />').text(data.joomlaVersion))


### PR DESCRIPTION
This simple PR removes commented code which was intended to be an info link in the debug plugin. From the code we can see the intention was for there to be an info page about the debug plugin. As we don't have any compulsory content this can never work so might as well remove the code as it cant be implemented

code review as the code has never been used and is commented out.
