### PR TITLE
[5.3] Change type of field "fieldparams" in table #_fields from text to mediumtext

### DIFF
--- a/administrator/components/com_admin/sql/updates/mysql/5.3.0-2024-10-13.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.3.0-2024-10-13.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__fields` MODIFY `fieldparams` MEDIUMTEXT;

--- a/administrator/components/com_admin/sql/updates/mysql/5.3.0-2024-10-13.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.3.0-2024-10-13.sql
@@ -1,1 +1,1 @@
-ALTER TABLE `#__fields` MODIFY `fieldparams` MEDIUMTEXT;
+ALTER TABLE `#__fields` MODIFY `fieldparams` MEDIUMTEXT NOT NULL;

--- a/installation/sql/mysql/supports.sql
+++ b/installation/sql/mysql/supports.sql
@@ -153,7 +153,7 @@ CREATE TABLE IF NOT EXISTS `#__fields` (
   `checked_out_time` datetime,
   `ordering` int NOT NULL DEFAULT 0,
   `params` text NOT NULL,
-  `fieldparams` text NOT NULL,
+  `fieldparams` mediumtext NOT NULL,
   `language` char(7) NOT NULL DEFAULT '',
   `created_time` datetime NOT NULL,
   `created_user_id` int unsigned NOT NULL DEFAULT 0,


### PR DESCRIPTION
Pull Request for Issue #43929 .

### Summary of Changes
alter `#__fields.fieldparams` to MEDIUMTEXT


### Testing Instructions
run the sql
```
ALTER TABLE `#__fields` MODIFY `fieldparams` MEDIUMTEXT NOT NULL;
```
or
https://artifacts.joomla.org/drone/joomla/joomla-cms/5.3-dev/44238/downloads/79556/


### Actual result BEFORE applying this Pull Request
the field is TEXT


### Expected result AFTER applying this Pull Request
the field is MEDIUMTEXT


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
