### PR TITLE
[5.3] Drone: Fixing nightly build version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -408,7 +408,7 @@ steps:
       - rclone delete nightly:/home/devj/public_html/nightlies/ --include "Joomla_$MINORVERSION.*"
       - rclone delete nightly:/home/devj/public_html/cache/com_content/
       - rclone copy ./transfer/ nightly:/home/devj/public_html/nightlies/
-      - curl -i -X POST -H 'Content-Type:application/json' -d '{"text":"Nightly Build for [Joomla $MINORVERSION](https://developer.joomla.org/nightly-builds.html) successfully built."}' $MATTERMOST_NIGHTLY_HOOK
+      - curl -i -X POST -H 'Content-Type:application/json' -d '{"text":"Nightly Build for [Joomla ${MINORVERSION}](https://developer.joomla.org/nightly-builds.html) successfully built."}' $MATTERMOST_NIGHTLY_HOOK
 
   - name: buildfailure
     image: joomlaprojects/docker-images:packager
@@ -417,7 +417,7 @@ steps:
         from_secret: mattermost_nightly_hook
     commands:
       - export MINORVERSION=${DRONE_BRANCH%-*}
-      - curl -i -X POST -H 'Content-Type:application/json' -d '{"text":"Nightly Build for [Joomla $MINORVERSION](https://developer.joomla.org/nightly-builds.html) FAILED to built."}' $MATTERMOST_NIGHTLY_HOOK
+      - curl -i -X POST -H 'Content-Type:application/json' -d '{"text":"Nightly Build for [Joomla ${MINORVERSION}](https://developer.joomla.org/nightly-builds.html) FAILED to built."}' $MATTERMOST_NIGHTLY_HOOK
     when:
       status:
         - failure
@@ -431,6 +431,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 4651bf03bdeacfec868856dca94418b8999543e6bc05c3797e927734c878ea89
+hmac: 8587cef2227502ec33fa0434dadf0a3178d6fa7cbbfbe4e962b3c8784c3a2c6f
 
 ...


### PR DESCRIPTION
### Summary of Changes
The `$MINORVERSION` currently in the message to Mattermost is not replaced properly on nightlybuild. This should hopefully fix that.
