### PR TITLE
[5.3] Fix for: Can't select menu item type

### DIFF
--- a/administrator/components/com_menus/src/View/Menutypes/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menutypes/HtmlView.php
@@ -46,6 +46,13 @@ class HtmlView extends BaseHtmlView
     protected $types;
 
     /**
+     * The model state
+     *
+     * @var object
+     */
+    protected $state;
+
+    /**
      * Display the view
      *
      * @param   string  $tpl  The name of the template file to parse; automatically searches through the template paths.

--- a/administrator/components/com_menus/src/View/Menutypes/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menutypes/HtmlView.php
@@ -62,7 +62,8 @@ class HtmlView extends BaseHtmlView
         /** @var MenutypesModel $model */
         $model = $this->getModel();
 
-        $types = $model->getTypeOptions();
+        $this->state = $model->getState();
+        $types       = $model->getTypeOptions();
 
         $this->addCustomTypes($types);
 

--- a/administrator/components/com_menus/src/View/Menutypes/HtmlView.php
+++ b/administrator/components/com_menus/src/View/Menutypes/HtmlView.php
@@ -48,7 +48,9 @@ class HtmlView extends BaseHtmlView
     /**
      * The model state
      *
-     * @var object
+     * @var    object
+     *
+     * @since  DEPLOY_VERSION
      */
     protected $state;
 


### PR DESCRIPTION
Pull Request for Issue #44250

### Summary of Changes
Added missing $this->state = $model->getState();


### Testing Instructions
* Install 5.3 current dev or alpha1
* Add new menu item
* Select Menutype 


### Actual result BEFORE applying this Pull Request
See issue #444250


### Expected result AFTER applying this Pull Request
No error

![D38A770B-804F-4F2F-8747-34639269CB8D](https://github.com/user-attachments/assets/a34c479d-deb7-4cc6-bbc7-bc34a5b6ad99)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
