### PR TITLE
[5.3] Cypress add test for 'can create menu item' -> administrator

### DIFF
--- a/tests/System/integration/administrator/components/com_menu/MenuItem.cy.js
+++ b/tests/System/integration/administrator/components/com_menu/MenuItem.cy.js
@@ -20,7 +20,7 @@ describe('Test in backend that the menu list', () => {
     cy.contains('Menus: New Item');
   });
 
-  it('can create menu item', () => {
+  it('can create a system link menu item', () => {
     cy.db_deleteMenuItem({ title: 'can create menu item' });
 
     cy.visit('administrator/index.php?option=com_menus&task=item.add')

--- a/tests/System/integration/administrator/components/com_menu/MenuItem.cy.js
+++ b/tests/System/integration/administrator/components/com_menu/MenuItem.cy.js
@@ -20,6 +20,29 @@ describe('Test in backend that the menu list', () => {
     cy.contains('Menus: New Item');
   });
 
+  it('can create menu item', () => {
+    cy.db_deleteMenuItem({ title: 'can create menu item' });
+
+    cy.visit('administrator/index.php?option=com_menus&task=item.add')
+
+    cy.contains('Menus: New Item');
+    cy.get('#jform_title').clear().type('can create menu item');
+    cy.get('button[data-modal-config*="Menu Item Type"]').first().click();
+
+    cy.contains('Menu Item Type');
+    cy.get('iframe').iframe().then($body => {
+      cy.wrap($body).find('.accordion-button').contains("System Links").click();
+      cy.wrap($body).find('a[data-type="url"]').click();
+    });
+
+    cy.get('input[name="jform[link]"]').click();
+    cy.get('input[name="jform[link]"]').type('#');
+
+    cy.clickToolbarButton('Save & Close');
+
+    cy.get('#system-message-container').contains('Menu item saved.').should('exist');
+  });
+
   it('can delete the test menu item', () => {
     cy.db_createMenuItem({ title: 'Test menu item' }).then(() => {
       cy.searchForItem('Test menu item');

--- a/tests/System/integration/administrator/components/com_menu/MenuItem.cy.js
+++ b/tests/System/integration/administrator/components/com_menu/MenuItem.cy.js
@@ -30,8 +30,8 @@ describe('Test in backend that the menu list', () => {
     cy.get('button[data-modal-config*="Menu Item Type"]').first().click();
 
     cy.contains('Menu Item Type');
-    cy.get('iframe').iframe().then($body => {
-      cy.wrap($body).find('.accordion-button').contains("System Links").click();
+    cy.get('iframe').iframe().then(($body) => {
+      cy.wrap($body).find('.accordion-button').contains('System Links').click();
       cy.wrap($body).find('a[data-type="url"]').click();
     });
 

--- a/tests/System/integration/administrator/components/com_menu/MenuItem.cy.js
+++ b/tests/System/integration/administrator/components/com_menu/MenuItem.cy.js
@@ -23,7 +23,7 @@ describe('Test in backend that the menu list', () => {
   it('can create a system link menu item', () => {
     cy.db_deleteMenuItem({ title: 'can create menu item' });
 
-    cy.visit('administrator/index.php?option=com_menus&task=item.add')
+    cy.visit('administrator/index.php?option=com_menus&task=item.add');
 
     cy.contains('Menus: New Item');
     cy.get('#jform_title').clear().type('can create menu item');


### PR DESCRIPTION
Pull Request for Issue #44250 and PR #44251.

### Summary of Changes

add test for 'can create menu item' -> administrator

### Testing Instructions

PR #44251 must be merged for this test to run successfully.
drone
code review

### Actual result BEFORE applying this Pull Request

no test for 'can create menu' in backend

### Expected result AFTER applying this Pull Request

test coverage

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
