### PR TITLE
[5.3] Loadmodule plugin remove unused options

### DIFF
--- a/administrator/language/en-GB/plg_content_loadmodule.ini
+++ b/administrator/language/en-GB/plg_content_loadmodule.ini
@@ -6,8 +6,9 @@
 PLG_CONTENT_LOADMODULE="Content - Load Modules"
 PLG_LOADMODULE_FIELD_STYLE_LABEL="Style"
 PLG_LOADMODULE_FIELD_VALUE_DIVS="Wrapped by Divs"
-PLG_LOADMODULE_FIELD_VALUE_HORIZONTAL="Wrapped by table (horizontal)"
-PLG_LOADMODULE_FIELD_VALUE_MULTIPLEDIVS="Wrapped by Multiple Divs"
 PLG_LOADMODULE_FIELD_VALUE_RAW="No wrapping (raw output)"
 PLG_LOADMODULE_FIELD_VALUE_TABLE="Wrapped by table (column)"
 PLG_LOADMODULE_XML_DESCRIPTION="Within content this plugin loads a Module by ID, Syntax: {loadmoduleid 1} or a Module by position, Syntax: {loadposition user1} or a Module by name, Syntax: {loadmodule mod_login}. Optionally can specify module style and for loadmodule a specific module by title, Syntax: {loadmodule mod_login,module title,style}."
+; Deprecated, will be removed with 6.0
+PLG_LOADMODULE_FIELD_VALUE_HORIZONTAL="Wrapped by table (horizontal)"
+PLG_LOADMODULE_FIELD_VALUE_MULTIPLEDIVS="Wrapped by Multiple Divs"

--- a/plugins/content/loadmodule/loadmodule.xml
+++ b/plugins/content/loadmodule/loadmodule.xml
@@ -31,9 +31,6 @@
 					<option value="none">PLG_LOADMODULE_FIELD_VALUE_RAW</option>
 					<option value="html5">PLG_LOADMODULE_FIELD_VALUE_DIVS</option>
 					<option value="table">PLG_LOADMODULE_FIELD_VALUE_TABLE</option>
-					<!-- @TODO: The following styles don't exist in default installation and can be removed in Joomla 5 -->
-					<option value="horz">PLG_LOADMODULE_FIELD_VALUE_HORIZONTAL</option>
-					<option value="rounded">PLG_LOADMODULE_FIELD_VALUE_MULTIPLEDIVS</option>
 				</field>
 			</fieldset>
 		</fields>


### PR DESCRIPTION
This simple PR removes two options from the loadmodule plugin which have not done anything since 4.0 as they are for module chromes that have not existed since 3.x

I marked the language strings as deprecated as _i think_ that is the requirement although they can probably just be deleted now. That's a maintainer decision

### Testing Instructions
code review


### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
