### PR TITLE
[6.2] Add PluginHelper::getPlugins() and deprecate old behavior

### DIFF
--- a/administrator/components/com_finder/src/Model/StatisticsModel.php
+++ b/administrator/components/com_finder/src/Model/StatisticsModel.php
@@ -75,7 +75,7 @@ class StatisticsModel extends BaseDatabaseModel
         $data->type_list = $db->loadObjectList();
 
         $lang    = Factory::getLanguage();
-        $plugins = PluginHelper::getPlugin('finder');
+        $plugins = PluginHelper::getPlugins('finder');
 
         foreach ($plugins as $plugin) {
             $lang->load('plg_finder_' . $plugin->name . '.sys', JPATH_ADMINISTRATOR)

--- a/administrator/components/com_media/src/Controller/PluginController.php
+++ b/administrator/components/com_media/src/Controller/PluginController.php
@@ -46,7 +46,7 @@ class PluginController extends BaseController
         try {
             // Load plugin names
             $pluginName = $this->input->getString('plugin', null);
-            $plugins    = PluginHelper::getPlugin('filesystem');
+            $plugins    = PluginHelper::getPlugins('filesystem');
 
             // If plugin name was not found in parameters redirect back to control panel
             if (!$pluginName || !$this->containsPlugin($plugins, $pluginName)) {

--- a/administrator/components/com_users/postinstall/multifactorauth.php
+++ b/administrator/components/com_users/postinstall/multifactorauth.php
@@ -27,7 +27,7 @@ use Joomla\Database\ParameterType;
  */
 function com_users_postinstall_mfa_condition(): bool
 {
-    return \count(PluginHelper::getPlugin('multifactorauth')) < 1;
+    return \count(PluginHelper::getPlugins('multifactorauth')) < 1;
 }
 
 /**

--- a/administrator/components/com_users/src/Helper/Mfa.php
+++ b/administrator/components/com_users/src/Helper/Mfa.php
@@ -336,7 +336,7 @@ abstract class Mfa
         }
 
         // I need at least one MFA method plugin for the setup interface to make any sense.
-        $plugins = PluginHelper::getPlugin('multifactorauth');
+        $plugins = PluginHelper::getPlugins('multifactorauth');
 
         if (\count($plugins) < 1) {
             return false;

--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -381,7 +381,7 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
 
         $captchaSet = $item->params->get('captcha', $app->get('captcha', '0'));
 
-        foreach (PluginHelper::getPlugin('captcha') as $plugin) {
+        foreach (PluginHelper::getPlugins('captcha') as $plugin) {
             if ($captchaSet === $plugin->name) {
                 $this->captchaEnabled = true;
                 break;

--- a/components/com_content/src/View/Form/HtmlView.php
+++ b/components/com_content/src/View/Form/HtmlView.php
@@ -179,7 +179,7 @@ class HtmlView extends BaseHtmlView
 
         $captchaSet = $params->get('captcha', Factory::getApplication()->get('captcha', '0'));
 
-        foreach (PluginHelper::getPlugin('captcha') as $plugin) {
+        foreach (PluginHelper::getPlugins('captcha') as $plugin) {
             if ($captchaSet === $plugin->name) {
                 $this->captchaEnabled = true;
                 break;

--- a/components/com_users/src/View/Registration/HtmlView.php
+++ b/components/com_users/src/View/Registration/HtmlView.php
@@ -114,7 +114,7 @@ class HtmlView extends BaseHtmlView
 
         $captchaSet = $this->params->get('captcha', Factory::getApplication()->get('captcha', '0'));
 
-        foreach (PluginHelper::getPlugin('captcha') as $plugin) {
+        foreach (PluginHelper::getPlugins('captcha') as $plugin) {
             if ($captchaSet === $plugin->name) {
                 $this->captchaEnabled = true;
                 break;

--- a/libraries/src/Editor/Button/ButtonsRegistry.php
+++ b/libraries/src/Editor/Button/ButtonsRegistry.php
@@ -99,7 +99,7 @@ final class ButtonsRegistry implements ButtonsRegistryInterface, DispatcherAware
         $dispatcher->dispatch($event->getName(), $event);
 
         // Load legacy buttons for backward compatibility
-        $plugins  = PluginHelper::getPlugin('editors-xtd');
+        $plugins  = PluginHelper::getPlugins('editors-xtd');
         $editorId = $options['editorId'] ?? '';
         $asset    = (int) ($options['asset'] ?? 0);
         $author   = (int) ($options['author'] ?? 0);

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -129,8 +129,7 @@ abstract class PluginHelper
     }
 
     /**
-     * Get the plugin data of a specific type if no specific plugin is specified
-     * otherwise only the specific plugin data is returned.
+     * Get a list of plugins with the respective data in a plugin group
      *
      * @param   string  $type    The plugin type, relates to the subdirectory in the plugins directory.
      *

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -102,6 +102,10 @@ abstract class PluginHelper
      * @return  mixed  An array of plugin data objects, or a plugin data object.
      *
      * @since   1.5
+     *
+     * @deprecated  __DEPLOY_VERSION__ starting with 7.0 this will only return a single plugin object
+     *              or null instead of an empty array or an array of plugin objects. For a plugin group
+     *              use PluginHelper::getPlugins() instead.
      */
     public static function getPlugin($type, $plugin = null)
     {
@@ -110,12 +114,7 @@ abstract class PluginHelper
 
         // Find the correct plugin(s) to return.
         if (!$plugin) {
-            foreach ($plugins as $p) {
-                // Is this the right plugin?
-                if ($p->type === $type) {
-                    $result[] = $p;
-                }
-            }
+            return self::getPlugins($type);
         } else {
             foreach ($plugins as $p) {
                 // Is this plugin in the right group?
@@ -123,6 +122,31 @@ abstract class PluginHelper
                     $result = $p;
                     break;
                 }
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Get the plugin data of a specific type if no specific plugin is specified
+     * otherwise only the specific plugin data is returned.
+     *
+     * @param   string  $type    The plugin type, relates to the subdirectory in the plugins directory.
+     *
+     * @return  object[]  An array of plugin data objects.
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public static function getPlugins($type)
+    {
+        $result  = [];
+        $plugins = static::load();
+
+        foreach ($plugins as $p) {
+            // Is this the right plugin?
+            if ($p->type === $type) {
+                $result[] = $p;
             }
         }
 

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -115,13 +115,13 @@ abstract class PluginHelper
         // Find the correct plugin(s) to return.
         if (!$plugin) {
             return self::getPlugins($type);
-        } else {
-            foreach ($plugins as $p) {
-                // Is this plugin in the right group?
-                if ($p->type === $type && $p->name === $plugin) {
-                    $result = $p;
-                    break;
-                }
+        }
+
+        foreach ($plugins as $p) {
+            // Is this plugin in the right group?
+            if ($p->type === $type && $p->name === $plugin) {
+                $result = $p;
+                break;
             }
         }
 


### PR DESCRIPTION
Pull Request for Issue #44270.

### Summary of Changes
`PluginHelper::getPlugin()` currently returns either an (empty) array of objects or a single object. This is the first step towards cleaning that code up by splitting the code up into a method to retrieve a single plugin (`getPlugin()`) and an array of plugins (`getPlugins()`).


### Testing Instructions
Codereview.



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
