### PR TITLE
[5.3] Remove autostart temp code

### DIFF
--- a/administrator/components/com_guidedtours/src/Table/TourTable.php
+++ b/administrator/components/com_guidedtours/src/Table/TourTable.php
@@ -109,12 +109,6 @@ class TourTable extends Table implements CurrentUserInterface
             $this->setTourUid();
         }
 
-        // set autostart
-        // @todo: remove once autostart has been added to the tour form
-        if (\is_null($this->autostart)) {
-            $this->autostart = 0;
-        }
-
         // make sure the uid is unique
         $this->ensureUniqueUid();
 


### PR DESCRIPTION
#43031 introduced some code

> At this point, the autostart is not present as an option to the user. Once we have the full functionality (we will make auto-start as an option to the tour in the form), we can remove that additional test.

The full functionality is now available and this code can be removed.

Testing is simple just try and duplicate an existing tour. It should be successfully duplicated both with and without this PR


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
