### PR TITLE
[5.2] Allow relative URLs in wrapper module and component

### DIFF
--- a/components/com_wrapper/tmpl/wrapper/default.xml
+++ b/components/com_wrapper/tmpl/wrapper/default.xml
@@ -18,6 +18,7 @@
 				type="url"
 				validate="url"
 				filter="url"
+				relative="true"
 				label="COM_WRAPPER_FIELD_URL_LABEL"
 				required="true"
 			/>

--- a/modules/mod_wrapper/mod_wrapper.xml
+++ b/modules/mod_wrapper/mod_wrapper.xml
@@ -28,6 +28,7 @@
 					type="url"
 					validate="url"
 					filter="url"
+					relative="true"
 					label="MOD_WRAPPER_FIELD_URL_LABEL"
 					required="true"
 				/>


### PR DESCRIPTION
Pull Request for Issue #44262 .

### Summary of Changes
Allow relative URLs in wrapper module and component.


### Testing Instructions
Use a relative URL in mod_wrapper and the wrapper menu item.


### Actual result BEFORE applying this Pull Request
* Validation error


### Expected result AFTER applying this Pull Request
* No validation error


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
