### PR TITLE
[5] Sync the sequence for pgsql after the root user is created

### DIFF
--- a/installation/src/Model/ConfigurationModel.php
+++ b/installation/src/Model/ConfigurationModel.php
@@ -561,7 +561,7 @@ class ConfigurationModel extends BaseInstallationModel
         try {
             $db->execute();
 
-            // Synch the sequence if pgsql 
+            // Synch the sequence if pgsql
             if (($db->getServerType() === 'postgresql') && (!$result)) {
                 $query = $db->getQuery(true)
                     ->select('MAX(id) +1 as id')

--- a/installation/src/Model/ConfigurationModel.php
+++ b/installation/src/Model/ConfigurationModel.php
@@ -560,6 +560,18 @@ class ConfigurationModel extends BaseInstallationModel
 
         try {
             $db->execute();
+
+            // Synch the sequence if pgsql 
+            if (($db->getServerType() === 'postgresql') && (!$result)) {
+                $query = $db->getQuery(true)
+                    ->select('MAX(id) +1 as id')
+                    ->from($db->quoteName('#__users'));
+                $db->setQuery($query);
+                $result = $db->loadResult();
+
+                $db->setQuery("SELECT setval('#__users_id_seq', " .  $result . ", false)")
+                    ->execute();
+            }
         } catch (\RuntimeException $e) {
             Factory::getApplication()->enqueueMessage($e->getMessage(), 'error');
 

--- a/installation/src/Model/ConfigurationModel.php
+++ b/installation/src/Model/ConfigurationModel.php
@@ -569,7 +569,7 @@ class ConfigurationModel extends BaseInstallationModel
                 $db->setQuery($query);
                 $result = $db->loadResult();
 
-                $db->setQuery("SELECT setval('#__users_id_seq', " .  $result . ", false)")
+                $db->setQuery('SELECT setval(' . $db->quote('#__users_id_seq') . ', ' .  $result . ', false)')
                     ->execute();
             }
         } catch (\RuntimeException $e) {

--- a/installation/src/Model/ConfigurationModel.php
+++ b/installation/src/Model/ConfigurationModel.php
@@ -564,7 +564,7 @@ class ConfigurationModel extends BaseInstallationModel
             // Synch the sequence if pgsql
             if (($db->getServerType() === 'postgresql') && (!$result)) {
                 $query = $db->getQuery(true)
-                    ->select('MAX(id) +1 as id')
+                    ->select('MAX(' . $db->quoteName('id') . ') + 1 AS ' . $db->quoteName('id'))
                     ->from($db->quoteName('#__users'));
                 $db->setQuery($query);
                 $result = $db->loadResult();


### PR DESCRIPTION
Pull Request for Issue # .
on installation joomla create a SuperUser whose id is generated random(1,1000)

but with postgresql the relative sequence `#__users_id_seq` is not setted is still 1, so as soon we create an user
whose id is equal to the id created for the Super User we got `duplicate key value violates unique constraint "jos_users_pkey`

### Summary of Changes
set the relative sequence `#__users_id_seq`   after the super user creation


### Testing Instructions
apply  pull PR
and run cypress install/installation.cy.js

and the run this test:

```
scripts/create 52 pgsql
cat > branch_52/tests/System/integration/install/duplicate.cy.js <<EOF
describe('Test duplicate key value error', () => {
  it('in creating 1,000 users', () => {
    for (let i = 1; i <= 1000; i++) {
        cy.db_createUser({username: \`test user \${i}\` });
    }
  });
});
EOF
```
scripts/test 52 system install/duplicate.cy.js 

### Actual result BEFORE applying this Pull Request

`duplicate key value violates unique constraint "jos_users_pkey`

### Expected result AFTER applying this Pull Request
no more duplicate error


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
