### PR TITLE
[5.2] Fix display of empty state view in clear cache

### DIFF
--- a/administrator/components/com_cache/src/View/Cache/HtmlView.php
+++ b/administrator/components/com_cache/src/View/Cache/HtmlView.php
@@ -104,7 +104,7 @@ class HtmlView extends BaseHtmlView
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
-        if (!\count($this->data) && $this->state->get('filter.search') === '') {
+        if (!\count($this->data) && ($this->state->get('filter.search') === null || $this->state->get('filter.search') === '')) {
             $this->setLayout('emptystate');
         }
 


### PR DESCRIPTION
Pull Request for Issue #44247 .

### Summary of Changes
PR #38671 did not account for search filter to be null when not using search, thus, won't display the empty state view when the cache folder is empty.

### Testing Instructions
Go to System > Clear Cache.
See empty state view when the cache folder is empty.
