### PR TITLE
Fix password toggle in subform dynamic field

### DIFF
--- a/build/media_source/com_associations/js/sidebyside.es6.js
+++ b/build/media_source/com_associations/js/sidebyside.es6.js
@@ -97,7 +97,7 @@ document.getElementById('reference-association').addEventListener('load', ({ tar
   content.querySelector('#jform_language').setAttribute('disabled', 'disabled');
 
   // Remove modal buttons on the reference
-  content.querySelector('#associations .btn').remove();
+  content.querySelector('#associations .btn')?.remove();
 
   document.querySelectorAll('#jform_itemlanguage option').forEach((option) => {
     const parse = option.value.split(':');
@@ -143,7 +143,7 @@ document.getElementById('target-association').addEventListener('load', ({ target
     // content.querySelector('#associations .btn').forEach(btn => btn.remove());
 
     // Always show General tab first if associations tab is selected on the reference
-    if (content.querySelector('#associations').classList.contains('active')) {
+    if (content.querySelector('#associations')?.classList.contains('active')) {
       content.querySelector('a[href="#associations"]').parentNode.classList.remove('active');
       content.querySelector('#associations').classList.remove('active');
 
@@ -221,8 +221,10 @@ document.getElementById('target-association').addEventListener('load', ({ target
 
     // - For chosen association selectors (menus).
     let chosenField = content.querySelector(`#jform_associations_${referenceLanguageCode}`);
-    chosenField.appendChild(createOption(referenceId, referenceTitle));
-    chosenField.value = referenceId;
+    if (chosenField) {
+      chosenField.appendChild(createOption(referenceId, referenceTitle));
+      chosenField.value = referenceId;
+    }
 
     document.querySelectorAll('#jform_itemlanguage option').forEach((option) => {
       const parse = option.value.split(':');

--- a/build/media_source/system/js/fields/passwordstrength.es6.js
+++ b/build/media_source/system/js/fields/passwordstrength.es6.js
@@ -116,7 +116,6 @@ class PasswordStrength {
         label.innerText = Joomla.Text._('JFIELD_PASSWORD_INDICATE_INCOMPLETE');
       }
       meter.value = score;
-  
       if (!element.value.length) {
         label.innerText = '';
         element.setAttribute('required', '');

--- a/build/media_source/system/js/fields/passwordstrength.es6.js
+++ b/build/media_source/system/js/fields/passwordstrength.es6.js
@@ -109,16 +109,18 @@ class PasswordStrength {
     const i = meter.getAttribute('id').replace(/^\D+/g, '');
     const label = element.parentNode.parentNode.querySelector(`#password-${i}`);
 
-    if (score === 100) {
-      label.innerText = Joomla.Text._('JFIELD_PASSWORD_INDICATE_COMPLETE');
-    } else {
-      label.innerText = Joomla.Text._('JFIELD_PASSWORD_INDICATE_INCOMPLETE');
-    }
-    meter.value = score;
-
-    if (!element.value.length) {
-      label.innerText = '';
-      element.setAttribute('required', '');
+    if (label) {
+      if (score === 100) {
+        label.innerText = Joomla.Text._('JFIELD_PASSWORD_INDICATE_COMPLETE');
+      } else {
+        label.innerText = Joomla.Text._('JFIELD_PASSWORD_INDICATE_INCOMPLETE');
+      }
+      meter.value = score;
+  
+      if (!element.value.length) {
+        label.innerText = '';
+        element.setAttribute('required', '');
+      }
     }
   };
 

--- a/build/media_source/system/js/fields/passwordview.es6.js
+++ b/build/media_source/system/js/fields/passwordview.es6.js
@@ -13,10 +13,11 @@
           ".input-password-toggle"
         );
 
-        const hasClickListener = toggleButton.getAttribute('clickListener') === 'true';
+        const hasClickListener =
+          toggleButton.getAttribute("clickListener") === "true";
 
         if (toggleButton && !hasClickListener) {
-          toggleButton.setAttribute('clickListener', 'true');
+          toggleButton.setAttribute("clickListener", "true");
           toggleButton.addEventListener("click", () => {
             const icon = toggleButton.firstElementChild;
             const srText = toggleButton.lastElementChild;
@@ -89,7 +90,20 @@
       });
   }
 
-  document.addEventListener("change", (e) => {
+  
+  const observer = new MutationObserver((mutationsList) => {
+    document.dispatchEvent(
+      new CustomEvent("domChanged", { detail: mutationsList })
+    );
+  });
+  
+  observer.observe(document, {
+    attributes: true,
+    childList: true,
+    subtree: true,
+  });
+
+  document.addEventListener("domChanged", (e) => {
     togglePassword();
   });
   document.addEventListener("DOMContentLoaded", (e) => {

--- a/build/media_source/system/js/fields/passwordview.es6.js
+++ b/build/media_source/system/js/fields/passwordview.es6.js
@@ -3,80 +3,100 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 ((document) => {
-  'use strict';
+  "use strict";
 
-  document.addEventListener('DOMContentLoaded', () => {
-    [].slice.call(document.querySelectorAll('input[type="password"]')).forEach((input) => {
-      const toggleButton = input.parentNode.querySelector('.input-password-toggle');
+  function togglePassword() {
+    [].slice
+      .call(document.querySelectorAll('input[type="password"]'))
+      .forEach((input) => {
+        const toggleButton = input.parentNode.querySelector(
+          ".input-password-toggle"
+        );
 
-      if (toggleButton) {
-        toggleButton.addEventListener('click', () => {
-          const icon = toggleButton.firstElementChild;
-          const srText = toggleButton.lastElementChild;
+        const hasClickListener = toggleButton.getAttribute('clickListener') === 'true';
 
-          if (input.type === 'password') {
-            // Update the icon class
-            icon.classList.remove('icon-eye');
-            icon.classList.add('icon-eye-slash');
+        if (toggleButton && !hasClickListener) {
+          toggleButton.setAttribute('clickListener', 'true');
+          toggleButton.addEventListener("click", () => {
+            const icon = toggleButton.firstElementChild;
+            const srText = toggleButton.lastElementChild;
 
-            // Update the input type
-            input.type = 'text';
+            if (input.type === "password") {
+              // Update the icon class
+              icon.classList.remove("icon-eye");
+              icon.classList.add("icon-eye-slash");
 
-            // Focus the input field
-            input.focus();
+              // Update the input type
+              input.type = "text";
 
-            // Update the text for screenreaders
-            srText.innerText = Joomla.Text._('JHIDEPASSWORD');
-          } else if (input.type === 'text') {
-            // Update the icon class
-            icon.classList.add('icon-eye');
-            icon.classList.remove('icon-eye-slash');
+              // Focus the input field
+              input.focus();
 
-            // Update the input type
-            input.type = 'password';
+              // Update the text for screenreaders
+              srText.innerText = Joomla.Text._("JHIDEPASSWORD");
+            } else if (input.type === "text") {
+              // Update the icon class
+              icon.classList.add("icon-eye");
+              icon.classList.remove("icon-eye-slash");
 
-            // Focus the input field
-            input.focus();
+              // Update the input type
+              input.type = "password";
 
-            // Update the text for screenreaders
-            srText.innerText = Joomla.Text._('JSHOWPASSWORD');
-          }
-        });
-      }
+              // Focus the input field
+              input.focus();
 
-      const modifyButton = input.parentNode.querySelector('.input-password-modify');
+              // Update the text for screenreaders
+              srText.innerText = Joomla.Text._("JSHOWPASSWORD");
+            }
+          });
+        }
 
-      if (modifyButton) {
-        modifyButton.addEventListener('click', () => {
-          const lock = !modifyButton.classList.contains('locked');
+        const modifyButton = input.parentNode.querySelector(
+          ".input-password-modify"
+        );
 
-          if (lock === true) {
-            // Add lock
-            modifyButton.classList.add('locked');
+        if (modifyButton) {
+          modifyButton.addEventListener("click", () => {
+            const lock = !modifyButton.classList.contains("locked");
 
-            // Reset value to empty string
-            input.value = '';
+            if (lock === true) {
+              // Add lock
+              modifyButton.classList.add("locked");
 
-            // Disable the field
-            input.setAttribute('disabled', '');
+              // Reset value to empty string
+              input.value = "";
 
-            // Update the text
-            modifyButton.innerText = Joomla.Text._('JMODIFY');
-          } else {
-            // Remove lock
-            modifyButton.classList.remove('locked');
+              // Disable the field
+              input.setAttribute("disabled", "");
 
-            // Enable the field
-            input.removeAttribute('disabled');
+              // Update the text
+              modifyButton.innerText = Joomla.Text._("JMODIFY");
+            } else {
+              // Remove lock
+              modifyButton.classList.remove("locked");
 
-            // Focus the input field
-            input.focus();
+              // Enable the field
+              input.removeAttribute("disabled");
 
-            // Update the text
-            modifyButton.innerText = Joomla.Text._('JCANCEL');
-          }
-        });
-      }
-    });
+              // Focus the input field
+              input.focus();
+
+              // Update the text
+              modifyButton.innerText = Joomla.Text._("JCANCEL");
+            }
+          });
+        }
+      });
+  }
+
+  document.addEventListener("change", (e) => {
+    togglePassword();
   });
+  document.addEventListener("DOMContentLoaded", (e) => {
+    togglePassword();
+  });
+
+  // ["DOMContentLoaded", "change"].forEach((evt) =>
+  //   document.addEventListener(evt, togglePassword, false)
+  // );
 })(document);

--- a/build/media_source/system/js/fields/passwordview.es6.js
+++ b/build/media_source/system/js/fields/passwordview.es6.js
@@ -3,114 +3,103 @@
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
  */
 ((document) => {
-  "use strict";
+  'use strict';
 
   function togglePassword() {
     [].slice
       .call(document.querySelectorAll('input[type="password"]'))
       .forEach((input) => {
-        const toggleButton = input.parentNode.querySelector(
-          ".input-password-toggle"
-        );
+        const toggleButton = input.parentNode.querySelector('.input-password-toggle');
 
-        const hasClickListener =
-          toggleButton.getAttribute("clickListener") === "true";
+        const hasClickListener = toggleButton.getAttribute('clickListener') === 'true';
 
         if (toggleButton && !hasClickListener) {
-          toggleButton.setAttribute("clickListener", "true");
-          toggleButton.addEventListener("click", () => {
+          toggleButton.setAttribute('clickListener', 'true');
+          toggleButton.addEventListener('click', () => {
             const icon = toggleButton.firstElementChild;
             const srText = toggleButton.lastElementChild;
 
-            if (input.type === "password") {
+            if (input.type === 'password') {
               // Update the icon class
-              icon.classList.remove("icon-eye");
-              icon.classList.add("icon-eye-slash");
+              icon.classList.remove('icon-eye');
+              icon.classList.add('icon-eye-slash');
 
               // Update the input type
-              input.type = "text";
+              input.type = 'text';
 
               // Focus the input field
               input.focus();
 
               // Update the text for screenreaders
-              srText.innerText = Joomla.Text._("JHIDEPASSWORD");
-            } else if (input.type === "text") {
+              srText.innerText = Joomla.Text._('JHIDEPASSWORD');
+            } else if (input.type === 'text') {
               // Update the icon class
-              icon.classList.add("icon-eye");
-              icon.classList.remove("icon-eye-slash");
+              icon.classList.add('icon-eye');
+              icon.classList.remove('icon-eye-slash');
 
               // Update the input type
-              input.type = "password";
+              input.type = 'password';
 
               // Focus the input field
               input.focus();
 
               // Update the text for screenreaders
-              srText.innerText = Joomla.Text._("JSHOWPASSWORD");
+              srText.innerText = Joomla.Text._('JSHOWPASSWORD');
             }
           });
         }
 
-        const modifyButton = input.parentNode.querySelector(
-          ".input-password-modify"
-        );
+        const modifyButton = input.parentNode.querySelector('.input-password-modify');
 
         if (modifyButton) {
-          modifyButton.addEventListener("click", () => {
-            const lock = !modifyButton.classList.contains("locked");
+          modifyButton.addEventListener('click', () => {
+            const lock = !modifyButton.classList.contains('locked');
 
             if (lock === true) {
               // Add lock
-              modifyButton.classList.add("locked");
+              modifyButton.classList.add('locked');
 
               // Reset value to empty string
-              input.value = "";
+              input.value = '';
 
               // Disable the field
-              input.setAttribute("disabled", "");
+              input.setAttribute('disabled', '');
 
               // Update the text
-              modifyButton.innerText = Joomla.Text._("JMODIFY");
+              modifyButton.innerText = Joomla.Text._('JMODIFY');
             } else {
               // Remove lock
-              modifyButton.classList.remove("locked");
+              modifyButton.classList.remove('locked');
 
               // Enable the field
-              input.removeAttribute("disabled");
+              input.removeAttribute('disabled');
 
               // Focus the input field
               input.focus();
 
               // Update the text
-              modifyButton.innerText = Joomla.Text._("JCANCEL");
+              modifyButton.innerText = Joomla.Text._('JCANCEL');
             }
           });
         }
       });
   }
-
-  
-  const observer = new MutationObserver((mutationsList) => {
-    document.dispatchEvent(
-      new CustomEvent("domChanged", { detail: mutationsList })
-    );
-  });
-  
-  observer.observe(document, {
+  new MutationObserver((mutationsList) => {
+    document.dispatchEvent(new CustomEvent('domChanged', { detail: mutationsList }));
+  }).observe(document, {
     attributes: true,
     childList: true,
     subtree: true,
   });
 
-  document.addEventListener("domChanged", (e) => {
+  document.addEventListener('domChanged', () => {
     togglePassword();
   });
-  document.addEventListener("DOMContentLoaded", (e) => {
+  document.addEventListener('DOMContentLoaded', () => {
     togglePassword();
   });
 
-  // ["DOMContentLoaded", "change"].forEach((evt) =>
+  // ['DOMContentLoaded', 'change'].forEach((evt) =>
   //   document.addEventListener(evt, togglePassword, false)
   // );
 })(document);


### PR DESCRIPTION
Pull Request for Issue #43240  .

### Summary of Changes

Implemented a new DOM change event that activates the password toggle (show/hide) functionality, allowing it to operate effectively for both dynamic and static form fields.

### Testing Instructions

described in the issue.

### Actual result BEFORE applying this Pull Request

described in the issue.

### Expected result AFTER applying this Pull Request

The password toggle function now operates as expected, enabling correct visibility control for password fields in dynamic subforms.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
