### PR TITLE
[5.2] Fix multi-line comment indentation in system test javascript

### DIFF
--- a/tests/System/plugins/db.mjs
+++ b/tests/System/plugins/db.mjs
@@ -94,10 +94,10 @@ function queryTestDB(joomlaQuery, config) {
   return new Promise((resolve, reject) => {
     // Create the connection and connect
     let connectionConfig;
-      /* Verify if the connection is a Unix socket by checking for the "unix:/" prefix.
-       * MariaDB and MySQL JS drivers do not support this prefix, so it must be removed.
-       * We standardise the use of this prefix with the PHP driver by handling it here.
-       */
+    /* Verify if the connection is a Unix socket by checking for the "unix:/" prefix.
+     * MariaDB and MySQL JS drivers do not support this prefix, so it must be removed.
+     * We standardise the use of this prefix with the PHP driver by handling it here.
+     */
     if (config.env.db_host.startsWith('unix:/')) {
       // If the host is a Unix socket, extract the socket path
       connectionConfig = {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) changes indentation of a multi-line comment in file `tests/System/plugins/db.mjs`.

The comment had been added with PR #44092 .

The javascript-cs check in Drone is ok with that comment in the 5.2-dev branch, but when doing the upmerge PR #44367 for the 5.3-dev branch I've noticed that it makes that check in Drone fail on that branch.

The reason for that difference is PR #44296 , which was merged in the 5.3-dev branch and updates our linter commands to support mjs.

I think it should be fixed in the 5.2-dev branch, so I've made this PR here. I will later care for the conflict in my upmerge PR when this one here will be merged before that one.

### Testing Instructions

Code review, and check if the javascript-cs step passes in Drone.

### Actual result BEFORE applying this Pull Request

The javascript-cs step passes in Drone.

The comment changed by this PR here is 2 spaces more indented than the code blockes above and below.

### Expected result AFTER applying this Pull Request

The javascript-cs step still passes in Drone.

Indentation of the comment changed by this PR here is the same as for the code blockes above and below.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
