### PR TITLE
[Guided Tours] Fix blank screen after a session time out on the steps page

### DIFF
--- a/administrator/components/com_guidedtours/src/Controller/StepController.php
+++ b/administrator/components/com_guidedtours/src/Controller/StepController.php
@@ -35,8 +35,8 @@ class StepController extends FormController
         $append = parent::getRedirectToListAppend();
         $tourId = $this->app->getUserState('com_guidedtours.tour_id');
         if (!empty($tourId)) {
-			$append .= '&tour_id=' . $tourId;
-		}
+            $append .= '&tour_id=' . $tourId;
+        }
 
         return $append;
     }

--- a/administrator/components/com_guidedtours/src/Controller/StepController.php
+++ b/administrator/components/com_guidedtours/src/Controller/StepController.php
@@ -23,4 +23,21 @@ use Joomla\CMS\MVC\Controller\FormController;
  */
 class StepController extends FormController
 {
+    /**
+     * Gets the URL arguments to append to a list redirect.
+     *
+     * @return  string  The arguments to append to the redirect URL.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    protected function getRedirectToListAppend()
+    {
+        $append = parent::getRedirectToListAppend();
+        $tourId = $this->app->getUserState('com_guidedtours.tour_id');
+        if (!empty($tourId)) {
+			$append .= '&tour_id=' . $tourId;
+		}
+
+        return $append;
+    }
 }


### PR DESCRIPTION
### Summary of Changes

This PR adds the missing `getRedirectToListAppend` function in the Step Controller that adds the missing tour_id query in the steps URL after returning from step edition.

### Testing Instructions

Go to the Global Configuration, 'System' tab. 
Set the session lifetime to 2mn.

Go to System -> Manage -> Guided Tours and go to the list of steps for a tour.
The URL in the browser address bar will be something like:
`administrator/index.php?option=com_guidedtours&view=steps&tour_id=X`

Edit a step. Cancel the edition (Select 'close').
The URL is now:
`administrator/index.php?option=com_guidedtours&view=steps`

Let the session run out.
Log back in.

### Actual result BEFORE applying this Pull Request

When the user logs back in, the page is blank.

### Expected result AFTER applying this Pull Request

When the user logs back in, the list of steps is available.
The URL when returning from step edition is:
`administrator/index.php?option=com_guidedtours&view=steps&tour_id=X`
(the tour_id query is always present).

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed