### PR TITLE
URL in email broken with Mail Template Layout

### DIFF
--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -328,8 +328,6 @@ class MailTemplate
                 $htmlBody = nl2br($this->replaceTags(Text::_($mail->body), $plainData, true), false);
             }
 
-            $htmlBody = MailHelper::convertRelativeToAbsoluteUrls($htmlBody);
-
             if ($useLayout) {
                 // Add additional data to the layout template
                 $this->addLayoutTemplateData([
@@ -380,6 +378,8 @@ class MailTemplate
 
                 $htmlBody = $this->replaceTags(Text::_($htmlBody), $this->data);
             }
+
+            $htmlBody = MailHelper::convertRelativeToAbsoluteUrls($htmlBody);
 
             $this->mailer->setBody($htmlBody);
         }


### PR DESCRIPTION
Pull Request for Issue #44377 .

### Summary of Changes

Move convertRelativeToAbsoluteUrls after replaceTags

### Testing Instructions

Mail template com_users.password_reset, HTML Body:

```html
<p>Hello,</p>
<p>
	A request has been made to reset your {SITENAME} account password. To reset your password, you will need to submit this verification code to verify that the request was legitimate.
</p>
<p>
    The verification code is {TOKEN}
</p>
<p>
	Click <a href="{LINK_HTML}">here</a> and proceed with resetting your password.    
</p>
<p>
    Thank you.
</p>
```

Go frontent.

Forgot your password?

Check email Joomla sent you.

### Actual result BEFORE applying this Pull Request

URL in email is broken: `https://www.mysite.com/https://www.mysite.com/component/users/reset.html?layout=confirm&amp;token=blablabla&amp;Itemid=123`

The `https://www.mysite.com` is dobled in email.

### Expected result AFTER applying this Pull Request

URL in email is correct: `https://www.mysite.com/component/users/reset.html?layout=confirm&amp;token=blablabla&amp;Itemid=123`

No dobled `https://www.mysite.com` in email.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
