### PR TITLE
[5] fix for Error with trashing items when items are checked out

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1106,8 +1106,6 @@ abstract class AdminModel extends FormModel
 
                     // Prune items that you can't change.
                     unset($pks[$i]);
-
-                    return false;
                 }
 
                 /**


### PR DESCRIPTION
Pull Request for Issue #44364 .

### Summary of Changes

just prune items that you can't change

### Testing Instructions
see #44364 for details


### Actual result BEFORE applying this Pull Request
No item is trashed but the message says "n-1 items are trashed" plus "checked-out" message


### Expected result AFTER applying this Pull Request

All items except the checked-out item are trashed

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
