### PR TITLE
Workflow compatible with CLIApplication

### DIFF
--- a/libraries/src/Workflow/Workflow.php
+++ b/libraries/src/Workflow/Workflow.php
@@ -9,7 +9,7 @@
 
 namespace Joomla\CMS\Workflow;
 
-use Joomla\CMS\Application\CMSApplication;
+use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Event\AbstractEvent;
 use Joomla\CMS\Event\Workflow\WorkflowTransitionEvent;
 use Joomla\CMS\Extension\ComponentInterface;
@@ -50,7 +50,7 @@ class Workflow
     /**
      * Application Object
      *
-     * @var    CMSApplication
+     * @var    CMSApplicationInterface
      * @since  4.0.0
      */
     protected $app;
@@ -98,13 +98,13 @@ class Workflow
     /**
      * Class constructor
      *
-     * @param   string           $extension  The extension name
-     * @param   ?CMSApplication  $app        Application Object
-     * @param   ?DatabaseDriver  $db         Database Driver Object
+     * @param   string                    $extension  The extension name
+     * @param   ?CMSApplicationInterface  $app        Application Object
+     * @param   ?DatabaseDriver           $db         Database Driver Object
      *
      * @since   4.0.0
      */
-    public function __construct(string $extension, ?CMSApplication $app = null, ?DatabaseDriver $db = null)
+    public function __construct(string $extension, ?CMSApplicationInterface $app = null, ?DatabaseDriver $db = null)
     {
         $this->extension = $extension;
 


### PR DESCRIPTION
Pull Request for Issue #40653 .

### Summary of Changes

`\Joomla\CMS\Workflow\Workflow` constructor now use CMSApplicationInterface insteadof CMSApplication. This make compatible with CliApplication which implements CMSApplicationInterface but not extends CMSApplication.

### Testing Instructions

Make CLI app which create instance of ArticleModel: $article = \Joomla\CMS\Factory::getApplication()->bootComponent('com_content')->getMVCFactory()->createModel('Article', 'Administrator');

### Actual result BEFORE applying this Pull Request

[TypeError]  Joomla\CMS\Workflow\Workflow::__construct(): Argument #2 ($app) must be of type ?Joomla\CMS\Application\CMSApplication, Joomla\CMS\Application\ConsoleApplication given, called in ....../libraries/src/MVC/Model/WorkflowBehaviorTrait.php on line 90        

### Expected result AFTER applying this Pull Request

I get model object

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
