### PR TITLE
Fix debugusergroup for the superuser group

### DIFF
--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -10,6 +10,7 @@
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Access\Access;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Layout\LayoutHelper;
@@ -23,6 +24,14 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('table.columns');
+
+/**
+ * Get the group ID and check if the group is a super user group
+ * Super user groups have the core.admin action allowed by default,
+ * but they have not the usual access checks.
+*/
+$groupId = $this->state->get('group_id');
+$isSuperUserGroup = Access::checkGroup($groupId, 'core.admin'); 
 
 ?>
 <form action="<?php echo Route::_('index.php?option=com_users&view=debuggroup&group_id=' . (int) $this->state->get('group_id')); ?>" method="post" name="adminForm" id="adminForm">
@@ -49,7 +58,7 @@ $wa->useScript('table.columns');
                 <?php foreach ($loginActions as $action) :
                     $name  = $action[0];
                     $check = $this->items[0]->checks[$name];
-                    if ($check === true) :
+                    if ($check === true || $isSuperUserGroup) :
                         $class  = 'text-success icon-check';
                         $button = 'btn-success';
                         $text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');
@@ -109,7 +118,7 @@ $wa->useScript('table.columns');
                                 <?php
                                 $name  = $action[0];
                                 $check = $item->checks[$name];
-                                if ($check === true) :
+                                if ($check === true || $isSuperUserGroup) :
                                     $class  = 'text-success icon-check';
                                     $button = 'btn-success';
                                     $text   = Text::_('COM_USERS_DEBUG_EXPLICIT_ALLOW');

--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -31,7 +31,7 @@ $wa->useScript('table.columns');
  * but they have not the usual access checks.
 */
 $groupId = $this->state->get('group_id');
-$isSuperUserGroup = Access::checkGroup($groupId, 'core.admin'); 
+$isSuperUserGroup = Access::checkGroup($groupId, 'core.admin');
 
 ?>
 <form action="<?php echo Route::_('index.php?option=com_users&view=debuggroup&group_id=' . (int) $this->state->get('group_id')); ?>" method="post" name="adminForm" id="adminForm">


### PR DESCRIPTION
Pull Request for Issue #44416 .

### Summary of Changes
The group of super users has all permissions per default, this is why the check for permission fails. 
The PR sets a switch for super user Group. 

Remark: 
As the super user has all permissions, we as well could remove the "show permissions " link in the Groups list.
Probably this would look like a bug "misssing permission button" for novice users, so I have chosen this solution.



### Testing Instructions
See #44416.
Check the group permissions of different groups, not only the super user group, before and after patch. 



### Actual result BEFORE applying this Pull Request
see #44416.


### Expected result AFTER applying this Pull Request
The super user has all permissions 
![grafik](https://github.com/user-attachments/assets/5f1622a2-626f-49bd-b34d-a33f7de4b774)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
