### PR TITLE
[5.2] Add missing html elements to sanitizer for finder debugging

### DIFF
--- a/build/media_source/com_finder/js/debug.es6.js
+++ b/build/media_source/com_finder/js/debug.es6.js
@@ -24,11 +24,14 @@
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         onSuccess: (response) => {
           const output = document.getElementById('indexer-output');
+          const allowedHtml = {
+            fieldset: [], legend: [], dl: ['class'], dt: ['class'], dd: ['class'],
+          };
           try {
             const parsed = JSON.parse(response);
-            output.innerHTML = Joomla.sanitizeHtml(parsed.rendered);
+            output.innerHTML = Joomla.sanitizeHtml(parsed.rendered, allowedHtml);
           } catch (e) {
-            output.innerHTML = Joomla.sanitizeHtml(response);
+            output.innerHTML = Joomla.sanitizeHtml(response, allowedHtml);
           }
         },
         onError: (xhr) => {


### PR DESCRIPTION
Fix for broken pr joomla/joomla-cms#44342 

That PR wasn't tested, sadly it was my fault that it has been merged.

This PR adds the missing HTML elements which need to be allowed for the sanitizer to not break the output.

Testing:

Run the  com_finder indexer in debug mode.
![image](https://github.com/user-attachments/assets/30fff374-25b4-4568-b47a-df5e4feed366)

After indexing an article the result should be shown in the output window.