### PR TITLE
[6.2] Add old data to model save events

### DIFF
--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -512,6 +512,7 @@ class CategoryModel extends AdminModel
         $input      = Factory::getApplication()->getInput();
         $pk         = (!empty($data['id'])) ? $data['id'] : (int) $this->getState($this->getName() . '.id');
         $isNew      = true;
+        $oldData    = [];
         $context    = $this->option . '.' . $this->name;
 
         if (!empty($data['tags']) && $data['tags'][0] != '') {
@@ -525,6 +526,7 @@ class CategoryModel extends AdminModel
         if ($pk > 0) {
             $table->load($pk);
             $isNew = false;
+            $oldData = get_object_vars($table);
         }
 
         // Set the new parent id if parent id not matched OR while New/Save as Copy .
@@ -571,7 +573,7 @@ class CategoryModel extends AdminModel
         }
 
         // Trigger the before save event.
-        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, &$table, $isNew, $data]);
+        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, &$table, $isNew, $data, $oldData]);
 
         if (\in_array(false, $result, true)) {
             $this->setError($table->getError());
@@ -697,7 +699,7 @@ class CategoryModel extends AdminModel
         }
 
         // Trigger the after save event.
-        Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, $isNew, $data]);
+        Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, $isNew, $data, $oldData]);
 
         // Rebuild the path for the category:
         if (!$table->rebuildPath($table->id)) {

--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -525,7 +525,7 @@ class CategoryModel extends AdminModel
         // Load the row if saving an existing category.
         if ($pk > 0) {
             $table->load($pk);
-            $isNew = false;
+            $isNew   = false;
             $oldData = get_object_vars($table);
         }
 

--- a/administrator/components/com_languages/src/Model/LanguageModel.php
+++ b/administrator/components/com_languages/src/Model/LanguageModel.php
@@ -186,8 +186,9 @@ class LanguageModel extends AdminModel
      */
     public function save($data)
     {
-        $langId = (!empty($data['lang_id'])) ? $data['lang_id'] : (int) $this->getState('language.id');
-        $isNew  = true;
+        $langId  = (!empty($data['lang_id'])) ? $data['lang_id'] : (int) $this->getState('language.id');
+        $isNew   = true;
+        $oldData = [];
 
         PluginHelper::importPlugin($this->events_map['save']);
 
@@ -198,6 +199,7 @@ class LanguageModel extends AdminModel
         if ($langId > 0) {
             $table->load($langId);
             $isNew = false;
+            $oldData = get_object_vars($table);
         }
 
         // Prevent white spaces, including East Asian double bytes.
@@ -237,7 +239,7 @@ class LanguageModel extends AdminModel
         }
 
         // Trigger the before save event.
-        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, &$table, $isNew]);
+        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, &$table, $isNew, $oldData]);
 
         // Check the event responses.
         if (\in_array(false, $result, true)) {
@@ -254,7 +256,7 @@ class LanguageModel extends AdminModel
         }
 
         // Trigger the after save event.
-        Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, $isNew]);
+        Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, $isNew, $oldData]);
 
         $this->setState('language.id', $table->lang_id);
 

--- a/administrator/components/com_languages/src/Model/LanguageModel.php
+++ b/administrator/components/com_languages/src/Model/LanguageModel.php
@@ -198,7 +198,7 @@ class LanguageModel extends AdminModel
         // Load the row if saving an existing item.
         if ($langId > 0) {
             $table->load($langId);
-            $isNew = false;
+            $isNew   = false;
             $oldData = get_object_vars($table);
         }
 

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -315,6 +315,7 @@ class TemplateModel extends AdminModel
         $template_id = (!empty($data['template_id'])) ? $data['template_id'] : $this->getState($this->getName() . '.template_id');
         $language    = (!empty($data['language'])) ? $data['language'] : $this->getState($this->getName() . '.language');
         $isNew       = true;
+        $oldData     = [];
 
         // Include the plugins for the save events.
         \Joomla\CMS\Plugin\PluginHelper::importPlugin($this->events_map['save']);
@@ -326,6 +327,7 @@ class TemplateModel extends AdminModel
 
             if ($table->subject) {
                 $isNew = false;
+                $oldData = get_object_vars($table);
             }
 
             // Load the default row
@@ -349,7 +351,7 @@ class TemplateModel extends AdminModel
             }
 
             // Trigger the before save event.
-            $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, $table, $isNew, $data]);
+            $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, $table, $isNew, $data, $oldData]);
 
             if (\in_array(false, $result, true)) {
                 $this->setError($table->getError());
@@ -368,7 +370,7 @@ class TemplateModel extends AdminModel
             $this->cleanCache();
 
             // Trigger the after save event.
-            Factory::getApplication()->triggerEvent($this->event_after_save, [$context, $table, $isNew, $data]);
+            Factory::getApplication()->triggerEvent($this->event_after_save, [$context, $table, $isNew, $data, $oldData]);
         } catch (\Exception $e) {
             $this->setError($e->getMessage());
 

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -326,7 +326,7 @@ class TemplateModel extends AdminModel
             $table->load(['template_id' => $template_id, 'language' => $language]);
 
             if ($table->subject) {
-                $isNew = false;
+                $isNew   = false;
                 $oldData = get_object_vars($table);
             }
 

--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -1325,7 +1325,7 @@ class ItemModel extends AdminModel
         // Load the row if saving an existing item.
         if ($pk > 0) {
             $table->load($pk);
-            $isNew = false;
+            $isNew   = false;
             $oldData = get_object_vars($table);
         }
 

--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -1313,6 +1313,7 @@ class ItemModel extends AdminModel
     {
         $pk      = $data['id'] ?? (int) $this->getState('item.id');
         $isNew   = true;
+        $oldData = [];
         $db      = $this->getDatabase();
         $query   = $db->getQuery(true);
         $table   = $this->getTable();
@@ -1325,6 +1326,7 @@ class ItemModel extends AdminModel
         if ($pk > 0) {
             $table->load($pk);
             $isNew = false;
+            $oldData = get_object_vars($table);
         }
 
         if (!$isNew) {
@@ -1401,7 +1403,7 @@ class ItemModel extends AdminModel
         }
 
         // Trigger the before save event.
-        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, &$table, $isNew, $data]);
+        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, &$table, $isNew, $data, $oldData]);
 
         // Store the data.
         if (\in_array(false, $result, true) || !$table->store()) {
@@ -1411,7 +1413,7 @@ class ItemModel extends AdminModel
         }
 
         // Trigger the after save event.
-        Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, $isNew]);
+        Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, $isNew, $oldData]);
 
         // Rebuild the tree path.
         if (!$table->rebuildPath($table->id)) {

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -909,7 +909,7 @@ class ModuleModel extends AdminModel
         // Load the row if saving an existing record.
         if ($pk > 0) {
             $table->load($pk);
-            $isNew = false;
+            $isNew   = false;
             $oldData = get_object_vars($table);
         }
 

--- a/administrator/components/com_modules/src/Model/ModuleModel.php
+++ b/administrator/components/com_modules/src/Model/ModuleModel.php
@@ -900,6 +900,7 @@ class ModuleModel extends AdminModel
         $table      = $this->getTable();
         $pk         = (!empty($data['id'])) ? $data['id'] : (int) $this->getState('module.id');
         $isNew      = true;
+        $oldData    = [];
         $context    = $this->option . '.' . $this->name;
 
         // Include the plugins for the save event.
@@ -909,6 +910,7 @@ class ModuleModel extends AdminModel
         if ($pk > 0) {
             $table->load($pk);
             $isNew = false;
+            $oldData = get_object_vars($table);
         }
 
         // Alter the title and published state for Save as Copy
@@ -940,7 +942,7 @@ class ModuleModel extends AdminModel
         }
 
         // Trigger the before save event.
-        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, &$table, $isNew]);
+        $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, &$table, $isNew, $oldData]);
 
         if (\in_array(false, $result, true)) {
             $this->setError($table->getError());
@@ -1029,7 +1031,7 @@ class ModuleModel extends AdminModel
         }
 
         // Trigger the after save event.
-        Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, $isNew]);
+        Factory::getApplication()->triggerEvent($this->event_after_save, [$context, &$table, $isNew, $oldData]);
 
         // Compute the extension id of this module in case the controller wants it.
         $query->clear()

--- a/administrator/components/com_tags/src/Model/TagModel.php
+++ b/administrator/components/com_tags/src/Model/TagModel.php
@@ -226,7 +226,7 @@ class TagModel extends AdminModel
             // Load the row if saving an existing tag.
             if ($pk > 0) {
                 $table->load($pk);
-                $isNew = false;
+                $isNew   = false;
                 $oldData = get_object_vars($table);
             }
 

--- a/administrator/components/com_tags/src/Model/TagModel.php
+++ b/administrator/components/com_tags/src/Model/TagModel.php
@@ -216,6 +216,7 @@ class TagModel extends AdminModel
         $input      = Factory::getApplication()->getInput();
         $pk         = (!empty($data['id'])) ? $data['id'] : (int) $this->getState($this->getName() . '.id');
         $isNew      = true;
+        $oldData    = [];
         $context    = $this->option . '.' . $this->name;
 
         // Include the plugins for the save events.
@@ -226,6 +227,7 @@ class TagModel extends AdminModel
             if ($pk > 0) {
                 $table->load($pk);
                 $isNew = false;
+                $oldData = get_object_vars($table);
             }
 
             // Set the new parent id if parent id not matched OR while New/Save as Copy .
@@ -267,7 +269,7 @@ class TagModel extends AdminModel
             }
 
             // Trigger the before save event.
-            $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, $table, $isNew, $data]);
+            $result = Factory::getApplication()->triggerEvent($this->event_before_save, [$context, $table, $isNew, $data, $oldData]);
 
             if (\in_array(false, $result, true)) {
                 $this->setError($table->getError());
@@ -283,7 +285,7 @@ class TagModel extends AdminModel
             }
 
             // Trigger the after save event.
-            Factory::getApplication()->triggerEvent($this->event_after_save, [$context, $table, $isNew]);
+            Factory::getApplication()->triggerEvent($this->event_after_save, [$context, $table, $isNew, $oldData]);
 
             // Rebuild the path for the tag:
             if (!$table->rebuildPath($table->id)) {

--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -477,7 +477,7 @@ class StyleModel extends AdminModel
         // Load the row if saving an existing record.
         if ($pk > 0) {
             $table->load($pk);
-            $isNew = false;
+            $isNew   = false;
             $oldData = get_object_vars($table);
         }
 

--- a/libraries/src/Event/Model/SaveEvent.php
+++ b/libraries/src/Event/Model/SaveEvent.php
@@ -28,7 +28,7 @@ abstract class SaveEvent extends ModelEvent
      * @since  5.0.0
      * @deprecated 5.0 will be removed in 6.0
      */
-    protected $legacyArgumentsOrder = ['context', 'subject', 'isNew', 'data'];
+    protected $legacyArgumentsOrder = ['context', 'subject', 'isNew', 'data', 'oldData'];
 
     /**
      * Setter for the subject argument.
@@ -92,5 +92,17 @@ abstract class SaveEvent extends ModelEvent
     public function getData()
     {
         return $this->arguments['data'];
+    }
+
+    /**
+     * Getter for the old data.
+     *
+     * @return  array
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function getOldData()
+    {
+        return $this->arguments['oldData'] ?? [];
     }
 }

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1251,9 +1251,9 @@ abstract class AdminModel extends FormModel
             $table->newTags = $data['tags'];
         }
 
-        $key   = $table->getKeyName();
-        $pk    = (isset($data[$key])) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
-        $isNew = true;
+        $key     = $table->getKeyName();
+        $pk      = (isset($data[$key])) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
+        $isNew   = true;
         $oldData = [];
 
         // Include the plugins for the save events.

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1254,6 +1254,7 @@ abstract class AdminModel extends FormModel
         $key   = $table->getKeyName();
         $pk    = (isset($data[$key])) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
         $isNew = true;
+        $oldData = [];
 
         // Include the plugins for the save events.
         PluginHelper::importPlugin($this->events_map['save'], null, true, $dispatcher);
@@ -1264,6 +1265,7 @@ abstract class AdminModel extends FormModel
             if ($pk > 0) {
                 $table->load($pk);
                 $isNew = false;
+                $oldData = get_object_vars($table);
             }
 
             // Bind the data.
@@ -1289,6 +1291,7 @@ abstract class AdminModel extends FormModel
                 'subject' => $table,
                 'isNew'   => $isNew,
                 'data'    => $data,
+                'oldData' => $oldData,
             ]);
             $result = $dispatcher->dispatch($this->event_before_save, $beforeSaveEvent)->getArgument('result', []);
 
@@ -1314,6 +1317,7 @@ abstract class AdminModel extends FormModel
                 'subject' => $table,
                 'isNew'   => $isNew,
                 'data'    => $data,
+                'oldData' => $oldData,
             ]));
         } catch (\Exception $e) {
             $this->setError($e->getMessage());

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1264,7 +1264,7 @@ abstract class AdminModel extends FormModel
             // Load the row if saving an existing record.
             if ($pk > 0) {
                 $table->load($pk);
-                $isNew = false;
+                $isNew   = false;
                 $oldData = get_object_vars($table);
             }
 


### PR DESCRIPTION
### Summary of Changes
This PR adds the data before the update in the table happend to the before and after save event.
This allows a plugin to check the changed values in the after save event and trigger further actions.

Before this PR, the Plugin needs to listen on the beforeSaveEvent, load the row from the database manually and preserve it in the plugin object and read the preserved data in the afterSaveEvent.

A event listener should be self contained and should not depend on any other plugin triggers (if possible).

In this case we now only need the afterSaveEvent and don't need to do another database query, which both increase performance.


### Testing Instructions
Create a plugin, or use an existing plugin which listen to the `onContentAfterSave` and `onContentBeforeSave` events.

Test with the all extensions (also 3rd party) especially

* com_content
* com_category
* com_language
* com_template (styles)
* com_menus
* com_modules
* com_tags
* com_mails (mail templates) 

check the value of $event->getArgument('oldData'); this should have the old values before the row has been updated.


### Actual result BEFORE applying this Pull Request
No old Data


### Expected result AFTER applying this Pull Request
Old Data exists


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [X] Pull Request link for manual.joomla.org: TBA
- [ ] No documentation changes for manual.joomla.org needed

### Additional information
This PR doesn't touch the UserBeforeSave and UserAfterSave event since it doesn't implement the `\Joomla\CMS\Event\Model\SaveEvent` class, the User Save events already include the old data. Never the less it would make sense to move the User Save events inline with all other Save events.

In the Documentation a migration part have to be added with motivate 3rd party extension developer to check there save function and also provide the old data to the event handler.