### PR TITLE
[5.2] Add required content filters for the administrator menu

### DIFF
--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -141,6 +141,14 @@ class ArticlesModel extends ListModel
             $this->context .= '.' . $forcedLanguage;
         }
 
+        // Required content filters for the administrator menu
+        $this->getUserStateFromRequest($this->context . '.filter.category_id', 'filter_category_id');
+        $this->getUserStateFromRequest($this->context . '.filter.level', 'filter_level');
+        $this->getUserStateFromRequest($this->context . '.filter.author_id', 'filter_author_id');
+        $this->getUserStateFromRequest($this->context . '.filter.tag', 'filter_tag', '');
+        $this->getUserStateFromRequest($this->context . '.filter.access', 'filter_access');
+        $this->getUserStateFromRequest($this->context . '.filter.language', 'filter_language', '');
+
         // List state information.
         parent::populateState($ordering, $direction);
 


### PR DESCRIPTION
Pull Request for Issue #44305 

### Summary of Changes

This fix adds the content filters back for the direct menu links to specific articles. See here for the issue and more details: https://github.com/joomla/joomla-cms/issues/44305

### Testing Instructions

Create a menu item as described in the linked issue. Check all filter options.

### Actual result BEFORE applying this Pull Request

The filters are not applied, and all articles are loaded.

### Expected result AFTER applying this Pull Request

The filters are applied correctly, and only corresponding articles are loaded.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
