### PR TITLE
[5.2] Fix JS CS missing trailing comma

### DIFF
--- a/tests/System/plugins/fs.mjs
+++ b/tests/System/plugins/fs.mjs
@@ -1,5 +1,5 @@
 import {
-  chmodSync, existsSync, writeFileSync, mkdirSync, rmSync, copyFileSync
+  chmodSync, existsSync, writeFileSync, mkdirSync, rmSync, copyFileSync,
 } from 'fs';
 import { dirname, join } from 'path';
 import { umask } from 'node:process';


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) fixes a small javascript code style error in file "tests/System/plugins/fs.mjs".

Here in the 5.2-dev branch, the linter does not complain about that, so the javascript-cs step passes.

But when doing my upmerge PR #44434 for 5.3-dev I've noticed that the javascript-cs step failed in Drone due to that CS error.

It was introduced with PR #44253 .

### Testing Instructions

Check that the javascript-cs passes in Drone for this PR here..

### Actual result BEFORE applying this Pull Request

The javascript-cs passes in Drone, but in the 5.3-dev branch it fails without this change.

### Expected result AFTER applying this Pull Request

The javascript-cs passes in Drone.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
