### PR TITLE
Removed hardcoded username from Actionlogs.cy.js

### DIFF
--- a/tests/System/integration/administrator/components/com_actionlogs/Actionlogs.cy.js
+++ b/tests/System/integration/administrator/components/com_actionlogs/Actionlogs.cy.js
@@ -19,7 +19,7 @@ describe('Test in backend that the action logs', () => {
     cy.doAdministratorLogout();
     cy.doAdministratorLogin();
     cy.visit('/administrator/index.php?option=com_actionlogs&view=actionlogs');
-    cy.contains('User ${Cypress.env('username')} logged in to admin');
+    cy.contains(`User ${Cypress.env('username')} logged in to admin`);
     cy.task('queryDB', 'TRUNCATE #__action_logs');
   });
 

--- a/tests/System/integration/administrator/components/com_actionlogs/Actionlogs.cy.js
+++ b/tests/System/integration/administrator/components/com_actionlogs/Actionlogs.cy.js
@@ -19,7 +19,7 @@ describe('Test in backend that the action logs', () => {
     cy.doAdministratorLogout();
     cy.doAdministratorLogin();
     cy.visit('/administrator/index.php?option=com_actionlogs&view=actionlogs');
-    cy.contains('User ' + Cypress.env('username') + ' logged in to admin');
+    cy.contains('User ${Cypress.env('username')} logged in to admin');
     cy.task('queryDB', 'TRUNCATE #__action_logs');
   });
 

--- a/tests/System/integration/administrator/components/com_actionlogs/Actionlogs.cy.js
+++ b/tests/System/integration/administrator/components/com_actionlogs/Actionlogs.cy.js
@@ -19,7 +19,7 @@ describe('Test in backend that the action logs', () => {
     cy.doAdministratorLogout();
     cy.doAdministratorLogin();
     cy.visit('/administrator/index.php?option=com_actionlogs&view=actionlogs');
-    cy.contains('User ci-admin logged in to admin');
+    cy.contains('User ' + Cypress.env('username') + ' logged in to admin');
     cy.task('queryDB', 'TRUNCATE #__action_logs');
   });
 


### PR DESCRIPTION
On line 22 "ci-admin" was hardcoded, causing the test to fail, if another user is configured in cypress.config.mjs

### Summary of Changes

replaced ci-admin with Cypress.env('username')

### Testing Instructions

Configure cypress.config.mjs to user other than "ci-admin"

### Actual result BEFORE applying this Pull Request

"can display a list of actions" will fail due to "ci-admin" not being found in log

### Expected result AFTER applying this Pull Request

Test will pass, due to searching for the actual username

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: 
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: 
- [x] No documentation changes for manual.joomla.org needed
