### PR TITLE
[5.2] Wrap long text to prevent layout displaying beyond viewport

### DIFF
--- a/administrator/components/com_finder/src/Controller/IndexerController.php
+++ b/administrator/components/com_finder/src/Controller/IndexerController.php
@@ -365,7 +365,7 @@ class IndexerController extends BaseController
             $output .= '<dl class="row">';
 
             foreach (DebugIndexer::$item as $key => $value) {
-                $output .= '<dt class="col-sm-2">' . $key . '</dt><dd class="col-sm-10">' . $value . '</dd>';
+                $output .= '<dt class="col-sm-2">' . $key . '</dt><dd class="col-sm-10 text-break">' . $value . '</dd>';
             }
 
             $output .= '</dl>';
@@ -375,7 +375,7 @@ class IndexerController extends BaseController
             $output .= '<dl class="row">';
 
             foreach (DebugIndexer::$item->getElements() as $key => $element) {
-                $output .= '<dt class="col-sm-2">' . $key . '</dt><dd class="col-sm-10">' . $element . '</dd>';
+                $output .= '<dt class="col-sm-2">' . $key . '</dt><dd class="col-sm-10 text-break">' . $element . '</dd>';
             }
 
             $output .= '</dl>';
@@ -392,7 +392,7 @@ class IndexerController extends BaseController
             ];
 
             foreach (DebugIndexer::$item->getInstructions() as $key => $element) {
-                $output .= '<dt class="col-sm-2">' . $contexts[$key] . '</dt><dd class="col-sm-10">' . json_encode($element) . '</dd>';
+                $output .= '<dt class="col-sm-2">' . $contexts[$key] . '</dt><dd class="col-sm-10 text-break">' . json_encode($element) . '</dd>';
             }
 
             $output .= '</dl>';
@@ -402,7 +402,7 @@ class IndexerController extends BaseController
             $output .= '<dl class="row">';
 
             foreach (DebugIndexer::$item->getTaxonomy() as $key => $element) {
-                $output .= '<dt class="col-sm-2">' . $key . '</dt><dd class="col-sm-10">' . json_encode($element) . '</dd>';
+                $output .= '<dt class="col-sm-2">' . $key . '</dt><dd class="col-sm-10 text-break">' . json_encode($element) . '</dd>';
             }
 
             $output .= '</dl>';


### PR DESCRIPTION
### Summary of Changes
Fix long text from displaying beyond viewport.


### Testing Instructions
Install  blog sample data.
Enable `Debug System`.
Go Components > Smart Search > Index.
Click `Index > Index Debugging`.
Select `Smart Search - Content`.
Click `Index` button.
See `Output` section.


### Actual result BEFORE applying this Pull Request
Horizontal scrollbar.


### Expected result AFTER applying this Pull Request
No horizontal scrollbar.