### PR TITLE
[5.2][cypress] lint mjs files

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "watch": "node build/build.js --watch",
     "watch:com_media": "node build/build.js --watch-com-media",
     "lint:js": "eslint --config build/.eslintrc --ignore-pattern '/media/' --ext .es6.js,.es6,.vue .",
-    "lint:testjs": "eslint --config build/.eslintrc --ext .js tests/System",
+    "lint:testjs": "eslint --config build/.eslintrc --ext .js,.mjs tests/System",
     "lint:css": "stylelint --config build/.stylelintrc.json \"administrator/components/com_media/resources/**/*.scss\" \"administrator/templates/**/*.scss\" \"build/media_source/**/*.scss\" \"build/media_source/**/*.css\" \"templates/**/*.scss\" \"installation/template/**/*.scss\"",
     "install": "node build/build.js --prepare",
     "update": "node build/build.js --copy-assets && node build/build.js --build-pages && node build/build.js --compile-js && node build/build.js --compile-css && node build/build.js --compile-bs && node --env-file=./build/production.env build/build.js --com-media",


### PR DESCRIPTION
Redo #43778 for J5.2

### Summary of Changes

add missing file extension to `lint:testjs`, lost during upmerge

### Testing Instructions

`npm run lint:testjs`

### Actual result BEFORE applying this Pull Request

*.mjs are not tested (eslint) in `javascript-cs`

### Expected result AFTER applying this Pull Request

*.mjs are tested (eslint) in `javascript-cs`
