### PR TITLE
[5.2] Add more site router tests (alias included)

### DIFF
--- a/tests/System/integration/site/components/com_contact/Router.cy.js
+++ b/tests/System/integration/site/components/com_contact/Router.cy.js
@@ -1,13 +1,20 @@
 describe('Test in frontend that the contact site router', () => {
+  afterEach(() => cy.db_updateExtensionParameter('sef_ids', '1', 'com_contact'));
+
   it('can process contact without a menu item', () => {
     cy.db_createContact({ name: 'Test Contact', alias: 'test-contact-router' }).then((contact) => {
+      const url = '/index.php/component/contact/contact/test-contact-router';
       cy.request({ url: `/index.php?option=com_contact&view=contact&id=${contact.id}`, followRedirect: false }).then((response) => {
         expect(response.status).to.eq(301);
-        expect(response.redirectedToUrl).to.match(/\/index\.php\/component\/contact\/contact\/test-contact-router$/);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
+      cy.request({ url: `/index.php?option=com_contact&view=contact&id=${contact.id}-${contact.alias}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(301);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
       });
 
-      cy.visit('/index.php/component/contact/contact/test-contact-router');
-      cy.url().should('match', /\/index\.php\/component\/contact\/contact\/test-contact-router$/);
+      cy.visit(url);
+      cy.url().should('match', new RegExp(`${url}$`));
       cy.title().should('equal', 'Test Contact');
       cy.get('main h1').contains('Home');
       cy.get('main h2').contains('Test Contact');
@@ -20,6 +27,7 @@ describe('Test in frontend that the contact site router', () => {
   });
 
   it('can process contact with a single contact menu item', () => {
+    const url = '/index.php/test-menu-contact-router';
     cy.db_createContact({ name: 'Test Contact', alias: 'test-contact-router' }).then((contact) => {
       cy.db_createMenuItem({
         title: 'Test Menu Single Contact',
@@ -27,13 +35,25 @@ describe('Test in frontend that the contact site router', () => {
         path: 'test-menu-contact-router',
         link: `index.php?option=com_contact&view=contact&id=${contact.id}`,
       });
+      cy.request({ url: `/index.php?option=com_contact&view=contact&id=${contact.id}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(301);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
+      cy.request({ url: `/index.php?option=com_contact&view=contact&id=${contact.id}-${contact.alias}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(301);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
       cy.request({ url: `/index.php?option=com_contact&view=contact&id=${contact.id}&catid=${contact.catid}`, followRedirect: false }).then((response) => {
         expect(response.status).to.eq(301);
-        expect(response.redirectedToUrl).to.match(/\/index\.php\/test-menu-contact-router$/);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
+      cy.request({ url: `/index.php?option=com_contact&view=contact&id=${contact.id}-${contact.alias}&catid=${contact.catid}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(301);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
       });
 
-      cy.visit('/index.php/test-menu-contact-router');
-      cy.url().should('match', /\/index\.php\/test-menu-contact-router$/);
+      cy.visit(url);
+      cy.url().should('match', new RegExp(`${url}$`));
       cy.title().should('equal', 'Test Menu Single Contact');
       cy.get('main h1').contains('Test Contact');
       cy.get('main h2').contains('Contact');
@@ -44,6 +64,7 @@ describe('Test in frontend that the contact site router', () => {
   });
 
   it('can process contact with a category list menu item', () => {
+    const url = '/index.php/test-menu-category-router/test-contact-router';
     cy.db_createContact({ name: 'Test Contact', alias: 'test-contact-router' }).then((contact) => {
       cy.db_createMenuItem({
         title: 'Test Menu Contact Category',
@@ -53,11 +74,15 @@ describe('Test in frontend that the contact site router', () => {
       });
       cy.request({ url: `/index.php?option=com_contact&view=contact&id=${contact.id}&catid=${contact.catid}`, followRedirect: false }).then((response) => {
         expect(response.status).to.eq(301);
-        expect(response.redirectedToUrl).to.match(/\/index\.php\/test-menu-category-router\/test-contact-router$/);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
+      cy.request({ url: `/index.php?option=com_contact&view=contact&id=${contact.id}-${contact.alias}&catid=${contact.catid}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(301);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
       });
 
-      cy.visit('/index.php/test-menu-category-router');
-      cy.url().should('match', /\/index\.php\/test-menu-category-router$/);
+      cy.visit(url.split('/').slice(0, -1).join('/'));
+      cy.url().should('match', new RegExp(`${url.split('/').slice(0, -1).join('/')}$`));
       cy.title().should('equal', 'Test Menu Contact Category');
       cy.get('main h1').contains('Uncategorised');
       cy.get('nav.mod-breadcrumbs__wrapper ol.mod-breadcrumbs').children().as('breadcrumb');
@@ -66,10 +91,10 @@ describe('Test in frontend that the contact site router', () => {
       cy.get('main div.com-contact-category a')
         .contains('Test Contact')
         .should('have.attr', 'href')
-        .and('match', /\/index\.php\/test-menu-category-router\/test-contact-router$/);
+        .and('match', new RegExp(`${url}$`));
 
-      cy.visit('/index.php/test-menu-category-router/test-contact-router');
-      cy.url().should('match', /\/index\.php\/test-menu-category-router\/test-contact-router$/);
+      cy.visit(url);
+      cy.url().should('match', new RegExp(`${url}$`));
       cy.title().should('equal', 'Test Contact');
       cy.get('main h1').contains('Test Contact');
       cy.get('main h2').contains('Contact');
@@ -81,6 +106,7 @@ describe('Test in frontend that the contact site router', () => {
   });
 
   it('can process contact with a categories list menu item', () => {
+    const url = '/index.php/test-menu-categories-router/uncategorised/test-contact-router';
     cy.db_createContact({ name: 'Test Contact', alias: 'test-contact-router' }).then((contact) => {
       cy.db_createMenuItem({
         title: 'Test Menu Contact Categories',
@@ -90,11 +116,11 @@ describe('Test in frontend that the contact site router', () => {
       });
       cy.request({ url: `/index.php?option=com_contact&view=contact&id=${contact.id}&catid=${contact.catid}`, followRedirect: false }).then((response) => {
         expect(response.status).to.eq(301);
-        expect(response.redirectedToUrl).to.match(/\/index\.php\/test-menu-categories-router\/uncategorised\/test-contact-router$/);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
       });
 
-      cy.visit('/index.php/test-menu-categories-router');
-      cy.url().should('match', /\/index\.php\/test-menu-categories-router$/);
+      cy.visit(url.split('/').slice(0, -2).join('/'));
+      cy.url().should('match', new RegExp(`${url.split('/').slice(0, -2).join('/')}$`));
       cy.title().should('equal', 'Test Menu Contact Categories');
       cy.get('nav.mod-breadcrumbs__wrapper ol.mod-breadcrumbs').children().as('breadcrumb');
       cy.get('@breadcrumb').should('have.length', 3);
@@ -102,10 +128,10 @@ describe('Test in frontend that the contact site router', () => {
       cy.get('main div.com-contact-categories h3 a')
         .contains('Uncategorised')
         .should('have.attr', 'href')
-        .and('match', /\/index\.php\/test-menu-categories-router\/uncategorised$/);
+        .and('match', new RegExp(`${url.split('/').slice(0, -1).join('/')}$`));
 
-      cy.visit('/index.php/test-menu-categories-router/uncategorised');
-      cy.url().should('match', /\/index\.php\/test-menu-categories-router\/uncategorised$/);
+      cy.visit(url.split('/').slice(0, -1).join('/'));
+      cy.url().should('match', new RegExp(`${url.split('/').slice(0, -1).join('/')}$`));
       cy.title().should('equal', 'Test Menu Contact Categories');
       cy.get('main h1').contains('Uncategorised');
       cy.get('nav.mod-breadcrumbs__wrapper ol.mod-breadcrumbs').children().as('breadcrumb');
@@ -115,10 +141,10 @@ describe('Test in frontend that the contact site router', () => {
       cy.get('main div.com-contact-category a')
         .contains('Test Contact')
         .should('have.attr', 'href')
-        .and('match', /\/index\.php\/test-menu-categories-router\/uncategorised\/test-contact-router$/);
+        .and('match', new RegExp(`${url}$`));
 
-      cy.visit('/index.php/test-menu-categories-router/uncategorised/test-contact-router');
-      cy.url().should('match', /\/index\.php\/test-menu-categories-router\/uncategorised\/test-contact-router$/);
+      cy.visit(url);
+      cy.url().should('match', new RegExp(`${url}$`));
       cy.title().should('equal', 'Test Contact');
       cy.get('main h1').contains('Test Contact');
       cy.get('main h2').contains('Contact');
@@ -127,6 +153,24 @@ describe('Test in frontend that the contact site router', () => {
       cy.get('@breadcrumb').eq(2).should('contain', 'Test Menu Contact Categories');
       cy.get('@breadcrumb').eq(3).should('contain', 'Uncategorised');
       cy.get('@breadcrumb').eq(4).should('contain', 'Test Contact');
+    });
+  });
+
+  it('can process contact with legacy routing', () => {
+    cy.db_updateExtensionParameter('sef_ids', '0', 'com_contact');
+    cy.db_createContact({ name: 'Test Contact', alias: 'test-contact-router' }).then((contact) => {
+      const url = `/index.php/component/contact/contact/${contact.id}-test-contact-router`;
+      cy.request({ url, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(200);
+      });
+      cy.request({ url: `/index.php?option=com_contact&view=contact&id=${contact.id}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(301);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
+      cy.request({ url: `/index.php?option=com_contact&view=contact&id=${contact.id}-${contact.alias}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(301);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
     });
   });
 });

--- a/tests/System/integration/site/components/com_content/Router.cy.js
+++ b/tests/System/integration/site/components/com_content/Router.cy.js
@@ -1,15 +1,24 @@
 describe('Test in frontend that the content site router', () => {
+  afterEach(() => cy.db_updateExtensionParameter('sef_ids', '1', 'com_content'));
+
   it('can process article without a menu item', () => {
+    const url = '/index.php/component/content/article/test-content-router';
     cy.db_createArticle({ title: 'Test Article', alias: 'test-content-router' }).then((article) => {
       cy.request({ url: `/index.php?option=com_content&view=article&id=${article.id}`, followRedirect: false }).then((response) => {
         expect(response.status).to.eq(200);
         // @TODO: Not working if 'Featured Articles' is home menu item
         // expect(response.status).to.eq(301);
-        // expect(response.redirectedToUrl).to.match(/\/index\.php\/component\/content\/article\/test-content-router$/);
+        // expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
+      cy.request({ url: `/index.php?option=com_content&view=article&id=${article.id}-${article.alias}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(200);
+        // @TODO: Not working if 'Featured Articles' is home menu item
+        // expect(response.status).to.eq(301);
+        // expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
       });
 
-      cy.visit('/index.php/component/content/article/test-content-router');
-      cy.url().should('match', /\/index\.php\/component\/content\/article\/test-content-router$/);
+      cy.visit(url);
+      cy.url().should('match', new RegExp(`${url}$`));
       cy.title().should('equal', 'Test Article');
       cy.get('main h1').contains('Home');
       cy.get('main h2').contains('Test Article');
@@ -21,6 +30,7 @@ describe('Test in frontend that the content site router', () => {
   });
 
   it('can process article with a single article menu item', () => {
+    const url = '/index.php/test-menu-article-router';
     cy.db_createArticle({ title: 'Test Article', alias: 'test-content-router' }).then((article) => {
       cy.db_createMenuItem({
         title: 'Test Menu Single Article',
@@ -28,13 +38,25 @@ describe('Test in frontend that the content site router', () => {
         path: 'test-menu-article-router',
         link: `index.php?option=com_content&view=article&id=${article.id}`,
       });
+      cy.request({ url: `/index.php?option=com_content&view=article&id=${article.id}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(301);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
+      cy.request({ url: `/index.php?option=com_content&view=article&id=${article.id}-${article.alias}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(301);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
       cy.request({ url: `/index.php?option=com_content&view=article&id=${article.id}&catid=${article.catid}`, followRedirect: false }).then((response) => {
         expect(response.status).to.eq(301);
-        expect(response.redirectedToUrl).to.match(/\/index\.php\/test-menu-article-router$/);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
+      cy.request({ url: `/index.php?option=com_content&view=article&id=${article.id}-${article.alias}&catid=${article.catid}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(301);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
       });
 
-      cy.visit('/index.php/test-menu-article-router');
-      cy.url().should('match', /\/index\.php\/test-menu-article-router$/);
+      cy.visit(url);
+      cy.url().should('match', new RegExp(`${url}$`));
       cy.title().should('equal', 'Test Article');
       cy.get('main h1').contains('Test Article');
       cy.get('nav.mod-breadcrumbs__wrapper ol.mod-breadcrumbs').children().as('breadcrumb');
@@ -44,6 +66,7 @@ describe('Test in frontend that the content site router', () => {
   });
 
   it('can process article with a category list menu item', () => {
+    const url = '/index.php/test-menu-category-router/test-content-router';
     cy.db_createArticle({ title: 'Test Article', alias: 'test-content-router' }).then((article) => {
       cy.db_createMenuItem({
         title: 'Test Menu Article Category',
@@ -53,11 +76,15 @@ describe('Test in frontend that the content site router', () => {
       });
       cy.request({ url: `/index.php?option=com_content&view=article&id=${article.id}&catid=${article.catid}`, followRedirect: false }).then((response) => {
         expect(response.status).to.eq(301);
-        expect(response.redirectedToUrl).to.match(/\/index\.php\/test-menu-category-router\/test-content-router$/);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
+      cy.request({ url: `/index.php?option=com_content&view=article&id=${article.id}-${article.alias}&catid=${article.catid}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(301);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
       });
 
-      cy.visit('/index.php/test-menu-category-router');
-      cy.url().should('match', /\/index\.php\/test-menu-category-router$/);
+      cy.visit(url.split('/').slice(0, -1).join('/'));
+      cy.url().should('match', new RegExp(`${url.split('/').slice(0, -1).join('/')}$`));
       cy.title().should('equal', 'Test Menu Article Category');
       cy.get('main h1').should('not.exist');
       cy.get('nav.mod-breadcrumbs__wrapper ol.mod-breadcrumbs').children().as('breadcrumb');
@@ -66,10 +93,10 @@ describe('Test in frontend that the content site router', () => {
       cy.get('main div.com-content-category a')
         .contains('Test Article')
         .should('have.attr', 'href')
-        .and('match', /\/index\.php\/test-menu-category-router\/test-content-router$/);
+        .and('match', new RegExp(`${url}$`));
 
-      cy.visit('/index.php/test-menu-category-router/test-content-router');
-      cy.url().should('match', /\/index\.php\/test-menu-category-router\/test-content-router$/);
+      cy.visit(url);
+      cy.url().should('match', new RegExp(`${url}$`));
       cy.title().should('equal', 'Test Article');
       cy.get('main h1').contains('Test Article');
       cy.get('nav.mod-breadcrumbs__wrapper ol.mod-breadcrumbs').children().as('breadcrumb');
@@ -80,6 +107,7 @@ describe('Test in frontend that the content site router', () => {
   });
 
   it('can process article with a categories list menu item', () => {
+    const url = '/index.php/test-menu-categories-router/uncategorised/test-content-router';
     cy.db_createArticle({ title: 'Test Article', alias: 'test-content-router' }).then((article) => {
       cy.db_createMenuItem({
         title: 'Test Menu Article Categories',
@@ -89,11 +117,11 @@ describe('Test in frontend that the content site router', () => {
       });
       cy.request({ url: `/index.php?option=com_content&view=article&id=${article.id}&catid=${article.catid}`, followRedirect: false }).then((response) => {
         expect(response.status).to.eq(301);
-        expect(response.redirectedToUrl).to.match(/\/index\.php\/test-menu-categories-router\/uncategorised\/test-content-router$/);
+        expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
       });
 
-      cy.visit('/index.php/test-menu-categories-router');
-      cy.url().should('match', /\/index\.php\/test-menu-categories-router$/);
+      cy.visit(url.split('/').slice(0, -2).join('/'));
+      cy.url().should('match', new RegExp(`${url.split('/').slice(0, -2).join('/')}$`));
       cy.title().should('equal', 'Test Menu Article Categories');
       cy.get('nav.mod-breadcrumbs__wrapper ol.mod-breadcrumbs').children().as('breadcrumb');
       cy.get('@breadcrumb').should('have.length', 3);
@@ -101,10 +129,10 @@ describe('Test in frontend that the content site router', () => {
       cy.get('main div.com-content-categories div a')
         .contains('Uncategorised')
         .should('have.attr', 'href')
-        .and('match', /\/index\.php\/test-menu-categories-router\/uncategorised$/);
+        .and('match', new RegExp(`${url.split('/').slice(0, -1).join('/')}$`));
 
-      cy.visit('/index.php/test-menu-categories-router/uncategorised');
-      cy.url().should('match', /\/index\.php\/test-menu-categories-router\/uncategorised$/);
+      cy.visit(`${url.split('/').slice(0, -1).join('/')}`);
+      cy.url().should('match', new RegExp(`${url.split('/').slice(0, -1).join('/')}$`));
       cy.title().should('equal', 'Uncategorised');
       cy.get('main h1').should('not.exist');
       cy.get('nav.mod-breadcrumbs__wrapper ol.mod-breadcrumbs').children().as('breadcrumb');
@@ -114,10 +142,10 @@ describe('Test in frontend that the content site router', () => {
       cy.get('main div.com-content-category-blog h2 a')
         .contains('Test Article')
         .should('have.attr', 'href')
-        .and('match', /\/index\.php\/test-menu-categories-router\/uncategorised\/test-content-router$/);
+        .and('match', new RegExp(`${url}$`));
 
-      cy.visit('/index.php/test-menu-categories-router/uncategorised/test-content-router');
-      cy.url().should('match', /\/index\.php\/test-menu-categories-router\/uncategorised\/test-content-router$/);
+      cy.visit(url);
+      cy.url().should('match', new RegExp(`${url}$`));
       cy.title().should('equal', 'Test Article');
       cy.get('main h1').contains('Test Article');
       cy.get('nav.mod-breadcrumbs__wrapper ol.mod-breadcrumbs').children().as('breadcrumb');
@@ -125,6 +153,28 @@ describe('Test in frontend that the content site router', () => {
       cy.get('@breadcrumb').eq(2).should('contain', 'Test Menu Article Categories');
       cy.get('@breadcrumb').eq(3).should('contain', 'Uncategorised');
       cy.get('@breadcrumb').eq(4).should('contain', 'Test Article');
+    });
+  });
+
+  it('can process article with legacy routing', () => {
+    cy.db_updateExtensionParameter('sef_ids', '0', 'com_content');
+    cy.db_createArticle({ title: 'Test Article', alias: 'test-content-router' }).then((article) => {
+      const url = `/index.php/component/content/article/${article.id}-test-content-router`;
+      cy.request({ url, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(200);
+      });
+      cy.request({ url: `/index.php?option=com_content&view=article&id=${article.id}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(200);
+        // @TODO: Not working if 'Featured Articles' is home menu item
+        // expect(response.status).to.eq(301);
+        // expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
+      cy.request({ url: `/index.php?option=com_content&view=article&id=${article.id}-${article.alias}`, followRedirect: false }).then((response) => {
+        expect(response.status).to.eq(200);
+        // @TODO: Not working if 'Featured Articles' is home menu item
+        // expect(response.status).to.eq(301);
+        // expect(response.redirectedToUrl).to.match(new RegExp(`${url}$`));
+      });
     });
   });
 });


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

add more tests to test site router (contact, content) with urls including contact's or article's alias

### Testing Instructions

drone ci

### Actual result BEFORE applying this Pull Request

system tests are ok

### Expected result AFTER applying this Pull Request

system tests are ok

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
