### PR TITLE
[5.3] Routing: Allow to mark parsed URLs as tainted

### DIFF
--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -81,6 +81,16 @@ class Router
     protected $cache = [];
 
     /**
+     * Flag to mark the last parsed URL as tainted
+     * If a URL could be read, but has errors, this
+     * flag can be set to true to mark the URL as errornous.
+     *
+     * @var    bool
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $tainted = false;
+
+    /**
      * Router instances container.
      *
      * @var    Router[]
@@ -140,6 +150,9 @@ class Router
      */
     public function parse(&$uri, $setVars = false)
     {
+        // Reset the tainted flag
+        $this->tainted = false;
+
         // Do the preprocess stage of the URL parse process
         $this->processParseRules($uri, self::PROCESS_BEFORE);
 
@@ -360,6 +373,34 @@ class Router
     public function getRules()
     {
         return $this->rules;
+    }
+
+    /**
+     * Set the currently parsed URL as tainted
+     * If a URL can be parsed, but not all parts were correct,
+     * (for example an ID was found, but the alias was wrong) the parsing
+     * can be marked as tainted. When the URL is marked as tainted, the router
+     * has to have returned correct data to create the right URL afterwards and
+     * can later do additional processing, like redirecting to the right URL.
+     * If the URL is demonstrably wrong, it should still throw a 404 exception.
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function setTainted()
+    {
+        $this->tainted = true;
+    }
+
+    /**
+     * Return if the last parsed URL was tainted.
+     *
+     * @return  bool
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public function isTainted()
+    {
+        return $this->tainted;
     }
 
     /**

--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -83,7 +83,7 @@ class Router
     /**
      * Flag to mark the last parsed URL as tainted
      * If a URL could be read, but has errors, this
-     * flag can be set to true to mark the URL as errornous.
+     * flag can be set to true to mark the URL as erroneous.
      *
      * @var    bool
      * @since  __DEPLOY_VERSION__

--- a/plugins/system/sef/src/Extension/Sef.php
+++ b/plugins/system/sef/src/Extension/Sef.php
@@ -102,6 +102,11 @@ final class Sef extends CMSPlugin implements SubscriberInterface
 
         $router = $this->getSiteRouter();
 
+        /**
+         * The URL was successfully parsed, but is "tainted", e.g. parts of
+         * it were recoverably wrong. So we take the parsed variables, build
+         * a new URL and redirect to that.
+         */
         if ($router->isTainted()) {
             $parsedVars = $router->getVars();
 

--- a/plugins/system/sef/src/Extension/Sef.php
+++ b/plugins/system/sef/src/Extension/Sef.php
@@ -100,6 +100,25 @@ final class Sef extends CMSPlugin implements SubscriberInterface
             return;
         }
 
+        $router = $this->getSiteRouter();
+
+        if ($router->isTainted()) {
+            $parsedVars = $router->getVars();
+
+            if ($app->getLanguageFilter()) {
+                $parsedVars['lang'] = $parsedVars['language'];
+                unset($parsedVars['language']);
+            }
+
+            $newRoute = Route::_($parsedVars, false);
+            $origUri  = clone Uri::getInstance();
+            $route    = $origUri->toString(['path', 'query']);
+
+            if ($route !== $newRoute) {
+                $app->redirect($newRoute, 301);
+            }
+        }
+
         // Enforce removing index.php with a redirect
         if ($app->get('sef_rewrite') && $this->params->get('indexphp')) {
             $this->removeIndexphp();


### PR DESCRIPTION
### Summary of Changes
This PR implements a flag in the router to mark parsed URLs as tainted. A tainted URL was able to be parsed, but has errors, for example it is missing the suffix or in a site with enabled IDs the alias of an article is wrong. In those cases the URL could be parsed, but it isn't the correct URL. In that cases we don't have to throw a 404, but can redirect to the correct URL. This is implemented in the SEF system plugin here as well, doing a 301 redirect when the URL is marked as tainted. The benefit is, that we prevent multiple redirects when more than one thing is wrong with the URL (for example missing suffix AND wrong alias for an ID)

This PR was made possible by the support of [djumla](https://www.djumla.de/). Thank you for that.


### Testing Instructions
Codereview


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [X] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/330
- [ ] No documentation changes for manual.joomla.org needed
