### PR TITLE
[5.3] Fix deprecation message in installation

### DIFF
--- a/installation/src/View/Remove/HtmlView.php
+++ b/installation/src/View/Remove/HtmlView.php
@@ -12,7 +12,7 @@ namespace Joomla\CMS\Installation\View\Remove;
 
 use Joomla\CMS\Installation\Model\ChecksModel;
 use Joomla\CMS\Installation\Model\LanguagesModel;
-use Joomla\CMS\Installation\View\DefaultView;
+use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Version;
 
 // phpcs:disable PSR1.Files.SideEffects
@@ -24,7 +24,7 @@ use Joomla\CMS\Version;
  *
  * @since  3.1
  */
-class HtmlView extends DefaultView
+class HtmlView extends BaseHtmlView
 {
     /**
      * Is the Joomla Version a development version?


### PR DESCRIPTION
Pull Request for Issue #44363 .

### Summary of Changes
Don't use default view, as it only loads the form, when available. But here we have no model at all, so no need to use that class.


### Testing Instructions
Like described in the issue install Joomla! 5.3 in PHP 8.3


### Actual result BEFORE applying this Pull Request
Deprecation message


### Expected result AFTER applying this Pull Request
No error message

