### PR TITLE
[5.2] Remove wrong class in cancel link in add verification code frontend page

### DIFF
--- a/components/com_users/tmpl/method/edit.php
+++ b/components/com_users/tmpl/method/edit.php
@@ -165,7 +165,7 @@ $hideSubmit   = !$this->renderOptions['show_submit'] && !$this->isEditExisting
                 </button>
 
                 <a href="<?php echo $cancelURL ?>"
-                   class="btn btn-sm btn-danger">
+                   class="btn btn-danger">
                     <span class="icon icon-cancel-2" aria-hidden="true"></span>
                     <?php echo Text::_('JCANCEL'); ?>
                 </a>


### PR DESCRIPTION
Pull Request for Issue #44472 

### Summary of Changes

Remove wrong class in cancel link


### Testing Instructions

See Issue #44472 - Apply Patch for fix

### Actual result BEFORE applying this Pull Request

Cancel link (button) has wrong size

### Expected result AFTER applying this Pull Request

Correct size

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
