### PR TITLE
[5.2] mod articles

### DIFF
--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -386,6 +386,7 @@ class ArticlesHelper implements DatabaseAwareInterface
                     // Remove any images and empty links from the intro text
                     $item->displayIntrotext = preg_replace(['/\\<img[^>]*>/', '/<a[^>]*><\\/a>/'], '', $item->displayIntrotext);
                 }
+
                 if ($introtext_limit != 0) {
                     $item->displayIntrotext = HTMLHelper::_('string.truncateComplex', $item->displayIntrotext, $introtext_limit);
                 }

--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -383,7 +383,7 @@ class ArticlesHelper implements DatabaseAwareInterface
 
                 // Remove any images belongs to the text
                 if (!$params->get('image')) {
-                    // Remove any images and empty anchor tags from the intro text
+                    // Remove any images and empty links from the intro text
                     $item->displayIntrotext = preg_replace(['/\\<img[^>]*>/', '/<a[^>]*><\\/a>/'], '', $item->displayIntrotext);
                 }
                 if ($introtext_limit != 0) {

--- a/modules/mod_articles/src/Helper/ArticlesHelper.php
+++ b/modules/mod_articles/src/Helper/ArticlesHelper.php
@@ -383,9 +383,9 @@ class ArticlesHelper implements DatabaseAwareInterface
 
                 // Remove any images belongs to the text
                 if (!$params->get('image')) {
-                    $item->displayIntrotext = preg_replace('/<img[^>]*>/', '', $item->displayIntrotext);
+                    // Remove any images and empty anchor tags from the intro text
+                    $item->displayIntrotext = preg_replace(['/\\<img[^>]*>/', '/<a[^>]*><\\/a>/'], '', $item->displayIntrotext);
                 }
-
                 if ($introtext_limit != 0) {
                     $item->displayIntrotext = HTMLHelper::_('string.truncateComplex', $item->displayIntrotext, $introtext_limit);
                 }

--- a/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
@@ -352,6 +352,8 @@ class ArticlesCategoryHelper implements DatabaseAwareInterface
     {
         $introtext = str_replace(['<p>', '</p>'], ' ', $introtext);
         $introtext = strip_tags($introtext, '<a><em><strong><joomla-hidden-mail>');
+        // Remove empty links
+        $introtext = preg_replace('/<a[^>]*><\\/a>/', '', $introtext);
 
         return trim($introtext);
     }

--- a/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
@@ -352,8 +352,6 @@ class ArticlesCategoryHelper implements DatabaseAwareInterface
     {
         $introtext = str_replace(['<p>', '</p>'], ' ', $introtext);
         $introtext = strip_tags($introtext, '<a><em><strong><joomla-hidden-mail>');
-        // Remove empty links
-        $introtext = preg_replace('/<a[^>]*><\\/a>/', '', $introtext);
 
         return trim($introtext);
     }


### PR DESCRIPTION
Remove any images and empty anchor tags from the intro text

Pull Request for Issue #44474 .
### Steps to reproduce the issue
Using the joomla sample data edit the article "joomla"
Add an image in the content and make the image a clickable link
View the source on the homepage for this article


### Before PR
The module is set to hide article images so the image inserted will not be displayed
The image is removed but the link remains but is not actionable as the content for the link (the image) has been removed

![Image](https://github.com/user-attachments/assets/7ccdf358-7fca-475f-8fe0-fa2b9e8ca644)

### After PR
The image and the empty link are removed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
