### PR TITLE
[5.2] mod articles_news

### DIFF
--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -138,7 +138,7 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
 
             // Remove any images belongs to the text
             if (!$params->get('image')) {
-                // Remove any images and empty anchor tags from the intro text
+                // Remove any images and empty links from the intro text
                 $item->introtext = preg_replace(['/\\<img[^>]*>/', '/<a[^>]*><\\/a>/'], '', $item->introtext);
             }
 

--- a/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
+++ b/modules/mod_articles_news/src/Helper/ArticlesNewsHelper.php
@@ -138,7 +138,8 @@ class ArticlesNewsHelper implements DatabaseAwareInterface
 
             // Remove any images belongs to the text
             if (!$params->get('image')) {
-                $item->introtext = preg_replace('/<img[^>]*>/', '', $item->introtext);
+                // Remove any images and empty anchor tags from the intro text
+                $item->introtext = preg_replace(['/\\<img[^>]*>/', '/<a[^>]*><\\/a>/'], '', $item->introtext);
             }
 
             // Show the Intro/Full image field of the article


### PR DESCRIPTION
Remove any images and empty anchor tags from the intro text

### Steps to reproduce the issue
Using the joomla sample data edit the article "joomla"
Add an image in the content and make the image a clickable link
Create an Article Newsflash Module for the category joomla
View the source on the homepage for this article


### Before PR
The module is set to hide article images so the image inserted will not be displayed
The image is removed but the link remains but is not actionable as the content for the link (the image) has been removed

![Image](https://github.com/user-attachments/assets/7ccdf358-7fca-475f-8fe0-fa2b9e8ca644)

### After PR
The image and the empty link are removed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
