### PR TITLE
[5.3] Router: Discover tainted URLs for core components

### DIFF
--- a/components/com_contact/src/Service/Router.php
+++ b/components/com_contact/src/Service/Router.php
@@ -197,13 +197,28 @@ class Router extends RouterView
             $category = $this->getCategories(['access' => false])->get($query['id']);
 
             if ($category) {
-                foreach ($category->getChildren() as $child) {
-                    if ($this->noIDs) {
+                if ($this->noIDs) {
+                    foreach ($category->getChildren() as $child) {
                         if ($child->alias == $segment) {
                             return $child->id;
                         }
-                    } else {
+                    }
+
+                    // We haven't found a matching category, but maybe we turned off IDs?
+                    foreach ($category->getChildren() as $child) {
                         if ($child->id == (int) $segment) {
+                            $this->app->getRouter()->setTainted();
+
+                            return $child->id;
+                        }
+                    }
+                } else {
+                    foreach ($category->getChildren() as $child) {
+                        if ($child->id == (int) $segment) {
+                            if ($child->id . '-' . $child->alias != $segment) {
+                                $this->app->getRouter()->setTainted();
+                            }
+
                             return $child->id;
                         }
                     }
@@ -241,20 +256,43 @@ class Router extends RouterView
             $dbquery = $this->db->getQuery(true);
             $dbquery->select($this->db->quoteName('id'))
                 ->from($this->db->quoteName('#__contact_details'))
-                ->where($this->db->quoteName('alias') . ' = :alias')
-                ->bind(':alias', $segment);
+                ->where($this->db->quoteName('alias') . ' = :segment')
+                ->bind(':segment', $segment);
 
             if (isset($query['id']) && $query['id']) {
-                $dbquery->where($this->db->quoteName('catid') . ' = :catid')
-                    ->bind(':catid', $query['id'], ParameterType::INTEGER);
+                $dbquery->where($this->db->quoteName('catid') . ' = :id')
+                    ->bind(':id', $query['id'], ParameterType::INTEGER);
             }
 
             $this->db->setQuery($dbquery);
 
-            return (int) $this->db->loadResult();
+            $id = (int) $this->db->loadResult();
+
+            // Do we have a URL with ID?
+            if ($id) {
+                return $id;
+            }
+
+            $this->app->getRouter()->setTainted();
         }
 
-        return (int) $segment;
+        $id = (int) $segment;
+
+        if ($id) {
+            $dbquery = $this->db->getQuery(true);
+            $dbquery->select($this->db->quoteName('alias'))
+                ->from($this->db->quoteName('#__contact_details'))
+                ->where($this->db->quoteName('id') . ' = :id')
+                ->bind(':id', $id);
+            $this->db->setQuery($dbquery);
+            $alias = $this->db->loadResult();
+
+            if ($alias && $id . '-' . $alias != $segment) {
+                $this->app->getRouter()->setTainted();
+            }
+        }
+
+        return $id;
     }
 
     /**

--- a/components/com_contact/src/Service/Router.php
+++ b/components/com_contact/src/Service/Router.php
@@ -283,7 +283,7 @@ class Router extends RouterView
             $dbquery->select($this->db->quoteName('alias'))
                 ->from($this->db->quoteName('#__contact_details'))
                 ->where($this->db->quoteName('id') . ' = :id')
-                ->bind(':id', $id);
+                ->bind(':id', $id, ParameterType::INTEGER);
             $this->db->setQuery($dbquery);
             $alias = $this->db->loadResult();
 

--- a/components/com_content/src/Service/Router.php
+++ b/components/com_content/src/Service/Router.php
@@ -198,13 +198,28 @@ class Router extends RouterView
             $category = $this->getCategories(['access' => false])->get($query['id']);
 
             if ($category) {
-                foreach ($category->getChildren() as $child) {
-                    if ($this->noIDs) {
+                if ($this->noIDs) {
+                    foreach ($category->getChildren() as $child) {
                         if ($child->alias == $segment) {
                             return $child->id;
                         }
-                    } else {
+                    }
+
+                    // We haven't found a matching category, but maybe we turned off IDs?
+                    foreach ($category->getChildren() as $child) {
                         if ($child->id == (int) $segment) {
+                            $this->app->getRouter()->setTainted();
+
+                            return $child->id;
+                        }
+                    }
+                } else {
+                    foreach ($category->getChildren() as $child) {
+                        if ($child->id == (int) $segment) {
+                            if ($child->id . '-' . $child->alias != $segment) {
+                                $this->app->getRouter()->setTainted();
+                            }
+
                             return $child->id;
                         }
                     }
@@ -252,10 +267,33 @@ class Router extends RouterView
 
             $this->db->setQuery($dbquery);
 
-            return (int) $this->db->loadResult();
+            $id = (int) $this->db->loadResult();
+
+            // Do we have a URL with ID?
+            if ($id) {
+                return $id;
+            }
+
+            $this->app->getRouter()->setTainted();
         }
 
-        return (int) $segment;
+        $id = (int) $segment;
+
+        if ($id) {
+            $dbquery = $this->db->getQuery(true);
+            $dbquery->select($this->db->quoteName('alias'))
+                ->from($this->db->quoteName('#__content'))
+                ->where($this->db->quoteName('id') . ' = :id')
+                ->bind(':id', $id);
+            $this->db->setQuery($dbquery);
+            $alias = $this->db->loadResult();
+
+            if ($alias && $id . '-' . $alias != $segment) {
+                $this->app->getRouter()->setTainted();
+            }
+        }
+
+        return $id;
     }
 
     /**

--- a/components/com_content/src/Service/Router.php
+++ b/components/com_content/src/Service/Router.php
@@ -284,7 +284,7 @@ class Router extends RouterView
             $dbquery->select($this->db->quoteName('alias'))
                 ->from($this->db->quoteName('#__content'))
                 ->where($this->db->quoteName('id') . ' = :id')
-                ->bind(':id', $id);
+                ->bind(':id', $id, ParameterType::INTEGER);
             $this->db->setQuery($dbquery);
             $alias = $this->db->loadResult();
 

--- a/components/com_newsfeeds/src/Service/Router.php
+++ b/components/com_newsfeeds/src/Service/Router.php
@@ -264,7 +264,7 @@ class Router extends RouterView
             $dbquery->select($this->db->quoteName('alias'))
                 ->from($this->db->quoteName('#__newsfeeds'))
                 ->where($this->db->quoteName('id') . ' = :id')
-                ->bind(':id', $id);
+                ->bind(':id', $id, ParameterType::INTEGER);
             $this->db->setQuery($dbquery);
             $alias = $this->db->loadResult();
 

--- a/components/com_newsfeeds/src/Service/Router.php
+++ b/components/com_newsfeeds/src/Service/Router.php
@@ -178,13 +178,28 @@ class Router extends RouterView
             $category = $this->getCategories(['access' => false])->get($query['id']);
 
             if ($category) {
-                foreach ($category->getChildren() as $child) {
-                    if ($this->noIDs) {
-                        if ($child->alias === $segment) {
+                if ($this->noIDs) {
+                    foreach ($category->getChildren() as $child) {
+                        if ($child->alias == $segment) {
                             return $child->id;
                         }
-                    } else {
+                    }
+
+                    // We haven't found a matching category, but maybe we turned off IDs?
+                    foreach ($category->getChildren() as $child) {
                         if ($child->id == (int) $segment) {
+                            $this->app->getRouter()->setTainted();
+
+                            return $child->id;
+                        }
+                    }
+                } else {
+                    foreach ($category->getChildren() as $child) {
+                        if ($child->id == (int) $segment) {
+                            if ($child->id . '-' . $child->alias != $segment) {
+                                $this->app->getRouter()->setTainted();
+                            }
+
                             return $child->id;
                         }
                     }
@@ -232,10 +247,33 @@ class Router extends RouterView
 
             $this->db->setQuery($dbquery);
 
-            return (int) $this->db->loadResult();
+            $id = (int) $this->db->loadResult();
+
+            // Do we have a URL with ID?
+            if ($id) {
+                return $id;
+            }
+
+            $this->app->getRouter()->setTainted();
         }
 
-        return (int) $segment;
+        $id = (int) $segment;
+
+        if ($id) {
+            $dbquery = $this->db->getQuery(true);
+            $dbquery->select($this->db->quoteName('alias'))
+                ->from($this->db->quoteName('#__newsfeeds'))
+                ->where($this->db->quoteName('id') . ' = :id')
+                ->bind(':id', $id);
+            $this->db->setQuery($dbquery);
+            $alias = $this->db->loadResult();
+
+            if ($alias && $id . '-' . $alias != $segment) {
+                $this->app->getRouter()->setTainted();
+            }
+        }
+
+        return $id;
     }
 
     /**


### PR DESCRIPTION
### Summary of Changes
The routing in Joomla has had 2 issues in the past: When IDs were enabled in URLs you could basically modify the alias part of the URL at will and if you wanted to switch from ID based URLs to those without, there was no way to automatically redirect everything. This PR tries to fix both issues.

The PR is depending on #44455 to mark a parsed URL as tainted. There are two modes here:

This PR was made possible by the support of [djumla](https://www.djumla.de/). Thank you for that.

#### IDs switched on
When reading the content item or category segment of a URL, the ID is read and based on that ID the alias is read from the database and if the two don't match, the URL is marked as tainted and later redirected to the "correct" URL. (#43992 is fixing the alias for that URL then) This prevents modified aliases in the URL.

#### IDs switched off
If IDs are switched off, we are first searching for the normal content item or category as we are doing now, but when we don't find a match, we assume that we are actually reading a legacy URL with IDs switched on. In that case we mark the URL as tainted (regardless of it being totally broken or not, since when we fail to parse the URL at all, we already throw a 404 before we reach the handling of tainted URLs) and then compare the segment with the segment we would get with IDs enabled. If that matches, we return the ID and later redirect to the correct URL. This means that you can switch from ID-based URLs to "clean" URLs and Joomla will automatically redirect all pages to the correct URLs.

### Testing Instructions
1. Apply both this PR and #44455 and switch on IDs in the integration tab of either com_content, com_contact or com_newsfeeds. Surf to URLs in your frontend containing IDs and modify the alias of either the category or the content item (article, contact or newsfeed) and load that URL.
2. Disable IDs for the component and reload the ID-based URL

### Actual result BEFORE applying this Pull Request
for 1.: You get the same content with more than one URL
for 2.: You get a 404 error


### Expected result AFTER applying this Pull Request
for 1.: You are redirected to the right URL again with the correct alias.
for 2.: You are redirected to the right URL without IDs


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
