### PR TITLE
[5.2] mod articles_category

### DIFF
--- a/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
+++ b/modules/mod_articles_category/src/Helper/ArticlesCategoryHelper.php
@@ -352,6 +352,8 @@ class ArticlesCategoryHelper implements DatabaseAwareInterface
     {
         $introtext = str_replace(['<p>', '</p>'], ' ', $introtext);
         $introtext = strip_tags($introtext, '<a><em><strong><joomla-hidden-mail>');
+        // Remove empty links
+        $introtext = preg_replace('/<a[^>]*><\\/a>/', '', $introtext);
 
         return trim($introtext);
     }


### PR DESCRIPTION
Remove empty anchor tags from the intro text

Pull Request for Issue #30564 .

### Steps to reproduce the issue
Using the joomla sample data edit the article "joomla"
Add an image in the content and make the image a clickable link
Create an Article category Module for the category joomla and in the display options set introtext to show
View the source on the homepage for this article


### Before PR
The module strips all images and leaves all links
The image is removed but the link remains but is not actionable as the content for the link (the image) has been removed

![Image](https://github.com/user-attachments/assets/7ccdf358-7fca-475f-8fe0-fa2b9e8ca644)

### After PR
The image and the empty link are removed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
