### PR TITLE
[5.2] Fix fixFilesystemPermissions method in script.php for not existing folder

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -3541,13 +3541,15 @@ class JoomlaInstallerScript
         }
 
         foreach ($folders as $folder) {
-            if (is_dir(JPATH_ROOT . $folder) && decoct(fileperms(JPATH_ROOT . $folder) & 0777) === '777') {
-                @chmod(JPATH_ROOT . $folder, 0755);
-            }
+            if (is_dir(JPATH_ROOT . $folder)) {
+                if (decoct(fileperms(JPATH_ROOT . $folder) & 0777) === '777') {
+                    @chmod(JPATH_ROOT . $folder, 0755);
+                }
 
-            foreach (Folder::files(JPATH_ROOT . $folder, '.', false, true) as $file) {
-                if (decoct(fileperms($file) & 0777) === '777') {
-                    @chmod($file, 0644);
+                foreach (Folder::files(JPATH_ROOT . $folder, '.', false, true) as $file) {
+                    if (decoct(fileperms($file) & 0777) === '777') {
+                        @chmod($file, 0644);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Pull Request for Issue #44482 .

### Summary of Changes

This pull request (PR) fixes an error in the "fixFilesystemPermissions" method which was added to script.php with my PR #44379 for fixing files and folder permissions when updating from 5.2.0 or 5.2.1.

When you have a 5.2.0 or 5.2.1 site with a long update history, it might be that e.g. the "images/sampledata/cassiopeia" folder is missing because we do not include the sample data images in our update packages.

It can also be that an administrator has deleted that folder in the media manager, which is also a valid use case.

In this case the "fixFilesystemPermissions" method causes an exception because it tries to get the list of files for a not existing folder.

This PR fixes that.

### Testing Instructions

On a 5.2.0 or 5.2.1 site, delete the folder "images/sampledata/cassiopeia" (or rename it if you want to restore it later).

Then switch on "Debug System" in global configuration and set "Error Reporting" to "Maximum".

Then update to either 5.2.2-rc1 or a current 5.3-dev nightly build to get the actual result.

Or with the same starting conditions, update to the patched package https://artifacts.joomla.org/drone/joomla/joomla-cms/5.2-dev/44483/downloads/80427/Joomla_5.2.2-rc1+pr.44483-Release_Candidate-Update_Package.zip or custom update URL https://artifacts.joomla.org/drone/joomla/joomla-cms/5.2-dev/44483/downloads/80427/pr_list.xml created by Drone for this PR to get the expected result.

### Actual result BEFORE applying this Pull Request

See issue #44482 .

### Expected result AFTER applying this Pull Request

Update succeeds.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
