### PR TITLE
[5.3] Smart Search: Improve Indexer::optimize()

### DIFF
--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -741,7 +741,7 @@ class Indexer
         $db->execute();
 
         // Delete all orphaned terms.
-        $query      = $db->getQuery(true);
+        $query = $db->getQuery(true);
         $query->delete($db->quoteName('#__finder_terms'))
             ->where($db->quoteName('links') . ' <= 0');
         $db->setQuery($query);

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -711,13 +711,6 @@ class Indexer
         // Get the database object.
         $db         = $this->db;
         $serverType = strtolower($db->getServerType());
-        $query      = $db->getQuery(true);
-
-        // Delete all orphaned terms.
-        $query->delete($db->quoteName('#__finder_terms'))
-            ->where($db->quoteName('links') . ' <= 0');
-        $db->setQuery($query);
-        $db->execute();
 
         // Delete all broken links. (Links missing the object)
         $query = $db->getQuery(true)
@@ -735,6 +728,25 @@ class Indexer
             ->where($db->quoteName('link_id') . ' NOT IN (' . $query2 . ')');
         $db->setQuery($query);
         $db->execute();
+
+        // Update count of links in terms table
+        $query  = $db->getQuery(true);
+        $query2 = $db->getQuery(true);
+        $query2->select('COUNT(lt.link_id)')
+            ->from($db->quoteName('#__finder_links_terms', 'lt'))
+            ->where($db->quoteName('lt.term_id') . ' = ' . $db->quoteName('t.term_id'));
+        $query->update($db->quoteName('#__finder_terms', 't'))
+            ->set($db->quoteName('t.links') . ' = (' . $query2 . ')');
+        $db->setQuery($query);
+        $db->execute();
+
+        // Delete all orphaned terms.
+        $query      = $db->getQuery(true);
+        $query->delete($db->quoteName('#__finder_terms'))
+            ->where($db->quoteName('links') . ' <= 0');
+        $db->setQuery($query);
+        $db->execute();
+
 
         // Delete all orphaned terms
         $query2 = $db->getQuery(true)

--- a/administrator/components/com_finder/src/Indexer/Taxonomy.php
+++ b/administrator/components/com_finder/src/Indexer/Taxonomy.php
@@ -439,7 +439,7 @@ class Taxonomy
             $db->setQuery($query);
             $nodes = $db->loadColumn();
 
-            if (!count($nodes)) {
+            if (!\count($nodes)) {
                 break;
             }
 

--- a/administrator/components/com_finder/src/Indexer/Taxonomy.php
+++ b/administrator/components/com_finder/src/Indexer/Taxonomy.php
@@ -425,6 +425,7 @@ class Taxonomy
         $db           = Factory::getDbo();
         $nodeTable    = new MapTable($db);
         $query        = $db->getQuery(true);
+        $query2       = $db->getQuery(true);
 
         $query->select($db->quoteName('t.id'))
             ->from($db->quoteName('#__finder_taxonomy', 't'))
@@ -432,15 +433,22 @@ class Taxonomy
             ->where($db->quoteName('t.parent_id') . ' > 1 ')
             ->where('t.lft + 1 = t.rgt')
             ->where($db->quoteName('m.link_id') . ' IS NULL');
+        $query2->delete($db->quoteName('#__finder_taxonomy', 't'));
 
         do {
             $db->setQuery($query);
             $nodes = $db->loadColumn();
 
-            foreach ($nodes as $node) {
-                $nodeTable->delete($node);
-                $affectedRows++;
+            if (!count($nodes)) {
+                break;
             }
+
+            $query2->clear('where')->where($db->quoteName('t.id') . ' IN (' . implode(',', $nodes) . ')');
+            $db->setQuery($query2);
+            $db->execute();
+            $affectedRows += $db->getAffectedRows();
+            $nodeTable->rebuild();
+            $nodeTable->rebuildPath();
         } while ($nodes);
 
         return $affectedRows;


### PR DESCRIPTION
### Summary of Changes
This PR does several optimizations for the optimize step of the indexing in Smart Search. With the current order, the count of links to terms is not updated and terms are deleted before other orphaned data might be removed. At the same time it uses a different method to delete orphaned taxonomies. Running the normal Table::delete() operation on the nested set table class of the taxonomy table is VERY expensive and takes ages. This new code deletes all orphaned leaf nodes in one step, then rebuilds the tree and the path and then tries that again until there are no orphaned leaf nodes anymore. This is by far quicker than the old method.


### Testing Instructions
Make sure that you have a sizeable Smart Search index. Go into the #__finder_links table and delete one or several rows. Now in the Index view of Smart Search click on Maintenance => Optimize.


### Actual result BEFORE applying this Pull Request
Optimize step takes quite some time and doesn't necessarily delete orphaned terms.


### Expected result AFTER applying this Pull Request
Optimize step is far quicker and deletes all orphaned terms.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
