### PR TITLE
[5.3] contact form address icons/images

### DIFF
--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -266,49 +266,49 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
                 if ($item->params->get('icon_address')) {
                     $item->params->set(
                         'marker_address',
-                        HTMLHelper::_('image', $item->params->get('icon_address', ''), Text::_('COM_CONTACT_ADDRESS'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_address', ''), '', false)
                     );
                 }
 
                 if ($item->params->get('icon_email')) {
                     $item->params->set(
                         'marker_email',
-                        HTMLHelper::_('image', $item->params->get('icon_email', ''), Text::_('COM_CONTACT_EMAIL'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_email', ''), '', false)
                     );
                 }
 
                 if ($item->params->get('icon_telephone')) {
                     $item->params->set(
                         'marker_telephone',
-                        HTMLHelper::_('image', $item->params->get('icon_telephone', ''), Text::_('COM_CONTACT_TELEPHONE'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_telephone', ''), '', false)
                     );
                 }
 
                 if ($item->params->get('icon_fax', '')) {
                     $item->params->set(
                         'marker_fax',
-                        HTMLHelper::_('image', $item->params->get('icon_fax', ''), Text::_('COM_CONTACT_FAX'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_fax', ''), '', false)
                     );
                 }
 
                 if ($item->params->get('icon_misc')) {
                     $item->params->set(
                         'marker_misc',
-                        HTMLHelper::_('image', $item->params->get('icon_misc', ''), Text::_('COM_CONTACT_OTHER_INFORMATION'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_misc', ''), '', false)
                     );
                 }
 
                 if ($item->params->get('icon_mobile')) {
                     $item->params->set(
                         'marker_mobile',
-                        HTMLHelper::_('image', $item->params->get('icon_mobile', ''), Text::_('COM_CONTACT_MOBILE'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_mobile', ''), '', false)
                     );
                 }
 
                 if ($item->params->get('icon_webpage')) {
                     $item->params->set(
                         'marker_webpage',
-                        HTMLHelper::_('image', $item->params->get('icon_webpage', ''), Text::_('COM_CONTACT_WEBPAGE'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_webpage', ''), '', false)
                     );
                 }
 

--- a/components/com_contact/tmpl/contact/default_address.php
+++ b/components/com_contact/tmpl/contact/default_address.php
@@ -29,12 +29,13 @@ $icon = $this->params->get('contact_icons') == 0;
     ) : ?>
         <dt>
             <?php if ($icon && !$this->params->get('marker_address')) : ?>
-                <span class="icon-address" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_ADDRESS'); ?></span>
+                <span class="icon-address" aria-hidden="true"></span>
             <?php else : ?>
                 <span class="<?php echo $this->params->get('marker_class'); ?>">
                     <?php echo $this->params->get('marker_address'); ?>
                 </span>
             <?php endif; ?>
+            <span class="visually-hidden"><?php echo Text::_('COM_CONTACT_ADDRESS'); ?></span>
         </dt>
 
         <?php if ($this->item->address && $this->params->get('show_street_address')) : ?>
@@ -78,12 +79,13 @@ $icon = $this->params->get('contact_icons') == 0;
 <?php if ($this->item->email_to && $this->params->get('show_email')) : ?>
     <dt>
         <?php if ($icon && !$this->params->get('marker_email')) : ?>
-            <span class="icon-envelope" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_EMAIL_LABEL'); ?></span>
+            <span class="icon-envelope" aria-hidden="true"></span>
         <?php else : ?>
             <span class="<?php echo $this->params->get('marker_class'); ?>">
                 <?php echo $this->params->get('marker_email'); ?>
             </span>
         <?php endif; ?>
+        <span class="visually-hidden"><?php echo Text::_('COM_CONTACT_EMAIL_LABEL'); ?></span>
     </dt>
     <dd>
         <span class="contact-emailto">
@@ -95,12 +97,13 @@ $icon = $this->params->get('contact_icons') == 0;
 <?php if ($this->item->telephone && $this->params->get('show_telephone')) : ?>
     <dt>
         <?php if ($icon && !$this->params->get('marker_telephone')) : ?>
-                <span class="icon-phone" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_TELEPHONE'); ?></span>
+                <span class="icon-phone" aria-hidden="true"></span>
         <?php else : ?>
             <span class="<?php echo $this->params->get('marker_class'); ?>">
                 <?php echo $this->params->get('marker_telephone'); ?>
             </span>
         <?php endif; ?>
+        <span class="visually-hidden"><?php echo Text::_('COM_CONTACT_TELEPHONE'); ?></span>
     </dt>
     <dd>
         <span class="contact-telephone">
@@ -111,28 +114,30 @@ $icon = $this->params->get('contact_icons') == 0;
 <?php if ($this->item->fax && $this->params->get('show_fax')) : ?>
     <dt>
         <?php if ($icon && !$this->params->get('marker_fax')) : ?>
-            <span class="icon-fax" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_FAX'); ?></span>
+            <span class="icon-fax" aria-hidden="true"></span>
         <?php else : ?>
             <span class="<?php echo $this->params->get('marker_class'); ?>">
                 <?php echo $this->params->get('marker_fax'); ?>
             </span>
         <?php endif; ?>
+        <span class="visually-hidden"><?php echo Text::_('COM_CONTACT_FAX'); ?></span>
     </dt>
     <dd>
         <span class="contact-fax">
-        <?php echo $this->item->fax; ?>
+            <?php echo $this->item->fax; ?>
         </span>
     </dd>
 <?php endif; ?>
 <?php if ($this->item->mobile && $this->params->get('show_mobile')) : ?>
     <dt>
         <?php if ($icon && !$this->params->get('marker_mobile')) : ?>
-            <span class="icon-mobile" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_MOBILE'); ?></span>
+            <span class="icon-mobile" aria-hidden="true"></span>
         <?php else : ?>
             <span class="<?php echo $this->params->get('marker_class'); ?>">
                 <?php echo $this->params->get('marker_mobile'); ?>
             </span>
         <?php endif; ?>
+        <span class="visually-hidden"><?php echo Text::_('COM_CONTACT_MOBILE'); ?></span>
     </dt>
     <dd>
         <span class="contact-mobile">
@@ -143,12 +148,13 @@ $icon = $this->params->get('contact_icons') == 0;
 <?php if ($this->item->webpage && $this->params->get('show_webpage')) : ?>
     <dt>
         <?php if ($icon && !$this->params->get('marker_webpage')) : ?>
-            <span class="icon-home" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_WEBPAGE'); ?></span>
+            <span class="icon-home" aria-hidden="true"></span>
         <?php else : ?>
             <span class="<?php echo $this->params->get('marker_class'); ?>">
                 <?php echo $this->params->get('marker_webpage'); ?>
             </span>
         <?php endif; ?>
+        <span class="visually-hidden"><?php echo Text::_('COM_CONTACT_WEBPAGE'); ?></span>
     </dt>
     <dd>
         <span class="contact-webpage">


### PR DESCRIPTION
Pull Request for Issue #37442 and more .

### Summary of Changes
This pull request focuses on improving accessibility by ensuring that visually hidden text is properly included for screen readers. The changes primarily involve modifying how icons/images and their corresponding text are handled in the `components/com_contact` directory.

### Accessibility Improvements:
There is no visible change with this PR
When using icons there is no change
When using images instead of icons it marks the images as decorative and correctly provides a definition term (dt) so that it ensures that screen readers can still access the necessary information without displaying it visually

### Testing Instructions

- Go to Global Configuration -> Component -> Contacts -> Icon panel
- Set Settings drop-down list to Icons
- Select any picture for Custom Email Icon
- Create a contact, add every contact datas (name, address, email, etc.)
- Display the created contact using any kind of template (preferable Cassiopeia) which doesn't use template override for the file "components/com_contact/tmpl/contact/default_address.php"
- Check the alt text of the selected image of email
- Check that there is a valid dt text


### Actual result BEFORE applying this Pull Request
When using images the dt is only an image with an alt description. This is not a valid dt AND the text for contact was using the wrong language string value


### Expected result AFTER applying this Pull Request
When using images or icons or any mix thereof all images are marked as decorative and icons are aria-hidden AND there is a valid dt for each element marked as screen reader only

![image](https://github.com/user-attachments/assets/4abe89fa-ff3e-441f-a8b2-ed3ffa621cb6)

**This PR is only for the address. Any comments about anything not touched by this PR will simply result in this PR being deleted**
### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
