### PR TITLE
[5.2] Allow multiselect for checkboxes

### DIFF
--- a/build/media_source/system/js/multiselect.es6.js
+++ b/build/media_source/system/js/multiselect.es6.js
@@ -47,7 +47,7 @@ class JMultiSelect {
   // Handle click on a row
   onRowClick({ target, shiftKey }) {
     // Do not interfere with links, buttons, inputs and other interactive elements
-    if (target.closest('a, button, input:not([type=checkbox]), select, textarea, details, dialog, audio, video')) {
+    if (!target.matches(this.boxSelector) && target.closest('a, button, input, select, textarea, details, dialog, audio, video')) {
       return;
     }
 

--- a/build/media_source/system/js/multiselect.es6.js
+++ b/build/media_source/system/js/multiselect.es6.js
@@ -47,7 +47,7 @@ class JMultiSelect {
   // Handle click on a row
   onRowClick({ target, shiftKey }) {
     // Do not interfere with links, buttons, inputs and other interactive elements
-    if (target.closest('a, button, input, select, textarea, details, dialog, audio, video')) {
+    if (target.closest('a, button, input:not([type=checkbox]), select, textarea, details, dialog, audio, video')) {
       return;
     }
 


### PR DESCRIPTION
### Summary of Changes
Restores multiselect behavior when SHIFT key is pressed in back end list views.

### Testing Instructions
- Create 5 articles in the back end.
- Select the first one in the list
- Hold SHIFT key and select the last one

### Actual result BEFORE applying this Pull Request
First and last one is selected and the text in between.

### Expected result AFTER applying this Pull Request
All articles are selected and no text.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
