### PR TITLE
Fix joomlaExtButtons TinyMCE plugin, buttons validation

### DIFF
--- a/build/media_source/plg_editors_tinymce/js/plugins/jxtdbuttons/plugin.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/jxtdbuttons/plugin.es6.js
@@ -15,7 +15,7 @@ const pluginSetUp = (editor) => {
   });
 
   // Get buttons list
-  const buttons = editor.options.get('joomlaExtButtons').names || [];
+  const buttons = editor.options.get('joomlaExtButtons')?.names || [];
 
   if (!buttons.length) {
     return;

--- a/build/media_source/plg_editors_tinymce/js/plugins/jxtdbuttons/plugin.es6.js
+++ b/build/media_source/plg_editors_tinymce/js/plugins/jxtdbuttons/plugin.es6.js
@@ -9,7 +9,10 @@ import { JoomlaEditor, JoomlaEditorButton } from 'editor-api';
  * @param {Editor} editor
  */
 const pluginSetUp = (editor) => {
-  editor.options.register('joomlaExtButtons', { processor: 'object', default: { names: [] } });
+  editor.options.register('joomlaExtButtons', {
+    // Check for Object with list of buttons, or empty list
+    processor: (val) => (typeof val === 'object' && Array.isArray(val.names)) || (Array.isArray(val) && val.length === 0),
+  });
 
   // Get buttons list
   const buttons = editor.options.get('joomlaExtButtons').names || [];


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

TinyMCE prints a warning about incorect value for joomlaExtButtons, when all buttons is disabled.
The PR is fixing it, by allowing the empty array of buttons.


### Testing Instructions
run `npm install`
Edit https://github.com/joomla/joomla-cms/blob/a0982cf3b718a76de4d09f04298a9beea775d9f9/administrator/components/com_content/forms/article.xml#L57
and set `buttons="false"`
Open Browser Dev console, and open any article for editing.


### Actual result BEFORE applying this Pull Request
Console warning: Invalid value passed for the joomlaExtButtons option. The value must be a object.


### Expected result AFTER applying this Pull Request
No warning


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
