### PR TITLE
[5.2] CoreButtonsTrait back() generates wrong button text

### DIFF
--- a/libraries/src/Toolbar/CoreButtonsTrait.php
+++ b/libraries/src/Toolbar/CoreButtonsTrait.php
@@ -154,8 +154,7 @@ trait CoreButtonsTrait
      */
     public function back(string $text = 'JTOOLBAR_BACK'): LinkButton
     {
-        return $this->link('back', $text)
-            ->url('javascript:history.back();');
+        return $this->link($text, 'javascript:history.back();');
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #44432  .

### Summary of Changes
Changed back function to use $text instead of 'back'


### Testing Instructions
`$toolbar = Toolbar::getInstance(); $toolbar->back('foobar');`


### Actual result BEFORE applying this Pull Request
`<a href="javascript:history.back();">back</a>` 


### Expected result AFTER applying this Pull Request
`<a href="javascript:history.back();">foobar</a>` 


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
