### PR TITLE
[5.3] Tags: Fix broken aliases in routing

### DIFF
--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -101,7 +101,7 @@ class Router extends RouterBase
     {
         // Make sure the alias for the tags is correct
         if (isset($query['id'])) {
-            if (!is_array($query['id'])) {
+            if (!\is_array($query['id'])) {
                 $query['id'] = [$query['id']];
             }
 

--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\Multilanguage;
 use Joomla\CMS\Menu\AbstractMenu;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Database\DatabaseInterface;
+use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
 use Joomla\Utilities\ArrayHelper;
 
@@ -98,6 +99,31 @@ class Router extends RouterBase
      */
     public function preprocess($query)
     {
+        // Make sure the alias for the tags is correct
+        if (isset($query['id'])) {
+            if (!is_array($query['id'])) {
+                $query['id'] = [$query['id']];
+            }
+
+            foreach ($query['id'] as &$item) {
+                if (!strpos($item, ':')) {
+                    $dbquery = $this->db->getQuery(true);
+                    $id      = (int) $item;
+
+                    $dbquery->select($dbquery->quoteName('alias'))
+                        ->from('#__tags')
+                        ->where($dbquery->quoteName('id') . ' = :key')
+                        ->bind(':key', $id, ParameterType::INTEGER);
+
+                    $obj = $this->db->setQuery($dbquery)->loadObject();
+
+                    if ($obj) {
+                        $item .= ':' . $obj->alias;
+                    }
+                }
+            }
+        }
+
         $active = $this->menu->getActive();
 
         /**

--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -222,10 +222,6 @@ class Router extends RouterBase
                 if (isset($query['id'])) {
                     $ids = $query['id'];
 
-                    if (!\is_array($ids)) {
-                        $ids = [$ids];
-                    }
-
                     foreach ($ids as $id) {
                         $segments[] = $id;
                     }


### PR DESCRIPTION
Pull Request for Issue #42208.

### Summary of Changes
The tags router currently does not fix incomplete URL parts like other components. Specifically it does not look up the alias for tags which were only references by an ID and didn't have the slug like expected. The code also unifies the IDs to be arrays as expected.


### Testing Instructions
Look up the ID of a tag of your choice which isn't directly linked via a menu item. Go into an article of your choosing and insert the following:
```
<a href="index.php?option=com_tags&view=tag&id=5">Test</a>
```
Adapt the `&id=5` to the ID of your chosen tag.


### Actual result BEFORE applying this Pull Request
The URL will look something like this: `http://domain.tld/tags-component/all-tags/5.html


### Expected result AFTER applying this Pull Request
The URL will look something like this: `http://domain.tld/tags-component/all-tags/lime.html



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
