### PR TITLE
[5.3] Send an event before an update site is downloaded

### DIFF
--- a/libraries/src/Event/Installer/BeforeUpdateSiteDownloadEvent.php
+++ b/libraries/src/Event/Installer/BeforeUpdateSiteDownloadEvent.php
@@ -1,0 +1,23 @@
+<?php
+
+/**
+ * Joomla! Content Management System
+ *
+ * @copyright  (C) 2024 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license    GNU General Public License version 2 or later; see LICENSE.txt
+ */
+
+namespace Joomla\CMS\Event\Installer;
+
+// phpcs:disable PSR1.Files.SideEffects
+\defined('_JEXEC') or die;
+// phpcs:enable PSR1.Files.SideEffects
+
+/**
+ * Class for update site events
+ *
+ * @since  __DEPLOY_VERSION__
+ */
+class BeforeUpdateSiteDownloadEvent extends BeforePackageDownloadEvent
+{
+}

--- a/libraries/src/Updater/UpdateAdapter.php
+++ b/libraries/src/Updater/UpdateAdapter.php
@@ -10,10 +10,12 @@
 namespace Joomla\CMS\Updater;
 
 use Joomla\CMS\Adapter\AdapterInstance;
+use Joomla\CMS\Event\Installer\BeforeUpdateSiteDownloadEvent;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Http\HttpFactory;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
+use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Version;
 use Joomla\Database\ParameterType;
 use Joomla\Registry\Registry;
@@ -245,10 +247,21 @@ abstract class UpdateAdapter extends AdapterInstance
         $httpOption = new Registry();
         $httpOption->set('userAgent', $version->getUserAgent('Joomla', true, false));
 
-        // JHttp transport throws an exception when there's no response.
+        $headers    = [];
+        $dispatcher = Factory::getApplication()->getDispatcher();
+        PluginHelper::importPlugin('installer', null, true, $dispatcher);
+        $event = new BeforeUpdateSiteDownloadEvent('onInstallerBeforeUpdateSiteDownload', [
+            'url'     => $url,
+            'headers' => $headers,
+        ]);
+        $dispatcher->dispatch('onInstallerBeforeUpdateSiteDownload', $event);
+        $url     = $event->getArgument('url', $url);
+        $headers = $event->getArgument('headers', $headers);
+
+        // Http transport throws an exception when there's no response.
         try {
             $http     = HttpFactory::getHttp($httpOption);
-            $response = $http->get($url, [], 20);
+            $response = $http->get($url, $headers, 20);
         } catch (\RuntimeException $e) {
             $response = null;
         }


### PR DESCRIPTION
### Summary of Changes
This pr adds the same logic for installer plugins to be able to modify the update site url and headers as when the extension is downloaded. A use case for this pr is to add some authentication before fetching the update site url like a bearer token, the download id or similar. For extension developers it has an additional benefit to install a plugin and modify update sites for specific clients without the extra step and a modification of the update site url in the database.

### Testing Instructions
- Install an older version of an extension or [DPCalendar Free](https://joomla.digital-peak.com/download/dpcalendar/dpcalendar-9.2.1) when you don't have one
- Or you can add the following code to the file /plugins/installer/packageinstaller/src/Extension/PackageInstaller.php

```
public function onInstallerBeforeUpdateSiteDownload(\Joomla\CMS\Event\Installer\BeforeUpdateSiteDownloadEvent $event): void
{
        $event->updateUrl($event->getUrl().'demo=1');
}
```

and replace the line 47 with:
```
return ['onInstallerAddInstallationTab' => 'onInstallerAddInstallationTab', 'onInstallerBeforeUpdateSiteDownload' => 'onInstallerBeforeUpdateSiteDownload'];
```

- Go to /administrator/index.php?option=com_installer&view=update
- Click on "Check for updates"

### Actual result BEFORE applying this Pull Request
- DPCalendar update can be found.
- No warning about an invalid url.

### Expected result AFTER applying this Pull Request
- DPCalendar update can be found.
- The following warning is displayed because it modifies the url that it is wrong and will be displayed. Like that we know the url gets modified:
_Update: Could not open update site 3 "Joomla! Update Component", URL: https://update.joomla.org/core/extensions/com_joomlaupdate.xmldemo=1_
![image](https://github.com/user-attachments/assets/7287a99b-ab9d-4b26-8a76-411bb073c76c)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/340
- [ ] No documentation changes for manual.joomla.org needed
