### PR TITLE
[5.2] User: Don't reset newly set requireReset

### DIFF
--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -649,8 +649,10 @@ class User
 
                 $array['password'] = UserHelper::hashPassword($array['password']);
 
-                // Reset the change password flag
-                $array['requireReset'] = 0;
+                // Reset the change password flag if it was set previously
+                if ($this->requireReset) {
+                    $array['requireReset'] = 0;
+                }
             } else {
                 $array['password'] = $this->password;
             }


### PR DESCRIPTION
Pull Request for Issue #40480.

### Summary of Changes
When an existing user is edited, the password is updated and the require password reset flag is set, the flag is directly unset again. When an admin in the backend for example resets an organisational account and resets the password to something like 123456 and wants the user to reset their password upon next login, this unintentionally clears that flag because the admin has just changed the password.


### Testing Instructions
1. Create a new user
2. Edit that new user and change the password AND set the switch to require password reset
3. Click on save


### Actual result BEFORE applying this Pull Request
The page reloads, the password is set to the new value and the require reset flag is set to NO.


### Expected result AFTER applying this Pull Request
The page reloads, the password is set to the new value and the require reset flag is still set to YES.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
