### PR TITLE
[5.2] User: Logout also when required to pw reset

### DIFF
--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -254,7 +254,7 @@ final class SiteApplication extends CMSApplication
              * $this->input->getCmd('option'); or $this->input->getCmd('view');
              * ex: due of the sef urls
              */
-            $this->checkUserRequireReset('com_users', 'profile', 'edit', 'com_users/profile.save,com_users/profile.apply,com_users/user.logout');
+            $this->checkUserRequireReset('com_users', 'profile', 'edit', 'com_users/profile.save,com_users/profile.apply,com_users/user.logout,com_users/user.menulogout');
         }
 
         // Dispatch the application


### PR DESCRIPTION
Pull Request for Issue #29576.

### Summary of Changes
When a user is required to reset their password, they can't use the direct-logout-menu-item.


### Testing Instructions
1. Create a menu item of type Users -> Logout
2. Create or edit a user and set the require password reset flag
3. Login in the frontend with this user
4. Click on the logout menu link


### Actual result BEFORE applying this Pull Request
Logout is denied.


### Expected result AFTER applying this Pull Request
Logout is allowed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
