### PR TITLE
[5.2] User: Allow MFA before password reset

### DIFF
--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -189,12 +189,16 @@ class AdministratorApplication extends CMSApplication
          * $this->input->getCmd('option'); or $this->input->getCmd('view');
          * ex: due of the sef urls
          */
-        $this->checkUserRequireReset('com_users', 'user', 'edit', '', [
+        $this->checkUserRequiresReset('com_users', 'user', 'edit', [
             ['option' => 'com_users', 'task' => 'user.edit'],
             ['option' => 'com_users', 'task' => 'user.save'],
             ['option' => 'com_users', 'task' => 'user.apply'],
             ['option' => 'com_users', 'view' => 'captivate'],
             ['option' => 'com_login', 'task' => 'logout'],
+            ['option' => 'com_users', 'view' => 'methods'],
+            ['option' => 'com_users', 'view' => 'method'],
+            ['option' => 'com_users', 'task' => 'method.add'],
+            ['option' => 'com_users', 'task' => 'method.save'],
         ]);
 
         // Dispatch the application
@@ -365,6 +369,21 @@ class AdministratorApplication extends CMSApplication
 
             $this->bootComponent('messages')->getMVCFactory()
                 ->createModel('Messages', 'Administrator')->purge($this->getIdentity() ? $this->getIdentity()->id : 0);
+
+            if ($result) {
+                // Check if the user is required to reset their password
+                $this->checkUserRequiresReset('com_users', 'user', 'edit', [
+                    ['option' => 'com_users', 'task' => 'user.edit'],
+                    ['option' => 'com_users', 'task' => 'user.save'],
+                    ['option' => 'com_users', 'task' => 'user.apply'],
+                    ['option' => 'com_users', 'view' => 'captivate'],
+                    ['option' => 'com_login', 'task' => 'logout'],
+                    ['option' => 'com_users', 'view' => 'methods'],
+                    ['option' => 'com_users', 'view' => 'method'],
+                    ['option' => 'com_users', 'task' => 'method.add'],
+                    ['option' => 'com_users', 'task' => 'method.save'],
+                ]);
+            }
         }
 
         return $result;

--- a/libraries/src/Application/AdministratorApplication.php
+++ b/libraries/src/Application/AdministratorApplication.php
@@ -189,7 +189,13 @@ class AdministratorApplication extends CMSApplication
          * $this->input->getCmd('option'); or $this->input->getCmd('view');
          * ex: due of the sef urls
          */
-        $this->checkUserRequireReset('com_users', 'user', 'edit', 'com_users/user.edit,com_users/user.save,com_users/user.apply,com_login/logout');
+        $this->checkUserRequireReset('com_users', 'user', 'edit', '', [
+            ['option' => 'com_users', 'task' => 'user.edit'],
+            ['option' => 'com_users', 'task' => 'user.save'],
+            ['option' => 'com_users', 'task' => 'user.apply'],
+            ['option' => 'com_users', 'view' => 'captivate'],
+            ['option' => 'com_login', 'task' => 'logout'],
+        ]);
 
         // Dispatch the application
         $this->dispatch();

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -383,7 +383,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 
             foreach ($tasks as $task) {
                 list($option, $t) = explode('/', $task);
-                $urls[] = ['option' => $option, 'task' => $t];
+                $urls[]           = ['option' => $option, 'task' => $t];
             }
         }
 

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -425,7 +425,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
             }
 
             // If the current URL matches an entry in $urls, we do not redirect
-            if (count($urls)) {
+            if (\count($urls)) {
                 $found = false;
 
                 foreach ($urls as $url) {

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -374,7 +374,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
         $urls = [];
 
         if ($this->get($name . '_reset_password_override', 0)) {
-            $tasks  = $this->get($name . '_reset_password_tasks', '');
+            $tasks = $this->get($name . '_reset_password_tasks', '');
         }
 
         // Check task

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -382,7 +382,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
             $tasks = explode(',', $tasks);
 
             foreach ($tasks as $task) {
-                list($option, $t) = explode('/', $task);
+                [$option, $t] = explode('/', $task);
                 $urls[]           = ['option' => $option, 'task' => $t];
             }
         }

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -383,7 +383,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 
             foreach ($tasks as $task) {
                 [$option, $t] = explode('/', $task);
-                $urls[]           = ['option' => $option, 'task' => $t];
+                $urls[]       = ['option' => $option, 'task' => $t];
             }
         }
 

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -254,13 +254,17 @@ final class SiteApplication extends CMSApplication
              * $this->input->getCmd('option'); or $this->input->getCmd('view');
              * ex: due of the sef urls
              */
-            $this->checkUserRequireReset('com_users', 'profile', 'edit', '', [
+            $this->checkUserRequiresReset('com_users', 'profile', 'edit', [
                 ['option' => 'com_users', 'task' => 'profile.save'],
                 ['option' => 'com_users', 'task' => 'profile.apply'],
                 ['option' => 'com_users', 'task' => 'user.logout'],
                 ['option' => 'com_users', 'task' => 'user.menulogout'],
                 ['option' => 'com_users', 'task' => 'captive.validate'],
                 ['option' => 'com_users', 'view' => 'captive'],
+                ['option' => 'com_users', 'view' => 'methods'],
+                ['option' => 'com_users', 'view' => 'method'],
+                ['option' => 'com_users', 'task' => 'method.add'],
+                ['option' => 'com_users', 'task' => 'method.save'],
                 ['option' => 'com_users', 'view' => 'profile', 'layout' => 'edit'],
             ]);
         }
@@ -688,7 +692,26 @@ final class SiteApplication extends CMSApplication
         // Set the access control action to check.
         $options['action'] = 'core.login.site';
 
-        return parent::login($credentials, $options);
+        $result = parent::login($credentials, $options);
+
+        if (!($result instanceof \Exception) && $result) {
+            // Check if the user is required to reset their password
+            $this->checkUserRequiresReset('com_users', 'profile', 'edit', [
+                ['option' => 'com_users', 'task' => 'profile.save'],
+                ['option' => 'com_users', 'task' => 'profile.apply'],
+                ['option' => 'com_users', 'task' => 'user.logout'],
+                ['option' => 'com_users', 'task' => 'user.menulogout'],
+                ['option' => 'com_users', 'task' => 'captive.validate'],
+                ['option' => 'com_users', 'view' => 'captive'],
+                ['option' => 'com_users', 'view' => 'methods'],
+                ['option' => 'com_users', 'view' => 'method'],
+                ['option' => 'com_users', 'task' => 'method.add'],
+                ['option' => 'com_users', 'task' => 'method.save'],
+                ['option' => 'com_users', 'view' => 'profile', 'layout' => 'edit'],
+            ]);
+        }
+
+        return $result;
     }
 
     /**

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -254,7 +254,15 @@ final class SiteApplication extends CMSApplication
              * $this->input->getCmd('option'); or $this->input->getCmd('view');
              * ex: due of the sef urls
              */
-            $this->checkUserRequireReset('com_users', 'profile', 'edit', 'com_users/profile.save,com_users/profile.apply,com_users/user.logout');
+            $this->checkUserRequireReset('com_users', 'profile', 'edit', '', [
+                ['option' => 'com_users', 'task' => 'profile.save'],
+                ['option' => 'com_users', 'task' => 'profile.apply'],
+                ['option' => 'com_users', 'task' => 'user.logout'],
+                ['option' => 'com_users', 'task' => 'user.menulogout'],
+                ['option' => 'com_users', 'task' => 'captive.validate'],
+                ['option' => 'com_users', 'view' => 'captive'],
+                ['option' => 'com_users', 'view' => 'profile', 'layout' => 'edit'],
+            ]);
         }
 
         // Dispatch the application


### PR DESCRIPTION
Pull Request for Issue #43311, #39895, #38788, #29576.

### Summary of Changes
When having MFA enabled for a user, you can't log out, can't force a password reset and can't setup MFA after first login.


### Testing Instructions
1. Create a user and setup MFA for that user. Save the user.
2. For this new user, set the "Require password reset" flag.
3. Try to login from the frontend.
4. Setup a second user and have the user configuration enforce MFA for that usergroup.
5. Force the user to reset their password
6. Try to login from the frontend.
7. Setup a third user without MFA (remember to disable enforcing MFA in the user configuration again)
8. Force the user to reset their password
9. Login with the user and try to logout again

### Actual result BEFORE applying this Pull Request
The user is stuck in a redirect loop or can't logout.


### Expected result AFTER applying this Pull Request
1-3 The user gets shown the MFA captive view and can type in the required code. Afterwards the user is redirected to a page to update their password.
4-6 The user is redirected to setup MFA and then to reset their password.
7-9 The user is able to logout


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
