### PR TITLE
[5.3] Contact icons etc [a11y]

### DIFF
--- a/components/com_contact/src/View/Contact/HtmlView.php
+++ b/components/com_contact/src/View/Contact/HtmlView.php
@@ -240,79 +240,65 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
         switch ($item->params->get('contact_icons')) {
             case 1:
                 // Text
-                $item->params->set('marker_address', Text::_('COM_CONTACT_ADDRESS') . ': ');
-                $item->params->set('marker_email', Text::_('JGLOBAL_EMAIL') . ': ');
-                $item->params->set('marker_telephone', Text::_('COM_CONTACT_TELEPHONE') . ': ');
-                $item->params->set('marker_fax', Text::_('COM_CONTACT_FAX') . ': ');
-                $item->params->set('marker_mobile', Text::_('COM_CONTACT_MOBILE') . ': ');
-                $item->params->set('marker_webpage', Text::_('COM_CONTACT_WEBPAGE') . ': ');
-                $item->params->set('marker_misc', Text::_('COM_CONTACT_OTHER_INFORMATION') . ': ');
                 $item->params->set('marker_class', 'jicons-text');
                 break;
 
             case 2:
                 // None
-                $item->params->set('marker_address', '');
-                $item->params->set('marker_email', '');
-                $item->params->set('marker_telephone', '');
-                $item->params->set('marker_mobile', '');
-                $item->params->set('marker_fax', '');
-                $item->params->set('marker_misc', '');
-                $item->params->set('marker_webpage', '');
-                $item->params->set('marker_class', 'jicons-none');
+                $item->params->set('marker_class', 'jicons-none visually-hidden');
                 break;
 
             default:
                 if ($item->params->get('icon_address')) {
                     $item->params->set(
                         'marker_address',
-                        HTMLHelper::_('image', $item->params->get('icon_address', ''), Text::_('COM_CONTACT_ADDRESS'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_address', ''), '', false)
                     );
                 }
 
                 if ($item->params->get('icon_email')) {
                     $item->params->set(
                         'marker_email',
-                        HTMLHelper::_('image', $item->params->get('icon_email', ''), Text::_('COM_CONTACT_EMAIL'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_email', ''), '', false)
                     );
                 }
 
                 if ($item->params->get('icon_telephone')) {
                     $item->params->set(
                         'marker_telephone',
-                        HTMLHelper::_('image', $item->params->get('icon_telephone', ''), Text::_('COM_CONTACT_TELEPHONE'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_telephone', ''), '', false)
                     );
                 }
 
-                if ($item->params->get('icon_fax', '')) {
+                if ($item->params->get('icon_fax')) {
                     $item->params->set(
                         'marker_fax',
-                        HTMLHelper::_('image', $item->params->get('icon_fax', ''), Text::_('COM_CONTACT_FAX'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_fax', ''), '', false)
                     );
                 }
 
                 if ($item->params->get('icon_misc')) {
                     $item->params->set(
                         'marker_misc',
-                        HTMLHelper::_('image', $item->params->get('icon_misc', ''), Text::_('COM_CONTACT_OTHER_INFORMATION'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_misc', ''), '', false)
                     );
                 }
 
                 if ($item->params->get('icon_mobile')) {
                     $item->params->set(
                         'marker_mobile',
-                        HTMLHelper::_('image', $item->params->get('icon_mobile', ''), Text::_('COM_CONTACT_MOBILE'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_mobile', ''), '', false)
                     );
                 }
 
                 if ($item->params->get('icon_webpage')) {
                     $item->params->set(
                         'marker_webpage',
-                        HTMLHelper::_('image', $item->params->get('icon_webpage', ''), Text::_('COM_CONTACT_WEBPAGE'), false)
+                        HTMLHelper::_('image', $item->params->get('icon_webpage', ''), '', false)
                     );
                 }
 
-                $item->params->set('marker_class', 'jicons-icons');
+                $item->params->set('marker_class', 'jicons-icons visually-hidden');
                 break;
         }
 

--- a/components/com_contact/tmpl/contact/default.php
+++ b/components/com_contact/tmpl/contact/default.php
@@ -25,7 +25,7 @@ $canDo   = ContentHelper::getActions('com_contact', 'category', $this->item->cat
 $canEdit = $canDo->get('core.edit') || ($canDo->get('core.edit.own') && $this->item->created_by === $this->getCurrentUser()->id);
 $htag    = $tparams->get('show_page_heading') ? 'h2' : 'h1';
 $htag2   = ($tparams->get('show_page_heading') && $tparams->get('show_name')) ? 'h3' : 'h2';
-
+$icon    = $this->params->get('contact_icons') == 0;
 ?>
 
 <div class="com-contact contact">
@@ -170,14 +170,14 @@ $htag2   = ($tparams->get('show_page_heading') && $tparams->get('show_name')) ? 
         <div class="com-contact__miscinfo contact-miscinfo">
             <dl class="dl-horizontal">
                 <dt>
-                    <?php if (!$this->params->get('marker_misc')) : ?>
-                        <span class="icon-info-circle" aria-hidden="true"></span>
-                        <span class="visually-hidden"><?php echo Text::_('COM_CONTACT_OTHER_INFORMATION'); ?></span>
-                    <?php else : ?>
-                        <span class="<?php echo $this->params->get('marker_class'); ?>">
+                    <?php if ($icon && !$this->params->get('marker_misc')) : ?>
+                        <span class="icon-home" aria-hidden="true"></span>
+                    <?php elseif ($icon && $this->params->get('marker_misc')) : ?>
+                        <span class="jicons-image">
                             <?php echo $this->params->get('marker_misc'); ?>
                         </span>
                     <?php endif; ?>
+                    <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_OTHER_INFORMATION'); ?></span>
                 </dt>
                 <dd>
                     <span class="contact-misc">

--- a/components/com_contact/tmpl/contact/default_address.php
+++ b/components/com_contact/tmpl/contact/default_address.php
@@ -29,12 +29,13 @@ $icon = $this->params->get('contact_icons') == 0;
     ) : ?>
         <dt>
             <?php if ($icon && !$this->params->get('marker_address')) : ?>
-                <span class="icon-address" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_ADDRESS'); ?></span>
-            <?php else : ?>
-                <span class="<?php echo $this->params->get('marker_class'); ?>">
+                <span class="icon-address" aria-hidden="true"></span>
+            <?php elseif ($icon && $this->params->get('marker_address')) : ?>
+                <span class="jicons-image">
                     <?php echo $this->params->get('marker_address'); ?>
                 </span>
             <?php endif; ?>
+            <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_ADDRESS'); ?></span>
         </dt>
 
         <?php if ($this->item->address && $this->params->get('show_street_address')) : ?>
@@ -78,12 +79,13 @@ $icon = $this->params->get('contact_icons') == 0;
 <?php if ($this->item->email_to && $this->params->get('show_email')) : ?>
     <dt>
         <?php if ($icon && !$this->params->get('marker_email')) : ?>
-            <span class="icon-envelope" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_EMAIL_LABEL'); ?></span>
-        <?php else : ?>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
+            <span class="icon-envelope" aria-hidden="true"></span>
+        <?php elseif ($icon && $this->params->get('marker_email')) : ?>
+            <span class="jicons-icon">
                 <?php echo $this->params->get('marker_email'); ?>
             </span>
         <?php endif; ?>
+        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_EMAIL_LABEL'); ?></span>
     </dt>
     <dd>
         <span class="contact-emailto">
@@ -95,12 +97,13 @@ $icon = $this->params->get('contact_icons') == 0;
 <?php if ($this->item->telephone && $this->params->get('show_telephone')) : ?>
     <dt>
         <?php if ($icon && !$this->params->get('marker_telephone')) : ?>
-                <span class="icon-phone" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_TELEPHONE'); ?></span>
-        <?php else : ?>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
+            <span class="icon-phone" aria-hidden="true"></span>
+        <?php elseif ($icon && $this->params->get('marker_telephone')) : ?>
+            <span class="jicons-image">
                 <?php echo $this->params->get('marker_telephone'); ?>
             </span>
         <?php endif; ?>
+        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_TELEPHONE'); ?></span>
     </dt>
     <dd>
         <span class="contact-telephone">
@@ -111,28 +114,30 @@ $icon = $this->params->get('contact_icons') == 0;
 <?php if ($this->item->fax && $this->params->get('show_fax')) : ?>
     <dt>
         <?php if ($icon && !$this->params->get('marker_fax')) : ?>
-            <span class="icon-fax" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_FAX'); ?></span>
-        <?php else : ?>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
+            <span class="icon-fax" aria-hidden="true"></span>
+        <?php elseif ($icon && $this->params->get('marker_fax')) : ?>
+            <span class="jicons-image">
                 <?php echo $this->params->get('marker_fax'); ?>
             </span>
         <?php endif; ?>
+        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_FAX'); ?></span>
     </dt>
     <dd>
         <span class="contact-fax">
-        <?php echo $this->item->fax; ?>
+            <?php echo $this->item->fax; ?>
         </span>
     </dd>
 <?php endif; ?>
 <?php if ($this->item->mobile && $this->params->get('show_mobile')) : ?>
     <dt>
         <?php if ($icon && !$this->params->get('marker_mobile')) : ?>
-            <span class="icon-mobile" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_MOBILE'); ?></span>
-        <?php else : ?>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
+            <span class="icon-mobile" aria-hidden="true"></span>
+        <?php elseif ($icon && $this->params->get('marker_mobile')) : ?>
+            <span class="jicons-image">
                 <?php echo $this->params->get('marker_mobile'); ?>
             </span>
         <?php endif; ?>
+        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_MOBILE'); ?></span>
     </dt>
     <dd>
         <span class="contact-mobile">
@@ -143,12 +148,13 @@ $icon = $this->params->get('contact_icons') == 0;
 <?php if ($this->item->webpage && $this->params->get('show_webpage')) : ?>
     <dt>
         <?php if ($icon && !$this->params->get('marker_webpage')) : ?>
-            <span class="icon-home" aria-hidden="true"></span><span class="visually-hidden"><?php echo Text::_('COM_CONTACT_WEBPAGE'); ?></span>
-        <?php else : ?>
-            <span class="<?php echo $this->params->get('marker_class'); ?>">
+            <span class="icon-home" aria-hidden="true"></span>
+        <?php elseif ($icon && $this->params->get('marker_webpage')) : ?>
+            <span class="jicons-image">
                 <?php echo $this->params->get('marker_webpage'); ?>
             </span>
         <?php endif; ?>
+        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_WEBPAGE'); ?></span>
     </dt>
     <dd>
         <span class="contact-webpage">

--- a/components/com_contact/tmpl/contact/default_address.php
+++ b/components/com_contact/tmpl/contact/default_address.php
@@ -103,7 +103,7 @@ $icon = $this->params->get('contact_icons') == 0;
                 <?php echo $this->params->get('marker_telephone'); ?>
             </span>
         <?php endif; ?>
-        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_TELEPHONE'); ?></span>
+        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_TELEPHONE'); ?>: </span>
     </dt>
     <dd>
         <span class="contact-telephone">
@@ -120,7 +120,7 @@ $icon = $this->params->get('contact_icons') == 0;
                 <?php echo $this->params->get('marker_fax'); ?>
             </span>
         <?php endif; ?>
-        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_FAX'); ?></span>
+        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_FAX'); ?>: </span>
     </dt>
     <dd>
         <span class="contact-fax">
@@ -137,7 +137,7 @@ $icon = $this->params->get('contact_icons') == 0;
                 <?php echo $this->params->get('marker_mobile'); ?>
             </span>
         <?php endif; ?>
-        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_MOBILE'); ?></span>
+        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_MOBILE'); ?>: </span>
     </dt>
     <dd>
         <span class="contact-mobile">
@@ -154,7 +154,7 @@ $icon = $this->params->get('contact_icons') == 0;
                 <?php echo $this->params->get('marker_webpage'); ?>
             </span>
         <?php endif; ?>
-        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_WEBPAGE'); ?></span>
+        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_WEBPAGE'); ?>: </span>
     </dt>
     <dd>
         <span class="contact-webpage">

--- a/components/com_contact/tmpl/contact/default_address.php
+++ b/components/com_contact/tmpl/contact/default_address.php
@@ -35,7 +35,7 @@ $icon = $this->params->get('contact_icons') == 0;
                     <?php echo $this->params->get('marker_address'); ?>
                 </span>
             <?php endif; ?>
-            <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_ADDRESS'); ?></span>
+            <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_ADDRESS'); ?>: </span>
         </dt>
 
         <?php if ($this->item->address && $this->params->get('show_street_address')) : ?>
@@ -85,7 +85,7 @@ $icon = $this->params->get('contact_icons') == 0;
                 <?php echo $this->params->get('marker_email'); ?>
             </span>
         <?php endif; ?>
-        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_EMAIL_LABEL'); ?></span>
+        <span class="<?php echo $this->params->get('marker_class'); ?>"><?php echo Text::_('COM_CONTACT_EMAIL_LABEL'); ?>: </span>
     </dt>
     <dd>
         <span class="contact-emailto">


### PR DESCRIPTION
Pull Request for Issue #37442 and more .

### Summary of Changes
This pull request focuses on improving accessibility by ensuring that visually hidden text is properly included for screen readers. The changes primarily involve modifying how icons/images and their corresponding text are handled in the `components/com_contact` directory.

### Accessibility Improvements:

- There is no visible change with this PR
- When using icons there is no change
- When using images instead of icons it marks the images as decorative and correctly provides a definition term (dt) so that it ensures that screen readers can still access the necessary information without displaying it visually
- When using "none" instead of icons it  correctly provides a definition term (dt) so that it ensures that screen readers can still access the necessary information without displaying it visually

### Bug Fix

- Although the component options let you select an image instead of an icon there was no code to render it
- The icons and the images used the same class so they could not be styled differently. This PR introduces a new css class for the images

### Testing Instructions

- Go to Global Configuration -> Component -> Contacts -> Icon panel
- Set Settings drop-down list to Icons
- Select any picture for the Icons
- Create a contact, add every contact datas (name, address, email, etc.)
- Display the created contact using any kind of template (preferable Cassiopeia) which doesn't use template override for the file "components/com_contact/tmpl/contact/default_address.php"
- Check the alt text of the images of email
- Check that there is a valid dt text


### Actual result BEFORE applying this Pull Request
When using images the dt is only an image with an alt description. This is not a valid dt AND the text for contact was using the wrong language string value


### Expected result AFTER applying this Pull Request
When using images or icons or any mix thereof all images are marked as decorative and icons are aria-hidden AND there is a valid dt for each element marked as screen reader only

![image](https://github.com/user-attachments/assets/e5e01346-412c-416e-9930-4ebbc2c23ebf)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

