### PR TITLE
[5.2] Plugins: Search not case-insensitive for unicode language

### DIFF
--- a/administrator/components/com_plugins/src/Model/PluginsModel.php
+++ b/administrator/components/com_plugins/src/Model/PluginsModel.php
@@ -135,7 +135,7 @@ class PluginsModel extends ListModel
                 $escapedSearchString = $this->refineSearchStringToRegex($search, '/');
 
                 foreach ($result as $i => $item) {
-                    if (!preg_match("/$escapedSearchString/i", $item->name)) {
+                    if (!preg_match("/$escapedSearchString/iu", $item->name)) {
                         unset($result[$i]);
                     }
                 }


### PR DESCRIPTION
Pull Request for Issue #36300.

### Summary of Changes
The search in the plugin list in the backend is not happening on the database level, but in PHP, since the names of the plugins are translated on the fly. The search in PHP is using the `i` modifier, which should make it case-insensitive, but without `u` this is still not searching for unicode characters and thus doesn't know if a unicode string is uppercase or not.


### Testing Instructions
1. Install the russian language in the Joomla site
2. Set the default language for the backend to russian
3. Go to the plugin manager and search for `пользователь`


### Actual result BEFORE applying this Pull Request
The result list is empty.


### Expected result AFTER applying this Pull Request
The result list displays several entries.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
