### PR TITLE
[5.2] Email Validation apostrophe

### DIFF
--- a/build/media_source/system/js/fields/validate.es6.js
+++ b/build/media_source/system/js/fields/validate.es6.js
@@ -34,7 +34,7 @@ class JFormValidator {
     });
     this.setHandler('email', (value) => {
       const newValue = punycode.toASCII(value);
-      const regex = /^[a-zA-Z0-9.!#$%&’*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
+      const regex = /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*$/;
       return regex.test(newValue);
     });
 


### PR DESCRIPTION
Pull Request for Issue #42357 .

### Summary of Changes
The email validation was changed in #12835 to fix the validation so that an email with a ' was accepted and that an email with a ` was not accepted.

It looks like when this script was changed to es6 (?) the fix was lost.

This PR simply restores that fix


### Testing Instructions
Create a user with the following email address `DeloresO'Grady@example.com`

This PR changes a js file so you either need to test with a prebuilt package OR `npm run build:js`

### Actual result BEFORE applying this Pull Request
User not created with an invalid email message


### Expected result AFTER applying this Pull Request
User created


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
