### PR TITLE
[5.3] Update PackageAdapter.php

### DIFF
--- a/libraries/src/Installer/Adapter/PackageAdapter.php
+++ b/libraries/src/Installer/Adapter/PackageAdapter.php
@@ -146,7 +146,7 @@ class PackageAdapter extends InstallerAdapter
         }
 
         foreach ($this->getManifest()->files->children() as $child) {
-            $file = $source . '/' . (string) $child;
+            $file = $source . '/' . trim((string) $child);
 
             if (is_dir($file)) {
                 // If it's actually a directory then fill it up


### PR DESCRIPTION
Remove whitespace around extension folder names.

Pull Request for Issue # .

Replacement for pull request 40989.

### Summary of Changes

Apply trim() function to filename.

An alternative solution would be to remove the whitespace in the manifest.
But why? It is valid XML and the installation failure can catch extension developers by surprise.

### Testing Instructions

Install attached test package.
[test1.zip](https://github.com/user-attachments/files/17921955/test1.zip)

### Actual result BEFORE applying this Pull Request

Package installation fails.

### Expected result AFTER applying this Pull Request

Package installation succeeds

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed