### PR TITLE
[5.2] Fix double closing Curly braces in inline style

### DIFF
--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -95,7 +95,7 @@ $wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
     ->addInlineStyle(':root[data-color-scheme="dark"] {
 		--link-color: ' . $linkColorDark . ';
 		--link-color-rgb: ' . $rd . ',' . $gd . ',' . $bd . ';
-        --link-color-rgb-hvr: ' . $linkColorDarkHvr . ';
+		--link-color-rgb-hvr: ' . $linkColorDarkHvr . ';
 		--template-special-color: #6fbfdb;
 	}');
 

--- a/administrator/templates/atum/index.php
+++ b/administrator/templates/atum/index.php
@@ -97,7 +97,7 @@ $wa->usePreset('template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr'))
 		--link-color-rgb: ' . $rd . ',' . $gd . ',' . $bd . ';
         --link-color-rgb-hvr: ' . $linkColorDarkHvr . ';
 		--template-special-color: #6fbfdb;
-	}}');
+	}');
 
 // Override 'template.active' asset to set correct ltr/rtl dependency
 $wa->registerStyle('template.active', '', [], [], ['template.atum.' . ($this->direction === 'rtl' ? 'rtl' : 'ltr')]);


### PR DESCRIPTION
Fix double closing Curly braces in inline style for `:root[data-color-scheme="dark"] {`


### Summary of Changes
Remove the extra curly brace.


### Testing Instructions
Just a look at code.


### Actual result BEFORE applying this Pull Request
Nothing changed


### Expected result AFTER applying this Pull Request
Nothing changed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
