### PR TITLE
Improve dark mode readability in compare view

### DIFF
--- a/build/media_source/com_contenthistory/js/admin-compare-compare.es6.js
+++ b/build/media_source/com_contenthistory/js/admin-compare-compare.es6.js
@@ -12,6 +12,8 @@
     return textarea.value;
   };
 
+  const isDarkMode = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+
   const compare = (original, changed) => {
     const display = changed.nextElementSibling;
     const diff = window.Diff.diffWords(original.innerHTML, changed.innerHTML);
@@ -21,11 +23,11 @@
       let color = '';
 
       if (part.added) {
-        color = '#a6f3a6';
+        color = isDarkMode ? '#4cfa4c' : '#a6f3a6'; // Green shades for dark mode and light mode
       }
 
       if (part.removed) {
-        color = '#f8cbcb';
+        color = isDarkMode ? '#e85c5c' : '#f8cbcb'; // Red shades for dark mode and light mode
       }
 
       // @todo use the tag MARK here not SPAN


### PR DESCRIPTION
Pull Request for Issue #44293 .
## Fixes
Fixes #44293

### Summary of Changes
Fix dark mode issue in the compare view by adjusting the background color for added and removed text to be more accessible.


### Testing Instructions
1.	Enable dark mode.
2.	Compare two versions of an article.
3.	Verify visibility of added (green) and removed (red) text.


### Actual result BEFORE applying this Pull Request
The added and removed text is not readable in dark mode.


### Expected result AFTER applying this Pull Request
Added text has a green background, and removed text has a red background, both readable in dark mode.


