### PR TITLE
[5.2] Tags: Make router discover 404s properly

### DIFF
--- a/components/com_tags/src/Service/Router.php
+++ b/components/com_tags/src/Service/Router.php
@@ -286,7 +286,15 @@ class Router extends RouterBase
 
         while (\count($segments)) {
             $id    = array_shift($segments);
-            $ids[] = $this->fixSegment($id);
+            $slug  = $this->fixSegment($id);
+
+            // We did not find the segment as a tag in the DB
+            if ($slug === $id) {
+                array_unshift($segments, $id);
+                break;
+            }
+
+            $ids[] = $slug;
         }
 
         if (\count($ids)) {


### PR DESCRIPTION
Pull Request for Issue #43543.

### Summary of Changes
The tags router will accept any input as a valid URL as long as there is at least one valid tag among them.


### Testing Instructions
1. Create a menu item to list all tags
2. Have one or more tags
3. Tag an item
4. go to the frontend and got to the tag
5. Add a random string to the URL, for example `/jhgh`


### Actual result BEFORE applying this Pull Request
URL returns a valid page.


### Expected result AFTER applying this Pull Request
URL returns a 404.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
