### PR TITLE
[5.2] Fix PHPCS nullable parameter

### DIFF
--- a/administrator/components/com_scheduler/src/Table/TaskTable.php
+++ b/administrator/components/com_scheduler/src/Table/TaskTable.php
@@ -193,7 +193,7 @@ class TaskTable extends Table implements CurrentUserInterface
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function _getAssetParentId(Table ?$table = null, $id = null): int
+    protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
         $assetId = null;
         $asset   = new Asset($this->getDbo(), $this->getDispatcher());

--- a/administrator/components/com_scheduler/src/Table/TaskTable.php
+++ b/administrator/components/com_scheduler/src/Table/TaskTable.php
@@ -193,7 +193,7 @@ class TaskTable extends Table implements CurrentUserInterface
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function _getAssetParentId(Table $table = null, $id = null): int
+    protected function _getAssetParentId(Table ?$table = null, $id = null): int
     {
         $assetId = null;
         $asset   = new Asset($this->getDbo(), $this->getDispatcher());


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

Fix PHPCS failing in Drone for the last commit in the 5.2-dev branch:

```
   1) administrator/components/com_scheduler/src/Table/TaskTable.php (nullable_type_declaration_for_default_null_value)
      ---------- begin diff ----------
--- /drone/src/administrator/components/com_scheduler/src/Table/TaskTable.php
+++ /drone/src/administrator/components/com_scheduler/src/Table/TaskTable.php
@@ -193,7 +193,7 @@
      *
      * @since   __DEPLOY_VERSION__
      */
-    protected function _getAssetParentId(Table $table = null, $id = null): int
+    protected function _getAssetParentId(?Table $table = null, $id = null): int
     {
         $assetId = null;
         $asset   = new Asset($this->getDbo(), $this->getDispatcher());

      ----------- end diff -----------
```

The error was introduced by the merged PR #42493 .

The doc block of that method is already correct for a nullable parameter.

### Testing Instructions

Check that PHPCS succeeds in Drone for this PR.

Check if creating a new task still works and if an asset is created for that task in the same way as without this PR regarding the parent asset.

### Actual result BEFORE applying this Pull Request

See https://ci.joomla.org/joomla/joomla-cms/80596/1/7 .

### Expected result AFTER applying this Pull Request

PHPCS succeeds. Nullable parameter is right.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
