### PR TITLE
[6.0] Revert wrong version changes from previous upmerge

### DIFF
--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,8 +6,8 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>5.3.0-alpha1-dev</version>
-	<creationDate>2024-11</creationDate>
+	<version>6.0.0-alpha1-dev</version>
+	<creationDate>2024-08</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 
 	<scriptfile>administrator/components/com_admin/script.php</scriptfile>

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -66,7 +66,7 @@ final class Version
      * @var    string
      * @since  3.8.0
      */
-    public const EXTRA_VERSION = 'alpha2-dev';
+    public const EXTRA_VERSION = 'alpha1-dev';
 
     /**
      * Development status.


### PR DESCRIPTION
Pull Request for https://github.com/joomla/joomla-cms/pull/44538#discussion_r1861108634 and https://github.com/joomla/joomla-cms/pull/44538#discussion_r1861109922 .

### Summary of Changes

This pull request (PR) reverts the version changes made with the last upmerge PR #44538 . 

### Testing Instructions

Code review.

And check the file names on the downloads page https://artifacts.joomla.org/drone/joomla/joomla-cms/6.0-dev/downloads/80582/ created by Drone for the upmerge PR #44538 and on the downloads page https://artifacts.joomla.org/drone/joomla/joomla-cms/6.0-dev/44544/downloads/80599/ for this PR here .

### Actual result BEFORE applying this Pull Request

Version is 6.0.0-alpha2-dev.

Downloads have wrong names, and so will the nightlies of next night if not fixed, and trying to download results in a 404.

### Expected result AFTER applying this Pull Request

Version is 6.0.0-alpha1-dev.

Downloads have the right names, and so will the nightlies of next night if this PR gets merged in time, and packages can be downloaded.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
