### PR TITLE
[5.3] Actionlogs User filter

### DIFF
--- a/administrator/components/com_actionlogs/forms/filter_actionlogs.xml
+++ b/administrator/components/com_actionlogs/forms/filter_actionlogs.xml
@@ -27,7 +27,7 @@
 		</field>
 		<field
 			name="user"
-			type="logcreator"
+			type="user"
 			label="COM_ACTIONLOGS_NAME"
 			class="js-select-submit-on-change"
 			>

--- a/administrator/components/com_actionlogs/src/Field/LogcreatorField.php
+++ b/administrator/components/com_actionlogs/src/Field/LogcreatorField.php
@@ -20,6 +20,10 @@ use Joomla\CMS\Form\Field\ListField;
  * Field to load a list of all users that have logged actions
  *
  * @since  3.9.0
+ *
+ * No longer used, will be removed without replacement
+ *
+ * @deprecated  7.0  will be removed in 7.0
  */
 class LogcreatorField extends ListField
 {


### PR DESCRIPTION
Loading all the users how have ever made an action in a gigantic list is non-performant on a site with a large number of users.

This PR changes the field to a user select. The downside is that you could select a user who has not made any actions but that is outweighed by the performace gain

Pull Request for Issue #43406

### Summary of Changes

This pull request includes a deprecation notice for the `LogcreatorField` class in the `administrator/components/com_actionlogs/src/Field/LogcreatorField.php` file. The class is marked for removal in version 7.0.

Deprecation notice:

* [`administrator/components/com_actionlogs/src/Field/LogcreatorField.php`](diffhunk://#diff-857ce10bd01312d091400fc8e63ff3bc22ff2d81d126de8740a76027236b1473R23-R26): Added a deprecation notice indicating that the `LogcreatorField` class will be removed in version 7.0 and is no longer used.

### Testing Instructions
Test that you can still select a user to filter by in the action logs

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
