### PR TITLE
[5.2] Uncaught TypeError: can't access property "getAttribute", toggleButton is null

### DIFF
--- a/build/media_source/system/js/fields/passwordview.es6.js
+++ b/build/media_source/system/js/fields/passwordview.es6.js
@@ -11,44 +11,45 @@
       .forEach((input) => {
         const toggleButton = input.parentNode.querySelector('.input-password-toggle');
 
-        const hasClickListener = toggleButton.getAttribute('clickListener') === 'true';
+        if (toggleButton) {
+          const hasClickListener = toggleButton.getAttribute('clickListener') === 'true';
 
-        if (toggleButton && !hasClickListener) {
-          toggleButton.setAttribute('clickListener', 'true');
-          toggleButton.addEventListener('click', () => {
-            const icon = toggleButton.firstElementChild;
-            const srText = toggleButton.lastElementChild;
+          if (!hasClickListener) {
+            toggleButton.setAttribute('clickListener', 'true');
+            toggleButton.addEventListener('click', () => {
+              const icon = toggleButton.firstElementChild;
+              const srText = toggleButton.lastElementChild;
 
-            if (input.type === 'password') {
-              // Update the icon class
-              icon.classList.remove('icon-eye');
-              icon.classList.add('icon-eye-slash');
+              if (input.type === 'password') {
+                // Update the icon class
+                icon.classList.remove('icon-eye');
+                icon.classList.add('icon-eye-slash');
 
-              // Update the input type
-              input.type = 'text';
+                // Update the input type
+                input.type = 'text';
 
-              // Focus the input field
-              input.focus();
+                // Focus the input field
+                input.focus();
 
-              // Update the text for screenreaders
-              srText.innerText = Joomla.Text._('JHIDEPASSWORD');
-            } else if (input.type === 'text') {
-              // Update the icon class
-              icon.classList.add('icon-eye');
-              icon.classList.remove('icon-eye-slash');
+                // Update the text for screenreaders
+                srText.innerText = Joomla.Text._('JHIDEPASSWORD');
+              } else if (input.type === 'text') {
+                // Update the icon class
+                icon.classList.add('icon-eye');
+                icon.classList.remove('icon-eye-slash');
 
-              // Update the input type
-              input.type = 'password';
+                // Update the input type
+                input.type = 'password';
 
-              // Focus the input field
-              input.focus();
+                // Focus the input field
+                input.focus();
 
-              // Update the text for screenreaders
-              srText.innerText = Joomla.Text._('JSHOWPASSWORD');
-            }
-          });
+                // Update the text for screenreaders
+                srText.innerText = Joomla.Text._('JSHOWPASSWORD');
+              }
+            });
+          }
         }
-
         const modifyButton = input.parentNode.querySelector('.input-password-modify');
 
         if (modifyButton) {


### PR DESCRIPTION
Pull Request for Issue #44553 .

### Summary of Changes
A check if the tooglebutton is existing was  missing

### Testing Instructions
Open browser console and go to global configuration and check the console. You will see an error, something like "Uncaught TypeError: can't access property "getAttribute", toggleButton is null ... ".


### Actual result BEFORE applying this Pull Request
You are also not able to change the smtp or DB passoword. You get errors in the console.

### Expected result AFTER applying this Pull Request
You can change the smtp or DB passoword. You don't get errors in the console (at least not the one from above).

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
