### PR TITLE
Changelog URL is not updated on package update

### DIFF
--- a/libraries/src/Installer/Adapter/PackageAdapter.php
+++ b/libraries/src/Installer/Adapter/PackageAdapter.php
@@ -541,7 +541,6 @@ class PackageAdapter extends InstallerAdapter
             $this->extension->name         = $this->name;
             $this->extension->type         = 'package';
             $this->extension->element      = $this->element;
-            $this->extension->changelogurl = $this->changelogurl;
 
             // There is no folder for packages
             $this->extension->folder    = '';
@@ -551,6 +550,9 @@ class PackageAdapter extends InstallerAdapter
             $this->extension->client_id = 0;
             $this->extension->params    = $this->parent->getParams();
         }
+
+        // Update changelogurl
+        $this->extension->changelogurl = $this->changelogurl;
 
         // Update the manifest cache for the entry
         $this->extension->manifest_cache = $this->parent->generateManifestCache();


### PR DESCRIPTION
### Pull request for issue

#40056 

### Summary of Changes

Updating a package with added/changed `<changelogurl>` in manifest XML doesn't update the `changelogurl` in `#__extensions` table.

### Testing Instructions

Install a package without `<changelogurl>` in package manifest.
Inistall a new version of this package with `<changelogurl>` in package manifest.

### Actual result BEFORE applying this Pull Request

`changelogurl` in `#__extensions` table is not updated for the package record.

### Expected result AFTER applying this Pull Request

`changelogurl` in `#__extensions` table is updated.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
