### PR TITLE
[5.2] Fix return typehint in IdentityAware trait

### DIFF
--- a/libraries/src/Application/IdentityAware.php
+++ b/libraries/src/Application/IdentityAware.php
@@ -36,7 +36,7 @@ trait IdentityAware
     /**
      * Get the application identity.
      *
-     * @return  User
+     * @return  ?User
      *
      * @since   4.0.0
      */


### PR DESCRIPTION
### Summary of Changes
Sync the return type of `IdentityAware::getIdentity()` method with `CMSApplicationInterface`


### Testing Instructions
Run PHPStan with for relevant code or code review


### Actual result BEFORE applying this Pull Request
Before PHPStan doesn't detect the return of `null` and would always expect an `User` object


### Expected result AFTER applying this Pull Request
PHPStan expects `null` or `User`


