### PR TITLE
[5.3] Add debug mode to build script and create nightly debug builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -384,6 +384,8 @@ steps:
       - git rev-parse origin/$MINORVERSION-dev > transfer/$MINORVERSION.txt
       - php build/build.php --remote=origin/$MINORVERSION-dev --exclude-gzip --disable-patch-packages
       - mv build/tmp/packages/* transfer/
+      - php build/build.php --remote=origin/$MINORVERSION-dev --exclude-zip --exclude-bzip2 --debug-build
+      - mv build/tmp/packages/* transfer/
 
   - name: upload
     image: joomlaprojects/docker-images:packager
@@ -431,6 +433,6 @@ trigger:
 
 ---
 kind: signature
-hmac: 8587cef2227502ec33fa0434dadf0a3178d6fa7cbbfbe4e962b3c8784c3a2c6f
+hmac: 8cfd796801cb7d0484c3b022f17dc6663109432397f6997650aeb0976c36a788
 
 ...

--- a/build/build.php
+++ b/build/build.php
@@ -463,6 +463,10 @@ $checksums = [];
 // For the packages, replace spaces in stability (RC) with underscores
 $packageStability = str_replace(' ', '_', Version::DEV_STATUS);
 
+if ($debugBuild) {
+    $packageStability .= '-Debug';
+}
+
 // Delete the files and folders we exclude from the packages (tests, docs, build, etc.).
 echo "Delete folders not included in packages.\n";
 

--- a/build/build.php
+++ b/build/build.php
@@ -240,7 +240,7 @@ $fullpath = $tmp . '/' . $time;
 $options = getopt('', ['help', 'remote::', 'exclude-zip', 'exclude-gzip', 'include-bzip2', 'exclude-zstd', 'debug-build', 'disable-patch-packages']);
 
 $remote             = $options['remote'] ?? false;
-$debugBuild           = isset($options['debug-build']);
+$debugBuild         = isset($options['debug-build']);
 $excludeZip         = isset($options['exclude-zip']);
 $excludeGzip        = isset($options['exclude-gzip']);
 $excludeBzip2       = !isset($options['include-bzip2']);


### PR DESCRIPTION
### Summary of Changes
Add --debug-build to build.php
Add drone nightly debug build

The Debug build includes the the following:

* All files from the git repo
* vendor folder with dev dependencies
* node_modules folder

This allows an easier integration into custom CIs for extension developers

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [X] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
