### PR TITLE
[5.2] Composer update joomla/application to 3.0.3 to fix PHP deprecations in Web Client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
   },
   "require": {
     "php": "^8.1.0",
-    "joomla/application": "^3.0.2",
+    "joomla/application": "^3.0.3",
     "joomla/archive": "^3.0.2",
     "joomla/authentication": "^3.0.1",
     "joomla/console": "^3.0.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f1f9d337d9ee7e6f717bf13b606a359",
+    "content-hash": "9b7f4af719557c545a076458a5217904",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -1051,16 +1051,16 @@
         },
         {
             "name": "joomla/application",
-            "version": "3.0.2",
+            "version": "3.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/application.git",
-                "reference": "dd055642fbe8d7b919a6c6c345a0d016b0981e65"
+                "reference": "e063a4a308729b930d853e29a9f7c303cac68629"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/application/zipball/dd055642fbe8d7b919a6c6c345a0d016b0981e65",
-                "reference": "dd055642fbe8d7b919a6c6c345a0d016b0981e65",
+                "url": "https://api.github.com/repos/joomla-framework/application/zipball/e063a4a308729b930d853e29a9f7c303cac68629",
+                "reference": "e063a4a308729b930d853e29a9f7c303cac68629",
                 "shasum": ""
             },
             "require": {
@@ -1144,7 +1144,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-07T16:49:02+00:00"
+            "time": "2024-12-04T18:09:37+00:00"
         },
         {
             "name": "joomla/archive",
@@ -10254,7 +10254,7 @@
         "ext-gd": "*",
         "ext-dom": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.1.0"
     },


### PR DESCRIPTION
Pull Request for Issues #39960 , #39637 , #43334 , #43916 and #44469 .

### Summary of Changes

This pull request (PR) updates the composer dependency "joomla/application" from version 3.0.2 to version 3.0.3.

See https://github.com/joomla-framework/application/releases/tag/3.0.3 for the changes.

### Testing Instructions

1. For issue #39960 : Make a GET request to a page on the site (frontend) without a User Agent header.
2. For issues #39637 and #44469 : Make a GET request to a page on the site (frontend) with User Agent "Chrome Privacy Preserving Prefetch Proxy".

You can modify the User Agent header in the developer tools of your browser.

### Actual result BEFORE applying this Pull Request

1. PHP warning `Deprecated: strpos(): Passing null to parameter #1 ($haystack)` at several places.
2. PHP warning `Undefined array key 1 in libraries/vendor/joomla/application/src/Web/WebClient.php on line 439`.

### Expected result AFTER applying this Pull Request

1. No such PHP warning.
2. No such PHP warning.

### Link to documentations
Please select:
- [X] No documentation changes for docs.joomla.org needed

- [X] No documentation changes for manual.joomla.org needed
