### PR TITLE
Fix phpdoc $module parameter type

### DIFF
--- a/libraries/src/Document/Renderer/Html/ModuleRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ModuleRenderer.php
@@ -28,9 +28,9 @@ class ModuleRenderer extends DocumentRenderer
     /**
      * Renders a module script and returns the results as a string
      *
-     * @param   string  $module   The name of the module to render
-     * @param   array   $attribs  Associative array of values
-     * @param   string  $content  If present, module information from the buffer will be used
+     * @param   string|object  $module   The name of the module to render
+     * @param   array          $attribs  Associative array of values
+     * @param   string         $content  If present, module information from the buffer will be used
      *
      * @return  string  The output of the script
      *


### PR DESCRIPTION
Fix the phpdoc $module parameter type


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
