### PR TITLE
[5.3] Admin: Contact view does not load with a large user base

### DIFF
--- a/administrator/components/com_contact/tmpl/contacts/default_batch_body.php
+++ b/administrator/components/com_contact/tmpl/contacts/default_batch_body.php
@@ -48,11 +48,6 @@ $noUser    = true;
                 <?php echo LayoutHelper::render('joomla.html.batch.tag', []); ?>
             </div>
         </div>
-        <div class="form-group col-md-6">
-            <div class="controls">
-                <?php echo LayoutHelper::render('joomla.html.batch.user', ['noUser' => $noUser]); ?>
-            </div>
-        </div>
     </div>
 </div>
 <div class="btn-toolbar p-3">

--- a/administrator/language/en-GB/com_contact.ini
+++ b/administrator/language/en-GB/com_contact.ini
@@ -196,6 +196,7 @@ COM_CONTACT_XML_DESCRIPTION="This component shows a listing of contact informati
 JGLOBAL_FIELDSET_DISPLAY_LINK_OPTIONS="Link options"
 JGLOBAL_FIELDSET_MISCELLANEOUS="Miscellaneous Information"
 JGLOBAL_NEWITEMSLAST_DESC="New Contacts default to the last position. Ordering can be changed after this Contact is saved."
+; Deprecated, will be removed with 7.0
 JLIB_HTML_BATCH_USER_LABEL="Set Linked User"
 
 JLIB_RULES_SETTING_NOTES_COM_CONTACT="Changes apply to this component only.<br><em><strong>Inherited</strong></em> - a Global Configuration setting or higher level setting is applied.<br><em><strong>Denied</strong></em> always wins - whatever is set at the Global or higher level and applies to all child elements.<br><em><strong>Allowed</strong></em> will enable the action for this component unless overruled by a Global Configuration setting." ; Alternate language strings for the rules form field

--- a/layouts/joomla/html/batch/user.php
+++ b/layouts/joomla/html/batch/user.php
@@ -6,6 +6,8 @@
  *
  * @copyright   (C) 2015 Open Source Matters, Inc. <https://www.joomla.org>
  * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * @deprecated  5.3 without replacement will be removed in 7.0
  */
 
 defined('_JEXEC') or die;


### PR DESCRIPTION
Pull Request for Issue #41187 .

### Summary of Changes
This PR removes the ability when using batch functions to set/change the linked user. As this loads all users on the site into a giant list it impacts performance of all functionality in the contact component list view. With enough users it can even prevent the page from loading.

I can't see a valid use case for even having the functionality to link multiple contacts to the same user. 

The field to select the users is therefore removed from the batch modal and the related files and strings are therefore marked as deprecated without replacement

### Testing Instructions
Open the batch modal for the contact manager


### Actual result BEFORE applying this Pull Request
Option to mass set linked user


### Expected result AFTER applying this Pull Request
Option no longer present


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
