### PR TITLE
[5.3]  logical css associations sidebyside

### DIFF
--- a/build/media_source/com_associations/css/sidebyside.css
+++ b/build/media_source/com_associations/css/sidebyside.css
@@ -4,7 +4,7 @@
  */
 
 .sidebyside .outer-panel {
-  float: left;
+  float: inline-start;
   width: 50%;
 }
 
@@ -33,11 +33,11 @@
 }
 
 .sidebyside .langtarget {
-  float: left;
+  float: inline-start;
 }
 
 .sidebyside .modaltarget {
-  float: left;
+  float: inline-start;
   margin-inline-start: .5rem;
 }
 
@@ -50,25 +50,8 @@
 }
 
 .target-text {
-  float: left;
+  float: inline-start;
   width: auto;
-}
-
-/* RTL overrides */
-[dir=rtl] .sidebyside .outer-panel {
-  float: right;
-}
-
-[dir=rtl] .sidebyside .langtarget {
-  float: right;
-}
-
-[dir=rtl] .sidebyside .modaltarget {
-  float: right;
-}
-
-[dir=rtl] .target-text {
-  float: right;
 }
 
 /* Responsive layout */


### PR DESCRIPTION
### Summary of Changes
Use logical CSS properties to avoid having to set different LTR and RTL css

Previously browsers didnt support logical css properties for floats. They do now https://caniuse.com/?search=float-inline


### Testing Instructions
Switch to an RTL language
As this is a scss change then you will need to either rebuild the css or test with a prebuilt package


### Actual result BEFORE applying this Pull Request
![image](https://github.com/user-attachments/assets/5950dd3a-f507-4d7e-bfa6-f49542c59404)



### Expected result AFTER applying this Pull Request
There should be no visible difference after this PR



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
