### PR TITLE
[5.2] useGlobal is wrong in global config

### DIFF
--- a/administrator/components/com_users/config.xml
+++ b/administrator/components/com_users/config.xml
@@ -72,7 +72,6 @@
 			label="COM_USERS_CONFIG_FIELD_CAPTCHA_LABEL"
 			folder="captcha"
 			filter="cmd"
-			useglobal="true"
 			>
 			<option value="0">JOPTION_DO_NOT_USE</option>
 		</field>


### PR DESCRIPTION
Pull Request for Issue # .

Related to #44614

### Summary of Changes
In a global config file, the useGlobal attribute is wrong. removed. 



### Testing Instructions
Open the user Options. See the Option Captcha 



### Actual result BEFORE applying this Pull Request
Before the PR see #44614


### Expected result AFTER applying this Pull Request
![grafik](https://github.com/user-attachments/assets/afea86f6-29ce-43a0-ab1a-a51a04bf2d9e)




### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
