### PR TITLE
[4.4] Update node_modules cross-spawn and nanoid

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "joomla",
-  "version": "4.4.9",
+  "version": "4.4.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "joomla",
-      "version": "4.4.9",
+      "version": "4.4.10",
       "hasInstallScript": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -3856,10 +3856,11 @@
       "integrity": "sha512-F4wsi+XkDHCOMrHMYjrTEE4QBOrsHHN5/2VsVAaRq8P7E5z7xQpT75S+f/9WikmBEailas3+yo+6zPIomW+NOA=="
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -7289,15 +7290,16 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.8",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
+      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the 2 NPM dependencies "cross-spawn" and "nanoid".
- "cross-spawn" is updated from version 7.0.3 to version 7.0.6.
See https://github.com/moxystudio/node-cross-spawn/blob/master/CHANGELOG.md for the changes.
- "nanoid" is updated from version 3.3.6 to version 3.3.8.
See https://github.com/ai/nanoid/blob/main/CHANGELOG.md for the changes.

This fixes 2 security vulnerabilities reported by `npm audit`, 1 high severity  for "cross-spawn" and 1 low severity for "nanoid".

As we do not ship the node_modules with our installation or update packages, these vulnerabilities do not affect Joomla end user but only development environments.

This PR can be merged at any time just before the next 4.4.10 security release.

### Testing Instructions

`npm audit`

### Actual result BEFORE applying this Pull Request

```
# npm audit report

cross-spawn  7.0.0 - 7.0.4
Severity: high
Regular Expression Denial of Service (ReDoS) in cross-spawn - https://github.com/advisories/GHSA-3xgq-45jj-v275
fix available via `npm audit fix`
node_modules/cross-spawn

nanoid  <3.3.8
Infinite loop in nanoid - https://github.com/advisories/GHSA-mwcw-c2x4-8c55
fix available via `npm audit fix`
node_modules/nanoid

tinymce  <=6.8.5
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling iframes - https://github.com/advisories/GHSA-438c-3975-5x3f
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
TinyMCE Cross-Site Scripting (XSS) vulnerability using noneditable_regexp option - https://github.com/advisories/GHSA-9hcv-j9pv-qmph
TinyMCE Cross-Site Scripting (XSS) vulnerability using noscript elements - https://github.com/advisories/GHSA-w9jx-4g6g-rp7x
fix available via `npm audit fix --force`
Will install tinymce@7.6.0, which is a breaking change
node_modules/tinymce

3 vulnerabilities (1 low, 1 moderate, 1 high)

To address issues that do not require attention, run:
  npm audit fix

To address all issues (including breaking changes), run:
  npm audit fix --force
```

### Expected result AFTER applying this Pull Request

```
# npm audit report

tinymce  <=6.8.5
Severity: moderate
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling iframes - https://github.com/advisories/GHSA-438c-3975-5x3f
TinyMCE Cross-Site Scripting (XSS) vulnerability in handling external SVG files through Object or Embed elements - https://github.com/advisories/GHSA-5359-pvf2-pw78
TinyMCE Cross-Site Scripting (XSS) vulnerability using noneditable_regexp option - https://github.com/advisories/GHSA-9hcv-j9pv-qmph
TinyMCE Cross-Site Scripting (XSS) vulnerability using noscript elements - https://github.com/advisories/GHSA-w9jx-4g6g-rp7x
fix available via `npm audit fix --force`
Will install tinymce@7.6.0, which is a breaking change
node_modules/tinymce

1 moderate severity vulnerability

To address all issues (including breaking changes), run:
  npm audit fix --force
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
