### PR TITLE
[5.3] Installing sample blog data with lang debug on

### DIFF
--- a/plugins/sampledata/blog/src/Extension/Blog.php
+++ b/plugins/sampledata/blog/src/Extension/Blog.php
@@ -105,6 +105,9 @@ final class Blog extends CMSPlugin
         $language   = Multilanguage::isEnabled() ? $this->getApplication()->getLanguage()->getTag() : '*';
         $langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
+        // Disable language debug to prevent debug_lang_const being added to the string
+        $this->getApplication()->getLanguage()->setDebug(false);
+
         /** @var \Joomla\Component\Tags\Administrator\Model\TagModel $model */
         $modelTag = $this->getApplication()->bootComponent('com_tags')->getMVCFactory()
             ->createModel('Tag', 'Administrator', ['ignore_request' => true]);
@@ -794,6 +797,9 @@ final class Blog extends CMSPlugin
         $language   = Multilanguage::isEnabled() ? $this->getApplication()->getLanguage()->getTag() : '*';
         $langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
 
+        // Disable language debug to prevent debug_lang_const being added to the string
+        $this->getApplication()->getLanguage()->setDebug(false);
+
         // Create the menu types.
         $menuTable = new \Joomla\Component\Menus\Administrator\Table\MenuTypeTable($this->getDatabase());
         $menuTypes = [];
@@ -1342,6 +1348,9 @@ final class Blog extends CMSPlugin
         // Detect language to be used.
         $language   = Multilanguage::isEnabled() ? $this->getApplication()->getLanguage()->getTag() : '*';
         $langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
+
+        // Disable language debug to prevent debug_lang_const being added to the string
+        $this->getApplication()->getLanguage()->setDebug(false);
 
         // Add Include Paths.
         /** @var \Joomla\Component\Modules\Administrator\Model\ModuleModel $model */
@@ -1896,6 +1905,9 @@ final class Blog extends CMSPlugin
         // Detect language to be used.
         $language   = Multilanguage::isEnabled() ? $this->getApplication()->getLanguage()->getTag() : '*';
         $langSuffix = ($language !== '*') ? ' (' . $language . ')' : '';
+
+        // Disable language debug to prevent debug_lang_const being added to the string
+        $this->getApplication()->getLanguage()->setDebug(false);
 
         foreach ($menuItems as $menuItem) {
             // Reset item.id in model state.


### PR DESCRIPTION
Pull Request for Issue #31160.

### Summary of Changes
Disable language debug to prevent debug_lang_const being added to the string


### Testing Instructions
Enable language debugging on a fresh installation, then install sample blog data



### Actual result BEFORE applying this Pull Request
Titles and texts have surrounding ** from language debugging
![image](https://github.com/user-attachments/assets/f0e56581-e6db-4c41-901b-5c57d2dea238)



### Expected result AFTER applying this Pull Request
Titles and texts are stored as usual
![image](https://github.com/user-attachments/assets/f1210224-253d-42c5-a328-0d2048604527)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
