### PR TITLE
[5.3] Tagged Items RSS category

### DIFF
--- a/components/com_tags/src/View/Tag/FeedView.php
+++ b/components/com_tags/src/View/Tag/FeedView.php
@@ -95,7 +95,7 @@ class FeedView extends BaseHtmlView
                 $feeditem->link        = Route::_($item->link);
                 $feeditem->description = $description;
                 $feeditem->date        = $date;
-                $feeditem->category    = $title;
+                $feeditem->category    = $item->core_category_title;
                 $feeditem->author      = $author;
 
                 if ($feedEmail === 'site') {

--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -591,6 +591,7 @@ class TagsHelper extends CMSHelper
                 'MAX(' . $db->quoteName('c.core_publish_down') . ') AS ' . $db->quoteName('core_publish_down'),
                 'MAX(' . $db->quoteName('ct.type_title') . ') AS ' . $db->quoteName('content_type_title'),
                 'MAX(' . $db->quoteName('ct.router') . ') AS ' . $db->quoteName('router'),
+                'MAX(' . $db->quoteName('tc.title') . ') AS ' . $db->quoteName('core_category_title'),
                 'CASE WHEN ' . $db->quoteName('c.core_created_by_alias') . ' > ' . $db->quote(' ')
                 . ' THEN ' . $db->quoteName('c.core_created_by_alias') . ' ELSE ' . $db->quoteName('ua.name') . ' END AS ' . $db->quoteName('author'),
                 $db->quoteName('ua.email', 'author_email'),


### PR DESCRIPTION
### Summary of Changes
The RSS feed for list of tagged items was incorrectly displaying the item title as the category


### Testing Instructions
With sample data installed create a menu item of type tagged items and tag of joomla
![image](https://github.com/user-attachments/assets/e3a7ae25-6a29-4b6b-a1f6-8d1106ee0015)

Visit that page on the front end and then append `?format=feed&type=rss` to the url


### Actual result BEFORE applying this Pull Request
![image](https://github.com/user-attachments/assets/f60341b3-3e73-408a-9370-e4b749a0678d)



### Expected result AFTER applying this Pull Request
![image](https://github.com/user-attachments/assets/9fb0ff33-31de-45c4-ad19-0c6b480811a5)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
