### PR TITLE
[5.2] Fix duplicate entry with the action logs by removing the second call to onJoomlaAfterUpdate

### DIFF
--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -891,10 +891,6 @@ ENDDATA;
 
         $app = Factory::getApplication();
 
-        // Trigger event after joomla update.
-        // @TODO: The event dispatched twice, here and at the end of current method. One of it should be removed.
-        $app->getDispatcher()->dispatch('onJoomlaAfterUpdate', new AfterJoomlaUpdateEvent('onJoomlaAfterUpdate'));
-
         // Remove the update package.
         $tempdir = $app->get('tmp_path');
 


### PR DESCRIPTION
### Summary of Changes

Fix duplicate entry with the action logs by removing the second call to onJoomlaAfterUpdate

### Testing Instructions

- Install the latest version of Joomla
- Check the action logs
- Reinstall the core from com_joomlaupdate
- Check the action logs again
- change the update server to this generated one: `https://artifacts.joomla.org/drone/joomla/joomla-cms/5.2-dev/44629/downloads/80905/pr_list.xml`
- Install the update
- check the action logs again
- reinstall the core files
- check the action logs again

### Actual result BEFORE applying this Pull Request

![image](https://github.com/user-attachments/assets/f25ca7d7-9807-49ba-a1b3-62a0055e5084)

### Expected result AFTER applying this Pull Request

![image](https://github.com/user-attachments/assets/f0746da4-f8f4-4137-967b-4c33f7f9b7b2)


### Link to documentations
- [X] No documentation changes for docs.joomla.org needed
- [X] No documentation changes for manual.joomla.org needed
