### PR TITLE
[5.3] Apply mail cloaking in finder results

### DIFF
--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -208,8 +208,9 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
         if (\is_array($this->results)) {
             $dispatcher = $this->getDispatcher();
 
-            // Import Finder plugins
+            // Import Content and Finder plugins
             PluginHelper::importPlugin('finder', null, true, $dispatcher);
+            PluginHelper::importPlugin('content', null, true, $dispatcher);
 
             foreach ($this->results as $result) {
                 $dispatcher->dispatch('onFinderResult', new ResultEvent('onFinderResult', [

--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -210,7 +210,7 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
 
             // Import Content and Finder plugins
             PluginHelper::importPlugin('finder', null, true, $dispatcher);
-            PluginHelper::importPlugin('content', 'emailcloak', true, $dispatcher);
+            PluginHelper::importPlugin('content', null, true, $dispatcher);
 
             foreach ($this->results as $result) {
                 $dispatcher->dispatch('onFinderResult', new ResultEvent('onFinderResult', [

--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -210,7 +210,7 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
 
             // Import Content and Finder plugins
             PluginHelper::importPlugin('finder', null, true, $dispatcher);
-            PluginHelper::importPlugin('content', null, true, $dispatcher);
+            PluginHelper::importPlugin('content', 'emailcloak', true, $dispatcher);
 
             foreach ($this->results as $result) {
                 $dispatcher->dispatch('onFinderResult', new ResultEvent('onFinderResult', [

--- a/plugins/content/emailcloak/src/Extension/EmailCloak.php
+++ b/plugins/content/emailcloak/src/Extension/EmailCloak.php
@@ -39,7 +39,7 @@ final class EmailCloak extends CMSPlugin implements SubscriberInterface
     {
         return [
             'onContentPrepare' => 'onContentPrepare',
-            'onFinderResult' => 'onFinderResult'
+            'onFinderResult'   => 'onFinderResult'
         ];
     }
 

--- a/plugins/content/emailcloak/src/Extension/EmailCloak.php
+++ b/plugins/content/emailcloak/src/Extension/EmailCloak.php
@@ -39,7 +39,7 @@ final class EmailCloak extends CMSPlugin implements SubscriberInterface
     {
         return [
             'onContentPrepare' => 'onContentPrepare',
-            'onFinderResult'   => 'onFinderResult'
+            'onFinderResult'   => 'onFinderResult',
         ];
     }
 

--- a/plugins/content/emailcloak/src/Extension/EmailCloak.php
+++ b/plugins/content/emailcloak/src/Extension/EmailCloak.php
@@ -11,6 +11,7 @@
 namespace Joomla\Plugin\Content\EmailCloak\Extension;
 
 use Joomla\CMS\Event\Content\ContentPrepareEvent;
+use Joomla\CMS\Event\Finder\ResultEvent;
 use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Plugin\CMSPlugin;
 use Joomla\Event\SubscriberInterface;
@@ -36,7 +37,33 @@ final class EmailCloak extends CMSPlugin implements SubscriberInterface
      */
     public static function getSubscribedEvents(): array
     {
-        return ['onContentPrepare' => 'onContentPrepare'];
+        return [
+            'onContentPrepare' => 'onContentPrepare',
+            'onFinderResult' => 'onFinderResult'
+        ];
+    }
+
+    /**
+     * Plugin that cloaks all emails in com_finder from spambots via Javascript.
+     *
+     * @param   ResultEvent  $event  Event instance
+     *
+     * @return  void
+     */
+    public function onFinderResult(ResultEvent $event)
+    {
+        $item = $event->getItem();
+
+        // If the item does not have a text property there is nothing to do
+        if (!isset($item->description)) {
+            return;
+        }
+
+        $text = $this->cloak($item->description);
+
+        if ($text) {
+            $item->description = $text;
+        }
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #43749

### Summary of Changes
Mail addresses in results in com_finder are currently uncloaked, as they are not passed through the OnContentPrepare event.

This PR adds an event handler for the finder results to the cloaking plugin and ensures that the content plugin group is loaded by com_finder.


### Testing Instructions
* Create an article with a searchword, following a a mail address
* Search for the word in com_finder
* Inspect the result using your browser dev tools


### Actual result BEFORE applying this Pull Request
Mail address in uncloaked.


### Expected result AFTER applying this Pull Request
Mail address is cloaked.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x ] No documentation changes for manual.joomla.org needed
