### PR TITLE
[5.3] Update MVCFactoryInterfaceInterface.php

### DIFF
--- a/build/phpstan/src/DynamicReturnType/MVCFactoryInterfaceInterface.php
+++ b/build/phpstan/src/DynamicReturnType/MVCFactoryInterfaceInterface.php
@@ -35,8 +35,16 @@ class MVCFactoryInterfaceInterface extends NamespaceBased
             return null;
         }
 
-        $name   = str_replace("'", '', $methodCall->getArgs()[0]->value->getAttribute('rawValue'));
-        $prefix = str_replace("'", '', $methodCall->getArgs()[1]->value->getAttribute('rawValue'));
+        $firstArg  = isset($methodCall->getArgs()[0]) ? $methodCall->getArgs()[0] : null;
+        $secondArg = isset($methodCall->getArgs()[1]) ? $methodCall->getArgs()[1] : null;
+
+        if (!isset($firstArg, $secondArg))
+        {
+            return null;
+        }
+
+        $name   = str_replace("'", '', $firstArg->value->getAttribute('rawValue'));
+        $prefix = str_replace("'", '', $secondArg->value->getAttribute('rawValue'));
 
         foreach ($this->findNamespaces($prefix) as $ns => $path) {
             foreach (['Controller', 'Model', 'View', 'Table'] as $type) {

--- a/build/phpstan/src/DynamicReturnType/MVCFactoryInterfaceInterface.php
+++ b/build/phpstan/src/DynamicReturnType/MVCFactoryInterfaceInterface.php
@@ -38,8 +38,7 @@ class MVCFactoryInterfaceInterface extends NamespaceBased
         $firstArg  = isset($methodCall->getArgs()[0]) ? $methodCall->getArgs()[0] : null;
         $secondArg = isset($methodCall->getArgs()[1]) ? $methodCall->getArgs()[1] : null;
 
-        if (!isset($firstArg, $secondArg))
-        {
+        if (!isset($firstArg, $secondArg)) {
             return null;
         }
 


### PR DESCRIPTION
- Tiny fix to handle edge case when methodCall does not match the actual number of args which leads to null hence an error

Pull Request for Issue # .

### Summary of Changes

Handle edge case with lead to null then error when arguments does not match what is expected for example when provided arguments are less the 1 or 2


### Testing Instructions
- Apply this pull request
- composer install
- php vendor/bin/phpstan -vvv --debug analyze


### Actual result BEFORE applying this Pull Request
- When phpstan analyze the codebase on this edge case. For example 1 argument rather then exactly 2. It shows an error


### Expected result AFTER applying this Pull Request
No more errors for this specific edge case (on argument count mismatch). Basically it returns null as soon as possible.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
