### PR TITLE
[5.2] Fix for: Article cannot be saved successfully on the front-end

### DIFF
--- a/build/media_source/com_content/js/form-edit.es6.js
+++ b/build/media_source/com_content/js/form-edit.es6.js
@@ -25,7 +25,7 @@
     document.querySelectorAll(`[${buttonDataSelector}]`).forEach((button) => {
       button.addEventListener('click', (e) => {
         e.preventDefault();
-        const task = e.target.getAttribute(buttonDataSelector);
+        const task = button.getAttribute(buttonDataSelector);
         submitTask(task);
       });
     });


### PR DESCRIPTION
Pull Request for Issue #37106 (or, at least, an issue having the exact same symptoms and behaviour).

### Summary of Changes
Modify the element used for button data selector when using any button of the com_content edit form on the front-end.


### Testing Instructions
Modify an existing article using the front-end. Save by clicking specifically on the checkbox icon in the save button (so that the `event.target` is the `span.icon-check`).

### Actual result BEFORE applying this Pull Request
The article is not saved, as the POST request sent to the server has an empty `task` field.


### Expected result AFTER applying this Pull Request
The article is correctly saved.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
