### PR TITLE
[5.3] Reverting change from CMS to framework Folder class

### DIFF
--- a/plugins/behaviour/compat/src/classmap/classmap.php
+++ b/plugins/behaviour/compat/src/classmap/classmap.php
@@ -484,7 +484,7 @@ JLoader::registerAlias(
 );
 
 JLoader::registerAlias('JFile', '\\Joomla\\CMS\\Filesystem\\File', '6.0');
-JLoader::registerAlias('JFolder', '\\Joomla\\Filesystem\\Folder', '6.0');
+JLoader::registerAlias('JFolder', '\\Joomla\\CMS\\Filesystem\\Folder', '6.0');
 JLoader::registerAlias('JFilesystemHelper', '\\Joomla\\CMS\\Filesystem\\FilesystemHelper', '6.0');
 JLoader::registerAlias('JFilesystemPatcher', '\\Joomla\\CMS\\Filesystem\\Patcher', '6.0');
 JLoader::registerAlias('JPath', '\\Joomla\\CMS\\Filesystem\\Path', '6.0');


### PR DESCRIPTION
### Summary of Changes
While doing some codereview, I noticed that #43958 is introducing a b/c break by switching the alias for `JFolder` from the CMS to the framework class. This is a problem since the framework class does not contain a `Folder::exists()` method, while the CMS class does have that method.


### Testing Instructions
Codereview.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
