### PR TITLE
[5.3] Update deleted files in script.php for the upcoming 5.3.0-alpha3

### DIFF
--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -2362,6 +2362,12 @@ class JoomlaInstallerScript
             '/media/system/css/joomla-core-loader.min.css',
             '/media/system/css/joomla-core-loader.min.css.gz',
             '/media/system/scss/joomla-core-loader.scss',
+            // From 5.3.0-alpha2 to 5.3.0-alpha3
+            '/administrator/components/com_scheduler/src/Table/LogsTable.php',
+            '/media/system/css/system-site-offline_rtl.css',
+            '/media/system/css/system-site-offline_rtl.min.css',
+            '/media/system/css/system-site-offline_rtl.min.css.gz',
+            '/media/system/scss/system-site-offline_rtl.scss',
         ];
 
         $folders = [


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the list of files to be deleted on update in script.php to the latest changes in the 5.3-dev branch.

Currently there are
- File "administrator/components/com_scheduler/src/Table/LogsTable.php" which has been renamed to "administrator/components/com_scheduler/src/Table/LogTable.php" with PR #44587 . As the renamed file has been added with PR #42530 in 5.3.0-alpha2, the rename is not a b/c break.
- CSS and SCSS files "/media/system/css/system-site-offline_rtl" which were removed by PR #44615 .

### Testing Instructions

Code review and check the changes from PRs #44587 and #44615 , or compare a recent 5.3-dev nightly build with a 5.3.0-alpha2 and check for files which exist only in the 5.3.0-alpha2 but not in 5.3-dev nightly build.

### Actual result BEFORE applying this Pull Request

The files added by this PR to the list are still there after an update from 5.3.0-alpha2 to 5.3-dev nightly build.

### Expected result AFTER applying this Pull Request

The files added by this PR to the list are deleted after an update from 5.3.0-alpha2 to 5.3-dev nightly build.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
