### PR TITLE
[5.3][cypress] do not ignore all uncaught:exception

### DIFF
--- a/tests/System/integration/administrator/components/com_media/Media.cy.js
+++ b/tests/System/integration/administrator/components/com_media/Media.cy.js
@@ -74,6 +74,7 @@ describe('Test in backend that the media manager', () => {
   });
 
   it('can display an error message when an invalid path is defined in the url', () => {
+    cy.on('uncaught:exception', () => false);
     cy.visit('/administrator/index.php?option=com_media&path=local-images:/invalid');
     cy.wait('@getMedia');
 
@@ -81,6 +82,7 @@ describe('Test in backend that the media manager', () => {
   });
 
   it('can display an error message when an invalid path is defined in the session', () => {
+    cy.on('uncaught:exception', () => false);
     window.sessionStorage.setItem('joomla.mediamanager', JSON.stringify({ selectedDirectory: 'local-images:/invalid' }));
     cy.visit('/administrator/index.php?option=com_media');
     cy.wait('@getMedia');

--- a/tests/System/support/index.js
+++ b/tests/System/support/index.js
@@ -3,11 +3,6 @@ import('joomla-cypress');
 
 before(() => {
   cy.task('startMailServer');
-  Cypress.on('uncaught:exception', (err, runnable) => {
-    console.log(`err :${err}`);
-    console.log(`runnable :${runnable}`);
-    return false;
-  });
 });
 
 afterEach(() => {


### PR DESCRIPTION
### Summary of Changes

At the moment all js errors do not lead to a direct failure of the system tests

So for example this #44553 error could be detected  and fixed before a release

### Testing Instructions

manipulate js code the get an exception and run a test which load this js file

### Actual result BEFORE applying this Pull Request

test not failing

### Expected result AFTER applying this Pull Request

test failing

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
