### PR TITLE
[5.2] Fix PHP Warning for debuguser, debuggroup

### DIFF
--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -36,6 +36,8 @@ $wa->useScript('table.columns');
         <?php else : ?>
             <?php
             // Split the actions table
+            $loginActions = [];
+            $actions      = [];
             foreach ($this->actions as $action) :
                 $name = $action[0];
                 if (in_array($name, ['core.login.site', 'core.login.admin', 'core.login.offline', 'core.login.api', 'core.admin'])) :

--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -39,6 +39,8 @@ $wa->useScript('table.columns');
         <?php else : ?>
             <?php
             // Split the actions table
+            $loginActions = [];
+            $actions      = [];
             foreach ($this->actions as $action) :
                 $name = $action[0];
                 if (in_array($name, ['core.login.site', 'core.login.admin', 'core.login.api', 'core.login.offline'])) :

--- a/administrator/components/com_users/tmpl/debuguser/default.php
+++ b/administrator/components/com_users/tmpl/debuguser/default.php
@@ -20,9 +20,6 @@ use Joomla\CMS\Router\Route;
 $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 
-$loginActions = [];
-$actions = [];
-
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('table.columns');


### PR DESCRIPTION
Pull Request for Issue #44685, replaces #44719

### Summary of Changes
Define arrays.


### Testing Instructions
see #44685, PHP warnings in debuguser and debuggroups.


### Actual result BEFORE applying this Pull Request
see #44685


### Expected result AFTER applying this Pull Request
No PHP warning


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
