### PR TITLE
[5.2] Fix password reset broken in backend

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -465,8 +465,8 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
         $url = Route::_('index.php?option=' . $option . '&view=' . $view . '&layout=' . $layout, false);
 
         // In the administrator we need a different URL
-        if (strtolower($name) === 'administrator') {
-            $user = Factory::getApplication()->getIdentity();
+        if ($this->isClient('administrator')) {
+            $user = $this->getIdentity();
             $url  = Route::_(
                 'index.php?option=' . $option . '&task=' . $view . '.' . $layout . '&id=' . $user->id,
                 false

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -406,74 +406,72 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      */
     protected function checkUserRequiresReset($option, $view, $layout, $urls = [])
     {
-        if ($this->getIdentity()->requireReset) {
-            $redirect = false;
+        // Password reset is not required for the user, no need to check it further
+        if (!$this->getIdentity()->requireReset) {
+            return;
+        }
 
-            /*
-             * By default user profile edit page is used.
-             * That page allows you to change more than just the password and might not be the desired behavior.
-             * This allows a developer to override the page that manage the password reset.
-             * (can be configured using the file: configuration.php, or if extended, through the global configuration form)
-             */
-            $name = $this->getName();
+        /*
+         * By default user profile edit page is used.
+         * That page allows you to change more than just the password and might not be the desired behavior.
+         * This allows a developer to override the page that manage the password reset.
+         * (can be configured using the file: configuration.php, or if extended, through the global configuration form)
+         */
+        $name = $this->getName();
 
-            if ($this->get($name . '_reset_password_override', 0)) {
-                $option = $this->get($name . '_reset_password_option', '');
-                $view   = $this->get($name . '_reset_password_view', '');
-                $layout = $this->get($name . '_reset_password_layout', '');
-                $urls   = $this->get($name . '_reset_password_urls', $urls);
-            }
+        if ($this->get($name . '_reset_password_override', 0)) {
+            $option = $this->get($name . '_reset_password_option', '');
+            $view   = $this->get($name . '_reset_password_view', '');
+            $layout = $this->get($name . '_reset_password_layout', '');
+            $urls   = $this->get($name . '_reset_password_urls', $urls);
+        }
 
-            // If the current URL matches an entry in $urls, we do not redirect
-            if (\count($urls)) {
-                $found = false;
+        /**
+         * The page which manage password reset always need to accessible, so if the current page
+         * is managing password reset page, no need to check it further
+         */
+        if ($this->input->getCmd('option', '') === $option
+            && $this->input->getCmd('view', '') === $view
+            && $this->input->getCmd('layout', '') == $layout) {
+            return;
+        }
 
-                foreach ($urls as $url) {
-                    $found2 = false;
+        // If the current URL matches an entry in $urls, we do not redirect
+        foreach ($urls as $url) {
+            $match = true;
 
-                    foreach ($url as $key => $value) {
-                        if ($this->input->getCmd($key) !== $value) {
-                            $found2 = false;
-                            break;
-                        }
-
-                        $found2 = true;
-                    }
-
-                    if ($found2) {
-                        $found = true;
-                        break;
-                    }
-                }
-
-                if (!$found) {
-                    $redirect = true;
-                }
-            } else {
-                if (
-                    $this->input->getCmd('option', '') !== $option || $this->input->getCmd('view', '') !== $view
-                    || $this->input->getCmd('layout', '') !== $layout
-                ) {
-                    // Requested a different option/view/layout
-                    $redirect = true;
+            foreach ($url as $key => $value) {
+                if ($this->input->getCmd($key) !== $value) {
+                    /**
+                     * The current URL does not meet this entry, get out of this loop
+                     * and check next entry
+                     */
+                    $match = false;
+                    break;
                 }
             }
 
-            if ($redirect) {
-                // Redirect to the profile edit page
-                $this->enqueueMessage(Text::_('JGLOBAL_PASSWORD_RESET_REQUIRED'), 'notice');
-
-                $url = Route::_('index.php?option=' . $option . '&view=' . $view . '&layout=' . $layout, false);
-
-                // In the administrator we need a different URL
-                if (strtolower($name) === 'administrator') {
-                    $user = Factory::getApplication()->getIdentity();
-                    $url  = Route::_('index.php?option=' . $option . '&task=' . $view . '.' . $layout . '&id=' . $user->id, false);
-                }
-
-                $this->redirect($url);
+            // The current URL meet the entry, no redirect is needed, just return early
+            if ($match) {
+                return;
             }
         }
+
+        // Redirect to the profile edit page
+        $this->enqueueMessage(Text::_('JGLOBAL_PASSWORD_RESET_REQUIRED'), 'notice');
+
+        $url = Route::_('index.php?option=' . $option . '&view=' . $view . '&layout=' . $layout, false);
+
+        // In the administrator we need a different URL
+        if (strtolower($name) === 'administrator') {
+            $user = Factory::getApplication()->getIdentity();
+            $url  = Route::_(
+                'index.php?option=' . $option . '&task=' . $view . '.' . $layout . '&id=' . $user->id,
+                false
+            );
+        }
+
+        $this->redirect($url);
     }
 
     /**

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -430,9 +430,11 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
          * The page which manage password reset always need to accessible, so if the current page
          * is managing password reset page, no need to check it further
          */
-        if ($this->input->getCmd('option', '') === $option
+        if (
+            $this->input->getCmd('option', '') === $option
             && $this->input->getCmd('view', '') === $view
-            && $this->input->getCmd('layout', '') == $layout) {
+            && $this->input->getCmd('layout', '') == $layout
+        ) {
             return;
         }
 

--- a/libraries/src/Application/SiteApplication.php
+++ b/libraries/src/Application/SiteApplication.php
@@ -265,7 +265,6 @@ final class SiteApplication extends CMSApplication
                 ['option' => 'com_users', 'view' => 'method'],
                 ['option' => 'com_users', 'task' => 'method.add'],
                 ['option' => 'com_users', 'task' => 'method.save'],
-                ['option' => 'com_users', 'view' => 'profile', 'layout' => 'edit'],
             ]);
         }
 
@@ -707,7 +706,6 @@ final class SiteApplication extends CMSApplication
                 ['option' => 'com_users', 'view' => 'method'],
                 ['option' => 'com_users', 'task' => 'method.add'],
                 ['option' => 'com_users', 'task' => 'method.save'],
-                ['option' => 'com_users', 'view' => 'profile', 'layout' => 'edit'],
             ]);
         }
 


### PR DESCRIPTION
Pull Request for Issue #44715

### Summary of Changes
This PR fixes password reset broken as described here https://github.com/joomla/joomla-cms/issues/44715. Further more, I improved code of `checkUserRequiresReset`, hopefully make it easier to understand and maintatin.

### Testing Instructions
- Follow instructions at https://github.com/joomla/joomla-cms/issues/44715, confirm the issue
- Apply patch, confirm that the issue is fixed
- Check and make sure **Require Password Reset** works when you login from frontend, too.


### Actual result BEFORE applying this Pull Request
- Infinitive redirection when login to backend using an account which has with **Require Password Reset** set to Yes

### Expected result AFTER applying this Pull Request
- No Infinitive redirection anymore. You can reset password when login using that account when login to administrator area of your site


### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
