### PR TITLE
[5.2] fix for Missing Actions Error in Permissions

### DIFF
--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -24,6 +24,10 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('table.columns');
 
+// Check if $actions is defined; initialize if not
+if (!isset($actions) || !is_array($actions)) {
+    $actions = [];
+}
 ?>
 <form action="<?php echo Route::_('index.php?option=com_users&view=debuggroup&group_id=' . (int) $this->state->get('group_id')); ?>" method="post" name="adminForm" id="adminForm">
     <div id="j-main-container" class="j-main-container">


### PR DESCRIPTION
### Summary of Changes
This PR **fixes some errors in the Permissions overview** for ``Configuration`` and ``Mail Templates``

### Testing Instructions
Make sure that **Error Reporting** is **set to Maximum**.

1. In Joomla back-end: Users > Groups > in "Users: Groups" overview, click on "Permissions"
![users-groups-permissions](https://github.com/user-attachments/assets/872d2a3f-3522-469f-883e-9cc05e9bc73e)

2. Click on "Filter Options", select "Configuration" or "Mail Templates
![filter-permissions-on-component](https://github.com/user-attachments/assets/596faace-1068-472c-84eb-ec35da0cd632)

### Actual result BEFORE applying this Pull Request

In both cases an error is shown:
```txt
Warning: Undefined variable $actions in /usr/local/apache2/htdocs/administrator/components/com_users/tmpl/debuggroup/default.php on line 86

Warning: foreach() argument must be of type array|object, null given in /usr/local/apache2/htdocs/administrator/components/com_users/tmpl/debuggroup/default.php on line 86

Warning: Undefined variable $actions in /usr/local/apache2/htdocs/administrator/components/com_users/tmpl/debuggroup/default.php on line 108

Warning: foreach() argument must be of type array|object, null given in /usr/local/apache2/htdocs/administrator/components/com_users/tmpl/debuggroup/default.php on line 108
```

#### Configuration 
![permissions-config-before](https://github.com/user-attachments/assets/b2908be5-8ccc-4c74-9c40-1a365ed9ef0f)

#### Mail Templates
![permissions-mailtemplates-before](https://github.com/user-attachments/assets/51365ecd-7ab6-4877-9445-3b3882efd85b)


### Expected result AFTER applying this Pull Request


#### Configuration 
![permissions-config-after](https://github.com/user-attachments/assets/2310e4e1-c46d-4692-b3b0-54819bed5d7f)


#### Mail Templates
![permissions-mailtemplates-after](https://github.com/user-attachments/assets/fc936159-99bc-4c8e-a075-e85ba986f77c)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
