### PR TITLE
[5.2] fix for Missing loginActions in Permissions for Post-installation Messages

### DIFF
--- a/administrator/components/com_users/tmpl/debuggroup/default.php
+++ b/administrator/components/com_users/tmpl/debuggroup/default.php
@@ -23,7 +23,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
 /** @var Joomla\CMS\WebAsset\WebAssetManager $wa */
 $wa = $this->getDocument()->getWebAssetManager();
 $wa->useScript('table.columns');
-
+$loginActions = [];
 ?>
 <form action="<?php echo Route::_('index.php?option=com_users&view=debuggroup&group_id=' . (int) $this->state->get('group_id')); ?>" method="post" name="adminForm" id="adminForm">
     <div id="j-main-container" class="j-main-container">


### PR DESCRIPTION
### Summary of Changes
This PR **fixes an error in the Permissions overview** for ``Post-installation Messages``
I found this error in the same component view after I created PR: https://github.com/joomla/joomla-cms/pull/44725
It can be tested separately from that other PR.

### Testing Instructions
Make sure that **Error Reporting** is **set to Maximum**.

1. In Joomla back-end: Users > Groups > in "Users: Groups" overview, click on "Permissions"
![users-groups-permissions](https://github.com/user-attachments/assets/872d2a3f-3522-469f-883e-9cc05e9bc73e)

2. Click on "Filter Options", select "Post-installation Messages"
![permissions-post-installation-select](https://github.com/user-attachments/assets/fae1cf80-613b-4ef3-9e77-2e9c590937ea)

### Actual result BEFORE applying this Pull Request
An error is displayed:
```txt
Warning: Undefined variable $loginActions in /usr/local/apache2/htdocs/administrator/components/com_users/tmpl/debuggroup/default.php on line 49

Warning: foreach() argument must be of type array|object, null given in /usr/local/apache2/htdocs/administrator/components/com_users/tmpl/debuggroup/default.php on line 49
```

![permissions-post-installation-msg-before](https://github.com/user-attachments/assets/f2871029-1cf3-4f1a-8100-f45788c4ea88)


### Expected result AFTER applying this Pull Request
![permissions-post-installation-msg-after](https://github.com/user-attachments/assets/21f5266f-7310-428b-b3ef-96b054acc0ed)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
