### PR TITLE
[5.2] Fix condition for joomla-update-quickicon

### DIFF
--- a/build/media_source/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
+++ b/build/media_source/plg_quickicon_joomlaupdate/js/jupdatecheck.es6.js
@@ -3,7 +3,7 @@
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  */
 
-if (Joomla && Joomla.getOptions('js-extensions-update')) {
+if (Joomla && Joomla.getOptions('js-joomla-update')) {
   const update = (type, text) => {
     const link = document.getElementById('plg_quickicon_joomlaupdate');
     if (link) {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Fix condition for the joomla update notification


### Testing Instructions
Deactivate the quickicon plugin for extension updates. 
Go to dashboard and see that the joomla-update-check does not work
Apply the patch (empty broser cache if needed)



### Actual result BEFORE applying this Pull Request
If the extension update plugin is deactivated, the joomla-update icon does not work


### Expected result AFTER applying this Pull Request
If the extension update plugin is deactivated, the joomla-update works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed
 
- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
