### PR TITLE
[5.2] Composer update enshrined/svg-sanitize to fix SVG uploads

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -101,7 +101,7 @@
     "ext-dom": "*",
     "composer/ca-bundle": "^1.5.1",
     "dragonmantank/cron-expression": "^3.3.3",
-    "enshrined/svg-sanitize": "^0.20.0",
+    "enshrined/svg-sanitize": "^0.21.0",
     "lcobucci/jwt": "^4.3.0",
     "web-token/jwt-library": "^3.4.6",
     "phpseclib/bcmath_compat": "^2.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9b7f4af719557c545a076458a5217904",
+    "content-hash": "e239d33518fe4b1ce5f63da240447409",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -424,16 +424,16 @@
         },
         {
             "name": "enshrined/svg-sanitize",
-            "version": "0.20.0",
+            "version": "0.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/darylldoyle/svg-sanitizer.git",
-                "reference": "068d9fcf912c88a0471d101d95a2caa87c50aee7"
+                "reference": "5e477468fac5c5ce933dce53af3e8e4e58dcccc9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/068d9fcf912c88a0471d101d95a2caa87c50aee7",
-                "reference": "068d9fcf912c88a0471d101d95a2caa87c50aee7",
+                "url": "https://api.github.com/repos/darylldoyle/svg-sanitizer/zipball/5e477468fac5c5ce933dce53af3e8e4e58dcccc9",
+                "reference": "5e477468fac5c5ce933dce53af3e8e4e58dcccc9",
                 "shasum": ""
             },
             "require": {
@@ -463,9 +463,9 @@
             "description": "An SVG sanitizer for PHP",
             "support": {
                 "issues": "https://github.com/darylldoyle/svg-sanitizer/issues",
-                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.20.0"
+                "source": "https://github.com/darylldoyle/svg-sanitizer/tree/0.21.0"
             },
-            "time": "2024-09-05T10:18:12+00:00"
+            "time": "2025-01-13T09:32:25+00:00"
         },
         {
             "name": "fig/link-util",


### PR DESCRIPTION
Pull Request for Issue #38532 (part) .

See https://github.com/joomla/joomla-cms/issues/38532#issuecomment-2586931516 .

### Summary of Changes

This pull request (PR) updates the composer dependency "enshrined/svg-sanitize" from 0.20.0 to the next version 0.21.0.

This fixes the upload of SVG files which contain a `dominant-baseline` attribute.

See https://github.com/darylldoyle/svg-sanitizer/pull/112 and https://github.com/darylldoyle/svg-sanitizer/releases/tag/0.21.0 .

### Testing Instructions

Set media options to allow `svg` files (allowed extensions), `svg` image files and `image/svg+xml` mimetype.

Go to media manager

Upload an SVG file which contains a `dominant-baseline` attribute.

You can download the SVG file from this issue https://github.com/darylldoyle/svg-sanitizer/issues/111 here: [svg-file](https://private-user-images.githubusercontent.com/1035170/401594000-94b4af6a-cd8f-4696-9a52-f01166547360.svg?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MzcyMTc2NzgsIm5iZiI6MTczNzIxNzM3OCwicGF0aCI6Ii8xMDM1MTcwLzQwMTU5NDAwMC05NGI0YWY2YS1jZDhmLTQ2OTYtOWE1Mi1mMDExNjY1NDczNjAuc3ZnP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI1MDExOCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNTAxMThUMTYyMjU4WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9OTkwYzJjMWM5Zjg3MTU4YjQ1Mjg5MTU1ZDlmZGYxZWFjM2JlZDE5ZDk3OTZmZGJkMmI1MmQ4NmM0YjExYWNiZiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QifQ.jsA1EovaLpMUK07QDR3S_XnPlndY8DS2sn_kcpnbrGg) .

### Actual result BEFORE applying this Pull Request

Error "Unable to upload file".

### Expected result AFTER applying this Pull Request

SVG file is uploaded and shows in media manager.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
