### PR TITLE
Revert "[5.2] Load the namespace from the cached manifest"

### DIFF
--- a/libraries/src/Component/ComponentHelper.php
+++ b/libraries/src/Component/ComponentHelper.php
@@ -383,7 +383,7 @@ class ComponentHelper
         $loader = function () {
             $db    = Factory::getDbo();
             $query = $db->getQuery(true)
-                ->select($db->quoteName(['extension_id', 'element', 'params', 'enabled', 'manifest_cache'], ['id', 'option', null, null, null]))
+                ->select($db->quoteName(['extension_id', 'element', 'params', 'enabled'], ['id', 'option', null, null]))
                 ->from($db->quoteName('#__extensions'))
                 ->where(
                     [
@@ -397,9 +397,6 @@ class ComponentHelper
             $db->setQuery($query);
 
             foreach ($db->getIterator() as $component) {
-                $component->namespace = (new Registry($component->manifest_cache))->get('namespace');
-                unset($component->manifest_cache);
-
                 $components[$component->option] = new ComponentRecord((array) $component);
             }
 


### PR DESCRIPTION
Reverts joomla/joomla-cms#44737

Reverting changes. For a few reasons:
- Loading a few bytes for nothing (in my test it add +100μs time to each request)
- The core does not read namespace from Db and we should not.

The PR for property deprecation https://github.com/joomla/joomla-cms/pull/44754

If we need access to extension NS we need to plan a better API.
Currently I cannot sugest anything better, but having it like in the PR is not a good thing.
