### PR TITLE
[5.2] Fix extension query in mailtemplates

### DIFF
--- a/administrator/components/com_mails/src/Model/TemplatesModel.php
+++ b/administrator/components/com_mails/src/Model/TemplatesModel.php
@@ -156,7 +156,7 @@ class TemplatesModel extends ListModel
         } else {
             // Only show mail template from enabled extensions
             $subQuery = $db->getQuery(true)
-                ->select($db->quoteName('name'))
+                ->select($db->quoteName('element'))
                 ->from($db->quoteName('#__extensions'))
                 ->where($db->quoteName('enabled') . ' = 1');
 


### PR DESCRIPTION
### Summary of Changes
The mail templates list view shows a list of all available templates from the #__mail_templates table. While doing so, it checks if the associated extension is enabled.

However, it uses the value of the "name" column in the #__extensions table for the subquery (which might hold a human-readable name and not the technical "element" name), causing templates to be not listed if the name and element of the associated extension do not align.


### Testing Instructions
* Temporarly change the value of the "name" column of com_contact in #__extensions from com_contact to Contact
* List the available mail templates


### Actual result BEFORE applying this Pull Request
* com_contact templates missing


### Expected result AFTER applying this Pull Request
* com_contact templates listed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ x] No documentation changes for manual.joomla.org needed
