### PR TITLE
[5.2] invalidate file cache upon copying folders

### DIFF
--- a/libraries/src/Filesystem/Folder.php
+++ b/libraries/src/Filesystem/Folder.php
@@ -147,6 +147,7 @@ abstract class Folder
                             if (!@copy($sfid, $dfid)) {
                                 throw new \RuntimeException('Copy file failed', -1);
                             }
+                            File::invalidateFileCache($dfid);
                         }
                         break;
                 }


### PR DESCRIPTION
### Summary of Changes

Currently, when copying a folder, the copied files do not get invalidated in the opcache. This PR fixes this.

Change in the framework filesystem: https://github.com/joomla-framework/filesystem/pull/74https://github.com/joomla-framework/filesystem/pull/74

This is the PR that introduced the opcache invalidation initially: https://github.com/joomla/joomla-cms/pull/32915

### Testing Instructions

none

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
