### PR TITLE
[5.2][Cypress] Minor Code Simplification

### DIFF
--- a/tests/System/integration/plugins/system/sef/SefPlugin.cy.js
+++ b/tests/System/integration/plugins/system/sef/SefPlugin.cy.js
@@ -9,10 +9,10 @@ describe('Test that the sef system plugin', () => {
     .then(() => cy.db_updateExtensionParameter('strictrouting', '1', 'plg_system_sef'));
 
   // Ensure that we always start with a clean SEF default state
-  beforeEach(() => setSefDefaults());
+  beforeEach(setSefDefaults);
 
   // Return to the clean SEF default state for subsequent Joomla System Tests
-  afterEach(() => setSefDefaults());
+  afterEach(setSefDefaults);
 
   it('can process if option \'sef\' disabled', () => {
     cy.config_setParameter('sef', false)


### PR DESCRIPTION
### Summary of Changes

Since `setSefDefaults` already returns a Promise (which Cypress understands and waits for), there's no need to wrap it in an anonymous function. Therefore, the code has been simplified to make it prettier and a little more suitable for the next copy&paste.

Thanks to @laoneo for the hint.

### Testing Instructions

Run Joomla System test `plugins/system/sef/SefPlugin.cy.js` with Cypress.

### Actual result BEFORE applying this Pull Request

Joomla System test `SefPlugin.cy.js` is running w/o errors.

### Expected result AFTER applying this Pull Request

Joomla System test `SefPlugin.cy.js` is still running w/o errors.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed