### PR TITLE
[6.2] Fix $dirname description

### DIFF
--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -48,7 +48,7 @@ extract($displayData);
  * @var   string   $accept          File types that are accepted.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*.
- * @var   string   $dirname         Field direction (ltr or rtl)
+ * @var   string   $dirname         Name of the form field direction (ltr or rtl).
  * @var   string   $addonBefore     The text to use in a bootstrap input group prepend
  * @var   string   $addonAfter      The text to use in a bootstrap input group append
  * @var   boolean  $charcounter     Does this field support a character counter?

--- a/layouts/joomla/form/field/text.php
+++ b/layouts/joomla/form/field/text.php
@@ -48,7 +48,7 @@ extract($displayData);
  * @var   string   $accept          File types that are accepted.
  * @var   string   $dataAttribute   Miscellaneous data attributes preprocessed for HTML output
  * @var   array    $dataAttributes  Miscellaneous data attribute for eg, data-*.
- * @var   string   $dirname         The directory name
+ * @var   string   $dirname         Field direction (ltr or rtl)
  * @var   string   $addonBefore     The text to use in a bootstrap input group prepend
  * @var   string   $addonAfter      The text to use in a bootstrap input group append
  * @var   boolean  $charcounter     Does this field support a character counter?

--- a/libraries/src/Form/Field/TextField.php
+++ b/libraries/src/Form/Field/TextField.php
@@ -196,7 +196,7 @@ class TextField extends FormField
 
             // Set the dirname.
             $dirname       = ($dirname === 'dirname' || $dirname === 'true' || $dirname === '1');
-            $this->dirname = $dirname ? $this->getName($this->fieldname . '_dir') : false;
+            $this->dirname = $dirname ? $this->getName($this->fieldname . '.dir') : false;
 
             $this->maxLength   = (int) $this->element['maxlength'];
             $this->charcounter = isset($this->element['charcounter']) && strtolower($this->element['charcounter']) === 'true';


### PR DESCRIPTION
### Testing Instructions
Code review.

https://github.com/joomla/joomla-cms/blob/88371b1ba08df96dff5bcad3cf703269d96aff21/libraries/src/Form/Field/TextField.php#L64-L70

Syntax should be `name.dir` but incorrectly changed in https://github.com/joomla/joomla-cms/pull/1758/commits/3f4285e23b4b66c9e9fe9a5918bde2e7e851f3ec