### PR TITLE
Update Developers link in README.md and README.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Do you want to improve Joomla?
 * Where to [request a feature](https://issues.joomla.org)?
 * How do you [report a bug](https://docs.joomla.org/Special:MyLanguage/Filing_bugs_and_issues) on the [Issue Tracker](https://issues.joomla.org)?
 * Get Involved: Joomla! is community developed software. [Join the community](https://volunteers.joomla.org).
-* Documentation for [Developers](https://docs.joomla.org/Special:MyLanguage/Portal:Developers).
+* Documentation for [Developers](https://manual.joomla.org/).
 * Documentation for [Web designers](https://docs.joomla.org/Special:MyLanguage/Web_designers).
 * Provide a translation for Joomla: [Joomla Crowdin Project](https://joomla.crowdin.com/cms)
 

--- a/README.txt
+++ b/README.txt
@@ -66,7 +66,7 @@ Joomla! CMS™
 	* Where to request a feature? https://issues.joomla.org
 	* How do you report a bug? https://docs.joomla.org/Special:MyLanguage/Filing_bugs_and_issues
 	* Get Involved: Joomla! is a community developed software. Join the community at https://volunteers.joomla.org
-	* Documentation for Developers: https://docs.joomla.org/Special:MyLanguage/Portal:Developers
+	* Documentation for Developers: https://manual.joomla.org/
 	* Documentation for Web designers: https://docs.joomla.org/Special:MyLanguage/Web_designers
 
 Copyright:


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

In the joomla/joomla-cms landing page on GitHub the README files have links to the Developers Portal page on docs.joomla.org. This PR changes the links to point to the new Manual at https://manual.joomla.org/

### Testing Instructions

Code Review

### Actual result BEFORE applying this Pull Request

Links to out of date locations

### Expected result AFTER applying this Pull Request

Links to up to date locations

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
