### PR TITLE
[5.2] [Security] Composer update symfony/http-client and symfony/process to version 6.4.15

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4344,16 +4344,16 @@
         },
         {
             "name": "symfony/http-client",
-            "version": "v6.4.11",
+            "version": "v6.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "4c92046bb788648ff1098cc66da69aa7eac8cb65"
+                "reference": "cb4073c905cd12b8496d24ac428a9228c1750670"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/4c92046bb788648ff1098cc66da69aa7eac8cb65",
-                "reference": "4c92046bb788648ff1098cc66da69aa7eac8cb65",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/cb4073c905cd12b8496d24ac428a9228c1750670",
+                "reference": "cb4073c905cd12b8496d24ac428a9228c1750670",
                 "shasum": ""
             },
             "require": {
@@ -4417,7 +4417,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v6.4.11"
+                "source": "https://github.com/symfony/http-client/tree/v6.4.15"
             },
             "funding": [
                 {
@@ -4433,7 +4433,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-26T06:30:21+00:00"
+            "time": "2024-11-13T13:40:18+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
@@ -10068,16 +10068,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.8",
+            "version": "v6.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5"
+                "reference": "3cb242f059c14ae08591c5c4087d1fe443564392"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/8d92dd79149f29e89ee0f480254db595f6a6a2c5",
-                "reference": "8d92dd79149f29e89ee0f480254db595f6a6a2c5",
+                "url": "https://api.github.com/repos/symfony/process/zipball/3cb242f059c14ae08591c5c4087d1fe443564392",
+                "reference": "3cb242f059c14ae08591c5c4087d1fe443564392",
                 "shasum": ""
             },
             "require": {
@@ -10109,7 +10109,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.8"
+                "source": "https://github.com/symfony/process/tree/v6.4.15"
             },
             "funding": [
                 {
@@ -10125,7 +10125,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T14:49:08+00:00"
+            "time": "2024-11-06T14:19:14+00:00"
         },
         {
             "name": "symfony/stopwatch",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the indirect composer dependencies "symfony/http-client" and "symfony/process", both to version 6.4.15, in order to fix 2 security vulnerability advisories (one low and one high severity) from `composer audit`.

When this PR is applied there is one medium severity security vulnerability advisory from `composer audit` remaining which is not fixed by this PR. To fix that would require to update "web-auth/webauthn-lib" to version 4.9.0 (or newer), but this would break our webauthn system plugin.

#### "symfony/http-client" is updated from version 6.4.11.

It is used by the "web-token/jwt-library" direct dependency and as indirect developer dependency. Change log:

[v6.4.12](https://github.com/symfony/http-client/releases/tag/v6.4.12)
- bug https://github.com/symfony/symfony/pull/58278
- bug https://github.com/symfony/symfony/pull/58218

[v6.4.13](https://github.com/symfony/http-client/releases/tag/v6.4.13)
- no significant changes

[v6.4.14](https://github.com/symfony/http-client/releases/tag/v6.4.14)
- security (low) https://github.com/advisories/GHSA-9c3x-r3wp-mgxm [HttpClient] Filter private IPs before connecting when Host == IP
- bug https://github.com/symfony/symfony/pull/58704

[v6.4.15](https://github.com/symfony/http-client/releases/tag/v6.4.15)
- security (low) https://github.com/advisories/GHSA-9c3x-r3wp-mgxm [HttpClient] Resolve hostnames in NoPrivateNetworkHttpClient

#### "symfony/process" is updated from version 6.4.8.

It is used only as an indirect development dependency. Change log:

[v6.4.12](https://github.com/symfony/process/releases/tag/v6.4.12)
- bug https://github.com/symfony/symfony/pull/58291
- bug https://github.com/symfony/symfony/pull/58195

[v6.4.13](https://github.com/symfony/process/releases/tag/v6.4.13)
- no significant changes

[v6.4.14](https://github.com/symfony/process/releases/tag/v6.4.14)
- security (high) https://github.com/advisories/GHSA-qq5c-677p-737q [Process] Use PATH before CD to load the shell on Windows
- bug https://github.com/symfony/symfony/pull/58752
- bug https://github.com/symfony/symfony/pull/58735
- bug https://github.com/symfony/symfony/pull/58723
- bug https://github.com/symfony/symfony/pull/58711

[v6.4.15](https://github.com/symfony/process/releases/tag/v6.4.15)
- no significant changes

(There were no versions 6.4.9 to 6.4.11.)

### Testing Instructions

This test requires a composer version 2.4 or newer and a git clone of this repository.

For the actual result, run `composer install` and then `composer audit` in a command shell window in the root folder of your git clone on the current 5.2-dev branch of this repository.

For the expected result, run `composer install` and then `composer audit` on a branch with this PR applied.

You can create such a branch in your git clone and then check out that branch with the following commands, assuming that you have a git clone of your fork of this repository, and `upstream` is the remote for this repository here:

```
git fetch upstream pull/44805/head:test-pr-44805
```
```
git checkout test-pr-44805
```

If you git clone is a clone of this repository here and not of your fork, replace the `upstream` by `origin` in the first command.

After that, run
```
composer install
```
```
composer audit
```

### Actual result BEFORE applying this Pull Request

`composer install` succeeds, no errors or warning.

`composer audit` result:

```
Found 3 security vulnerability advisories affecting 3 packages:
+-------------------+----------------------------------------------------------------------------------+
| Package           | symfony/http-client                                                              |
| Severity          | low                                                                              |
| CVE               | CVE-2024-50342                                                                   |
| Title             | CVE-2024-50342: Internal address and port enumeration allowed by                 |
|                   | NoPrivateNetworkHttpClient                                                       |
| URL               | https://symfony.com/cve-2024-50342                                               |
| Affected versions | >=4.3.0,<4.4.0|>=4.4.0,<5.0.0|>=5.0.0,<5.1.0|>=5.1.0,<5.2.0|>=5.2.0,<5.3.0|>=5.3 |
|                   | .0,<5.4.0|>=5.4.0,<5.4.47|>=6.0.0,<6.1.0|>=6.1.0,<6.2.0|>=6.2.0,<6.3.0|>=6.3.0,< |
|                   | 6.4.0|>=6.4.0,<6.4.15|>=7.0.0,<7.1.0|>=7.1.0,<7.1.8                              |
| Reported at       | 2024-11-13T08:00:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | symfony/process                                                                  |
| Severity          | high                                                                             |
| CVE               | CVE-2024-51736                                                                   |
| Title             | CVE-2024-51736: Command execution hijack on Windows with Process class           |
| URL               | https://symfony.com/cve-2024-51736                                               |
| Affected versions | >=2.0.0,<3.0.0|>=3.0.0,<4.0.0|>=4.0.0,<5.0.0|>=5.0.0,<5.1.0|>=5.1.0,<5.2.0|>=5.2 |
|                   | .0,<5.3.0|>=5.3.0,<5.4.0|>=5.4.0,<5.4.46|>=6.0.0,<6.1.0|>=6.1.0,<6.2.0|>=6.2.0,< |
|                   | 6.3.0|>=6.3.0,<6.4.0|>=6.4.0,<6.4.14|>=7.0.0,<7.1.0|>=7.1.0,<7.1.7               |
| Reported at       | 2024-11-05T08:00:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```

### Expected result AFTER applying this Pull Request

`composer install` succeeds, no errors or warning.

`composer audit` result:

```
Found 1 security vulnerability advisory affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | web-auth/webauthn-lib                                                            |
| Severity          | medium                                                                           |
| CVE               | CVE-2024-39912                                                                   |
| Title             | The FIDO2/Webauthn Support for PHP library allows enumeration of valid usernames  |
| URL               | https://github.com/advisories/GHSA-875x-g8p7-5w27                                |
| Affected versions | >=4.5.0,<4.9.0                                                                   |
| Reported at       | 2024-07-15T16:37:49+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 1 abandoned package:
+---------------------------+----------------------------------------------------------------------------------+
| Abandoned Package         | Suggested Replacement                                                            |
+---------------------------+----------------------------------------------------------------------------------+
| web-auth/metadata-service | web-auth/webauthn-lib                                                            |
+---------------------------+----------------------------------------------------------------------------------+
```
To fix the remaining advisory it would need to update "web-auth/webauthn-lib" to version 4.9.0 (or newer), which would also remove the abandoned "web-auth/metadata-service" package, but this would break our webauthn system plugin as that still uses the abandoned package.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
