### PR TITLE
[4.4] [Security] Composer update symfony/process to version 5.4.47

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -9965,9 +9965,9 @@
         "ext-simplexml": "*",
         "ext-gd": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -9710,16 +9710,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v5.4.28",
+            "version": "v5.4.47",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b"
+                "reference": "5d1662fb32ebc94f17ddb8d635454a776066733d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b",
-                "reference": "45261e1fccad1b5447a8d7a8e67aa7b4a9798b7b",
+                "url": "https://api.github.com/repos/symfony/process/zipball/5d1662fb32ebc94f17ddb8d635454a776066733d",
+                "reference": "5d1662fb32ebc94f17ddb8d635454a776066733d",
                 "shasum": ""
             },
             "require": {
@@ -9752,7 +9752,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v5.4.28"
+                "source": "https://github.com/symfony/process/tree/v5.4.47"
             },
             "funding": [
                 {
@@ -9768,7 +9768,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-07T10:36:04+00:00"
+            "time": "2024-11-06T11:36:42+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -9965,9 +9965,9 @@
         "ext-simplexml": "*",
         "ext-gd": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "7.2.5"
     },
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the indirect composer dependency "symfony/process" from version 5.4.28 to 5.4.47 in order to fix a security vulnerability advisory of high severity reported by `composer audit`. "symfony/process" is used only as an indirect development dependency.

When this PR is applied there are 2 security vulnerability advisories for "laminas/laminas-diactoros" remaining.
- CVE-2023-29530 "HTTP Multiline Header Termination" (high severity):
This is already fixed with `build/composer_patches/4.4.4-2024-04-13_php-laminas-diactoros.patch` so it is not relevant.
- CVE-2022-31109 "HTTP Host Header Attack" (medium severity):
This might not be fixable with a simple patch. Am still investigating and will do a separate PR if it is possible and this one here is already merged.

All changes of the package from 5.4.28 to 5.4.47: https://github.com/symfony/process/compare/v5.4.28...v5.4.47

Release notes:
- https://github.com/symfony/process/releases/tag/v5.4.34
- https://github.com/symfony/process/releases/tag/v5.4.35
- https://github.com/symfony/process/releases/tag/v5.4.36
- https://github.com/symfony/process/releases/tag/v5.4.39
- https://github.com/symfony/process/releases/tag/v5.4.40
- https://github.com/symfony/process/releases/tag/v5.4.44
- https://github.com/symfony/process/releases/tag/v5.4.45
- https://github.com/symfony/process/releases/tag/v5.4.46
- https://github.com/symfony/process/releases/tag/v5.4.47

(There were no versions from 5.4.29 to 5.4.33 and 5.4.37 and 5.4.38.)

### Testing Instructions

This test requires a composer version 2.4 or newer and a git clone of this repository.

For the actual result, run `composer install` and then `composer audit` in a command shell window in the root folder of your git clone on the current 4.4-dev branch of this repository.

For the expected result, run `composer install` and then `composer audit` on a branch with this PR applied.

You can create such a branch in your git clone and then check out that branch with the following commands, assuming that you have a git clone of your fork of this repository, and `upstream` is the remote for this repository here:

```
git fetch upstream pull/44807/head:test-pr-44807
```
```
git checkout test-pr-44807
```

If you git clone is a clone of this repository here and not of your fork, replace the `upstream` by `origin` in the first command.

After that, run
```
composer install
```
```
composer audit
```

### Actual result BEFORE applying this Pull Request

`composer install` succeeds, no errors or warning.

`composer audit` result:

```
Found 3 security vulnerability advisories affecting 2 packages:
+-------------------+----------------------------------------------------------------------------------+
| Package           | laminas/laminas-diactoros                                                        |
| Severity          | high                                                                             |
| CVE               | CVE-2023-29530                                                                   |
| Title             | HTTP Multiline Header Termination                                                |
| URL               | https://github.com/advisories/GHSA-xv3h-4844-9h36                                |
| Affected versions | >=2.25.0,<2.25.2|>=2.24.0,<2.24.2|=2.23.0|=2.22.0|=2.21.0|=2.20.0|=2.19.0|<2.18. |
|                   | 1                                                                                |
| Reported at       | 2023-04-24T22:42:39+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | laminas/laminas-diactoros                                                        |
| Severity          | medium                                                                           |
| CVE               | CVE-2022-31109                                                                   |
| Title             | Diactoros before 2.11.1 vulnerable to HTTP Host Header Attack.                   |
| URL               | https://github.com/advisories/GHSA-8274-h5jp-97vr                                |
| Affected versions | <2.11.1                                                                          |
| Reported at       | 2022-07-25T19:29:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | symfony/process                                                                  |
| Severity          | high                                                                             |
| CVE               | CVE-2024-51736                                                                   |
| Title             | CVE-2024-51736: Command execution hijack on Windows with Process class           |
| URL               | https://symfony.com/cve-2024-51736                                               |
| Affected versions | >=2.0.0,<3.0.0|>=3.0.0,<4.0.0|>=4.0.0,<5.0.0|>=5.0.0,<5.1.0|>=5.1.0,<5.2.0|>=5.2 |
|                   | .0,<5.3.0|>=5.3.0,<5.4.0|>=5.4.0,<5.4.46|>=6.0.0,<6.1.0|>=6.1.0,<6.2.0|>=6.2.0,< |
|                   | 6.3.0|>=6.3.0,<6.4.0|>=6.4.0,<6.4.14|>=7.0.0,<7.1.0|>=7.1.0,<7.1.7               |
| Reported at       | 2024-11-05T08:00:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 3 abandoned packages:
+--------------------------+----------------------------------------------------------------------------------+
| Abandoned Package        | Suggested Replacement                                                            |
+--------------------------+----------------------------------------------------------------------------------+
| fgrosse/phpasn1          | none                                                                             |
| php-cs-fixer/diff        | none                                                                             |
| phpunit/php-token-stream | none                                                                             |
+--------------------------+----------------------------------------------------------------------------------+
```

### Expected result AFTER applying this Pull Request

`composer install` succeeds, no errors or warning.

`composer audit` result:

```
Found 2 security vulnerability advisories affecting 1 package:
+-------------------+----------------------------------------------------------------------------------+
| Package           | laminas/laminas-diactoros                                                        |
| Severity          | high                                                                             |
| CVE               | CVE-2023-29530                                                                   |
| Title             | HTTP Multiline Header Termination                                                |
| URL               | https://github.com/advisories/GHSA-xv3h-4844-9h36                                |
| Affected versions | >=2.25.0,<2.25.2|>=2.24.0,<2.24.2|=2.23.0|=2.22.0|=2.21.0|=2.20.0|=2.19.0|<2.18. |
|                   | 1                                                                                |
| Reported at       | 2023-04-24T22:42:39+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
+-------------------+----------------------------------------------------------------------------------+
| Package           | laminas/laminas-diactoros                                                        |
| Severity          | medium                                                                           |
| CVE               | CVE-2022-31109                                                                   |
| Title             | Diactoros before 2.11.1 vulnerable to HTTP Host Header Attack.                   |
| URL               | https://github.com/advisories/GHSA-8274-h5jp-97vr                                |
| Affected versions | <2.11.1                                                                          |
| Reported at       | 2022-07-25T19:29:00+00:00                                                        |
+-------------------+----------------------------------------------------------------------------------+
Found 3 abandoned packages:
+--------------------------+----------------------------------------------------------------------------------+
| Abandoned Package        | Suggested Replacement                                                            |
+--------------------------+----------------------------------------------------------------------------------+
| fgrosse/phpasn1          | none                                                                             |
| php-cs-fixer/diff        | none                                                                             |
| phpunit/php-token-stream | none                                                                             |
+--------------------------+----------------------------------------------------------------------------------+
```

There are 2 security vulnerability advisories for "laminas/laminas-diactoros" remaining.
- CVE-2023-29530 "HTTP Multiline Header Termination" (high severity):
This is already fixed with `build/composer_patches/4.4.4-2024-04-13_php-laminas-diactoros.patch` so it is not relevant.
- CVE-2022-31109 "HTTP Host Header Attack" (medium severity):
This might not be fixable with a simple patch. Am still investigating and will do a separate PR if it is possible and this one here is already merged.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
