### PR TITLE
[5.2] add PHP8.4 to PhpVersionCheck quickicon

### DIFF
--- a/plugins/quickicon/phpversioncheck/src/Extension/PhpVersionCheck.php
+++ b/plugins/quickicon/phpversioncheck/src/Extension/PhpVersionCheck.php
@@ -147,6 +147,10 @@ final class PhpVersionCheck extends CMSPlugin implements SubscriberInterface
                 'security' => '2025-12-31',
                 'eos'      => '2027-12-31',
             ],
+            '8.4' => [
+                'security' => '2026-12-31',
+                'eos'      => '2028-12-31',
+            ],
         ];
 
         // Fill our return array with default values


### PR DESCRIPTION
### Summary of Changes

add PHP8.4 to PhpVersionCheck quickicon

### Testing Instructions

check dates here: https://www.php.net/supported-versions.php
![image](https://github.com/user-attachments/assets/9ef74989-2ccc-4753-93b0-990d04721aca)

### Actual result BEFORE applying this Pull Request

no check for PHP8.4

### Expected result AFTER applying this Pull Request

check PHP8.4

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
