### PR TITLE
[5.3] Switching voku/portable-utf8 to own fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,11 @@
       "type": "vcs",
       "url": "https://github.com/joomla-backports/php-tuf.git",
       "no-api": true
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/joomla-backports/portable-utf8.git",
+      "no-api": true
     }
   ],
   "autoload": {
@@ -106,7 +111,7 @@
     "web-token/jwt-library": "^3.4.6",
     "phpseclib/bcmath_compat": "^2.0.3",
     "jfcherng/php-diff": "^6.16.2",
-    "voku/portable-utf8": "^6.0.13",
+    "voku/portable-utf8": "dev-joomla-5.3",
     "php-tuf/php-tuf": "^1.0.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "68cb46ab32a1db1fe2152c1c756e2568",
+    "content-hash": "66fec8ab5e955efb2b3db4e6860c0f52",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -6054,16 +6054,16 @@
         },
         {
             "name": "voku/portable-utf8",
-            "version": "6.0.13",
+            "version": "dev-joomla-5.3",
             "source": {
                 "type": "git",
-                "url": "https://github.com/voku/portable-utf8.git",
-                "reference": "b8ce36bf26593e5c2e81b1850ef0ffb299d2043f"
+                "url": "https://github.com/joomla-backports/portable-utf8.git",
+                "reference": "eeb3d9e390411cd31af808caa7f7de337ea3a24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-utf8/zipball/b8ce36bf26593e5c2e81b1850ef0ffb299d2043f",
-                "reference": "b8ce36bf26593e5c2e81b1850ef0ffb299d2043f",
+                "url": "https://api.github.com/repos/joomla-backports/portable-utf8/zipball/eeb3d9e390411cd31af808caa7f7de337ea3a24c",
+                "reference": "eeb3d9e390411cd31af808caa7f7de337ea3a24c",
                 "shasum": ""
             },
             "require": {
@@ -6092,14 +6092,18 @@
             },
             "type": "library",
             "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
                 "psr-4": {
                     "voku\\": "src/voku/"
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "autoload-dev": {
+                "psr-4": {
+                    "voku\\tests\\": "tests/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "(Apache-2.0 or GPL-2.0)"
             ],
@@ -6120,40 +6124,14 @@
             "description": "Portable UTF-8 library - performance optimized (unicode) string functions for php.",
             "homepage": "https://github.com/voku/portable-utf8",
             "keywords": [
-                "UTF",
                 "clean",
                 "php",
                 "unicode",
+                "utf",
                 "utf-8",
                 "utf8"
             ],
-            "support": {
-                "issues": "https://github.com/voku/portable-utf8/issues",
-                "source": "https://github.com/voku/portable-utf8/tree/6.0.13"
-            },
-            "funding": [
-                {
-                    "url": "https://www.paypal.me/moelleken",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/voku",
-                    "type": "github"
-                },
-                {
-                    "url": "https://opencollective.com/portable-utf8",
-                    "type": "open_collective"
-                },
-                {
-                    "url": "https://www.patreon.com/voku",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/voku/portable-utf8",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-03-08T08:35:38+00:00"
+            "time": "2024-11-20T09:42:04+00:00"
         },
         {
             "name": "wamania/php-stemmer",
@@ -10243,7 +10221,8 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "tobscure/json-api": 20
+        "tobscure/json-api": 20,
+        "voku/portable-utf8": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,


### PR DESCRIPTION
### Summary of Changes
The voku/portable-utf8 package unfortunately seems to not be maintained anymore and especially in PHP 8.4 throws massive notices. Unfortunately we adopted it as a direct dependency to fix another issue with it in the past and are now stuck with it for compatibility reasons until the end of 5.x. #44654 removes it entirely for Joomla 6. To fix the PHP 8.4 issues, we forked the repo and added those fixes there. We are not going to maintain that repo.


### Testing Instructions
- Run `composer i`
- Open the administrator login


### Actual result BEFORE applying this Pull Request
Lots of PHP notices, among them issues relating to voku/portable-utf8


### Expected result AFTER applying this Pull Request
The notices for voku/portable-utf8 are gone.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [X] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/381
- [ ] No documentation changes for manual.joomla.org needed
