### PR TITLE
[4.4] Fix namespace map creation on PHP 8.4

### DIFF
--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -144,8 +144,11 @@ class JNamespacePsr4Map
          */
         $error_reporting = error_reporting(0);
 
+        // Convert array of lines to string
+        $content = implode("\n", $content);
+
         try {
-            File::write($this->file, implode("\n", $content));
+            File::write($this->file, $content);
         } catch (Exception $e) {
             Log::add('Could not save ' . $this->file, Log::WARNING);
 


### PR DESCRIPTION
### Summary of Changes
Backport of the 5.x fix to the 4.x branch, see #44789

The creation of the namespace map file fails on PHP 8.4 as the content is implicitly provided to File::write as reference, causing this message:

> Joomla\Filesystem \File: write: Argument #2 ($buffer) could not be passed by reference


### Testing Instructions
* Enable PHP 8.4
* Remove the namespace map file `autoload_psr4.php` in the cache folder
* Refresh the backend

### Actual result BEFORE applying this Pull Request
* Error message shown


### Expected result AFTER applying this Pull Request
* File created


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
