### PR TITLE
[5.3] onContentPrepareForm should return void instead of boolean

### DIFF
--- a/plugins/content/confirmconsent/src/Extension/ConfirmConsent.php
+++ b/plugins/content/confirmconsent/src/Extension/ConfirmConsent.php
@@ -56,7 +56,7 @@ final class ConfirmConsent extends CMSPlugin implements SubscriberInterface
      *
      * @param   PrepareFormEvent $event  The event instance.
      *
-     * @return  boolean
+     * @return  void
      *
      * @since   3.9.0
      */
@@ -65,7 +65,7 @@ final class ConfirmConsent extends CMSPlugin implements SubscriberInterface
         $form = $event->getForm();
 
         if ($this->getApplication()->isClient('administrator') || !\in_array($form->getName(), $this->supportedContext)) {
-            return true;
+            return;
         }
 
         $this->loadLanguage();
@@ -95,7 +95,5 @@ final class ConfirmConsent extends CMSPlugin implements SubscriberInterface
 					</field>
 				</fieldset>
 			</form>');
-
-        return true;
     }
 }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
While review code of the already merged PR https://github.com/joomla/joomla-cms/pull/43426, I found a small issue with the code. The `onContentPrepareForm` method of `ConfirmConsent` class should not return boolean value, it should return void instead, like in the System - Fields plugin code https://github.com/joomla/joomla-cms/blob/5.3-dev/plugins/system/fields/src/Extension/Fields.php#L247

In general, when converting our plugins to use `SubscriberInterface`, the event listeners should always return void. If we need to pass result back, use $`event->addResult` method instead of return command

### Testing Instructions
Code review should be enough

### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
