### PR TITLE
[5.3] Remove useless return statement

### DIFF
--- a/plugins/user/terms/src/Extension/Terms.php
+++ b/plugins/user/terms/src/Extension/Terms.php
@@ -80,8 +80,6 @@ final class Terms extends CMSPlugin implements SubscriberInterface
         // Push the terms and conditions article ID into the terms field.
         $form->setFieldAttribute('terms', 'article', $termsarticle, 'terms');
         $form->setFieldAttribute('terms', 'note', $termsnote, 'terms');
-
-        return true;
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Follow up for the merged PR https://github.com/joomla/joomla-cms/pull/43427 . Remove the `return true;` statement because the method should have `void` return type


### Testing Instructions
Can be merged by review as discussed in the PR. Ping @laoneo 


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works