### PR TITLE
[5.3] Remove useless clone statement

### DIFF
--- a/administrator/components/com_banners/src/Model/BannerModel.php
+++ b/administrator/components/com_banners/src/Model/BannerModel.php
@@ -442,7 +442,7 @@ class BannerModel extends AdminModel
         // Alter the name for save as copy
         if ($input->get('task') == 'save2copy') {
             /** @var \Joomla\Component\Banners\Administrator\Table\BannerTable $origTable */
-            $origTable = clone $this->getTable();
+            $origTable = $this->getTable();
             $origTable->load($input->getInt('id'));
 
             if ($data['name'] == $origTable->name) {

--- a/administrator/components/com_categories/src/Model/CategoryModel.php
+++ b/administrator/components/com_categories/src/Model/CategoryModel.php
@@ -534,7 +534,7 @@ class CategoryModel extends AdminModel
 
         // Alter the title for save as copy
         if ($input->get('task') == 'save2copy') {
-            $origTable = clone $this->getTable();
+            $origTable = $this->getTable();
             $origTable->load($input->getInt('id'));
 
             if ($data['title'] == $origTable->title) {

--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -316,7 +316,7 @@ class ContactModel extends AdminModel
 
         // Alter the name for save as copy
         if ($input->get('task') == 'save2copy') {
-            $origTable = clone $this->getTable();
+            $origTable = $this->getTable();
             $origTable->load($input->getInt('id'));
 
             if ($data['name'] == $origTable->name) {

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -140,7 +140,7 @@ class FieldModel extends AdminModel
         $input = Factory::getApplication()->getInput();
 
         if ($input->get('task') == 'save2copy') {
-            $origTable = clone $this->getTable();
+            $origTable = $this->getTable();
             $origTable->load($input->getInt('id'));
 
             if ($data['title'] == $origTable->title) {

--- a/administrator/components/com_guidedtours/src/Model/StepModel.php
+++ b/administrator/components/com_guidedtours/src/Model/StepModel.php
@@ -98,7 +98,7 @@ class StepModel extends AdminModel
         }
 
         if ($input->get('task') == 'save2copy') {
-            $origTable = clone $this->getTable();
+            $origTable = $this->getTable();
             $origTable->load($input->getInt('id'));
 
             $data['published'] = 0;

--- a/administrator/components/com_guidedtours/src/Model/TourModel.php
+++ b/administrator/components/com_guidedtours/src/Model/TourModel.php
@@ -68,7 +68,7 @@ class TourModel extends AdminModel
         }
 
         if ($input->get('task') == 'save2copy') {
-            $origTable = clone $this->getTable();
+            $origTable = $this->getTable();
             $origTable->load($input->getInt('id'));
 
             $data['published'] = 0;

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
@@ -215,7 +215,7 @@ class NewsfeedModel extends AdminModel
 
         // Alter the name for save as copy
         if ($input->get('task') == 'save2copy') {
-            $origTable = clone $this->getTable();
+            $origTable = $this->getTable();
             $origTable->load($input->getInt('id'));
 
             if ($data['name'] == $origTable->name) {

--- a/administrator/components/com_workflow/src/Model/StageModel.php
+++ b/administrator/components/com_workflow/src/Model/StageModel.php
@@ -117,7 +117,7 @@ class StageModel extends AdminModel
         }
 
         if ($input->get('task') == 'save2copy') {
-            $origTable = clone $this->getTable();
+            $origTable = $this->getTable();
 
             // Alter the title for save as copy
             if ($origTable->load(['title' => $data['title']])) {

--- a/administrator/components/com_workflow/src/Model/TransitionModel.php
+++ b/administrator/components/com_workflow/src/Model/TransitionModel.php
@@ -167,7 +167,7 @@ class TransitionModel extends AdminModel
         }
 
         if ($input->get('task') == 'save2copy') {
-            $origTable = clone $this->getTable();
+            $origTable = $this->getTable();
 
             // Alter the title for save as copy
             if ($origTable->load(['title' => $data['title']])) {

--- a/administrator/components/com_workflow/src/Model/WorkflowModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowModel.php
@@ -106,7 +106,7 @@ class WorkflowModel extends AdminModel
         }
 
         if ($input->get('task') == 'save2copy') {
-            $origTable = clone $this->getTable();
+            $origTable = $this->getTable();
 
             // Alter the title for save as copy
             if ($origTable->load(['title' => $data['title']])) {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
`$this->getTable()` always return new table object, so having clone statement here is useless, thus I remove it.


### Testing Instructions
- Uses Joomla 5.3 nightly build
- Click on an banner to edit
- Press Save As Copy button in the toolbar


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
