### PR TITLE
[5.3] Improve System - Debug plugin code

### DIFF
--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -14,6 +14,7 @@ use DebugBar\DataCollector\MessagesCollector;
 use DebugBar\DebugBar;
 use DebugBar\OpenHandler;
 use Joomla\Application\ApplicationEvents;
+use Joomla\Application\Event\ApplicationEvent;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Document\HtmlDocument;
 use Joomla\CMS\Event\Application\AfterRespondEvent;
@@ -268,13 +269,13 @@ final class Debug extends CMSPlugin implements SubscriberInterface
     /**
      * Show the debug info.
      *
-     * @param  AfterRespondEvent $event  The event instance.
+     * @param   AfterRespondEvent|ApplicationEvent  $event  The event instance.
      *
      * @return  void
      *
      * @since   1.6
      */
-    public function onAfterRespond(AfterRespondEvent $event): void
+    public function onAfterRespond(AfterRespondEvent|ApplicationEvent $event): void
     {
         $endTime    = microtime(true) - $this->timeInOnAfterDisconnect;
         $endMemory  = memory_get_peak_usage(false);

--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -16,6 +16,9 @@ use DebugBar\OpenHandler;
 use Joomla\Application\ApplicationEvents;
 use Joomla\CMS\Application\CMSApplicationInterface;
 use Joomla\CMS\Document\HtmlDocument;
+use Joomla\CMS\Event\Application\AfterRespondEvent;
+use Joomla\CMS\Event\Application\BeforeCompileHeadEvent;
+use Joomla\CMS\Event\Application\BeforeRespondEvent;
 use Joomla\CMS\Event\Plugin\AjaxEvent;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\Log\LogEntry;
@@ -172,14 +175,16 @@ final class Debug extends CMSPlugin implements SubscriberInterface
         $this->setApplication($app);
         $this->setDatabase($db);
 
-        $this->debugLang = $this->getApplication()->get('debug_lang');
+        $app  = $this->getApplication();
+
+        $this->debugLang = $app->get('debug_lang');
 
         // Skip the plugin if debug is off
-        if (!$this->debugLang && !$this->getApplication()->get('debug')) {
+        if (!$this->debugLang && !$app->get('debug')) {
             return;
         }
 
-        $this->getApplication()->set('gzip', false);
+        $app->set('gzip', false);
         ob_start();
         ob_implicit_flush(false);
 
@@ -195,19 +200,19 @@ final class Debug extends CMSPlugin implements SubscriberInterface
 
         // Check whether we want to track the request history for future use.
         if ($this->params->get('track_request_history', false)) {
-            $storagePath = JPATH_CACHE . '/plg_system_debug_' . $this->getApplication()->getName();
+            $storagePath = JPATH_CACHE . '/plg_system_debug_' . $app->getName();
             $this->debugBar->setStorage(new FileStorage($storagePath));
         }
 
-        $this->debugBar->setHttpDriver(new JoomlaHttpDriver($this->getApplication()));
+        $this->debugBar->setHttpDriver(new JoomlaHttpDriver($app));
 
-        $this->isAjax = $this->getApplication()->getInput()->get('option') === 'com_ajax'
-            && $this->getApplication()->getInput()->get('plugin') === 'debug' && $this->getApplication()->getInput()->get('group') === 'system';
+        $this->isAjax = $app->getInput()->get('option') === 'com_ajax'
+            && $app->getInput()->get('plugin') === 'debug' && $app->getInput()->get('group') === 'system';
 
         $this->showLogs = (bool) $this->params->get('logs', true);
 
         // Log deprecated class aliases
-        if ($this->showLogs && $this->getApplication()->get('log_deprecated')) {
+        if ($this->showLogs && $app->get('log_deprecated')) {
             foreach (\JLoader::getDeprecatedAliases() as $deprecation) {
                 Log::add(
                     \sprintf(
@@ -226,11 +231,13 @@ final class Debug extends CMSPlugin implements SubscriberInterface
     /**
      * Add an assets for debugger.
      *
+     * @param  BeforeCompileHeadEvent $event  The event instance.
+     *
      * @return  void
      *
      * @since   4.0.0
      */
-    public function onBeforeCompileHead()
+    public function onBeforeCompileHead(BeforeCompileHeadEvent $event): void
     {
         // Only if debugging or language debug is enabled.
         if ((JDEBUG || $this->debugLang) && $this->isAuthorisedDisplayDebug() && $this->getApplication()->getDocument() instanceof HtmlDocument) {
@@ -261,11 +268,13 @@ final class Debug extends CMSPlugin implements SubscriberInterface
     /**
      * Show the debug info.
      *
+     * @param  AfterRespondEvent $event  The event instance.
+     *
      * @return  void
      *
      * @since   1.6
      */
-    public function onAfterRespond()
+    public function onAfterRespond(AfterRespondEvent $event): void
     {
         $endTime    = microtime(true) - $this->timeInOnAfterDisconnect;
         $endMemory  = memory_get_peak_usage(false);
@@ -371,7 +380,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
     /**
      * AJAX handler
      *
-     * @param AjaxEvent $event
+     * @param  AjaxEvent $event  The event instance.
      *
      * @return  void
      *
@@ -413,22 +422,20 @@ final class Debug extends CMSPlugin implements SubscriberInterface
             return $result;
         }
 
+        $result = true;
+
         // If the user is not allowed to view the output then end here.
         $filterGroups = (array) $this->params->get('filter_groups', []);
 
         if (!empty($filterGroups)) {
-            $userGroups = $this->getApplication()->getIdentity()->get('groups');
+            $userGroups = $this->getApplication()->getIdentity()->groups;
 
             if (!array_intersect($filterGroups, $userGroups)) {
                 $result = false;
-
-                return false;
             }
         }
 
-        $result = true;
-
-        return true;
+        return $result;
     }
 
     /**
@@ -440,7 +447,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
      *
      * @since   4.0.0
      */
-    public function onAfterDisconnect(ConnectionEvent $event)
+    public function onAfterDisconnect(ConnectionEvent $event): void
     {
         if (!JDEBUG) {
             return;
@@ -657,11 +664,13 @@ final class Debug extends CMSPlugin implements SubscriberInterface
     /**
      * Add server timing headers when profile is activated.
      *
+     * @param   BeforeRespondEvent  $event  The event instance.
+     *
      * @return  void
      *
      * @since   4.1.0
      */
-    public function onBeforeRespond(): void
+    public function onBeforeRespond(BeforeRespondEvent $event): void
     {
         if (!JDEBUG || !$this->params->get('profile', 1)) {
             return;

--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -175,7 +175,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
         $this->setApplication($app);
         $this->setDatabase($db);
 
-        $app  = $this->getApplication();
+        $app = $this->getApplication();
 
         $this->debugLang = $app->get('debug_lang');
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR makes some small improvement to System  - Debug plugin code:

- Add missing parameter $event for event listener methods
- Declare void return type for event listener mehods
- Introduce local $app variable to avoid repeat call to $this->getApplication() to get application object
- Minor improvement to isAuthorisedDisplayDebug code: Remove use of deprecated get method to get user groups and hopefully the code is easier to read.


### Testing Instructions
- Use Joomla 5.3 nightly build
- Make sure System - Debug plugin is enabled
- Go to System - Global Configuration, set **Debug System** to **Yes**
- Check and make sure Debug plugin still works as before

### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed