### PR TITLE
[5.3] Revert new option and db column from PR 44640 and always exclude current user from email notifications

### DIFF
--- a/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
@@ -126,7 +126,7 @@ class ActionlogModel extends BaseDatabaseModel implements UserFactoryAwareInterf
         $query = $db->getQuery(true);
 
         $query
-            ->select($db->quoteName(['u.email', 'u.username', 'l.extensions', 'l.exclude_self']))
+            ->select($db->quoteName(['u.email', 'u.username', 'l.extensions']))
             ->from($db->quoteName('#__users', 'u'))
             ->where($db->quoteName('u.block') . ' = 0')
             ->join(
@@ -142,7 +142,7 @@ class ActionlogModel extends BaseDatabaseModel implements UserFactoryAwareInterf
         $recipients = [];
 
         foreach ($users as $user) {
-            if ($user->username === $this->getCurrentUser()->username && $user->exclude_self) {
+            if ($user->username === $this->getCurrentUser()->username) {
                 continue;
             }
 

--- a/administrator/components/com_admin/sql/updates/mysql/5.3.0-2024-12-19.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.3.0-2024-12-19.sql
@@ -1,6 +1,6 @@
 -- --------------------------------------------------------
 -- The following statement which was introduced with 5.3.0-alpha3
 -- has been disabled as it was reverted with 5.3.0-beta1.
--- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+-- See https://github.com/joomla/joomla-cms/pull/44846 for details.
 --
 -- ALTER TABLE `#__action_logs_users` ADD COLUMN `exclude_self` tinyint NOT NULL DEFAULT 0;

--- a/administrator/components/com_admin/sql/updates/mysql/5.3.0-2024-12-19.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.3.0-2024-12-19.sql
@@ -1,1 +1,6 @@
-ALTER TABLE `#__action_logs_users` ADD COLUMN `exclude_self` tinyint NOT NULL DEFAULT 0;
+-- --------------------------------------------------------
+-- The following statement which was introduced with 5.3.0-alpha3
+-- has been disabled as it was reverted with 5.3.0-beta1.
+-- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+--
+-- ALTER TABLE `#__action_logs_users` ADD COLUMN `exclude_self` tinyint NOT NULL DEFAULT 0;

--- a/administrator/components/com_admin/sql/updates/mysql/5.3.0-2025-02-09.sql
+++ b/administrator/components/com_admin/sql/updates/mysql/5.3.0-2025-02-09.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `#__action_logs_users` DROP COLUMN `exclude_self` /** CAN FAIL **/;

--- a/administrator/components/com_admin/sql/updates/postgresql/5.3.0-2024-12-19.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.3.0-2024-12-19.sql
@@ -1,1 +1,6 @@
-ALTER TABLE "#__action_logs_users" ADD COLUMN "exclude_self" integer DEFAULT 0 NOT NULL;
+-- --------------------------------------------------------
+-- The following statement which was introduced with 5.3.0-alpha3
+-- has been disabled as it was reverted with 5.3.0-beta1.
+-- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+--
+-- ALTER TABLE "#__action_logs_users" ADD COLUMN "exclude_self" integer DEFAULT 0 NOT NULL;

--- a/administrator/components/com_admin/sql/updates/postgresql/5.3.0-2024-12-19.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.3.0-2024-12-19.sql
@@ -1,6 +1,6 @@
 -- --------------------------------------------------------
 -- The following statement which was introduced with 5.3.0-alpha3
 -- has been disabled as it was reverted with 5.3.0-beta1.
--- See https://github.com/joomla/joomla-cms/pull/XXXXX for details.
+-- See https://github.com/joomla/joomla-cms/pull/44846 for details.
 --
 -- ALTER TABLE "#__action_logs_users" ADD COLUMN "exclude_self" integer DEFAULT 0 NOT NULL;

--- a/administrator/components/com_admin/sql/updates/postgresql/5.3.0-2025-02-09.sql
+++ b/administrator/components/com_admin/sql/updates/postgresql/5.3.0-2025-02-09.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "#__action_logs_users" DROP COLUMN "exclude_self" /** CAN FAIL **/;

--- a/administrator/language/en-GB/plg_system_actionlogs.ini
+++ b/administrator/language/en-GB/plg_system_actionlogs.ini
@@ -10,7 +10,6 @@ PLG_SYSTEM_ACTIONLOGS_INFO_LABEL="Information"
 PLG_SYSTEM_ACTIONLOGS_JOOMLA_ACTIONLOG_DISABLED="Action Log - Joomla"
 PLG_SYSTEM_ACTIONLOGS_JOOMLA_ACTIONLOG_DISABLED_REDIRECT="The %s plugin is disabled."
 PLG_SYSTEM_ACTIONLOGS_NOTIFICATIONS="Email Notifications"
-PLG_SYSTEM_ACTIONLOGS_NOTIFICATIONS_EXCLUDE="Exclude Self"
 PLG_SYSTEM_ACTIONLOGS_OPTIONS="User Actions Log Options"
 PLG_SYSTEM_ACTIONLOGS_XML_DESCRIPTION="Records the actions of users on the site so they can be reviewed if required."
 ; Common content type log messages

--- a/installation/sql/mysql/extensions.sql
+++ b/installation/sql/mysql/extensions.sql
@@ -887,7 +887,6 @@ CREATE TABLE IF NOT EXISTS `#__action_logs_users` (
   `user_id` int UNSIGNED NOT NULL,
   `notify` tinyint UNSIGNED NOT NULL,
   `extensions` text NOT NULL,
-  `exclude_self` tinyint UNSIGNED NOT NULL DEFAULT 0,
   PRIMARY KEY (`user_id`),
   KEY `idx_notify` (`notify`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 DEFAULT COLLATE=utf8mb4_unicode_ci;

--- a/installation/sql/postgresql/extensions.sql
+++ b/installation/sql/postgresql/extensions.sql
@@ -848,7 +848,6 @@ CREATE TABLE "#__action_logs_users" (
   "user_id" integer NOT NULL,
   "notify" integer NOT NULL,
   "extensions" text NOT NULL,
-  "exclude_self" integer NOT NULL DEFAULT 0,
   PRIMARY KEY ("user_id")
 );
 

--- a/plugins/system/actionlogs/forms/actionlogs.xml
+++ b/plugins/system/actionlogs/forms/actionlogs.xml
@@ -24,18 +24,6 @@
 				showon="actionlogsNotify:1"
 				default="com_content"
 			/>
-			<field
-				name="actionlogsExcludeSelf"
-				type="radio"
-				label="PLG_SYSTEM_ACTIONLOGS_NOTIFICATIONS_EXCLUDE"
-				layout="joomla.form.field.radio.switcher"
-				showon="actionlogsNotify:1"
-				default="0"
-				filter="integer"
-				>
-				<option value="0">JNO</option>
-				<option value="1">JYES</option>
-			</field>
 		</fields>
 	</fieldset>
 </form>

--- a/plugins/system/actionlogs/src/Extension/ActionLogs.php
+++ b/plugins/system/actionlogs/src/Extension/ActionLogs.php
@@ -175,7 +175,7 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
         $id = (int) $data->id;
 
         $query = $db->getQuery(true)
-            ->select($db->quoteName(['notify', 'extensions', 'exclude_self']))
+            ->select($db->quoteName(['notify', 'extensions']))
             ->from($db->quoteName('#__action_logs_users'))
             ->where($db->quoteName('user_id') . ' = :userid')
             ->bind(':userid', $id, ParameterType::INTEGER);
@@ -193,10 +193,9 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
         // Load plugin language files.
         $this->loadLanguage();
 
-        $data->actionlogs                        = new \stdClass();
-        $data->actionlogs->actionlogsNotify      = $values->notify;
-        $data->actionlogs->actionlogsExtensions  = $values->extensions;
-        $data->actionlogs->actionlogsExcludeSelf = $values->exclude_self;
+        $data->actionlogs                       = new \stdClass();
+        $data->actionlogs->actionlogsNotify     = $values->notify;
+        $data->actionlogs->actionlogsExtensions = $values->extensions;
 
         if (!HTMLHelper::isRegistered('users.actionlogsNotify')) {
             HTMLHelper::register('users.actionlogsNotify', [__CLASS__, 'renderActionlogsNotify']);
@@ -204,10 +203,6 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
 
         if (!HTMLHelper::isRegistered('users.actionlogsExtensions')) {
             HTMLHelper::register('users.actionlogsExtensions', [__CLASS__, 'renderActionlogsExtensions']);
-        }
-
-        if (!HTMLHelper::isRegistered('users.actionlogsExcludeSelf')) {
-            HTMLHelper::register('users.actionlogsExcludeSelf', [__CLASS__, 'renderActionlogsExcludeSelf']);
         }
     }
 
@@ -253,10 +248,9 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
         // If preferences don't exist, insert.
         if (!$exists && $authorised && isset($user['actionlogs'])) {
             $notify  = (int) $user['actionlogs']['actionlogsNotify'];
-            $exclude = (int) $user['actionlogs']['actionlogsExcludeSelf'];
-            $values  = [':userid', ':notify', ':exclude'];
-            $bind    = [$userid, $notify, $exclude];
-            $columns = ['user_id', 'notify', 'exclude_self'];
+            $values  = [':userid', ':notify'];
+            $bind    = [$userid, $notify];
+            $columns = ['user_id', 'notify'];
 
             $query->bind($values, $bind, ParameterType::INTEGER);
 
@@ -276,11 +270,6 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
             $values = [$db->quoteName('notify') . ' = :notify'];
 
             $query->bind(':notify', $notify, ParameterType::INTEGER);
-
-            $exclude  = (int) $user['actionlogs']['actionlogsExcludeSelf'];
-            $values[] = $db->quoteName('exclude_self') . ' = :exclude';
-
-            $query->bind(':exclude', $exclude, ParameterType::INTEGER);
 
             if (isset($user['actionlogs']['actionlogsExtensions'])) {
                 $values[]  = $db->quoteName('extensions') . ' = :extension';
@@ -356,20 +345,6 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
     }
 
     /**
-     * Method to render a value.
-     *
-     * @param   integer|string  $value  The value (0 or 1).
-     *
-     * @return  string  The rendered value.
-     *
-     * @since   5.3.0
-     */
-    public static function renderActionlogsExcludeSelf($value)
-    {
-        return Text::_($value ? 'JYES' : 'JNO');
-    }
-
-    /**
      * Method to render a list of extensions.
      *
      * @param   array|string  $extensions  Array of extensions or an empty string if none selected.
@@ -419,7 +394,7 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
         $db = $this->getDatabase();
 
         $query = $db->getQuery(true)
-            ->select($db->quoteName(['user_id', 'notify', 'extensions', 'exclude_self']))
+            ->select($db->quoteName(['user_id', 'notify', 'extensions']))
             ->from($db->quoteName('#__action_logs_users'));
 
         try {


### PR DESCRIPTION
Pull Request for Issue #44827 - alternative 2 .

The other alternative would be PR #44845 .

### Summary of Changes

This pull request (PR) reverts the action log system plugin's configuration option and the corresponding database column in the `#__action_logs_users` table, which were added with PR #44640 and released with 5.3.0-alpha3, and changes code so that the current user is always excluded from email notifications.

The code could possibly be improved so that certain kinds of actions would not be excluded.

### Testing Instructions

_Will be added sooner or later._

### Actual result BEFORE applying this Pull Request

_Will be added sooner or later._

### Expected result AFTER applying this Pull Request

_Will be added sooner or later._

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
