### PR TITLE
[5.3] Improve System - Keyboard Shortcuts plugin code

### DIFF
--- a/plugins/system/shortcut/src/Extension/Shortcut.php
+++ b/plugins/system/shortcut/src/Extension/Shortcut.php
@@ -10,6 +10,7 @@
 
 namespace Joomla\Plugin\System\Shortcut\Extension;
 
+use Joomla\CMS\Event\Application\BeforeCompileHeadEvent;
 use Joomla\CMS\Event\GenericEvent;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Plugin\CMSPlugin;
@@ -57,20 +58,23 @@ final class Shortcut extends CMSPlugin implements SubscriberInterface
     /**
      * Add the javascript for the shortcuts
      *
+     * @param   BeforeCompileHeadEvent  $event  The event instance.
+     *
      * @return  void
      *
      * @since   4.2.0
      */
-    public function initialize()
+    public function initialize(BeforeCompileHeadEvent $event): void
     {
-        if (!$this->getApplication()->isClient('administrator')) {
+        $app = $event->getApplication();
+        if (!$app->isClient('administrator')) {
             return;
         }
 
         // Load translations
         $this->loadLanguage();
 
-        $context = $this->getApplication()->getInput()->get('option') . '.' . $this->getApplication()->getInput()->get('view');
+        $context = $app->getInput()->get('option') . '.' . $app->getInput()->get('view');
 
         $shortcuts = [];
 
@@ -92,7 +96,7 @@ final class Shortcut extends CMSPlugin implements SubscriberInterface
         Text::script('PLG_SYSTEM_SHORTCUT_THEN');
         Text::script('JCLOSE');
 
-        $document = $this->getApplication()->getDocument();
+        $document = $app->getDocument();
         $wa       = $document->getWebAssetManager();
         $wa->registerAndUseScript(
             'plg_system_shortcut.shortcut',
@@ -111,28 +115,29 @@ final class Shortcut extends CMSPlugin implements SubscriberInterface
     /**
      * Add default shortcuts to the document
      *
-     * @param   Event  $event  The event
+     * @param   Event  $event  The event instance.
      *
      * @return  void
      *
      * @since   4.2.0
      */
-    public function addShortcuts(Event $event)
+    public function addShortcuts(Event $event): void
     {
         $shortcuts = $event->getArgument('shortcuts', []);
 
+        $language  = $this->getApplication()->getLanguage();
         $shortcuts = array_merge(
             $shortcuts,
             [
-                'applyKey'   => (object) ['selector' => 'joomla-toolbar-button .button-apply', 'shortcut' => 'A', 'title' => $this->getApplication()->getLanguage()->_('JAPPLY')],
-                'saveKey'    => (object) ['selector' => 'joomla-toolbar-button .button-save', 'shortcut' => 'S', 'title' => $this->getApplication()->getLanguage()->_('JTOOLBAR_SAVE')],
-                'cancelKey'  => (object) ['selector' => 'joomla-toolbar-button .button-cancel', 'shortcut' => 'Q', 'title' => $this->getApplication()->getLanguage()->_('JCANCEL')],
-                'newKey'     => (object) ['selector' => 'joomla-toolbar-button .button-new', 'shortcut' => 'N', 'title' => $this->getApplication()->getLanguage()->_('JTOOLBAR_NEW')],
-                'searchKey'  => (object) ['selector' => 'input[placeholder=' . $this->getApplication()->getLanguage()->_('JSEARCH_FILTER') . ']', 'shortcut' => 'F', 'title' => $this->getApplication()->getLanguage()->_('JSEARCH_FILTER')],
-                'optionKey'  => (object) ['selector' => 'joomla-toolbar-button .button-options', 'shortcut' => 'O', 'title' => $this->getApplication()->getLanguage()->_('JOPTIONS')],
-                'helpKey'    => (object) ['selector' => 'joomla-toolbar-button .button-help', 'shortcut' => 'H', 'title' => $this->getApplication()->getLanguage()->_('JHELP')],
-                'toggleMenu' => (object) ['selector' => '#menu-collapse', 'shortcut' => 'M', 'title' => $this->getApplication()->getLanguage()->_('JTOGGLE_SIDEBAR_MENU')],
-                'dashboard'  => (object) ['selector' => (string) new Uri(Route::_('index.php?')), 'shortcut' => 'D', 'title' => $this->getApplication()->getLanguage()->_('JHOMEDASHBOARD')],
+                'applyKey'   => (object) ['selector' => 'joomla-toolbar-button .button-apply', 'shortcut' => 'A', 'title' => $language->_('JAPPLY')],
+                'saveKey'    => (object) ['selector' => 'joomla-toolbar-button .button-save', 'shortcut' => 'S', 'title' => $language->_('JTOOLBAR_SAVE')],
+                'cancelKey'  => (object) ['selector' => 'joomla-toolbar-button .button-cancel', 'shortcut' => 'Q', 'title' => $language->_('JCANCEL')],
+                'newKey'     => (object) ['selector' => 'joomla-toolbar-button .button-new', 'shortcut' => 'N', 'title' => $language->_('JTOOLBAR_NEW')],
+                'searchKey'  => (object) ['selector' => 'input[placeholder=' . $language->_('JSEARCH_FILTER') . ']', 'shortcut' => 'F', 'title' => $language->_('JSEARCH_FILTER')],
+                'optionKey'  => (object) ['selector' => 'joomla-toolbar-button .button-options', 'shortcut' => 'O', 'title' => $language->_('JOPTIONS')],
+                'helpKey'    => (object) ['selector' => 'joomla-toolbar-button .button-help', 'shortcut' => 'H', 'title' => $language->_('JHELP')],
+                'toggleMenu' => (object) ['selector' => '#menu-collapse', 'shortcut' => 'M', 'title' => $language->_('JTOGGLE_SIDEBAR_MENU')],
+                'dashboard'  => (object) ['selector' => (string) new Uri(Route::_('index.php?')), 'shortcut' => 'D', 'title' => $language->_('JHOMEDASHBOARD')],
             ]
         );
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Like similar PRs, this PR improves code of **System - Keyboard Shortcuts**:

- Introduce local variables $app, $language to avoid repeat call to methods to get object. That would make the system runs slight faster.
- Add missing $event parameter for initialize method
- Declare void return type for event listener methods

### Testing Instructions
- Use Joomla 5.3 nightly build
- Apply patch, confirm that Keyboard Shortcuts still work as before. For example, go to Articles Management screen, press **J**, then **N** and confirm that add article screen is displayed (same as you press New button in the toolbar)


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
