### PR TITLE
[5.3] Improve system skipto plugin code

### DIFF
--- a/plugins/system/skipto/src/Extension/Skipto.php
+++ b/plugins/system/skipto/src/Extension/Skipto.php
@@ -73,6 +73,7 @@ final class Skipto extends CMSPlugin implements SubscriberInterface
         $this->loadLanguage();
 
         // Add plugin settings and strings for translations in JavaScript.
+        $language = $app->getLanguage();
         $document->addScriptOptions(
             'skipto-settings',
             [
@@ -87,24 +88,24 @@ final class Skipto extends CMSPlugin implements SubscriberInterface
                         'displayOption' => 'popup',
 
                         // Button labels and messages
-                        'buttonLabel'            => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_TITLE'),
-                        'buttonTooltipAccesskey' => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_ACCESS_KEY'),
+                        'buttonLabel'            => $language->_('PLG_SYSTEM_SKIPTO_TITLE'),
+                        'buttonTooltipAccesskey' => $language->_('PLG_SYSTEM_SKIPTO_ACCESS_KEY'),
 
                         // Menu labels and messages
-                        'landmarkGroupLabel'  => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_LANDMARK'),
-                        'headingGroupLabel'   => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_HEADING'),
-                        'mofnGroupLabel'      => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_HEADING_MOFN'),
-                        'headingLevelLabel'   => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_HEADING_LEVEL'),
-                        'mainLabel'           => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_LANDMARK_MAIN'),
-                        'searchLabel'         => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_LANDMARK_SEARCH'),
-                        'navLabel'            => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_LANDMARK_NAV'),
-                        'regionLabel'         => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_LANDMARK_REGION'),
-                        'asideLabel'          => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_LANDMARK_ASIDE'),
-                        'footerLabel'         => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_LANDMARK_FOOTER'),
-                        'headerLabel'         => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_LANDMARK_HEADER'),
-                        'formLabel'           => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_LANDMARK_FORM'),
-                        'msgNoLandmarksFound' => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_LANDMARK_NONE'),
-                        'msgNoHeadingsFound'  => $app->getLanguage()->_('PLG_SYSTEM_SKIPTO_HEADING_NONE'),
+                        'landmarkGroupLabel'  => $language->_('PLG_SYSTEM_SKIPTO_LANDMARK'),
+                        'headingGroupLabel'   => $language->_('PLG_SYSTEM_SKIPTO_HEADING'),
+                        'mofnGroupLabel'      => $language->_('PLG_SYSTEM_SKIPTO_HEADING_MOFN'),
+                        'headingLevelLabel'   => $language->_('PLG_SYSTEM_SKIPTO_HEADING_LEVEL'),
+                        'mainLabel'           => $language->_('PLG_SYSTEM_SKIPTO_LANDMARK_MAIN'),
+                        'searchLabel'         => $language->_('PLG_SYSTEM_SKIPTO_LANDMARK_SEARCH'),
+                        'navLabel'            => $language->_('PLG_SYSTEM_SKIPTO_LANDMARK_NAV'),
+                        'regionLabel'         => $language->_('PLG_SYSTEM_SKIPTO_LANDMARK_REGION'),
+                        'asideLabel'          => $language->_('PLG_SYSTEM_SKIPTO_LANDMARK_ASIDE'),
+                        'footerLabel'         => $language->_('PLG_SYSTEM_SKIPTO_LANDMARK_FOOTER'),
+                        'headerLabel'         => $language->_('PLG_SYSTEM_SKIPTO_LANDMARK_HEADER'),
+                        'formLabel'           => $language->_('PLG_SYSTEM_SKIPTO_LANDMARK_FORM'),
+                        'msgNoLandmarksFound' => $language->_('PLG_SYSTEM_SKIPTO_LANDMARK_NONE'),
+                        'msgNoHeadingsFound'  => $language->_('PLG_SYSTEM_SKIPTO_HEADING_NONE'),
 
                         // Selectors for landmark and headings sections
                         'headings'  => 'h1, h2, h3',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Just a small change to System - Skip-To Navigation plugin: Introduce $language variable to avoid repeat call to get language object.

### Testing Instructions
- Honestly, I do not know how to use this feature. So if you want to test it, just use Joomla 5.3, then apply patch, access to administrator area of your site and confirm that it is still loading OK.
- Code review should be enough, too. It is just a simple change, and I am not doing this by hand. I just use phpstorm refactor feature to introduce this variable, so that should not be any mistake


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
