### PR TITLE
[5.2][system tests] Do not delete tuf metadata

### DIFF
--- a/tests/System/plugins/db.mjs
+++ b/tests/System/plugins/db.mjs
@@ -159,6 +159,11 @@ function deleteInsertedItems(config) {
       return;
     }
 
+    // Ignore tuf_metadata
+    if (item.table === `${config.env.db_prefix}tuf_metadata`) {
+      return;
+    }
+
     // Delete the items from the database
     promises.push(queryTestDB(`DELETE FROM ${item.table} WHERE id IN (${item.rows.join(',')})`, config).then(() => {
       // Cleanup some tables we do not have control over from inserted items


### PR DESCRIPTION
Pull Request for Issue #44859 .

### Summary of Changes

Do not delete `tuf_metadata` in afterEach() `cleanupDB`

### Testing Instructions

- run specs `tests/System/integration/administrator/components/com_joomlaupdate/Update.cy.js`
- check content of `tuf_metadata` table

### Actual result BEFORE applying this Pull Request

table is empty

### Expected result AFTER applying this Pull Request

one entry with id=1

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
