### PR TITLE
[5.2] Set column alias for BannerTable, fix warning on Save As Copy

### DIFF
--- a/administrator/components/com_banners/src/Table/BannerTable.php
+++ b/administrator/components/com_banners/src/Table/BannerTable.php
@@ -57,6 +57,7 @@ class BannerTable extends Table implements VersionableTableInterface
 
         $this->created = Factory::getDate()->toSql();
         $this->setColumnAlias('published', 'state');
+        $this->setColumnAlias('title', 'name');
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #44863.

### Summary of Changes
This PR fixes small issue reported as https://github.com/joomla/joomla-cms/issues/44863


### Testing Instructions
- Use Joomla 5.2
- See https://github.com/joomla/joomla-cms/issues/44863, confirm the issue
- Apply patch, confirm the issue fixed.

### Actual result BEFORE applying this Pull Request
- There is warning on PHP error log when Save As Copy a banner


### Expected result AFTER applying this Pull Request
- No warning anymore


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
