### PR TITLE
[5.3] Copy the cypress config to not interfere with the cs task

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -135,7 +135,7 @@ steps:
     environment:
       CYPRESS_VERIFY_TIMEOUT: 100000
     commands:
-      - mv cypress.config.dist.mjs cypress.config.mjs
+      - cp cypress.config.dist.mjs cypress.config.mjs
       - npx cypress install
       - npx cypress verify
 
@@ -433,6 +433,6 @@ trigger:
 
 ---
 kind: signature
-hmac: caca91b7aa40832a891260e03c42f8b7fc31b6971d201bf69291a87b158d5ce7
+hmac: fedcefde305c98f4dfc926b9039f83692827337da9e689e423c9de93a97248dd
 
 ...


### PR DESCRIPTION
### Summary of Changes
The javascript code style task does also check the `cypress.config.dist.mjs` file. Unfortunately when the  prepare_system_tests runs at the same time, he moves the file and the following error happens. Better to copy it.

```
+ npm run lint:js

> joomla@5.3.0 lint:js

> eslint --config build/.eslintrc --ignore-pattern '/media/' --ext .mjs,.es6.js,.es6,.vue --max-warnings=0 .

Oops! Something went wrong! :(

ESLint: 8.57.1

Error: ENOENT: no such file or directory, open '/drone/src/cypress.config.dist.mjs'

    at Object.readFileSync (node:fs:443:20)

    at CLIEngine.executeOnFiles (/drone/src/node_modules/eslint/lib/cli-engine/cli-engine.js:835:26)

    at ESLint.lintFiles (/drone/src/node_modules/eslint/lib/eslint/eslint.js:551:23)

    at Object.execute (/drone/src/node_modules/eslint/lib/cli.js:421:36)

    at async main (/drone/src/node_modules/eslint/bin/eslint.js:152:22)
```