### PR TITLE
[5.3] Use str_ends_with for components code

### DIFF
--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -884,7 +884,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
         }
 
         // We are creating a new item so we don't have an item id so don't allow.
-        if (substr($permission['component'], -6) === '.false') {
+        if (str_ends_with($permission['component'], '.false')) {
             $app->enqueueMessage(Text::_('JLIB_RULES_SAVE_BEFORE_CHANGE_PERMISSIONS'), 'error');
 
             return false;

--- a/administrator/components/com_joomlaupdate/extract.php
+++ b/administrator/components/com_joomlaupdate/extract.php
@@ -1316,7 +1316,7 @@ class ZIPExtraction
      */
     private function isIgnoredDirectory(string $shortFilename): bool
     {
-        $check = substr($shortFilename, -1) == '/' ? rtrim($shortFilename, '/') : \dirname($shortFilename);
+        $check = str_ends_with($shortFilename, '/') ? rtrim($shortFilename, '/') : \dirname($shortFilename);
 
         return \in_array($check, $this->ignoreDirectories);
     }
@@ -1375,7 +1375,7 @@ class ZIPExtraction
         }
 
         // Remove any trailing slash
-        if (substr($filename, -1) == '/') {
+        if (str_ends_with($filename, '/')) {
             $filename = substr($filename, 0, -1);
         }
 

--- a/administrator/components/com_joomlaupdate/finalisation.php
+++ b/administrator/components/com_joomlaupdate/finalisation.php
@@ -201,7 +201,7 @@ namespace Joomla\Filesystem
              */
             public static function delete(string $folderName): bool
             {
-                if (substr($folderName, -1) == '/') {
+                if (str_ends_with($folderName, '/')) {
                     $folderName = substr($folderName, 0, -1);
                 }
 

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -1101,7 +1101,7 @@ class TemplateModel extends FormModel
                         $path = $folder . '/' . $view . '/tmpl';
 
                         // The new scheme, the views are directly in the component/tmpl folder
-                        if (!is_dir($path) && substr($folder, -4) == 'tmpl') {
+                        if (!is_dir($path) && str_ends_with($folder, 'tmpl')) {
                             $path = $folder . '/' . $view;
                         }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses [StrEndsWithRector](https://getrector.com/rule-detail/str-ends-with-rector) rector to convert code of our components to use `str_ends_with`  function. This is done automatically by rector, no manual change included.


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner, easier to read code

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
