### PR TITLE
[5.3] Use str_contains function for components

### DIFF
--- a/administrator/components/com_associations/src/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/src/Helper/AssociationsHelper.php
@@ -193,7 +193,7 @@ class AssociationsHelper extends ContentHelper
      */
     private static function getExtensionRealName($extensionName)
     {
-        return strpos($extensionName, 'com_') === false ? $extensionName : substr($extensionName, 4);
+        return !str_contains($extensionName, 'com_') ? $extensionName : substr($extensionName, 4);
     }
 
     /**

--- a/administrator/components/com_categories/src/Field/CategoryeditField.php
+++ b/administrator/components/com_categories/src/Field/CategoryeditField.php
@@ -196,7 +196,7 @@ class CategoryeditField extends ListField
 
         // Filter language
         if (!empty($this->element['language'])) {
-            if (strpos($this->element['language'], ',') !== false) {
+            if (str_contains($this->element['language'], ',')) {
                 $language = explode(',', $this->element['language']);
             } else {
                 $language = $this->element['language'];

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -959,7 +959,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
                 /** @var Asset $parentAsset */
                 $parentAsset = Table::getInstance('Asset');
 
-                if (strpos($asset->name, '.') !== false) {
+                if (str_contains($asset->name, '.')) {
                     $assetParts = explode('.', $asset->name);
                     $parentAsset->loadByName($assetParts[0]);
                     $parentAssetId = $parentAsset->id;

--- a/administrator/components/com_content/src/Event/Model/FeatureEvent.php
+++ b/administrator/components/com_content/src/Event/Model/FeatureEvent.php
@@ -42,7 +42,7 @@ class FeatureEvent extends AbstractImmutableEvent
             throw new \BadMethodCallException("Argument 'extension' of event $this->name is not of type 'string'");
         }
 
-        if (strpos($arguments['extension'], '.') === false) {
+        if (!str_contains($arguments['extension'], '.')) {
             throw new \BadMethodCallException("Argument 'extension' of event $this->name has wrong format. Valid format: 'component.section'");
         }
 

--- a/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
+++ b/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
@@ -69,7 +69,7 @@ class HtmlView extends BaseHtmlView
             $parts     = explode('.', $dashboard);
             $component = $parts[0];
 
-            if (strpos($component, 'com_') === false) {
+            if (!str_contains($component, 'com_')) {
                 $component = 'com_' . $component;
             }
 

--- a/administrator/components/com_guidedtours/src/Model/StepModel.php
+++ b/administrator/components/com_guidedtours/src/Model/StepModel.php
@@ -81,7 +81,7 @@ class StepModel extends AdminModel
         $tour->load($data['tour_id']);
 
         // Language keys must include GUIDEDTOUR to prevent save issues
-        if (strpos($data['description'], 'GUIDEDTOUR') !== false) {
+        if (str_contains($data['description'], 'GUIDEDTOUR')) {
             $data['description'] = strip_tags($data['description']);
         }
 

--- a/administrator/components/com_guidedtours/src/Model/TourModel.php
+++ b/administrator/components/com_guidedtours/src/Model/TourModel.php
@@ -63,7 +63,7 @@ class TourModel extends AdminModel
         $input = Factory::getApplication()->getInput();
 
         // Language keys must include GUIDEDTOUR to prevent save issues
-        if (strpos($data['description'], 'GUIDEDTOUR') !== false) {
+        if (str_contains($data['description'], 'GUIDEDTOUR')) {
             $data['description'] = strip_tags($data['description']);
         }
 

--- a/administrator/components/com_installer/src/Model/LanguagesModel.php
+++ b/administrator/components/com_installer/src/Model/LanguagesModel.php
@@ -166,8 +166,8 @@ class LanguagesModel extends ListModel
 
             if ($search) {
                 if (
-                    strpos(strtolower($language->name), $search) === false
-                    && strpos(strtolower($language->element), $search) === false
+                    !str_contains(strtolower($language->name), $search)
+                    && !str_contains(strtolower($language->element), $search)
                 ) {
                     continue;
                 }

--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -253,7 +253,7 @@ class ManageModel extends InstallerModel
             $langstring = 'COM_INSTALLER_TYPE_TYPE_' . strtoupper($row->type);
             $rowtype    = Text::_($langstring);
 
-            if (strpos($rowtype, $langstring) !== false) {
+            if (str_contains($rowtype, $langstring)) {
                 $rowtype = $row->type;
             }
 

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -421,7 +421,7 @@ class UpdateModel extends ListModel
         $sources = $update->get('downloadSources', []);
 
         if ($extra_query = $update->get('extra_query')) {
-            $url .= (strpos($url, '?') === false) ? '?' : '&amp;';
+            $url .= (!str_contains($url, '?')) ? '?' : '&amp;';
             $url .= $extra_query;
         }
 
@@ -432,7 +432,7 @@ class UpdateModel extends ListModel
             $url  = trim($name->url);
 
             if ($extra_query) {
-                $url .= (strpos($url, '?') === false) ? '?' : '&amp;';
+                $url .= (!str_contains($url, '?')) ? '?' : '&amp;';
                 $url .= $extra_query;
             }
 

--- a/administrator/components/com_joomlaupdate/extract.php
+++ b/administrator/components/com_joomlaupdate/extract.php
@@ -567,7 +567,7 @@ class ZIPExtraction
     public function setFilename(string $value)
     {
         // Security check: disallow remote filenames
-        if (!empty($value) && strpos($value, '://') !== false) {
+        if (!empty($value) && str_contains($value, '://')) {
             $this->setError('Invalid archive location');
 
             return;

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -404,7 +404,7 @@ class UpdateModel extends BaseDatabaseModel
         // Remove protocol, path and query string from URL
         $basename = basename($packageURL);
 
-        if (strpos($basename, '?') !== false) {
+        if (str_contains($basename, '?')) {
             $basename = substr($basename, 0, strpos($basename, '?'));
         }
 

--- a/administrator/components/com_languages/src/Model/StringsModel.php
+++ b/administrator/components/com_languages/src/Model/StringsModel.php
@@ -90,7 +90,7 @@ class StringsModel extends BaseDatabaseModel
         // Parse all found ini files and add the strings to the database cache.
         foreach ($files as $file) {
             // Only process if language file is for selected language
-            if (strpos($file, $language, \strlen($base)) === false) {
+            if (!str_contains(substr($file, \strlen($base)), $language)) {
                 continue;
             }
 

--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -82,7 +82,7 @@ class DisplayController extends BaseController
 
         $app->login($credentials, ['action' => 'core.login.admin']);
 
-        if (Uri::isInternal($return) && strpos($return, 'tmpl=component') === false) {
+        if (Uri::isInternal($return) && !str_contains($return, 'tmpl=component')) {
             $app->redirect($return);
         } else {
             $app->redirect('index.php');

--- a/administrator/components/com_menus/src/Model/ItemsModel.php
+++ b/administrator/components/com_menus/src/Model/ItemsModel.php
@@ -497,7 +497,7 @@ class ItemsModel extends ListModel
         if ($name == 'com_menus.items.filter') {
             $clientId = $this->getState('filter.client_id');
             $form->setFieldAttribute('menutype', 'clientid', $clientId);
-        } elseif (false !== strpos($name, 'com_menus.items.modal.')) {
+        } elseif (str_contains($name, 'com_menus.items.modal.')) {
             $form->removeField('client_id');
 
             $clientId = $this->getState('filter.client_id');

--- a/administrator/components/com_menus/src/Model/MenutypesModel.php
+++ b/administrator/components/com_menus/src/Model/MenutypesModel.php
@@ -470,7 +470,7 @@ class MenutypesModel extends BaseDatabaseModel
         // Build list of standard layout names
         foreach ($layouts as $layout) {
             // Ignore private layouts.
-            if (strpos(basename($layout), '_') === false) {
+            if (!str_contains(basename($layout), '_')) {
                 // Get the layout name.
                 $layoutNames[] = basename($layout, '.xml');
             }
@@ -509,7 +509,7 @@ class MenutypesModel extends BaseDatabaseModel
         // Process the found layouts.
         foreach ($layouts as $layout) {
             // Ignore private layouts.
-            if (strpos(basename($layout), '_') === false) {
+            if (!str_contains(basename($layout), '_')) {
                 $file = $layout;
 
                 // Get the layout name.

--- a/administrator/components/com_postinstall/src/Helper/PostinstallHelper.php
+++ b/administrator/components/com_postinstall/src/Helper/PostinstallHelper.php
@@ -32,9 +32,9 @@ class PostinstallHelper
      */
     public function parsePath($path)
     {
-        if (strpos($path, 'site://') !== false) {
+        if (str_contains($path, 'site://')) {
             $path = JPATH_ROOT . str_replace('site://', '/', $path);
-        } elseif (strpos($path, 'admin://') !== false) {
+        } elseif (str_contains($path, 'admin://')) {
             $path = JPATH_ADMINISTRATOR . str_replace('admin://', '/', $path);
         }
 

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -574,7 +574,7 @@ class TemplateModel extends FormModel
      */
     private function getSafeName($name)
     {
-        if (strpos($name, '-') !== false && preg_match('/[0-9]/', $name)) {
+        if (str_contains($name, '-') && preg_match('/[0-9]/', $name)) {
             // Get the extension
             $extension = File::getExt($name);
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses [StrContainsRector](https://getrector.com/rule-detail/str-contains-rector) rector rule to convert code of our components to use `str_contains`  function. This is done automatically by rector, no manual change included.


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner, easier to read code

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
