### PR TITLE
[5.2] PHP Deprecated: trim(): Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -172,11 +172,11 @@ class Category extends Nested implements VersionableTableInterface, TaggableTabl
             return false;
         }
 
-        $this->alias = trim($this->alias);
-
         if (empty($this->alias)) {
             $this->alias = $this->title;
         }
+
+        $this->alias = trim($this->alias);
 
         $this->alias = ApplicationHelper::stringURLSafe($this->alias, $this->language);
 

--- a/libraries/src/Table/Category.php
+++ b/libraries/src/Table/Category.php
@@ -172,11 +172,11 @@ class Category extends Nested implements VersionableTableInterface, TaggableTabl
             return false;
         }
 
+        $this->alias = trim($this->alias ?? '');
+
         if (empty($this->alias)) {
             $this->alias = $this->title;
         }
-
-        $this->alias = trim($this->alias);
 
         $this->alias = ApplicationHelper::stringURLSafe($this->alias, $this->language);
 


### PR DESCRIPTION
Pull Request for Issue ##44872 .

### Summary of Changes
fix PHP Deprecated: trim(): Passing null to parameter


### Testing Instructions
Set Error Reporting to Maximum.
Edit a banner.
Type in a new category.
Select Save & Close button.
See PHP error log:


### Actual result BEFORE applying this Pull Request
Deprecated


### Expected result AFTER applying this Pull Request

no more Deprecated

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
