### PR TITLE
[6.0] Extend lifespan of CMSObject and fix deprecations tags

### DIFF
--- a/libraries/src/Object/CMSObject.php
+++ b/libraries/src/Object/CMSObject.php
@@ -21,7 +21,7 @@ namespace Joomla\CMS\Object;
  *
  * @since       1.7.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.0 will be removed in 7.0
  *              Use \stdClass or \Joomla\Registry\Registry instead.
  *              Example: new \Joomla\Registry\Registry();
  */
@@ -52,7 +52,7 @@ class CMSObject extends \stdClass
      *
      * @since   1.7.0
      *
-     * @deprecated  4.3 will be removed in 6.0
+     * @deprecated  3.1.4 will be removed in 7.0
      *              Classes should provide their own __toString() implementation.
      */
     public function __toString()

--- a/libraries/src/Object/LegacyErrorHandlingTrait.php
+++ b/libraries/src/Object/LegacyErrorHandlingTrait.php
@@ -19,7 +19,7 @@ namespace Joomla\CMS\Object;
  *
  * @since       4.3.0
  *
- * @deprecated  4.3 will be removed in 6.0
+ * @deprecated  4.3 will be removed in 7.0
  *              Will be removed without replacement
  *              Throw an Exception instead of setError
  */
@@ -46,7 +46,7 @@ trait LegacyErrorHandlingTrait
      *
      * @since   1.7.0
      *
-     * @deprecated  3.1.4 will be removed in 6.0
+     * @deprecated  3.1.4 will be removed in 7.0
      *              Will be removed without replacement
      *              Catch thrown Exceptions instead of getError
      */
@@ -78,7 +78,7 @@ trait LegacyErrorHandlingTrait
      *
      * @since   1.7.0
      *
-     * @deprecated  3.1.4 will be removed in 6.0
+     * @deprecated  3.1.4 will be removed in 7.0
      *              Will be removed without replacement
      *              Catch thrown Exceptions instead of getErrors
      */
@@ -96,7 +96,7 @@ trait LegacyErrorHandlingTrait
      *
      * @since   1.7.0
      *
-     * @deprecated  3.1.4 will be removed in 6.0
+     * @deprecated  3.1.4 will be removed in 7.0
      *              Will be removed without replacement
      *              Throw an Exception instead of using setError
      */

--- a/libraries/src/Object/LegacyPropertyManagementTrait.php
+++ b/libraries/src/Object/LegacyPropertyManagementTrait.php
@@ -19,7 +19,7 @@ namespace Joomla\CMS\Object;
  *
  * @since       4.3.0
  *
- * @deprecated  4.3.0 will be removed in 6.0
+ * @deprecated  4.3.0 will be removed in 7.0
  *              Will be removed without replacement
  *              Create proper setter functions for the individual properties or use a \Joomla\Registry\Registry
  */
@@ -35,7 +35,7 @@ trait LegacyPropertyManagementTrait
      *
      * @since   1.7.0
      *
-     * @deprecated 4.3.0 will be removed in 6.0
+     * @deprecated 4.3.0 will be removed in 7.0
      *             Defining dynamic properties should not be used anymore
      */
     public function def($property, $default = null)
@@ -57,7 +57,7 @@ trait LegacyPropertyManagementTrait
      *
      * @see     CMSObject::getProperties()
      *
-     * @deprecated 4.3.0 will be removed in 6.0
+     * @deprecated 4.3.0 will be removed in 7.0
      *             Create a proper getter function for the property
      */
     public function get($property, $default = null)
@@ -80,7 +80,7 @@ trait LegacyPropertyManagementTrait
      *
      * @see     CMSObject::get()
      *
-     * @deprecated 4.3.0 will be removed in 6.0
+     * @deprecated 4.3.0 will be removed in 7.0
      *             Create a proper getter function for the property
      */
     public function getProperties($public = true)
@@ -126,7 +126,7 @@ trait LegacyPropertyManagementTrait
      *
      * @since   1.7.0
      *
-     * @deprecated 4.3.0 will be removed in 6.0
+     * @deprecated 4.3.0 will be removed in 7.0
      *             Create a proper setter function for the property
      */
     public function set($property, $value = null)
@@ -148,7 +148,7 @@ trait LegacyPropertyManagementTrait
      *
      * @see     CMSObject::set()
      *
-     * @deprecated 4.3.0 will be removed in 6.0
+     * @deprecated 4.3.0 will be removed in 7.0
      *             Create a proper setter function for the property
      */
     public function setProperties($properties)


### PR DESCRIPTION
### Summary of Changes
As all the traces of the `CMSObject` class got removed now in 6.0. We should extend it's lifespan for another major release at least. Additionally the old deprecation versions are restored.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/387
- [ ] No documentation changes for manual.joomla.org needed
