### PR TITLE
[5.3] Remove unnecessary array internal pointer resets

### DIFF
--- a/libraries/src/Form/Field/ChromestyleField.php
+++ b/libraries/src/Form/Field/ChromestyleField.php
@@ -155,8 +155,6 @@ class ChromestyleField extends GroupedlistField
             }
         }
 
-        reset($groups);
-
         return $groups;
     }
 

--- a/libraries/src/Form/Field/GroupedlistField.php
+++ b/libraries/src/Form/Field/GroupedlistField.php
@@ -142,8 +142,6 @@ class GroupedlistField extends FormField
             }
         }
 
-        reset($groups);
-
         return $groups;
     }
 

--- a/libraries/src/Form/Field/HeadertagField.php
+++ b/libraries/src/Form/Field/HeadertagField.php
@@ -48,8 +48,6 @@ class HeadertagField extends ListField
             $options[] = $tmp;
         }
 
-        reset($options);
-
         return $options;
     }
 }

--- a/libraries/src/Form/Field/ListField.php
+++ b/libraries/src/Form/Field/ListField.php
@@ -208,8 +208,6 @@ class ListField extends FormField
             array_unshift($options, $tmp);
         }
 
-        reset($options);
-
         return $options;
     }
 

--- a/libraries/src/Form/Field/ModuletagField.php
+++ b/libraries/src/Form/Field/ModuletagField.php
@@ -48,8 +48,6 @@ class ModuletagField extends ListField
             $options[] = $tmp;
         }
 
-        reset($options);
-
         return $options;
     }
 }


### PR DESCRIPTION
Code cleanup reported by PhpStorm inspections. The internal pointer is already set to the first element.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
