### PR TITLE
[5.3] Replace calls to dirname(__FILE) with __DIR__

### DIFF
--- a/administrator/components/com_joomlaupdate/extract.php
+++ b/administrator/components/com_joomlaupdate/extract.php
@@ -1956,7 +1956,7 @@ if ($enabled) {
             @unlink($basePath . 'update.php');
 
             // Import a custom finalisation file
-            $filename = \dirname(__FILE__) . '/finalisation.php';
+            $filename = __DIR__ . '/finalisation.php';
 
             if (file_exists($filename)) {
                 clearFileInOPCache($filename);

--- a/administrator/index.php
+++ b/administrator/index.php
@@ -29,4 +29,4 @@ if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<')) {
 \define('_JEXEC', 1);
 
 // Run the application - All executable code should be triggered through this file
-require_once \dirname(__FILE__) . '/includes/app.php';
+require_once __DIR__ . '/includes/app.php';

--- a/api/index.php
+++ b/api/index.php
@@ -28,4 +28,4 @@ if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<')) {
 \define('_JEXEC', 1);
 
 // Run the application - All executable code should be triggered through this file
-require_once \dirname(__FILE__) . '/includes/app.php';
+require_once __DIR__ . '/includes/app.php';

--- a/index.php
+++ b/index.php
@@ -29,4 +29,4 @@ if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<')) {
 define('_JEXEC', 1);
 
 // Run the application - All executable code should be triggered through this file
-require_once dirname(__FILE__) . '/includes/app.php';
+require_once __DIR__ . '/includes/app.php';

--- a/installation/index.php
+++ b/installation/index.php
@@ -29,4 +29,4 @@ if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<')) {
 \define('_JEXEC', 1);
 
 // Run the application - All executable code should be triggered through this file
-require_once \dirname(__FILE__) . '/includes/app.php';
+require_once __DIR__ . '/includes/app.php';

--- a/installation/joomla.php
+++ b/installation/joomla.php
@@ -36,4 +36,4 @@ if (version_compare(PHP_VERSION, JOOMLA_MINIMUM_PHP, '<')) {
 \define('_JCLI_INSTALLATION', 1);
 
 // Run the application - All executable code should be triggered through this file
-require_once \dirname(__FILE__) . '/includes/cli.php';
+require_once __DIR__ . '/includes/cli.php';


### PR DESCRIPTION
Use the `__DIR__` constant. It's shorter and doesn't require a function call.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
