### PR TITLE
[5.3] Replace str*() calls with more readable str_*() calls

### DIFF
--- a/administrator/components/com_associations/src/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/src/Helper/AssociationsHelper.php
@@ -193,7 +193,7 @@ class AssociationsHelper extends ContentHelper
      */
     private static function getExtensionRealName($extensionName)
     {
-        return strpos($extensionName, 'com_') === false ? $extensionName : substr($extensionName, 4);
+        return !str_contains($extensionName, 'com_') ? $extensionName : substr($extensionName, 4);
     }
 
     /**

--- a/administrator/components/com_banners/src/Model/BannerModel.php
+++ b/administrator/components/com_banners/src/Model/BannerModel.php
@@ -417,7 +417,7 @@ class BannerModel extends AdminModel
         if ($createCategory && $this->canCreateCategory()) {
             $category = [
                 // Remove #new# prefix, if exists.
-                'title'     => strpos($data['catid'], '#new#') === 0 ? substr($data['catid'], 5) : $data['catid'],
+                'title'     => str_starts_with($data['catid'], '#new#') ? substr($data['catid'], 5) : $data['catid'],
                 'parent_id' => 1,
                 'extension' => 'com_banners',
                 'language'  => $data['language'],

--- a/administrator/components/com_categories/src/Field/CategoryeditField.php
+++ b/administrator/components/com_categories/src/Field/CategoryeditField.php
@@ -196,7 +196,7 @@ class CategoryeditField extends ListField
 
         // Filter language
         if (!empty($this->element['language'])) {
-            if (strpos($this->element['language'], ',') !== false) {
+            if (str_contains($this->element['language'], ',')) {
                 $language = explode(',', $this->element['language']);
             } else {
                 $language = $this->element['language'];

--- a/administrator/components/com_categories/tmpl/categories/default.php
+++ b/administrator/components/com_categories/tmpl/categories/default.php
@@ -145,7 +145,7 @@ if ($saveOrder && !empty($this->items)) {
                                         foreach ($this->ordering as $k => $v) {
                                             $v = implode('-', $v);
                                             $v = '-' . $v . '-';
-                                            if (strpos($v, '-' . $_currentParentId . '-') !== false) {
+                                            if (str_contains($v, '-' . $_currentParentId . '-')) {
                                                 $parentsStr .= ' ' . $k;
                                                 $_currentParentId = $k;
                                                 break;

--- a/administrator/components/com_config/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_config/src/Dispatcher/Dispatcher.php
@@ -45,7 +45,7 @@ class Dispatcher extends ComponentDispatcher
         $view      = $this->input->getCmd('view');
         $component = $this->input->getCmd('component');
 
-        if ($component && (substr($task, 0, 10) === 'component.' || $view === 'component')) {
+        if ($component && (str_starts_with($task, 'component.') || $view === 'component')) {
             // User is changing component settings, check if he has permission to do that
             $canAccess = ConfigHelper::canChangeComponentConfig($component);
         } else {

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -884,7 +884,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
         }
 
         // We are creating a new item so we don't have an item id so don't allow.
-        if (substr($permission['component'], -6) === '.false') {
+        if (str_ends_with($permission['component'], '.false')) {
             $app->enqueueMessage(Text::_('JLIB_RULES_SAVE_BEFORE_CHANGE_PERMISSIONS'), 'error');
 
             return false;
@@ -959,7 +959,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
                 /** @var Asset $parentAsset */
                 $parentAsset = Table::getInstance('Asset');
 
-                if (strpos($asset->name, '.') !== false) {
+                if (str_contains($asset->name, '.')) {
                     $assetParts = explode('.', $asset->name);
                     $parentAsset->loadByName($assetParts[0]);
                     $parentAssetId = $parentAsset->id;

--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -292,7 +292,7 @@ class ContactModel extends AdminModel
         if ($createCategory && $this->canCreateCategory()) {
             $category = [
                 // Remove #new# prefix, if exists.
-                'title'     => strpos($data['catid'], '#new#') === 0 ? substr($data['catid'], 5) : $data['catid'],
+                'title'     => str_starts_with($data['catid'], '#new#') ? substr($data['catid'], 5) : $data['catid'],
                 'parent_id' => 1,
                 'extension' => 'com_contact',
                 'language'  => $data['language'],

--- a/administrator/components/com_content/src/Event/Model/FeatureEvent.php
+++ b/administrator/components/com_content/src/Event/Model/FeatureEvent.php
@@ -42,7 +42,7 @@ class FeatureEvent extends AbstractImmutableEvent
             throw new \BadMethodCallException("Argument 'extension' of event $this->name is not of type 'string'");
         }
 
-        if (strpos($arguments['extension'], '.') === false) {
+        if (!str_contains($arguments['extension'], '.')) {
             throw new \BadMethodCallException("Argument 'extension' of event $this->name has wrong format. Valid format: 'component.section'");
         }
 

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -682,7 +682,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
         if ($createCategory && $this->canCreateCategory()) {
             $category = [
                 // Remove #new# prefix, if exists.
-                'title'     => strpos($data['catid'], '#new#') === 0 ? substr($data['catid'], 5) : $data['catid'],
+                'title'     => str_starts_with($data['catid'], '#new#') ? substr($data['catid'], 5) : $data['catid'],
                 'parent_id' => 1,
                 'extension' => 'com_content',
                 'language'  => $data['language'],

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -39,11 +39,11 @@ $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $saveOrder = $listOrder == 'a.ordering';
 
-if (strpos($listOrder, 'publish_up') !== false) {
+if (str_contains($listOrder, 'publish_up')) {
     $orderingColumn = 'publish_up';
-} elseif (strpos($listOrder, 'publish_down') !== false) {
+} elseif (str_contains($listOrder, 'publish_down')) {
     $orderingColumn = 'publish_down';
-} elseif (strpos($listOrder, 'modified') !== false) {
+} elseif (str_contains($listOrder, 'modified')) {
     $orderingColumn = 'modified';
 } else {
     $orderingColumn = 'created';

--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -39,11 +39,11 @@ $listOrder = $this->escape($this->state->get('list.ordering'));
 $listDirn  = $this->escape($this->state->get('list.direction'));
 $saveOrder = $listOrder == 'fp.ordering';
 
-if (strpos($listOrder, 'publish_up') !== false) {
+if (str_contains($listOrder, 'publish_up')) {
     $orderingColumn = 'publish_up';
-} elseif (strpos($listOrder, 'publish_down') !== false) {
+} elseif (str_contains($listOrder, 'publish_down')) {
     $orderingColumn = 'publish_down';
-} elseif (strpos($listOrder, 'modified') !== false) {
+} elseif (str_contains($listOrder, 'modified')) {
     $orderingColumn = 'modified';
 } else {
     $orderingColumn = 'created';

--- a/administrator/components/com_cpanel/src/Controller/DisplayController.php
+++ b/administrator/components/com_cpanel/src/Controller/DisplayController.php
@@ -75,7 +75,7 @@ class DisplayController extends BaseController
             $appendLink .= '&function=' . $function;
         }
 
-        if (substr($position, 0, 6) != 'cpanel') {
+        if (!str_starts_with($position, 'cpanel')) {
             $position = 'cpanel';
         }
 

--- a/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
+++ b/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
@@ -69,7 +69,7 @@ class HtmlView extends BaseHtmlView
             $parts     = explode('.', $dashboard);
             $component = $parts[0];
 
-            if (strpos($component, 'com_') === false) {
+            if (!str_contains($component, 'com_')) {
                 $component = 'com_' . $component;
             }
 

--- a/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
+++ b/administrator/components/com_fields/src/Plugin/FieldsPlugin.php
@@ -343,7 +343,7 @@ abstract class FieldsPlugin extends CMSPlugin
     protected function getFormPath(Form $form, $data)
     {
         // Check if the field form is calling us
-        if (strpos($form->getName(), 'com_fields.field') !== 0) {
+        if (!str_starts_with($form->getName(), 'com_fields.field')) {
             return null;
         }
 

--- a/administrator/components/com_guidedtours/src/Model/StepModel.php
+++ b/administrator/components/com_guidedtours/src/Model/StepModel.php
@@ -81,7 +81,7 @@ class StepModel extends AdminModel
         $tour->load($data['tour_id']);
 
         // Language keys must include GUIDEDTOUR to prevent save issues
-        if (strpos($data['description'], 'GUIDEDTOUR') !== false) {
+        if (str_contains($data['description'], 'GUIDEDTOUR')) {
             $data['description'] = strip_tags($data['description']);
         }
 

--- a/administrator/components/com_guidedtours/src/Model/TourModel.php
+++ b/administrator/components/com_guidedtours/src/Model/TourModel.php
@@ -63,7 +63,7 @@ class TourModel extends AdminModel
         $input = Factory::getApplication()->getInput();
 
         // Language keys must include GUIDEDTOUR to prevent save issues
-        if (strpos($data['description'], 'GUIDEDTOUR') !== false) {
+        if (str_contains($data['description'], 'GUIDEDTOUR')) {
             $data['description'] = strip_tags($data['description']);
         }
 

--- a/administrator/components/com_guidedtours/tmpl/step/edit.php
+++ b/administrator/components/com_guidedtours/tmpl/step/edit.php
@@ -38,7 +38,7 @@ $this->useCoreUI = true;
 
     <?php echo LayoutHelper::render('joomla.edit.title_alias', $this); ?>
 
-    <?php if ($this->item->id != 0 && strpos($this->item->title, 'GUIDEDTOUR') !== false) : ?>
+    <?php if ($this->item->id != 0 && str_contains($this->item->title, 'GUIDEDTOUR')) : ?>
         <div class="row title-alias form-vertical mb-3">
             <div class="col-12">
                 <?php $this->form->setFieldAttribute('title_translation', 'label', Text::sprintf('COM_GUIDEDTOURS_STEP_TITLE_TRANSLATION', $lang)); ?>
@@ -55,7 +55,7 @@ $this->useCoreUI = true;
             <div class="col-lg-9">
                 <?php echo $this->form->renderField('description'); ?>
 
-                <?php if ($this->item->id != 0 && strpos($this->item->description, 'GUIDEDTOUR') !== false) : ?>
+                <?php if ($this->item->id != 0 && str_contains($this->item->description, 'GUIDEDTOUR')) : ?>
                     <?php $this->form->setFieldAttribute('description_translation', 'label', Text::sprintf('COM_GUIDEDTOURS_STEP_DESCRIPTION_TRANSLATION', $lang)); ?>
                     <?php echo $this->form->renderField('description_translation'); ?>
                 <?php endif; ?>

--- a/administrator/components/com_guidedtours/tmpl/tour/edit.php
+++ b/administrator/components/com_guidedtours/tmpl/tour/edit.php
@@ -41,7 +41,7 @@ $wa->useScript('keepalive')
         </div>
     </div>
 
-    <?php if ($this->item->id != 0 && strpos($this->item->title, 'GUIDEDTOUR') !== false) : ?>
+    <?php if ($this->item->id != 0 && str_contains($this->item->title, 'GUIDEDTOUR')) : ?>
         <div class="row title-alias form-vertical mb-3">
             <div class="col-12">
                 <?php $this->form->setFieldAttribute('title_translation', 'label', Text::sprintf('COM_GUIDEDTOURS_TITLE_TRANSLATION', $lang)); ?>
@@ -59,7 +59,7 @@ $wa->useScript('keepalive')
                 <?php echo $this->form->renderField('url'); ?>
                 <?php echo $this->form->renderField('description'); ?>
 
-                <?php if ($this->item->id != 0 && strpos($this->item->description, 'GUIDEDTOUR') !== false) : ?>
+                <?php if ($this->item->id != 0 && str_contains($this->item->description, 'GUIDEDTOUR')) : ?>
                     <?php $this->form->setFieldAttribute('description_translation', 'label', Text::sprintf('COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION', $lang)); ?>
                     <?php echo $this->form->renderField('description_translation'); ?>
                 <?php endif; ?>

--- a/administrator/components/com_installer/src/Model/LanguagesModel.php
+++ b/administrator/components/com_installer/src/Model/LanguagesModel.php
@@ -166,8 +166,8 @@ class LanguagesModel extends ListModel
 
             if ($search) {
                 if (
-                    strpos(strtolower($language->name), $search) === false
-                    && strpos(strtolower($language->element), $search) === false
+                    !str_contains(strtolower($language->name), $search)
+                    && !str_contains(strtolower($language->element), $search)
                 ) {
                     continue;
                 }

--- a/administrator/components/com_installer/src/Model/ManageModel.php
+++ b/administrator/components/com_installer/src/Model/ManageModel.php
@@ -253,7 +253,7 @@ class ManageModel extends InstallerModel
             $langstring = 'COM_INSTALLER_TYPE_TYPE_' . strtoupper($row->type);
             $rowtype    = Text::_($langstring);
 
-            if (strpos($rowtype, $langstring) !== false) {
+            if (str_contains($rowtype, $langstring)) {
                 $rowtype = $row->type;
             }
 

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -421,7 +421,7 @@ class UpdateModel extends ListModel
         $sources = $update->get('downloadSources', []);
 
         if ($extra_query = $update->get('extra_query')) {
-            $url .= (strpos($url, '?') === false) ? '?' : '&amp;';
+            $url .= (!str_contains($url, '?')) ? '?' : '&amp;';
             $url .= $extra_query;
         }
 
@@ -432,7 +432,7 @@ class UpdateModel extends ListModel
             $url  = trim($name->url);
 
             if ($extra_query) {
-                $url .= (strpos($url, '?') === false) ? '?' : '&amp;';
+                $url .= (!str_contains($url, '?')) ? '?' : '&amp;';
                 $url .= $extra_query;
             }
 

--- a/administrator/components/com_installer/tmpl/languages/default.php
+++ b/administrator/components/com_installer/tmpl/languages/default.php
@@ -92,7 +92,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                 <td class="d-none d-md-table-cell">
                                         <?php $minorVersion = $version::MAJOR_VERSION . '.' . $version::MINOR_VERSION; ?>
                                         <?php // Display a Note if language pack version is not equal to Joomla version ?>
-                                        <?php if (strpos($language->version, $minorVersion) !== 0 || strpos($language->version, $currentShortVersion) !== 0) : ?>
+                                        <?php if (!str_starts_with($language->version, $minorVersion) || !str_starts_with($language->version, $currentShortVersion)) : ?>
                                             <span class="badge bg-warning"><?php echo $language->version; ?></span>
                                             <span class="icon-info-circle" aria-hidden="true" tabindex="0"></span>
                                             <div role="tooltip" class="text-start" id="tip<?php echo $language->code; ?>">

--- a/administrator/components/com_joomlaupdate/extract.php
+++ b/administrator/components/com_joomlaupdate/extract.php
@@ -567,7 +567,7 @@ class ZIPExtraction
     public function setFilename(string $value)
     {
         // Security check: disallow remote filenames
-        if (!empty($value) && strpos($value, '://') !== false) {
+        if (!empty($value) && str_contains($value, '://')) {
             $this->setError('Invalid archive location');
 
             return;
@@ -1316,7 +1316,7 @@ class ZIPExtraction
      */
     private function isIgnoredDirectory(string $shortFilename): bool
     {
-        $check = substr($shortFilename, -1) == '/' ? rtrim($shortFilename, '/') : \dirname($shortFilename);
+        $check = str_ends_with($shortFilename, '/') ? rtrim($shortFilename, '/') : \dirname($shortFilename);
 
         return \in_array($check, $this->ignoreDirectories);
     }
@@ -1375,7 +1375,7 @@ class ZIPExtraction
         }
 
         // Remove any trailing slash
-        if (substr($filename, -1) == '/') {
+        if (str_ends_with($filename, '/')) {
             $filename = substr($filename, 0, -1);
         }
 

--- a/administrator/components/com_joomlaupdate/finalisation.php
+++ b/administrator/components/com_joomlaupdate/finalisation.php
@@ -201,7 +201,7 @@ namespace Joomla\Filesystem
              */
             public static function delete(string $folderName): bool
             {
-                if (substr($folderName, -1) == '/') {
+                if (str_ends_with($folderName, '/')) {
                     $folderName = substr($folderName, 0, -1);
                 }
 

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -404,7 +404,7 @@ class UpdateModel extends BaseDatabaseModel
         // Remove protocol, path and query string from URL
         $basename = basename($packageURL);
 
-        if (strpos($basename, '?') !== false) {
+        if (str_contains($basename, '?')) {
             $basename = substr($basename, 0, strpos($basename, '?'));
         }
 

--- a/administrator/components/com_languages/tmpl/installed/default.php
+++ b/administrator/components/com_languages/tmpl/installed/default.php
@@ -108,7 +108,7 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                             <td class="d-none d-md-table-cell text-center">
                             <?php $minorVersion = $version::MAJOR_VERSION . '.' . $version::MINOR_VERSION; ?>
                             <?php // Display a Note if language pack version is not equal to Joomla version ?>
-                            <?php if (strpos($row->version, $minorVersion) !== 0 || strpos($row->version, $currentShortVersion) !== 0) : ?>
+                            <?php if (!str_starts_with($row->version, $minorVersion) || !str_starts_with($row->version, $currentShortVersion)) : ?>
                                 <span class="badge bg-warning" title="<?php echo Text::_('JGLOBAL_LANGUAGE_VERSION_NOT_PLATFORM'); ?>"><?php echo $row->version; ?></span>
                             <?php else : ?>
                                 <span class="badge bg-success"><?php echo $row->version; ?></span>

--- a/administrator/components/com_login/src/Controller/DisplayController.php
+++ b/administrator/components/com_login/src/Controller/DisplayController.php
@@ -82,7 +82,7 @@ class DisplayController extends BaseController
 
         $app->login($credentials, ['action' => 'core.login.admin']);
 
-        if (Uri::isInternal($return) && strpos($return, 'tmpl=component') === false) {
+        if (Uri::isInternal($return) && !str_contains($return, 'tmpl=component')) {
             $app->redirect($return);
         } else {
             $app->redirect('index.php');

--- a/administrator/components/com_login/src/Model/LoginModel.php
+++ b/administrator/components/com_login/src/Model/LoginModel.php
@@ -90,7 +90,7 @@ class LoginModel extends BaseDatabaseModel
         }
 
         // If we didn't find it, and the name is mod_something, create a dummy object.
-        if (\is_null($result) && substr($name, 0, 4) == 'mod_') {
+        if (\is_null($result) && str_starts_with($name, 'mod_')) {
             $result            = new \stdClass();
             $result->id        = 0;
             $result->title     = '';

--- a/administrator/components/com_menus/src/Controller/ItemController.php
+++ b/administrator/components/com_menus/src/Controller/ItemController.php
@@ -330,7 +330,7 @@ class ItemController extends FormController
         if ($data['type'] == 'url') {
             $data['link'] = str_replace(['"', '>', '<'], '', $data['link']);
 
-            if (strstr($data['link'], ':')) {
+            if (str_contains($data['link'], ':')) {
                 $segments = explode(':', $data['link']);
                 $protocol = strtolower($segments[0]);
                 $scheme   = [

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -72,7 +72,7 @@ class MenusHelper extends ContentHelper
         if (\is_string($request)) {
             $args = [];
 
-            if (strpos($request, 'index.php') === 0) {
+            if (str_starts_with($request, 'index.php')) {
                 parse_str(parse_url(htmlspecialchars_decode($request), PHP_URL_QUERY), $args);
             } else {
                 parse_str($request, $args);
@@ -480,7 +480,7 @@ class MenusHelper extends ContentHelper
                 ];
                 $table->load($keys);
             } elseif ($item->type == 'url' || $item->type == 'component') {
-                if (substr($item->link, 0, 8) === 'special:') {
+                if (str_starts_with($item->link, 'special:')) {
                     $special = substr($item->link, 8);
 
                     if ($special === 'language-forum') {

--- a/administrator/components/com_menus/src/Model/ItemsModel.php
+++ b/administrator/components/com_menus/src/Model/ItemsModel.php
@@ -497,7 +497,7 @@ class ItemsModel extends ListModel
         if ($name == 'com_menus.items.filter') {
             $clientId = $this->getState('filter.client_id');
             $form->setFieldAttribute('menutype', 'clientid', $clientId);
-        } elseif (false !== strpos($name, 'com_menus.items.modal.')) {
+        } elseif (str_contains($name, 'com_menus.items.modal.')) {
             $form->removeField('client_id');
 
             $clientId = $this->getState('filter.client_id');

--- a/administrator/components/com_menus/src/Model/MenutypesModel.php
+++ b/administrator/components/com_menus/src/Model/MenutypesModel.php
@@ -279,7 +279,7 @@ class MenutypesModel extends BaseDatabaseModel
             $view = basename($viewPath);
 
             // Ignore private views.
-            if (strpos($view, '_') !== 0) {
+            if (!str_starts_with($view, '_')) {
                 // Determine if a metadata file exists for the view.
                 $file = $viewPath . '/metadata.xml';
 
@@ -470,7 +470,7 @@ class MenutypesModel extends BaseDatabaseModel
         // Build list of standard layout names
         foreach ($layouts as $layout) {
             // Ignore private layouts.
-            if (strpos(basename($layout), '_') === false) {
+            if (!str_contains(basename($layout), '_')) {
                 // Get the layout name.
                 $layoutNames[] = basename($layout, '.xml');
             }
@@ -509,7 +509,7 @@ class MenutypesModel extends BaseDatabaseModel
         // Process the found layouts.
         foreach ($layouts as $layout) {
             // Ignore private layouts.
-            if (strpos(basename($layout), '_') === false) {
+            if (!str_contains(basename($layout), '_')) {
                 $file = $layout;
 
                 // Get the layout name.

--- a/administrator/components/com_menus/tmpl/items/default.php
+++ b/administrator/components/com_menus/tmpl/items/default.php
@@ -123,7 +123,7 @@ $assoc   = Associations::isEnabled() && $this->state->get('filter.client_id') ==
                                         $v = implode('-', $v);
                                         $v = '-' . $v . '-';
 
-                                        if (strpos($v, '-' . $_currentParentId . '-') !== false) {
+                                        if (str_contains($v, '-' . $_currentParentId . '-')) {
                                             $parentsStr .= ' ' . $k;
                                             $_currentParentId = $k;
                                             break;

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
@@ -191,7 +191,7 @@ class NewsfeedModel extends AdminModel
         if ($createCategory && $this->canCreateCategory()) {
             $category = [
                 // Remove #new# prefix, if exists.
-                'title'     => strpos($data['catid'], '#new#') === 0 ? substr($data['catid'], 5) : $data['catid'],
+                'title'     => str_starts_with($data['catid'], '#new#') ? substr($data['catid'], 5) : $data['catid'],
                 'parent_id' => 1,
                 'extension' => 'com_newsfeeds',
                 'language'  => $data['language'],

--- a/administrator/components/com_postinstall/src/Helper/PostinstallHelper.php
+++ b/administrator/components/com_postinstall/src/Helper/PostinstallHelper.php
@@ -32,9 +32,9 @@ class PostinstallHelper
      */
     public function parsePath($path)
     {
-        if (strpos($path, 'site://') !== false) {
+        if (str_contains($path, 'site://')) {
             $path = JPATH_ROOT . str_replace('site://', '/', $path);
-        } elseif (strpos($path, 'admin://') !== false) {
+        } elseif (str_contains($path, 'admin://')) {
             $path = JPATH_ADMINISTRATOR . str_replace('admin://', '/', $path);
         }
 

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -692,7 +692,7 @@ class TaskModel extends AdminModel
         ];
 
         $ruleType        = $executionRules['rule-type'];
-        $ruleClass       = strpos($ruleType, 'interval') === 0 ? 'interval' : $ruleType;
+        $ruleClass       = str_starts_with($ruleType, 'interval') ? 'interval' : $ruleType;
         $buildExpression = '';
 
         if ($ruleClass === 'interval') {

--- a/administrator/components/com_tags/tmpl/tags/default.php
+++ b/administrator/components/com_tags/tmpl/tags/default.php
@@ -148,7 +148,7 @@ if ($saveOrder && !empty($this->items)) {
                             foreach ($this->ordering as $k => $v) {
                                 $v = implode('-', $v);
                                 $v = '-' . $v . '-';
-                                if (strpos($v, '-' . $_currentParentId . '-') !== false) {
+                                if (str_contains($v, '-' . $_currentParentId . '-')) {
                                     $parentsStr .= ' ' . $k;
                                     $_currentParentId = $k;
                                     break;

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -574,7 +574,7 @@ class TemplateModel extends FormModel
      */
     private function getSafeName($name)
     {
-        if (strpos($name, '-') !== false && preg_match('/[0-9]/', $name)) {
+        if (str_contains($name, '-') && preg_match('/[0-9]/', $name)) {
             // Get the extension
             $extension = File::getExt($name);
 
@@ -1101,7 +1101,7 @@ class TemplateModel extends FormModel
                         $path = $folder . '/' . $view . '/tmpl';
 
                         // The new scheme, the views are directly in the component/tmpl folder
-                        if (!is_dir($path) && substr($folder, -4) == 'tmpl') {
+                        if (!is_dir($path) && str_ends_with($folder, 'tmpl')) {
                             $path = $folder . '/' . $view;
                         }
 

--- a/administrator/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_users/src/Dispatcher/Dispatcher.php
@@ -59,7 +59,7 @@ class Dispatcher extends ComponentDispatcher
         $isAllowedTask = array_reduce(
             $allowedViews,
             function ($carry, $taskPrefix) use ($task) {
-                return $carry || strpos($task ?? '', $taskPrefix . '.') === 0;
+                return $carry || str_starts_with($task ?? '', $taskPrefix . '.');
             },
             false
         );

--- a/administrator/components/com_users/src/Model/LevelModel.php
+++ b/administrator/components/com_users/src/Model/LevelModel.php
@@ -68,7 +68,7 @@ class LevelModel extends AdminModel
                      * than the 'access' field they are on their own unfortunately.
                      * Also make sure the table prefix matches the live db prefix (eg, it is not a "bak_" table)
                      */
-                    if (strpos($checktable, $prefix) === 0 && isset($fields['access'])) {
+                    if (str_starts_with($checktable, $prefix) && isset($fields['access'])) {
                         // Lookup the distinct values of the field.
                         $query->clear('from')
                             ->from($db->quoteName($checktable));

--- a/administrator/components/com_users/src/Service/Encrypt.php
+++ b/administrator/components/com_users/src/Service/Encrypt.php
@@ -75,7 +75,7 @@ class Encrypt
      */
     public function decrypt(string $data, bool $legacy = false): string
     {
-        if (substr($data, 0, 12) != '###AES128###') {
+        if (!str_starts_with($data, '###AES128###')) {
             return $data;
         }
 

--- a/administrator/components/com_users/tmpl/captive/default.php
+++ b/administrator/components/com_users/tmpl/captive/default.php
@@ -89,7 +89,7 @@ $this->getDocument()->getWebAssetManager()
                     $this->renderOptions['input_attributes']
                 );
 
-                if (strpos($attributes['class'], 'form-control') === false) {
+                if (!str_contains($attributes['class'], 'form-control')) {
                     $attributes['class'] .= ' form-control';
                 }
                 ?>

--- a/administrator/components/com_users/tmpl/method/edit.php
+++ b/administrator/components/com_users/tmpl/method/edit.php
@@ -145,7 +145,7 @@ $hideSubmit   = !$this->renderOptions['show_submit'] && !$this->isEditExisting
                     $this->renderOptions['input_attributes']
                 );
 
-                if (strpos($attributes['class'], 'form-control') === false) {
+                if (!str_contains($attributes['class'], 'form-control')) {
                     $attributes['class'] .= ' form-control';
                 }
                 ?>

--- a/administrator/components/com_workflow/tmpl/workflows/default.php
+++ b/administrator/components/com_workflow/tmpl/workflows/default.php
@@ -32,7 +32,7 @@ $saveOrder = $listOrder == 'w.ordering';
 $orderingColumn = 'created';
 $saveOrderingUrl = '';
 
-if (strpos($listOrder, 'modified') !== false) {
+if (str_contains($listOrder, 'modified')) {
     $orderingColumn = 'modified';
 }
 

--- a/administrator/modules/mod_login/tmpl/default.php
+++ b/administrator/modules/mod_login/tmpl/default.php
@@ -76,7 +76,7 @@ Text::script('JHIDEPASSWORD');
             <?php endif; ?>
             <?php foreach ($extraButtons as $button) :
                 $dataAttributeKeys = array_filter(array_keys($button), function ($key) {
-                    return substr($key, 0, 5) == 'data-';
+                    return str_starts_with($key, 'data-');
                 });
                 ?>
             <div class="form-group">

--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -293,7 +293,7 @@ class CssMenu
                 continue;
             }
 
-            if (!empty($item->link) && substr($item->link, 0, 8) === 'special:') {
+            if (!empty($item->link) && str_starts_with($item->link, 'special:')) {
                 $special = substr($item->link, 8);
 
                 if ($special === 'language-forum') {
@@ -498,7 +498,7 @@ class CssMenu
         }
 
         // We were passed a class name
-        if (substr($identifier, 0, 6) == 'class:') {
+        if (str_starts_with($identifier, 'class:')) {
             $class = substr($identifier, 6);
         } else {
             // We were passed background icon url. Build the CSS class for the icon

--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -90,10 +90,10 @@ if ($iconClass === '' && $itemIconClass) {
 }
 
 if ($iconImage) {
-    if (substr($iconImage, 0, 6) == 'class:' && substr($iconImage, 6) == 'icon-home') {
+    if (str_starts_with($iconImage, 'class:') && substr($iconImage, 6) == 'icon-home') {
         $iconImage = '<span class="home-image icon-home" aria-hidden="true"></span>';
         $iconImage .= '<span class="visually-hidden">' . Text::_('JDEFAULT') . '</span>';
-    } elseif (substr($iconImage, 0, 6) == 'image:') {
+    } elseif (str_starts_with($iconImage, 'image:')) {
         $iconImage = '&nbsp;<span class="badge">' . substr($iconImage, 6) . '</span>';
     } else {
         $iconImage = '';

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -61,7 +61,7 @@ abstract class Menu
         ]))->getArgument('subject', $children);
 
         foreach ($children as $item) {
-            if (substr($item->link, 0, 8) === 'special:') {
+            if (str_starts_with($item->link, 'special:')) {
                 $special = substr($item->link, 8);
 
                 if ($special === 'language-forum') {
@@ -203,10 +203,10 @@ abstract class Menu
                 $iconImage = $item->icon;
 
                 if ($iconImage) {
-                    if (substr($iconImage, 0, 6) === 'class:' && substr($iconImage, 6) === 'icon-home') {
+                    if (str_starts_with($iconImage, 'class:') && substr($iconImage, 6) === 'icon-home') {
                         $iconImage = '<span class="home-image icon-home" aria-hidden="true"></span>';
                         $iconImage .= '<span class="visually-hidden">' . Text::_('JDEFAULT') . '</span>';
-                    } elseif (substr($iconImage, 0, 6) === 'image:') {
+                    } elseif (str_starts_with($iconImage, 'image:')) {
                         $iconImage = '&nbsp;<span class="badge bg-secondary">' . substr($iconImage, 6) . '</span>';
                     }
 

--- a/administrator/modules/mod_submenu/tmpl/default.php
+++ b/administrator/modules/mod_submenu/tmpl/default.php
@@ -25,9 +25,9 @@ $user = $app->getIdentity();
                 <?php
                     $child->img = $child->img ?? '';
 
-                if (substr($child->img, 0, 6) === 'class:') {
+                if (str_starts_with($child->img, 'class:')) {
                     $iconImage = '<span class="icon-' . substr($child->img, 6) . '" aria-hidden="true"></span>';
-                } elseif (substr($child->img, 0, 6) === 'image:') {
+                } elseif (str_starts_with($child->img, 'image:')) {
                     $iconImage = '<img src="' . substr($child->img, 6) . '" aria-hidden="true">';
                 } elseif (!empty($child->img)) {
                     $iconImage = '<img src="' . $child->img . '" aria-hidden="true">';

--- a/administrator/templates/atum/html/layouts/status.php
+++ b/administrator/templates/atum/html/layouts/status.php
@@ -27,7 +27,7 @@ foreach ($modules as $key => $mod) {
     $out = $renderer->render($mod);
 
     if ($out !== '') {
-        if (strpos($out, 'data-bs-toggle="modal"') !== false) {
+        if (str_contains($out, 'data-bs-toggle="modal"')) {
             $dom = new \DOMDocument();
             $dom->loadHTML('<?xml encoding="utf-8" ?>' . $out);
             $els = $dom->getElementsByTagName('a');

--- a/api/components/com_media/src/Controller/MediaController.php
+++ b/api/components/com_media/src/Controller/MediaController.php
@@ -212,7 +212,7 @@ class MediaController extends ApiController
         }
 
         // Content is only required when it is a file
-        if (empty($content) && strpos($path, '.') !== false) {
+        if (empty($content) && str_contains($path, '.')) {
             $missingParameters[] = 'content';
         }
 

--- a/components/com_banners/src/Model/BannersModel.php
+++ b/components/com_banners/src/Model/BannersModel.php
@@ -216,7 +216,7 @@ class BannersModel extends ListModel
                         . ' = SUBSTRING(' . $bounded[1] . ',1,LENGTH(' . $db->quoteName('cl.metakey_prefix') . '))'
                         . ' OR ' . $db->quoteName('a.own_prefix') . ' = 0'
                         . ' AND ' . $db->quoteName('cl.own_prefix') . ' = 0'
-                        . ' AND ' . ($prefix == substr($keyword, 0, \strlen($prefix)) ? '0 = 0' : '0 != 0');
+                        . ' AND ' . (str_starts_with($keyword, $prefix) ? '0 = 0' : '0 != 0');
 
                     $condition2 = $db->quoteName('a.metakey') . ' ' . $query->regexp($bounded[2]);
 

--- a/components/com_config/src/Dispatcher/Dispatcher.php
+++ b/components/com_config/src/Dispatcher/Dispatcher.php
@@ -41,7 +41,7 @@ class Dispatcher extends ComponentDispatcher
         $view = $this->input->get('view');
         $user = $this->app->getIdentity();
 
-        if (substr($task, 0, 8) === 'modules.' || $view === 'modules') {
+        if (str_starts_with($task, 'modules.') || $view === 'modules') {
             if (!$user->authorise('module.edit.frontend', 'com_modules.module.' . $this->input->get('id'))) {
                 throw new NotAllowed($this->app->getLanguage()->_('JERROR_ALERTNOAUTHOR'), 403);
             }

--- a/components/com_contact/tmpl/contact/default_links.php
+++ b/components/com_contact/tmpl/contact/default_links.php
@@ -25,7 +25,7 @@ defined('_JEXEC') or die;
             endif;
 
             // Add 'http://' if not present
-            $link = (0 === strpos($link, 'http')) ? $link : 'http://' . $link;
+            $link = (str_starts_with($link, 'http')) ? $link : 'http://' . $link;
 
             // If no label is present, take the link
             $label = $label ?: $link;

--- a/components/com_users/tmpl/captive/default.php
+++ b/components/com_users/tmpl/captive/default.php
@@ -90,7 +90,7 @@ $this->getDocument()->getWebAssetManager()
                         $this->renderOptions['input_attributes']
                     );
 
-                    if (strpos($attributes['class'], 'form-control') === false) {
+                    if (!str_contains($attributes['class'], 'form-control')) {
                         $attributes['class'] .= ' form-control';
                     }
                     ?>

--- a/components/com_users/tmpl/login/default_login.php
+++ b/components/com_users/tmpl/login/default_login.php
@@ -69,7 +69,7 @@ $usersConfig = ComponentHelper::getParams('com_users');
 
             <?php foreach ($this->extraButtons as $button) :
                 $dataAttributeKeys = array_filter(array_keys($button), function ($key) {
-                    return substr($key, 0, 5) == 'data-';
+                    return str_starts_with($key, 'data-');
                 });
                 ?>
                 <div class="com-users-login__submit control-group">

--- a/components/com_users/tmpl/method/edit.php
+++ b/components/com_users/tmpl/method/edit.php
@@ -145,7 +145,7 @@ $hideSubmit   = !$this->renderOptions['show_submit'] && !$this->isEditExisting
                     $this->renderOptions['input_attributes']
                 );
 
-                if (strpos($attributes['class'], 'form-control') === false) {
+                if (!str_contains($attributes['class'], 'form-control')) {
                     $attributes['class'] .= ' form-control';
                 }
                 ?>

--- a/components/com_wrapper/src/View/Wrapper/HtmlView.php
+++ b/components/com_wrapper/src/View/Wrapper/HtmlView.php
@@ -88,13 +88,13 @@ class HtmlView extends BaseHtmlView
 
         if ($params->def('add_scheme', 1)) {
             // Adds 'http://' or 'https://' if none is set
-            if (strpos($url, '//') === 0) {
+            if (str_starts_with($url, '//')) {
                 // URL without scheme in component. Prepend current scheme.
                 $wrapper->url = Uri::getInstance()->toString(['scheme']) . substr($url, 2);
-            } elseif (strpos($url, '/') === 0) {
+            } elseif (str_starts_with($url, '/')) {
                 // Relative URL in component. Use scheme + host + port.
                 $wrapper->url = Uri::getInstance()->toString(['scheme', 'host', 'port']) . $url;
-            } elseif (strpos($url, 'http://') !== 0 && strpos($url, 'https://') !== 0) {
+            } elseif (!str_starts_with($url, 'http://') && !str_starts_with($url, 'https://')) {
                 // URL doesn't start with either 'http://' or 'https://'. Add current scheme.
                 $wrapper->url = Uri::getInstance()->toString(['scheme']) . $url;
             } else {

--- a/installation/src/Model/DatabaseModel.php
+++ b/installation/src/Model/DatabaseModel.php
@@ -204,7 +204,7 @@ class DatabaseModel extends BaseInstallationModel
         }
 
         // @internal Check for asc(00) Null in name.
-        if (strpos($options->db_name, \chr(00)) !== false) {
+        if (str_contains($options->db_name, \chr(00))) {
             throw new \RuntimeException(Text::_('INSTL_DATABASE_NAME_INVALID_CHAR'));
         }
 
@@ -339,7 +339,7 @@ class DatabaseModel extends BaseInstallationModel
         if ($tables) {
             foreach ($tables as $table) {
                 // If the table uses the given prefix, back it up.
-                if (strpos($table, $prefix) === 0) {
+                if (str_starts_with($table, $prefix)) {
                     // Backup table name.
                     $backupTable = str_replace($prefix, $backup, $table);
 

--- a/layouts/joomla/content/category_default.php
+++ b/layouts/joomla/content/category_default.php
@@ -45,7 +45,7 @@ $afterDisplayContent = trim(implode("\n", $results));
  * This will work for the core components but not necessarily for other components
  * that may have different pluralisation rules.
  */
-if (substr($className, -1) === 's') {
+if (str_ends_with($className, 's')) {
     $className = rtrim($className, 's');
 }
 

--- a/layouts/joomla/edit/params.php
+++ b/layouts/joomla/edit/params.php
@@ -62,7 +62,7 @@ if (!$displayData->get('show_options', 1)) {
         }
 
         // Check if it is the correct fieldset to ignore
-        if (strpos($name, 'basic') === 0) {
+        if (str_starts_with($name, 'basic')) {
             // Ignore only the fieldsets which are defined by the options not the custom fields ones
             $ignoreFieldsets[] = $name;
         }

--- a/layouts/joomla/form/field/radio/buttons.php
+++ b/layouts/joomla/form/field/radio/buttons.php
@@ -44,8 +44,8 @@ extract($displayData);
  */
 
 $alt         = preg_replace('/[^a-zA-Z0-9_\-]/', '_', $name);
-$isBtnGroup  = strpos(trim($class), 'btn-group') !== false;
-$isBtnYesNo  = strpos(trim($class), 'btn-group-yesno') !== false;
+$isBtnGroup  = str_contains(trim($class), 'btn-group');
+$isBtnYesNo  = str_contains(trim($class), 'btn-group-yesno');
 $classToggle = $isBtnGroup ? 'btn-check' : 'form-check-input';
 $btnClass    = $isBtnGroup ? 'btn btn-outline-secondary' : 'form-check-label';
 $blockStart  = $isBtnGroup ? '' : '<div class="form-check">';

--- a/layouts/joomla/icon/iconclass.php
+++ b/layouts/joomla/icon/iconclass.php
@@ -36,7 +36,7 @@ $html       = $displayData['html'] ?? true;
 $icon       = str_replace('icon-icon-', 'icon-', $icon);
 
 switch ($icon) {
-    case (strpos($icon, 'icon-') !== false):
+    case (str_contains($icon, 'icon-')):
         $iconPrefix = $displayData['prefix'] ?? null;
         break;
 

--- a/layouts/joomla/toolbar/link.php
+++ b/layouts/joomla/toolbar/link.php
@@ -24,7 +24,7 @@ extract($displayData, EXTR_OVERWRITE);
  * @var   string  $htmlAttributes
  */
 
-$margin = (strpos($url ?? '', 'index.php?option=com_config') === false) ? '' : 'ms-auto';
+$margin = (!str_contains($url ?? '', 'index.php?option=com_config')) ? '' : 'ms-auto';
 $target = empty($target) ? '' : 'target="' . $target . '"';
 ?>
 <joomla-toolbar-button class="<?php echo $margin; ?>">

--- a/libraries/loader.php
+++ b/libraries/loader.php
@@ -200,7 +200,7 @@ abstract class JLoader
             }
 
             // If we are importing a library from the Joomla namespace set the class to autoload.
-            if (strpos($path, 'joomla') === 0) {
+            if (str_starts_with($path, 'joomla')) {
                 // Since we are in the Joomla namespace prepend the classname with J.
                 $class = 'J' . $class;
 
@@ -504,7 +504,7 @@ abstract class JLoader
 
         // Loop through registered namespaces until we find a match.
         foreach (self::$namespaces as $ns => $paths) {
-            if (strpos($class, "{$ns}\\") === 0) {
+            if (str_starts_with($class, "{$ns}\\")) {
                 $nsPath = trim(str_replace('\\', DIRECTORY_SEPARATOR, $ns), DIRECTORY_SEPARATOR);
 
                 // Loop through paths registered to this namespace until we find a match.
@@ -512,7 +512,7 @@ abstract class JLoader
                     $classFilePath = realpath($path . DIRECTORY_SEPARATOR . substr_replace($classPath, '', 0, strlen($nsPath) + 1));
 
                     // We do not allow files outside the namespace root to be loaded
-                    if (strpos($classFilePath, realpath($path)) !== 0) {
+                    if (!str_starts_with($classFilePath, realpath($path))) {
                         continue;
                     }
 
@@ -592,7 +592,7 @@ abstract class JLoader
         foreach (self::$prefixes as $prefix => $lookup) {
             $chr = strlen($prefix) < strlen($class) ? $class[strlen($prefix)] : 0;
 
-            if (strpos($class, $prefix) === 0 && ($chr === strtoupper($chr))) {
+            if (str_starts_with($class, $prefix) && ($chr === strtoupper($chr))) {
                 return self::_load(substr($class, strlen($prefix)), $lookup);
             }
         }
@@ -621,7 +621,7 @@ abstract class JLoader
             $path = realpath($base . '/' . implode('/', array_map('strtolower', $parts)) . '.php');
 
             // Load the file if it exists and is in the lookup path.
-            if (strpos($path, realpath($base)) === 0 && is_file($path)) {
+            if (str_starts_with($path, realpath($base)) && is_file($path)) {
                 $found = (bool) include_once $path;
 
                 if ($found) {
@@ -639,7 +639,7 @@ abstract class JLoader
                 $path = realpath($base . '/' . implode('/', array_map('strtolower', [$parts[0], $parts[0]])) . '.php');
 
                 // Load the file if it exists and is in the lookup path.
-                if (strpos($path, realpath($base)) === 0 && is_file($path)) {
+                if (str_starts_with($path, realpath($base)) && is_file($path)) {
                     $found = (bool) include_once $path;
 
                     if ($found) {

--- a/libraries/namespacemap.php
+++ b/libraries/namespacemap.php
@@ -221,7 +221,7 @@ class JNamespacePsr4Map
             }
 
             // Check if we need to use administrator path
-            $isAdministrator = strpos($namespacePath, JPATH_ADMINISTRATOR) === 0;
+            $isAdministrator = str_starts_with($namespacePath, JPATH_ADMINISTRATOR);
             $path            = substr($namespacePath, strlen($isAdministrator ? JPATH_ADMINISTRATOR : JPATH_SITE));
 
             // Add the site path when a component

--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -408,7 +408,7 @@ abstract class WebApplication extends AbstractWebApplication
             $uri = Uri::getInstance($this->get('uri.request'));
 
             // If we are working from a CGI SAPI with the 'cgi.fix_pathinfo' directive disabled we use PHP_SELF.
-            if (strpos(PHP_SAPI, 'cgi') !== false && !\ini_get('cgi.fix_pathinfo') && !empty($_SERVER['REQUEST_URI'])) {
+            if (str_contains(PHP_SAPI, 'cgi') && !\ini_get('cgi.fix_pathinfo') && !empty($_SERVER['REQUEST_URI'])) {
                 // We aren't expecting PATH_INFO within PHP_SELF so this should work.
                 $path = \dirname($_SERVER['PHP_SELF']);
             } else {
@@ -420,7 +420,7 @@ abstract class WebApplication extends AbstractWebApplication
         $host = $uri->toString(['scheme', 'user', 'pass', 'host', 'port']);
 
         // Check if the path includes "index.php".
-        if (strpos($path, 'index.php') !== false) {
+        if (str_contains($path, 'index.php')) {
             // Remove the index.php portion of the path.
             $path = substr_replace($path, '', strpos($path, 'index.php'), 9);
         }
@@ -441,7 +441,7 @@ abstract class WebApplication extends AbstractWebApplication
         $mediaURI = trim($this->get('media_uri', ''));
 
         if ($mediaURI) {
-            if (strpos($mediaURI, '://') !== false) {
+            if (str_contains($mediaURI, '://')) {
                 $this->set('uri.media.full', $mediaURI);
                 $this->set('uri.media.path', $mediaURI);
             } else {

--- a/libraries/src/Authentication/Password/MD5Handler.php
+++ b/libraries/src/Authentication/Password/MD5Handler.php
@@ -89,7 +89,7 @@ class MD5Handler implements HandlerInterface, CheckIfRehashNeededHandlerInterfac
 
         // Compile the hash to compare
         // If the salt is empty AND there is a ':' in the original hash, we must append ':' at the end
-        $testcrypt = md5($plaintext . $salt) . ($salt ? ':' . $salt : (strpos($hashed, ':') !== false ? ':' : ''));
+        $testcrypt = md5($plaintext . $salt) . ($salt ? ':' . $salt : (str_contains($hashed, ':') ? ':' : ''));
 
         return Crypt::timingSafeCompare($hashed, $testcrypt);
     }

--- a/libraries/src/Cache/Storage/ApcuStorage.php
+++ b/libraries/src/Cache/Storage/ApcuStorage.php
@@ -170,7 +170,7 @@ class ApcuStorage extends CacheStorage
                 $internalKey = $key['key'];
             }
 
-            if (strpos($internalKey, $secret . '-cache-' . $group . '-') === 0 xor $mode !== 'group') {
+            if (str_starts_with($internalKey, $secret . '-cache-' . $group . '-') xor $mode !== 'group') {
                 apcu_delete($internalKey);
             }
         }

--- a/libraries/src/Cache/Storage/MemcachedStorage.php
+++ b/libraries/src/Cache/Storage/MemcachedStorage.php
@@ -307,7 +307,7 @@ class MemcachedStorage extends CacheStorage
             $prefix = $this->_hash . '-cache-' . $group . '-';
 
             foreach ($index as $key => $value) {
-                if (strpos($value->name, $prefix) === 0 xor $mode !== 'group') {
+                if (str_starts_with($value->name, $prefix) xor $mode !== 'group') {
                     static::$_db->delete($value->name);
                     unset($index[$key]);
                 }

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -286,11 +286,11 @@ class RedisStorage extends CacheStorage
         $secret = $this->_hash;
 
         foreach ($allKeys as $key) {
-            if (strpos($key, $secret . '-cache-' . $group . '-') === 0 && $mode === 'group') {
+            if (str_starts_with($key, $secret . '-cache-' . $group . '-') && $mode === 'group') {
                 static::$_redis->del($key);
             }
 
-            if (strpos($key, $secret . '-cache-' . $group . '-') !== 0 && $mode !== 'group') {
+            if (!str_starts_with($key, $secret . '-cache-' . $group . '-') && $mode !== 'group') {
                 static::$_redis->del($key);
             }
         }

--- a/libraries/src/Client/FtpClient.php
+++ b/libraries/src/Client/FtpClient.php
@@ -479,9 +479,9 @@ class FtpClient
         }
 
         // Match the system string to an OS
-        if (strpos(strtoupper($ret), 'MAC') !== false) {
+        if (str_contains(strtoupper($ret), 'MAC')) {
             $ret = 'MAC';
-        } elseif (strpos(strtoupper($ret), 'WIN') !== false) {
+        } elseif (str_contains(strtoupper($ret), 'WIN')) {
             $ret = 'WIN';
         } else {
             $ret = 'UNIX';

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -127,7 +127,7 @@ class SetConfigurationCommand extends AbstractCommand
         $collected = [];
 
         foreach ($options as $option) {
-            if (strpos($option, '=') === false) {
+            if (!str_contains($option, '=')) {
                 $this->ioStyle->error('Options and values should be separated by "="');
 
                 return false;

--- a/libraries/src/Date/Date.php
+++ b/libraries/src/Date/Date.php
@@ -312,19 +312,19 @@ class Date extends \DateTime
 
         if ($translate) {
             // Manually modify the month and day strings in the formatted time.
-            if (strpos($return, self::DAY_ABBR) !== false) {
+            if (str_contains($return, self::DAY_ABBR)) {
                 $return = str_replace(self::DAY_ABBR, $this->dayToString(parent::format('w'), true), $return);
             }
 
-            if (strpos($return, self::DAY_NAME) !== false) {
+            if (str_contains($return, self::DAY_NAME)) {
                 $return = str_replace(self::DAY_NAME, $this->dayToString(parent::format('w')), $return);
             }
 
-            if (strpos($return, self::MONTH_ABBR) !== false) {
+            if (str_contains($return, self::MONTH_ABBR)) {
                 $return = str_replace(self::MONTH_ABBR, $this->monthToString(parent::format('n'), true), $return);
             }
 
-            if (strpos($return, self::MONTH_NAME) !== false) {
+            if (str_contains($return, self::MONTH_NAME)) {
                 $return = str_replace(self::MONTH_NAME, $this->monthToString(parent::format('n')), $return);
             }
         }

--- a/libraries/src/Dispatcher/ComponentDispatcher.php
+++ b/libraries/src/Dispatcher/ComponentDispatcher.php
@@ -118,7 +118,7 @@ class ComponentDispatcher extends Dispatcher
         $command = $this->input->getCmd('task', 'display');
 
         // Check for a controller.task command.
-        if (strpos($command, '.') !== false) {
+        if (str_contains($command, '.')) {
             // Explode the controller.task command.
             list($controller, $task) = explode('.', $command);
 

--- a/libraries/src/Document/Renderer/Feed/RssRenderer.php
+++ b/libraries/src/Document/Renderer/Feed/RssRenderer.php
@@ -173,7 +173,7 @@ class RssRenderer extends DocumentRenderer
                 $itemlink = implode('/', array_map('rawurlencode', explode('/', $itemlink)));
             }
 
-            if ((strpos($itemlink, 'http://') === false) && (strpos($itemlink, 'https://') === false)) {
+            if ((!str_contains($itemlink, 'http://')) && (!str_contains($itemlink, 'https://'))) {
                 $itemlink = str_replace(' ', '%20', $url . $itemlink);
             }
 

--- a/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
+++ b/libraries/src/Document/Renderer/Html/ScriptsRenderer.php
@@ -185,7 +185,7 @@ class ScriptsRenderer extends DocumentRenderer
         $this->renderedSrc[$src] = true;
 
         // Check if script uses media version.
-        if ($version && strpos($src, '?') === false && ($mediaVersion || $version !== 'auto')) {
+        if ($version && !str_contains($src, '?') && ($mediaVersion || $version !== 'auto')) {
             $src .= '?' . ($version === 'auto' ? $mediaVersion : $version);
         }
 

--- a/libraries/src/Document/Renderer/Html/StylesRenderer.php
+++ b/libraries/src/Document/Renderer/Html/StylesRenderer.php
@@ -174,7 +174,7 @@ class StylesRenderer extends DocumentRenderer
         $this->renderedSrc[$src] = true;
 
         // Check if script uses media version.
-        if ($version && strpos($src, '?') === false && ($mediaVersion || $version !== 'auto')) {
+        if ($version && !str_contains($src, '?') && ($mediaVersion || $version !== 'auto')) {
             $src .= '?' . ($version === 'auto' ? $mediaVersion : $version);
         }
 

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -543,8 +543,8 @@ class Browser
              * user agent string, which we can use to look for mobile agents.
              */
             if (
-                strpos($this->agent, 'MOT-') !== false
-                || strpos($this->lowerAgent, 'j-') !== false
+                str_contains($this->agent, 'MOT-')
+                || str_contains($this->lowerAgent, 'j-')
                 || preg_match('/(mobileexplorer|openwave|opera mini|opera mobi|operamini|avantgo|wap|elaine)/i', $this->agent)
                 || preg_match('/(iPhone|iPod|iPad|Android|Mobile|Phone|BlackBerry|Xiino|Palmscape|palmsource)/i', $this->agent)
                 || preg_match('/(Nokia|Ericsson|docomo|digital paths|portalmmm|CriOS[\/ ]([0-9.]+))/i', $this->agent)
@@ -561,7 +561,7 @@ class Browser
             if (preg_match('|Edge\/([0-9.]+)|', $this->agent, $version)) {
                 $this->setBrowser('edge');
 
-                if (strpos($version[1], '.') !== false) {
+                if (str_contains($version[1], '.')) {
                     list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
                 } else {
                     $this->majorVersion = $version[1];
@@ -601,9 +601,9 @@ class Browser
 
                 list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
             } elseif (
-                strpos($this->lowerAgent, 'elaine/') !== false
-                || strpos($this->lowerAgent, 'palmsource') !== false
-                || strpos($this->lowerAgent, 'digital paths') !== false
+                str_contains($this->lowerAgent, 'elaine/')
+                || str_contains($this->lowerAgent, 'palmsource')
+                || str_contains($this->lowerAgent, 'digital paths')
             ) {
                 $this->setBrowser('palm');
             } elseif (
@@ -615,11 +615,11 @@ class Browser
                 $this->setBrowser('msie');
 
                 // Special case for IE 11+
-                if (strpos($version[0], 'Trident') !== false && strpos($version[0], 'rv:') !== false) {
+                if (str_contains($version[0], 'Trident') && str_contains($version[0], 'rv:')) {
                     preg_match('|rv:([0-9.]+)|', $this->agent, $version);
                 }
 
-                if (strpos($version[1], '.') !== false) {
+                if (str_contains($version[1], '.')) {
                     list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
                 } else {
                     $this->majorVersion = $version[1];
@@ -634,7 +634,7 @@ class Browser
                 }
             } elseif (preg_match('|ANTFresco\/([0-9]+)|', $this->agent, $version)) {
                 $this->setBrowser('fresco');
-            } elseif (strpos($this->lowerAgent, 'avantgo') !== false) {
+            } elseif (str_contains($this->lowerAgent, 'avantgo')) {
                 $this->setBrowser('avantgo');
             } elseif (preg_match('|[Kk]onqueror\/([0-9]+)|', $this->agent, $version) || preg_match('|Safari/([0-9]+)\.?([0-9]+)?|', $this->agent, $version)) {
                 // Konqueror and Apple's Safari both use the KHTML rendering engine.
@@ -645,7 +645,7 @@ class Browser
                     $this->minorVersion = $version[2];
                 }
 
-                if (strpos($this->agent, 'Safari') !== false && $this->majorVersion >= 60) {
+                if (str_contains($this->agent, 'Safari') && $this->majorVersion >= 60) {
                     // Safari.
                     $this->setBrowser('safari');
                     $this->identifyBrowserVersion();
@@ -660,25 +660,25 @@ class Browser
                 $this->setBrowser('links');
             } elseif (preg_match('|HotJava\/([0-9]+)|', $this->agent, $version)) {
                 $this->setBrowser('hotjava');
-            } elseif (strpos($this->agent, 'UP/') !== false || strpos($this->agent, 'UP.B') !== false || strpos($this->agent, 'UP.L') !== false) {
+            } elseif (str_contains($this->agent, 'UP/') || str_contains($this->agent, 'UP.B') || str_contains($this->agent, 'UP.L')) {
                 $this->setBrowser('up');
-            } elseif (strpos($this->agent, 'Xiino/') !== false) {
+            } elseif (str_contains($this->agent, 'Xiino/')) {
                 $this->setBrowser('xiino');
-            } elseif (strpos($this->agent, 'Palmscape/') !== false) {
+            } elseif (str_contains($this->agent, 'Palmscape/')) {
                 $this->setBrowser('palmscape');
-            } elseif (strpos($this->agent, 'Nokia') !== false) {
+            } elseif (str_contains($this->agent, 'Nokia')) {
                 $this->setBrowser('nokia');
-            } elseif (strpos($this->agent, 'Ericsson') !== false) {
+            } elseif (str_contains($this->agent, 'Ericsson')) {
                 $this->setBrowser('ericsson');
-            } elseif (strpos($this->lowerAgent, 'wap') !== false) {
+            } elseif (str_contains($this->lowerAgent, 'wap')) {
                 $this->setBrowser('wap');
-            } elseif (strpos($this->lowerAgent, 'docomo') !== false || strpos($this->lowerAgent, 'portalmmm') !== false) {
+            } elseif (str_contains($this->lowerAgent, 'docomo') || str_contains($this->lowerAgent, 'portalmmm')) {
                 $this->setBrowser('imode');
-            } elseif (strpos($this->agent, 'BlackBerry') !== false) {
+            } elseif (str_contains($this->agent, 'BlackBerry')) {
                 $this->setBrowser('blackberry');
-            } elseif (strpos($this->agent, 'MOT-') !== false) {
+            } elseif (str_contains($this->agent, 'MOT-')) {
                 $this->setBrowser('motorola');
-            } elseif (strpos($this->lowerAgent, 'j-') !== false) {
+            } elseif (str_contains($this->lowerAgent, 'j-')) {
                 $this->setBrowser('mml');
             } elseif (preg_match('|Mozilla\/([0-9.]+)|', $this->agent, $version)) {
                 $this->setBrowser('mozilla');
@@ -701,9 +701,9 @@ class Browser
      */
     protected function _setPlatform()
     {
-        if (strpos($this->lowerAgent, 'wind') !== false) {
+        if (str_contains($this->lowerAgent, 'wind')) {
             $this->platform = 'win';
-        } elseif (strpos($this->lowerAgent, 'mac') !== false) {
+        } elseif (str_contains($this->lowerAgent, 'mac')) {
             $this->platform = 'mac';
         } else {
             $this->platform = 'unix';
@@ -854,11 +854,11 @@ class Browser
         if (!empty($this->accept)) {
             $wildcard_match = false;
 
-            if (strpos($this->accept, $mimetype) !== false) {
+            if (str_contains($this->accept, $mimetype)) {
                 return true;
             }
 
-            if (strpos($this->accept, '*/*') !== false) {
+            if (str_contains($this->accept, '*/*')) {
                 $wildcard_match = true;
 
                 if ($type !== 'image') {
@@ -867,7 +867,7 @@ class Browser
             }
 
             // Deal with Mozilla pjpeg/jpeg issue
-            if ($this->isBrowser('mozilla') && ($mimetype === 'image/pjpeg') && (strpos($this->accept, 'image/jpeg') !== false)) {
+            if ($this->isBrowser('mozilla') && ($mimetype === 'image/pjpeg') && (str_contains($this->accept, 'image/jpeg'))) {
                 return true;
             }
 

--- a/libraries/src/Event/AbstractEvent.php
+++ b/libraries/src/Event/AbstractEvent.php
@@ -84,7 +84,7 @@ abstract class AbstractEvent extends Event
          * the onTableBeforeLoad event name.
          */
         if (!$eventClassName || !class_exists($eventClassName, true)) {
-            $bareName       = strpos($eventName, 'on') === 0 ? substr($eventName, 2) : $eventName;
+            $bareName       = str_starts_with($eventName, 'on') ? substr($eventName, 2) : $eventName;
             $parts          = Normalise::fromCamelCase($bareName, true);
             $eventClassName = __NAMESPACE__ . '\\' . ucfirst(array_shift($parts)) . '\\';
             $eventClassName .= implode('', $parts);

--- a/libraries/src/Event/View/DisplayEvent.php
+++ b/libraries/src/Event/View/DisplayEvent.php
@@ -51,7 +51,7 @@ class DisplayEvent extends AbstractImmutableEvent
             throw new \BadMethodCallException("Argument 'extension' of event {$this->name} is not of type 'string'");
         }
 
-        if (strpos($arguments['extension'], '.') === false) {
+        if (!str_contains($arguments['extension'], '.')) {
             throw new \BadMethodCallException("Argument 'extension' of event {$this->name} has wrong format. Valid format: 'component.section'");
         }
 

--- a/libraries/src/Event/Workflow/AbstractEvent.php
+++ b/libraries/src/Event/Workflow/AbstractEvent.php
@@ -42,7 +42,7 @@ abstract class AbstractEvent extends AbstractImmutableEvent
             throw new \BadMethodCallException("Argument 'extension' of event {$this->name} is required but has not been provided");
         }
 
-        if (strpos($arguments['extension'], '.') === false) {
+        if (!str_contains($arguments['extension'], '.')) {
             throw new \BadMethodCallException("Argument 'extension' of event {$this->name} has wrong format. Valid format: 'component.section'");
         }
 

--- a/libraries/src/Filesystem/File.php
+++ b/libraries/src/Filesystem/File.php
@@ -56,7 +56,7 @@ class File
         $ext = substr($file, $dot + 1);
 
         // Extension cannot contain slashes.
-        if (strpos($ext, '/') !== false || (DIRECTORY_SEPARATOR === '\\' && strpos($ext, '\\') !== false)) {
+        if (str_contains($ext, '/') || (DIRECTORY_SEPARATOR === '\\' && str_contains($ext, '\\'))) {
             return '';
         }
 

--- a/libraries/src/Filesystem/Folder.php
+++ b/libraries/src/Filesystem/Folder.php
@@ -237,7 +237,7 @@ abstract class Folder
                 foreach ($obdArray as $test) {
                     $test = Path::clean($test);
 
-                    if (strpos($path, $test) === 0 || strpos($path, realpath($test)) === 0) {
+                    if (str_starts_with($path, $test) || str_starts_with($path, realpath($test))) {
                         $inBaseDir = true;
                         break;
                     }

--- a/libraries/src/Filter/InputFilter.php
+++ b/libraries/src/Filter/InputFilter.php
@@ -265,7 +265,7 @@ class InputFilter extends BaseInputFilter
 
                 // 1. Null byte check
                 if ($options['null_byte']) {
-                    if (strstr($intendedName, "\x00")) {
+                    if (str_contains($intendedName, "\x00")) {
                         return false;
                     }
                 }
@@ -335,7 +335,7 @@ class InputFilter extends BaseInputFilter
 
                                 if ($collide) {
                                     // These are suspicious text files which may have the short tag (<?) in them
-                                    if (strstr($data, '<?')) {
+                                    if (str_contains($data, '<?')) {
                                         return false;
                                     }
                                 }
@@ -370,7 +370,7 @@ class InputFilter extends BaseInputFilter
                                      * file extension in them
                                      */
                                     foreach ($options['forbidden_extensions'] as $ext) {
-                                        if (strstr($data, '.' . $ext)) {
+                                        if (str_contains($data, '.' . $ext)) {
                                             return false;
                                         }
                                     }

--- a/libraries/src/Form/Field/CaptchaField.php
+++ b/libraries/src/Form/Field/CaptchaField.php
@@ -139,7 +139,7 @@ class CaptchaField extends FormField
         // Obs: Don't put required="required" in the xml file, you just need to have validate="captcha"
         $this->required = true;
 
-        if (strpos($this->class, 'required') === false) {
+        if (!str_contains($this->class, 'required')) {
             $this->class .= ' required';
         }
 

--- a/libraries/src/Form/Field/MediaField.php
+++ b/libraries/src/Form/Field/MediaField.php
@@ -274,7 +274,7 @@ class MediaField extends FormField
         }
 
         // Value in new format such as images/headers/blue-flower.jpg#joomlaImage://local-images/headers/blue-flower.jpg?width=700&height=180
-        if ($this->value && strpos($this->value, '#') !== false) {
+        if ($this->value && str_contains($this->value, '#')) {
             $uri     = new Uri(explode('#', $this->value)[1]);
             $adapter = $uri->getHost();
             $path    = $uri->getPath();

--- a/libraries/src/Form/Field/SchemaorgComponentSectionsField.php
+++ b/libraries/src/Form/Field/SchemaorgComponentSectionsField.php
@@ -46,7 +46,7 @@ class SchemaorgComponentSectionsField extends ComponentsField
         $options   = [];
         $options[] = HTMLHelper::_('select.option', ' ', Text::_('JNONE'));
         foreach ($items as $item) {
-            if (substr($item->value, 0, 4) !== 'com_') {
+            if (!str_starts_with($item->value, 'com_')) {
                 continue;
             }
 

--- a/libraries/src/Form/Field/TagField.php
+++ b/libraries/src/Form/Field/TagField.php
@@ -153,7 +153,7 @@ class TagField extends ListField
             }
         } elseif (!empty($this->element['language'])) {
             // Filter language
-            if (strpos($this->element['language'], ',') !== false) {
+            if (str_contains($this->element['language'], ',')) {
                 $language = explode(',', $this->element['language']);
             } else {
                 $language = [$this->element['language']];

--- a/libraries/src/Form/Field/TimezoneField.php
+++ b/libraries/src/Form/Field/TimezoneField.php
@@ -128,7 +128,7 @@ class TimezoneField extends GroupedlistField
         // Build the group lists.
         foreach ($zones as $zone) {
             // Time zones not in a group we will ignore.
-            if (strpos($zone, '/') === false) {
+            if (!str_contains($zone, '/')) {
                 continue;
             }
 

--- a/libraries/src/Form/Field/UsergrouplistField.php
+++ b/libraries/src/Form/Field/UsergrouplistField.php
@@ -54,7 +54,7 @@ class UsergrouplistField extends ListField
      */
     public function setup(\SimpleXMLElement $element, $value, $group = null)
     {
-        if (\is_string($value) && strpos($value, ',') !== false) {
+        if (\is_string($value) && str_contains($value, ',')) {
             $value = explode(',', $value);
         }
 

--- a/libraries/src/Form/Field/WorkflowComponentSectionsField.php
+++ b/libraries/src/Form/Field/WorkflowComponentSectionsField.php
@@ -48,7 +48,7 @@ class WorkflowComponentSectionsField extends ComponentsField
         $options[] = HTMLHelper::_('select.option', ' ', Text::_('JNONE'));
 
         foreach ($items as $item) {
-            if (substr($item->value, 0, 4) !== 'com_') {
+            if (!str_starts_with($item->value, 'com_')) {
                 continue;
             }
 

--- a/libraries/src/Form/Filter/TelFilter.php
+++ b/libraries/src/Form/Filter/TelFilter.php
@@ -47,11 +47,11 @@ class TelFilter implements FormFilterInterface
         if (preg_match('/^(?:\+?1[-. ]?)?\(?([2-9][0-8][0-9])\)?[-. ]?([2-9][0-9]{2})[-. ]?([0-9]{4})$/', $value) == 1) {
             $number = (string) preg_replace('/[^\d]/', '', $value);
 
-            if (substr($number, 0, 1) === '1') {
+            if (str_starts_with($number, '1')) {
                 $number = substr($number, 1);
             }
 
-            if (substr($number, 0, 2) === '+1') {
+            if (str_starts_with($number, '+1')) {
                 $number = substr($number, 2);
             }
 
@@ -65,7 +65,7 @@ class TelFilter implements FormFilterInterface
             $result      = $countrycode . '.' . $number;
         } elseif (preg_match('/^\+[0-9]{1,3}\.[0-9]{4,14}(?:x.+)?$/', $value) == 1) {
             // If not, does it match EPP?
-            if (strstr($value, 'x')) {
+            if (str_contains($value, 'x')) {
                 $xpos  = strpos($value, 'x');
                 $value = substr($value, 0, $xpos);
             }

--- a/libraries/src/Form/Filter/UrlFilter.php
+++ b/libraries/src/Form/Filter/UrlFilter.php
@@ -67,7 +67,7 @@ class UrlFilter implements FormFilterInterface
             $protocol = 'http';
 
             // If it looks like an internal link, then add the root.
-            if (substr($value, 0, 9) === 'index.php') {
+            if (str_starts_with($value, 'index.php')) {
                 $value = Uri::root() . $value;
             } else {
                 // Otherwise we treat it as an external link.
@@ -81,7 +81,7 @@ class UrlFilter implements FormFilterInterface
             // If it starts with the host string, just prepend the protocol.
             if (substr($value, 0) === $host) {
                 $value = 'http://' . $value;
-            } elseif (substr($value, 0, 1) !== '/') {
+            } elseif (!str_starts_with($value, '/')) {
                 // Otherwise if it doesn't start with "/" prepend the prefix of the current site.
                 $value = Uri::root(true) . '/' . $value;
             }

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1705,7 +1705,7 @@ class Form implements CurrentUserInterface
             $forms[$name] = Factory::getContainer()->get(FormFactoryInterface::class)->createForm($name, $options);
 
             // Load the data.
-            if (substr($data, 0, 1) === '<') {
+            if (str_starts_with($data, '<')) {
                 if ($forms[$name]->load($data, $replace, $xpath) == false) {
                     throw new \RuntimeException(\sprintf('%s() could not load form', __METHOD__));
                 }

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -497,7 +497,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
 
             default:
                 // Check for data attribute
-                if (strpos($name, 'data-') === 0 && \array_key_exists($name, $this->dataAttributes)) {
+                if (str_starts_with($name, 'data-') && \array_key_exists($name, $this->dataAttributes)) {
                     return $this->dataAttributes[$name];
                 }
         }
@@ -593,7 +593,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
 
             default:
                 // Detect data attribute(s)
-                if (strpos($name, 'data-') === 0) {
+                if (str_starts_with($name, 'data-')) {
                     $this->dataAttributes[$name] = $value;
                 } else {
                     if (property_exists(__CLASS__, $name)) {
@@ -671,7 +671,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
 
         // Lets detect miscellaneous data attribute. For eg, data-*
         foreach ($this->element->attributes() as $key => $value) {
-            if (strpos($key, 'data-') === 0) {
+            if (str_starts_with($key, 'data-')) {
                 // Data attribute key value pair
                 $this->dataAttributes[$key] = $value;
             }
@@ -1094,7 +1094,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
             }
 
             // Check for a callback filter
-            if (strpos($filter, '::') !== false) {
+            if (str_contains($filter, '::')) {
                 if (\is_callable(explode('::', $filter))) {
                     return \call_user_func(explode('::', $filter), $value);
                 }

--- a/libraries/src/Form/FormHelper.php
+++ b/libraries/src/Form/FormHelper.php
@@ -509,7 +509,7 @@ class FormHelper
                 continue;
             }
 
-            $compareEqual     = strpos($showOnPart, '!:') === false;
+            $compareEqual     = !str_contains($showOnPart, '!:');
             $showOnPartBlocks = explode(($compareEqual ? ':' : '!:'), $showOnPart, 2);
 
             $dotPos = strpos($showOnPartBlocks[0], '.');

--- a/libraries/src/Form/FormRule.php
+++ b/libraries/src/Form/FormRule.php
@@ -85,7 +85,7 @@ class FormRule
 
         // Add unicode property support if available.
         if ($unicodePropertiesSupport) {
-            $this->modifiers = (strpos($this->modifiers, 'u') !== false) ? $this->modifiers : $this->modifiers . 'u';
+            $this->modifiers = (str_contains($this->modifiers, 'u')) ? $this->modifiers : $this->modifiers . 'u';
         }
 
         // Test the value against the regular expression.

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -404,7 +404,7 @@ abstract class HTMLHelper
         }
 
         // If http is present in filename
-        if (strpos($file, 'http') === 0 || strpos($file, '//') === 0) {
+        if (str_starts_with($file, 'http') || str_starts_with($file, '//')) {
             $includes = [$file];
         } else {
             // Extract extension and strip the file
@@ -755,7 +755,7 @@ abstract class HTMLHelper
             // Go through each argument
             foreach (explode(' ', $attribs) as $attribute) {
                 // When an argument without a value, default to an empty string
-                if (strpos($attribute, '=') === false) {
+                if (!str_contains($attribute, '=')) {
                     $attributes[$attribute] = '';
                     continue;
                 }
@@ -1037,7 +1037,7 @@ abstract class HTMLHelper
         // Don't process empty strings
         if ($content !== '' || $title !== '') {
             // Split title into title and content if the title contains '::' (old Mootools format).
-            if ($content === '' && !(strpos($title, '::') === false)) {
+            if ($content === '' && !(!str_contains($title, '::'))) {
                 list($title, $content) = explode('::', $title, 2);
             }
 
@@ -1355,7 +1355,7 @@ abstract class HTMLHelper
          * If there is % character left after replacing, that mean one of unsupported format is used
          * the conversion false
          */
-        if (strpos($format, '%') !== false) {
+        if (str_contains($format, '%')) {
             return false;
         }
 

--- a/libraries/src/HTML/Helpers/Number.php
+++ b/libraries/src/HTML/Helpers/Number.php
@@ -58,7 +58,7 @@ abstract class Number
             list(, $oBytes, $oUnit) = $matches;
 
             if ($oUnit && is_numeric($oBytes)) {
-                $oBase  = $iec && strpos($oUnit, 'i') === false ? 1000 : 1024;
+                $oBase  = $iec && !str_contains($oUnit, 'i') ? 1000 : 1024;
                 $factor = pow($oBase, stripos('BKMGTPEZY', $oUnit[0]));
                 $oBytes *= $factor;
             }

--- a/libraries/src/HTML/Helpers/Select.php
+++ b/libraries/src/HTML/Helpers/Select.php
@@ -140,7 +140,7 @@ abstract class Select
         $id = str_replace(['[', ']', ' '], '', $id);
 
         // If the selectbox contains "form-select-color-state" then load the JS file
-        if (strpos($attribs, 'form-select-color-state') !== false) {
+        if (str_contains($attribs, 'form-select-color-state')) {
             Factory::getDocument()->getWebAssetManager()
                 ->registerAndUseScript(
                     'webcomponent.select-colour',

--- a/libraries/src/HTML/Helpers/StringHelper.php
+++ b/libraries/src/HTML/Helpers/StringHelper.php
@@ -67,7 +67,7 @@ abstract class StringHelper
         if ($length > 0 && FrameworkStringHelper::strlen($text) > $length) {
             $tmp = trim(FrameworkStringHelper::substr($text, 0, $length));
 
-            if ($tmp[0] === '<' && strpos($tmp, '>') === false) {
+            if ($tmp[0] === '<' && !str_contains($tmp, '>')) {
                 return '...';
             }
 
@@ -165,7 +165,7 @@ abstract class StringHelper
         }
 
         // Take care of short simple cases.
-        if ($maxLength <= 3 && $html[0] !== '<' && strpos(substr($html, 0, $maxLength - 1), '<') === false && $baseLength > $maxLength) {
+        if ($maxLength <= 3 && $html[0] !== '<' && !str_contains(substr($html, 0, $maxLength - 1), '<') && $baseLength > $maxLength) {
             return '...';
         }
 
@@ -196,7 +196,7 @@ abstract class StringHelper
 
         // If the plain text is shorter than the max length the variable will not end in ...
         // In that case we use the whole string.
-        if (substr($ptString, -3) !== '...') {
+        if (!str_ends_with($ptString, '...')) {
             return $html;
         }
 

--- a/libraries/src/Helper/AuthenticationHelper.php
+++ b/libraries/src/Helper/AuthenticationHelper.php
@@ -131,7 +131,7 @@ abstract class AuthenticationHelper
 
                 // Unset anything that doesn't conform to a button definition
                 foreach (array_keys($button) as $key) {
-                    if (substr($key, 0, 5) == 'data-') {
+                    if (str_starts_with($key, 'data-')) {
                         continue;
                     }
 

--- a/libraries/src/Helper/MediaHelper.php
+++ b/libraries/src/Helper/MediaHelper.php
@@ -385,7 +385,7 @@ class MediaHelper
             $d = dir($dir);
 
             while (($entry = $d->read()) !== false) {
-                if ($entry[0] !== '.' && strpos($entry, '.html') === false && strpos($entry, '.php') === false && is_file($dir . DIRECTORY_SEPARATOR . $entry)) {
+                if ($entry[0] !== '.' && !str_contains($entry, '.html') && !str_contains($entry, '.php') && is_file($dir . DIRECTORY_SEPARATOR . $entry)) {
                     $total_file++;
                 }
 

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -63,7 +63,7 @@ abstract class ModuleHelper
         }
 
         // If we didn't find it, and the name is mod_something, create a dummy object
-        if ($result === null && strpos($name, 'mod_') === 0) {
+        if ($result === null && str_starts_with($name, 'mod_')) {
             $result         = static::createDummyModule();
             $result->module = $name;
         }
@@ -319,7 +319,7 @@ abstract class ModuleHelper
         $defaultLayout = $layout;
         $template      = $templateObj->template;
 
-        if (strpos($layout, ':') !== false) {
+        if (str_contains($layout, ':')) {
             // Get the template and file name from the string
             $temp          = explode(':', $layout);
             $template      = $temp[0] === '_' ? $template : $temp[0];

--- a/libraries/src/Helper/PublicFolderGeneratorHelper.php
+++ b/libraries/src/Helper/PublicFolderGeneratorHelper.php
@@ -100,7 +100,7 @@ PHP;
         $root                = JPATH_ROOT . '/';
         $defineRoot          = '\'' . JPATH_ROOT . '\'';
 
-        if (substr($destinationPath, 0, 1) !== '/') {
+        if (!str_starts_with($destinationPath, '/')) {
             $fullDestinationPath = JPATH_ROOT . '/' . $destinationPath;
             $root                = '';
             $dirsToRoot          = substr_count($destinationPath, '/');
@@ -190,7 +190,7 @@ PHP;
      */
     private function createSymlink(string $source, string $dest, string $base): void
     {
-        if (substr($source, 0, 1) !== '/') {
+        if (!str_starts_with($source, '/')) {
             $source = str_repeat('../', substr_count($dest, '/')) . $source;
             $dest   = $base . $dest;
         }

--- a/libraries/src/Helper/TagsHelper.php
+++ b/libraries/src/Helper/TagsHelper.php
@@ -108,7 +108,7 @@ class TagsHelper extends CMSHelper
         $typeId = $ucm->getTypeId();
 
         // Insert the new tag maps
-        if (strpos(implode(',', $tags), '#') !== false) {
+        if (str_contains(implode(',', $tags), '#')) {
             $tags = $this->createTagsFromField($tags);
         }
 
@@ -246,7 +246,7 @@ class TagsHelper extends CMSHelper
 
         foreach ($tags as $key => $tag) {
             // User is not allowed to create tags, so don't create.
-            if (!$canCreate && strpos($tag, '#new#') !== false) {
+            if (!$canCreate && str_contains($tag, '#new#')) {
                 continue;
             }
 

--- a/libraries/src/Http/Transport/CurlTransport.php
+++ b/libraries/src/Http/Transport/CurlTransport.php
@@ -77,7 +77,7 @@ class CurlTransport extends AbstractTransport implements TransportInterface
         // If data exists let's encode it and make sure our Content-type header is set.
         if (isset($data)) {
             // If the data is a scalar value simply add it to the cURL post fields.
-            if (\is_scalar($data) || (isset($headers['Content-Type']) && strpos($headers['Content-Type'], 'multipart/form-data') === 0)) {
+            if (\is_scalar($data) || (isset($headers['Content-Type']) && str_starts_with($headers['Content-Type'], 'multipart/form-data'))) {
                 $options[CURLOPT_POSTFIELDS] = $data;
             } else {
                 // Otherwise we need to encode the value first.

--- a/libraries/src/Input/Cli.php
+++ b/libraries/src/Input/Cli.php
@@ -147,7 +147,7 @@ class Cli extends Input
             $arg = $argv[$i];
 
             // --foo --bar=baz
-            if (substr($arg, 0, 2) === '--') {
+            if (str_starts_with($arg, '--')) {
                 $eqPos = strpos($arg, '=');
 
                 // --foo
@@ -169,7 +169,7 @@ class Cli extends Input
                     $value     = substr($arg, $eqPos + 1);
                     $out[$key] = $value;
                 }
-            } elseif (substr($arg, 0, 1) === '-') {
+            } elseif (str_starts_with($arg, '-')) {
                 // -k=value -abc
                 // -k=value
                 if (substr($arg, 2, 1) === '=') {

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -521,7 +521,7 @@ class ComponentAdapter extends InstallerAdapter
     {
         $element = parent::getElement($element);
 
-        if (strpos($element, 'com_') !== 0) {
+        if (!str_starts_with($element, 'com_')) {
             $element = 'com_' . $element;
         }
 

--- a/libraries/src/Installer/InstallerHelper.php
+++ b/libraries/src/Installer/InstallerHelper.php
@@ -290,7 +290,7 @@ abstract class InstallerHelper
     {
         $default = uniqid();
 
-        if (!\is_string($url) || strpos($url, '/') === false) {
+        if (!\is_string($url) || !str_contains($url, '/')) {
             return $default;
         }
 

--- a/libraries/src/Language/Language.php
+++ b/libraries/src/Language/Language.php
@@ -277,7 +277,7 @@ class Language extends BaseLanguage
             // Javascript filter
             $string = addslashes($string);
         } elseif ($interpretBackSlashes) {
-            if (strpos($string, '\\') !== false) {
+            if (str_contains($string, '\\')) {
                 // Interpret \n and \t characters
                 $string = str_replace(['\\\\', '\t', '\n'], ["\\", "\t", "\n"], $string);
             }

--- a/libraries/src/Language/Text.php
+++ b/libraries/src/Language/Text.php
@@ -92,7 +92,7 @@ class Text
     private static function passSprintf(&$string, $jsSafe = false, $interpretBackSlashes = true, $script = false)
     {
         // Check if string contains a comma
-        if (empty($string) || strpos($string, ',') === false) {
+        if (empty($string) || !str_contains($string, ',')) {
             return false;
         }
 

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -300,7 +300,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface, L
         }
 
         // Check for a controller.task command.
-        if (strpos($command, '.') !== false) {
+        if (str_contains($command, '.')) {
             // Explode the controller.task command.
             list($type, $task) = explode('.', $command);
 
@@ -750,7 +750,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface, L
         if (!$prefix) {
             if ($this->factory instanceof LegacyFactory) {
                 $prefix = $this->model_prefix;
-            } elseif (!empty($config['base_path']) && strpos(Path::clean($config['base_path']), JPATH_ADMINISTRATOR) === 0) {
+            } elseif (!empty($config['base_path']) && str_starts_with(Path::clean($config['base_path']), JPATH_ADMINISTRATOR)) {
                 // When the frontend uses an administrator model
                 $prefix = 'Administrator';
             } else {
@@ -861,7 +861,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface, L
         if (!$prefix) {
             if ($this->factory instanceof LegacyFactory) {
                 $prefix = $this->getName() . 'View';
-            } elseif (!empty($config['base_path']) && strpos(Path::clean($config['base_path']), JPATH_ADMINISTRATOR) === 0) {
+            } elseif (!empty($config['base_path']) && str_starts_with(Path::clean($config['base_path']), JPATH_ADMINISTRATOR)) {
                 // When the front uses an administrator view
                 $prefix = 'Administrator';
             } else {

--- a/libraries/src/MVC/Model/FormBehaviorTrait.php
+++ b/libraries/src/MVC/Model/FormBehaviorTrait.php
@@ -93,7 +93,7 @@ trait FormBehaviorTrait
         }
 
         // Load the data.
-        if (substr($source, 0, 1) === '<') {
+        if (str_starts_with($source, '<')) {
             if ($form->load($source, false, $xpath) == false) {
                 throw new \RuntimeException('Form::loadForm could not load form');
             }

--- a/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
+++ b/libraries/src/MVC/Model/LegacyModelLoaderTrait.php
@@ -160,12 +160,12 @@ trait LegacyModelLoaderTrait
         $sitePath  = Path::clean(JPATH_SITE . '/components/' . $componentName);
 
         foreach (self::addIncludePath() as $path) {
-            if (strpos($path, $adminPath) !== false) {
+            if (str_contains($path, $adminPath)) {
                 $client = 'Administrator';
                 break;
             }
 
-            if (strpos($path, $sitePath) !== false) {
+            if (str_contains($path, $sitePath)) {
                 $client = 'Site';
                 break;
             }

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -646,7 +646,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
         $new_state = $input->get($request, null, $type);
 
         // BC for Search Tools which uses different naming
-        if ($new_state === null && strpos($request, 'filter_') === 0) {
+        if ($new_state === null && str_starts_with($request, 'filter_')) {
             $name    = substr($request, 7);
             $filters = $app->getInput()->get('filter', [], 'array');
 

--- a/libraries/src/MVC/View/HtmlView.php
+++ b/libraries/src/MVC/View/HtmlView.php
@@ -281,7 +281,7 @@ class HtmlView extends AbstractView implements CurrentUserInterface
     {
         $previous = $this->_layout;
 
-        if (strpos($layout, ':') === false) {
+        if (!str_contains($layout, ':')) {
             $this->_layout = $layout;
         } else {
             // Convert parameter to array based on :

--- a/libraries/src/Mail/MailHelper.php
+++ b/libraries/src/Mail/MailHelper.php
@@ -136,7 +136,7 @@ abstract class MailHelper
         $allowed = "a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-";
         $regex   = "/^[$allowed][\.$allowed]{0,63}$/";
 
-        if (!preg_match($regex, $local) || substr($local, -1) === '.' || $local[0] === '.' || preg_match('/\.\./', $local)) {
+        if (!preg_match($regex, $local) || str_ends_with($local, '.') || $local[0] === '.' || preg_match('/\.\./', $local)) {
             return false;
         }
 
@@ -173,7 +173,7 @@ abstract class MailHelper
             }
 
             // Check for a dash at the beginning of the domain
-            if (strpos($domain, '-') === 0) {
+            if (str_starts_with($domain, '-')) {
                 return false;
             }
 
@@ -202,7 +202,7 @@ abstract class MailHelper
         $siteUrl = Uri::root();
 
         // Replace none SEF URLs by absolute SEF URLs
-        if (strpos($content, 'href="index.php?') !== false) {
+        if (str_contains($content, 'href="index.php?')) {
             preg_match_all('#href="index.php\?([^"]+)"#m', $content, $matches);
 
             foreach ($matches[1] as $urlQueryString) {
@@ -221,7 +221,7 @@ abstract class MailHelper
         $attributes = ['href=', 'src=', 'poster=', 'loading=', 'data-path='];
 
         foreach ($attributes as $attribute) {
-            if (strpos($content, $attribute) !== false) {
+            if (str_contains($content, $attribute)) {
                 // If the attribute is 'loading=', remove loading="lazy"
                 if ($attribute === 'loading=') {
                     $content = preg_replace('/\s' . $attribute . '"lazy"/i', '', $content);

--- a/libraries/src/Object/LegacyPropertyManagementTrait.php
+++ b/libraries/src/Object/LegacyPropertyManagementTrait.php
@@ -89,7 +89,7 @@ trait LegacyPropertyManagementTrait
 
         if ($public) {
             foreach ($vars as $key => $value) {
-                if ('_' == substr($key, 0, 1)) {
+                if (str_starts_with($key, '_')) {
                     unset($vars[$key]);
                 }
             }

--- a/libraries/src/Pathway/SitePathway.php
+++ b/libraries/src/Pathway/SitePathway.php
@@ -60,7 +60,7 @@ class SitePathway extends Pathway
                             break;
 
                         case 'url':
-                            if ((strpos($link->link, 'index.php?') === 0) && (strpos($link->link, 'Itemid=') === false)) {
+                            if ((str_starts_with($link->link, 'index.php?')) && (!str_contains($link->link, 'Itemid='))) {
                                 // If this is an internal Joomla link, ensure the Itemid is set.
                                 $url = $link->link . '&Itemid=' . $link->id;
                             } else {

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -215,7 +215,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
 
         /** @var \ReflectionMethod $method */
         foreach ($methods as $method) {
-            if (substr($method->name, 0, 2) !== 'on') {
+            if (!str_starts_with($method->name, 'on')) {
                 continue;
             }
 

--- a/libraries/src/Plugin/PluginHelper.php
+++ b/libraries/src/Plugin/PluginHelper.php
@@ -61,7 +61,7 @@ abstract class PluginHelper
         $defaultLayout = $layout;
         $template      = $templateObj->template;
 
-        if (strpos($layout, ':') !== false) {
+        if (str_contains($layout, ':')) {
             // Get the template and file name from the string
             $temp          = explode(':', $layout);
             $template      = $temp[0] === '_' ? $templateObj->template : $temp[0];

--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -172,7 +172,7 @@ class ApiRouter extends Router
         $path = ltrim($path, '/');
 
         // We can only remove index.php if it's present in the beginning of the route
-        if (strpos($path, 'index.php') !== 0) {
+        if (!str_starts_with($path, 'index.php')) {
             return $path;
         }
 

--- a/libraries/src/Router/Route.php
+++ b/libraries/src/Router/Route.php
@@ -128,7 +128,7 @@ class Route
     public static function link($client, $url, $xhtml = true, $tls = self::TLS_IGNORE, $absolute = false)
     {
         // If we cannot process this $url exit early.
-        if (!\is_array($url) && (strpos($url, '&') !== 0) && (strpos($url, 'index.php') !== 0)) {
+        if (!\is_array($url) && (!str_starts_with($url, '&')) && (!str_starts_with($url, 'index.php'))) {
             return $url;
         }
 

--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -460,7 +460,7 @@ class Router
      */
     protected function createUri($url)
     {
-        if (!\is_array($url) && substr($url, 0, 1) !== '&') {
+        if (!\is_array($url) && !str_starts_with($url, '&')) {
             return new Uri($url);
         }
 
@@ -469,7 +469,7 @@ class Router
         if (\is_string($url)) {
             $vars = [];
 
-            if (strpos($url, '&amp;') !== false) {
+            if (str_contains($url, '&amp;')) {
                 $url = str_replace('&amp;', '&', $url);
             }
 

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -178,7 +178,7 @@ class SiteRouter extends Router
         $route = $uri->getPath();
 
         // Identify format
-        if (!(substr($route, -9) === 'index.php' || substr($route, -1) === '/') && $suffix = pathinfo($route, PATHINFO_EXTENSION)) {
+        if (!(str_ends_with($route, 'index.php') || str_ends_with($route, '/')) && $suffix = pathinfo($route, PATHINFO_EXTENSION)) {
             $uri->setVar('format', $suffix);
             $route = str_replace('.' . $suffix, '', $route);
             $uri->setPath($route);
@@ -509,7 +509,7 @@ class SiteRouter extends Router
         $route = $uri->getPath();
 
         // Identify format
-        if (!(substr($route, -9) === 'index.php' || substr($route, -1) === '/') && $format = $uri->getVar('format', 'html')) {
+        if (!(str_ends_with($route, 'index.php') || str_ends_with($route, '/')) && $format = $uri->getVar('format', 'html')) {
             $route .= '.' . $format;
             $uri->setPath($route);
             $uri->delVar('format');

--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -354,7 +354,7 @@ class MysqlChangeItem extends ChangeItem
         // Skip types that do not support default values
         $type = strtolower($type);
 
-        if (substr($type, -4) === 'text' || substr($type, -4) === 'blob') {
+        if (str_ends_with($type, 'text') || str_ends_with($type, 'blob')) {
             return false;
         }
 

--- a/libraries/src/Session/Session.php
+++ b/libraries/src/Session/Session.php
@@ -202,7 +202,7 @@ class Session extends BaseSession
          * This is no longer the case in Joomla 4 and will be converted
          * when saving new values in `self::set()`
          */
-        if (strpos($name, '.') !== false && parent::has('__' . $name)) {
+        if (str_contains($name, '.') && parent::has('__' . $name)) {
             return parent::get('__' . $name, $default);
         }
 
@@ -281,7 +281,7 @@ class Session extends BaseSession
          * This is no longer the case in Joomla 4 and will be converted
          * when saving new values in `self::set()`
          */
-        if (strpos($name, '.') !== false && parent::has('__' . $name)) {
+        if (str_contains($name, '.') && parent::has('__' . $name)) {
             return true;
         }
 

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -604,7 +604,7 @@ abstract class Table extends \stdClass implements TableInterface, DispatcherAwar
         // Get the default values for the class from the table.
         foreach ($this->getFields() as $k => $v) {
             // If the property is not the primary key or private, reset it.
-            if (!\in_array($k, $this->_tbl_keys) && (strpos($k, '_') !== 0)) {
+            if (!\in_array($k, $this->_tbl_keys) && (!str_starts_with($k, '_'))) {
                 $this->$k = $v->Default;
             }
         }

--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -223,7 +223,7 @@ JS
     {
         $url = $url ?? '';
 
-        if (strpos($url, 'http') !== 0) {
+        if (!str_starts_with($url, 'http')) {
             $url = Uri::base() . $url;
         }
 

--- a/libraries/src/Updater/Adapter/CollectionAdapter.php
+++ b/libraries/src/Updater/Adapter/CollectionAdapter.php
@@ -227,7 +227,7 @@ class CollectionAdapter extends UpdateAdapter
 
         if (!xml_parse($this->xmlParser, $response->body)) {
             // If the URL is missing the .xml extension, try appending it and retry loading the update
-            if (!$this->appendExtension && (substr($this->_url, -4) !== '.xml')) {
+            if (!$this->appendExtension && (!str_ends_with($this->_url, '.xml'))) {
                 $options['append_extension'] = true;
 
                 return $this->findUpdate($options);

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -286,7 +286,7 @@ class ExtensionAdapter extends UpdateAdapter
 
         if (!xml_parse($this->xmlParser, $response->body)) {
             // If the URL is missing the .xml extension, try appending it and retry loading the update
-            if (!$this->appendExtension && (substr($this->_url, -4) !== '.xml')) {
+            if (!$this->appendExtension && (!str_ends_with($this->_url, '.xml'))) {
                 $options['append_extension'] = true;
 
                 return $this->findUpdate($options);

--- a/libraries/src/Updater/UpdateAdapter.php
+++ b/libraries/src/Updater/UpdateAdapter.php
@@ -229,8 +229,8 @@ abstract class UpdateAdapter extends AdapterInstance
             $this->appendExtension = $options['append_extension'];
         }
 
-        if ($this->appendExtension && (substr($url, -4) !== '.xml')) {
-            if (substr($url, -1) !== '/') {
+        if ($this->appendExtension && (!str_ends_with($url, '.xml'))) {
+            if (!str_ends_with($url, '/')) {
                 $url .= '/';
             }
 
@@ -281,7 +281,7 @@ abstract class UpdateAdapter extends AdapterInstance
 
         if ($response === null || $response->code !== 200) {
             // If the URL is missing the .xml extension, try appending it and retry loading the update
-            if (!$this->appendExtension && (substr($url, -4) !== '.xml')) {
+            if (!$this->appendExtension && (!str_ends_with($url, '.xml'))) {
                 $options['append_extension'] = true;
 
                 return $this->getUpdateSiteResponse($options);

--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -148,7 +148,7 @@ class Uri extends \Joomla\Uri\Uri
             } else {
                 static::$base['prefix'] = $uri->toString(['scheme', 'host', 'port']);
 
-                if (strpos(PHP_SAPI, 'cgi') !== false && !\ini_get('cgi.fix_pathinfo') && !empty($_SERVER['REQUEST_URI'])) {
+                if (str_contains(PHP_SAPI, 'cgi') && !\ini_get('cgi.fix_pathinfo') && !empty($_SERVER['REQUEST_URI'])) {
                     // PHP-CGI on Apache with "cgi.fix_pathinfo = 0"
 
                     // We shouldn't have user-supplied PATH_INFO in PHP_SELF in this case
@@ -248,9 +248,9 @@ class Uri extends \Joomla\Uri\Uri
 
         // @see UriTest
         if (
-            empty($host) && strpos($uri->path, 'index.php') === 0
+            empty($host) && str_starts_with($uri->path, 'index.php')
             || !empty($host) && preg_match('#^' . preg_quote(static::base(), '#') . '#', $base)
-            || !empty($host) && $host === static::getInstance(static::base())->host && strpos($uri->path, 'index.php') !== false
+            || !empty($host) && $host === static::getInstance(static::base())->host && str_contains($uri->path, 'index.php')
             || !empty($host) && $base === $host && preg_match('#^' . preg_quote($base, '#') . '#', static::base())
         ) {
             return true;

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -465,22 +465,22 @@ abstract class UserHelper
         $container         = Factory::getContainer();
 
         // Cheaply try to determine the algorithm in use otherwise fall back to the chained handler
-        if (strpos($hash, '$P$') === 0) {
+        if (str_starts_with($hash, '$P$')) {
             /** @var PHPassHandler $handler */
             $handler = $container->get(PHPassHandler::class);
-        } elseif (strpos($hash, '$argon2id') === 0) {
+        } elseif (str_starts_with($hash, '$argon2id')) {
             // Check for Argon2id hashes
             /** @var Argon2idHandler $handler */
             $handler = $container->get(Argon2idHandler::class);
 
             $passwordAlgorithm = self::HASH_ARGON2ID;
-        } elseif (strpos($hash, '$argon2i') === 0) {
+        } elseif (str_starts_with($hash, '$argon2i')) {
             // Check for Argon2i hashes
             /** @var Argon2iHandler $handler */
             $handler = $container->get(Argon2iHandler::class);
 
             $passwordAlgorithm = self::HASH_ARGON2I;
-        } elseif (strpos($hash, '$2') === 0) {
+        } elseif (str_starts_with($hash, '$2')) {
             // Check for bcrypt hashes
             /** @var BCryptHandler $handler */
             $handler = $container->get(BCryptHandler::class);

--- a/libraries/src/WebAsset/WebAssetItem.php
+++ b/libraries/src/WebAsset/WebAssetItem.php
@@ -333,7 +333,7 @@ class WebAssetItem implements WebAssetItemInterface
      */
     protected function isPathExternal(string $path): bool
     {
-        return strpos($path, 'http://') === 0 || strpos($path, 'https://') === 0 || strpos($path, '//') === 0;
+        return str_starts_with($path, 'http://') || str_starts_with($path, 'https://') || str_starts_with($path, '//');
     }
 
     /**
@@ -348,6 +348,6 @@ class WebAssetItem implements WebAssetItemInterface
     protected function isPathAbsolute(string $path): bool
     {
         // We have a full path or not
-        return strpos($path, '/') !== false && is_file(JPATH_ROOT . '/' . $path);
+        return str_contains($path, '/') && is_file(JPATH_ROOT . '/' . $path);
     }
 }

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -198,7 +198,7 @@ class WebAssetManager implements WebAssetManagerInterface
     {
         $method = strtolower($method);
 
-        if (0 === strpos($method, 'use')) {
+        if (str_starts_with($method, 'use')) {
             $type = substr($method, 3);
 
             if (empty($arguments[0])) {
@@ -208,7 +208,7 @@ class WebAssetManager implements WebAssetManagerInterface
             return $this->useAsset($type, $arguments[0]);
         }
 
-        if (0 === strpos($method, 'addinline')) {
+        if (str_starts_with($method, 'addinline')) {
             $type = substr($method, 9);
 
             if (empty($arguments[0])) {
@@ -218,7 +218,7 @@ class WebAssetManager implements WebAssetManagerInterface
             return $this->addInline($type, ...$arguments);
         }
 
-        if (0 === strpos($method, 'disable')) {
+        if (str_starts_with($method, 'disable')) {
             $type = substr($method, 7);
 
             if (empty($arguments[0])) {
@@ -228,7 +228,7 @@ class WebAssetManager implements WebAssetManagerInterface
             return $this->disableAsset($type, $arguments[0]);
         }
 
-        if (0 === strpos($method, 'register')) {
+        if (str_starts_with($method, 'register')) {
             // Check for registerAndUse<Type>
             $andUse = substr($method, 8, 6) === 'anduse';
 

--- a/modules/mod_banners/tmpl/default.php
+++ b/modules/mod_banners/tmpl/default.php
@@ -35,7 +35,7 @@ use Joomla\CMS\Uri\Uri;
             <?php $imageurl = $imageobject->url; ?>
             <?php if (!empty($imageurl) && (MediaHelper::isImage($imageurl) || MediaHelper::getMimeType($imageurl) === 'image/svg+xml')) : ?>
                 <?php // Image based banner ?>
-                <?php $baseurl = strpos($imageurl, 'http') === 0 ? '' : Uri::base(); ?>
+                <?php $baseurl = str_starts_with($imageurl, 'http') ? '' : Uri::base(); ?>
                 <?php $alt = $item->params->get('alt'); ?>
                 <?php $alt = $alt ?: $item->name; ?>
                 <?php $alt = $alt ?: Text::_('MOD_BANNERS_BANNER'); ?>

--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -77,7 +77,7 @@ Text::script('JHIDEPASSWORD');
 
         <?php foreach ($extraButtons as $button) :
             $dataAttributeKeys = array_filter(array_keys($button), function ($key) {
-                return substr($key, 0, 5) == 'data-';
+                return str_starts_with($key, 'data-');
             });
             ?>
             <div class="mod-login__submit form-group">

--- a/modules/mod_menu/src/Helper/MenuHelper.php
+++ b/modules/mod_menu/src/Helper/MenuHelper.php
@@ -125,7 +125,7 @@ class MenuHelper
                             break;
 
                         case 'url':
-                            if ((strpos($item->link, 'index.php?') === 0) && (strpos($item->link, 'Itemid=') === false)) {
+                            if ((str_starts_with($item->link, 'index.php?')) && (!str_contains($item->link, 'Itemid='))) {
                                 // If this is an internal Joomla link, ensure the Itemid is set.
                                 $item->flink = $item->link . '&Itemid=' . $item->id;
                             }
@@ -150,7 +150,7 @@ class MenuHelper
                             break;
                     }
 
-                    if ((strpos($item->flink, 'index.php?') !== false) && strcasecmp(substr($item->flink, 0, 4), 'http')) {
+                    if ((str_contains($item->flink, 'index.php?')) && strcasecmp(substr($item->flink, 0, 4), 'http')) {
                         $item->flink = Route::_($item->flink, true, $itemParams->get('secure'));
                     } else {
                         $item->flink = Route::_($item->flink);

--- a/modules/mod_wrapper/src/Helper/WrapperHelper.php
+++ b/modules/mod_wrapper/src/Helper/WrapperHelper.php
@@ -49,10 +49,10 @@ class WrapperHelper
 
         if ($params->get('add')) {
             // Adds 'http://' if none is set
-            if (strpos($url, '/') === 0) {
+            if (str_starts_with($url, '/')) {
                 // Relative URL in component. use server http_host.
                 $url = 'http://' . $app->getInput()->server->get('HTTP_HOST') . $url;
-            } elseif (strpos($url, 'http') === false && strpos($url, 'https') === false) {
+            } elseif (!str_contains($url, 'http') && !str_contains($url, 'https')) {
                 $url = 'http://' . $url;
             }
         }

--- a/plugins/api-authentication/token/src/Extension/Token.php
+++ b/plugins/api-authentication/token/src/Extension/Token.php
@@ -131,7 +131,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
             $authHeader  = $this->getApplication()->getInput()->server->get('REDIRECT_HTTP_AUTHORIZATION', '', 'string');
         }
 
-        if (substr($authHeader, 0, 7) == 'Bearer ') {
+        if (str_starts_with($authHeader, 'Bearer ')) {
             $parts       = explode(' ', $authHeader, 2);
             $tokenString = trim($parts[1]);
             $tokenString = $this->filter->clean($tokenString, 'BASE64');
@@ -149,7 +149,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
         // The token is a base64 encoded string. Make sure we can decode it.
         $authString = @base64_decode($tokenString);
 
-        if (empty($authString) || (strpos($authString, ':') === false)) {
+        if (empty($authString) || (!str_contains($authString, ':'))) {
             return;
         }
 

--- a/plugins/behaviour/taggable/src/Extension/Taggable.php
+++ b/plugins/behaviour/taggable/src/Extension/Taggable.php
@@ -173,7 +173,7 @@ final class Taggable extends CMSPlugin implements SubscriberInterface
         if (empty($newTags)) {
             $result = $tagsHelper->postStoreProcess($table);
         } else {
-            if (\is_string($newTags) && (strpos($newTags, ',') !== false)) {
+            if (\is_string($newTags) && (str_contains($newTags, ','))) {
                 $newTags = explode(',', $newTags);
             } elseif (!\is_array($newTags)) {
                 $newTags = (array) $newTags;

--- a/plugins/content/fields/src/Extension/Fields.php
+++ b/plugins/content/fields/src/Extension/Fields.php
@@ -74,17 +74,17 @@ final class Fields extends CMSPlugin implements SubscriberInterface
         }
 
         // Prepare the text
-        if (property_exists($item, 'text') && strpos($item->text, 'field') !== false) {
+        if (property_exists($item, 'text') && str_contains($item->text, 'field')) {
             $item->text = $this->prepare($item->text, $context, $item);
         }
 
         // Prepare the intro text
-        if (property_exists($item, 'introtext') && \is_string($item->introtext) && strpos($item->introtext, 'field') !== false) {
+        if (property_exists($item, 'introtext') && \is_string($item->introtext) && str_contains($item->introtext, 'field')) {
             $item->introtext = $this->prepare($item->introtext, $context, $item);
         }
 
         // Prepare the full text
-        if (!empty($item->fulltext) && strpos($item->fulltext, 'field') !== false) {
+        if (!empty($item->fulltext) && str_contains($item->fulltext, 'field')) {
             $item->fulltext = $this->prepare($item->fulltext, $context, $item);
         }
     }

--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -164,7 +164,7 @@ trait DisplayTrait
 
                 // if we have a name and path, add it to the list
                 if ($external['name'] != '' && $path != '') {
-                    $externalPlugins[$external['name']] = substr($path, 0, 1) == '/' ? Uri::root() . substr($path, 1) : $path;
+                    $externalPlugins[$external['name']] = str_starts_with($path, '/') ? Uri::root() . substr($path, 1) : $path;
                 }
             }
         }
@@ -205,7 +205,7 @@ trait DisplayTrait
              * If URL, just pass it to $content_css
              * else, assume it is a file name in the current template folder
              */
-            $content_css = strpos($content_css_custom, 'http') !== false
+            $content_css = str_contains($content_css_custom, 'http')
                 ? $content_css_custom
                 : $this->includeRelativeFiles('css', $content_css_custom);
         } else {
@@ -383,11 +383,11 @@ trait DisplayTrait
         $custom_button = trim($levelParams->get('custom_button', ''));
 
         if ($custom_plugin) {
-            $plugins   = array_merge($plugins, explode(strpos($custom_plugin, ',') !== false ? ',' : ' ', $custom_plugin));
+            $plugins   = array_merge($plugins, explode(str_contains($custom_plugin, ',') ? ',' : ' ', $custom_plugin));
         }
 
         if ($custom_button) {
-            $toolbar1  = array_merge($toolbar1, explode(strpos($custom_button, ',') !== false ? ',' : ' ', $custom_button));
+            $toolbar1  = array_merge($toolbar1, explode(str_contains($custom_button, ',') ? ',' : ' ', $custom_button));
         }
 
         // Merge the two toolbars for backwards compatibility

--- a/plugins/system/debug/src/DataCollector/QueryCollector.php
+++ b/plugins/system/debug/src/DataCollector/QueryCollector.php
@@ -219,7 +219,7 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
 
                     $isCaller = 0;
 
-                    if (\Joomla\Database\DatabaseDriver::class === $class && false === strpos($file, 'DatabaseDriver.php')) {
+                    if (\Joomla\Database\DatabaseDriver::class === $class && !str_contains($file, 'DatabaseDriver.php')) {
                         $callerLocation = $location;
                         $isCaller       = 1;
                     }

--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -365,8 +365,8 @@ final class Debug extends CMSPlugin implements SubscriberInterface
 
         // No debug for Safari and Chrome redirection.
         if (
-            strpos($contents, '<html><head><meta http-equiv="refresh" content="0;') === 0
-            && strpos(strtolower($_SERVER['HTTP_USER_AGENT'] ?? ''), 'webkit') !== false
+            str_starts_with($contents, '<html><head><meta http-equiv="refresh" content="0;')
+            && str_contains(strtolower($_SERVER['HTTP_USER_AGENT'] ?? ''), 'webkit')
         ) {
             $this->debugBar->stackData();
 
@@ -619,7 +619,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
                     $category = $entry->category;
                     $relative = $file ? str_replace(JPATH_ROOT, '', $file) : '';
 
-                    if ($relative && 0 === strpos($relative, '/libraries/src')) {
+                    if ($relative && str_starts_with($relative, '/libraries/src')) {
                         if (!$logDeprecatedCore) {
                             break;
                         }
@@ -688,13 +688,13 @@ final class Debug extends CMSPlugin implements SubscriberInterface
             }
 
             // Collect the module render time
-            if (strpos($mark->label, 'mod_') !== false) {
+            if (str_contains($mark->label, 'mod_')) {
                 $moduleTime += $mark->time;
                 continue;
             }
 
             // Collect the access render time
-            if (strpos($mark->label, 'Access:') !== false) {
+            if (str_contains($mark->label, 'Access:')) {
                 $accessTime += $mark->time;
                 continue;
             }

--- a/plugins/system/fields/src/Extension/Fields.php
+++ b/plugins/system/fields/src/Extension/Fields.php
@@ -288,7 +288,7 @@ final class Fields extends CMSPlugin implements SubscriberInterface
         $context = $form->getName();
 
         // When a category is edited, the context is com_categories.categorycom_content
-        if (strpos($context, 'com_categories.category') === 0) {
+        if (str_starts_with($context, 'com_categories.category')) {
             $context = str_replace('com_categories.category', '', $context) . '.categories';
             $data    = $data ?: $this->getApplication()->getInput()->get('jform', [], 'array');
 

--- a/plugins/system/httpheaders/src/Extension/Httpheaders.php
+++ b/plugins/system/httpheaders/src/Extension/Httpheaders.php
@@ -310,12 +310,12 @@ final class Httpheaders extends CMSPlugin implements SubscriberInterface
                 }
 
                 // Append the script hashes placeholder
-                if ($scriptHashesEnabled && strpos($cspValue->directive, 'script-src') === 0) {
+                if ($scriptHashesEnabled && str_starts_with($cspValue->directive, 'script-src')) {
                     $cspValue->value = '{script-hashes} ' . $cspValue->value;
                 }
 
                 // Append the style hashes placeholder
-                if ($styleHashesEnabled && strpos($cspValue->directive, 'style-src') === 0) {
+                if ($styleHashesEnabled && str_starts_with($cspValue->directive, 'style-src')) {
                     $cspValue->value = '{style-hashes} ' . $cspValue->value;
                 }
 
@@ -327,7 +327,7 @@ final class Httpheaders extends CMSPlugin implements SubscriberInterface
                 if (
                     $strictDynamicEnabled
                     && $cspValue->directive === 'script-src'
-                    && strpos($cspValue->value, 'strict-dynamic') === false
+                    && !str_contains($cspValue->value, 'strict-dynamic')
                 ) {
                     $cspValue->value = "'strict-dynamic' " . $cspValue->value;
                 }

--- a/plugins/system/languagefilter/src/Extension/LanguageFilter.php
+++ b/plugins/system/languagefilter/src/Extension/LanguageFilter.php
@@ -514,7 +514,7 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
             $language_new = $this->languageFactory->createLanguage($lang_code, (bool) $app->get('debug_lang'));
 
             foreach ($language->getPaths() as $extension => $files) {
-                if (strpos($extension, 'plg_system') !== false) {
+                if (str_contains($extension, 'plg_system')) {
                     $extension_name = substr($extension, 11);
 
                     $language_new->load($extension, JPATH_ADMINISTRATOR)

--- a/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
+++ b/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
@@ -301,10 +301,10 @@ final class PrivacyConsent extends CMSPlugin implements SubscriberInterface
                 'method', 'methods', 'captive', 'callback',
             ];
             $isAllowedUserTask = \in_array($task, $allowedUserTasks)
-                || substr($task, 0, 8) === 'captive.'
-                || substr($task, 0, 8) === 'methods.'
-                || substr($task, 0, 7) === 'method.'
-                || substr($task, 0, 9) === 'callback.';
+                || str_starts_with($task, 'captive.')
+                || str_starts_with($task, 'methods.')
+                || str_starts_with($task, 'method.')
+                || str_starts_with($task, 'callback.');
 
             if (
                 ($option == 'com_users' && $isAllowedUserTask)

--- a/plugins/system/redirect/src/Extension/Redirect.php
+++ b/plugins/system/redirect/src/Extension/Redirect.php
@@ -120,7 +120,7 @@ final class Redirect extends CMSPlugin implements SubscriberInterface
          * Why is this (still) here?
          * Because hackers still try urls with mosConfig_* and Url Injection with =http[s]:// and we dont want to log/redirect these requests
          */
-        if ($skipUrl || (strpos($url, 'mosConfig_') !== false) || (strpos($url, '=http') !== false)) {
+        if ($skipUrl || (str_contains($url, 'mosConfig_')) || (str_contains($url, '=http'))) {
             return;
         }
 
@@ -203,7 +203,7 @@ final class Redirect extends CMSPlugin implements SubscriberInterface
                     $newUrl .= '?' . $urlQuery;
                 }
 
-                $dest = Uri::isInternal($newUrl) || strpos($newUrl, 'http') === false ?
+                $dest = Uri::isInternal($newUrl) || !str_contains($newUrl, 'http') ?
                     Route::_($newUrl) : $newUrl;
 
                 // In case the url contains double // lets remove it

--- a/plugins/system/sef/src/Extension/Sef.php
+++ b/plugins/system/sef/src/Extension/Sef.php
@@ -226,7 +226,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         $prefix = $app->getDocument()->getType() === 'feed' ? Uri::root() : '';
 
         // Replace index.php URI by SEF URI.
-        if (strpos($buffer, 'href="' . $prefix . 'index.php?') !== false) {
+        if (str_contains($buffer, 'href="' . $prefix . 'index.php?')) {
             preg_match_all('#href="' . $prefix . 'index.php\?([^"]+)"#m', $buffer, $matches);
 
             foreach ($matches[1] as $urlQueryString) {
@@ -245,14 +245,14 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         $attributes = ['href=', 'src=', 'poster='];
 
         foreach ($attributes as $attribute) {
-            if (strpos($buffer, $attribute) !== false) {
+            if (str_contains($buffer, $attribute)) {
                 $regex  = '#\s' . $attribute . '"(?!/|' . $protocols . '|\#|\')([^"]*)"#m';
                 $buffer = preg_replace($regex, ' ' . $attribute . '"' . $base . '$1"', $buffer);
                 $this->checkBuffer($buffer);
             }
         }
 
-        if (strpos($buffer, 'srcset=') !== false) {
+        if (str_contains($buffer, 'srcset=')) {
             $regex = '#\s+srcset="([^"]+)"#m';
 
             $buffer = preg_replace_callback(
@@ -273,7 +273,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         }
 
         // Replace all unknown protocols in javascript window open events.
-        if (strpos($buffer, 'window.open(') !== false) {
+        if (str_contains($buffer, 'window.open(')) {
             $regex  = '#onclick="window.open\(\'(?!/|' . $protocols . '|\#)([^/]+[^\']*?\')#m';
             $buffer = preg_replace($regex, 'onclick="window.open(\'' . $base . '$1', $buffer);
             $this->checkBuffer($buffer);
@@ -283,7 +283,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         $attributes = ['onmouseover=', 'onmouseout='];
 
         foreach ($attributes as $attribute) {
-            if (strpos($buffer, $attribute) !== false) {
+            if (str_contains($buffer, $attribute)) {
                 $regex  = '#' . $attribute . '"this.src=([\']+)(?!/|' . $protocols . '|\#|\')([^"]+)"#m';
                 $buffer = preg_replace($regex, $attribute . '"this.src=$1' . $base . '$2"', $buffer);
                 $this->checkBuffer($buffer);
@@ -291,7 +291,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         }
 
         // Replace all unknown protocols in CSS background image.
-        if (strpos($buffer, 'style=') !== false) {
+        if (str_contains($buffer, 'style=')) {
             $regex_url  = '\s*url\s*\(([\'\"]|\&\#0?3[49];)?(?!/|\&\#0?3[49];|' . $protocols . '|\#)([^\)\'\"]+)([\'\"]|\&\#0?3[49];)?\)';
             $regex      = '#style=\s*([\'\"])(.*):' . $regex_url . '#m';
             $buffer     = preg_replace($regex, 'style=$1$2: url($3' . $base . '$4$5)', $buffer);
@@ -299,7 +299,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         }
 
         // Replace all unknown protocols in OBJECT param tag.
-        if (strpos($buffer, '<param') !== false) {
+        if (str_contains($buffer, '<param')) {
             // OBJECT <param name="xx", value="yy"> -- fix it only inside the <param> tag.
             $regex  = '#(<param\s+)name\s*=\s*"(movie|src|url)"[^>]\s*value\s*=\s*"(?!/|' . $protocols . '|\#|\')([^"]*)"#m';
             $buffer = preg_replace($regex, '$1name="$2" value="' . $base . '$3"', $buffer);
@@ -312,7 +312,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         }
 
         // Replace all unknown protocols in OBJECT tag.
-        if (strpos($buffer, '<object') !== false) {
+        if (str_contains($buffer, '<object')) {
             $regex  = '#(<object\s+[^>]*)data\s*=\s*"(?!/|' . $protocols . '|\#|\')([^"]*)"#m';
             $buffer = preg_replace($regex, '$1data="' . $base . '$2"', $buffer);
             $this->checkBuffer($buffer);
@@ -334,7 +334,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         $origUri = Uri::getInstance();
         $route   = $origUri->getPath();
 
-        if (substr($route, -9) === 'index.php' || substr($route, -1) === '/') {
+        if (str_ends_with($route, 'index.php') || str_ends_with($route, '/')) {
             // We don't want suffixes when the URL ends in index.php or with a /
             return;
         }
@@ -375,7 +375,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
     {
         $origUri = Uri::getInstance();
 
-        if (substr($origUri->getPath(), -9) === 'index.php') {
+        if (str_ends_with($origUri->getPath(), 'index.php')) {
             // Remove trailing index.php
             $origUri->setPath(substr($origUri->getPath(), 0, -9));
             $this->getApplication()->redirect($origUri->toString(), 301);

--- a/plugins/system/webauthn/src/CredentialRepository.php
+++ b/plugins/system/webauthn/src/CredentialRepository.php
@@ -562,7 +562,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
         }
 
         // Was the credential stored unencrypted (e.g. the site's secret was empty)?
-        if ((strpos($credential, '{') !== false) && (strpos($credential, '"publicKeyCredentialId"') !== false)) {
+        if ((str_contains($credential, '{')) && (str_contains($credential, '"publicKeyCredentialId"'))) {
             return $credential;
         }
 

--- a/plugins/task/updatenotification/src/Extension/UpdateNotification.php
+++ b/plugins/task/updatenotification/src/Extension/UpdateNotification.php
@@ -127,7 +127,7 @@ final class UpdateNotification extends CMSPlugin implements SubscriberInterface
         // If we're here, we have updates. First, get a link to the Joomla! Update component.
         $baseURL  = Uri::base();
         $baseURL  = rtrim($baseURL, '/');
-        $baseURL .= (substr($baseURL, -13) !== 'administrator') ? '/administrator/' : '/';
+        $baseURL .= (!str_ends_with($baseURL, 'administrator')) ? '/administrator/' : '/';
         $baseURL .= 'index.php?option=com_joomlaupdate';
         $uri      = new Uri($baseURL);
 

--- a/plugins/user/joomla/src/Extension/Joomla.php
+++ b/plugins/user/joomla/src/Extension/Joomla.php
@@ -202,7 +202,7 @@ final class Joomla extends CMSPlugin implements SubscriberInterface
         }
 
         // Check if we have a sensible from email address, if not bail out as mail would not be sent anyway
-        if (strpos($app->get('mailfrom'), '@') === false) {
+        if (!str_contains($app->get('mailfrom'), '@')) {
             $app->enqueueMessage($language->_('JERROR_SENDING_EMAIL'), 'warning');
 
             return;

--- a/plugins/user/profile/src/Extension/Profile.php
+++ b/plugins/user/profile/src/Extension/Profile.php
@@ -157,7 +157,7 @@ final class Profile extends CMSPlugin implements SubscriberInterface
         // Convert website URL to utf8 for display
         $value = htmlspecialchars(PunycodeHelper::urlToUTF8($value), ENT_QUOTES, 'UTF-8');
 
-        if (strpos($value, 'http') === 0) {
+        if (str_starts_with($value, 'http')) {
             return '<a href="' . $value . '">' . $value . '</a>';
         }
 

--- a/templates/cassiopeia/offline.php
+++ b/templates/cassiopeia/offline.php
@@ -140,7 +140,7 @@ $wa->getAsset('style', 'fontawesome')->setAttribute('rel', 'lazy-stylesheet');
 
                         <?php foreach ($extraButtons as $button) :
                             $dataAttributeKeys = array_filter(array_keys($button), function ($key) {
-                                return substr($key, 0, 5) == 'data-';
+                                return str_starts_with($key, 'data-');
                             });
                             ?>
                             <div class="mod-login__submit form-group">


### PR DESCRIPTION
Replace str*() calls with more readable str_*() calls introduced in PHP 8.0.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
