### PR TITLE
[5.3] Remove unused variable store Exception in try catch block

### DIFF
--- a/administrator/components/com_actionlogs/src/Controller/ActionlogsController.php
+++ b/administrator/components/com_actionlogs/src/Controller/ActionlogsController.php
@@ -87,7 +87,7 @@ class ActionlogsController extends AdminController
         if (\count($data)) {
             try {
                 $rows = ActionlogsHelper::getCsvData($data);
-            } catch (\InvalidArgumentException $exception) {
+            } catch (\InvalidArgumentException) {
                 $this->setMessage(Text::_('COM_ACTIONLOGS_ERROR_COULD_NOT_EXPORT_DATA'), 'error');
                 $this->setRedirect(Route::_('index.php?option=com_actionlogs&view=actionlogs', false));
 

--- a/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
+++ b/administrator/components/com_actionlogs/src/Helper/ActionlogsHelper.php
@@ -310,7 +310,7 @@ class ActionlogsHelper
 
         try {
             $rows = $db->loadObjectList();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $rows = [];
         }
 

--- a/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
@@ -91,7 +91,7 @@ class ActionlogModel extends BaseDatabaseModel implements UserFactoryAwareInterf
             try {
                 $db->insertObject('#__action_logs', $logMessage);
                 $loggedMessages[] = $logMessage;
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 // Ignore it
             }
         }
@@ -99,7 +99,7 @@ class ActionlogModel extends BaseDatabaseModel implements UserFactoryAwareInterf
         try {
             // Send notification email to users who choose to be notified about the action logs
             $this->sendNotificationEmails($loggedMessages, $user->name, $context);
-        } catch (MailDisabledException | phpMailerException $e) {
+        } catch (MailDisabledException | phpMailerException) {
             // Ignore it
         }
     }

--- a/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogsModel.php
@@ -363,7 +363,7 @@ class ActionlogsModel extends ListModel
     {
         try {
             $this->getDatabase()->truncateTable('#__action_logs');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
 

--- a/administrator/components/com_admin/script.php
+++ b/administrator/components/com_admin/script.php
@@ -3306,7 +3306,7 @@ class JoomlaInstallerScript
         try {
             // Using hard-coded string because a new language string would not be available in all cases
             Log::add('Fixing permissions for files and folders.', Log::INFO, 'Update');
-        } catch (\RuntimeException $exception) {
+        } catch (\RuntimeException) {
             // Informational log only
         }
 

--- a/administrator/components/com_admin/src/Model/SysinfoModel.php
+++ b/administrator/components/com_admin/src/Model/SysinfoModel.php
@@ -466,7 +466,7 @@ class SysinfoModel extends BaseDatabaseModel
         } catch (\Exception $e) {
             try {
                 Log::add(Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()), Log::WARNING, 'jerror');
-            } catch (\RuntimeException $exception) {
+            } catch (\RuntimeException) {
                 Factory::getApplication()->enqueueMessage(
                     Text::sprintf('JLIB_DATABASE_ERROR_FUNCTION_FAILED', $e->getCode(), $e->getMessage()),
                     'warning'

--- a/administrator/components/com_associations/src/Model/AssociationsModel.php
+++ b/administrator/components/com_associations/src/Model/AssociationsModel.php
@@ -480,7 +480,7 @@ class AssociationsModel extends ListModel
 
         try {
             $db->execute();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             $app->enqueueMessage(Text::_('COM_ASSOCIATIONS_PURGE_FAILED'), 'error');
 
             return false;
@@ -543,7 +543,7 @@ class AssociationsModel extends ListModel
 
             try {
                 $db->execute();
-            } catch (ExecutionFailureException $e) {
+            } catch (ExecutionFailureException) {
                 $app->enqueueMessage(Text::_('COM_ASSOCIATIONS_DELETE_ORPHANS_FAILED'), 'error');
 
                 return false;

--- a/administrator/components/com_cache/src/Model/CacheModel.php
+++ b/administrator/components/com_cache/src/Model/CacheModel.php
@@ -153,10 +153,10 @@ class CacheModel extends ListModel
                 } else {
                     $this->_data = [];
                 }
-            } catch (CacheConnectingException $exception) {
+            } catch (CacheConnectingException) {
                 $this->setError(Text::_('COM_CACHE_ERROR_CACHE_CONNECTION_FAILED'));
                 $this->_data = [];
-            } catch (UnsupportedCacheException $exception) {
+            } catch (UnsupportedCacheException) {
                 $this->setError(Text::_('COM_CACHE_ERROR_CACHE_DRIVER_UNSUPPORTED'));
                 $this->_data = [];
             }
@@ -224,9 +224,9 @@ class CacheModel extends ListModel
     {
         try {
             $this->getCache()->clean($group);
-        } catch (CacheConnectingException $exception) {
+        } catch (CacheConnectingException) {
             return false;
-        } catch (UnsupportedCacheException $exception) {
+        } catch (UnsupportedCacheException) {
             return false;
         }
 
@@ -264,9 +264,9 @@ class CacheModel extends ListModel
     {
         try {
             Factory::getCache('')->gc();
-        } catch (CacheConnectingException $exception) {
+        } catch (CacheConnectingException) {
             return false;
-        } catch (UnsupportedCacheException $exception) {
+        } catch (UnsupportedCacheException) {
             return false;
         }
 

--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -488,7 +488,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
                 } else {
                     $revisedDbo->truncateTable('#__session');
                 }
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 /*
                  * The database API logs errors on failures so we don't need to add any error handling mechanisms here.
                  * Also, this data won't be added or checked anymore once the configuration is saved, so it'll purge itself
@@ -519,7 +519,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
                             Log::WARNING,
                             'jerror'
                         );
-                    } catch (\RuntimeException $logException) {
+                    } catch (\RuntimeException) {
                         $app->enqueueMessage(
                             Text::sprintf(
                                 'COM_CONFIG_ERROR_CUSTOM_SESSION_FILESYSTEM_PATH_NOTWRITABLE_USING_DEFAULT',
@@ -596,7 +596,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
                         Log::WARNING,
                         'jerror'
                     );
-                } catch (\RuntimeException $logException) {
+                } catch (\RuntimeException) {
                     $app->enqueueMessage(
                         Text::sprintf('COM_CONFIG_ERROR_CUSTOM_CACHE_PATH_NOTWRITABLE_USING_DEFAULT', $path, JPATH_CACHE),
                         'warning'
@@ -612,7 +612,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
             if ($error) {
                 try {
                     Log::add(Text::sprintf('COM_CONFIG_ERROR_CACHE_PATH_NOTWRITABLE', $path), Log::WARNING, 'jerror');
-                } catch (\RuntimeException $exception) {
+                } catch (\RuntimeException) {
                     $app->enqueueMessage(Text::sprintf('COM_CONFIG_ERROR_CACHE_PATH_NOTWRITABLE', $path), 'warning');
                 }
 
@@ -629,16 +629,16 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
         if ((!$data['caching'] && $prev['caching']) || $data['cache_handler'] !== $prev['cache_handler']) {
             try {
                 Factory::getCache()->clean();
-            } catch (CacheConnectingException $exception) {
+            } catch (CacheConnectingException) {
                 try {
                     Log::add(Text::_('COM_CONFIG_ERROR_CACHE_CONNECTION_FAILED'), Log::WARNING, 'jerror');
-                } catch (\RuntimeException $logException) {
+                } catch (\RuntimeException) {
                     $app->enqueueMessage(Text::_('COM_CONFIG_ERROR_CACHE_CONNECTION_FAILED'), 'warning');
                 }
-            } catch (UnsupportedCacheException $exception) {
+            } catch (UnsupportedCacheException) {
                 try {
                     Log::add(Text::_('COM_CONFIG_ERROR_CACHE_DRIVER_UNSUPPORTED'), Log::WARNING, 'jerror');
-                } catch (\RuntimeException $logException) {
+                } catch (\RuntimeException) {
                     $app->enqueueMessage(Text::_('COM_CONFIG_ERROR_CACHE_DRIVER_UNSUPPORTED'), 'warning');
                 }
             }
@@ -672,7 +672,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
                         Log::WARNING,
                         'jerror'
                     );
-                } catch (\RuntimeException $logException) {
+                } catch (\RuntimeException) {
                     $app->enqueueMessage(
                         Text::sprintf('COM_CONFIG_ERROR_CUSTOM_TEMP_PATH_NOTWRITABLE_USING_DEFAULT', $path, $defaultTmpPath),
                         'warning'
@@ -687,7 +687,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
             if ($error) {
                 try {
                     Log::add(Text::sprintf('COM_CONFIG_ERROR_TMP_PATH_NOTWRITABLE', $path), Log::WARNING, 'jerror');
-                } catch (\RuntimeException $exception) {
+                } catch (\RuntimeException) {
                     $app->enqueueMessage(Text::sprintf('COM_CONFIG_ERROR_TMP_PATH_NOTWRITABLE', $path), 'warning');
                 }
             }
@@ -721,7 +721,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
                         Log::WARNING,
                         'jerror'
                     );
-                } catch (\RuntimeException $logException) {
+                } catch (\RuntimeException) {
                     $app->enqueueMessage(
                         Text::sprintf('COM_CONFIG_ERROR_CUSTOM_LOG_PATH_NOTWRITABLE_USING_DEFAULT', $path, $defaultLogPath),
                         'warning'
@@ -735,7 +735,7 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
             if ($error) {
                 try {
                     Log::add(Text::sprintf('COM_CONFIG_ERROR_LOG_PATH_NOTWRITABLE', $path), Log::WARNING, 'jerror');
-                } catch (\RuntimeException $exception) {
+                } catch (\RuntimeException) {
                     $app->enqueueMessage(Text::sprintf('COM_CONFIG_ERROR_LOG_PATH_NOTWRITABLE', $path), 'warning');
                 }
             }

--- a/administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
+++ b/administrator/components/com_contenthistory/src/Helper/ContenthistoryHelper.php
@@ -201,7 +201,7 @@ class ContenthistoryHelper
 
             try {
                 $result = $db->loadResult();
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // Ignore any errors and just return false
                 return false;
             }

--- a/administrator/components/com_contenthistory/src/Model/HistoryModel.php
+++ b/administrator/components/com_contenthistory/src/Model/HistoryModel.php
@@ -152,7 +152,7 @@ class HistoryModel extends ListModel
                     if ($error) {
                         try {
                             Log::add($error, Log::WARNING, 'jerror');
-                        } catch (\RuntimeException $exception) {
+                        } catch (\RuntimeException) {
                             Factory::getApplication()->enqueueMessage($error, 'warning');
                         }
 
@@ -161,7 +161,7 @@ class HistoryModel extends ListModel
 
                     try {
                         Log::add(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), Log::WARNING, 'jerror');
-                    } catch (\RuntimeException $exception) {
+                    } catch (\RuntimeException) {
                         Factory::getApplication()->enqueueMessage(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), 'warning');
                     }
 
@@ -259,7 +259,7 @@ class HistoryModel extends ListModel
                     if ($error) {
                         try {
                             Log::add($error, Log::WARNING, 'jerror');
-                        } catch (\RuntimeException $exception) {
+                        } catch (\RuntimeException) {
                             Factory::getApplication()->enqueueMessage($error, 'warning');
                         }
 
@@ -268,7 +268,7 @@ class HistoryModel extends ListModel
 
                     try {
                         Log::add(Text::_('COM_CONTENTHISTORY_ERROR_KEEP_NOT_PERMITTED'), Log::WARNING, 'jerror');
-                    } catch (\RuntimeException $exception) {
+                    } catch (\RuntimeException) {
                         Factory::getApplication()->enqueueMessage(Text::_('COM_CONTENTHISTORY_ERROR_KEEP_NOT_PERMITTED'), 'warning');
                     }
 

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -329,7 +329,7 @@ class FieldModel extends AdminModel
         if ($rule instanceof DatabaseAwareInterface) {
             try {
                 $rule->setDatabase($this->getDatabase());
-            } catch (DatabaseNotFoundException $e) {
+            } catch (DatabaseNotFoundException) {
                 @trigger_error(\sprintf('Database must be set, this will not be caught anymore in 5.0.'), E_USER_DEPRECATED);
                 $rule->setDatabase(Factory::getContainer()->get(DatabaseInterface::class));
             }
@@ -1060,11 +1060,11 @@ class FieldModel extends AdminModel
                 // Try to get the categories for this component and section
                 try {
                     $cat = $componentObject->getCategory([], $section ?: '');
-                } catch (SectionNotFoundException $e) {
+                } catch (SectionNotFoundException) {
                     // Not found for component and section -> Now try once more without the section, so only component
                     try {
                         $cat = $componentObject->getCategory();
-                    } catch (SectionNotFoundException $e) {
+                    } catch (SectionNotFoundException) {
                         // If we haven't found it now, return (no categories available for this component)
                         return null;
                     }

--- a/administrator/components/com_fields/src/Model/FieldsModel.php
+++ b/administrator/components/com_fields/src/Model/FieldsModel.php
@@ -213,11 +213,11 @@ class FieldsModel extends ListModel
                         // Try to get the categories for this component and section
                         try {
                             $cat = $componentObject->getCategory([], $parts[1] ?: '');
-                        } catch (SectionNotFoundException $e) {
+                        } catch (SectionNotFoundException) {
                             // Not found for component and section -> Now try once more without the section, so only component
                             try {
                                 $cat = $componentObject->getCategory();
-                            } catch (SectionNotFoundException $e) {
+                            } catch (SectionNotFoundException) {
                                 // If we haven't found it now, return (no categories available for this component)
                                 return null;
                             }

--- a/administrator/components/com_finder/src/Controller/IndexerController.php
+++ b/administrator/components/com_finder/src/Controller/IndexerController.php
@@ -65,7 +65,7 @@ class IndexerController extends BaseController
         // Log the start
         try {
             Log::add('Starting the indexer', Log::INFO);
-        } catch (\RuntimeException $exception) {
+        } catch (\RuntimeException) {
             // Informational log only
         }
 
@@ -137,7 +137,7 @@ class IndexerController extends BaseController
         // Log the start
         try {
             Log::add('Starting the indexer batch process', Log::INFO);
-        } catch (\RuntimeException $exception) {
+        } catch (\RuntimeException) {
             // Informational log only
         }
 
@@ -196,7 +196,7 @@ class IndexerController extends BaseController
             // Log batch completion and memory high-water mark.
             try {
                 Log::add('Batch completed, peak memory usage: ' . number_format(memory_get_peak_usage(true)) . ' bytes', Log::INFO);
-            } catch (\RuntimeException $exception) {
+            } catch (\RuntimeException) {
                 // Informational log only
             }
 
@@ -293,7 +293,7 @@ class IndexerController extends BaseController
         if ($data instanceof \Exception) {
             try {
                 Log::add($data->getMessage(), Log::ERROR);
-            } catch (\RuntimeException $exception) {
+            } catch (\RuntimeException) {
                 // Informational log only
             }
 

--- a/administrator/components/com_finder/src/Field/ContentmapField.php
+++ b/administrator/components/com_finder/src/Field/ContentmapField.php
@@ -63,7 +63,7 @@ class ContentmapField extends GroupedlistField
 
         try {
             $contentMap = $db->loadObjectList();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return [];
         }
 

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -186,7 +186,7 @@ class Indexer
                      */
                     $memory_table_limit = (int) ($heapsize->Value / 800);
                     $data->options->set('memory_table_limit', $memory_table_limit);
-                } catch (\Exception $e) {
+                } catch (\Exception) {
                     // Something failed. We fall back to a reasonable guess.
                     $data->options->set('memory_table_limit', 7500);
                 }
@@ -1008,7 +1008,7 @@ class Indexer
                 // Set the tokens aggregate table to Memory.
                 $db->setQuery('ALTER TABLE ' . $db->quoteName('#__finder_tokens_aggregate') . ' ENGINE = MEMORY');
                 $db->execute();
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 $supported = false;
 
                 return true;

--- a/administrator/components/com_finder/src/Indexer/Language.php
+++ b/administrator/components/com_finder/src/Indexer/Language.php
@@ -81,7 +81,7 @@ class Language
                     break;
                 }
             }
-        } catch (NotFoundException $e) {
+        } catch (NotFoundException) {
             // We don't have a stemmer for the language
         }
     }

--- a/administrator/components/com_finder/src/Response/Response.php
+++ b/administrator/components/com_finder/src/Response/Response.php
@@ -152,7 +152,7 @@ class Response
             // Log the error
             try {
                 Log::add($state->getMessage(), Log::ERROR);
-            } catch (\RuntimeException $exception) {
+            } catch (\RuntimeException) {
                 // Informational log only
             }
 

--- a/administrator/components/com_finder/src/Service/HTML/Filter.php
+++ b/administrator/components/com_finder/src/Service/HTML/Filter.php
@@ -69,7 +69,7 @@ class Filter
 
             try {
                 $filter = $db->loadObject();
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 return null;
             }
 
@@ -100,7 +100,7 @@ class Filter
 
         try {
             $branches = $db->loadObjectList('id');
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return null;
         }
 
@@ -141,7 +141,7 @@ class Filter
 
             try {
                 $nodes = $db->loadObjectList('id');
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 return null;
             }
 
@@ -238,7 +238,7 @@ class Filter
 
                 try {
                     $filter = $db->loadObject();
-                } catch (\RuntimeException $e) {
+                } catch (\RuntimeException) {
                     return null;
                 }
 
@@ -273,7 +273,7 @@ class Filter
 
             try {
                 $branches = $db->loadObjectList('id');
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 return null;
             }
 
@@ -321,7 +321,7 @@ class Filter
 
                 try {
                     $bv->nodes = $db->loadObjectList('id');
-                } catch (\RuntimeException $e) {
+                } catch (\RuntimeException) {
                     return null;
                 }
 

--- a/administrator/components/com_finder/src/Service/HTML/Finder.php
+++ b/administrator/components/com_finder/src/Service/HTML/Finder.php
@@ -50,7 +50,7 @@ class Finder
 
         try {
             $rows = $db->loadObjectList();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return [];
         }
 

--- a/administrator/components/com_guidedtours/src/Model/TourModel.php
+++ b/administrator/components/com_guidedtours/src/Model/TourModel.php
@@ -562,7 +562,7 @@ class TourModel extends AdminModel
             if ($result === null) {
                 return false;
             }
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return false;
         }
 
@@ -597,7 +597,7 @@ class TourModel extends AdminModel
 
         try {
             $result = $db->setQuery($query)->loadResult();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
 

--- a/administrator/components/com_installer/src/Helper/InstallerHelper.php
+++ b/administrator/components/com_installer/src/Helper/InstallerHelper.php
@@ -324,7 +324,7 @@ class InstallerHelper
 
         try {
             $extension = new CMSObject($db->setQuery($query)->loadAssoc());
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return [
                 'supported' => false,
                 'valid'     => false,
@@ -481,7 +481,7 @@ class InstallerHelper
             }
 
             return $items;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return [];
         }
     }

--- a/administrator/components/com_installer/src/Model/DatabaseModel.php
+++ b/administrator/components/com_installer/src/Model/DatabaseModel.php
@@ -479,7 +479,7 @@ class DatabaseModel extends InstallerModel
 
         try {
             $db->execute();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             return false;
         }
 

--- a/administrator/components/com_installer/src/Model/DiscoverModel.php
+++ b/administrator/components/com_installer/src/Model/DiscoverModel.php
@@ -260,7 +260,7 @@ class DiscoverModel extends InstallerModel
 
         try {
             $db->execute();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             $this->_message = Text::_('COM_INSTALLER_MSG_DISCOVER_FAILEDTOPURGEEXTENSIONS');
 
             return false;

--- a/administrator/components/com_installer/src/Model/InstallModel.php
+++ b/administrator/components/com_installer/src/Model/InstallModel.php
@@ -330,7 +330,7 @@ class InstallModel extends BaseDatabaseModel
         // Move uploaded file.
         try {
             File::upload($tmp_src, $tmp_dest, false, true);
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
             Factory::getApplication()->enqueueMessage(Text::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR'), 'error');
 
             return false;

--- a/administrator/components/com_installer/src/Model/LanguagesModel.php
+++ b/administrator/components/com_installer/src/Model/LanguagesModel.php
@@ -136,7 +136,7 @@ class LanguagesModel extends ListModel
 
         try {
             $response = HttpFactory::getHttp()->get($updateSite);
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $response = null;
         }
 

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -286,7 +286,7 @@ class UpdateModel extends ListModel
 
         try {
             $db->truncateTable('#__updates');
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             $this->_message = Text::_('JLIB_INSTALLER_FAILED_TO_PURGE_UPDATES');
 
             return false;

--- a/administrator/components/com_installer/src/Model/UpdatesiteModel.php
+++ b/administrator/components/com_installer/src/Model/UpdatesiteModel.php
@@ -161,7 +161,7 @@ class UpdatesiteModel extends AdminModel
 
         try {
             $db->setQuery($query)->execute();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // No problem if this fails for any reason.
         }
 

--- a/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
+++ b/administrator/components/com_joomlaupdate/src/Controller/UpdateController.php
@@ -375,7 +375,7 @@ class UpdateController extends BaseController
 
         try {
             Log::add(Text::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_FILE', $tempFile), Log::INFO, 'Update');
-        } catch (\RuntimeException $exception) {
+        } catch (\RuntimeException) {
             // Informational log only
         }
 

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -384,7 +384,7 @@ class UpdateModel extends BaseDatabaseModel
 
         try {
             $head = HttpFactory::getHttp($httpOptions)->head($packageURL);
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             // Passing false here -> download failed message
             return $response;
         }
@@ -395,7 +395,7 @@ class UpdateModel extends BaseDatabaseModel
 
             try {
                 $head = HttpFactory::getHttp($httpOptions)->head($packageURL);
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 // Passing false here -> download failed message
                 return $response;
             }
@@ -512,7 +512,7 @@ class UpdateModel extends BaseDatabaseModel
         if (is_file($target)) {
             try {
                 File::delete($target);
-            } catch (FilesystemException $exception) {
+            } catch (FilesystemException) {
                 return false;
             }
         }
@@ -520,7 +520,7 @@ class UpdateModel extends BaseDatabaseModel
         // Download the package
         try {
             $result = HttpFactory::getHttp([], ['curl', 'stream'])->get($url);
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return false;
         }
 
@@ -534,7 +534,7 @@ class UpdateModel extends BaseDatabaseModel
         // Write the file to disk
         try {
             File::write($target, $body);
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
             return false;
         }
 
@@ -619,7 +619,7 @@ ENDDATA;
         if (is_file($configpath)) {
             try {
                 File::delete($configpath);
-            } catch (FilesystemException $exception) {
+            } catch (FilesystemException) {
                 return false;
             }
         }
@@ -627,7 +627,7 @@ ENDDATA;
         // Write new file. First try with File.
         try {
             $result = File::write($configpath, $data);
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
             // In case File failed but direct access could help.
             $fp = @fopen($configpath, 'wt');
 
@@ -926,7 +926,7 @@ ENDDATA;
 
         try {
             Log::add(Text::sprintf('COM_JOOMLAUPDATE_UPDATE_LOG_COMPLETE', \JVERSION), Log::INFO, 'Update');
-        } catch (\RuntimeException $exception) {
+        } catch (\RuntimeException) {
             // Informational log only
         }
     }
@@ -1075,7 +1075,7 @@ ENDDATA;
             if ($file !== null && is_file($file)) {
                 try {
                     File::delete($file);
-                } catch (FilesystemException $exception) {
+                } catch (FilesystemException) {
                 }
             }
         }
@@ -1596,7 +1596,7 @@ ENDDATA;
 
         try {
             $response = $http->get($updateSiteInfo['location']);
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $response = null;
         }
 

--- a/administrator/components/com_login/src/Model/LoginModel.php
+++ b/administrator/components/com_login/src/Model/LoginModel.php
@@ -179,7 +179,7 @@ class LoginModel extends BaseDatabaseModel
 
         try {
             return $clean = $cache->get($loader, [], md5(serialize([$clientId, $lang])));
-        } catch (CacheExceptionInterface $cacheException) {
+        } catch (CacheExceptionInterface) {
             try {
                 return $loader();
             } catch (ExecutionFailureException $databaseException) {

--- a/administrator/components/com_mails/src/Model/TemplateModel.php
+++ b/administrator/components/com_mails/src/Model/TemplateModel.php
@@ -126,7 +126,7 @@ class TemplateModel extends AdminModel
 
         try {
             $attachmentPath = rtrim(Path::check(JPATH_ROOT . '/' . $params->get('attachment_folder')), \DIRECTORY_SEPARATOR);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $attachmentPath = '';
         }
 

--- a/administrator/components/com_media/src/Model/ApiModel.php
+++ b/administrator/components/com_media/src/Model/ApiModel.php
@@ -170,7 +170,7 @@ class ApiModel extends BaseDatabaseModel
     {
         try {
             $file = $this->getFile($adapter, $path . '/' . $name);
-        } catch (FileNotFoundException $e) {
+        } catch (FileNotFoundException) {
             // Do nothing
         }
 
@@ -220,7 +220,7 @@ class ApiModel extends BaseDatabaseModel
     {
         try {
             $file = $this->getFile($adapter, $path . '/' . $name);
-        } catch (FileNotFoundException $e) {
+        } catch (FileNotFoundException) {
             // Do nothing
         }
 

--- a/administrator/components/com_media/src/Provider/ProviderManagerHelperTrait.php
+++ b/administrator/components/com_media/src/Provider/ProviderManagerHelperTrait.php
@@ -154,7 +154,7 @@ trait ProviderManagerHelperTrait
             $defaultFilePath = ComponentHelper::getParams('com_media')->get('file_path', 'files');
             $defaultAdapter  = $this->getAdapter('local-' . $defaultFilePath);
             // @TODO: Need a proper configuration for default adapter.
-        } catch (ProviderAccountNotFoundException $e) {
+        } catch (ProviderAccountNotFoundException) {
             $defaultAdapter = null;
         }
 

--- a/administrator/components/com_menus/src/Controller/ItemsController.php
+++ b/administrator/components/com_menus/src/Controller/ItemsController.php
@@ -194,7 +194,7 @@ class ItemsController extends AdminController
         if (empty($cid)) {
             try {
                 Log::add(Text::_($this->text_prefix . '_NO_ITEM_SELECTED'), Log::WARNING, 'jerror');
-            } catch (\RuntimeException $exception) {
+            } catch (\RuntimeException) {
                 $this->setMessage(Text::_($this->text_prefix . '_NO_ITEM_SELECTED'), 'warning');
             }
         } else {

--- a/administrator/components/com_menus/src/Field/MenuItemByTypeField.php
+++ b/administrator/components/com_menus/src/Field/MenuItemByTypeField.php
@@ -197,7 +197,7 @@ class MenuItemByTypeField extends GroupedlistField
 
             try {
                 $menuTitle = $db->loadResult();
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 $menuTitle = $menuType;
             }
 

--- a/administrator/components/com_menus/src/Helper/MenusHelper.php
+++ b/administrator/components/com_menus/src/Helper/MenusHelper.php
@@ -383,7 +383,7 @@ class MenusHelper extends ContentHelper
                     $root->addChild($menuitem);
                 }
             }
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             Factory::getApplication()->enqueueMessage(Text::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
         }
 
@@ -719,7 +719,7 @@ class MenusHelper extends ContentHelper
 
                     return;
                 }
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $item->link = '';
 
                 return;

--- a/administrator/components/com_menus/src/Service/HTML/Menus.php
+++ b/administrator/components/com_menus/src/Service/HTML/Menus.php
@@ -121,7 +121,7 @@ class Menus
 
         try {
             $registry->loadString($params);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Invalid JSON
         }
 

--- a/administrator/components/com_messages/src/Model/MessageModel.php
+++ b/administrator/components/com_messages/src/Model/MessageModel.php
@@ -102,7 +102,7 @@ class MessageModel extends AdminModel implements UserFactoryAwareInterface
 
                     try {
                         Log::add(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), Log::WARNING, 'jerror');
-                    } catch (\RuntimeException $exception) {
+                    } catch (\RuntimeException) {
                         Factory::getApplication()->enqueueMessage(Text::_('JLIB_APPLICATION_ERROR_DELETE_NOT_PERMITTED'), 'warning');
                     }
 
@@ -266,7 +266,7 @@ class MessageModel extends AdminModel implements UserFactoryAwareInterface
 
                     try {
                         Log::add(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), Log::WARNING, 'jerror');
-                    } catch (\RuntimeException $exception) {
+                    } catch (\RuntimeException) {
                         Factory::getApplication()->enqueueMessage(Text::_('JLIB_APPLICATION_ERROR_EDITSTATE_NOT_PERMITTED'), 'warning');
                     }
 

--- a/administrator/components/com_redirect/src/Model/LinksModel.php
+++ b/administrator/components/com_redirect/src/Model/LinksModel.php
@@ -73,7 +73,7 @@ class LinksModel extends ListModel
 
         try {
             $db->execute();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
 

--- a/administrator/components/com_scheduler/src/Field/CronField.php
+++ b/administrator/components/com_scheduler/src/Field/CronField.php
@@ -159,7 +159,7 @@ class CronField extends ListField
         if ($this->wildcard) {
             try {
                 $options[] = HTMLHelper::_('select.option', '*', '*');
-            } catch (\InvalidArgumentException $e) {
+            } catch (\InvalidArgumentException) {
             }
         }
 
@@ -180,7 +180,7 @@ class CronField extends ListField
         for ([$i, $l] = [$optionLower, 0]; $i <= $optionUpper; $i++, $l++) {
             try {
                 $options[] = HTMLHelper::_('select.option', (string) ($i), $labels[$l]);
-            } catch (\InvalidArgumentException $e) {
+            } catch (\InvalidArgumentException) {
             }
         }
 

--- a/administrator/components/com_scheduler/src/Field/TaskTypeField.php
+++ b/administrator/components/com_scheduler/src/Field/TaskTypeField.php
@@ -58,7 +58,7 @@ class TaskTypeField extends ListField
         $addTypeAsOption = function (TaskOption $type) use (&$options) {
             try {
                 $options[] = HTMLHelper::_('select.option', $type->id, $type->title);
-            } catch (\InvalidArgumentException $e) {
+            } catch (\InvalidArgumentException) {
             }
         };
 

--- a/administrator/components/com_scheduler/src/Model/LogsModel.php
+++ b/administrator/components/com_scheduler/src/Model/LogsModel.php
@@ -66,7 +66,7 @@ class LogsModel extends ListModel
     {
         try {
             $this->getDatabase()->truncateTable('#__scheduler_logs');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
 

--- a/administrator/components/com_scheduler/src/Model/TaskModel.php
+++ b/administrator/components/com_scheduler/src/Model/TaskModel.php
@@ -398,7 +398,7 @@ class TaskModel extends AdminModel
 
             $db->setQuery($lockQuery)->execute();
             $affectedRows = $db->getAffectedRows();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return null;
         } finally {
             $db->unlockTables();
@@ -428,7 +428,7 @@ class TaskModel extends AdminModel
 
         try {
             $runningCount = $db->setQuery($lockCountQuery)->loadResult();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return false;
         }
 
@@ -527,7 +527,7 @@ class TaskModel extends AdminModel
 
         try {
             return $db->setQuery($idQuery)->loadColumn();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return [];
         }
     }
@@ -551,7 +551,7 @@ class TaskModel extends AdminModel
 
         try {
             $task = $db->setQuery($getQuery)->loadObject();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return null;
         }
 

--- a/administrator/components/com_scheduler/src/Scheduler/Scheduler.php
+++ b/administrator/components/com_scheduler/src/Scheduler/Scheduler.php
@@ -139,7 +139,7 @@ class Scheduler
 
         try {
             $task->run();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // We suppress the exception here, it's still accessible with `$task->getContent()['exception']`.
         }
 
@@ -221,7 +221,7 @@ class Scheduler
 
             /** @var TaskModel $model */
             $model = $component->getMVCFactory()->createModel('Task', 'Administrator', ['ignore_request' => true]);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
         }
 
         if (!isset($model)) {
@@ -293,7 +293,7 @@ class Scheduler
             /** @var TasksModel $model */
             $model = $component->getMVCFactory()
                 ->createModel('Tasks', 'Administrator', ['ignore_request' => true]);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
         }
 
         if (!$model) {

--- a/administrator/components/com_scheduler/src/Task/Task.php
+++ b/administrator/components/com_scheduler/src/Task/Task.php
@@ -333,7 +333,7 @@ class Task implements LoggerAwareInterface
         try {
             $db->lockTable('#__scheduler_tasks');
             $db->setQuery($query)->execute();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return false;
         } finally {
             $db->unlockTables();
@@ -395,7 +395,7 @@ class Task implements LoggerAwareInterface
 
         try {
             $db->setQuery($query)->execute();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return false;
         }
 
@@ -446,7 +446,7 @@ class Task implements LoggerAwareInterface
 
         try {
             $db->setQuery($query)->execute();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
         }
 
         $this->set('next_execution', $nextExec);

--- a/administrator/components/com_scheduler/src/Task/TaskOption.php
+++ b/administrator/components/com_scheduler/src/Task/TaskOption.php
@@ -105,7 +105,7 @@ class TaskOption
                     Log::WARNING,
                     'deprecated'
                 );
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 // Pass
             }
 

--- a/administrator/components/com_scheduler/src/Traits/TaskPluginTrait.php
+++ b/administrator/components/com_scheduler/src/Traits/TaskPluginTrait.php
@@ -143,7 +143,7 @@ trait TaskPluginTrait
 
         try {
             $enhancementFormFile = Path::check($enhancementFormFile);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
 

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -764,7 +764,7 @@ class TemplateModel extends FormModel
                     if (is_file($src)) {
                         try {
                             File::copy($src, $dst);
-                        } catch (FilesystemException $exception) {
+                        } catch (FilesystemException) {
                         }
                     }
                 }
@@ -832,7 +832,7 @@ class TemplateModel extends FormModel
 
             try {
                 $result = File::move($file, \dirname($file) . $newFile) && $result;
-            } catch (FilesystemException $exception) {
+            } catch (FilesystemException) {
                 $result = false;
             }
         }
@@ -852,7 +852,7 @@ class TemplateModel extends FormModel
 
             try {
                 $result = File::write($xmlFile, $contents) && $result;
-            } catch (FilesystemException $exception) {
+            } catch (FilesystemException) {
                 $result = false;
             }
         }
@@ -945,7 +945,7 @@ class TemplateModel extends FormModel
 
             try {
                 $filePath = Path::check($fileName);
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_ERROR_SOURCE_FILE_NOT_FOUND'), 'error');
 
                 return;
@@ -1028,7 +1028,7 @@ class TemplateModel extends FormModel
 
         try {
             File::write($filePath, $data['source']);
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
             $app->enqueueMessage(Text::sprintf('COM_TEMPLATES_ERROR_FAILED_TO_SAVE_FILENAME', $fileName), 'error');
 
             return false;
@@ -1282,7 +1282,7 @@ class TemplateModel extends FormModel
 
             try {
                 $return = File::copy($file, $htmlFilePath, '', true);
-            } catch (FilesystemException $exception) {
+            } catch (FilesystemException) {
                 $return = false;
             }
         }
@@ -1307,7 +1307,7 @@ class TemplateModel extends FormModel
 
             try {
                 $return = File::delete($filePath);
-            } catch (FilesystemException $exception) {
+            } catch (FilesystemException) {
                 $return = false;
             }
 
@@ -1398,7 +1398,7 @@ class TemplateModel extends FormModel
 
             try {
                 File::upload($file['tmp_name'], Path::clean($path . '/' . $location . '/' . $fileName));
-            } catch (FilesystemException $exception) {
+            } catch (FilesystemException) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_FILE_UPLOAD_ERROR'), 'error');
 
                 return false;
@@ -1759,7 +1759,7 @@ class TemplateModel extends FormModel
 
             try {
                 File::copy($path . $relPath, $newPath);
-            } catch (FilesystemException $exception) {
+            } catch (FilesystemException) {
                 return false;
             }
 
@@ -1995,7 +1995,7 @@ class TemplateModel extends FormModel
 
         try {
             $xml = simplexml_load_string(file_get_contents($xmlFile));
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $app->enqueueMessage(Text::_('COM_TEMPLATES_ERROR_COULD_NOT_READ'), 'error');
 
             return false;
@@ -2059,7 +2059,7 @@ class TemplateModel extends FormModel
 
         try {
             $result = File::write($xmlFile, $dom->saveXML());
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
             $app->enqueueMessage(Text::_('COM_TEMPLATES_ERROR_COULD_NOT_WRITE'), 'error');
 
             return false;
@@ -2139,7 +2139,7 @@ class TemplateModel extends FormModel
 
         try {
             $parentStyle = $db->loadObjectList();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $app->enqueueMessage(Text::_('COM_TEMPLATES_ERROR_STYLE_NOT_FOUND'), 'error');
 
             return false;
@@ -2162,7 +2162,7 @@ class TemplateModel extends FormModel
 
             try {
                 $db->execute();
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_ERROR_COULD_NOT_READ'), 'error');
 
                 return false;

--- a/administrator/components/com_templates/src/View/Template/HtmlView.php
+++ b/administrator/components/com_templates/src/View/Template/HtmlView.php
@@ -191,7 +191,7 @@ class HtmlView extends BaseHtmlView
             try {
                 $this->image = $model->getImage();
                 $this->type  = 'image';
-            } catch (\RuntimeException $exception) {
+            } catch (\RuntimeException) {
                 $app->enqueueMessage(Text::_('COM_TEMPLATES_GD_EXTENSION_NOT_AVAILABLE'));
                 $this->type = 'home';
             }

--- a/administrator/components/com_users/src/Controller/CaptiveController.php
+++ b/administrator/components/com_users/src/Controller/CaptiveController.php
@@ -107,7 +107,7 @@ class CaptiveController extends BaseController implements UserFactoryAwareInterf
         try {
             // Suppress all modules on the page except those explicitly allowed
             $model->suppressAllModules();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // If we can't kill the modules we can still survive.
         }
 

--- a/administrator/components/com_users/src/Helper/Mfa.php
+++ b/administrator/components/com_users/src/Helper/Mfa.php
@@ -272,7 +272,7 @@ abstract class Mfa
 
         try {
             $ids = $db->setQuery($query)->loadColumn() ?: [];
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $ids = [];
         }
 

--- a/administrator/components/com_users/src/Model/MethodsModel.php
+++ b/administrator/components/com_users/src/Model/MethodsModel.php
@@ -197,7 +197,7 @@ class MethodsModel extends BaseDatabaseModel
 
         try {
             $result = $db->setQuery($query)->loadResult();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return;
         }
 

--- a/administrator/components/com_users/src/Model/UsersModel.php
+++ b/administrator/components/com_users/src/Model/UsersModel.php
@@ -598,7 +598,7 @@ class UsersModel extends ListModel
 
         try {
             $result = $db->setQuery($query)->loadColumn();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $result = [];
         }
 

--- a/administrator/components/com_users/src/Service/Encrypt.php
+++ b/administrator/components/com_users/src/Service/Encrypt.php
@@ -125,7 +125,7 @@ class Encrypt
     {
         try {
             return Factory::getApplication()->get('secret', '');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return '';
         }
     }

--- a/administrator/components/com_users/src/View/SiteTemplateTrait.php
+++ b/administrator/components/com_users/src/View/SiteTemplateTrait.php
@@ -53,7 +53,7 @@ trait SiteTemplateTrait
             $refTemplate = $refApp->getProperty('template');
             $refTemplate->setAccessible(true);
             $refTemplate->setValue($app, null);
-        } catch (\ReflectionException $e) {
+        } catch (\ReflectionException) {
             return;
         }
 

--- a/administrator/components/com_users/src/View/User/HtmlView.php
+++ b/administrator/components/com_users/src/View/User/HtmlView.php
@@ -135,7 +135,7 @@ class HtmlView extends BaseHtmlView implements UserFactoryAwareInterface
                 $this->mfaConfigurationUI = Mfa::canShowConfigurationInterface($userBeingEdited)
                     ? Mfa::getConfigurationInterface($userBeingEdited)
                     : '';
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // In case something goes really wrong with the plugins; prevents hard breaks.
                 $this->mfaConfigurationUI = null;
             }

--- a/components/com_banners/src/Model/BannerModel.php
+++ b/components/com_banners/src/Model/BannerModel.php
@@ -193,7 +193,7 @@ class BannerModel extends BaseDatabaseModel
 
             try {
                 $this->_item = $cache->get($loader, [$id], md5(__METHOD__ . $id));
-            } catch (CacheExceptionInterface $e) {
+            } catch (CacheExceptionInterface) {
                 $this->_item = $loader($id);
             }
         }

--- a/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
+++ b/components/com_newsfeeds/src/View/Newsfeed/HtmlView.php
@@ -180,9 +180,9 @@ class HtmlView extends BaseHtmlView
         try {
             $feed         = new FeedFactory();
             $this->rssDoc = $feed->getFeed($item->link);
-        } catch (\InvalidArgumentException $e) {
+        } catch (\InvalidArgumentException) {
             $msg = Text::_('COM_NEWSFEEDS_ERRORS_FEED_NOT_RETRIEVED');
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $msg = Text::_('COM_NEWSFEEDS_ERRORS_FEED_NOT_RETRIEVED');
         }
 

--- a/components/com_privacy/src/Model/ConfirmModel.php
+++ b/components/com_privacy/src/Model/ConfirmModel.php
@@ -105,7 +105,7 @@ class ConfirmModel extends AdminModel
 
             try {
                 $table->store();
-            } catch (ExecutionFailureException $exception) {
+            } catch (ExecutionFailureException) {
                 // The error will be logged in the database API, we just need to catch it here to not let things fatal out
             }
 

--- a/components/com_privacy/src/Model/RemindModel.php
+++ b/components/com_privacy/src/Model/RemindModel.php
@@ -85,7 +85,7 @@ class RemindModel extends AdminModel
 
         try {
             $remind = $db->loadObject();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             $this->setError(Text::_('COM_PRIVACY_ERROR_NO_PENDING_REMIND'));
 
             return false;

--- a/components/com_users/src/Model/LoginModel.php
+++ b/components/com_users/src/Model/LoginModel.php
@@ -148,7 +148,7 @@ class LoginModel extends FormModel
 
         try {
             return $db->loadResult();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return '';
         }
     }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses [RemoveUnusedVariableInCatchRector](https://getrector.com/rule-detail/remove-unused-variable-in-catch-rector) rector rule to remove unused variable in try catch block in our components code. This is done automatically by rector, no manual change included.


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner code.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
