### PR TITLE
[5.3] Change list to array destruct for components code

### DIFF
--- a/administrator/components/com_associations/src/Controller/AssociationController.php
+++ b/administrator/components/com_associations/src/Controller/AssociationController.php
@@ -39,7 +39,7 @@ class AssociationController extends FormController
      */
     public function edit($key = null, $urlVar = null)
     {
-        list($extensionName, $typeName) = explode('.', $this->input->get('itemtype', '', 'string'), 2);
+        [$extensionName, $typeName] = explode('.', $this->input->get('itemtype', '', 'string'), 2);
 
         $id = $this->input->get('id', 0, 'int');
 
@@ -67,7 +67,7 @@ class AssociationController extends FormController
     {
         $this->checkToken();
 
-        list($extensionName, $typeName) = explode('.', $this->input->get('itemtype', '', 'string'), 2);
+        [$extensionName, $typeName] = explode('.', $this->input->get('itemtype', '', 'string'), 2);
 
         // Only check in, if component item type allows to check out.
         if (AssociationsHelper::typeSupportsCheckout($extensionName, $typeName)) {

--- a/administrator/components/com_associations/src/Controller/AssociationsController.php
+++ b/administrator/components/com_associations/src/Controller/AssociationsController.php
@@ -94,7 +94,7 @@ class AssociationsController extends AdminController
         $this->setRedirect(Route::_('index.php?option=' . $this->option . '&view=' . $this->view_list, false));
 
         // Figure out if the item supports checking and check it in
-        list($extensionName, $typeName) = explode('.', $this->input->get('itemtype'));
+        [$extensionName, $typeName] = explode('.', $this->input->get('itemtype'));
 
         $extension = AssociationsHelper::getSupportedExtension($extensionName);
         $types     = $extension->get('types');

--- a/administrator/components/com_associations/src/Dispatcher/Dispatcher.php
+++ b/administrator/components/com_associations/src/Dispatcher/Dispatcher.php
@@ -43,7 +43,7 @@ class Dispatcher extends ComponentDispatcher
         $itemType = $this->input->get('itemtype', '', 'string');
 
         if ($itemType !== '') {
-            list($extensionName, $typeName) = explode('.', $itemType);
+            [$extensionName, $typeName] = explode('.', $itemType);
 
             if (!AssociationsHelper::hasSupport($extensionName)) {
                 throw new \Exception(

--- a/administrator/components/com_associations/src/Field/ItemlanguageField.php
+++ b/administrator/components/com_associations/src/Field/ItemlanguageField.php
@@ -46,7 +46,7 @@ class ItemlanguageField extends ListField
     {
         $input = Factory::getApplication()->getInput();
 
-        list($extensionName, $typeName) = explode('.', $input->get('itemtype', '', 'string'), 2);
+        [$extensionName, $typeName] = explode('.', $input->get('itemtype', '', 'string'), 2);
 
         // Get the extension specific helper method
         $helper = AssociationsHelper::getExtensionHelper($extensionName);

--- a/administrator/components/com_associations/src/Model/AssociationsModel.php
+++ b/administrator/components/com_associations/src/Model/AssociationsModel.php
@@ -154,7 +154,7 @@ class AssociationsModel extends ListModel
     {
         $type         = null;
 
-        list($extensionName, $typeName) = explode('.', $this->state->get('itemtype'), 2);
+        [$extensionName, $typeName] = explode('.', $this->state->get('itemtype'), 2);
 
         $extension = AssociationsHelper::getSupportedExtension($extensionName);
         $types     = $extension->get('types');

--- a/administrator/components/com_associations/src/View/Associations/HtmlView.php
+++ b/administrator/components/com_associations/src/View/Associations/HtmlView.php
@@ -140,7 +140,7 @@ class HtmlView extends BaseHtmlView
         } elseif ($this->state->get('itemtype') != '' && $this->state->get('language') != '') {
             $type = null;
 
-            list($extensionName, $typeName) = explode('.', $this->state->get('itemtype'), 2);
+            [$extensionName, $typeName] = explode('.', $this->state->get('itemtype'), 2);
 
             $extension = AssociationsHelper::getSupportedExtension($extensionName);
 

--- a/administrator/components/com_banners/src/Model/BannerModel.php
+++ b/administrator/components/com_banners/src/Model/BannerModel.php
@@ -447,8 +447,8 @@ class BannerModel extends AdminModel
 
             if ($data['name'] == $origTable->name) {
                 [$name, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['name']);
-                $data['name']       = $name;
-                $data['alias']      = $alias;
+                $data['name']  = $name;
+                $data['alias'] = $alias;
             } else {
                 if ($data['alias'] == $origTable->alias) {
                     $data['alias'] = '';

--- a/administrator/components/com_banners/src/Model/BannerModel.php
+++ b/administrator/components/com_banners/src/Model/BannerModel.php
@@ -446,7 +446,7 @@ class BannerModel extends AdminModel
             $origTable->load($input->getInt('id'));
 
             if ($data['name'] == $origTable->name) {
-                list($name, $alias) = $this->generateNewTitle($data['catid'], $data['alias'], $data['name']);
+                [$name, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['name']);
                 $data['name']       = $name;
                 $data['alias']      = $alias;
             } else {

--- a/administrator/components/com_banners/src/Model/BannerModel.php
+++ b/administrator/components/com_banners/src/Model/BannerModel.php
@@ -447,8 +447,8 @@ class BannerModel extends AdminModel
 
             if ($data['name'] == $origTable->name) {
                 [$name, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['name']);
-                $data['name']  = $name;
-                $data['alias'] = $alias;
+                $data['name']   = $name;
+                $data['alias']  = $alias;
             } else {
                 if ($data['alias'] == $origTable->alias) {
                     $data['alias'] = '';

--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -320,7 +320,7 @@ class ContactModel extends AdminModel
             $origTable->load($input->getInt('id'));
 
             if ($data['name'] == $origTable->name) {
-                list($name, $alias) = $this->generateNewTitle($data['catid'], $data['alias'], $data['name']);
+                [$name, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['name']);
                 $data['name']       = $name;
                 $data['alias']      = $alias;
             } else {

--- a/administrator/components/com_contact/src/Model/ContactModel.php
+++ b/administrator/components/com_contact/src/Model/ContactModel.php
@@ -321,8 +321,8 @@ class ContactModel extends AdminModel
 
             if ($data['name'] == $origTable->name) {
                 [$name, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['name']);
-                $data['name']       = $name;
-                $data['alias']      = $alias;
+                $data['name']   = $name;
+                $data['alias']  = $alias;
             } else {
                 if ($data['alias'] == $origTable->alias) {
                     $data['alias'] = '';

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -769,7 +769,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
                 }
 
                 [$title, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['title']);
-                $data['alias']       = $alias;
+                $data['alias']   = $alias;
 
                 if (isset($msg)) {
                     $app->enqueueMessage($msg, 'warning');

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -746,8 +746,8 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 
             if ($data['title'] == $origTable->title) {
                 [$title, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['title']);
-                $data['title']       = $title;
-                $data['alias']       = $alias;
+                $data['title']   = $title;
+                $data['alias']   = $alias;
             } elseif ($data['alias'] == $origTable->alias) {
                 $data['alias'] = '';
             }

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -745,7 +745,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
             }
 
             if ($data['title'] == $origTable->title) {
-                list($title, $alias) = $this->generateNewTitle($data['catid'], $data['alias'], $data['title']);
+                [$title, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['title']);
                 $data['title']       = $title;
                 $data['alias']       = $alias;
             } elseif ($data['alias'] == $origTable->alias) {
@@ -768,7 +768,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
                     $msg = Text::_('COM_CONTENT_SAVE_WARNING');
                 }
 
-                list($title, $alias) = $this->generateNewTitle($data['catid'], $data['alias'], $data['title']);
+                [$title, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['title']);
                 $data['alias']       = $alias;
 
                 if (isset($msg)) {

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -145,9 +145,9 @@ class FieldModel extends AdminModel
 
             if ($data['title'] == $origTable->title) {
                 [$title, $name] = $this->generateNewTitle($data['group_id'], $data['name'], $data['title']);
-                $data['title']      = $title;
-                $data['label']      = $title;
-                $data['name']       = $name;
+                $data['title']  = $title;
+                $data['label']  = $title;
+                $data['name']   = $name;
             } else {
                 if ($data['name'] == $origTable->name) {
                     $data['name'] = '';

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -144,7 +144,7 @@ class FieldModel extends AdminModel
             $origTable->load($input->getInt('id'));
 
             if ($data['title'] == $origTable->title) {
-                list($title, $name) = $this->generateNewTitle($data['group_id'], $data['name'], $data['title']);
+                [$title, $name] = $this->generateNewTitle($data['group_id'], $data['name'], $data['title']);
                 $data['title']      = $title;
                 $data['label']      = $title;
                 $data['name']       = $name;

--- a/administrator/components/com_guidedtours/src/Helper/GuidedtoursHelper.php
+++ b/administrator/components/com_guidedtours/src/Helper/GuidedtoursHelper.php
@@ -46,7 +46,7 @@ class GuidedtoursHelper
 
         // The uid has an extension separator so we need to check the extension language files
         if (strpos($uid, '.') > 0) {
-            list($extension, $tourid) = explode('.', $uid, 2);
+            [$extension, $tourid] = explode('.', $uid, 2);
 
             $source = '';
 

--- a/administrator/components/com_mails/src/View/Template/HtmlView.php
+++ b/administrator/components/com_mails/src/View/Template/HtmlView.php
@@ -90,7 +90,7 @@ class HtmlView extends BaseHtmlView
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
-        list($extension, $template_id) = explode('.', $this->item->template_id, 2);
+        [$extension, $template_id] = explode('.', $this->item->template_id, 2);
         $fields                        = ['subject', 'body', 'htmlbody'];
         $this->templateData            = [];
 

--- a/administrator/components/com_mails/src/View/Template/HtmlView.php
+++ b/administrator/components/com_mails/src/View/Template/HtmlView.php
@@ -91,8 +91,8 @@ class HtmlView extends BaseHtmlView
         }
 
         [$extension, $template_id] = explode('.', $this->item->template_id, 2);
-        $fields                        = ['subject', 'body', 'htmlbody'];
-        $this->templateData            = [];
+        $fields                    = ['subject', 'body', 'htmlbody'];
+        $this->templateData        = [];
 
         MailsHelper::loadTranslationFiles($extension, $this->item->language);
 

--- a/administrator/components/com_media/src/Controller/ApiController.php
+++ b/administrator/components/com_media/src/Controller/ApiController.php
@@ -276,7 +276,7 @@ class ApiController extends BaseController
         }
 
         if ($newPath != null && $newPath !== $adapter . ':' . $path) {
-            list($destinationAdapter, $destinationPath) = explode(':', $newPath, 2);
+            [$destinationAdapter, $destinationPath] = explode(':', $newPath, 2);
 
             if ($move) {
                 $destinationPath = $this->getModel()->move($adapter, $path, $destinationPath, false);

--- a/administrator/components/com_media/src/Model/FileModel.php
+++ b/administrator/components/com_media/src/Model/FileModel.php
@@ -65,7 +65,7 @@ class FileModel extends FormModel
      */
     public function getFileInformation($path)
     {
-        list($adapter, $path) = explode(':', $path, 2);
+        [$adapter, $path] = explode(':', $path, 2);
 
         return $this->bootComponent('com_media')->getMVCFactory()->createModel('Api', 'Administrator')
             ->getFile($adapter, $path, ['url' => true, 'content' => true]);

--- a/administrator/components/com_media/src/Provider/ProviderManager.php
+++ b/administrator/components/com_media/src/Provider/ProviderManager.php
@@ -119,7 +119,7 @@ class ProviderManager
      */
     public function getAdapter($name)
     {
-        list($provider, $account) = array_pad(explode('-', $name, 2), 2, null);
+        [$provider, $account] = array_pad(explode('-', $name, 2), 2, null);
 
         if ($account == null) {
             throw new ProviderAccountIsEmptyException(Text::_('COM_MEDIA_ERROR_ACCOUNT_NOT_SET'));

--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -278,7 +278,7 @@ class ItemModel extends AdminModel
             $table->home  = 0;
 
             // Alter the title & alias
-            list($title, $alias) = $this->generateNewTitle($table->parent_id, $table->alias, $table->title);
+            [$title, $alias] = $this->generateNewTitle($table->parent_id, $table->alias, $table->title);
             $table->title        = $title;
             $table->alias        = $alias;
 
@@ -1109,7 +1109,7 @@ class ItemModel extends AdminModel
                 // If custom layout, get the xml file from the template folder
                 // template folder is first part of file name -- template:folder
                 if (!$formFile && (strpos($layout, ':') > 0)) {
-                    list($altTmpl, $altLayout) = explode(':', $layout);
+                    [$altTmpl, $altLayout] = explode(':', $layout);
 
                     $templatePath = Path::clean($clientInfo->path . '/templates/' . $altTmpl . '/html/' . $option . '/' . $view . '/' . $altLayout . '.xml');
 
@@ -1380,7 +1380,7 @@ class ItemModel extends AdminModel
             $origTable->load($this->getState('item.id'));
 
             if ($table->title === $origTable->title) {
-                list($title, $alias) = $this->generateNewTitle($table->parent_id, $table->alias, $table->title);
+                [$title, $alias] = $this->generateNewTitle($table->parent_id, $table->alias, $table->title);
                 $table->title        = $title;
                 $table->alias        = $alias;
             }

--- a/administrator/components/com_menus/src/Model/ItemModel.php
+++ b/administrator/components/com_menus/src/Model/ItemModel.php
@@ -279,8 +279,8 @@ class ItemModel extends AdminModel
 
             // Alter the title & alias
             [$title, $alias] = $this->generateNewTitle($table->parent_id, $table->alias, $table->title);
-            $table->title        = $title;
-            $table->alias        = $alias;
+            $table->title    = $title;
+            $table->alias    = $alias;
 
             // Check the row.
             if (!$table->check()) {
@@ -1381,8 +1381,8 @@ class ItemModel extends AdminModel
 
             if ($table->title === $origTable->title) {
                 [$title, $alias] = $this->generateNewTitle($table->parent_id, $table->alias, $table->title);
-                $table->title        = $title;
-                $table->alias        = $alias;
+                $table->title    = $title;
+                $table->alias    = $alias;
             }
 
             if ($table->alias === $origTable->alias) {

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
@@ -219,7 +219,7 @@ class NewsfeedModel extends AdminModel
             $origTable->load($input->getInt('id'));
 
             if ($data['name'] == $origTable->name) {
-                list($name, $alias) = $this->generateNewTitle($data['catid'], $data['alias'], $data['name']);
+                [$name, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['name']);
                 $data['name']       = $name;
                 $data['alias']      = $alias;
             } else {

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedModel.php
@@ -220,8 +220,8 @@ class NewsfeedModel extends AdminModel
 
             if ($data['name'] == $origTable->name) {
                 [$name, $alias] = $this->generateNewTitle($data['catid'], $data['alias'], $data['name']);
-                $data['name']       = $name;
-                $data['alias']      = $alias;
+                $data['name']   = $name;
+                $data['alias']  = $alias;
             } else {
                 if ($data['alias'] == $origTable->alias) {
                     $data['alias'] = '';

--- a/administrator/components/com_scheduler/src/Helper/ExecRuleHelper.php
+++ b/administrator/components/com_scheduler/src/Helper/ExecRuleHelper.php
@@ -111,11 +111,11 @@ class ExecRuleHelper
                 $nextExec      = $string ? $nextExec->toSql() : $nextExec;
                 break;
             case 'interval-days':
-                $now                 = Factory::getDate('now', 'UTC');
-                $intervalDays        = $executionRules['interval-days'];
-                $interval            = new \DateInterval('P' . $intervalDays . 'D');
-                $nextExec            = $now->add($interval);
-                $execTime            = $executionRules['exec-time'];
+                $now             = Factory::getDate('now', 'UTC');
+                $intervalDays    = $executionRules['interval-days'];
+                $interval        = new \DateInterval('P' . $intervalDays . 'D');
+                $nextExec        = $now->add($interval);
+                $execTime        = $executionRules['exec-time'];
                 [$hour, $minute] = explode(':', $execTime);
                 $nextExec->setTime($hour, $minute);
                 $nextExec = $string ? $nextExec->toSql() : $nextExec;
@@ -130,7 +130,7 @@ class ExecRuleHelper
                 $nextExecMonth  = $nextExec->format('n');
                 $nextExec->setDate($nextExecYear, $nextExecMonth, $execDay);
 
-                $execTime            = $executionRules['exec-time'];
+                $execTime        = $executionRules['exec-time'];
                 [$hour, $minute] = explode(':', $execTime);
                 $nextExec->setTime($hour, $minute);
                 $nextExec = $string ? $nextExec->toSql() : $nextExec;

--- a/administrator/components/com_scheduler/src/Helper/ExecRuleHelper.php
+++ b/administrator/components/com_scheduler/src/Helper/ExecRuleHelper.php
@@ -116,7 +116,7 @@ class ExecRuleHelper
                 $interval            = new \DateInterval('P' . $intervalDays . 'D');
                 $nextExec            = $now->add($interval);
                 $execTime            = $executionRules['exec-time'];
-                list($hour, $minute) = explode(':', $execTime);
+                [$hour, $minute] = explode(':', $execTime);
                 $nextExec->setTime($hour, $minute);
                 $nextExec = $string ? $nextExec->toSql() : $nextExec;
                 break;
@@ -131,7 +131,7 @@ class ExecRuleHelper
                 $nextExec->setDate($nextExecYear, $nextExecMonth, $execDay);
 
                 $execTime            = $executionRules['exec-time'];
-                list($hour, $minute) = explode(':', $execTime);
+                [$hour, $minute] = explode(':', $execTime);
                 $nextExec->setTime($hour, $minute);
                 $nextExec = $string ? $nextExec->toSql() : $nextExec;
                 break;

--- a/administrator/components/com_tags/src/Model/TagModel.php
+++ b/administrator/components/com_tags/src/Model/TagModel.php
@@ -240,8 +240,8 @@ class TagModel extends AdminModel
 
                 if ($data['title'] == $origTable->title) {
                     [$title, $alias] = $this->generateNewTitle($data['parent_id'], $data['alias'], $data['title']);
-                    $data['title']       = $title;
-                    $data['alias']       = $alias;
+                    $data['title']   = $title;
+                    $data['alias']   = $alias;
                 } elseif ($data['alias'] == $origTable->alias) {
                     $data['alias'] = '';
                 }

--- a/administrator/components/com_tags/src/Model/TagModel.php
+++ b/administrator/components/com_tags/src/Model/TagModel.php
@@ -239,7 +239,7 @@ class TagModel extends AdminModel
                 $origTable->load($input->getInt('id'));
 
                 if ($data['title'] == $origTable->title) {
-                    list($title, $alias) = $this->generateNewTitle($data['parent_id'], $data['alias'], $data['title']);
+                    [$title, $alias] = $this->generateNewTitle($data['parent_id'], $data['alias'], $data['title']);
                     $data['title']       = $title;
                     $data['alias']       = $alias;
                 } elseif ($data['alias'] == $origTable->alias) {

--- a/administrator/components/com_workflow/src/Model/StageModel.php
+++ b/administrator/components/com_workflow/src/Model/StageModel.php
@@ -121,7 +121,7 @@ class StageModel extends AdminModel
 
             // Alter the title for save as copy
             if ($origTable->load(['title' => $data['title']])) {
-                list($title)   = $this->generateNewTitle(0, '', $data['title']);
+                [$title]   = $this->generateNewTitle(0, '', $data['title']);
                 $data['title'] = $title;
             }
 

--- a/administrator/components/com_workflow/src/Model/StageModel.php
+++ b/administrator/components/com_workflow/src/Model/StageModel.php
@@ -121,7 +121,7 @@ class StageModel extends AdminModel
 
             // Alter the title for save as copy
             if ($origTable->load(['title' => $data['title']])) {
-                [$title]   = $this->generateNewTitle(0, '', $data['title']);
+                [$title]       = $this->generateNewTitle(0, '', $data['title']);
                 $data['title'] = $title;
             }
 

--- a/administrator/components/com_workflow/src/Model/TransitionModel.php
+++ b/administrator/components/com_workflow/src/Model/TransitionModel.php
@@ -171,7 +171,7 @@ class TransitionModel extends AdminModel
 
             // Alter the title for save as copy
             if ($origTable->load(['title' => $data['title']])) {
-                [$title]   = $this->generateNewTitle(0, '', $data['title']);
+                [$title]       = $this->generateNewTitle(0, '', $data['title']);
                 $data['title'] = $title;
             }
 

--- a/administrator/components/com_workflow/src/Model/TransitionModel.php
+++ b/administrator/components/com_workflow/src/Model/TransitionModel.php
@@ -171,7 +171,7 @@ class TransitionModel extends AdminModel
 
             // Alter the title for save as copy
             if ($origTable->load(['title' => $data['title']])) {
-                list($title)   = $this->generateNewTitle(0, '', $data['title']);
+                [$title]   = $this->generateNewTitle(0, '', $data['title']);
                 $data['title'] = $title;
             }
 

--- a/administrator/components/com_workflow/src/Model/WorkflowModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowModel.php
@@ -110,7 +110,7 @@ class WorkflowModel extends AdminModel
 
             // Alter the title for save as copy
             if ($origTable->load(['title' => $data['title']])) {
-                [$title]   = $this->generateNewTitle(0, '', $data['title']);
+                [$title]       = $this->generateNewTitle(0, '', $data['title']);
                 $data['title'] = $title;
             }
 

--- a/administrator/components/com_workflow/src/Model/WorkflowModel.php
+++ b/administrator/components/com_workflow/src/Model/WorkflowModel.php
@@ -110,7 +110,7 @@ class WorkflowModel extends AdminModel
 
             // Alter the title for save as copy
             if ($origTable->load(['title' => $data['title']])) {
-                list($title)   = $this->generateNewTitle(0, '', $data['title']);
+                [$title]   = $this->generateNewTitle(0, '', $data['title']);
                 $data['title'] = $title;
             }
 

--- a/components/com_contact/src/Service/Router.php
+++ b/components/com_contact/src/Service/Router.php
@@ -160,7 +160,7 @@ class Router extends RouterView
     public function getContactSegment($id, $query)
     {
         if ($this->noIDs && strpos($id, ':')) {
-            list($void, $segment) = explode(':', $id, 2);
+            [$void, $segment] = explode(':', $id, 2);
 
             return [$void => $segment];
         }

--- a/components/com_content/src/Service/Router.php
+++ b/components/com_content/src/Service/Router.php
@@ -161,7 +161,7 @@ class Router extends RouterView
     public function getArticleSegment($id, $query)
     {
         if ($this->noIDs && strpos($id, ':')) {
-            list($void, $segment) = explode(':', $id, 2);
+            [$void, $segment] = explode(':', $id, 2);
 
             return [$void => $segment];
         }

--- a/components/com_newsfeeds/src/Service/Router.php
+++ b/components/com_newsfeeds/src/Service/Router.php
@@ -156,7 +156,7 @@ class Router extends RouterView
     public function getNewsfeedSegment($id, $query)
     {
         if ($this->noIDs && strpos($id, ':')) {
-            list($void, $segment) = explode(':', $id, 2);
+            [$void, $segment] = explode(':', $id, 2);
 
             return [$void => $segment];
         }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses [ListToArrayDestructRector](https://getrector.com/rule-detail/list-to-array-destruct-rector) rector rule to change code form using list function to user more modern array destruct syntax in our components code. This is done automatically by rector, no manual change included.


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner code using modern syntax

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
