### PR TITLE
[5.3] Make mailtemplate information available in mail template layout

### DIFF
--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -333,7 +333,7 @@ class MailTemplate
                 $this->addLayoutTemplateData([
                     'siteName' => $app->get('sitename'),
                     'lang'     => substr($this->language, 0, 2),
-                    'mail'   => $mail
+                    'mail'     => $mail,
                 ]);
 
                 $layout = $config->get('mail_htmllayout', 'mailtemplate');

--- a/libraries/src/Mail/MailTemplate.php
+++ b/libraries/src/Mail/MailTemplate.php
@@ -333,6 +333,7 @@ class MailTemplate
                 $this->addLayoutTemplateData([
                     'siteName' => $app->get('sitename'),
                     'lang'     => substr($this->language, 0, 2),
+                    'mail'   => $mail
                 ]);
 
                 $layout = $config->get('mail_htmllayout', 'mailtemplate');


### PR DESCRIPTION
### Summary of Changes
The new mail template layout introduced in 5.3 (https://docs.joomla.org/J5.x:Managing_Mail_Template_Layout) currently has no access to the actual mail template. This prevents some interesting usecases, accessing the parameters of the template to retrieve extra information.

This PR adds $mail to the rendered layout, making the template available on render.

### Testing Instructions
* Configure your site for the usage of HTML templates by setting the Mail Format to "HTML" and enabling the "Mail Template Layout" in the mail template settings
* Add a temporary debug statement to `layouts/joomla/mail/mailtemplate.php` around line 34: `var_dump($extraData);die();`
* trigger the submission of a system mail, i.e. by starting a password reset


### Actual result BEFORE applying this Pull Request
No information about the current template is available in the debug output.


### Expected result AFTER applying this Pull Request
The debug output has a "mail" item, comparable to this output:
![Bildschirmfoto 2025-02-22 um 09 39 51](https://github.com/user-attachments/assets/7ec2a54f-eda7-4f05-889d-2f197ebbb79e)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
