### PR TITLE
[5.2] Composer update maximebf/debugbar to 1.23.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
     "symfony/yaml": "^6.4.11",
     "typo3/phar-stream-wrapper": "^3.1.7",
     "wamania/php-stemmer": "^3.0.1",
-    "maximebf/debugbar": "^1.23.0",
+    "maximebf/debugbar": "^1.23.6",
     "tobscure/json-api": "dev-joomla-backports",
     "willdurand/negotiation": "^3.1.0",
     "ext-json": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e239d33518fe4b1ce5f63da240447409",
+    "content-hash": "1c0c2e8997137370931be7b027104d50",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -2864,16 +2864,16 @@
         },
         {
             "name": "maximebf/debugbar",
-            "version": "v1.23.0",
+            "version": "v1.23.6",
             "source": {
                 "type": "git",
-                "url": "https://github.com/maximebf/php-debugbar.git",
-                "reference": "0143b7c17daad5336ebd406c279333c84723cc41"
+                "url": "https://github.com/php-debugbar/php-debugbar.git",
+                "reference": "4b3d5f1afe09a7db5a9d3282890f49f6176d6542"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maximebf/php-debugbar/zipball/0143b7c17daad5336ebd406c279333c84723cc41",
-                "reference": "0143b7c17daad5336ebd406c279333c84723cc41",
+                "url": "https://api.github.com/repos/php-debugbar/php-debugbar/zipball/4b3d5f1afe09a7db5a9d3282890f49f6176d6542",
+                "reference": "4b3d5f1afe09a7db5a9d3282890f49f6176d6542",
                 "shasum": ""
             },
             "require": {
@@ -2925,10 +2925,10 @@
                 "debugbar"
             ],
             "support": {
-                "issues": "https://github.com/maximebf/php-debugbar/issues",
-                "source": "https://github.com/maximebf/php-debugbar/tree/v1.23.0"
+                "issues": "https://github.com/php-debugbar/php-debugbar/issues",
+                "source": "https://github.com/php-debugbar/php-debugbar/tree/v1.23.6"
             },
-            "time": "2024-09-10T17:28:47+00:00"
+            "time": "2025-02-13T12:22:36+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the composed dependency "maximebf/debugbar" from version 1.23.0 to version 1.23.6.

Release notes:
- https://github.com/php-debugbar/php-debugbar/releases/tag/v1.23.1
- https://github.com/php-debugbar/php-debugbar/releases/tag/v1.23.2
- https://github.com/php-debugbar/php-debugbar/releases/tag/v1.23.3
- https://github.com/php-debugbar/php-debugbar/releases/tag/v1.23.4
- https://github.com/php-debugbar/php-debugbar/releases/tag/v1.23.5
- https://github.com/php-debugbar/php-debugbar/releases/tag/v1.23.6

This fixes a few small bugs (which might not be relevant for the CMS core but maybe for 3rd party extensions) and PHP 8.4 deprecations.

There is another PR for 5.3-dev, PR #44902 , which is different to this one here as with version 2 the composer package was renamed.

This will cause merge conflicts for the upmerge from 5.2-dev to 5.3-dev after the 2 PRs will be merged, which have to be resolved by keeping the version from 5.3-dev.

### Testing Instructions

Enable "Debug System" in Global Configuration and set "Error Reporting" to "Maximum".

Then use all features of the debug bar.

Change some option of the "System - Debug" plugin, e.g. enable previously disabled options or vice versa, and check the result in the debug bar.

### Actual result BEFORE applying this Pull Request

Debug bar works.

### Expected result AFTER applying this Pull Request

Debug bar works as before.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
