### PR TITLE
[5.2][UnitTest] Use @backupGlobals to backup $_SERVER

### DIFF
--- a/tests/Unit/Libraries/Cms/Environment/BrowserTest.php
+++ b/tests/Unit/Libraries/Cms/Environment/BrowserTest.php
@@ -17,20 +17,11 @@ use Joomla\Tests\Unit\UnitTestCase;
  * Test class for JBrowser.
  *
  * @since   4.0.0
+ *
+ * @backupGlobals enabled
  */
 class BrowserTest extends UnitTestCase
 {
-    /**
-     * Backup of the SERVER superglobal
-     *
-     * @var  array
-     *
-     * @return  void
-     *
-     * @since   4.0.0
-     */
-    protected $backupServer;
-
     /**
      * Object being tested
      *

--- a/tests/Unit/Libraries/Cms/Uri/UriTest.php
+++ b/tests/Unit/Libraries/Cms/Uri/UriTest.php
@@ -19,6 +19,8 @@ use Joomla\Tests\Unit\UnitTestCase;
  * @package     Joomla.UnitTest
  * @subpackage  Uri
  * @since       1.7.0
+ *
+ * @backupGlobals enabled
  */
 class UriTest extends UnitTestCase
 {
@@ -26,14 +28,6 @@ class UriTest extends UnitTestCase
      * @var    Uri
      */
     protected $object;
-
-    /**
-     * Backup of the SERVER superglobal
-     *
-     * @var    array
-     * @since  3.6
-     */
-    protected $backupServer;
 
     /**
      * Sets up the fixture, for example, opens a network connection.
@@ -46,7 +40,6 @@ class UriTest extends UnitTestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->backupServer = $_SERVER;
         Uri::reset();
 
         $_SERVER['HTTP_HOST']   = 'www.example.com:80';
@@ -68,8 +61,6 @@ class UriTest extends UnitTestCase
      */
     protected function tearDown(): void
     {
-        $_SERVER = $this->backupServer;
-        unset($this->backupServer);
         unset($this->object);
         parent::tearDown();
     }


### PR DESCRIPTION
### Summary of Changes

Some tests need to backup the `$_SERVER` super-global array before execution. To do this they save  the `$_SERVER` to protected property. But PHPUnit for a long time supports a [@backupGlobal](https://docs.phpunit.de/en/9.6/annotations.html#backupglobals) annotation for these cases.

### Testing Instructions

Launch tests and ensure there are no errors:

```sh
php libraries/vendor/bin/phpunit tests/Unit
```

### Link to documentations

Please select:

- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
