### PR TITLE
[5.3] Use str_starts_with function for libraries code

### DIFF
--- a/libraries/src/Cache/Storage/ApcuStorage.php
+++ b/libraries/src/Cache/Storage/ApcuStorage.php
@@ -170,7 +170,7 @@ class ApcuStorage extends CacheStorage
                 $internalKey = $key['key'];
             }
 
-            if (strpos($internalKey, $secret . '-cache-' . $group . '-') === 0 xor $mode !== 'group') {
+            if (str_starts_with($internalKey, $secret . '-cache-' . $group . '-') xor $mode !== 'group') {
                 apcu_delete($internalKey);
             }
         }

--- a/libraries/src/Cache/Storage/MemcachedStorage.php
+++ b/libraries/src/Cache/Storage/MemcachedStorage.php
@@ -307,7 +307,7 @@ class MemcachedStorage extends CacheStorage
             $prefix = $this->_hash . '-cache-' . $group . '-';
 
             foreach ($index as $key => $value) {
-                if (strpos($value->name, $prefix) === 0 xor $mode !== 'group') {
+                if (str_starts_with($value->name, $prefix) xor $mode !== 'group') {
                     static::$_db->delete($value->name);
                     unset($index[$key]);
                 }

--- a/libraries/src/Cache/Storage/RedisStorage.php
+++ b/libraries/src/Cache/Storage/RedisStorage.php
@@ -286,11 +286,11 @@ class RedisStorage extends CacheStorage
         $secret = $this->_hash;
 
         foreach ($allKeys as $key) {
-            if (strpos($key, $secret . '-cache-' . $group . '-') === 0 && $mode === 'group') {
+            if (str_starts_with($key, $secret . '-cache-' . $group . '-') && $mode === 'group') {
                 static::$_redis->del($key);
             }
 
-            if (strpos($key, $secret . '-cache-' . $group . '-') !== 0 && $mode !== 'group') {
+            if (!str_starts_with($key, $secret . '-cache-' . $group . '-') && $mode !== 'group') {
                 static::$_redis->del($key);
             }
         }

--- a/libraries/src/Event/AbstractEvent.php
+++ b/libraries/src/Event/AbstractEvent.php
@@ -84,7 +84,7 @@ abstract class AbstractEvent extends Event
          * the onTableBeforeLoad event name.
          */
         if (!$eventClassName || !class_exists($eventClassName, true)) {
-            $bareName       = strpos($eventName, 'on') === 0 ? substr($eventName, 2) : $eventName;
+            $bareName       = str_starts_with($eventName, 'on') ? substr($eventName, 2) : $eventName;
             $parts          = Normalise::fromCamelCase($bareName, true);
             $eventClassName = __NAMESPACE__ . '\\' . ucfirst(array_shift($parts)) . '\\';
             $eventClassName .= implode('', $parts);

--- a/libraries/src/Filesystem/Folder.php
+++ b/libraries/src/Filesystem/Folder.php
@@ -237,7 +237,7 @@ abstract class Folder
                 foreach ($obdArray as $test) {
                     $test = Path::clean($test);
 
-                    if (strpos($path, $test) === 0 || strpos($path, realpath($test)) === 0) {
+                    if (str_starts_with($path, $test) || str_starts_with($path, realpath($test))) {
                         $inBaseDir = true;
                         break;
                     }

--- a/libraries/src/Form/Field/SchemaorgComponentSectionsField.php
+++ b/libraries/src/Form/Field/SchemaorgComponentSectionsField.php
@@ -46,7 +46,7 @@ class SchemaorgComponentSectionsField extends ComponentsField
         $options   = [];
         $options[] = HTMLHelper::_('select.option', ' ', Text::_('JNONE'));
         foreach ($items as $item) {
-            if (substr($item->value, 0, 4) !== 'com_') {
+            if (!str_starts_with($item->value, 'com_')) {
                 continue;
             }
 

--- a/libraries/src/Form/Field/WorkflowComponentSectionsField.php
+++ b/libraries/src/Form/Field/WorkflowComponentSectionsField.php
@@ -48,7 +48,7 @@ class WorkflowComponentSectionsField extends ComponentsField
         $options[] = HTMLHelper::_('select.option', ' ', Text::_('JNONE'));
 
         foreach ($items as $item) {
-            if (substr($item->value, 0, 4) !== 'com_') {
+            if (!str_starts_with($item->value, 'com_')) {
                 continue;
             }
 

--- a/libraries/src/Form/Filter/TelFilter.php
+++ b/libraries/src/Form/Filter/TelFilter.php
@@ -47,11 +47,11 @@ class TelFilter implements FormFilterInterface
         if (preg_match('/^(?:\+?1[-. ]?)?\(?([2-9][0-8][0-9])\)?[-. ]?([2-9][0-9]{2})[-. ]?([0-9]{4})$/', $value) == 1) {
             $number = (string) preg_replace('/[^\d]/', '', $value);
 
-            if (substr($number, 0, 1) === '1') {
+            if (str_starts_with($number, '1')) {
                 $number = substr($number, 1);
             }
 
-            if (substr($number, 0, 2) === '+1') {
+            if (str_starts_with($number, '+1')) {
                 $number = substr($number, 2);
             }
 

--- a/libraries/src/Form/Filter/UrlFilter.php
+++ b/libraries/src/Form/Filter/UrlFilter.php
@@ -67,7 +67,7 @@ class UrlFilter implements FormFilterInterface
             $protocol = 'http';
 
             // If it looks like an internal link, then add the root.
-            if (substr($value, 0, 9) === 'index.php') {
+            if (str_starts_with($value, 'index.php')) {
                 $value = Uri::root() . $value;
             } else {
                 // Otherwise we treat it as an external link.
@@ -81,7 +81,7 @@ class UrlFilter implements FormFilterInterface
             // If it starts with the host string, just prepend the protocol.
             if (substr($value, 0) === $host) {
                 $value = 'http://' . $value;
-            } elseif (substr($value, 0, 1) !== '/') {
+            } elseif (!str_starts_with($value, '/')) {
                 // Otherwise if it doesn't start with "/" prepend the prefix of the current site.
                 $value = Uri::root(true) . '/' . $value;
             }

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1705,7 +1705,7 @@ class Form implements CurrentUserInterface
             $forms[$name] = Factory::getContainer()->get(FormFactoryInterface::class)->createForm($name, $options);
 
             // Load the data.
-            if (substr($data, 0, 1) === '<') {
+            if (str_starts_with($data, '<')) {
                 if ($forms[$name]->load($data, $replace, $xpath) == false) {
                     throw new \RuntimeException(\sprintf('%s() could not load form', __METHOD__));
                 }

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -497,7 +497,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
 
             default:
                 // Check for data attribute
-                if (strpos($name, 'data-') === 0 && \array_key_exists($name, $this->dataAttributes)) {
+                if (str_starts_with($name, 'data-') && \array_key_exists($name, $this->dataAttributes)) {
                     return $this->dataAttributes[$name];
                 }
         }
@@ -593,7 +593,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
 
             default:
                 // Detect data attribute(s)
-                if (strpos($name, 'data-') === 0) {
+                if (str_starts_with($name, 'data-')) {
                     $this->dataAttributes[$name] = $value;
                 } else {
                     if (property_exists(__CLASS__, $name)) {
@@ -671,7 +671,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
 
         // Lets detect miscellaneous data attribute. For eg, data-*
         foreach ($this->element->attributes() as $key => $value) {
-            if (strpos($key, 'data-') === 0) {
+            if (str_starts_with($key, 'data-')) {
                 // Data attribute key value pair
                 $this->dataAttributes[$key] = $value;
             }

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -404,7 +404,7 @@ abstract class HTMLHelper
         }
 
         // If http is present in filename
-        if (strpos($file, 'http') === 0 || strpos($file, '//') === 0) {
+        if (str_starts_with($file, 'http') || str_starts_with($file, '//')) {
             $includes = [$file];
         } else {
             // Extract extension and strip the file

--- a/libraries/src/Helper/AuthenticationHelper.php
+++ b/libraries/src/Helper/AuthenticationHelper.php
@@ -131,7 +131,7 @@ abstract class AuthenticationHelper
 
                 // Unset anything that doesn't conform to a button definition
                 foreach (array_keys($button) as $key) {
-                    if (substr($key, 0, 5) == 'data-') {
+                    if (str_starts_with($key, 'data-')) {
                         continue;
                     }
 

--- a/libraries/src/Helper/ModuleHelper.php
+++ b/libraries/src/Helper/ModuleHelper.php
@@ -63,7 +63,7 @@ abstract class ModuleHelper
         }
 
         // If we didn't find it, and the name is mod_something, create a dummy object
-        if ($result === null && strpos($name, 'mod_') === 0) {
+        if ($result === null && str_starts_with($name, 'mod_')) {
             $result         = static::createDummyModule();
             $result->module = $name;
         }

--- a/libraries/src/Helper/PublicFolderGeneratorHelper.php
+++ b/libraries/src/Helper/PublicFolderGeneratorHelper.php
@@ -100,7 +100,7 @@ PHP;
         $root                = JPATH_ROOT . '/';
         $defineRoot          = '\'' . JPATH_ROOT . '\'';
 
-        if (substr($destinationPath, 0, 1) !== '/') {
+        if (!str_starts_with($destinationPath, '/')) {
             $fullDestinationPath = JPATH_ROOT . '/' . $destinationPath;
             $root                = '';
             $dirsToRoot          = substr_count($destinationPath, '/');
@@ -190,7 +190,7 @@ PHP;
      */
     private function createSymlink(string $source, string $dest, string $base): void
     {
-        if (substr($source, 0, 1) !== '/') {
+        if (!str_starts_with($source, '/')) {
             $source = str_repeat('../', substr_count($dest, '/')) . $source;
             $dest   = $base . $dest;
         }

--- a/libraries/src/Http/Transport/CurlTransport.php
+++ b/libraries/src/Http/Transport/CurlTransport.php
@@ -77,7 +77,7 @@ class CurlTransport extends AbstractTransport implements TransportInterface
         // If data exists let's encode it and make sure our Content-type header is set.
         if (isset($data)) {
             // If the data is a scalar value simply add it to the cURL post fields.
-            if (\is_scalar($data) || (isset($headers['Content-Type']) && strpos($headers['Content-Type'], 'multipart/form-data') === 0)) {
+            if (\is_scalar($data) || (isset($headers['Content-Type']) && str_starts_with($headers['Content-Type'], 'multipart/form-data'))) {
                 $options[CURLOPT_POSTFIELDS] = $data;
             } else {
                 // Otherwise we need to encode the value first.

--- a/libraries/src/Input/Cli.php
+++ b/libraries/src/Input/Cli.php
@@ -147,7 +147,7 @@ class Cli extends Input
             $arg = $argv[$i];
 
             // --foo --bar=baz
-            if (substr($arg, 0, 2) === '--') {
+            if (str_starts_with($arg, '--')) {
                 $eqPos = strpos($arg, '=');
 
                 // --foo
@@ -169,7 +169,7 @@ class Cli extends Input
                     $value     = substr($arg, $eqPos + 1);
                     $out[$key] = $value;
                 }
-            } elseif (substr($arg, 0, 1) === '-') {
+            } elseif (str_starts_with($arg, '-')) {
                 // -k=value -abc
                 // -k=value
                 if (substr($arg, 2, 1) === '=') {

--- a/libraries/src/Installer/Adapter/ComponentAdapter.php
+++ b/libraries/src/Installer/Adapter/ComponentAdapter.php
@@ -521,7 +521,7 @@ class ComponentAdapter extends InstallerAdapter
     {
         $element = parent::getElement($element);
 
-        if (strpos($element, 'com_') !== 0) {
+        if (!str_starts_with($element, 'com_')) {
             $element = 'com_' . $element;
         }
 

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -750,7 +750,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface, L
         if (!$prefix) {
             if ($this->factory instanceof LegacyFactory) {
                 $prefix = $this->model_prefix;
-            } elseif (!empty($config['base_path']) && strpos(Path::clean($config['base_path']), JPATH_ADMINISTRATOR) === 0) {
+            } elseif (!empty($config['base_path']) && str_starts_with(Path::clean($config['base_path']), JPATH_ADMINISTRATOR)) {
                 // When the frontend uses an administrator model
                 $prefix = 'Administrator';
             } else {
@@ -861,7 +861,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface, L
         if (!$prefix) {
             if ($this->factory instanceof LegacyFactory) {
                 $prefix = $this->getName() . 'View';
-            } elseif (!empty($config['base_path']) && strpos(Path::clean($config['base_path']), JPATH_ADMINISTRATOR) === 0) {
+            } elseif (!empty($config['base_path']) && str_starts_with(Path::clean($config['base_path']), JPATH_ADMINISTRATOR)) {
                 // When the front uses an administrator view
                 $prefix = 'Administrator';
             } else {

--- a/libraries/src/MVC/Model/FormBehaviorTrait.php
+++ b/libraries/src/MVC/Model/FormBehaviorTrait.php
@@ -93,7 +93,7 @@ trait FormBehaviorTrait
         }
 
         // Load the data.
-        if (substr($source, 0, 1) === '<') {
+        if (str_starts_with($source, '<')) {
             if ($form->load($source, false, $xpath) == false) {
                 throw new \RuntimeException('Form::loadForm could not load form');
             }

--- a/libraries/src/MVC/Model/ListModel.php
+++ b/libraries/src/MVC/Model/ListModel.php
@@ -646,7 +646,7 @@ class ListModel extends BaseDatabaseModel implements FormFactoryAwareInterface, 
         $new_state = $input->get($request, null, $type);
 
         // BC for Search Tools which uses different naming
-        if ($new_state === null && strpos($request, 'filter_') === 0) {
+        if ($new_state === null && str_starts_with($request, 'filter_')) {
             $name    = substr($request, 7);
             $filters = $app->getInput()->get('filter', [], 'array');
 

--- a/libraries/src/Mail/MailHelper.php
+++ b/libraries/src/Mail/MailHelper.php
@@ -173,7 +173,7 @@ abstract class MailHelper
             }
 
             // Check for a dash at the beginning of the domain
-            if (strpos($domain, '-') === 0) {
+            if (str_starts_with($domain, '-')) {
                 return false;
             }
 

--- a/libraries/src/Object/LegacyPropertyManagementTrait.php
+++ b/libraries/src/Object/LegacyPropertyManagementTrait.php
@@ -89,7 +89,7 @@ trait LegacyPropertyManagementTrait
 
         if ($public) {
             foreach ($vars as $key => $value) {
-                if ('_' == substr($key, 0, 1)) {
+                if (str_starts_with($key, '_')) {
                     unset($vars[$key]);
                 }
             }

--- a/libraries/src/Pathway/SitePathway.php
+++ b/libraries/src/Pathway/SitePathway.php
@@ -60,7 +60,7 @@ class SitePathway extends Pathway
                             break;
 
                         case 'url':
-                            if ((strpos($link->link, 'index.php?') === 0) && (strpos($link->link, 'Itemid=') === false)) {
+                            if ((str_starts_with($link->link, 'index.php?')) && (strpos($link->link, 'Itemid=') === false)) {
                                 // If this is an internal Joomla link, ensure the Itemid is set.
                                 $url = $link->link . '&Itemid=' . $link->id;
                             } else {

--- a/libraries/src/Plugin/CMSPlugin.php
+++ b/libraries/src/Plugin/CMSPlugin.php
@@ -215,7 +215,7 @@ abstract class CMSPlugin implements DispatcherAwareInterface, PluginInterface, L
 
         /** @var \ReflectionMethod $method */
         foreach ($methods as $method) {
-            if (substr($method->name, 0, 2) !== 'on') {
+            if (!str_starts_with($method->name, 'on')) {
                 continue;
             }
 

--- a/libraries/src/Router/ApiRouter.php
+++ b/libraries/src/Router/ApiRouter.php
@@ -172,7 +172,7 @@ class ApiRouter extends Router
         $path = ltrim($path, '/');
 
         // We can only remove index.php if it's present in the beginning of the route
-        if (strpos($path, 'index.php') !== 0) {
+        if (!str_starts_with($path, 'index.php')) {
             return $path;
         }
 

--- a/libraries/src/Router/Route.php
+++ b/libraries/src/Router/Route.php
@@ -128,7 +128,7 @@ class Route
     public static function link($client, $url, $xhtml = true, $tls = self::TLS_IGNORE, $absolute = false)
     {
         // If we cannot process this $url exit early.
-        if (!\is_array($url) && (strpos($url, '&') !== 0) && (strpos($url, 'index.php') !== 0)) {
+        if (!\is_array($url) && (!str_starts_with($url, '&')) && (!str_starts_with($url, 'index.php'))) {
             return $url;
         }
 

--- a/libraries/src/Router/Router.php
+++ b/libraries/src/Router/Router.php
@@ -460,7 +460,7 @@ class Router
      */
     protected function createUri($url)
     {
-        if (!\is_array($url) && substr($url, 0, 1) !== '&') {
+        if (!\is_array($url) && !str_starts_with($url, '&')) {
             return new Uri($url);
         }
 

--- a/libraries/src/Table/Table.php
+++ b/libraries/src/Table/Table.php
@@ -604,7 +604,7 @@ abstract class Table extends \stdClass implements TableInterface, DispatcherAwar
         // Get the default values for the class from the table.
         foreach ($this->getFields() as $k => $v) {
             // If the property is not the primary key or private, reset it.
-            if (!\in_array($k, $this->_tbl_keys) && (strpos($k, '_') !== 0)) {
+            if (!\in_array($k, $this->_tbl_keys) && (!str_starts_with($k, '_'))) {
                 $this->$k = $v->Default;
             }
         }

--- a/libraries/src/Toolbar/Button/PopupButton.php
+++ b/libraries/src/Toolbar/Button/PopupButton.php
@@ -223,7 +223,7 @@ JS
     {
         $url = $url ?? '';
 
-        if (strpos($url, 'http') !== 0) {
+        if (!str_starts_with($url, 'http')) {
             $url = Uri::base() . $url;
         }
 

--- a/libraries/src/Uri/Uri.php
+++ b/libraries/src/Uri/Uri.php
@@ -248,7 +248,7 @@ class Uri extends \Joomla\Uri\Uri
 
         // @see UriTest
         if (
-            empty($host) && strpos($uri->path, 'index.php') === 0
+            empty($host) && str_starts_with($uri->path, 'index.php')
             || !empty($host) && preg_match('#^' . preg_quote(static::base(), '#') . '#', $base)
             || !empty($host) && $host === static::getInstance(static::base())->host && strpos($uri->path, 'index.php') !== false
             || !empty($host) && $base === $host && preg_match('#^' . preg_quote($base, '#') . '#', static::base())

--- a/libraries/src/User/UserHelper.php
+++ b/libraries/src/User/UserHelper.php
@@ -465,22 +465,22 @@ abstract class UserHelper
         $container         = Factory::getContainer();
 
         // Cheaply try to determine the algorithm in use otherwise fall back to the chained handler
-        if (strpos($hash, '$P$') === 0) {
+        if (str_starts_with($hash, '$P$')) {
             /** @var PHPassHandler $handler */
             $handler = $container->get(PHPassHandler::class);
-        } elseif (strpos($hash, '$argon2id') === 0) {
+        } elseif (str_starts_with($hash, '$argon2id')) {
             // Check for Argon2id hashes
             /** @var Argon2idHandler $handler */
             $handler = $container->get(Argon2idHandler::class);
 
             $passwordAlgorithm = self::HASH_ARGON2ID;
-        } elseif (strpos($hash, '$argon2i') === 0) {
+        } elseif (str_starts_with($hash, '$argon2i')) {
             // Check for Argon2i hashes
             /** @var Argon2iHandler $handler */
             $handler = $container->get(Argon2iHandler::class);
 
             $passwordAlgorithm = self::HASH_ARGON2I;
-        } elseif (strpos($hash, '$2') === 0) {
+        } elseif (str_starts_with($hash, '$2')) {
             // Check for bcrypt hashes
             /** @var BCryptHandler $handler */
             $handler = $container->get(BCryptHandler::class);

--- a/libraries/src/WebAsset/WebAssetItem.php
+++ b/libraries/src/WebAsset/WebAssetItem.php
@@ -333,7 +333,7 @@ class WebAssetItem implements WebAssetItemInterface
      */
     protected function isPathExternal(string $path): bool
     {
-        return strpos($path, 'http://') === 0 || strpos($path, 'https://') === 0 || strpos($path, '//') === 0;
+        return str_starts_with($path, 'http://') || str_starts_with($path, 'https://') || str_starts_with($path, '//');
     }
 
     /**

--- a/libraries/src/WebAsset/WebAssetManager.php
+++ b/libraries/src/WebAsset/WebAssetManager.php
@@ -198,7 +198,7 @@ class WebAssetManager implements WebAssetManagerInterface
     {
         $method = strtolower($method);
 
-        if (0 === strpos($method, 'use')) {
+        if (str_starts_with($method, 'use')) {
             $type = substr($method, 3);
 
             if (empty($arguments[0])) {
@@ -208,7 +208,7 @@ class WebAssetManager implements WebAssetManagerInterface
             return $this->useAsset($type, $arguments[0]);
         }
 
-        if (0 === strpos($method, 'addinline')) {
+        if (str_starts_with($method, 'addinline')) {
             $type = substr($method, 9);
 
             if (empty($arguments[0])) {
@@ -218,7 +218,7 @@ class WebAssetManager implements WebAssetManagerInterface
             return $this->addInline($type, ...$arguments);
         }
 
-        if (0 === strpos($method, 'disable')) {
+        if (str_starts_with($method, 'disable')) {
             $type = substr($method, 7);
 
             if (empty($arguments[0])) {
@@ -228,7 +228,7 @@ class WebAssetManager implements WebAssetManagerInterface
             return $this->disableAsset($type, $arguments[0]);
         }
 
-        if (0 === strpos($method, 'register')) {
+        if (str_starts_with($method, 'register')) {
             // Check for registerAndUse<Type>
             $andUse = substr($method, 8, 6) === 'anduse';
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses **[StrStartsWithRector](https://getrector.com/rule-detail/str-starts-with-rector)** rule to convert our libraries code to use [str_starts_with](https://www.php.net/manual/en/function.str-starts-with.php) function. It does not change any existing behavior, just make the code cleaner and easier to read.

### Testing Instructions
Need to have code review for every single change here.

### Actual result BEFORE applying this Pull Request
Works

### Expected result AFTER applying this Pull Request
Works, with cleaner, easier to read code.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed