### PR TITLE
[5.3] Use str_ends_with function for libraries code

### DIFF
--- a/libraries/src/HTML/Helpers/StringHelper.php
+++ b/libraries/src/HTML/Helpers/StringHelper.php
@@ -196,7 +196,7 @@ abstract class StringHelper
 
         // If the plain text is shorter than the max length the variable will not end in ...
         // In that case we use the whole string.
-        if (substr($ptString, -3) !== '...') {
+        if (!str_ends_with($ptString, '...')) {
             return $html;
         }
 

--- a/libraries/src/Mail/MailHelper.php
+++ b/libraries/src/Mail/MailHelper.php
@@ -136,7 +136,7 @@ abstract class MailHelper
         $allowed = "a-zA-Z0-9.!#$%&'*+\/=?^_`{|}~-";
         $regex   = "/^[$allowed][\.$allowed]{0,63}$/";
 
-        if (!preg_match($regex, $local) || substr($local, -1) === '.' || $local[0] === '.' || preg_match('/\.\./', $local)) {
+        if (!preg_match($regex, $local) || str_ends_with($local, '.') || $local[0] === '.' || preg_match('/\.\./', $local)) {
             return false;
         }
 

--- a/libraries/src/Router/SiteRouter.php
+++ b/libraries/src/Router/SiteRouter.php
@@ -178,7 +178,7 @@ class SiteRouter extends Router
         $route = $uri->getPath();
 
         // Identify format
-        if (!(substr($route, -9) === 'index.php' || substr($route, -1) === '/') && $suffix = pathinfo($route, PATHINFO_EXTENSION)) {
+        if (!(str_ends_with($route, 'index.php') || str_ends_with($route, '/')) && $suffix = pathinfo($route, PATHINFO_EXTENSION)) {
             $uri->setVar('format', $suffix);
             $route = str_replace('.' . $suffix, '', $route);
             $uri->setPath($route);
@@ -509,7 +509,7 @@ class SiteRouter extends Router
         $route = $uri->getPath();
 
         // Identify format
-        if (!(substr($route, -9) === 'index.php' || substr($route, -1) === '/') && $format = $uri->getVar('format', 'html')) {
+        if (!(str_ends_with($route, 'index.php') || str_ends_with($route, '/')) && $format = $uri->getVar('format', 'html')) {
             $route .= '.' . $format;
             $uri->setPath($route);
             $uri->delVar('format');

--- a/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
+++ b/libraries/src/Schema/ChangeItem/MysqlChangeItem.php
@@ -354,7 +354,7 @@ class MysqlChangeItem extends ChangeItem
         // Skip types that do not support default values
         $type = strtolower($type);
 
-        if (substr($type, -4) === 'text' || substr($type, -4) === 'blob') {
+        if (str_ends_with($type, 'text') || str_ends_with($type, 'blob')) {
             return false;
         }
 

--- a/libraries/src/Updater/Adapter/CollectionAdapter.php
+++ b/libraries/src/Updater/Adapter/CollectionAdapter.php
@@ -227,7 +227,7 @@ class CollectionAdapter extends UpdateAdapter
 
         if (!xml_parse($this->xmlParser, $response->body)) {
             // If the URL is missing the .xml extension, try appending it and retry loading the update
-            if (!$this->appendExtension && (substr($this->_url, -4) !== '.xml')) {
+            if (!$this->appendExtension && (!str_ends_with($this->_url, '.xml'))) {
                 $options['append_extension'] = true;
 
                 return $this->findUpdate($options);

--- a/libraries/src/Updater/Adapter/ExtensionAdapter.php
+++ b/libraries/src/Updater/Adapter/ExtensionAdapter.php
@@ -286,7 +286,7 @@ class ExtensionAdapter extends UpdateAdapter
 
         if (!xml_parse($this->xmlParser, $response->body)) {
             // If the URL is missing the .xml extension, try appending it and retry loading the update
-            if (!$this->appendExtension && (substr($this->_url, -4) !== '.xml')) {
+            if (!$this->appendExtension && (!str_ends_with($this->_url, '.xml'))) {
                 $options['append_extension'] = true;
 
                 return $this->findUpdate($options);

--- a/libraries/src/Updater/UpdateAdapter.php
+++ b/libraries/src/Updater/UpdateAdapter.php
@@ -229,8 +229,8 @@ abstract class UpdateAdapter extends AdapterInstance
             $this->appendExtension = $options['append_extension'];
         }
 
-        if ($this->appendExtension && (substr($url, -4) !== '.xml')) {
-            if (substr($url, -1) !== '/') {
+        if ($this->appendExtension && (!str_ends_with($url, '.xml'))) {
+            if (!str_ends_with($url, '/')) {
                 $url .= '/';
             }
 
@@ -281,7 +281,7 @@ abstract class UpdateAdapter extends AdapterInstance
 
         if ($response === null || $response->code !== 200) {
             // If the URL is missing the .xml extension, try appending it and retry loading the update
-            if (!$this->appendExtension && (substr($url, -4) !== '.xml')) {
+            if (!$this->appendExtension && (!str_ends_with($url, '.xml'))) {
                 $options['append_extension'] = true;
 
                 return $this->getUpdateSiteResponse($options);


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses **[StrEndsWithRector](https://getrector.com/rule-detail/str-ends-with-rector)** rule to convert our libraries code to use [str_ends_with](https://www.php.net/manual/en/function.str-ends-with.php) function. It does not change any existing behavior, just make the code cleaner and easier to read. The change is done automatically by rector, no manual change included here.

### Testing Instructions
Need to have code review for every single change here.

### Actual result BEFORE applying this Pull Request
Works

### Expected result AFTER applying this Pull Request
Works, with cleaner, easier to read code.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed