### PR TITLE
[5.3] Changes unneeded null check to ?? operator for libraries

### DIFF
--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -829,7 +829,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
      */
     public function isHttpsForced($clientId = null)
     {
-        $clientId = (int) ($clientId !== null ? $clientId : $this->getClientId());
+        $clientId = (int) ($clientId ?? $this->getClientId());
         $forceSsl = (int) $this->get('force_ssl');
 
         if ($clientId === 0 && $forceSsl === 2) {

--- a/libraries/src/HTML/Helpers/Access.php
+++ b/libraries/src/HTML/Helpers/Access.php
@@ -293,7 +293,7 @@ abstract class Access
             $name,
             [
                 'id'          => $config['id'] ?? 'assetgroups_' . (++$count),
-                'list.attr'   => $attribs === null ? 'class="inputbox" size="3"' : $attribs,
+                'list.attr'   => $attribs ?? 'class="inputbox" size="3"',
                 'list.select' => (int) $selected,
             ]
         );

--- a/libraries/src/HTML/Helpers/Bootstrap.php
+++ b/libraries/src/HTML/Helpers/Bootstrap.php
@@ -849,7 +849,7 @@ HTMLSTR;
     {
         static $tabLayout = null;
 
-        $tabLayout = $tabLayout === null ? new FileLayout('libraries.html.bootstrap.tab.addtab') : $tabLayout;
+        $tabLayout = $tabLayout ?? new FileLayout('libraries.html.bootstrap.tab.addtab');
         $active    = (static::$loaded[__CLASS__ . '::startTabSet'][$selector]['active'] == $id) ? ' active' : '';
 
         return $tabLayout->render(['id' => preg_replace('/^[\.#]/', '', $id), 'active' => $active, 'title' => $title]);

--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -1080,7 +1080,7 @@ class Image
     protected function sanitizeHeight($height, $width)
     {
         // If no height was given we will assume it is a square and use the width.
-        $height = ($height === null) ? $width : $height;
+        $height = $height ?? $width;
 
         // If we were given a percentage, calculate the integer value.
         if (preg_match('/^[0-9]+(\.[0-9]+)?\%$/', $height)) {
@@ -1119,7 +1119,7 @@ class Image
     protected function sanitizeWidth($width, $height)
     {
         // If no width was given we will assume it is a square and use the height.
-        $width = ($width === null) ? $height : $width;
+        $width = $width ?? $height;
 
         // If we were given a percentage, calculate the integer value.
         if (preg_match('/^[0-9]+(\.[0-9]+)?\%$/', $width)) {

--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -1116,7 +1116,7 @@ abstract class AdminModel extends FormModel
                  */
                 $publishedColumnName = $table->getColumnAlias('published');
 
-                if (property_exists($table, $publishedColumnName) && (isset($table->$publishedColumnName) ? $table->$publishedColumnName : $value) == $value) {
+                if (property_exists($table, $publishedColumnName) && ($table->$publishedColumnName ?? $value) == $value) {
                     unset($pks[$i]);
                 }
             }
@@ -1252,7 +1252,7 @@ abstract class AdminModel extends FormModel
         }
 
         $key   = $table->getKeyName();
-        $pk    = (isset($data[$key])) ? $data[$key] : (int) $this->getState($this->getName() . '.id');
+        $pk    = $data[$key] ?? (int) $this->getState($this->getName() . '.id');
         $isNew = true;
 
         // Include the plugins for the save events.

--- a/libraries/src/Mail/Mail.php
+++ b/libraries/src/Mail/Mail.php
@@ -406,7 +406,7 @@ class Mail extends PHPMailer implements MailerInterface
                 }
 
                 foreach ($path as $key => $file) {
-                    $result = parent::addAttachment($file, isset($name[$key]) ? $name[$key] : '', $encoding, $type, $disposition);
+                    $result = parent::addAttachment($file, $name[$key] ?? '', $encoding, $type, $disposition);
                 }
 
                 // Check for boolean false return if exception handling is disabled

--- a/libraries/src/Session/MetadataManager.php
+++ b/libraries/src/Session/MetadataManager.php
@@ -233,7 +233,7 @@ final class MetadataManager
         $sessionId   = $session->getId();
         $userIsGuest = $user->guest;
         $userId      = $user->id;
-        $username    = $user->username === null ? '' : $user->username;
+        $username    = $user->username ?? '';
 
         $query->bind(':session_id', $sessionId)
             ->bind(':guest', $userIsGuest, ParameterType::INTEGER)
@@ -290,7 +290,7 @@ final class MetadataManager
         $sessionId   = $session->getId();
         $userIsGuest = $user->guest;
         $userId      = $user->id;
-        $username    = $user->username === null ? '' : $user->username;
+        $username    = $user->username ?? '';
 
         $query->bind(':session_id', $sessionId)
             ->bind(':guest', $userIsGuest, ParameterType::INTEGER)

--- a/libraries/src/Table/MenuType.php
+++ b/libraries/src/Table/MenuType.php
@@ -197,7 +197,7 @@ class MenuType extends Table implements CurrentUserInterface
     public function delete($pk = null)
     {
         $k  = $this->_tbl_key;
-        $pk = $pk === null ? $this->$k : $pk;
+        $pk = $pk ?? $this->$k;
 
         // If no primary key is given, return false.
         if ($pk !== null) {
@@ -316,6 +316,6 @@ class MenuType extends Table implements CurrentUserInterface
             $assetId = $asset->id;
         }
 
-        return $assetId === null ? parent::_getAssetParentId($table, $id) : $assetId;
+        return $assetId ?? parent::_getAssetParentId($table, $id);
     }
 }

--- a/libraries/src/Updater/Updater.php
+++ b/libraries/src/Updater/Updater.php
@@ -305,7 +305,7 @@ class Updater extends Adapter
                                 'element'   => $current_update->element,
                                 'type'      => $current_update->type,
                                 'client_id' => $current_update->client_id,
-                                'folder'    => isset($current_update->folder) ? $current_update->folder : '',
+                                'folder'    => $current_update->folder ?? '',
                             ]
                         );
 
@@ -315,7 +315,7 @@ class Updater extends Adapter
                                 'element'   => $current_update->element,
                                 'type'      => $current_update->type,
                                 'client_id' => $current_update->client_id,
-                                'folder'    => isset($current_update->folder) ? $current_update->folder : '',
+                                'folder'    => $current_update->folder ?? '',
                             ]
                         );
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses [TernaryToNullCoalescingRector](https://getrector.com/rule-detail/ternary-to-null-coalescing-rector) rector rule to change unneeded null check to `??` operator for our libraries code. This is done automatically by rector, no manual change included.


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner, easier to read code

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
