### PR TITLE
[5.3] Use ternary operator for libraries

### DIFF
--- a/libraries/src/Form/Field/CalendarField.php
+++ b/libraries/src/Form/Field/CalendarField.php
@@ -233,16 +233,16 @@ class CalendarField extends FormField
         $return = parent::setup($element, $value, $group);
 
         if ($return) {
-            $this->maxlength    = (int) $this->element['maxlength'] ? (int) $this->element['maxlength'] : 45;
-            $this->format       = (string) $this->element['format'] ? (string) $this->element['format'] : '%Y-%m-%d';
-            $this->filterFormat = (string) $this->element['filterformat'] ? (string) $this->element['filterformat'] : '';
-            $this->filter       = (string) $this->element['filter'] ? (string) $this->element['filter'] : 'USER_UTC';
-            $this->todaybutton  = (string) $this->element['todaybutton'] ? (string) $this->element['todaybutton'] : 'true';
-            $this->weeknumbers  = (string) $this->element['weeknumbers'] ? (string) $this->element['weeknumbers'] : 'true';
-            $this->showtime     = (string) $this->element['showtime'] ? (string) $this->element['showtime'] : 'false';
-            $this->filltable    = (string) $this->element['filltable'] ? (string) $this->element['filltable'] : 'true';
-            $this->timeformat   = (int) $this->element['timeformat'] ? (int) $this->element['timeformat'] : 24;
-            $this->singleheader = (string) $this->element['singleheader'] ? (string) $this->element['singleheader'] : 'false';
+            $this->maxlength    = (int) $this->element['maxlength'] ?: 45;
+            $this->format       = (string) $this->element['format'] ?: '%Y-%m-%d';
+            $this->filterFormat = (string) $this->element['filterformat'] ?: '';
+            $this->filter       = (string) $this->element['filter'] ?: 'USER_UTC';
+            $this->todaybutton  = (string) $this->element['todaybutton'] ?: 'true';
+            $this->weeknumbers  = (string) $this->element['weeknumbers'] ?: 'true';
+            $this->showtime     = (string) $this->element['showtime'] ?: 'false';
+            $this->filltable    = (string) $this->element['filltable'] ?: 'true';
+            $this->timeformat   = (int) $this->element['timeformat'] ?: 24;
+            $this->singleheader = (string) $this->element['singleheader'] ?: 'false';
             $this->minyear      = \strlen((string) $this->element['minyear']) ? (int) $this->element['minyear'] : null;
             $this->maxyear      = \strlen((string) $this->element['maxyear']) ? (int) $this->element['maxyear'] : null;
 

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1487,7 +1487,7 @@ class Form implements CurrentUserInterface
          * else the value of the 'default' attribute for the field.
          */
         if ($value === null) {
-            $default = (string) ($element['default'] ? $element['default'] : $element->default);
+            $default = (string) ($element['default'] ?: $element->default);
 
             if (($translate = $element['translate_default']) && ((string) $translate === 'true' || (string) $translate === '1')) {
                 $lang = Factory::getLanguage();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses [TernaryToElvisRector](https://getrector.com/rule-detail/ternary-to-elvis-rector) rector rule to improve libraries code using `?:` operator instead of `?` operator, where useful. This is done automatically by rector, no manual change included.


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner, easier to read code

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed