### PR TITLE
[5.4] Set initial version and code name

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Overview
 ---------------------
 * This is the source of Joomla! 5.x.
 * Joomla's [Official website](https://www.joomla.org).
-* Joomla! 5.3 [version history](https://docs.joomla.org/Special:MyLanguage/Joomla_5.3_version_history).
+* Joomla! 5.4 [version history](https://docs.joomla.org/Special:MyLanguage/Joomla_5.4_version_history).
 * Detailed changes are in the [changelog](https://github.com/joomla/joomla-cms/commits/5.3-dev).
 
 What is Joomla?

--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Build Status
 
 | Drone-CI                                                                                                                                 | AppVeyor                                                                                                                                                           | PHP                                                                           | Node                                                                                 | npm                                                                             |
 |------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
-| [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg?branch=5.3-dev)](https://ci.joomla.org/joomla/joomla-cms) | [![Build status](https://ci.appveyor.com/api/projects/status/ru6sxal8jmfckvjc/branch/5.3-dev?svg=true)](https://ci.appveyor.com/project/release-joomla/joomla-cms) | [![PHP](https://img.shields.io/badge/PHP-V8.1.0-green)](https://www.php.net/) | [![node-lts](https://img.shields.io/badge/Node-V20.0-green)](https://nodejs.org/en/) | [![npm](https://img.shields.io/badge/npm-v10.1.0-green)](https://nodejs.org/en/) |
+| [![Build Status](https://ci.joomla.org/api/badges/joomla/joomla-cms/status.svg?branch=5.4-dev)](https://ci.joomla.org/joomla/joomla-cms) | [![Build status](https://ci.appveyor.com/api/projects/status/ru6sxal8jmfckvjc/branch/5.4-dev?svg=true)](https://ci.appveyor.com/project/release-joomla/joomla-cms) | [![PHP](https://img.shields.io/badge/PHP-V8.1.0-green)](https://www.php.net/) | [![node-lts](https://img.shields.io/badge/Node-V20.0-green)](https://nodejs.org/en/) | [![npm](https://img.shields.io/badge/npm-v10.1.0-green)](https://nodejs.org/en/) |
 
 Overview
 ---------------------
 * This is the source of Joomla! 5.x.
 * Joomla's [Official website](https://www.joomla.org).
 * Joomla! 5.4 [version history](https://docs.joomla.org/Special:MyLanguage/Joomla_5.4_version_history).
-* Detailed changes are in the [changelog](https://github.com/joomla/joomla-cms/commits/5.3-dev).
+* Detailed changes are in the [changelog](https://github.com/joomla/joomla-cms/commits/5.4-dev).
 
 What is Joomla?
 ---------------------
@@ -45,9 +45,9 @@ git clone https://github.com/joomla/joomla-cms.git
 ```bash
 cd joomla-cms
 ```
-- Go to the 5.3-dev branch:
+- Go to the 5.4-dev branch:
 ```bash
-git checkout 5.3-dev
+git checkout 5.4-dev
 ```
 - Install all the needed composer packages:
 ```bash

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Joomla! CMS™
 1- Overview
 	* This is a Joomla! 5.x installation/upgrade package.
 	* Joomla! Official site: https://www.joomla.org
-	* Joomla! 5.3 version history - https://docs.joomla.org/Special:MyLanguage/Joomla_5.3_version_history
+	* Joomla! 5.4 version history - https://docs.joomla.org/Special:MyLanguage/Joomla_5.4_version_history
 	* Detailed changes in the Changelog: https://github.com/joomla/joomla-cms/commits/5.3-dev
 
 2- What is Joomla?

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Joomla! CMS™
 	* This is a Joomla! 5.x installation/upgrade package.
 	* Joomla! Official site: https://www.joomla.org
 	* Joomla! 5.4 version history - https://docs.joomla.org/Special:MyLanguage/Joomla_5.4_version_history
-	* Detailed changes in the Changelog: https://github.com/joomla/joomla-cms/commits/5.3-dev
+	* Detailed changes in the Changelog: https://github.com/joomla/joomla-cms/commits/5.4-dev
 
 2- What is Joomla?
 	* Joomla! is a Content Management System (CMS) which enables you to build websites and powerful online applications.

--- a/administrator/language/en-GB/install.xml
+++ b/administrator/language/en-GB/install.xml
@@ -2,8 +2,8 @@
 <extension client="administrator" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.3.0</version>
-	<creationDate>2025-01</creationDate>
+	<version>5.4.0</version>
+	<creationDate>2025-02</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/administrator/language/en-GB/langmetadata.xml
+++ b/administrator/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="administrator">
 	<name>English (en-GB)</name>
-	<version>5.3.0</version>
-	<creationDate>2025-01</creationDate>
+	<version>5.4.0</version>
+	<creationDate>2025-02</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/administrator/manifests/files/joomla.xml
+++ b/administrator/manifests/files/joomla.xml
@@ -6,8 +6,8 @@
 	<authorUrl>www.joomla.org</authorUrl>
 	<copyright>(C) 2019 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>
-	<version>5.3.0-alpha4-dev</version>
-	<creationDate>2025-01</creationDate>
+	<version>5.4.0-alpha1-dev</version>
+	<creationDate>2025-02</creationDate>
 	<description>FILES_JOOMLA_XML_DESCRIPTION</description>
 
 	<scriptfile>administrator/components/com_admin/script.php</scriptfile>

--- a/administrator/manifests/packages/pkg_en-GB.xml
+++ b/administrator/manifests/packages/pkg_en-GB.xml
@@ -2,8 +2,8 @@
 <extension type="package" method="upgrade">
 	<name>English (en-GB) Language Pack</name>
 	<packagename>en-GB</packagename>
-	<version>5.3.0.1</version>
-	<creationDate>2025-01</creationDate>
+	<version>5.4.0.1</version>
+	<creationDate>2025-02</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/api/language/en-GB/install.xml
+++ b/api/language/en-GB/install.xml
@@ -2,8 +2,8 @@
 <extension client="api" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.3.0</version>
-	<creationDate>2025-01</creationDate>
+	<version>5.4.0</version>
+	<creationDate>2025-02</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/api/language/en-GB/langmetadata.xml
+++ b/api/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="api">
 	<name>English (en-GB)</name>
-	<version>5.3.0</version>
-	<creationDate>2025-01</creationDate>
+	<version>5.4.0</version>
+	<creationDate>2025-02</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/build.xml
+++ b/build.xml
@@ -85,7 +85,7 @@
 			<arg value="--template" />
 			<arg value="joomla" />
 			<arg value="--title" />
-			<arg value="Joomla! CMS 5.3 API" />
+			<arg value="Joomla! CMS 5.4 API" />
 		</exec>
 	</target>
 

--- a/installation/language/en-GB/langmetadata.xml
+++ b/installation/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="installation">
 	<name>English (United Kingdom)</name>
-	<version>5.3.0</version>
-	<creationDate>2025-01</creationDate>
+	<version>5.4.0</version>
+	<creationDate>2025-02</creationDate>
 	<author>Joomla! Project</author>
 	<copyright>(C) 2005 Open Source Matters, Inc.</copyright>
 	<license>GNU General Public License version 2 or later; see LICENSE.txt</license>

--- a/language/en-GB/install.xml
+++ b/language/en-GB/install.xml
@@ -2,8 +2,8 @@
 <extension client="site" type="language" method="upgrade">
 	<name>English (en-GB)</name>
 	<tag>en-GB</tag>
-	<version>5.3.0</version>
-	<creationDate>2025-01</creationDate>
+	<version>5.4.0</version>
+	<creationDate>2025-02</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/language/en-GB/langmetadata.xml
+++ b/language/en-GB/langmetadata.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metafile client="site">
 	<name>English (en-GB)</name>
-	<version>5.3.0</version>
-	<creationDate>2025-01</creationDate>
+	<version>5.4.0</version>
+	<creationDate>2025-02</creationDate>
 	<author>Joomla! Project</author>
 	<authorEmail>admin@joomla.org</authorEmail>
 	<authorUrl>www.joomla.org</authorUrl>

--- a/libraries/src/Version.php
+++ b/libraries/src/Version.php
@@ -47,7 +47,7 @@ final class Version
      * @var    integer
      * @since  3.8.0
      */
-    public const MINOR_VERSION = 3;
+    public const MINOR_VERSION = 4;
 
     /**
      * Patch release version.
@@ -66,7 +66,7 @@ final class Version
      * @var    string
      * @since  3.8.0
      */
-    public const EXTRA_VERSION = 'alpha4-dev';
+    public const EXTRA_VERSION = 'alpha1-dev';
 
     /**
      * Development status.
@@ -82,7 +82,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const CODENAME = 'Timu';
+    public const CODENAME = 'Kutegemea';
 
     /**
      * Release date.
@@ -90,7 +90,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const RELDATE = '21-January-2025';
+    public const RELDATE = '18-February-2025';
 
     /**
      * Release time.
@@ -98,7 +98,7 @@ final class Version
      * @var    string
      * @since  3.5
      */
-    public const RELTIME = '16:01';
+    public const RELTIME = '16:00';
 
     /**
      * Release timezone.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joomla",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joomla",
-  "version": "5.3.0",
+  "version": "5.4.0",
   "description": "Joomla CMS",
   "license": "GPL-2.0-or-later",
   "repository": {


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) initializes Joomla version and code name on the 5.4-dev branch.

### Testing Instructions

Code review.

Or run the following command on a git clone of this repository on a clean, current 5.4-dev branch on Linux or Windows with WSL and PHP CLI available:
```
php ./build/bump.php -v 5.4.0-alpha1-dev -c "Kutegemea" -d "2025-02-18 16:00"
```

Then check for changes e.g. with `git status` and sort out all replacements of `__DEPLOY_VERSION__` in PHP files as these replacements should be done with the next version bump on the 5.3-dev branch.

Finally replace the remaining occurrences of "5.3" in files `README.md` and `README.txt` which were not caught by the `bump.php` script, which are
- query parameters with branch name in the URls for the Drone and Appveyor badges in the `README.md` file
- instructions in the `README.md` file to check out the 5.4-dev branch
- link to commit history of the branch on GitHub in both files

### Actual result BEFORE applying this Pull Request

Joomla version and code name on the 5.4-dev branch are the same as on the 5.3-dev branch.

### Expected result AFTER applying this Pull Request

The 5.4-dev branch has the right version and a new code name.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
