### PR TITLE
[5.3] Use str_starts_with function for modules and plugins

### DIFF
--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -293,7 +293,7 @@ class CssMenu
                 continue;
             }
 
-            if (!empty($item->link) && substr($item->link, 0, 8) === 'special:') {
+            if (!empty($item->link) && str_starts_with($item->link, 'special:')) {
                 $special = substr($item->link, 8);
 
                 if ($special === 'language-forum') {
@@ -498,7 +498,7 @@ class CssMenu
         }
 
         // We were passed a class name
-        if (substr($identifier, 0, 6) == 'class:') {
+        if (str_starts_with($identifier, 'class:')) {
             $class = substr($identifier, 6);
         } else {
             // We were passed background icon url. Build the CSS class for the icon

--- a/administrator/modules/mod_submenu/src/Menu/Menu.php
+++ b/administrator/modules/mod_submenu/src/Menu/Menu.php
@@ -61,7 +61,7 @@ abstract class Menu
         ]))->getArgument('subject', $children);
 
         foreach ($children as $item) {
-            if (substr($item->link, 0, 8) === 'special:') {
+            if (str_starts_with($item->link, 'special:')) {
                 $special = substr($item->link, 8);
 
                 if ($special === 'language-forum') {
@@ -203,10 +203,10 @@ abstract class Menu
                 $iconImage = $item->icon;
 
                 if ($iconImage) {
-                    if (substr($iconImage, 0, 6) === 'class:' && substr($iconImage, 6) === 'icon-home') {
+                    if (str_starts_with($iconImage, 'class:') && substr($iconImage, 6) === 'icon-home') {
                         $iconImage = '<span class="home-image icon-home" aria-hidden="true"></span>';
                         $iconImage .= '<span class="visually-hidden">' . Text::_('JDEFAULT') . '</span>';
-                    } elseif (substr($iconImage, 0, 6) === 'image:') {
+                    } elseif (str_starts_with($iconImage, 'image:')) {
                         $iconImage = '&nbsp;<span class="badge bg-secondary">' . substr($iconImage, 6) . '</span>';
                     }
 

--- a/modules/mod_menu/src/Helper/MenuHelper.php
+++ b/modules/mod_menu/src/Helper/MenuHelper.php
@@ -125,7 +125,7 @@ class MenuHelper
                             break;
 
                         case 'url':
-                            if ((strpos($item->link, 'index.php?') === 0) && (strpos($item->link, 'Itemid=') === false)) {
+                            if ((str_starts_with($item->link, 'index.php?')) && (strpos($item->link, 'Itemid=') === false)) {
                                 // If this is an internal Joomla link, ensure the Itemid is set.
                                 $item->flink = $item->link . '&Itemid=' . $item->id;
                             }

--- a/modules/mod_wrapper/src/Helper/WrapperHelper.php
+++ b/modules/mod_wrapper/src/Helper/WrapperHelper.php
@@ -49,7 +49,7 @@ class WrapperHelper
 
         if ($params->get('add')) {
             // Adds 'http://' if none is set
-            if (strpos($url, '/') === 0) {
+            if (str_starts_with($url, '/')) {
                 // Relative URL in component. use server http_host.
                 $url = 'http://' . $app->getInput()->server->get('HTTP_HOST') . $url;
             } elseif (strpos($url, 'http') === false && strpos($url, 'https') === false) {

--- a/plugins/api-authentication/token/src/Extension/Token.php
+++ b/plugins/api-authentication/token/src/Extension/Token.php
@@ -131,7 +131,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
             $authHeader  = $this->getApplication()->getInput()->server->get('REDIRECT_HTTP_AUTHORIZATION', '', 'string');
         }
 
-        if (substr($authHeader, 0, 7) == 'Bearer ') {
+        if (str_starts_with($authHeader, 'Bearer ')) {
             $parts       = explode(' ', $authHeader, 2);
             $tokenString = trim($parts[1]);
             $tokenString = $this->filter->clean($tokenString, 'BASE64');

--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -164,7 +164,7 @@ trait DisplayTrait
 
                 // if we have a name and path, add it to the list
                 if ($external['name'] != '' && $path != '') {
-                    $externalPlugins[$external['name']] = substr($path, 0, 1) == '/' ? Uri::root() . substr($path, 1) : $path;
+                    $externalPlugins[$external['name']] = str_starts_with($path, '/') ? Uri::root() . substr($path, 1) : $path;
                 }
             }
         }

--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -365,7 +365,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
 
         // No debug for Safari and Chrome redirection.
         if (
-            strpos($contents, '<html><head><meta http-equiv="refresh" content="0;') === 0
+            str_starts_with($contents, '<html><head><meta http-equiv="refresh" content="0;')
             && strpos(strtolower($_SERVER['HTTP_USER_AGENT'] ?? ''), 'webkit') !== false
         ) {
             $this->debugBar->stackData();
@@ -619,7 +619,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
                     $category = $entry->category;
                     $relative = $file ? str_replace(JPATH_ROOT, '', $file) : '';
 
-                    if ($relative && 0 === strpos($relative, '/libraries/src')) {
+                    if ($relative && str_starts_with($relative, '/libraries/src')) {
                         if (!$logDeprecatedCore) {
                             break;
                         }

--- a/plugins/system/fields/src/Extension/Fields.php
+++ b/plugins/system/fields/src/Extension/Fields.php
@@ -288,7 +288,7 @@ final class Fields extends CMSPlugin implements SubscriberInterface
         $context = $form->getName();
 
         // When a category is edited, the context is com_categories.categorycom_content
-        if (strpos($context, 'com_categories.category') === 0) {
+        if (str_starts_with($context, 'com_categories.category')) {
             $context = str_replace('com_categories.category', '', $context) . '.categories';
             $data    = $data ?: $this->getApplication()->getInput()->get('jform', [], 'array');
 

--- a/plugins/system/httpheaders/src/Extension/Httpheaders.php
+++ b/plugins/system/httpheaders/src/Extension/Httpheaders.php
@@ -310,12 +310,12 @@ final class Httpheaders extends CMSPlugin implements SubscriberInterface
                 }
 
                 // Append the script hashes placeholder
-                if ($scriptHashesEnabled && strpos($cspValue->directive, 'script-src') === 0) {
+                if ($scriptHashesEnabled && str_starts_with($cspValue->directive, 'script-src')) {
                     $cspValue->value = '{script-hashes} ' . $cspValue->value;
                 }
 
                 // Append the style hashes placeholder
-                if ($styleHashesEnabled && strpos($cspValue->directive, 'style-src') === 0) {
+                if ($styleHashesEnabled && str_starts_with($cspValue->directive, 'style-src')) {
                     $cspValue->value = '{style-hashes} ' . $cspValue->value;
                 }
 

--- a/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
+++ b/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
@@ -301,10 +301,10 @@ final class PrivacyConsent extends CMSPlugin implements SubscriberInterface
                 'method', 'methods', 'captive', 'callback',
             ];
             $isAllowedUserTask = \in_array($task, $allowedUserTasks)
-                || substr($task, 0, 8) === 'captive.'
-                || substr($task, 0, 8) === 'methods.'
-                || substr($task, 0, 7) === 'method.'
-                || substr($task, 0, 9) === 'callback.';
+                || str_starts_with($task, 'captive.')
+                || str_starts_with($task, 'methods.')
+                || str_starts_with($task, 'method.')
+                || str_starts_with($task, 'callback.');
 
             if (
                 ($option == 'com_users' && $isAllowedUserTask)

--- a/plugins/user/profile/src/Extension/Profile.php
+++ b/plugins/user/profile/src/Extension/Profile.php
@@ -157,7 +157,7 @@ final class Profile extends CMSPlugin implements SubscriberInterface
         // Convert website URL to utf8 for display
         $value = htmlspecialchars(PunycodeHelper::urlToUTF8($value), ENT_QUOTES, 'UTF-8');
 
-        if (strpos($value, 'http') === 0) {
+        if (str_starts_with($value, 'http')) {
             return '<a href="' . $value . '">' . $value . '</a>';
         }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses **[StrStartsWithRector](https://getrector.com/rule-detail/str-starts-with-rector)** rule to convert our modules and plugins code to use [str_starts_with](https://www.php.net/manual/en/function.str-starts-with.php) function. It does not change any existing behavior, just make the code cleaner and easier to read.

### Testing Instructions
Need to have code review for every single change here.

### Actual result BEFORE applying this Pull Request
Works

### Expected result AFTER applying this Pull Request
Works, with cleaner, easier to read code.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed