### PR TITLE
[5.3] Use str_ends_with function for modules plugins

### DIFF
--- a/plugins/system/sef/src/Extension/Sef.php
+++ b/plugins/system/sef/src/Extension/Sef.php
@@ -334,7 +334,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         $origUri = Uri::getInstance();
         $route   = $origUri->getPath();
 
-        if (substr($route, -9) === 'index.php' || substr($route, -1) === '/') {
+        if (str_ends_with($route, 'index.php') || str_ends_with($route, '/')) {
             // We don't want suffixes when the URL ends in index.php or with a /
             return;
         }
@@ -375,7 +375,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
     {
         $origUri = Uri::getInstance();
 
-        if (substr($origUri->getPath(), -9) === 'index.php') {
+        if (str_ends_with($origUri->getPath(), 'index.php')) {
             // Remove trailing index.php
             $origUri->setPath(substr($origUri->getPath(), 0, -9));
             $this->getApplication()->redirect($origUri->toString(), 301);

--- a/plugins/task/updatenotification/src/Extension/UpdateNotification.php
+++ b/plugins/task/updatenotification/src/Extension/UpdateNotification.php
@@ -127,7 +127,7 @@ final class UpdateNotification extends CMSPlugin implements SubscriberInterface
         // If we're here, we have updates. First, get a link to the Joomla! Update component.
         $baseURL  = Uri::base();
         $baseURL  = rtrim($baseURL, '/');
-        $baseURL .= (substr($baseURL, -13) !== 'administrator') ? '/administrator/' : '/';
+        $baseURL .= (!str_ends_with($baseURL, 'administrator')) ? '/administrator/' : '/';
         $baseURL .= 'index.php?option=com_joomlaupdate';
         $uri      = new Uri($baseURL);
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses **[StrEndsWithRector](https://getrector.com/rule-detail/str-ends-with-rector)** rule to convert our modules and plugins code to use [str_ends_with](https://www.php.net/manual/en/function.str-ends-with.php) function. It does not change any existing behavior, just make the code cleaner and easier to read. The change is done automatically by rector, no manual change included here.

### Testing Instructions
Need to have code review for every single change here.

### Actual result BEFORE applying this Pull Request
Works

### Expected result AFTER applying this Pull Request
Works, with cleaner, easier to read code.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed