### PR TITLE
[5.3] Use str_contains function for modules plugins

### DIFF
--- a/modules/mod_menu/src/Helper/MenuHelper.php
+++ b/modules/mod_menu/src/Helper/MenuHelper.php
@@ -125,7 +125,7 @@ class MenuHelper
                             break;
 
                         case 'url':
-                            if ((strpos($item->link, 'index.php?') === 0) && (strpos($item->link, 'Itemid=') === false)) {
+                            if ((strpos($item->link, 'index.php?') === 0) && (!str_contains($item->link, 'Itemid='))) {
                                 // If this is an internal Joomla link, ensure the Itemid is set.
                                 $item->flink = $item->link . '&Itemid=' . $item->id;
                             }
@@ -150,7 +150,7 @@ class MenuHelper
                             break;
                     }
 
-                    if ((strpos($item->flink, 'index.php?') !== false) && strcasecmp(substr($item->flink, 0, 4), 'http')) {
+                    if ((str_contains($item->flink, 'index.php?')) && strcasecmp(substr($item->flink, 0, 4), 'http')) {
                         $item->flink = Route::_($item->flink, true, $itemParams->get('secure'));
                     } else {
                         $item->flink = Route::_($item->flink);

--- a/modules/mod_wrapper/src/Helper/WrapperHelper.php
+++ b/modules/mod_wrapper/src/Helper/WrapperHelper.php
@@ -52,7 +52,7 @@ class WrapperHelper
             if (strpos($url, '/') === 0) {
                 // Relative URL in component. use server http_host.
                 $url = 'http://' . $app->getInput()->server->get('HTTP_HOST') . $url;
-            } elseif (strpos($url, 'http') === false && strpos($url, 'https') === false) {
+            } elseif (!str_contains($url, 'http') && !str_contains($url, 'https')) {
                 $url = 'http://' . $url;
             }
         }

--- a/plugins/api-authentication/token/src/Extension/Token.php
+++ b/plugins/api-authentication/token/src/Extension/Token.php
@@ -149,7 +149,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
         // The token is a base64 encoded string. Make sure we can decode it.
         $authString = @base64_decode($tokenString);
 
-        if (empty($authString) || (strpos($authString, ':') === false)) {
+        if (empty($authString) || (!str_contains($authString, ':'))) {
             return;
         }
 

--- a/plugins/behaviour/taggable/src/Extension/Taggable.php
+++ b/plugins/behaviour/taggable/src/Extension/Taggable.php
@@ -173,7 +173,7 @@ final class Taggable extends CMSPlugin implements SubscriberInterface
         if (empty($newTags)) {
             $result = $tagsHelper->postStoreProcess($table);
         } else {
-            if (\is_string($newTags) && (strpos($newTags, ',') !== false)) {
+            if (\is_string($newTags) && (str_contains($newTags, ','))) {
                 $newTags = explode(',', $newTags);
             } elseif (!\is_array($newTags)) {
                 $newTags = (array) $newTags;

--- a/plugins/content/fields/src/Extension/Fields.php
+++ b/plugins/content/fields/src/Extension/Fields.php
@@ -74,17 +74,17 @@ final class Fields extends CMSPlugin implements SubscriberInterface
         }
 
         // Prepare the text
-        if (property_exists($item, 'text') && strpos($item->text, 'field') !== false) {
+        if (property_exists($item, 'text') && str_contains($item->text, 'field')) {
             $item->text = $this->prepare($item->text, $context, $item);
         }
 
         // Prepare the intro text
-        if (property_exists($item, 'introtext') && \is_string($item->introtext) && strpos($item->introtext, 'field') !== false) {
+        if (property_exists($item, 'introtext') && \is_string($item->introtext) && str_contains($item->introtext, 'field')) {
             $item->introtext = $this->prepare($item->introtext, $context, $item);
         }
 
         // Prepare the full text
-        if (!empty($item->fulltext) && strpos($item->fulltext, 'field') !== false) {
+        if (!empty($item->fulltext) && str_contains($item->fulltext, 'field')) {
             $item->fulltext = $this->prepare($item->fulltext, $context, $item);
         }
     }

--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -205,7 +205,7 @@ trait DisplayTrait
              * If URL, just pass it to $content_css
              * else, assume it is a file name in the current template folder
              */
-            $content_css = strpos($content_css_custom, 'http') !== false
+            $content_css = str_contains($content_css_custom, 'http')
                 ? $content_css_custom
                 : $this->includeRelativeFiles('css', $content_css_custom);
         } else {
@@ -383,11 +383,11 @@ trait DisplayTrait
         $custom_button = trim($levelParams->get('custom_button', ''));
 
         if ($custom_plugin) {
-            $plugins   = array_merge($plugins, explode(strpos($custom_plugin, ',') !== false ? ',' : ' ', $custom_plugin));
+            $plugins   = array_merge($plugins, explode(str_contains($custom_plugin, ',') ? ',' : ' ', $custom_plugin));
         }
 
         if ($custom_button) {
-            $toolbar1  = array_merge($toolbar1, explode(strpos($custom_button, ',') !== false ? ',' : ' ', $custom_button));
+            $toolbar1  = array_merge($toolbar1, explode(str_contains($custom_button, ',') ? ',' : ' ', $custom_button));
         }
 
         // Merge the two toolbars for backwards compatibility

--- a/plugins/system/debug/src/DataCollector/QueryCollector.php
+++ b/plugins/system/debug/src/DataCollector/QueryCollector.php
@@ -219,7 +219,7 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
 
                     $isCaller = 0;
 
-                    if (\Joomla\Database\DatabaseDriver::class === $class && false === strpos($file, 'DatabaseDriver.php')) {
+                    if (\Joomla\Database\DatabaseDriver::class === $class && !str_contains($file, 'DatabaseDriver.php')) {
                         $callerLocation = $location;
                         $isCaller       = 1;
                     }

--- a/plugins/system/debug/src/Extension/Debug.php
+++ b/plugins/system/debug/src/Extension/Debug.php
@@ -366,7 +366,7 @@ final class Debug extends CMSPlugin implements SubscriberInterface
         // No debug for Safari and Chrome redirection.
         if (
             strpos($contents, '<html><head><meta http-equiv="refresh" content="0;') === 0
-            && strpos(strtolower($_SERVER['HTTP_USER_AGENT'] ?? ''), 'webkit') !== false
+            && str_contains(strtolower($_SERVER['HTTP_USER_AGENT'] ?? ''), 'webkit')
         ) {
             $this->debugBar->stackData();
 
@@ -688,13 +688,13 @@ final class Debug extends CMSPlugin implements SubscriberInterface
             }
 
             // Collect the module render time
-            if (strpos($mark->label, 'mod_') !== false) {
+            if (str_contains($mark->label, 'mod_')) {
                 $moduleTime += $mark->time;
                 continue;
             }
 
             // Collect the access render time
-            if (strpos($mark->label, 'Access:') !== false) {
+            if (str_contains($mark->label, 'Access:')) {
                 $accessTime += $mark->time;
                 continue;
             }

--- a/plugins/system/httpheaders/src/Extension/Httpheaders.php
+++ b/plugins/system/httpheaders/src/Extension/Httpheaders.php
@@ -327,7 +327,7 @@ final class Httpheaders extends CMSPlugin implements SubscriberInterface
                 if (
                     $strictDynamicEnabled
                     && $cspValue->directive === 'script-src'
-                    && strpos($cspValue->value, 'strict-dynamic') === false
+                    && !str_contains($cspValue->value, 'strict-dynamic')
                 ) {
                     $cspValue->value = "'strict-dynamic' " . $cspValue->value;
                 }

--- a/plugins/system/languagefilter/src/Extension/LanguageFilter.php
+++ b/plugins/system/languagefilter/src/Extension/LanguageFilter.php
@@ -514,7 +514,7 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
             $language_new = $this->languageFactory->createLanguage($lang_code, (bool) $app->get('debug_lang'));
 
             foreach ($language->getPaths() as $extension => $files) {
-                if (strpos($extension, 'plg_system') !== false) {
+                if (str_contains($extension, 'plg_system')) {
                     $extension_name = substr($extension, 11);
 
                     $language_new->load($extension, JPATH_ADMINISTRATOR)

--- a/plugins/system/redirect/src/Extension/Redirect.php
+++ b/plugins/system/redirect/src/Extension/Redirect.php
@@ -120,7 +120,7 @@ final class Redirect extends CMSPlugin implements SubscriberInterface
          * Why is this (still) here?
          * Because hackers still try urls with mosConfig_* and Url Injection with =http[s]:// and we dont want to log/redirect these requests
          */
-        if ($skipUrl || (strpos($url, 'mosConfig_') !== false) || (strpos($url, '=http') !== false)) {
+        if ($skipUrl || (str_contains($url, 'mosConfig_')) || (str_contains($url, '=http'))) {
             return;
         }
 
@@ -203,7 +203,7 @@ final class Redirect extends CMSPlugin implements SubscriberInterface
                     $newUrl .= '?' . $urlQuery;
                 }
 
-                $dest = Uri::isInternal($newUrl) || strpos($newUrl, 'http') === false ?
+                $dest = Uri::isInternal($newUrl) || !str_contains($newUrl, 'http') ?
                     Route::_($newUrl) : $newUrl;
 
                 // In case the url contains double // lets remove it

--- a/plugins/system/sef/src/Extension/Sef.php
+++ b/plugins/system/sef/src/Extension/Sef.php
@@ -226,7 +226,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         $prefix = $app->getDocument()->getType() === 'feed' ? Uri::root() : '';
 
         // Replace index.php URI by SEF URI.
-        if (strpos($buffer, 'href="' . $prefix . 'index.php?') !== false) {
+        if (str_contains($buffer, 'href="' . $prefix . 'index.php?')) {
             preg_match_all('#href="' . $prefix . 'index.php\?([^"]+)"#m', $buffer, $matches);
 
             foreach ($matches[1] as $urlQueryString) {
@@ -245,14 +245,14 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         $attributes = ['href=', 'src=', 'poster='];
 
         foreach ($attributes as $attribute) {
-            if (strpos($buffer, $attribute) !== false) {
+            if (str_contains($buffer, $attribute)) {
                 $regex  = '#\s' . $attribute . '"(?!/|' . $protocols . '|\#|\')([^"]*)"#m';
                 $buffer = preg_replace($regex, ' ' . $attribute . '"' . $base . '$1"', $buffer);
                 $this->checkBuffer($buffer);
             }
         }
 
-        if (strpos($buffer, 'srcset=') !== false) {
+        if (str_contains($buffer, 'srcset=')) {
             $regex = '#\s+srcset="([^"]+)"#m';
 
             $buffer = preg_replace_callback(
@@ -273,7 +273,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         }
 
         // Replace all unknown protocols in javascript window open events.
-        if (strpos($buffer, 'window.open(') !== false) {
+        if (str_contains($buffer, 'window.open(')) {
             $regex  = '#onclick="window.open\(\'(?!/|' . $protocols . '|\#)([^/]+[^\']*?\')#m';
             $buffer = preg_replace($regex, 'onclick="window.open(\'' . $base . '$1', $buffer);
             $this->checkBuffer($buffer);
@@ -283,7 +283,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         $attributes = ['onmouseover=', 'onmouseout='];
 
         foreach ($attributes as $attribute) {
-            if (strpos($buffer, $attribute) !== false) {
+            if (str_contains($buffer, $attribute)) {
                 $regex  = '#' . $attribute . '"this.src=([\']+)(?!/|' . $protocols . '|\#|\')([^"]+)"#m';
                 $buffer = preg_replace($regex, $attribute . '"this.src=$1' . $base . '$2"', $buffer);
                 $this->checkBuffer($buffer);
@@ -291,7 +291,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         }
 
         // Replace all unknown protocols in CSS background image.
-        if (strpos($buffer, 'style=') !== false) {
+        if (str_contains($buffer, 'style=')) {
             $regex_url  = '\s*url\s*\(([\'\"]|\&\#0?3[49];)?(?!/|\&\#0?3[49];|' . $protocols . '|\#)([^\)\'\"]+)([\'\"]|\&\#0?3[49];)?\)';
             $regex      = '#style=\s*([\'\"])(.*):' . $regex_url . '#m';
             $buffer     = preg_replace($regex, 'style=$1$2: url($3' . $base . '$4$5)', $buffer);
@@ -299,7 +299,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         }
 
         // Replace all unknown protocols in OBJECT param tag.
-        if (strpos($buffer, '<param') !== false) {
+        if (str_contains($buffer, '<param')) {
             // OBJECT <param name="xx", value="yy"> -- fix it only inside the <param> tag.
             $regex  = '#(<param\s+)name\s*=\s*"(movie|src|url)"[^>]\s*value\s*=\s*"(?!/|' . $protocols . '|\#|\')([^"]*)"#m';
             $buffer = preg_replace($regex, '$1name="$2" value="' . $base . '$3"', $buffer);
@@ -312,7 +312,7 @@ final class Sef extends CMSPlugin implements SubscriberInterface
         }
 
         // Replace all unknown protocols in OBJECT tag.
-        if (strpos($buffer, '<object') !== false) {
+        if (str_contains($buffer, '<object')) {
             $regex  = '#(<object\s+[^>]*)data\s*=\s*"(?!/|' . $protocols . '|\#|\')([^"]*)"#m';
             $buffer = preg_replace($regex, '$1data="' . $base . '$2"', $buffer);
             $this->checkBuffer($buffer);

--- a/plugins/system/webauthn/src/CredentialRepository.php
+++ b/plugins/system/webauthn/src/CredentialRepository.php
@@ -562,7 +562,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
         }
 
         // Was the credential stored unencrypted (e.g. the site's secret was empty)?
-        if ((strpos($credential, '{') !== false) && (strpos($credential, '"publicKeyCredentialId"') !== false)) {
+        if ((str_contains($credential, '{')) && (str_contains($credential, '"publicKeyCredentialId"'))) {
             return $credential;
         }
 

--- a/plugins/user/joomla/src/Extension/Joomla.php
+++ b/plugins/user/joomla/src/Extension/Joomla.php
@@ -202,7 +202,7 @@ final class Joomla extends CMSPlugin implements SubscriberInterface
         }
 
         // Check if we have a sensible from email address, if not bail out as mail would not be sent anyway
-        if (strpos($app->get('mailfrom'), '@') === false) {
+        if (!str_contains($app->get('mailfrom'), '@')) {
             $app->enqueueMessage($language->_('JERROR_SENDING_EMAIL'), 'warning');
 
             return;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses **[StrContainsRector](https://getrector.com/rule-detail/str-contains-rector)** rule to convert our modules and plugins code to use [str_contains](https://www.php.net/manual/en/function.str-contains.php) function. It does not change any existing behavior, just make the code cleaner and easier to read. The change is done automatically by rector, no manual change included here.

### Testing Instructions
Need to have code review for every single change here.

### Actual result BEFORE applying this Pull Request
Works

### Expected result AFTER applying this Pull Request
Works, with cleaner, easier to read code.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed