### PR TITLE
[5.3] Fields batch copy category

### DIFF
--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -1168,7 +1168,6 @@ class FieldModel extends AdminModel
 
         foreach ($pks as $pk) {
             if ($user->authorise('core.create', $component . '.fieldgroup.' . $value)) {
-
                 // Find all assigned categories to this field
                 $db    = $this->getDatabase();
                 $query = $db->getQuery(true);

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -1168,6 +1168,17 @@ class FieldModel extends AdminModel
 
         foreach ($pks as $pk) {
             if ($user->authorise('core.create', $component . '.fieldgroup.' . $value)) {
+
+                // Find all assigned categories to this field
+                $db = $this->getDatabase();
+                $query = $db->getQuery(true);
+
+                $query->select($db->quoteName('category_id'))
+                    ->from($db->quoteName('#__fields_categories'))
+                    ->where($db->quoteName('field_id') . ' = ' . (int) $pk);
+
+                $assignedCatIds = $db->setQuery($query)->loadColumn();
+
                 $table->reset();
                 $table->load($pk);
 
@@ -1193,6 +1204,17 @@ class FieldModel extends AdminModel
 
                 // Get the new item ID
                 $newId = $table->id;
+
+                // Inset the assigned categories
+                if (!empty($assignedCatIds)) {
+                    $tuple           = new \stdClass();
+                    $tuple->field_id = $newId;
+
+                    foreach ($assignedCatIds as $catId) {
+                        $tuple->category_id = $catId;
+                        $db->insertObject('#__fields_categories', $tuple);
+                    }
+                }
 
                 // Add the new ID to the array
                 $newIds[$pk] = $newId;

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -1170,7 +1170,7 @@ class FieldModel extends AdminModel
             if ($user->authorise('core.create', $component . '.fieldgroup.' . $value)) {
 
                 // Find all assigned categories to this field
-                $db = $this->getDatabase();
+                $db    = $this->getDatabase();
                 $query = $db->getQuery(true);
 
                 $query->select($db->quoteName('category_id'))


### PR DESCRIPTION
Pull Request for Issue #38382, #43438 .

### Summary of Changes
Batch copy of fields now copies also categories


### Testing Instructions
You need a few fields and different situations. 
Some should be assigned to categories, other should be assigned to all, they schoud be in differnt groups.
You can also check the table #_fiels_categories.


### Actual result BEFORE applying this Pull Request
When fields are copied with batch copy, the assigned categories are lost


### Expected result AFTER applying this Pull Request
Copied fields have the same assigned categories as the original fields


### Link to documentations
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
