### PR TITLE
[5.3] Update sa11y

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9453,9 +9453,9 @@
       }
     },
     "node_modules/sa11y": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/sa11y/-/sa11y-4.1.0.tgz",
-      "integrity": "sha512-Og7LtlOQn88wAgEFNsRvUH1wv5LYUUt7GWA6Nk/Opm1buv/pP0HoLEftPt+AJI68argoWqSz4ZEmkULa8kZgvA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/sa11y/-/sa11y-4.1.1.tgz",
+      "integrity": "sha512-mATbmsSVZky5RtyJbm39XjwntSxb3YADvgk5cdyP/8Em8G8O0mwHoKqyUx7A10QJNJmwfnUDOYuqv83Y14ZcBA==",
       "dependencies": {
         "apca-w3": "^0.1.9",
         "tippy.js": "^6.3.7"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9453,10 +9453,9 @@
       }
     },
     "node_modules/sa11y": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/sa11y/-/sa11y-4.0.4.tgz",
-      "integrity": "sha512-6uTJWz4hkIE2nv3CItOGBG1x21Xck6dq57H9G6oET8k2eldR0PhrgjuuO4NPNRYfnbCKUAEB/LDxueRH26qLzg==",
-      "license": "GPL-2.0-or-later",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/sa11y/-/sa11y-4.1.0.tgz",
+      "integrity": "sha512-Og7LtlOQn88wAgEFNsRvUH1wv5LYUUt7GWA6Nk/Opm1buv/pP0HoLEftPt+AJI68argoWqSz4ZEmkULa8kZgvA==",
       "dependencies": {
         "apca-w3": "^0.1.9",
         "tippy.js": "^6.3.7"


### PR DESCRIPTION
Updates sa11y used in the jooa11y plugin to 4.1.0

This fixes some minor bugs with the current version used in 5.3 (sa11y 4.0.3)

https://github.com/ryersondmp/sa11y/releases

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
