### PR TITLE
[5.3] Fix dispatcher ACl checks: ignore any non-display tasks

### DIFF
--- a/components/com_privacy/src/Dispatcher/Dispatcher.php
+++ b/components/com_privacy/src/Dispatcher/Dispatcher.php
@@ -36,6 +36,16 @@ class Dispatcher extends ComponentDispatcher
         parent::checkAccess();
 
         $view = $this->input->get('view');
+        $task = $this->input->get('task', 'display');
+
+        // Ignore any-non-"display" tasks
+        if (str_contains($task, '.')) {
+            $task = explode('.', $task)[1];
+        }
+
+        if ($task !== 'display') {
+            return;
+        }
 
         // Submitting information requests and confirmation through the frontend is restricted to authenticated users at this time
         if (\in_array($view, ['confirm', 'request']) && $this->app->getIdentity()->guest) {

--- a/components/com_users/src/Dispatcher/Dispatcher.php
+++ b/components/com_users/src/Dispatcher/Dispatcher.php
@@ -38,6 +38,16 @@ class Dispatcher extends ComponentDispatcher
 
         $view = $this->input->get('view');
         $user = $this->app->getIdentity();
+        $task = $this->input->get('task', 'display');
+
+        // Ignore any-non-"display" tasks
+        if (str_contains($task, '.')) {
+            $task = explode('.', $task)[1];
+        }
+
+        if ($task !== 'display') {
+            return;
+        }
 
         // Do any specific processing by view.
         switch ($view) {


### PR DESCRIPTION
Pull Request for Issue #44732

### Summary of Changes
The security fix introduced in Joomla 5.2.3 causes issues in the "admin needs to approve new user registration" feature, if specific conditions are met. 

That's because the ACL check, if access to a specific view (in this case the registration view) can be granted now happens before the actual task is performed, redirecting the admin user to the profile page. This PR now prevents the execution of the checks for non-display tasks.

### Testing Instructions
* Create a 5.x site, create a menu item for the user registration with access level set to "public"
* Configure the site to require user approval by admins
* Register a new user in the frontend
* Confirm the registration using the link in the email
* Click on the confirmation link that the admin receives. It will point to the registration menu item and the task ("registration.activate") and the token will be appended
* You'll be asked to login using your admin account

### Actual result BEFORE applying this Pull Request
You are redirected to the profile page, user is not approved


### Expected result AFTER applying this Pull Request
User is approved


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
