### PR TITLE
[5.3] Fix MailsHelper::loadTranslationFiles bug

### DIFF
--- a/administrator/components/com_mails/src/Helper/MailsHelper.php
+++ b/administrator/components/com_mails/src/Helper/MailsHelper.php
@@ -75,7 +75,7 @@ abstract class MailsHelper
             return;
         }
 
-        $lang   = Factory::getLanguage();
+        $lang   = Factory::getApplication()->getLanguage();
         $source = '';
 
         switch (substr($extension, 0, 3)) {
@@ -83,8 +83,8 @@ abstract class MailsHelper
             default:
                 $source = JPATH_ADMINISTRATOR . '/components/' . $extension;
 
-                $lang->load($extension, JPATH_BASE, $language, true)
-                || $lang->load($extension, JPATH_BASE . '/components/' . $extension, $language, true);
+                $lang->load($extension, JPATH_SITE, $language, true)
+                || $lang->load($extension, JPATH_SITE . '/components/' . $extension, $language, true);
 
                 break;
 


### PR DESCRIPTION
Pull Request for Issue #44686.

### Summary of Changes
This PR fixes wrong code implemented in PR https://github.com/joomla/joomla-cms/pull/44730. We need to load frontend language files, so the code should  use JPATH_SITE instead of JPATH_BASE as implemented in the PR.

I also replace the deprecated `Factory::getLanguage()` method by `Factory::getApplication()->getLanguage()`

### Testing Instructions
- Use Joomla 5.3 nightly build
- Go to mailtemplates and open Contacts: Contact Form Mail
- See that the language strings are not translated
- Do not save but cancel (!)
- Apply the patch
- Notice that the string is now translated


### Actual result BEFORE applying this Pull Request
Strings are not translated


### Expected result AFTER applying this Pull Request

Strings are  translated



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed