### PR TITLE
[5.3] Display Mail Templates data use current language

### DIFF
--- a/administrator/components/com_mails/src/View/Templates/HtmlView.php
+++ b/administrator/components/com_mails/src/View/Templates/HtmlView.php
@@ -11,6 +11,7 @@
 namespace Joomla\Component\Mails\Administrator\View\Templates;
 
 use Joomla\CMS\Component\ComponentHelper;
+use Joomla\CMS\Factory;
 use Joomla\CMS\Form\Form;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\GenericDataException;
@@ -117,8 +118,10 @@ class HtmlView extends BaseHtmlView
             }
         }
 
+        $currentLanguageTag = Factory::getApplication()->getLanguage()->getTag();
+
         foreach ($extensions as $extension) {
-            MailsHelper::loadTranslationFiles($extension, $defaultLanguageTag);
+            MailsHelper::loadTranslationFiles($extension, $currentLanguageTag);
         }
 
         $this->addToolbar();


### PR DESCRIPTION
Pull Request for Issue #44879.

### Summary of Changes
Currently, the Mail Templates management screen always use site default language to display mail template data (Title, Description...). This PR modifies code to display data using the current language instead, fix the issue https://github.com/joomla/joomla-cms/issues/44879

### Testing Instructions
See https://github.com/joomla/joomla-cms/issues/44879, understand the issue. Apply path, confirm that the issue fixed.

### Actual result BEFORE applying this Pull Request
Mail Templates always site default language for displaying data


### Expected result AFTER applying this Pull Request
Mail Templates use current language to display data


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
