### PR TITLE
[5.3] Fix field group permission check

### DIFF
--- a/administrator/components/com_fields/src/Model/GroupModel.php
+++ b/administrator/components/com_fields/src/Model/GroupModel.php
@@ -120,14 +120,13 @@ class GroupModel extends AdminModel
             return false;
         }
 
-        // Modify the form based on Edit State access controls.
-        if (empty($data['context'])) {
-            $data['context'] = $context;
-        }
+        $record          = new \stdClass();
+        $record->context = $context;
+        $record->id      = $jinput->get('id');
 
         $user = $this->getCurrentUser();
 
-        if (!$user->authorise('core.edit.state', $context . '.fieldgroup.' . $jinput->get('id'))) {
+        if (!$this->canEditState($record)) {
             // Disable fields for display.
             $form->setFieldAttribute('ordering', 'disabled', 'true');
             $form->setFieldAttribute('state', 'disabled', 'true');
@@ -160,7 +159,9 @@ class GroupModel extends AdminModel
             return false;
         }
 
-        return $this->getCurrentUser()->authorise('core.delete', $record->context . '.fieldgroup.' . (int) $record->id);
+        $component = explode('.', $record->context)[0];
+
+        return $this->getCurrentUser()->authorise('core.delete', $component . '.fieldgroup.' . (int) $record->id);
     }
 
     /**
@@ -177,13 +178,15 @@ class GroupModel extends AdminModel
     {
         $user = $this->getCurrentUser();
 
+        $component = explode('.', $record->context)[0];
+
         // Check for existing fieldgroup.
         if (!empty($record->id)) {
-            return $user->authorise('core.edit.state', $record->context . '.fieldgroup.' . (int) $record->id);
+            return $user->authorise('core.edit.state', $component . '.fieldgroup.' . (int) $record->id);
         }
 
         // Default to component settings.
-        return $user->authorise('core.edit.state', $record->context);
+        return $user->authorise('core.edit.state', $component);
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #44542.

### Summary of Changes
Currently, the `GroupModel` model uses wrong asset name for permission check, so permission checking for field groups does not work at all. The right name of assist is something like `com_content.fieldgroup.20 `but we are checking using `com_content.article.fieldgroup.20 `. This PR fixes that wrong behavior

### Testing Instructions
- Use Joomla 5.3
- Create a new field group for Content. Look at Permissions tab, set **Edit State** permission of that field for Administrator user group to Denied.
- Save it.
- Logout, then login using an Administrator account.
- Check on the checkbox next to the field group and try to use Publish button in the toolbar to publish that 
- Try to click on field group to edit

### Actual result BEFORE applying this Pull Request
You can publish field group, although Administrator does not have permission to do that.
You can change value for Published field of the field group

### Expected result AFTER applying this Pull Request

- There is an error message when try to publish that field group
- You are not allowed to change Published field for the field group

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
