### PR TITLE
[5.3] Remove unused exception variable in catch for modules and plugins

### DIFF
--- a/administrator/modules/mod_feed/src/Helper/FeedHelper.php
+++ b/administrator/modules/mod_feed/src/Helper/FeedHelper.php
@@ -43,7 +43,7 @@ class FeedHelper
         // Get RSS parsed object
         try {
             $rssDoc = $feed->getFeed($rssurl);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return Text::_('MOD_FEED_ERR_FEED_NOT_RETRIEVED');
         }
 

--- a/administrator/modules/mod_privacy_dashboard/src/Helper/PrivacyDashboardHelper.php
+++ b/administrator/modules/mod_privacy_dashboard/src/Helper/PrivacyDashboardHelper.php
@@ -50,7 +50,7 @@ class PrivacyDashboardHelper
 
         try {
             return $db->loadObjectList();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             return [];
         }
     }

--- a/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
+++ b/administrator/modules/mod_stats_admin/src/Helper/StatsAdminHelper.php
@@ -96,7 +96,7 @@ class StatsAdminHelper
 
             try {
                 $items = $db->loadResult();
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 $items = false;
             }
 

--- a/modules/mod_articles_archive/src/Helper/ArticlesArchiveHelper.php
+++ b/modules/mod_articles_archive/src/Helper/ArticlesArchiveHelper.php
@@ -67,7 +67,7 @@ class ArticlesArchiveHelper implements DatabaseAwareInterface
 
         try {
             $rows = (array) $db->loadObjectList();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $app->enqueueMessage(Text::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
             return [];

--- a/modules/mod_feed/src/Helper/FeedHelper.php
+++ b/modules/mod_feed/src/Helper/FeedHelper.php
@@ -42,7 +42,7 @@ class FeedHelper
         try {
             $feed   = new FeedFactory();
             $rssDoc = $feed->getFeed($rssurl);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return Text::_('MOD_FEED_ERR_FEED_NOT_RETRIEVED');
         }
 

--- a/modules/mod_related_items/src/Helper/RelatedItemsHelper.php
+++ b/modules/mod_related_items/src/Helper/RelatedItemsHelper.php
@@ -86,7 +86,7 @@ class RelatedItemsHelper implements DatabaseAwareInterface
 
             try {
                 $metakey = trim($db->loadResult());
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 $app->enqueueMessage(Text::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
                 return [];
@@ -150,7 +150,7 @@ class RelatedItemsHelper implements DatabaseAwareInterface
 
                 try {
                     $articleIds = $db->loadColumn();
-                } catch (\RuntimeException $e) {
+                } catch (\RuntimeException) {
                     $app->enqueueMessage(Text::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
                     return [];

--- a/modules/mod_stats/src/Helper/StatsHelper.php
+++ b/modules/mod_stats/src/Helper/StatsHelper.php
@@ -106,7 +106,7 @@ class StatsHelper implements DatabaseAwareInterface
 
             try {
                 $items = $db->loadResult();
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 $items = false;
             }
 
@@ -134,7 +134,7 @@ class StatsHelper implements DatabaseAwareInterface
 
             try {
                 $hits = $db->loadResult();
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 $hits = false;
             }
 

--- a/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
+++ b/modules/mod_tags_similar/src/Helper/TagsSimilarHelper.php
@@ -204,7 +204,7 @@ class TagsSimilarHelper implements DatabaseAwareInterface
 
         try {
             $results = $db->loadObjectList();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $results = [];
             $app->enqueueMessage(Text::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
         }

--- a/modules/mod_users_latest/src/Helper/UsersLatestHelper.php
+++ b/modules/mod_users_latest/src/Helper/UsersLatestHelper.php
@@ -69,7 +69,7 @@ class UsersLatestHelper implements DatabaseAwareInterface
 
         try {
             return (array) $db->loadObjectList();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $app->enqueueMessage(Text::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
             return [];

--- a/modules/mod_whosonline/src/Helper/WhosonlineHelper.php
+++ b/modules/mod_whosonline/src/Helper/WhosonlineHelper.php
@@ -49,7 +49,7 @@ class WhosonlineHelper
 
         try {
             $sessions = (array) $db->loadObjectList();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $sessions = [];
         }
 
@@ -113,7 +113,7 @@ class WhosonlineHelper
 
         try {
             return (array) $db->loadObjectList();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return [];
         }
     }

--- a/plugins/actionlog/joomla/src/Extension/Joomla.php
+++ b/plugins/actionlog/joomla/src/Extension/Joomla.php
@@ -316,7 +316,7 @@ final class Joomla extends ActionLogPlugin implements SubscriberInterface
 
         try {
             $items = $db->loadObjectList($params->id_holder);
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $items = [];
         }
 
@@ -875,7 +875,7 @@ final class Joomla extends ActionLogPlugin implements SubscriberInterface
 
         try {
             $loggedInUser = $db->loadObject();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             return;
         }
 

--- a/plugins/api-authentication/token/src/Extension/Token.php
+++ b/plugins/api-authentication/token/src/Extension/Token.php
@@ -180,7 +180,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
          */
         try {
             $siteSecret = $this->getApplication()->get('secret');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return;
         }
 
@@ -282,7 +282,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
             $query->bind(':userId', $userId, ParameterType::INTEGER);
 
             return $db->setQuery($query)->loadResult();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return null;
         }
     }
@@ -313,7 +313,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
             $value = $db->setQuery($query)->loadResult();
 
             return $value == 1;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }

--- a/plugins/authentication/cookie/src/Extension/Cookie.php
+++ b/plugins/authentication/cookie/src/Extension/Cookie.php
@@ -208,7 +208,7 @@ final class Cookie extends CMSPlugin implements SubscriberInterface
 
         try {
             $result = $db->setQuery($query)->loadObject();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $response->status = Authentication::STATUS_FAILURE;
 
             return;
@@ -303,7 +303,7 @@ final class Cookie extends CMSPlugin implements SubscriberInterface
                     if ($results === null) {
                         $unique = true;
                     }
-                } catch (\RuntimeException $e) {
+                } catch (\RuntimeException) {
                     $errorCount++;
 
                     // We'll let this query fail up to 5 times before giving up, there's probably a bigger issue at this point
@@ -370,7 +370,7 @@ final class Cookie extends CMSPlugin implements SubscriberInterface
 
         try {
             $db->setQuery($query)->execute();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             // We aren't concerned with errors from this query, carry on
         }
     }
@@ -416,7 +416,7 @@ final class Cookie extends CMSPlugin implements SubscriberInterface
 
         try {
             $db->setQuery($query)->execute();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             // We aren't concerned with errors from this query, carry on
         }
 

--- a/plugins/content/confirmconsent/src/Field/ConsentBoxField.php
+++ b/plugins/content/confirmconsent/src/Field/ConsentBoxField.php
@@ -250,7 +250,7 @@ class ConsentBoxField extends CheckboxesField
 
         try {
             $article = $db->loadObject();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             // Something at the database layer went wrong
             return Route::_(
                 'index.php?option=com_content&view=article&id='

--- a/plugins/editors/tinymce/src/PluginTraits/ActiveSiteTemplate.php
+++ b/plugins/editors/tinymce/src/PluginTraits/ActiveSiteTemplate.php
@@ -47,7 +47,7 @@ trait ActiveSiteTemplate
 
         try {
             return $db->loadObject();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $this->getApplication()->enqueueMessage(Text::_('JERROR_AN_ERROR_HAS_OCCURRED'), 'error');
 
             return new \stdClass();

--- a/plugins/extension/finder/src/Extension/Finder.php
+++ b/plugins/extension/finder/src/Extension/Finder.php
@@ -177,7 +177,7 @@ final class Finder extends CMSPlugin implements SubscriberInterface
         try {
             $db->setQuery($query);
             $db->execute();
-        } catch (\Exception $ex) {
+        } catch (\Exception) {
             // It would be nice if the common word is stored to the DB, but it isn't super important
         }
     }

--- a/plugins/filesystem/local/src/Adapter/LocalAdapter.php
+++ b/plugins/filesystem/local/src/Adapter/LocalAdapter.php
@@ -262,7 +262,7 @@ class LocalAdapter implements AdapterInterface
 
         try {
             File::write($localPath, $data);
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
         }
 
         if ($this->thumbnails && MediaHelper::isImage(pathinfo($localPath)['basename'])) {
@@ -303,7 +303,7 @@ class LocalAdapter implements AdapterInterface
 
         try {
             File::write($localPath, $data);
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
         }
 
         if ($this->thumbnails && MediaHelper::isImage(pathinfo($localPath)['basename'])) {
@@ -426,7 +426,7 @@ class LocalAdapter implements AdapterInterface
                 $obj->height = $props->height;
 
                 $obj->thumb_path = $this->thumbnails ? $this->getThumbnail($path) : $this->getUrl($obj->path);
-            } catch (UnparsableImageException $e) {
+            } catch (UnparsableImageException) {
                 // Ignore the exception - it's an image that we don't know how to parse right now
             }
         }
@@ -537,7 +537,7 @@ class LocalAdapter implements AdapterInterface
 
         try {
             File::copy($sourcePath, $destinationPath);
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
             throw new \Exception(Text::_('COM_MEDIA_COPY_FILE_NOT_POSSIBLE'));
         }
     }
@@ -564,7 +564,7 @@ class LocalAdapter implements AdapterInterface
             if (is_file($destinationPath)) {
                 File::delete($destinationPath);
             }
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
             throw new \Exception(Text::_('COM_MEDIA_COPY_FOLDER_DESTINATION_CAN_NOT_DELETE'));
         }
 
@@ -652,7 +652,7 @@ class LocalAdapter implements AdapterInterface
 
         try {
             File::move($sourcePath, $destinationPath);
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
             throw new \Exception(Text::_('COM_MEDIA_MOVE_FILE_NOT_POSSIBLE'));
         }
     }
@@ -679,7 +679,7 @@ class LocalAdapter implements AdapterInterface
             if (is_file($destinationPath)) {
                 File::delete($destinationPath);
             }
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
             throw new \Exception(Text::_('COM_MEDIA_MOVE_FOLDER_NOT_POSSIBLE'));
         }
 
@@ -860,7 +860,7 @@ class LocalAdapter implements AdapterInterface
 
         try {
             File::delete($tmpFile);
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
         }
 
         if (!$can) {
@@ -986,7 +986,7 @@ class LocalAdapter implements AdapterInterface
     {
         try {
             (new Image($path))->createThumbnails([$this->thumbnailSize[0] . 'x' . $this->thumbnailSize[1]], Image::SCALE_INSIDE, \dirname($thumbnailPath), true);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
 

--- a/plugins/installer/override/src/Extension/Override.php
+++ b/plugins/installer/override/src/Extension/Override.php
@@ -175,7 +175,7 @@ final class Override extends CMSPlugin implements SubscriberInterface
         try {
             /** @var \Joomla\Component\Templates\Administrator\Model\TemplateModel $templateModel */
             $templateModel = $this->getModel();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return [];
         }
 

--- a/plugins/multifactorauth/email/src/Extension/Email.php
+++ b/plugins/multifactorauth/email/src/Extension/Email.php
@@ -173,7 +173,7 @@ class Email extends CMSPlugin implements SubscriberInterface
 
         try {
             $this->sendCode($key, $user);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return;
         }
 
@@ -476,7 +476,7 @@ class Email extends CMSPlugin implements SubscriberInterface
                     'user_id' => $user->id,
                 ]
             );
-        } catch (\Exception $event) {
+        } catch (\Exception) {
             // Fail gracefully
         }
     }

--- a/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
+++ b/plugins/multifactorauth/webauthn/src/Extension/Webauthn.php
@@ -344,7 +344,7 @@ class Webauthn extends CMSPlugin implements SubscriberInterface
             ob_start();
             include $layoutPath;
             $html = ob_get_clean();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return;
         }
 
@@ -422,7 +422,7 @@ class Webauthn extends CMSPlugin implements SubscriberInterface
         } catch (\Exception $e) {
             try {
                 $this->getApplication()->enqueueMessage($e->getMessage(), 'error');
-            } catch (\Exception $e) {
+            } catch (\Exception) {
             }
 
             $event->addResult(false);

--- a/plugins/multifactorauth/webauthn/src/Helper/Credentials.php
+++ b/plugins/multifactorauth/webauthn/src/Helper/Credentials.php
@@ -105,7 +105,7 @@ abstract class Credentials
 
         try {
             $publicKeyCredentialCreationOptions = unserialize(base64_decode($encodedOptions));
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $publicKeyCredentialCreationOptions = null;
         }
 
@@ -274,7 +274,7 @@ abstract class Credentials
         try {
             $app      = Factory::getApplication();
             $siteName = $app->get('sitename');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $siteName = 'Joomla! Site';
         }
 

--- a/plugins/multifactorauth/yubikey/src/Extension/Yubikey.php
+++ b/plugins/multifactorauth/yubikey/src/Extension/Yubikey.php
@@ -319,7 +319,7 @@ class Yubikey extends CMSPlugin implements SubscriberInterface
                     return $rec->method === $record->method;
                 }
             );
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $records = [];
         }
 
@@ -409,7 +409,7 @@ class Yubikey extends CMSPlugin implements SubscriberInterface
                 } else {
                     continue;
                 }
-            } catch (\Exception $exc) {
+            } catch (\Exception) {
                 // No response, continue with the next server
                 continue;
             }

--- a/plugins/sampledata/multilang/src/Extension/MultiLanguage.php
+++ b/plugins/sampledata/multilang/src/Extension/MultiLanguage.php
@@ -527,7 +527,7 @@ final class MultiLanguage extends CMSPlugin implements SubscriberInterface
 
         try {
             $db->execute();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             return false;
         }
 
@@ -553,7 +553,7 @@ final class MultiLanguage extends CMSPlugin implements SubscriberInterface
 
             try {
                 $db->execute();
-            } catch (ExecutionFailureException $e) {
+            } catch (ExecutionFailureException) {
                 return false;
             }
         }
@@ -590,7 +590,7 @@ final class MultiLanguage extends CMSPlugin implements SubscriberInterface
 
         try {
             $db->execute();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             return false;
         }
 
@@ -922,7 +922,7 @@ final class MultiLanguage extends CMSPlugin implements SubscriberInterface
 
             try {
                 $db->execute();
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 return false;
             }
         }
@@ -956,7 +956,7 @@ final class MultiLanguage extends CMSPlugin implements SubscriberInterface
 
         try {
             $db->execute();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return false;
         }
 
@@ -1132,7 +1132,7 @@ final class MultiLanguage extends CMSPlugin implements SubscriberInterface
             if ($stage_id) {
                 $workflow->createAssociation($newId, $stage_id);
             }
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             return false;
         }
 

--- a/plugins/schemaorg/custom/src/Extension/Custom.php
+++ b/plugins/schemaorg/custom/src/Extension/Custom.php
@@ -76,7 +76,7 @@ final class Custom extends CMSPlugin implements SubscriberInterface
             $schema = new Registry($subject->schema);
 
             $json = (new Registry($schema->get('json')))->toArray();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             $this->getApplication()->enqueueMessage(Text::_('PLG_SCHEMAORG_CUSTOM_JSON_ERROR'), 'error');
             return;
         }

--- a/plugins/system/actionlogs/src/Extension/ActionLogs.php
+++ b/plugins/system/actionlogs/src/Extension/ActionLogs.php
@@ -182,7 +182,7 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
 
         try {
             $values = $db->setQuery($query)->loadObject();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             return;
         }
 
@@ -292,7 +292,7 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
 
         try {
             $db->setQuery($query)->execute();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             // Do nothing.
         }
     }
@@ -325,7 +325,7 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
 
         try {
             $db->setQuery($query)->execute();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             // Do nothing.
         }
     }
@@ -399,7 +399,7 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
 
         try {
             $values = $db->setQuery($query)->loadObjectList();
-        } catch (ExecutionFailureException $e) {
+        } catch (ExecutionFailureException) {
             return;
         }
 
@@ -420,7 +420,7 @@ final class ActionLogs extends CMSPlugin implements SubscriberInterface
 
             try {
                 $db->setQuery($query)->execute();
-            } catch (ExecutionFailureException $e) {
+            } catch (ExecutionFailureException) {
                 // Do nothing.
             }
         }

--- a/plugins/system/guidedtours/src/Extension/GuidedTours.php
+++ b/plugins/system/guidedtours/src/Extension/GuidedTours.php
@@ -214,7 +214,7 @@ final class GuidedTours extends CMSPlugin implements SubscriberInterface
 
                     try {
                         $result = $db->setQuery($query)->loadResult();
-                    } catch (\Exception $e) {
+                    } catch (\Exception) {
                         // Do not start the tour.
                         continue;
                     }

--- a/plugins/system/log/src/Extension/Log.php
+++ b/plugins/system/log/src/Extension/Log.php
@@ -81,7 +81,7 @@ final class Log extends CMSPlugin implements SubscriberInterface
 
         try {
             Logger::add($errorlog['comment'], Logger::INFO, $errorlog['status']);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // If the log file is unwriteable during login then we should not go to the error page
             return;
         }

--- a/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
+++ b/plugins/system/privacyconsent/src/Extension/PrivacyConsent.php
@@ -200,7 +200,7 @@ final class PrivacyConsent extends CMSPlugin implements SubscriberInterface
 
             try {
                 $this->getDatabase()->insertObject('#__privacy_consents', $userNote);
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // Do nothing if the save fails
             }
 

--- a/plugins/system/redirect/src/Extension/Redirect.php
+++ b/plugins/system/redirect/src/Extension/Redirect.php
@@ -214,7 +214,7 @@ final class Redirect extends CMSPlugin implements SubscriberInterface
 
                 try {
                     $this->getDatabase()->updateObject('#__redirect_links', $redirect, 'id');
-                } catch (\Exception $e) {
+                } catch (\Exception) {
                     // We don't log issues for now
                 }
 

--- a/plugins/system/schedulerunner/src/Extension/ScheduleRunner.php
+++ b/plugins/system/schedulerunner/src/Extension/ScheduleRunner.php
@@ -163,7 +163,7 @@ final class ScheduleRunner extends CMSPlugin implements SubscriberInterface
         // Suppress all errors to avoid any output
         try {
             $this->runScheduler();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
         }
 
         ob_end_clean();

--- a/plugins/system/stats/src/Extension/Stats.php
+++ b/plugins/system/stats/src/Extension/Stats.php
@@ -498,7 +498,7 @@ final class Stats extends CMSPlugin implements SubscriberInterface
             $result = $db->setQuery($query)->execute();
 
             $this->clearCacheGroups(['com_plugins']);
-        } catch (\Exception $exc) {
+        } catch (\Exception) {
             // If we failed to execute
             $db->unlockTables();
             $result = false;
@@ -507,7 +507,7 @@ final class Stats extends CMSPlugin implements SubscriberInterface
         try {
             // Unlock the tables after writing
             $db->unlockTables();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // If we can't lock the tables assume we have somehow failed
             $result = false;
         }
@@ -585,7 +585,7 @@ final class Stats extends CMSPlugin implements SubscriberInterface
 
                 $cache = Cache::getInstance('callback', $options);
                 $cache->clean();
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // Ignore it
             }
         }
@@ -623,7 +623,7 @@ final class Stats extends CMSPlugin implements SubscriberInterface
             $result = $db->setQuery($query)->execute();
 
             $this->clearCacheGroups(['com_plugins']);
-        } catch (\Exception $exc) {
+        } catch (\Exception) {
             // If we failed to execute
             $db->unlockTables();
             $result = false;
@@ -632,7 +632,7 @@ final class Stats extends CMSPlugin implements SubscriberInterface
         try {
             // Unlock the tables after writing
             $db->unlockTables();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // If we can't lock the tables assume we have somehow failed
             $result = false;
         }

--- a/plugins/system/tasknotification/src/Extension/TaskNotification.php
+++ b/plugins/system/tasknotification/src/Extension/TaskNotification.php
@@ -97,7 +97,7 @@ final class TaskNotification extends CMSPlugin implements SubscriberInterface
 
         try {
             $formFile = Path::check($formFile);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Log?
             return false;
         }
@@ -290,7 +290,7 @@ final class TaskNotification extends CMSPlugin implements SubscriberInterface
 
         try {
             $users = $db->loadObjectList();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return;
         }
 
@@ -323,7 +323,7 @@ final class TaskNotification extends CMSPlugin implements SubscriberInterface
 
                     $mailer->send();
                     $mailSent = true;
-                } catch (MailerException $exception) {
+                } catch (MailerException) {
                     Log::add($this->getApplication()->getLanguage()->_('PLG_SYSTEM_TASK_NOTIFICATION_NOTIFY_SEND_EMAIL_FAIL'), Log::ERROR);
                 }
             }

--- a/plugins/system/webauthn/src/Authentication.php
+++ b/plugins/system/webauthn/src/Authentication.php
@@ -308,7 +308,7 @@ final class Authentication
         /** @var PublicKeyCredentialCreationOptions|null $publicKeyCredentialCreationOptions */
         try {
             $publicKeyCredentialCreationOptions = unserialize(base64_decode($encodedOptions));
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             Log::add('The plg_system_webauthn.publicKeyCredentialCreationOptions in the session is invalid', Log::NOTICE, 'webauthn.system');
             $publicKeyCredentialCreationOptions = null;
         }
@@ -392,7 +392,7 @@ final class Authentication
                 '/templates/',
                 '/templates/' . $this->app->getTemplate(),
             ];
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return null;
         }
 
@@ -502,7 +502,7 @@ final class Authentication
 
         try {
             $publicKeyCredentialRequestOptions = unserialize(base64_decode($encodedOptions));
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             Log::add('Invalid plg_system_webauthn.publicKeyCredentialRequestOptions in the session', Log::NOTICE, 'webauthn.system');
 
             throw new \RuntimeException(Text::_('PLG_SYSTEM_WEBAUTHN_ERR_CREATE_INVALID_LOGIN_REQUEST'));

--- a/plugins/system/webauthn/src/CredentialRepository.php
+++ b/plugins/system/webauthn/src/CredentialRepository.php
@@ -79,7 +79,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
 
         try {
             return PublicKeyCredentialSource::createFromArray(json_decode($json, true));
-        } catch (\Throwable $e) {
+        } catch (\Throwable) {
             return null;
         }
     }
@@ -136,7 +136,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
 
             try {
                 return PublicKeyCredentialSource::createFromArray($data);
-            } catch (\InvalidArgumentException $e) {
+            } catch (\InvalidArgumentException) {
                 return null;
             }
         };
@@ -222,7 +222,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
             $o->user_id = $oldRecord->user_id;
             $o->label   = $oldRecord->label;
             $update     = true;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
         }
 
         $o->credential = $this->encryptCredential($o->credential);
@@ -304,7 +304,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
                 $record['credential'] = PublicKeyCredentialSource::createFromArray($data);
 
                 return $record;
-            } catch (\InvalidArgumentException $e) {
+            } catch (\InvalidArgumentException) {
                 $record['credential'] = null;
 
                 return $record;
@@ -338,7 +338,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
             $count = $db->setQuery($query)->loadResult();
 
             return $count > 0;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
     }
@@ -473,7 +473,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
 
         try {
             $numRecords = $db->setQuery($query)->loadResult();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return null;
         }
 
@@ -501,7 +501,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
         while (true) {
             try {
                 $ids = $db->setQuery($query, $start, $limit)->loadColumn();
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 return null;
             }
 
@@ -585,7 +585,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
             /** @var Registry $config */
             $config = $app->getConfig();
             $secret = $config->get('secret', '');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $secret = '';
         }
 
@@ -621,7 +621,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
 
             try {
                 $tzDefault = Factory::getApplication()->get('offset');
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $tzDefault = 'GMT';
             }
 
@@ -634,7 +634,7 @@ final class CredentialRepository implements PublicKeyCredentialSourceRepository,
                 $userTimeZone = new \DateTimeZone($tz);
 
                 $jDate->setTimezone($userTimeZone);
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // Nothing. Fall back to UTC.
             }
         }

--- a/plugins/system/webauthn/src/Extension/Webauthn.php
+++ b/plugins/system/webauthn/src/Extension/Webauthn.php
@@ -155,7 +155,7 @@ final class Webauthn extends CMSPlugin implements SubscriberInterface
     {
         try {
             $app = Factory::getApplication();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return [];
         }
 

--- a/plugins/system/webauthn/src/MetadataRepository.php
+++ b/plugins/system/webauthn/src/MetadataRepository.php
@@ -128,7 +128,7 @@ final class MetadataRepository implements MetadataStatementRepository
         try {
             $jwtConfig = Configuration::forUnsecuredSigner();
             $token     = $jwtConfig->parser()->parse($rawJwt);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return;
         }
 
@@ -153,7 +153,7 @@ final class MetadataRepository implements MetadataStatementRepository
                 }
 
                 return MetadataStatement::createFromArray($array);
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 return null;
             }
         };

--- a/plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
+++ b/plugins/system/webauthn/src/PluginTraits/AdditionalLoginButtons.php
@@ -138,7 +138,7 @@ trait AdditionalLoginButtons
              */
             try {
                 $document = $this->getApplication()->getDocument();
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 $document = null;
             }
 

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerChallenge.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerChallenge.php
@@ -89,7 +89,7 @@ trait AjaxHandlerChallenge
 
         try {
             $myUser = Factory::getContainer()->get(UserFactoryInterface::class)->loadUserById($userId);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $myUser = new User();
         }
 

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerDelete.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerDelete.php
@@ -81,7 +81,7 @@ trait AjaxHandlerDelete
         // Delete the record
         try {
             $repository->remove($credentialId);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $event->addResult(false);
 
             return;

--- a/plugins/system/webauthn/src/PluginTraits/AjaxHandlerSaveLabel.php
+++ b/plugins/system/webauthn/src/PluginTraits/AjaxHandlerSaveLabel.php
@@ -90,7 +90,7 @@ trait AjaxHandlerSaveLabel
         // Save the new label
         try {
             $repository->setLabel($credentialId, $newLabel);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $event->addResult(false);
 
             return;

--- a/plugins/system/webauthn/src/PluginTraits/UserDeletion.php
+++ b/plugins/system/webauthn/src/PluginTraits/UserDeletion.php
@@ -66,7 +66,7 @@ trait UserDeletion
 
             try {
                 $db->setQuery($query)->execute();
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // Don't worry if this fails
             }
 

--- a/plugins/task/checkfiles/src/Extension/Checkfiles.php
+++ b/plugins/task/checkfiles/src/Extension/Checkfiles.php
@@ -143,7 +143,7 @@ final class Checkfiles extends CMSPlugin implements SubscriberInterface
 
             try {
                 $image->resize($newWidth, $newHeight, false);
-            } catch (\LogicException $e) {
+            } catch (\LogicException) {
                 $this->logTask($this->getApplication()->getLanguage()->_('PLG_TASK_CHECK_FILES_LOG_RESIZE_FAIL'), 'error');
 
                 return TaskStatus::KNOCKOUT;

--- a/plugins/task/deleteactionlogs/src/Extension/DeleteActionLogs.php
+++ b/plugins/task/deleteactionlogs/src/Extension/DeleteActionLogs.php
@@ -94,7 +94,7 @@ final class DeleteActionLogs extends CMSPlugin implements SubscriberInterface
 
             try {
                 $db->execute();
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 // Ignore it
                 return Status::KNOCKOUT;
             }

--- a/plugins/task/globalcheckin/src/Extension/Globalcheckin.php
+++ b/plugins/task/globalcheckin/src/Extension/Globalcheckin.php
@@ -114,7 +114,7 @@ class Globalcheckin extends CMSPlugin implements SubscriberInterface
 
             try {
                 $db->execute();
-            } catch (ExecutionFailureException $e) {
+            } catch (ExecutionFailureException) {
                 // This failure isn't critical, don't care too much
                 $failed = true;
             }

--- a/plugins/task/privacyconsent/src/Extension/PrivacyConsent.php
+++ b/plugins/task/privacyconsent/src/Extension/PrivacyConsent.php
@@ -133,7 +133,7 @@ final class PrivacyConsent extends CMSPlugin implements SubscriberInterface
 
         try {
             $users = $db->setQuery($query)->loadObjectList();
-        } catch (\RuntimeException $exception) {
+        } catch (\RuntimeException) {
             return Status::KNOCKOUT;
         }
 
@@ -183,10 +183,10 @@ final class PrivacyConsent extends CMSPlugin implements SubscriberInterface
 
                 try {
                     $db->execute();
-                } catch (\RuntimeException $e) {
+                } catch (\RuntimeException) {
                     return Status::KNOCKOUT;
                 }
-            } catch (MailDisabledException | phpmailerException $exception) {
+            } catch (MailDisabledException | phpmailerException) {
                 return Status::KNOCKOUT;
             }
         }
@@ -222,7 +222,7 @@ final class PrivacyConsent extends CMSPlugin implements SubscriberInterface
 
         try {
             $users = $db->loadObjectList();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             return Status::KNOCKOUT;
         }
 
@@ -246,7 +246,7 @@ final class PrivacyConsent extends CMSPlugin implements SubscriberInterface
 
             try {
                 $db->execute();
-            } catch (\RuntimeException $e) {
+            } catch (\RuntimeException) {
                 return Status::KNOCKOUT;
             }
 

--- a/plugins/task/requests/src/Extension/Requests.php
+++ b/plugins/task/requests/src/Extension/Requests.php
@@ -146,7 +146,7 @@ final class Requests extends CMSPlugin implements SubscriberInterface
             File::write($responseFilename, $responseBody);
             $this->snapshot['output_file'] = $responseFilename;
             $responseStatus                = 'SAVED';
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $this->logTask($this->getApplication()->getLanguage()->_('PLG_TASK_REQUESTS_TASK_GET_REQUEST_LOG_UNWRITEABLE_OUTPUT'), 'error');
             $responseStatus = 'NOT_SAVED';
         }

--- a/plugins/task/rotatelogs/src/Extension/RotateLogs.php
+++ b/plugins/task/rotatelogs/src/Extension/RotateLogs.php
@@ -103,7 +103,7 @@ final class RotateLogs extends CMSPlugin implements SubscriberInterface
                 foreach ($files as $file) {
                     try {
                         File::delete($logPath . '/' . $file);
-                    } catch (FilesystemException $exception) {
+                    } catch (FilesystemException) {
                     }
                 }
             } else {
@@ -146,7 +146,7 @@ final class RotateLogs extends CMSPlugin implements SubscriberInterface
 
         try {
             File::move($path . '/' . $filename, $rotatedFile);
-        } catch (FilesystemException $exception) {
+        } catch (FilesystemException) {
         }
     }
 

--- a/plugins/task/sitestatus/src/Extension/SiteStatus.php
+++ b/plugins/task/sitestatus/src/Extension/SiteStatus.php
@@ -171,7 +171,7 @@ final class SiteStatus extends CMSPlugin implements SubscriberInterface
             // Attempt to write the configuration file as a PHP class named JConfig.
             $configuration = $config->toString('PHP', ['class' => 'JConfig', 'closingtag' => false]);
             File::write($file, $configuration);
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $this->logTask($this->getApplication()->getLanguage()->_('PLG_TASK_SITE_STATUS_ERROR_WRITE_FAILED'), 'error');
 
             return Status::KNOCKOUT;

--- a/plugins/task/updatenotification/src/Extension/UpdateNotification.php
+++ b/plugins/task/updatenotification/src/Extension/UpdateNotification.php
@@ -203,7 +203,7 @@ final class UpdateNotification extends CMSPlugin implements SubscriberInterface
             } catch (MailDisabledException | phpMailerException $exception) {
                 try {
                     $this->logTask($jLanguage->_($exception->getMessage()));
-                } catch (\RuntimeException $exception) {
+                } catch (\RuntimeException) {
                     return Status::KNOCKOUT;
                 }
             }
@@ -300,7 +300,7 @@ final class UpdateNotification extends CMSPlugin implements SubscriberInterface
 
             $db->setQuery($query);
             $ret = $db->loadObjectList();
-        } catch (\Exception $exc) {
+        } catch (\Exception) {
             return $ret;
         }
 

--- a/plugins/user/joomla/src/Extension/Joomla.php
+++ b/plugins/user/joomla/src/Extension/Joomla.php
@@ -164,7 +164,7 @@ final class Joomla extends CMSPlugin implements SubscriberInterface
 
         try {
             $db->setQuery($query)->execute();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Do nothing
         }
     }
@@ -349,7 +349,7 @@ final class Joomla extends CMSPlugin implements SubscriberInterface
 
         try {
             $db->setQuery($query)->execute();
-        } catch (\RuntimeException $e) {
+        } catch (\RuntimeException) {
             // The old session is already invalidated, don't let this block logging in
         }
 

--- a/plugins/user/profile/src/Extension/Profile.php
+++ b/plugins/user/profile/src/Extension/Profile.php
@@ -328,7 +328,7 @@ final class Profile extends CMSPlugin implements SubscriberInterface
             try {
                 $date       = new Date($data['profile']['dob']);
                 $this->date = $date->format('Y-m-d H:i:s');
-            } catch (\Exception $e) {
+            } catch (\Exception) {
                 // Throw an exception if date is not valid.
                 throw new \InvalidArgumentException($this->getApplication()->getLanguage()->_('PLG_USER_PROFILE_ERROR_INVALID_DOB'));
             }

--- a/plugins/user/token/src/Extension/Token.php
+++ b/plugins/user/token/src/Extension/Token.php
@@ -158,7 +158,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
 
                 $data->{$this->profileKeyPrefix}[$k] = $v[1];
             }
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // We suppress any database error. It means we get no token saved by default.
         }
 
@@ -428,7 +428,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
             $query->bind(':profileKey', $profileKey, ParameterType::STRING);
 
             $db->setQuery($query)->execute();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             // Do nothing.
         }
     }
@@ -473,7 +473,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
             $query->bind(':userId', $userId, ParameterType::INTEGER);
 
             return $db->setQuery($query)->loadResult();
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return null;
         }
     }
@@ -553,7 +553,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
 
         try {
             $siteSecret = $this->getApplication()->get('secret');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $siteSecret = '';
         }
 
@@ -620,7 +620,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
 
         try {
             $numRows = $db->setQuery($q)->loadResult() ?? 0;
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             return false;
         }
 

--- a/plugins/user/token/src/Field/JoomlatokenField.php
+++ b/plugins/user/token/src/Field/JoomlatokenField.php
@@ -104,7 +104,7 @@ class JoomlatokenField extends TextField
 
         try {
             $siteSecret = Factory::getApplication()->get('secret');
-        } catch (\Exception $e) {
+        } catch (\Exception) {
             $siteSecret = '';
         }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses [RemoveUnusedVariableInCatchRector](https://getrector.com/rule-detail/remove-unused-variable-in-catch-rector) rector rule to remove unused exception variable in try catch block in our modules and plugins code. This is done automatically by rector, no manual change included.

### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner code.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed