### PR TITLE
[5.3] Changes unneeded null check to ?? operator for modules and plugins

### DIFF
--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -236,7 +236,7 @@ class CssMenu
 
             $table->load(['menutype' => $menutype]);
 
-            $menutype = isset($table->title) ? $table->title : $menutype;
+            $menutype = $table->title ?? $menutype;
             $message  = Text::sprintf('MOD_MENU_IMPORTANT_ITEMS_INACCESSIBLE_LIST_WARNING', $menutype, implode(', ', $missing), $uri);
 
             $this->application->enqueueMessage($message, 'warning');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses [TernaryToNullCoalescingRector](https://getrector.com/rule-detail/ternary-to-null-coalescing-rector) rector rule to change unneeded null check to `??` operator for our modules and plugins code. This is done automatically by rector, no manual change included. (for this specific rule, only one file is changed :D )


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner, easier to read code

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
