### PR TITLE
[5.3] Change list() to array destruct for modules and plugins code

### DIFF
--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -353,7 +353,7 @@ class CssMenu
                     continue;
                 }
 
-                list($assetName) = isset($query['context']) ? explode('.', $query['context'], 2) : ['com_fields'];
+                [$assetName] = isset($query['context']) ? explode('.', $query['context'], 2) : ['com_fields'];
             } elseif ($item->element === 'com_cpanel' && $item->link === 'index.php') {
                 continue;
             } elseif (
@@ -382,7 +382,7 @@ class CssMenu
                     continue;
                 }
 
-                list($assetName) = isset($query['extension']) ? explode('.', $query['extension'], 2) : ['com_workflow'];
+                [$assetName] = isset($query['extension']) ? explode('.', $query['extension'], 2) : ['com_workflow'];
             } elseif (\in_array($item->element, ['com_config', 'com_privacy', 'com_actionlogs'], true) && !$user->authorise('core.admin')) {
                 // Special case for components which only allow super user access
                 $parent->removeChild($item);

--- a/plugins/actionlog/joomla/src/Extension/Joomla.php
+++ b/plugins/actionlog/joomla/src/Extension/Joomla.php
@@ -164,7 +164,7 @@ final class Joomla extends ActionLogPlugin implements SubscriberInterface
             return;
         }
 
-        list($option, $contentType) = explode('.', $params->type_alias);
+        [$option, $contentType] = explode('.', $params->type_alias);
 
         if (!$this->checkLoggable($option)) {
             return;
@@ -272,7 +272,7 @@ final class Joomla extends ActionLogPlugin implements SubscriberInterface
             return;
         }
 
-        list(, $contentType) = explode('.', $params->type_alias);
+        [, $contentType] = explode('.', $params->type_alias);
 
         switch ($value) {
             case 0:
@@ -544,7 +544,7 @@ final class Joomla extends ActionLogPlugin implements SubscriberInterface
             return;
         }
 
-        list(, $contentType) = explode('.', $params->type_alias);
+        [, $contentType] = explode('.', $params->type_alias);
 
         if ($isNew) {
             $messageLanguageKey = $params->text_prefix . '_' . $params->type_title . '_ADDED';

--- a/plugins/api-authentication/token/src/Extension/Token.php
+++ b/plugins/api-authentication/token/src/Extension/Token.php
@@ -163,7 +163,7 @@ final class Token extends CMSPlugin implements SubscriberInterface
             return;
         }
 
-        list($algo, $userId, $tokenHMAC) = $parts;
+        [$algo, $userId, $tokenHMAC] = $parts;
 
         /**
          * Verify the HMAC algorithm requested in the token string is allowed

--- a/plugins/system/debug/src/JavascriptRenderer.php
+++ b/plugins/system/debug/src/JavascriptRenderer.php
@@ -55,7 +55,7 @@ class JavascriptRenderer extends DebugBarJavascriptRenderer
      */
     public function renderHead()
     {
-        list($cssFiles, $jsFiles, $inlineCss, $inlineJs, $inlineHead) = $this->getAssets(null, self::RELATIVE_URL);
+        [$cssFiles, $jsFiles, $inlineCss, $inlineJs, $inlineHead] = $this->getAssets(null, self::RELATIVE_URL);
         $html                                                         = '';
         $doc                                                          = Factory::getApplication()->getDocument();
 

--- a/plugins/system/debug/src/JavascriptRenderer.php
+++ b/plugins/system/debug/src/JavascriptRenderer.php
@@ -56,8 +56,8 @@ class JavascriptRenderer extends DebugBarJavascriptRenderer
     public function renderHead()
     {
         [$cssFiles, $jsFiles, $inlineCss, $inlineJs, $inlineHead] = $this->getAssets(null, self::RELATIVE_URL);
-        $html                                                         = '';
-        $doc                                                          = Factory::getApplication()->getDocument();
+        $html                                                     = '';
+        $doc                                                      = Factory::getApplication()->getDocument();
 
         foreach ($cssFiles as $file) {
             $html .= \sprintf('<link rel="stylesheet" type="text/css" href="%s">' . "\n", $file);

--- a/plugins/user/contactcreator/src/Extension/ContactCreator.php
+++ b/plugins/user/contactcreator/src/Extension/ContactCreator.php
@@ -108,7 +108,7 @@ final class ContactCreator extends CMSPlugin implements SubscriberInterface
 
             // Check if the contact already exists to generate new name & alias if required
             if ($contact->id == 0) {
-                list($name, $alias) = $this->generateAliasAndName($contact->alias, $contact->name, $categoryId);
+                [$name, $alias] = $this->generateAliasAndName($contact->alias, $contact->name, $categoryId);
 
                 $contact->name  = $name;
                 $contact->alias = $alias;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses [ListToArrayDestructRector](https://getrector.com/rule-detail/list-to-array-destruct-rector) rector rule to change code form using list function to user more modern array destruct syntax in our modules and plugins code. This is done automatically by rector, no manual change included.

### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner code using modern syntax

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed