### PR TITLE
[5.3] Use null coalescing assignment operator for modules and plugins

### DIFF
--- a/administrator/modules/mod_menu/src/Menu/CssMenu.php
+++ b/administrator/modules/mod_menu/src/Menu/CssMenu.php
@@ -284,8 +284,8 @@ class CssMenu
                 continue;
             }
 
-            $item->scope = $item->scope ?? 'default';
-            $item->icon  = $item->icon ?? '';
+            $item->scope ??= 'default';
+            $item->icon  ??= '';
 
             // Whether this scope can be displayed. Applies only to preset items. Db driven items should use un/published state.
             if (($item->scope === 'help' && $this->params->get('showhelp', 1) == 0) || ($item->scope === 'edit' && !$this->params->get('shownew', 1))) {

--- a/plugins/editors/tinymce/src/PluginTraits/XTDButtons.php
+++ b/plugins/editors/tinymce/src/PluginTraits/XTDButtons.php
@@ -74,7 +74,7 @@ trait XTDButtons
             if ($link && $link[0] !== '#') {
                 $link           = str_contains($link, '&amp;') ? htmlspecialchars_decode($link) : $link;
                 $link           = Uri::base(true) . '/' . $link;
-                $options['src'] = $options['src'] ?? $link;
+                $options['src'] ??= $link;
             }
 
             // Set action to "modal" for legacy buttons, when possible
@@ -85,9 +85,9 @@ trait XTDButtons
                 $wa->useScript('joomla.dialog');
                 $legacyModal = false;
 
-                $options['popupType']  = $options['popupType'] ?? 'iframe';
-                $options['textHeader'] = $options['textHeader'] ?? $title;
-                $options['iconHeader'] = $options['iconHeader'] ?? 'icon-' . $icon;
+                $options['popupType']  ??= 'iframe';
+                $options['textHeader'] ??= $title;
+                $options['iconHeader'] ??= 'icon-' . $icon;
             }
 
             $coreButton            = [];

--- a/plugins/system/debug/src/DataCollector/ProfileCollector.php
+++ b/plugins/system/debug/src/DataCollector/ProfileCollector.php
@@ -263,7 +263,7 @@ class ProfileCollector extends AbstractDataCollector
      */
     public function collect(): array
     {
-        $this->requestEndTime = $this->requestEndTime ?? microtime(true);
+        $this->requestEndTime ??= microtime(true);
 
         $start = $this->requestStartTime;
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses [NullCoalescingOperatorRector](https://getrector.com/rule-detail/null-coalescing-operator-rector) rector rule to improve our modules and plugins code using `??=` operator. This is done automatically by rector, no manual change included.

### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner, easier to read code

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
