### PR TITLE
[5.3] Change list() to array destruct for libraries code

### DIFF
--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -133,7 +133,7 @@ class SetConfigurationCommand extends AbstractCommand
                 return false;
             }
 
-            list($option, $value) = explode('=', $option);
+            [$option, $value] = explode('=', $option);
 
             $collected[$option] = $value;
         }

--- a/libraries/src/Dispatcher/ComponentDispatcher.php
+++ b/libraries/src/Dispatcher/ComponentDispatcher.php
@@ -120,7 +120,7 @@ class ComponentDispatcher extends Dispatcher
         // Check for a controller.task command.
         if (str_contains($command, '.')) {
             // Explode the controller.task command.
-            list($controller, $task) = explode('.', $command);
+            [$controller, $task] = explode('.', $command);
 
             $this->input->set('controller', $controller);
             $this->input->set('task', $task);

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -848,7 +848,7 @@ class Browser
      */
     public function isViewable($mimetype)
     {
-        $mimetype             = strtolower($mimetype);
+        $mimetype         = strtolower($mimetype);
         [$type, $subtype] = explode('/', $mimetype);
 
         if (!empty($this->accept)) {

--- a/libraries/src/Environment/Browser.php
+++ b/libraries/src/Environment/Browser.php
@@ -562,7 +562,7 @@ class Browser
                 $this->setBrowser('edge');
 
                 if (str_contains($version[1], '.')) {
-                    list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+                    [$this->majorVersion, $this->minorVersion] = explode('.', $version[1]);
                 } else {
                     $this->majorVersion = $version[1];
                     $this->minorVersion = 0;
@@ -574,11 +574,11 @@ class Browser
                  */
                 $this->setBrowser('edg');
 
-                list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+                [$this->majorVersion, $this->minorVersion] = explode('.', $version[1]);
             } elseif (preg_match('|Opera[\/ ]([0-9.]+)|', $this->agent, $version)) {
                 $this->setBrowser('opera');
 
-                list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+                [$this->majorVersion, $this->minorVersion] = explode('.', $version[1]);
 
                 /*
                  * Due to changes in Opera UA, we need to check Version/xx.yy,
@@ -591,7 +591,7 @@ class Browser
                 // Opera 15+
                 $this->setBrowser('opera');
 
-                list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+                [$this->majorVersion, $this->minorVersion] = explode('.', $version[1]);
             } elseif (
                 preg_match('/Chrome[\/ ]([0-9.]+)/i', $this->agent, $version)
                 || preg_match('/CrMo[\/ ]([0-9.]+)/i', $this->agent, $version)
@@ -599,7 +599,7 @@ class Browser
             ) {
                 $this->setBrowser('chrome');
 
-                list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+                [$this->majorVersion, $this->minorVersion] = explode('.', $version[1]);
             } elseif (
                 str_contains($this->lowerAgent, 'elaine/')
                 || str_contains($this->lowerAgent, 'palmsource')
@@ -620,7 +620,7 @@ class Browser
                 }
 
                 if (str_contains($version[1], '.')) {
-                    list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+                    [$this->majorVersion, $this->minorVersion] = explode('.', $version[1]);
                 } else {
                     $this->majorVersion = $version[1];
                     $this->minorVersion = 0;
@@ -653,7 +653,7 @@ class Browser
             } elseif (preg_match('|Firefox\/([0-9.]+)|', $this->agent, $version)) {
                 $this->setBrowser('firefox');
 
-                list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+                [$this->majorVersion, $this->minorVersion] = explode('.', $version[1]);
             } elseif (preg_match('|Lynx\/([0-9]+)|', $this->agent, $version)) {
                 $this->setBrowser('lynx');
             } elseif (preg_match('|Links \(([0-9]+)|', $this->agent, $version)) {
@@ -683,7 +683,7 @@ class Browser
             } elseif (preg_match('|Mozilla\/([0-9.]+)|', $this->agent, $version)) {
                 $this->setBrowser('mozilla');
 
-                list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+                [$this->majorVersion, $this->minorVersion] = explode('.', $version[1]);
             }
         }
     }
@@ -733,7 +733,7 @@ class Browser
     protected function identifyBrowserVersion()
     {
         if (preg_match('|Version[/ ]([0-9.]+)|', $this->agent, $version)) {
-            list($this->majorVersion, $this->minorVersion) = explode('.', $version[1]);
+            [$this->majorVersion, $this->minorVersion] = explode('.', $version[1]);
 
             return;
         }
@@ -849,7 +849,7 @@ class Browser
     public function isViewable($mimetype)
     {
         $mimetype             = strtolower($mimetype);
-        list($type, $subtype) = explode('/', $mimetype);
+        [$type, $subtype] = explode('/', $mimetype);
 
         if (!empty($this->accept)) {
             $wildcard_match = false;

--- a/libraries/src/Extension/ExtensionManagerTrait.php
+++ b/libraries/src/Extension/ExtensionManagerTrait.php
@@ -156,7 +156,7 @@ trait ExtensionManagerTrait
                     $container->set($type, new Module(new ModuleDispatcherFactory(''), new HelperFactory('')));
                     break;
                 case PluginInterface::class:
-                    list($pluginName, $pluginType) = explode(':', $extensionName);
+                    [$pluginName, $pluginType] = explode(':', $extensionName);
                     $container->set($type, $this->loadPluginFromFilesystem($pluginName, $pluginType));
             }
         }

--- a/libraries/src/Form/Field/TimezoneField.php
+++ b/libraries/src/Form/Field/TimezoneField.php
@@ -133,7 +133,7 @@ class TimezoneField extends GroupedlistField
             }
 
             // Get the group/locale from the timezone.
-            list($group, $locale) = explode('/', $zone, 2);
+            [$group, $locale] = explode('/', $zone, 2);
 
             // Only use known groups.
             if (\in_array($group, self::$zones)) {

--- a/libraries/src/Form/FormHelper.php
+++ b/libraries/src/Form/FormHelper.php
@@ -214,7 +214,7 @@ class FormHelper
 
             if (strpos($name, '.')) {
                 [$subPrefix, $name] = explode('.', $name);
-                $subPrefix              = ucfirst($subPrefix) . '\\';
+                $subPrefix          = ucfirst($subPrefix) . '\\';
             }
 
             // Compile the classname

--- a/libraries/src/Form/FormHelper.php
+++ b/libraries/src/Form/FormHelper.php
@@ -213,7 +213,7 @@ class FormHelper
             $subPrefix = '';
 
             if (strpos($name, '.')) {
-                list($subPrefix, $name) = explode('.', $name);
+                [$subPrefix, $name] = explode('.', $name);
                 $subPrefix              = ucfirst($subPrefix) . '\\';
             }
 
@@ -229,7 +229,7 @@ class FormHelper
         $prefix = 'J';
 
         if (strpos($type, '.')) {
-            list($prefix, $type) = explode('.', $type);
+            [$prefix, $type] = explode('.', $type);
         }
 
         $class = StringHelper::ucfirst($prefix, '_') . 'Form' . StringHelper::ucfirst($entity, '_') . StringHelper::ucfirst($type, '_');

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -761,8 +761,8 @@ abstract class HTMLHelper
                 }
 
                 // Set the attribute
-                [$key, $value] = explode('=', $attribute);
-                $attributes[$key]  = trim($value, '"');
+                [$key, $value]    = explode('=', $attribute);
+                $attributes[$key] = trim($value, '"');
             }
 
             // Add the attributes from the string to the original attributes

--- a/libraries/src/HTML/HTMLHelper.php
+++ b/libraries/src/HTML/HTMLHelper.php
@@ -124,7 +124,7 @@ abstract class HTMLHelper
      */
     final public static function _(string $key, ...$methodArgs)
     {
-        list($key, $prefix, $file, $func) = static::extract($key);
+        [$key, $prefix, $file, $func] = static::extract($key);
 
         if (\array_key_exists($key, static::$registry)) {
             $function = static::$registry[$key];
@@ -215,7 +215,7 @@ abstract class HTMLHelper
             E_USER_DEPRECATED
         );
 
-        list($key) = static::extract($key);
+        [$key] = static::extract($key);
 
         static::$registry[$key] = $function;
 
@@ -240,7 +240,7 @@ abstract class HTMLHelper
             E_USER_DEPRECATED
         );
 
-        list($key) = static::extract($key);
+        [$key] = static::extract($key);
 
         if (isset(static::$registry[$key])) {
             unset(static::$registry[$key]);
@@ -262,7 +262,7 @@ abstract class HTMLHelper
      */
     public static function isRegistered($key)
     {
-        list($key) = static::extract($key);
+        [$key] = static::extract($key);
 
         return isset(static::$registry[$key]);
     }
@@ -480,12 +480,12 @@ abstract class HTMLHelper
                         // If the file contains any /: it can be in a media extension subfolder
                         if (strpos($file, '/')) {
                             // Divide the file extracting the extension as the first part before /
-                            list($extension, $file) = explode('/', $file, 2);
+                            [$extension, $file] = explode('/', $file, 2);
 
                             // If the file yet contains any /: it can be a plugin
                             if (strpos($file, '/')) {
                                 // Divide the file extracting the element as the first part before /
-                                list($element, $file) = explode('/', $file, 2);
+                                [$element, $file] = explode('/', $file, 2);
 
                                 // Try to deal with plugins group in the media folder
                                 $found = static::addFileToBuffer(JPATH_PUBLIC . "/media/$extension/$element/$folder/$file", $ext, $debugMode);
@@ -761,7 +761,7 @@ abstract class HTMLHelper
                 }
 
                 // Set the attribute
-                list($key, $value) = explode('=', $attribute);
+                [$key, $value] = explode('=', $attribute);
                 $attributes[$key]  = trim($value, '"');
             }
 
@@ -1038,7 +1038,7 @@ abstract class HTMLHelper
         if ($content !== '' || $title !== '') {
             // Split title into title and content if the title contains '::' (old Mootools format).
             if ($content === '' && !(!str_contains($title, '::'))) {
-                list($title, $content) = explode('::', $title, 2);
+                [$title, $content] = explode('::', $title, 2);
             }
 
             // Pass texts through Text if required.

--- a/libraries/src/HTML/Helpers/Number.php
+++ b/libraries/src/HTML/Helpers/Number.php
@@ -55,7 +55,7 @@ abstract class Number
             $oBytes = $bytes;
         } else {
             preg_match('/(.*?)\s?((?:[KMGTPEZY]i?)?B?)$/i', trim($bytes), $matches);
-            list(, $oBytes, $oUnit) = $matches;
+            [, $oBytes, $oUnit] = $matches;
 
             if ($oUnit && is_numeric($oBytes)) {
                 $oBase  = $iec && !str_contains($oUnit, 'i') ? 1000 : 1024;

--- a/libraries/src/Input/Cli.php
+++ b/libraries/src/Input/Cli.php
@@ -113,7 +113,7 @@ class Cli extends Input
     public function unserialize($input)
     {
         // Unserialize the executable, args, options, data, and inputs.
-        list($this->executable, $this->args, $this->options, $this->data, $this->inputs) = unserialize($input);
+        [$this->executable, $this->args, $this->options, $this->data, $this->inputs] = unserialize($input);
 
         // Load the filter.
         if (isset($this->options['filter'])) {

--- a/libraries/src/Input/Input.php
+++ b/libraries/src/Input/Input.php
@@ -210,7 +210,7 @@ class Input extends \Joomla\Input\Input
     public function unserialize($input)
     {
         // Unserialize the options, data, and inputs.
-        list($this->options, $this->data, $this->inputs) = unserialize($input);
+        [$this->options, $this->data, $this->inputs] = unserialize($input);
 
         // Load the filter.
         if (isset($this->options['filter'])) {

--- a/libraries/src/MVC/Controller/BaseController.php
+++ b/libraries/src/MVC/Controller/BaseController.php
@@ -302,7 +302,7 @@ class BaseController implements ControllerInterface, DispatcherAwareInterface, L
         // Check for a controller.task command.
         if (str_contains($command, '.')) {
             // Explode the controller.task command.
-            list($type, $task) = explode('.', $command);
+            [$type, $task] = explode('.', $command);
 
             // Define the controller filename and path.
             $file       = self::createFileName('controller', ['name' => $type, 'format' => $format]);

--- a/libraries/src/Table/Content.php
+++ b/libraries/src/Table/Content.php
@@ -156,7 +156,7 @@ class Content extends Table implements VersionableTableInterface, TaggableTableI
                 $this->introtext = $array['articletext'];
                 $this->fulltext  = '';
             } else {
-                list($this->introtext, $this->fulltext) = preg_split($pattern, $array['articletext'], 2);
+                [$this->introtext, $this->fulltext] = preg_split($pattern, $array['articletext'], 2);
             }
         }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR uses [ListToArrayDestructRector](https://getrector.com/rule-detail/list-to-array-destruct-rector) rector rule to change code form using list function to user more modern array destruct syntax in our libraries code. This is done automatically by rector, no manual change included.

### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner code using modern syntax

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed