### PR TITLE
[5.3] Improve api app code using rector rules

### DIFF
--- a/api/components/com_media/src/Controller/MediaController.php
+++ b/api/components/com_media/src/Controller/MediaController.php
@@ -212,7 +212,7 @@ class MediaController extends ApiController
         }
 
         // Content is only required when it is a file
-        if (empty($content) && strpos($path, '.') !== false) {
+        if (empty($content) && str_contains($path, '.')) {
             $missingParameters[] = 'content';
         }
 

--- a/api/components/com_media/src/Model/AdapterModel.php
+++ b/api/components/com_media/src/Model/AdapterModel.php
@@ -35,7 +35,7 @@ class AdapterModel extends BaseModel
      */
     public function getItem(): \stdClass
     {
-        list($provider, $account) = array_pad(explode('-', $this->getState('id'), 2), 2, null);
+        [$provider, $account] = array_pad(explode('-', $this->getState('id'), 2), 2, null);
 
         if ($account === null) {
             throw new \Exception('Account was not set');

--- a/api/components/com_media/src/Model/MediaModel.php
+++ b/api/components/com_media/src/Model/MediaModel.php
@@ -77,7 +77,7 @@ class MediaModel extends BaseModel implements ListModelInterface
         ['adapter' => $adapterName, 'path' => $path] = $this->resolveAdapterAndPath($this->getState('path', ''));
         try {
             $files = $this->mediaApiModel->getFiles($adapterName, $path, $options);
-        } catch (FileNotFoundException $e) {
+        } catch (FileNotFoundException) {
             throw new ResourceNotFound(
                 Text::sprintf('WEBSERVICE_COM_MEDIA_FILE_NOT_FOUND', $path),
                 404

--- a/api/components/com_media/src/Model/MediumModel.php
+++ b/api/components/com_media/src/Model/MediumModel.php
@@ -69,7 +69,7 @@ class MediumModel extends BaseModel
 
         try {
             return $this->mediaApiModel->getFile($adapterName, $path, $options);
-        } catch (FileNotFoundException $e) {
+        } catch (FileNotFoundException) {
             throw new ResourceNotFound(
                 Text::sprintf('WEBSERVICE_COM_MEDIA_FILE_NOT_FOUND', $path),
                 404
@@ -121,7 +121,7 @@ class MediumModel extends BaseModel
                     $this->mediaApiModel->move($adapterName, $oldPath, $path, $override),
                     '/'
                 );
-            } catch (FileNotFoundException $e) {
+            } catch (FileNotFoundException) {
                 throw new Save(
                     Text::sprintf(
                         'WEBSERVICE_COM_MEDIA_FILE_NOT_FOUND',
@@ -159,7 +159,7 @@ class MediumModel extends BaseModel
                     );
 
                 $resultPath = $dirname . '/' . $name;
-            } catch (FileNotFoundException $e) {
+            } catch (FileNotFoundException) {
                 throw new Save(
                     Text::sprintf(
                         'WEBSERVICE_COM_MEDIA_FILE_NOT_FOUND',
@@ -167,7 +167,7 @@ class MediumModel extends BaseModel
                     ),
                     404
                 );
-            } catch (FileExistsException $e) {
+            } catch (FileExistsException) {
                 throw new Save(
                     Text::sprintf(
                         'WEBSERVICE_COM_MEDIA_FILE_EXISTS',
@@ -175,7 +175,7 @@ class MediumModel extends BaseModel
                     ),
                     400
                 );
-            } catch (InvalidPathException $e) {
+            } catch (InvalidPathException) {
                 throw new Save(
                     Text::sprintf(
                         'WEBSERVICE_COM_MEDIA_BAD_FILE_TYPE',
@@ -201,7 +201,7 @@ class MediumModel extends BaseModel
                     $dirname,
                     $content
                 );
-            } catch (FileNotFoundException $e) {
+            } catch (FileNotFoundException) {
                 throw new Save(
                     Text::sprintf(
                         'WEBSERVICE_COM_MEDIA_FILE_NOT_FOUND',
@@ -209,7 +209,7 @@ class MediumModel extends BaseModel
                     ),
                     404
                 );
-            } catch (InvalidPathException $e) {
+            } catch (InvalidPathException) {
                 throw new Save(
                     Text::sprintf(
                         'WEBSERVICE_COM_MEDIA_BAD_FILE_TYPE',
@@ -250,7 +250,7 @@ class MediumModel extends BaseModel
 
         try {
             $this->mediaApiModel->delete($adapterName, $path);
-        } catch (FileNotFoundException $e) {
+        } catch (FileNotFoundException) {
             throw new Save(
                 Text::sprintf('WEBSERVICE_COM_MEDIA_FILE_NOT_FOUND', $path),
                 404


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The api does not contain much code, so I run several rector rules at once (same as the rules I use for components and libraries code) to improve code of our api application. All the changes here are done by rector, no manual change needed.

Turned out, only 3 rules applied:

- [ListToArrayDestructRector](https://getrector.com/rule-detail/list-to-array-destruct-rector)
- [StrContainsRector](https://getrector.com/rule-detail/str-contains-rector)
- [RemoveUnusedVariableInCatchRector](https://getrector.com/rule-detail/remove-unused-variable-in-catch-rector)

### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner code


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed