### PR TITLE
[5.2] Fix set frontediting option from CLI after installation

### DIFF
--- a/installation/src/Model/ConfigurationModel.php
+++ b/installation/src/Model/ConfigurationModel.php
@@ -371,6 +371,7 @@ class ConfigurationModel extends BaseInstallationModel
         $registry->set('captcha', '0');
         $registry->set('list_limit', 20);
         $registry->set('access', 1);
+        $registry->set('frontediting', 1);
 
         // Debug settings.
         $registry->set('debug', false);


### PR DESCRIPTION
Pull Request for Issue #44934 .

### Summary of Changes
The property `frontediting` doesn't exist in the initial `configuration.php` file, and config:set refuses to add it.


### Testing Instructions
Install Joomla 5.2.4.
Run `php cli/joomla.php config:set frontediting=0`.
Apply patch.
Delete `configuration.php`.
Install Joomla 5.2.4.
Run `php cli/joomla.php config:set frontediting=0`.


### Actual result BEFORE applying this Pull Request
> [ERROR] Can't find option *frontediting* in configuration list


### Expected result AFTER applying this Pull Request
> [OK] Configuration set

