### PR TITLE
[5.2] Avoid warning when deleting media file

### DIFF
--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -543,7 +543,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
     {
         $context = $event->getContext();
 
-        if ($context === 'com_media.file') {
+        if (empty($event->getItem()->id)) {
             return;
         }
 

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -542,7 +542,12 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
     public function onContentAfterDelete(Model\AfterDeleteEvent $event)
     {
         $context = $event->getContext();
-        $itemId  = $event->getItem()->id;
+
+        if ($context === 'com_media.file') {
+            return;
+        }
+
+        $itemId = $event->getItem()->id;
 
         $this->deleteSchemaOrg($itemId, $context);
     }

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -547,9 +547,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
             return;
         }
 
-        $itemId = $event->getItem()->id;
-
-        $this->deleteSchemaOrg($itemId, $context);
+        $this->deleteSchemaOrg($event->getItem()->id, $context);
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
avoid warning when deleting media file


### Testing Instructions

set error reporting to max
delete a media file
check php_errors

### Actual result BEFORE applying this Pull Request
`PHP Warning:  Undefined property: Joomla\CMS\Object\CMSObject::$id in plugins\system\schemaorg\src\Extension\Schemaorg.php on line 545`


### Expected result AFTER applying this Pull Request
no more warning


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
