### PR TITLE
[5.3] Simplify code using PHPCS Fixer no_unneeded_control_parentheses rule

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -91,6 +91,8 @@ $config
             'native_function_invocation'                       => ['include' => ['@compiler_optimized']],
             // Adds null to type declarations when parameter have a default null value
             'nullable_type_declaration_for_default_null_value' => true,
+            // Removes unneeded parentheses around control statements
+            'no_unneeded_control_parentheses'                  => true,
         ]
     )
     ->setFinder($finder);

--- a/administrator/components/com_associations/src/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/src/Helper/AssociationsHelper.php
@@ -593,7 +593,7 @@ class AssociationsHelper extends ContentHelper
 
         $userId = Factory::getUser()->id;
 
-        return ($item->{$checkedOutFieldName} == $userId || $item->{$checkedOutFieldName} == 0);
+        return $item->{$checkedOutFieldName} == $userId || $item->{$checkedOutFieldName} == 0;
     }
 
     /**

--- a/administrator/components/com_categories/src/Controller/CategoryController.php
+++ b/administrator/components/com_categories/src/Controller/CategoryController.php
@@ -76,7 +76,7 @@ class CategoryController extends FormController
     {
         $user = $this->app->getIdentity();
 
-        return ($user->authorise('core.create', $this->extension) || \count($user->getAuthorisedCategories($this->extension, 'core.create')));
+        return $user->authorise('core.create', $this->extension) || \count($user->getAuthorisedCategories($this->extension, 'core.create'));
     }
 
     /**

--- a/administrator/components/com_contact/src/Extension/ContactComponent.php
+++ b/administrator/components/com_contact/src/Extension/ContactComponent.php
@@ -142,7 +142,7 @@ class ContactComponent extends MVCComponent implements
      */
     protected function getTableNameForSection(?string $section = null)
     {
-        return ($section === 'category' ? 'categories' : 'contact_details');
+        return $section === 'category' ? 'categories' : 'contact_details';
     }
 
     /**

--- a/administrator/components/com_installer/src/Controller/ManageController.php
+++ b/administrator/components/com_installer/src/Controller/ManageController.php
@@ -173,7 +173,7 @@ class ManageController extends BaseController
 
         $output = $model->loadChangelog($eid, $source);
 
-        echo (new JsonResponse($output));
+        echo new JsonResponse($output);
     }
 
     /**

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -701,7 +701,7 @@ class TemplateModel extends FormModel
             ->bind(':name', $name);
         $db->setQuery($query);
 
-        return ($db->loadResult() == 0);
+        return $db->loadResult() == 0;
     }
 
     /**

--- a/administrator/components/com_users/src/Controller/GroupController.php
+++ b/administrator/components/com_users/src/Controller/GroupController.php
@@ -44,7 +44,7 @@ class GroupController extends FormController
      */
     protected function allowSave($data, $key = 'id')
     {
-        return ($this->app->getIdentity()->authorise('core.admin', $this->option) && parent::allowSave($data, $key));
+        return $this->app->getIdentity()->authorise('core.admin', $this->option) && parent::allowSave($data, $key);
     }
 
     /**

--- a/administrator/components/com_users/src/Controller/LevelController.php
+++ b/administrator/components/com_users/src/Controller/LevelController.php
@@ -47,7 +47,7 @@ class LevelController extends FormController
      */
     protected function allowSave($data, $key = 'id')
     {
-        return ($this->app->getIdentity()->authorise('core.admin', $this->option) && parent::allowSave($data, $key));
+        return $this->app->getIdentity()->authorise('core.admin', $this->option) && parent::allowSave($data, $key);
     }
 
     /**

--- a/components/com_contact/src/Controller/ContactController.php
+++ b/components/com_contact/src/Controller/ContactController.php
@@ -364,7 +364,7 @@ class ContactController extends FormController implements UserFactoryAwareInterf
 
             // Fallback on edit.own.
             if ($user->authorise('core.edit.own', $this->option . '.category.' . $categoryId)) {
-                return ($record->created_by === $user->id);
+                return $record->created_by === $user->id;
             }
 
             return false;

--- a/components/com_content/helpers/icon.php
+++ b/components/com_content/helpers/icon.php
@@ -125,6 +125,6 @@ abstract class JHtmlIcon
      */
     private static function getIcon()
     {
-        return (new \Joomla\Component\Content\Administrator\Service\HTML\Icon(Joomla\CMS\Factory::getApplication()));
+        return new \Joomla\Component\Content\Administrator\Service\HTML\Icon(Joomla\CMS\Factory::getApplication());
     }
 }

--- a/components/com_finder/src/Model/SearchModel.php
+++ b/components/com_finder/src/Model/SearchModel.php
@@ -543,7 +543,7 @@ class SearchModel extends ListModel
                 $this->setState('list.ordering', 'l.sale_price');
                 break;
 
-            case ($order === 'relevance' && !empty($this->includedTerms)):
+            case $order === 'relevance' && !empty($this->includedTerms):
                 $this->setState('list.ordering', 'm.weight');
                 break;
 

--- a/components/com_finder/src/View/Search/HtmlView.php
+++ b/components/com_finder/src/View/Search/HtmlView.php
@@ -299,7 +299,7 @@ class HtmlView extends BaseHtmlView implements SiteRouterAwareInterface
         $filetofind = $this->_createFileName('template', ['name' => $file]);
         $exists     = Path::find($this->_path['template'], $filetofind);
 
-        return ($exists ? $layout : 'result');
+        return $exists ? $layout : 'result';
     }
 
     /**

--- a/libraries/src/Client/FtpClient.php
+++ b/libraries/src/Client/FtpClient.php
@@ -344,7 +344,7 @@ class FtpClient
      */
     public function isConnected()
     {
-        return ($this->_conn);
+        return $this->_conn;
     }
 
     /**

--- a/libraries/src/Console/SetConfigurationCommand.php
+++ b/libraries/src/Console/SetConfigurationCommand.php
@@ -205,7 +205,7 @@ class SetConfigurationCommand extends AbstractCommand
      */
     public function getInitialConfigurationOptions(): Registry
     {
-        return (new Registry(new \JConfig()));
+        return new Registry(new \JConfig());
     }
 
 

--- a/libraries/src/Helper/UserGroupsHelper.php
+++ b/libraries/src/Helper/UserGroupsHelper.php
@@ -171,7 +171,7 @@ final class UserGroupsHelper
      */
     public function has($id)
     {
-        return (\array_key_exists($id, $this->groups) && $this->groups[$id] !== false);
+        return \array_key_exists($id, $this->groups) && $this->groups[$id] !== false;
     }
 
     /**

--- a/libraries/src/Image/Image.php
+++ b/libraries/src/Image/Image.php
@@ -225,10 +225,10 @@ class Image
     private static function getOrientationString(int $width, int $height): string
     {
         switch (true) {
-            case ($width > $height):
+            case $width > $height:
                 return self::ORIENTATION_LANDSCAPE;
 
-            case ($width < $height):
+            case $width < $height:
                 return self::ORIENTATION_PORTRAIT;
 
             default:


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR improves code quality of our code base by running PHPCS Fixer for [no_unneeded_control_parentheses](https://cs.symfony.com/doc/rules/control_structure/no_unneeded_control_parentheses.html) rule.


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner code


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
