### PR TITLE
[5.3] Combine multiple unset call into one call

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -91,6 +91,8 @@ $config
             'native_function_invocation'                       => ['include' => ['@compiler_optimized']],
             // Adds null to type declarations when parameter have a default null value
             'nullable_type_declaration_for_default_null_value' => true,
+            // Calling unset on multiple items should be done in one call
+            'combine_consecutive_unsets'                       => true,
         ]
     )
     ->setFinder($finder);

--- a/administrator/components/com_associations/src/View/Associations/HtmlView.php
+++ b/administrator/components/com_associations/src/View/Associations/HtmlView.php
@@ -174,8 +174,8 @@ class HtmlView extends BaseHtmlView
 
                 // Dynamic filter form.
                 // This selectors doesn't have to activate the filter bar.
-                unset($this->activeFilters['itemtype']);
-                unset($this->activeFilters['language']);
+                unset($this->activeFilters['itemtype'], $this->activeFilters['language']);
+
 
                 // Remove filters options depending on selected type.
                 if (empty($support['state'])) {

--- a/administrator/components/com_associations/src/View/Associations/HtmlView.php
+++ b/administrator/components/com_associations/src/View/Associations/HtmlView.php
@@ -176,7 +176,6 @@ class HtmlView extends BaseHtmlView
                 // This selectors doesn't have to activate the filter bar.
                 unset($this->activeFilters['itemtype'], $this->activeFilters['language']);
 
-
                 // Remove filters options depending on selected type.
                 if (empty($support['state'])) {
                     unset($this->activeFilters['state']);

--- a/administrator/components/com_config/src/Model/ComponentModel.php
+++ b/administrator/components/com_config/src/Model/ComponentModel.php
@@ -201,8 +201,8 @@ class ComponentModel extends FormModel
             }
 
             // We don't need this anymore
-            unset($data['option']);
-            unset($data['params']['rules']);
+            unset($data['option'], $data['params']['rules']);
+
         }
 
         // Load the previous Data

--- a/administrator/components/com_config/src/Model/ComponentModel.php
+++ b/administrator/components/com_config/src/Model/ComponentModel.php
@@ -202,7 +202,6 @@ class ComponentModel extends FormModel
 
             // We don't need this anymore
             unset($data['option'], $data['params']['rules']);
-
         }
 
         // Load the previous Data

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1417,8 +1417,6 @@ ENDDATA;
             // Remove unused fields so they do not cause javascript errors during pre-update check
             unset($decode->description, $decode->copyright, $decode->creationDate);
 
-
-
             $this->translateExtensionName($extension);
             $extension->version
                 = $decode->version ?? Text::_('COM_JOOMLAUPDATE_PREUPDATE_UNKNOWN_EXTENSION_MANIFESTCACHE_VERSION');
@@ -1477,8 +1475,6 @@ ENDDATA;
 
             // Remove unused fields so they do not cause javascript errors during pre-update check
             unset($decode->description, $decode->copyright, $decode->creationDate);
-
-
 
             $this->translateExtensionName($plugin);
             $plugin->version = $decode->version ?? Text::_('COM_JOOMLAUPDATE_PREUPDATE_UNKNOWN_EXTENSION_MANIFESTCACHE_VERSION');

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -1415,9 +1415,9 @@ ENDDATA;
             $decode = json_decode($extension->manifest_cache);
 
             // Remove unused fields so they do not cause javascript errors during pre-update check
-            unset($decode->description);
-            unset($decode->copyright);
-            unset($decode->creationDate);
+            unset($decode->description, $decode->copyright, $decode->creationDate);
+
+
 
             $this->translateExtensionName($extension);
             $extension->version
@@ -1476,9 +1476,9 @@ ENDDATA;
             $decode = json_decode($plugin->manifest_cache);
 
             // Remove unused fields so they do not cause javascript errors during pre-update check
-            unset($decode->description);
-            unset($decode->copyright);
-            unset($decode->creationDate);
+            unset($decode->description, $decode->copyright, $decode->creationDate);
+
+
 
             $this->translateExtensionName($plugin);
             $plugin->version = $decode->version ?? Text::_('COM_JOOMLAUPDATE_PREUPDATE_UNKNOWN_EXTENSION_MANIFESTCACHE_VERSION');

--- a/administrator/components/com_menus/src/Model/MenutypesModel.php
+++ b/administrator/components/com_menus/src/Model/MenutypesModel.php
@@ -537,8 +537,8 @@ class MenutypesModel extends BaseDatabaseModel
 
                             // If the view is hidden from the menu, discard it and move on to the next view.
                             if (!empty($menu['hidden']) && $menu['hidden'] == 'true') {
-                                unset($xml);
-                                unset($o);
+                                unset($xml, $o);
+
                                 continue;
                             }
 

--- a/administrator/components/com_menus/src/Model/MenutypesModel.php
+++ b/administrator/components/com_menus/src/Model/MenutypesModel.php
@@ -538,7 +538,6 @@ class MenutypesModel extends BaseDatabaseModel
                             // If the view is hidden from the menu, discard it and move on to the next view.
                             if (!empty($menu['hidden']) && $menu['hidden'] == 'true') {
                                 unset($xml, $o);
-
                                 continue;
                             }
 

--- a/administrator/components/com_modules/src/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Modules/HtmlView.php
@@ -157,7 +157,6 @@ class HtmlView extends BaseHtmlView
             // If in the frontend state and language should not activate the search tools.
             if (Factory::getApplication()->isClient('site')) {
                 unset($this->activeFilters['state'], $this->activeFilters['language']);
-
             }
         }
 

--- a/administrator/components/com_modules/src/View/Modules/HtmlView.php
+++ b/administrator/components/com_modules/src/View/Modules/HtmlView.php
@@ -156,8 +156,8 @@ class HtmlView extends BaseHtmlView
 
             // If in the frontend state and language should not activate the search tools.
             if (Factory::getApplication()->isClient('site')) {
-                unset($this->activeFilters['state']);
-                unset($this->activeFilters['language']);
+                unset($this->activeFilters['state'], $this->activeFilters['language']);
+
             }
         }
 

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -2002,9 +2002,10 @@ class TemplateModel extends FormModel
         }
 
         $user = $this->getCurrentUser();
-        unset($xml->languages, $xml->media, $xml->files, $xml->parent, $xml->inheritable, $xml->update, $xml->updateservers);
 
         // Remove the update parts
+        unset($xml->languages, $xml->media, $xml->files, $xml->parent, $xml->inheritable, $xml->update, $xml->updateservers);
+
         if (isset($xml->creationDate)) {
             $xml->creationDate = (new Date('now'))->format('F Y');
         } else {

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -2002,15 +2002,15 @@ class TemplateModel extends FormModel
         }
 
         $user = $this->getCurrentUser();
-        unset($xml->languages);
-        unset($xml->media);
-        unset($xml->files);
-        unset($xml->parent);
-        unset($xml->inheritable);
+        unset($xml->languages, $xml->media, $xml->files, $xml->parent, $xml->inheritable, $xml->update, $xml->updateservers);
+
+
+
+
 
         // Remove the update parts
-        unset($xml->update);
-        unset($xml->updateservers);
+
+
 
         if (isset($xml->creationDate)) {
             $xml->creationDate = (new Date('now'))->format('F Y');

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -2004,7 +2004,15 @@ class TemplateModel extends FormModel
         $user = $this->getCurrentUser();
 
         // Remove the update parts
-        unset($xml->languages, $xml->media, $xml->files, $xml->parent, $xml->inheritable, $xml->update, $xml->updateservers);
+        unset(
+            $xml->languages,
+            $xml->media,
+            $xml->files,
+            $xml->parent,
+            $xml->inheritable,
+            $xml->update,
+            $xml->updateservers
+        );
 
         if (isset($xml->creationDate)) {
             $xml->creationDate = (new Date('now'))->format('F Y');

--- a/administrator/components/com_templates/src/Model/TemplateModel.php
+++ b/administrator/components/com_templates/src/Model/TemplateModel.php
@@ -2004,14 +2004,7 @@ class TemplateModel extends FormModel
         $user = $this->getCurrentUser();
         unset($xml->languages, $xml->media, $xml->files, $xml->parent, $xml->inheritable, $xml->update, $xml->updateservers);
 
-
-
-
-
         // Remove the update parts
-
-
-
         if (isset($xml->creationDate)) {
             $xml->creationDate = (new Date('now'))->format('F Y');
         } else {

--- a/api/components/com_languages/src/View/Overrides/JsonapiView.php
+++ b/api/components/com_languages/src/View/Overrides/JsonapiView.php
@@ -99,7 +99,6 @@ class JsonapiView extends BaseApiView
         $item->value = $item->override;
         unset($item->key, $item->override);
 
-
         return parent::prepareItem($item);
     }
 }

--- a/api/components/com_languages/src/View/Overrides/JsonapiView.php
+++ b/api/components/com_languages/src/View/Overrides/JsonapiView.php
@@ -97,8 +97,8 @@ class JsonapiView extends BaseApiView
     {
         $item->id    = $item->key;
         $item->value = $item->override;
-        unset($item->key);
-        unset($item->override);
+        unset($item->key, $item->override);
+
 
         return parent::prepareItem($item);
     }

--- a/libraries/src/Changelog/Changelog.php
+++ b/libraries/src/Changelog/Changelog.php
@@ -288,8 +288,8 @@ class Changelog
                         $this->$key = $val;
                     }
 
-                    unset($this->latest);
-                    unset($this->currentChangelog);
+                    unset($this->latest, $this->currentChangelog);
+
                 } elseif (isset($this->currentChangelog)) {
                     // The update might be for an older version of j!
                     unset($this->currentChangelog);

--- a/libraries/src/Changelog/Changelog.php
+++ b/libraries/src/Changelog/Changelog.php
@@ -289,7 +289,6 @@ class Changelog
                     }
 
                     unset($this->latest, $this->currentChangelog);
-
                 } elseif (isset($this->currentChangelog)) {
                     // The update might be for an older version of j!
                     unset($this->currentChangelog);

--- a/libraries/src/Input/Cli.php
+++ b/libraries/src/Input/Cli.php
@@ -91,8 +91,8 @@ class Cli extends Input
 
         // Remove $_ENV and $_SERVER from the inputs.
         $inputs = $this->inputs;
-        unset($inputs['env']);
-        unset($inputs['server']);
+        unset($inputs['env'], $inputs['server']);
+
 
         // Serialize the executable, args, options, data, and inputs.
         return serialize([$this->executable, $this->args, $this->options, $this->data, $inputs]);

--- a/libraries/src/Input/Cli.php
+++ b/libraries/src/Input/Cli.php
@@ -93,7 +93,6 @@ class Cli extends Input
         $inputs = $this->inputs;
         unset($inputs['env'], $inputs['server']);
 
-
         // Serialize the executable, args, options, data, and inputs.
         return serialize([$this->executable, $this->args, $this->options, $this->data, $inputs]);
     }

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -307,8 +307,8 @@ class AdminController extends BaseController
         // Remove zero PKs and corresponding order values resulting from input filter for PK
         foreach ($pks as $i => $pk) {
             if ($pk === 0) {
-                unset($pks[$i]);
-                unset($order[$i]);
+                unset($pks[$i], $order[$i]);
+
             }
         }
 
@@ -402,8 +402,8 @@ class AdminController extends BaseController
         // Remove zero PKs and corresponding order values resulting from input filter for PK
         foreach ($pks as $i => $pk) {
             if ($pk === 0) {
-                unset($pks[$i]);
-                unset($order[$i]);
+                unset($pks[$i], $order[$i]);
+
             }
         }
 

--- a/libraries/src/MVC/Controller/AdminController.php
+++ b/libraries/src/MVC/Controller/AdminController.php
@@ -308,7 +308,6 @@ class AdminController extends BaseController
         foreach ($pks as $i => $pk) {
             if ($pk === 0) {
                 unset($pks[$i], $order[$i]);
-
             }
         }
 
@@ -403,7 +402,6 @@ class AdminController extends BaseController
         foreach ($pks as $i => $pk) {
             if ($pk === 0) {
                 unset($pks[$i], $order[$i]);
-
             }
         }
 

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -488,7 +488,6 @@ class Update
                     }
 
                     unset($this->latest, $this->currentUpdate);
-
                 } elseif (isset($this->currentUpdate)) {
                     // The update might be for an older version of j!
                     unset($this->currentUpdate);

--- a/libraries/src/Updater/Update.php
+++ b/libraries/src/Updater/Update.php
@@ -487,8 +487,8 @@ class Update
                         $this->$key = $val;
                     }
 
-                    unset($this->latest);
-                    unset($this->currentUpdate);
+                    unset($this->latest, $this->currentUpdate);
+
                 } elseif (isset($this->currentUpdate)) {
                     // The update might be for an older version of j!
                     unset($this->currentUpdate);

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -658,7 +658,12 @@ class User
             }
 
             // Prevent updating internal fields
-            unset($array['registerDate'], $array['lastvisitDate'], $array['lastResetTime'], $array['resetCount']);
+            unset(
+                $array['registerDate'],
+                $array['lastvisitDate'],
+                $array['lastResetTime'],
+                $array['resetCount']
+            );
         }
 
         if (\array_key_exists('params', $array)) {

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -659,9 +659,6 @@ class User
 
             // Prevent updating internal fields
             unset($array['registerDate'], $array['lastvisitDate'], $array['lastResetTime'], $array['resetCount']);
-
-
-
         }
 
         if (\array_key_exists('params', $array)) {

--- a/libraries/src/User/User.php
+++ b/libraries/src/User/User.php
@@ -658,10 +658,10 @@ class User
             }
 
             // Prevent updating internal fields
-            unset($array['registerDate']);
-            unset($array['lastvisitDate']);
-            unset($array['lastResetTime']);
-            unset($array['resetCount']);
+            unset($array['registerDate'], $array['lastvisitDate'], $array['lastResetTime'], $array['resetCount']);
+
+
+
         }
 
         if (\array_key_exists('params', $array)) {

--- a/plugins/system/languagefilter/src/Extension/LanguageFilter.php
+++ b/plugins/system/languagefilter/src/Extension/LanguageFilter.php
@@ -160,8 +160,8 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
 
             foreach ($this->sefs as $sef => $language) {
                 if (!\array_key_exists($language->lang_code, LanguageHelper::getInstalledLanguages(0))) {
-                    unset($this->lang_codes[$language->lang_code]);
-                    unset($this->sefs[$language->sef]);
+                    unset($this->lang_codes[$language->lang_code], $this->sefs[$language->sef]);
+
                 }
             }
         }

--- a/plugins/system/languagefilter/src/Extension/LanguageFilter.php
+++ b/plugins/system/languagefilter/src/Extension/LanguageFilter.php
@@ -161,7 +161,6 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
             foreach ($this->sefs as $sef => $language) {
                 if (!\array_key_exists($language->lang_code, LanguageHelper::getInstalledLanguages(0))) {
                     unset($this->lang_codes[$language->lang_code], $this->sefs[$language->sef]);
-
                 }
             }
         }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR improves code quality of our code base by running PHPCS Fixer for [combine_consecutive_unsets](https://cs.symfony.com/doc/rules/language_construct/combine_consecutive_unsets.html) rule.


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works, with cleaner code


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
