### PR TITLE
[5.2.4] com_contact : Send Copy to Submitter does not work anymore

### DIFF
--- a/components/com_contact/forms/contact.xml
+++ b/components/com_contact/forms/contact.xml
@@ -58,7 +58,6 @@
 			type="checkbox"
 			label="COM_CONTACT_CONTACT_EMAIL_A_COPY_LABEL"
 			id="contact-email-copy"
-			default="0"
 		/>
 	</fieldset>
 


### PR DESCRIPTION
Pull Request for Issue #44987 .

### Summary of Changes

Delete default="0" for ontact_email_copy checkbox.
This is related to #37174

### Testing Instructions
Joomla 5.2.4
In administrator, enable Send Copy to Submitter parameter in Contacts component parameters (tab form).
"Send a copy to yourself" checkbox appears in your contact form.

Fill up all required field in your contact form and  check "Send a copy to yourself" checkbox. 

### Actual result BEFORE applying this Pull Request
Email is sent to the contact but the user doesn't receive anything.

### Expected result AFTER applying this Pull Request

Email is sent to the contact and a copy of this email is sent to the user.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
