### PR TITLE
[5.3] Avoid warning when deleting media file/folder

### DIFF
--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -541,7 +541,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
      */
     public function onContentAfterDelete(Model\AfterDeleteEvent $event)
     {
-        if (empty($event->getItem()->id)){
+        if (empty($event->getItem()->id)) {
             return;
         }
 

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -541,10 +541,11 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
      */
     public function onContentAfterDelete(Model\AfterDeleteEvent $event)
     {
-        $context = $event->getContext();
-        $itemId  = $event->getItem()->id;
+        if (empty($event->getItem()->id)){
+            return;
+        }
 
-        $this->deleteSchemaOrg($itemId, $context);
+        $this->deleteSchemaOrg($event->getItem()->id, $event->getContext());
     }
 
     /**

--- a/plugins/system/schemaorg/src/Extension/Schemaorg.php
+++ b/plugins/system/schemaorg/src/Extension/Schemaorg.php
@@ -541,7 +541,7 @@ final class Schemaorg extends CMSPlugin implements SubscriberInterface
      */
     public function onContentAfterDelete(Model\AfterDeleteEvent $event)
     {
-        if (empty($event->getItem()->id)) {
+        if (!$this->isSupported($event->getContext())) {
             return;
         }
 


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
avoid warning when deleting media file/folder


### Testing Instructions

set error reporting to max
delete a media file/folder
check php_errors

### Actual result BEFORE applying this Pull Request
`PHP Warning:  Undefined property: Joomla\CMS\Object\CMSObject::$id in plugins\system\schemaorg\src\Extension\Schemaorg.php on line 545`


### Expected result AFTER applying this Pull Request
no more warning


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
