### PR TITLE
Add border last element media breadcrumbs

### DIFF
--- a/build/media_source/com_media/scss/components/_media-breadcrumb.scss
+++ b/build/media_source/com_media/scss/components/_media-breadcrumb.scss
@@ -34,9 +34,8 @@
     a {
       color: var(--body-color);
     }
-    &::before,
     &::after {
-      border: none;
+      border-inline-start-color: $breadcrumbs-current-bg;
     }
   }
   &:hover {
@@ -62,7 +61,7 @@
     border-inline-start: 10px solid transparent;
   }
   &::before {
-    border-inline-start-color: $border-color;
+    border-inline-start-color: var(--gray-400);
   }
   &::after {
     border-inline-start-color: $breadcrumbs-bg;


### PR DESCRIPTION
Pull Request for Issue disscused in PR https://github.com/joomla/joomla-cms/pull/44212#issuecomment-2630590521

### Summary of Changes
Added the "border" to the last element in the breadcrumbs again. Changed the color to make it better visible in light mode.


### Testing Instructions
See PR #44212 


### Actual result BEFORE applying this Pull Request
No border / arrow on last element
![grafik](https://github.com/user-attachments/assets/1aeb603c-ee2a-4dea-ace8-9eeba9bfa1bc)

![grafik](https://github.com/user-attachments/assets/c3d9a593-4639-41e7-9cea-c6e9850b9ce8)


### Expected result AFTER applying this Pull Request
Border / arrow on last element

![grafik](https://github.com/user-attachments/assets/9fbe6b9b-2bad-4a35-9b4b-55c685e21388)

![grafik](https://github.com/user-attachments/assets/0104fcbf-c32c-4b42-ae2b-6358426e49ab)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x ] No documentation changes for manual.joomla.org needed
