### PR TITLE
[5.2] Disable compat plugin for system tests

### DIFF
--- a/tests/System/integration/install/Installation.cy.js
+++ b/tests/System/integration/install/Installation.cy.js
@@ -19,6 +19,9 @@ describe('Install Joomla', () => {
     cy.task('deleteRelativePath', 'configuration.php');
     cy.installJoomla(config);
 
+    // Disable compat plugin
+    cy.db_enableExtension(0, 'plg_behaviour_compat');
+
     cy.doAdministratorLogin(config.username, config.password, false);
     cy.cancelTour();
     cy.disableStatistics();


### PR DESCRIPTION
### Summary of Changes

Disables compat plugin before execute system tests
Clean/New joomla installation should work without compat plugin

### Testing Instructions

- drone ci
- check if compat plugin is disabled

### Actual result BEFORE applying this Pull Request

compat plugin is enabled during system tests

### Expected result AFTER applying this Pull Request

compat plugin is disabled during system tests (and afterwards)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
