### PR TITLE
[5.3] better use str_starts_with

### DIFF
--- a/administrator/components/com_associations/src/Helper/AssociationsHelper.php
+++ b/administrator/components/com_associations/src/Helper/AssociationsHelper.php
@@ -193,7 +193,7 @@ class AssociationsHelper extends ContentHelper
      */
     private static function getExtensionRealName($extensionName)
     {
-        return !str_contains($extensionName, 'com_') ? $extensionName : substr($extensionName, 4);
+        return !str_starts_with($extensionName, 'com_') ? $extensionName : substr($extensionName, 4);
     }
 
     /**

--- a/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
+++ b/administrator/components/com_cpanel/src/View/Cpanel/HtmlView.php
@@ -69,7 +69,7 @@ class HtmlView extends BaseHtmlView
             $parts     = explode('.', $dashboard);
             $component = $parts[0];
 
-            if (!str_contains($component, 'com_')) {
+            if (!str_starts_with($component, 'com_')) {
                 $component = 'com_' . $component;
             }
 

--- a/administrator/components/com_postinstall/src/Helper/PostinstallHelper.php
+++ b/administrator/components/com_postinstall/src/Helper/PostinstallHelper.php
@@ -32,9 +32,9 @@ class PostinstallHelper
      */
     public function parsePath($path)
     {
-        if (str_contains($path, 'site://')) {
+        if (str_starts_with($path, 'site://')) {
             $path = JPATH_ROOT . str_replace('site://', '/', $path);
-        } elseif (str_contains($path, 'admin://')) {
+        } elseif (str_starts_with($path, 'admin://')) {
             $path = JPATH_ADMINISTRATOR . str_replace('admin://', '/', $path);
         }
 

--- a/modules/mod_wrapper/src/Helper/WrapperHelper.php
+++ b/modules/mod_wrapper/src/Helper/WrapperHelper.php
@@ -52,7 +52,7 @@ class WrapperHelper
             if (str_starts_with($url, '/')) {
                 // Relative URL in component. use server http_host.
                 $url = 'http://' . $app->getInput()->server->get('HTTP_HOST') . $url;
-            } elseif (!str_contains($url, 'http') && !str_contains($url, 'https')) {
+            } elseif (!str_starts_with($url, 'http://') && !str_starts_with($url, 'https://')) {
                 $url = 'http://' . $url;
             }
         }

--- a/plugins/system/languagefilter/src/Extension/LanguageFilter.php
+++ b/plugins/system/languagefilter/src/Extension/LanguageFilter.php
@@ -514,7 +514,7 @@ final class LanguageFilter extends CMSPlugin implements SubscriberInterface
             $language_new = $this->languageFactory->createLanguage($lang_code, (bool) $app->get('debug_lang'));
 
             foreach ($language->getPaths() as $extension => $files) {
-                if (str_contains($extension, 'plg_system')) {
+                if (str_starts_with($extension, 'plg_system')) {
                     $extension_name = substr($extension, 11);
 
                     $language_new->load($extension, JPATH_ADMINISTRATOR)


### PR DESCRIPTION
Follow-Pull Request for #44875 and #44938
@joomdonation

### Summary of Changes

Better use `str_starts_with` if a `substr` command (or concatenate string) comes after it

### Testing Instructions

code review?

### Actual result BEFORE applying this Pull Request

?

### Expected result AFTER applying this Pull Request

better checked string before perform action

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
