### PR TITLE
[5.3][ cypress] null coalescing operator

### DIFF
--- a/components/com_users/src/Model/ResetModel.php
+++ b/components/com_users/src/Model/ResetModel.php
@@ -527,7 +527,7 @@ class ResetModel extends FormModel implements UserFactoryAwareInterface
         $resetHours = (int) $params->get('reset_time');
         $result     = true;
 
-        $lastResetTime       = strtotime($user->lastResetTime) ?: 0;
+        $lastResetTime       = strtotime($user->lastResetTime ?? '') ?: 0;
         $hoursSinceLastReset = (strtotime(Factory::getDate()->toSql()) - $lastResetTime) / 3600;
 
         if ($hoursSinceLastReset > $resetHours) {

--- a/components/com_users/src/Model/ResetModel.php
+++ b/components/com_users/src/Model/ResetModel.php
@@ -527,7 +527,7 @@ class ResetModel extends FormModel implements UserFactoryAwareInterface
         $resetHours = (int) $params->get('reset_time');
         $result     = true;
 
-        $lastResetTime       = strtotime($user->lastResetTime ?? '') ?: 0;
+        $lastResetTime       = $user->lastResetTime === null ? 0 : strtotime($user->lastResetTime);
         $hoursSinceLastReset = (strtotime(Factory::getDate()->toSql()) - $lastResetTime) / 3600;
 
         if ($hoursSinceLastReset > $resetHours) {


### PR DESCRIPTION
Pull Request for Issue #45006 .

### Summary of Changes
null coalescing operator



### Testing Instructions
run `npx cypress run --spec '.\tests\System\integration\site\components\com_users\Reset.cy.js'`

check php_errors.log


### Actual result BEFORE applying this Pull Request
`PHP Deprecated:  strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated in ..\components\com_users\src\Model\ResetModel.php on line 530: Passing null to parameter #1 ($datetime) of type string is deprecated in ..\components\com_users\src\Model\ResetModel.php on line 530`


### Expected result AFTER applying this Pull Request

no more `PHP Deprecated:  strtotime():`

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
