### PR TITLE
[5.3] Remove redundant entry in the npm tools

### DIFF
--- a/build/build-modules-js/init/minify-vendor.mjs
+++ b/build/build-modules-js/init/minify-vendor.mjs
@@ -9,7 +9,6 @@ const RootPath = process.cwd();
 const folders = [
   'media/vendor/accessibility/js',
   'media/vendor/chosen/js',
-  'media/vendor/codemirror',
   'media/vendor/debugbar',
   'media/vendor/diff/js',
   'media/vendor/es-module-shims/js',


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

- In J5 codemirror was upgraded to v6 with it's own build script but there's an entry in the minification of the vendors pointing to the vendor/codemirror folder. This is redundant 

### Testing Instructions

- Code review, the build, minification of any codemirror asset is happening on it's own script: https://github.com/joomla/joomla-cms/blob/5.2-dev/build/build-modules-js/javascript/build-codemirror.es6.js

### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed


@Fedik 