### PR TITLE
[5.x][docu] Minor fix sudo

### DIFF
--- a/tests/System/README.md
+++ b/tests/System/README.md
@@ -290,7 +290,7 @@ sudo npm run cypress:run
 
 If the `root` user does not have a Cypress installation, you can use the Cypress installation cache of the current user:
 ```
-CYPRESS_CACHE_FOLDER=$HOME/.cache/Cypress sudo npm run cypress:run
+sudo CYPRESS_CACHE_FOLDER=$HOME/.cache/Cypress npm run cypress:run
 ```
 
 


### PR DESCRIPTION
### Summary of Changes

`tests/System/README.md` docu change only.

The `CYPRESS_CACHE_FOLDER` environment variable must be set within the `sudo` command.

### Testing Instructions

The given troubleshooting tip is testable e.g. on Ubuntu Linux.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
