### PR TITLE
[5.3] Remove useless sprintf function call

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -97,6 +97,8 @@ $config
             'combine_consecutive_issets'                       => true,
             // Calling unset on multiple items should be done in one call
             'combine_consecutive_unsets'                       => true,
+            // There must be no sprintf calls with only the first argument
+            'no_useless_sprintf'                               => true,
         ]
     )
     ->setFinder($finder);

--- a/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
+++ b/administrator/components/com_actionlogs/src/Model/ActionlogModel.php
@@ -58,7 +58,7 @@ class ActionlogModel extends BaseDatabaseModel implements UserFactoryAwareInterf
         try {
             $user = $userId ? $this->getUserFactory()->loadUserById($userId) : $this->getCurrentUser();
         } catch (\UnexpectedValueException $e) {
-            @trigger_error(\sprintf('UserFactory must be set, this will not be caught anymore in 7.0.'), E_USER_DEPRECATED);
+            @trigger_error('UserFactory must be set, this will not be caught anymore in 7.0.', E_USER_DEPRECATED);
             $user = Factory::getUser($userId);
         }
 

--- a/administrator/components/com_fields/src/Model/FieldModel.php
+++ b/administrator/components/com_fields/src/Model/FieldModel.php
@@ -330,7 +330,7 @@ class FieldModel extends AdminModel
             try {
                 $rule->setDatabase($this->getDatabase());
             } catch (DatabaseNotFoundException) {
-                @trigger_error(\sprintf('Database must be set, this will not be caught anymore in 5.0.'), E_USER_DEPRECATED);
+                @trigger_error('Database must be set, this will not be caught anymore in 5.0.', E_USER_DEPRECATED);
                 $rule->setDatabase(Factory::getContainer()->get(DatabaseInterface::class));
             }
         }

--- a/administrator/components/com_finder/src/Indexer/Indexer.php
+++ b/administrator/components/com_finder/src/Indexer/Indexer.php
@@ -122,7 +122,7 @@ class Indexer
     public function __construct(?DatabaseInterface $db = null)
     {
         if ($db === null) {
-            @trigger_error(\sprintf('Database will be mandatory in 5.0.'), E_USER_DEPRECATED);
+            @trigger_error('Database will be mandatory in 5.0.', E_USER_DEPRECATED);
             $db = Factory::getContainer()->get(DatabaseInterface::class);
         }
 

--- a/administrator/components/com_finder/src/Indexer/Query.php
+++ b/administrator/components/com_finder/src/Indexer/Query.php
@@ -208,7 +208,7 @@ class Query
     public function __construct($options, ?DatabaseInterface $db = null)
     {
         if ($db === null) {
-            @trigger_error(\sprintf('Database will be mandatory in 5.0.'), E_USER_DEPRECATED);
+            @trigger_error('Database will be mandatory in 5.0.', E_USER_DEPRECATED);
             $db = Factory::getContainer()->get(DatabaseInterface::class);
         }
 

--- a/libraries/src/Categories/Categories.php
+++ b/libraries/src/Categories/Categories.php
@@ -237,7 +237,7 @@ class Categories implements CategoryInterface, DatabaseAwareInterface
         try {
             $db = $this->getDatabase();
         } catch (DatabaseNotFoundException) {
-            @trigger_error(\sprintf('Database must be set, this will not be caught anymore in 5.0.'), E_USER_DEPRECATED);
+            @trigger_error('Database must be set, this will not be caught anymore in 5.0.', E_USER_DEPRECATED);
             $db = Factory::getContainer()->get(DatabaseInterface::class);
         }
 

--- a/libraries/src/Form/Form.php
+++ b/libraries/src/Form/Form.php
@@ -1466,7 +1466,7 @@ class Form implements CurrentUserInterface
             try {
                 $field->setDatabase($this->getDatabase());
             } catch (DatabaseNotFoundException) {
-                @trigger_error(\sprintf('Database must be set, this will not be caught anymore in 5.0.'), E_USER_DEPRECATED);
+                @trigger_error('Database must be set, this will not be caught anymore in 5.0.', E_USER_DEPRECATED);
                 $field->setDatabase(Factory::getContainer()->get(DatabaseInterface::class));
             }
         }

--- a/libraries/src/Form/FormField.php
+++ b/libraries/src/Form/FormField.php
@@ -1218,7 +1218,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
                 try {
                     $rule->setDatabase($this->getDatabase());
                 } catch (DatabaseNotFoundException) {
-                    @trigger_error(\sprintf('Database must be set, this will not be caught anymore in 5.0.'), E_USER_DEPRECATED);
+                    @trigger_error('Database must be set, this will not be caught anymore in 5.0.', E_USER_DEPRECATED);
                     $rule->setDatabase(Factory::getContainer()->get(DatabaseInterface::class));
                 }
             }
@@ -1243,7 +1243,7 @@ abstract class FormField implements DatabaseAwareInterface, CurrentUserInterface
                 try {
                     $rule->setDatabase($this->getDatabase());
                 } catch (DatabaseNotFoundException) {
-                    @trigger_error(\sprintf('Database must be set, this will not be caught anymore in 5.0.'), E_USER_DEPRECATED);
+                    @trigger_error('Database must be set, this will not be caught anymore in 5.0.', E_USER_DEPRECATED);
                     $rule->setDatabase(Factory::getContainer()->get(DatabaseInterface::class));
                 }
             }

--- a/libraries/src/MVC/Factory/MVCFactory.php
+++ b/libraries/src/MVC/Factory/MVCFactory.php
@@ -171,7 +171,7 @@ class MVCFactory implements MVCFactoryInterface, FormFactoryAwareInterface, Site
             try {
                 $model->setDatabase($this->getDatabase());
             } catch (DatabaseNotFoundException) {
-                @trigger_error(\sprintf('Database must be set, this will not be caught anymore in 5.0.'), E_USER_DEPRECATED);
+                @trigger_error('Database must be set, this will not be caught anymore in 5.0.', E_USER_DEPRECATED);
                 $model->setDatabase(Factory::getContainer()->get(DatabaseInterface::class));
             }
         }
@@ -267,7 +267,7 @@ class MVCFactory implements MVCFactoryInterface, FormFactoryAwareInterface, Site
         try {
             $db = \array_key_exists('dbo', $config) ? $config['dbo'] : $this->getDatabase();
         } catch (DatabaseNotFoundException) {
-            @trigger_error(\sprintf('Database must be set, this will not be caught anymore in 5.0.'), E_USER_DEPRECATED);
+            @trigger_error('Database must be set, this will not be caught anymore in 5.0.', E_USER_DEPRECATED);
             $db = Factory::getContainer()->get(DatabaseInterface::class);
         }
 

--- a/libraries/src/MVC/Model/BaseDatabaseModel.php
+++ b/libraries/src/MVC/Model/BaseDatabaseModel.php
@@ -105,7 +105,7 @@ abstract class BaseDatabaseModel extends BaseModel implements
         $db = \array_key_exists('dbo', $config) ? $config['dbo'] : Factory::getDbo();
 
         if ($db) {
-            @trigger_error(\sprintf('Database is not available in constructor in 6.0.'), E_USER_DEPRECATED);
+            @trigger_error('Database is not available in constructor in 6.0.', E_USER_DEPRECATED);
             $this->setDatabase($db);
 
             // Is needed, when models use the deprecated MVC DatabaseAwareTrait, as the trait is overriding the local functions

--- a/libraries/src/Menu/SiteMenu.php
+++ b/libraries/src/Menu/SiteMenu.php
@@ -72,7 +72,7 @@ class SiteMenu extends AbstractMenu implements CacheControllerFactoryAwareInterf
         $this->language = isset($options['language']) && $options['language'] instanceof Language ? $options['language'] : Factory::getLanguage();
 
         if (!isset($options['db']) || !($options['db'] instanceof DatabaseDriver)) {
-            @trigger_error(\sprintf('Database will be mandatory in 5.0.'), E_USER_DEPRECATED);
+            @trigger_error('Database will be mandatory in 5.0.', E_USER_DEPRECATED);
             $options['db'] = Factory::getContainer()->get(DatabaseDriver::class);
         }
 

--- a/libraries/src/Table/ContentType.php
+++ b/libraries/src/Table/ContentType.php
@@ -57,13 +57,13 @@ class ContentType extends Table
 
         // Check for valid name.
         if (trim($this->type_title) === '') {
-            throw new \UnexpectedValueException(\sprintf('The title is empty'));
+            throw new \UnexpectedValueException('The title is empty');
         }
 
         $this->type_title = ucfirst($this->type_title);
 
         if (empty($this->type_alias)) {
-            throw new \UnexpectedValueException(\sprintf('The type_alias is empty'));
+            throw new \UnexpectedValueException('The type_alias is empty');
         }
 
         return true;


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Calling sprintf function with only the first argument is useless because it will just return the passed string. This PR removes these useless function calls using PHPCS Fixer [no_useless_sprintf](https://cs.symfony.com/doc/rules/function_notation/no_useless_sprintf.html).


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
