### PR TITLE
[5.3][webservices] Undefined property: stdClass::$modified_by

### DIFF
--- a/administrator/components/com_contact/src/Model/ContactsModel.php
+++ b/administrator/components/com_contact/src/Model/ContactsModel.php
@@ -158,7 +158,7 @@ class ContactsModel extends ListModel
                         'list.select',
                         'a.id, a.name, a.alias, a.checked_out, a.checked_out_time, a.catid, a.user_id' .
                         ', a.published, a.access, a.created, a.created_by, a.ordering, a.featured, a.language' .
-                        ', a.publish_up, a.publish_down'
+                        ', a.publish_up, a.publish_down, a.modified_by'
                     )
                 )
             )

--- a/administrator/components/com_newsfeeds/src/Model/NewsfeedsModel.php
+++ b/administrator/components/com_newsfeeds/src/Model/NewsfeedsModel.php
@@ -170,6 +170,7 @@ class NewsfeedsModel extends ListModel
                     $db->quoteName('a.language'),
                     $db->quoteName('a.publish_up'),
                     $db->quoteName('a.publish_down'),
+                    $db->quoteName('a.modified_by'),
                 ]
             )
         )

--- a/api/components/com_newsfeeds/src/View/Feeds/JsonapiView.php
+++ b/api/components/com_newsfeeds/src/View/Feeds/JsonapiView.php
@@ -91,6 +91,7 @@ class JsonapiView extends BaseApiView
         'editor',
         'access_level',
         'category_title',
+        'modified_by',
     ];
 
     /**


### PR DESCRIPTION
Pull Request for Issue #44947 .

### Summary of Changes

define `$modified_by`

### Testing Instructions

Do an API  GETcall to

-  /api/index.php/v1/newsfeeds/feeds
-  /api/index.php/v1/contacts

See PHP error log.

### Actual result BEFORE applying this Pull Request

Undefined property: stdClass::$modified_by in \api\components\com_newsfeeds\src\Serializer\NewsfeedSerializer.php on line 110
Undefined property: stdClass::$modified_by in \api\components\com_newsfeeds\src\Serializer\NewsfeedSerializer.php on line 111
 Undefined property: stdClass::$modified_by in \api\components\com_contact\src\Serializer\ContactSerializer.php on line 110
Undefined property: stdClass::$modified_by in \api\components\com_contact\src\Serializer\ContactSerializer.php on line 111
### Expected result AFTER applying this Pull Request
no more



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
