### PR TITLE
[5.3][cypress] install  extension From Url

### DIFF
--- a/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
+++ b/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
@@ -1,0 +1,22 @@
+describe('Test in backend that the Installer', () => {
+  beforeEach(() => {
+    cy.doAdministratorLogin();
+    cy.visit('/administrator/index.php?option=com_installer&view=install');
+  });
+
+  it('has a title', () => {
+    cy.get('h1.page-title').should('contain.text', 'Extensions: Install');
+  });
+
+  it('can install extension from URL tab', () => {
+    cy.wait(2000); // Wait for the page to load
+    cy.get('joomla-tab-element#url').should('exist');
+    cy.get('joomla-tab-element#url').click({ force: true });
+    cy.get('button#installbutton_url').should('contain.text', 'Check & Install');
+    cy.wait(3000);
+    cy.get('input#install_url').type('https://github.com/joomla-extensions/patchtester/releases/download/4.4.0/com_patchtester_4.4.0.zip', { force: true }); // Fill in the input field
+    cy.get('button#installbutton_url').click({ force: true });
+    // Check if the installation was successful
+    cy.contains('Installation of the component was successful.');
+  });
+});

--- a/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
+++ b/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
@@ -9,11 +9,9 @@ describe('Test in backend that the Installer', () => {
   });
 
   it('can install extension from URL tab', () => {
-    cy.wait(2000); // Wait for the page to load
     cy.get('joomla-tab-element#url').should('exist');
     cy.get('joomla-tab-element#url').click({ force: true });
     cy.get('button#installbutton_url').should('contain.text', 'Check & Install');
-    cy.wait(3000);
     cy.get('input#install_url').type('https://github.com/joomla-extensions/patchtester/releases/download/4.4.0/com_patchtester_4.4.0.zip', { force: true }); // Fill in the input field
     cy.get('button#installbutton_url').click({ force: true });
     // Check if the installation was successful

--- a/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
+++ b/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
@@ -16,6 +16,7 @@ describe('Test in backend that the Installer', () => {
     cy.get('button#installbutton_url').click({ force: true });
     // Check if the installation was successful
     cy.contains('Installation of the component was successful.');
+
     // Uninstall the component
     cy.visit('/administrator/index.php?option=com_installer&view=manage');
     cy.searchForItem('Joomla! Patch Tester');

--- a/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
+++ b/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
@@ -8,7 +8,7 @@ describe('Test in backend that the Installer', () => {
     cy.get('h1.page-title').should('contain.text', 'Extensions: Install');
   });
 
-  it('can install extension from URL tab', () => {
+  it('can install a component from URL tab', () => {
     cy.get('joomla-tab-element#url').should('exist');
     cy.get('joomla-tab-element#url').click({ force: true });
     cy.get('button#installbutton_url').should('contain.text', 'Check & Install');
@@ -16,5 +16,14 @@ describe('Test in backend that the Installer', () => {
     cy.get('button#installbutton_url').click({ force: true });
     // Check if the installation was successful
     cy.contains('Installation of the component was successful.');
+    // Uninstall the component
+    cy.visit('/administrator/index.php?option=com_installer&view=manage');
+    cy.searchForItem('Joomla! Patch Tester');
+    cy.checkAllResults();
+    cy.clickToolbarButton('Action');
+    cy.contains('Uninstall').click();
+    cy.clickDialogConfirm(true);
+    // Check if the uninstallation was successful
+    cy.contains('Uninstalling the component was successful');
   });
 });

--- a/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
+++ b/tests/System/integration/administrator/components/com_installer/FromUrl.cy.js
@@ -8,7 +8,7 @@ describe('Test in backend that the Installer', () => {
     cy.get('h1.page-title').should('contain.text', 'Extensions: Install');
   });
 
-  it('can install a component from URL tab', () => {
+  it('can install and uninstall a component from URL tab', () => {
     cy.get('joomla-tab-element#url').should('exist');
     cy.get('joomla-tab-element#url').click({ force: true });
     cy.get('button#installbutton_url').should('contain.text', 'Check & Install');


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

add test for install extension from Url

### Testing Instructions
run npx cypress run --spec '.\tests\System\integration\administrator\component\com_installer\FromUrl.cy.js'


### Actual result BEFORE applying this Pull Request
n/a


### Expected result AFTER applying this Pull Request
a test


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
