### PR TITLE
[5.3][com_templates] remove php warning

### DIFF
--- a/administrator/components/com_templates/src/Model/StyleModel.php
+++ b/administrator/components/com_templates/src/Model/StyleModel.php
@@ -396,8 +396,10 @@ class StyleModel extends AdminModel
 
         // Load the core and/or local language file(s).
         // Default to using parent template language constants
-        $lang->load('tpl_' . $data->parent, $client->path)
-            || $lang->load('tpl_' . $data->parent, $client->path . '/templates/' . $data->parent);
+        if (isset($data->parent)) {
+            $lang->load('tpl_' . $data->parent, $client->path)
+                || $lang->load('tpl_' . $data->parent, $client->path . '/templates/' . $data->parent);
+        }
 
         // Apply any, optional, overrides for child template language constants
         $lang->load('tpl_' . $template, $client->path)


### PR DESCRIPTION
Pull Request for Issue #45001 and #42236 .

### Summary of Changes
remove warning


### Testing Instructions
Go to System > Administrator Template Styles.
Edit Atum - Default.
Click Save button.
See PHP error log.

or 
run 
`npx cypress run --spec '.\tests\System\integration\api\com_templates\Administrator.cy.js'`

`npx cypress run --spec '.\tests\System\integration\api\com_templates\Site.cy.js'`


### Actual result BEFORE applying this Pull Request

PHP Warning:  Attempt to read property "parent" on array in \administrator\components\com_templates\src\Model\StyleModel.php on line 399

PHP Warning:  Attempt to read property "parent" on array in \administrator\components\com_templates\src\Model\StyleModel.php on line 400

PHP Warning:  Attempt to read property "parent" on array in \administrator\components\com_templates\src\Model\StyleModel.php on line 400



### Expected result AFTER applying this Pull Request

no more warning

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
