### PR TITLE
[5.3][cypress] add param default for edit field

### DIFF
--- a/tests/System/support/commands/db.mjs
+++ b/tests/System/support/commands/db.mjs
@@ -339,7 +339,7 @@ Cypress.Commands.add('db_createField', (field) => {
     language: '*',
     created_time: '2023-01-01 20:00:00',
     modified_time: '2023-01-01 20:00:00',
-    params: '',
+    params: '{"searchindex":"0"}',
     fieldparams: '',
   };
 


### PR DESCRIPTION
Pull Request for Issue #45002 .

### Summary of Changes
add param default for edit field


### Testing Instructions

npx cypress run --spec '.\tests\System\integration\administrator\components\com_fields\Field.cy.js'

### Actual result BEFORE applying this Pull Request
PHP Warning:  Undefined array key "searchindex" in D:\repos\j51\administrator\components\com_fields\src\Model\FieldModel.php on line 126


### Expected result AFTER applying this Pull Request
no more warning


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
