### PR TITLE
[5.3] Fix wording (#44954)

### DIFF
--- a/administrator/language/en-GB/plg_extension_joomlaupdate.ini
+++ b/administrator/language/en-GB/plg_extension_joomlaupdate.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EXTENSION_JOOMLAUPDATE="Extension - Joomla! Update"
-PLG_EXTENSION_JOOMLAUPDATE_XML_DESCRIPTION="Purges the core updates after release channel changes."
+PLG_EXTENSION_JOOMLAUPDATE_XML_DESCRIPTION="Purges the core updates after update channel changes."

--- a/administrator/language/en-GB/plg_extension_joomlaupdate.sys.ini
+++ b/administrator/language/en-GB/plg_extension_joomlaupdate.sys.ini
@@ -4,4 +4,4 @@
 ; Note : All ini files need to be saved as UTF-8
 
 PLG_EXTENSION_JOOMLAUPDATE="Extension - Joomla! Update"
-PLG_EXTENSION_JOOMLAUPDATE_XML_DESCRIPTION="Purges the core updates after release channel changes."
+PLG_EXTENSION_JOOMLAUPDATE_XML_DESCRIPTION="Purges the core updates after update channel changes."


### PR DESCRIPTION
Pull Request for PR #44954 .

### Summary of Changes

It is not the release channel that is changed, but the update channel. The translation is now clearer.

![update-channel](https://github.com/user-attachments/assets/176d2f51-7c9c-4f33-a547-f62014f76fca)


### Testing Instructions

.

### Actual result BEFORE applying this Pull Request

`PLG_EXTENSION_JOOMLAUPDATE_XML_DESCRIPTION="Purges the core updates after release channel changes."`

### Expected result AFTER applying this Pull Request

`PLG_EXTENSION_JOOMLAUPDATE_XML_DESCRIPTION="Purges the core updates after update channel changes."`

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
