### PR TITLE
[5.2] Fixed view references in com_content xml

### DIFF
--- a/components/com_content/tmpl/categories/default.xml
+++ b/components/com_content/tmpl/categories/default.xml
@@ -461,7 +461,7 @@
 				class="form-select"
 				menuitems="true"
 				extension="com_content"
-				view="article"
+				view="categories"
 			/>
 
 			<field

--- a/components/com_content/tmpl/category/blog.xml
+++ b/components/com_content/tmpl/category/blog.xml
@@ -387,7 +387,7 @@
 				class="form-select"
 				menuitems="true"
 				extension="com_content"
-				view="article"
+				view="category"
 			/>
 
 			<field

--- a/components/com_content/tmpl/category/default.xml
+++ b/components/com_content/tmpl/category/default.xml
@@ -405,7 +405,7 @@
 				class="form-select"
 				menuitems="true"
 				extension="com_content"
-				view="article"
+				view="category"
 			/>
 
 			<field


### PR DESCRIPTION
Pull Request for Issue #45066 .

### Summary of Changes
Changed 

/components/com_content/tmpl/categories/default.xml
/components/com_content/tmpl/category/blog.xml
/components/com_content/tmpl/category/list.xml

to reference the correct views rather than "article" to get the according layouts to choose from in Options

### Testing Instructions
Create override for category or categories. Create an (e.g.) Category Blog menu entry; go to Options -> Choose a Layout


### Actual result BEFORE applying this Pull Request
Pulldown only shows "Default" only, although e.g. Category Blog should have blog and list by the component. Additionally overrides from the template are not shown.


### Expected result AFTER applying this Pull Request
Pulldown shows proper views from Component (e.g. blog & list for category blog) and overrides from template.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
