### PR TITLE
[53][Cypress] Don't Force SSL

### DIFF
--- a/tests/System/integration/install/Installation.cy.js
+++ b/tests/System/integration/install/Installation.cy.js
@@ -36,6 +36,5 @@ describe('Install Joomla', () => {
     cy.config_setParameter('mailer', 'smtp');
     cy.config_setParameter('smtphost', Cypress.env('smtp_host'));
     cy.config_setParameter('smtpport', Cypress.env('smtp_port'));
-    cy.config_setParameter('force_ssl', '2');
   });
 });


### PR DESCRIPTION
### Summary of Changes

With #44850 during Joomla installation the configuration parameter `force_ssl` is set to 2 (Force HTTP Entire Site). This prevents the Joomla System Tests from running on HTTP. And as the test shows it is not necessary for the Joomla System Tests. Even without explicit setting the parameter `force_ssl` the Joomla System Tests can be run over either HTTP or HTTPS.

### Testing Instructions

Run Joomla System Tests once with HTTP and once with HTTPS by web server setup and configuring `baseUrl` in `cypress.config.mjs` accordingly.

### Actual result BEFORE applying this Pull Request

* On HTTP the Joomla System Tests
  * `install/Installation.cy.js` and API tests are working
  * ❌ 94 of 134 tests are failing with network error, e.g. `administrator/components/com_banners/Banner.cy.js`
* ✅ On HTTPS the Joomla System Tests are passing successfully

### Expected result AFTER applying this Pull Request

* ✅ On HTTP the Joomla System Tests are passing successfully
* ✅ On HTTPS the Joomla System Tests are passing successfully

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
