### PR TITLE
[5.3][cypress] PHP Warning:  Undefined array key "menuordering" on patch com_menus

### DIFF
--- a/tests/System/integration/api/com_menus/AdministratorMenuItems.cy.js
+++ b/tests/System/integration/api/com_menus/AdministratorMenuItems.cy.js
@@ -45,7 +45,7 @@ describe('Test that menu items administrator API endpoint', () => {
 
   it('can update an administrator menu item', () => {
     cy.db_createMenuItem({ title: 'automated test administrator menu item', type: 'component', client_id: 1 })
-      .then((id) => cy.api_patch(`/menus/administrator/items/${id}`, { title: 'updated automated test administrator menu item', type: 'component' }))
+      .then((id) => cy.api_patch(`/menus/administrator/items/${id}`, { title: 'updated automated test administrator menu item', type: 'component', menuordering: id }))
       .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
         .its('title')
         .should('include', 'updated automated test administrator menu item'));

--- a/tests/System/integration/api/com_menus/SiteMenuItems.cy.js
+++ b/tests/System/integration/api/com_menus/SiteMenuItems.cy.js
@@ -44,7 +44,7 @@ describe('Test that menu items site API endpoint', () => {
 
   it('can update a site menu item', () => {
     cy.db_createMenuItem({ title: 'updated automated test site menu item', type: 'component' })
-      .then((id) => cy.api_patch(`/menus/site/items/${id}`, { title: 'automated test site menu item', type: 'component' }))
+      .then((id) => cy.api_patch(`/menus/site/items/${id}`, { title: 'automated test site menu item', type: 'component', menuordering: id }))
       .then((response) => cy.wrap(response).its('body').its('data').its('attributes')
         .its('title')
         .should('include', 'automated test site menu item'));


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
set menuordering in PATCH 


### Testing Instructions
`npx cypress run --spec '.\tests\System\integration\api\com_menus\SiteMenuItems.cy.js`
`npx cypress run --spec '.\tests\System\integration\api\com_menus\AdministratorMenuItems.cy.js`

### Actual result BEFORE applying this Pull Request

PHP Warning:  Undefined array key "menuordering" in ..\administrator\components\com_menus\src\Model\ItemModel.php on line 1333  etc

### Expected result AFTER applying this Pull Request
no more


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
