### PR TITLE
[5.3][cypress] PHP Warning Undefined array key "parent_id" on POST com_banners 

### DIFF
--- a/tests/System/integration/api/com_banners/Categories.cy.js
+++ b/tests/System/integration/api/com_banners/Categories.cy.js
@@ -17,7 +17,12 @@ describe('Test that banners categories API endpoint', () => {
   });
 
   it('can create a category', () => {
-    cy.api_post('/banners/categories', { title: 'automated test banner category', description: 'automated test banner category description' })
+    cy.api_post('/banners/categories', {
+      title: 'automated test banner category',
+      description: 'automated test banner category description',
+      parent_id: 1,
+      extension: 'com_banners',
+    })
       .then((response) => {
         cy.wrap(response).its('body').its('data').its('attributes')
           .its('title')


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
set parent_id


### Testing Instructions

npx cypress run --spec '.\tests\System\integration\api\com_banners\Categories.cy.js

### Actual result BEFORE applying this Pull Request

PHP Warning:  Undefined array key "parent_id" in ...\administrator\components\com_categories\src\Model\CategoryModel.php on line 531

### Expected result AFTER applying this Pull Request
no more


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
