### PR TITLE
fix(calendar): properly highlight selected day using Bootstrap variab…

### DIFF
--- a/build/media_source/system/css/fields/calendar.css
+++ b/build/media_source/system/css/fields/calendar.css
@@ -98,9 +98,9 @@ div.calendar-container table td.title { /* This holds the current "month, year" 
   background-color: var(--calendar-week-bg, #f4f4f4);
 }
 
-.calendar-container table tbody td.day.selected { /* Cell showing today date */
-  color: var(--btn-primary-color);
-  background: var(--btn-primary-bg);
+.calendar-container table tbody td.day.selected {
+  color: var(--btn-primary-color, #fff) !important;
+  background: var(--btn-primary-bg, #007db0) !important;
   border: 0;
 }
 
@@ -127,9 +127,9 @@ div.calendar-container table td.title { /* This holds the current "month, year" 
 }
 
 .calendar-container table tbody td.day:hover {
-  color: var(--btn-primary-color);
+  color: var(--btn-primary-color, #fff);
   cursor: pointer;
-  background: var(--btn-primary-bg);
+  background: var(--btn-primary-bg, #007db0);
 }
 
 .calendar-container table tbody td.day:hover:after {


### PR DESCRIPTION


Pull Request for Issue  #45082

### Summary of Changes

<li>Fixed the issue where the selected day in the calendar was not highlighted in the frontend.</li>
<li>Used Bootstrap variables instead of hardcoded colors to ensure consistency across themes.</li>
<li>Ensured that the selected date now appears correctly, matching the backend styling.</li>



### Testing Instructions
<li>Open an article and try to set a publishing date (this opens the calendar).</li>
<li>Select a date and verify that it is properly highlighted.</li>
<li>Check the styling across different browsers (Chrome, Firefox, Edge, Safari).</li>
<li>Ensure the hover effect is also applied correctly without overriding Bootstrap styles.</li>




### Actual result BEFORE applying this Pull Request
<li>The selected date in the frontend calendar was not highlighted.</li>
<li>The backend calendar displayed the highlight correctly, but the frontend did not.</li>




### Expected result AFTER applying this Pull Request
<li>The selected date is now correctly highlighted in the frontend, matching the backend styling.</li>
<li>Bootstrap variables are used for colors, ensuring better theme compatibility.</li>



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
