### PR TITLE
[5.2] Updated User Profile Display with selected options

### DIFF
--- a/components/com_users/tmpl/profile/default_params.php
+++ b/components/com_users/tmpl/profile/default_params.php
@@ -32,13 +32,11 @@ use Joomla\CMS\Language\Text;
                             <?php echo HTMLHelper::_('users.' . $field->fieldname, $field->value); ?>
                         <?php elseif (HTMLHelper::isRegistered('users.' . $field->type)) : ?>
                             <?php echo HTMLHelper::_('users.' . $field->type, $field->value); ?>
+                        <?php elseif (!empty($this->data->params) && is_array($field->options) && count($field->options) > 0) : ?>
+                            <?php $optionIndex = array_search($this->data->params[$field->fieldname], array_column($field->options, 'value')); ?>
+                            <?php echo HTMLHelper::_('users.value', ((array)$field->options[$optionIndex])['text']); ?>
                         <?php else : ?>
-                            <?php if (!empty($this->data->params) && is_array($field->options) && count($field->options) > 0) : ?>
-                                <?php $optionIndex = array_search($this->data->params[$field->fieldname], array_column($field->options, 'value')); ?>
-                                <?php echo HTMLHelper::_('users.value', ((array)$field->options[$optionIndex])['text']); ?>
-                            <?php else : ?>
-                                <?php echo HTMLHelper::_('users.value', $field->value); ?>
-                            <?php endif; ?>
+                            <?php echo HTMLHelper::_('users.value', $field->value); ?>
                         <?php endif; ?>
                     </dd>
                 <?php endif; ?>

--- a/components/com_users/tmpl/profile/default_params.php
+++ b/components/com_users/tmpl/profile/default_params.php
@@ -33,7 +33,7 @@ use Joomla\CMS\Language\Text;
                         <?php elseif (HTMLHelper::isRegistered('users.' . $field->type)) : ?>
                             <?php echo HTMLHelper::_('users.' . $field->type, $field->value); ?>
                         <?php else : ?>
-                            <?php if (is_array($field->options) && count($field->options) > 0) : ?>
+                            <?php if (!empty($this->data->params) && is_array($field->options) && count($field->options) > 0) : ?>
                                 <?php $optionIndex = array_search($this->data->params[$field->fieldname], array_column($field->options, 'value')); ?>
                                 <?php echo HTMLHelper::_('users.value', ((array)$field->options[$optionIndex])['text']); ?>
                             <?php else : ?>

--- a/components/com_users/tmpl/profile/default_params.php
+++ b/components/com_users/tmpl/profile/default_params.php
@@ -33,7 +33,12 @@ use Joomla\CMS\Language\Text;
                         <?php elseif (HTMLHelper::isRegistered('users.' . $field->type)) : ?>
                             <?php echo HTMLHelper::_('users.' . $field->type, $field->value); ?>
                         <?php else : ?>
-                            <?php echo HTMLHelper::_('users.value', $field->value); ?>
+                            <?php if (is_array($field->options) && count($field->options) > 0) : ?>
+                                <?php $optionIndex = array_search($this->data->params[$field->fieldname], array_column($field->options, 'value')); ?>
+                                <?php echo HTMLHelper::_('users.value', ((array)$field->options[$optionIndex])['text']); ?>
+                            <?php else : ?>
+                                <?php echo HTMLHelper::_('users.value', $field->value); ?>
+                            <?php endif; ?>
                         <?php endif; ?>
                     </dd>
                 <?php endif; ?>


### PR DESCRIPTION
Pull Request for Issue #45079.

### Summary of Changes

Updated the display of the frontend User Profile to show the text of the selected option rather than the database value.

### Testing Instructions

These are purely visual changes.
1. Create a frontend menu item User Profile.
2. View the menu item as a registered user in the browser.

### Actual result BEFORE applying this Pull Request

e.g. display for allowing auto starting tours `Allow Auto Starting Tours 0`

### Expected result AFTER applying this Pull Request

e.g. display for allowing auto starting tours `Allow Auto Starting Tours No`

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
