### PR TITLE
[5.3] Catch undefined cors options when saving global options

### DIFF
--- a/administrator/components/com_config/src/Model/ApplicationModel.php
+++ b/administrator/components/com_config/src/Model/ApplicationModel.php
@@ -745,10 +745,10 @@ class ApplicationModel extends FormModel implements MailerFactoryAwareInterface
         $config = new Registry($data);
 
         // Overwrite webservices cors settings
-        $app->set('cors', $data['cors']);
-        $app->set('cors_allow_origin', $data['cors_allow_origin']);
-        $app->set('cors_allow_headers', $data['cors_allow_headers']);
-        $app->set('cors_allow_methods', $data['cors_allow_methods']);
+        $app->set('cors', $data['cors'] ?? 0);
+        $app->set('cors_allow_origin', $data['cors_allow_origin'] ?? '*');
+        $app->set('cors_allow_headers', $data['cors_allow_headers'] ?? 'Content-Type,X-Joomla-Token');
+        $app->set('cors_allow_methods', $data['cors_allow_methods'] ?? '');
 
         // Clear cache of com_config component.
         $this->cleanCache('_system');


### PR DESCRIPTION
### Summary of Changes
When saving an option on cli, then are undefined property warnings thrown on error reporting maximum. This happens only when Joomla is installed through cli with the `php installation/joomla.php` command.

### Testing Instructions
Execut `cli/joomla.php config:set debug=1` on the console within the joomla root folder.

### Actual result BEFORE applying this Pull Request
The following four warnings are displayed:

```
Warning: Undefined array key "cors" in /var/www/html/Projects/cms5/administrator/components/com_config/src/Model/ApplicationModel.php on line 748

Warning: Undefined array key "cors_allow_origin" in /var/www/html/Projects/cms5/administrator/components/com_config/src/Model/ApplicationModel.php on line 749

Warning: Undefined array key "cors_allow_headers" in /var/www/html/Projects/cms5/administrator/components/com_config/src/Model/ApplicationModel.php on line 750

Warning: Undefined array key "cors_allow_methods" in /var/www/html/Projects/cms5/administrator/components/com_config/src/Model/ApplicationModel.php on line 751
```

### Expected result AFTER applying this Pull Request
No warnings.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
