### PR TITLE
[5.3][cypress]PHP Warning Undefined array key "parent_id" on POST com_contacts

### DIFF
--- a/tests/System/integration/api/com_contact/Categories.cy.js
+++ b/tests/System/integration/api/com_contact/Categories.cy.js
@@ -17,7 +17,12 @@ describe('Test that contact categories API endpoint', () => {
   });
 
   it('can create a category', () => {
-    cy.api_post('/contacts/categories', { title: 'automated test contact category', description: 'automated test contact category description' })
+    cy.api_post('/contacts/categories', {
+      title: 'automated test contact category',
+      description: 'automated test contact category description',
+      parent_id: 1,
+      extension: 'com_contacts',
+     })
       .then((response) => {
         cy.wrap(response).its('body').its('data').its('attributes')
           .its('title')

--- a/tests/System/integration/api/com_contact/Categories.cy.js
+++ b/tests/System/integration/api/com_contact/Categories.cy.js
@@ -22,7 +22,7 @@ describe('Test that contact categories API endpoint', () => {
       description: 'automated test contact category description',
       parent_id: 1,
       extension: 'com_contacts',
-     })
+    })
       .then((response) => {
         cy.wrap(response).its('body').its('data').its('attributes')
           .its('title')


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
add parent_id


### Testing Instructions
 npx cypress run --spec '.\tests\System\integration\api\com_contact\Categories.cy.js'


### Actual result BEFORE applying this Pull Request
```
[10-Mar-2025 15:25:58 UTC] PHP Warning:  Undefined array key "parent_id" in D:\repos\j51\administrator\components\com_categories\src\Model\CategoryModel.php on line 531
[10-Mar-2025 15:25:58 UTC] PHP Warning:  Undefined array key "id" in D:\repos\j51\administrator\components\com_categories\src\Model\CategoryModel.php on line 531
[10-Mar-2025 15:25:58 UTC] PHP Warning:  Undefined array key "parent_id" in D:\repos\j51\administrator\components\com_categories\src\Model\CategoryModel.php on line 532

```

### Expected result AFTER applying this Pull Request

no errors

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
