### PR TITLE
[5.3]allowTourAutoStart in user profile

### DIFF
--- a/components/com_users/forms/frontend.xml
+++ b/components/com_users/forms/frontend.xml
@@ -45,17 +45,6 @@
 				<option value="dark">COM_USERS_USER_COLORSCHEME_OPTION_DARK</option>
 			</field>
 
-			<field
-				name="allowTourAutoStart"
-				type="list"
-				label="COM_USERS_USER_ALLOWTOURAUTOSTART_LABEL"
-				default=""
-				validate="options"
-				>
-				<option value="">JOPTION_USE_DEFAULT</option>
-				<option value="0">JNO</option>
-				<option value="1">JYES</option>
-			</field>
 		</fieldset>
 	</fields>
 </form>

--- a/components/com_users/forms/frontend_admin.xml
+++ b/components/com_users/forms/frontend_admin.xml
@@ -22,6 +22,17 @@
 				>
 				<option value="">JOPTION_USE_DEFAULT</option>
 			</field>
+			<field
+				name="allowTourAutoStart"
+				type="list"
+				label="COM_USERS_USER_ALLOWTOURAUTOSTART_LABEL"
+				default=""
+				validate="options"
+				>
+				<option value="">JOPTION_USE_DEFAULT</option>
+				<option value="0">JNO</option>
+				<option value="1">JYES</option>
+			</field>
 		</fieldset>
 	</fields>
 </form>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
The param allowTourAutoStart is an admin interface only param. It makes no sense to display the field in the user profile page nor in the edit profile page.

This PR moves it to the frontend_admin.xml file with the other admin interface only params


### Testing Instructions
Create a menu item to display the user profile
Login as a registered user and check the profile
Login as a registered user and edit the profile
Login as an administrator user and check the profile
Login as an administrator user and edit the profile



### Actual result BEFORE applying this Pull Request
Registered user displays the params for Auto starting tours
Administrator user displays the params for Auto starting tours
![image](https://github.com/user-attachments/assets/a504571b-70ae-4742-91d3-2e25f0014e8c)
![image](https://github.com/user-attachments/assets/bc4ee22e-b1f9-4409-bda6-72f3f7d9cdab)


### Expected result AFTER applying this Pull Request
Registered user does not display the params for Auto starting tours
Administrator user displays the params for Auto starting tours

![image](https://github.com/user-attachments/assets/f7e2729e-8fa1-431a-9ed6-76b1c156b0fe)
![image](https://github.com/user-attachments/assets/fa2d6702-e49a-4111-bfc1-4e2aa2a5472c)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
