### PR TITLE
[5.3] System test in media manager to prevent a rename

### DIFF
--- a/tests/System/integration/administrator/components/com_media/Media.cy.js
+++ b/tests/System/integration/administrator/components/com_media/Media.cy.js
@@ -89,4 +89,22 @@ describe('Test in backend that the media manager', () => {
 
     cy.checkForSystemMessage('File or Folder not found');
   });
+
+  it('can not rename to malicious file', () => {
+    cy.visit('/administrator/index.php?option=com_media');
+    cy.wait('@getMedia');
+
+    cy.window()
+      .then((win) => win.Joomla.getOptions('csrf.token'))
+      .then((token) => cy.request({
+        method: 'put',
+        url: '/administrator/index.php?option=com_media&format=json&mediatypes=0,1,2,3&task=api.files&path=local-images%3A%2Fpowered_by.png',
+        body: { [token]: '1', newPath: 'local-images:/powered.php', move: 0 },
+        failOnStatusCode: false,
+      }))
+      .then((response) => {
+        expect(response.status).to.eq(500);
+        cy.readFile('images/powered.php').should('not.exist');
+      });
+  });
 });


### PR DESCRIPTION
### Summary of Changes
Pull request to actually check if an image can be renamed to a different one with a PHP file extension.

See https://developer.joomla.org/security-centre/961-20250301-core-malicious-file-uploads-via-media-managere-malicious-file-uploads-via-media-manager.html for more details.
