### PR TITLE
[5.3] Clean up CategoryEdit form field

### DIFF
--- a/administrator/components/com_categories/src/Field/CategoryeditField.php
+++ b/administrator/components/com_categories/src/Field/CategoryeditField.php
@@ -152,16 +152,18 @@ class CategoryeditField extends ListField
         // Let's get the id for the current item, either category or content item.
         $jinput = Factory::getApplication()->getInput();
 
-        // Load the category options for a given extension.
+        // Is this field used to select parent category for a category ?
+        $isParentCategoryField = isset($this->element['parent']) || $jinput->getCmd('option') === 'com_categories';
+
+        // The extension to load categories
+        $extension = isset($this->element['extension']) ? (string) $this->element['extension'] : (string) $jinput->getCmd('extension', 'com_content');
 
         // For categories the old category is the category id or 0 for new category.
-        if ($this->element['parent'] || $jinput->get('option') == 'com_categories') {
+        if ($isParentCategoryField) {
             $oldCat    = $jinput->get('id', 0);
             $oldParent = $this->form->getValue($name, 0);
-            $extension = $this->element['extension'] ? (string) $this->element['extension'] : (string) $jinput->get('extension', 'com_content');
         } else { // For items the old category is the category they are in when opened or 0 if new.
             $oldCat    = $this->form->getValue($name, 0);
-            $extension = $this->element['extension'] ? (string) $this->element['extension'] : (string) $jinput->get('option', 'com_content');
         }
 
         // Account for case that a submitted form has a multi-value category id field (e.g. a filtering form), just use the first category
@@ -186,7 +188,7 @@ class CategoryeditField extends ListField
             ->from($db->quoteName('#__categories', 'a'));
 
         // Filter by the extension type
-        if ($this->element['parent'] == true || $jinput->get('option') == 'com_categories') {
+        if ($isParentCategoryField) {
             $query->where('(' . $db->quoteName('a.extension') . ' = :extension OR ' . $db->quoteName('a.parent_id') . ' = 0)')
                 ->bind(':extension', $extension);
         } else {
@@ -195,7 +197,7 @@ class CategoryeditField extends ListField
         }
 
         // Filter language
-        if (!empty($this->element['language'])) {
+        if (isset($this->element['language'])) {
             if (str_contains($this->element['language'], ',')) {
                 $language = explode(',', $this->element['language']);
             } else {
@@ -219,7 +221,7 @@ class CategoryeditField extends ListField
         $query->order($db->quoteName('a.lft') . ' ASC');
 
         // If parent isn't explicitly stated but we are in com_categories assume we want parents
-        if ($oldCat != 0 && ($this->element['parent'] == true || $jinput->get('option') == 'com_categories')) {
+        if ($oldCat != 0 && $isParentCategoryField) {
             // Prevent parenting to children of this item.
             // To rearrange parents and children move the children up, not the parents down.
             $query->join(
@@ -244,10 +246,8 @@ class CategoryeditField extends ListField
         // Pad the option text with spaces using depth level as a multiplier.
         foreach ($options as $option) {
             // Translate ROOT
-            if ($this->element['parent'] == true || $jinput->get('option') == 'com_categories') {
-                if ($option->level == 0) {
-                    $option->text = Text::_('JGLOBAL_ROOT_PARENT');
-                }
+            if ($isParentCategoryField && $option->level == 0) {
+                $option->text = Text::_('JGLOBAL_ROOT_PARENT');
             }
 
             if ($option->published == 1) {
@@ -311,7 +311,7 @@ class CategoryeditField extends ListField
         }
 
         if (
-            $oldCat != 0 && ($this->element['parent'] == true || $jinput->get('option') == 'com_categories')
+            $oldCat != 0 && $isParentCategoryField
             && !isset($options[0])
             && isset($this->element['show_root'])
         ) {

--- a/administrator/components/com_categories/src/Field/CategoryeditField.php
+++ b/administrator/components/com_categories/src/Field/CategoryeditField.php
@@ -155,15 +155,16 @@ class CategoryeditField extends ListField
         // Is this field used to select parent category for a category ?
         $isParentCategoryField = isset($this->element['parent']) || $jinput->getCmd('option') === 'com_categories';
 
-        // The extension to load categories
-        $extension = isset($this->element['extension']) ? (string) $this->element['extension'] : (string) $jinput->getCmd('extension', 'com_content');
+        // Load the category options for a given extension.
 
         // For categories the old category is the category id or 0 for new category.
         if ($isParentCategoryField) {
             $oldCat    = $jinput->get('id', 0);
             $oldParent = $this->form->getValue($name, 0);
+            $extension = $this->element['extension'] ? (string) $this->element['extension'] : (string) $jinput->get('extension', 'com_content');
         } else { // For items the old category is the category they are in when opened or 0 if new.
             $oldCat    = $this->form->getValue($name, 0);
+            $extension = $this->element['extension'] ? (string) $this->element['extension'] : (string) $jinput->get('option', 'com_content');
         }
 
         // Account for case that a submitted form has a multi-value category id field (e.g. a filtering form), just use the first category


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
While doing code review for PR https://github.com/joomla/joomla-cms/pull/44885, I noticed some bad code in [CategoryeditField](https://github.com/joomla/joomla-cms/blob/5.3-dev/administrator/components/com_categories/src/Field/CategoryeditField.php) class. This PR improves code of that class, make code cleaner and easier to read:

- Introduce local variable $isParentCategoryField instead of repeating call code $this->element['parent'] || $jinput->get('option') == 'com_categories' everywhere when we need to check if this field is used to allow choosing parent categories.
- Use `isset($this->element['extension'])` to check if the extension attribute is defined for the field. It's more cleaner than just use $this->element['extension'] in the if condition check. Similar for other code which is used to check for existence of an attribute in the field.


### Testing Instructions
- Use Joomla 5.3
- Edit a category, and look at categories displayed in **Parent** field. Make sure it is the same before and after applying changes from this PR.
- Edit an article, and look at categories displayed in **Category**  field. Make sure it is the same before and after applying changes from this PR.


### Actual result BEFORE applying this Pull Request
Works

### Expected result AFTER applying this Pull Request
Works, with cleaner code, and slight faster.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
