### PR TITLE
[5.3][cypress]PHP Warning Undefined array key "parent_id" on POST com_newsfeeds

### DIFF
--- a/tests/System/integration/api/com_newsfeed/Categories.cy.js
+++ b/tests/System/integration/api/com_newsfeed/Categories.cy.js
@@ -15,7 +15,12 @@ describe('Test that newsfeed categories API endpoint', () => {
   });
 
   it('can create a category', () => {
-    cy.api_post('/newsfeeds/categories', { title: 'automated test feed category', description: 'automated test feed category description' })
+    cy.api_post('/newsfeeds/categories', {
+      title: 'automated test feed category',
+      description: 'automated test feed category description',
+      parent_id: 1,
+      extension: 'com_newsfeeds',
+    })
       .then((response) => {
         cy.wrap(response).its('body').its('data').its('attributes')
           .its('title')


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
add parent_id


### Testing Instructions

run

`npx cypress run --spec '.\tests\System\integration\api\com_newsfeeds\Categories.cy.js'`

### Actual result BEFORE applying this Pull Request

PHP Warning 

### Expected result AFTER applying this Pull Request

no more

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
