### PR TITLE
[5.3][cypress]  api test wrong route

### DIFF
--- a/tests/System/integration/api/Basic.cy.js
+++ b/tests/System/integration/api/Basic.cy.js
@@ -13,7 +13,7 @@ describe('Test that the API', () => {
 
   it('returns not found return code when wrong route is set', () => {
     cy.api_getBearerToken().then((token) => cy.request({
-      method: 'GET', url: '/api/index.php/v1/content/articles/1', headers: { Authorization: `Bearer ${token}` }, failOnStatusCode: false,
+      method: 'GET', url: '/api/index.php/v1/invalid', headers: { Authorization: `Bearer ${token}` }, failOnStatusCode: false,
     })
       .its('status').should('equal', 404));
   });


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
test a real  wrong route


### Testing Instructions
run 

`npx cypress run --spec '.\tests\System\integration\api\Basic.cy.js'`

### Actual result BEFORE applying this Pull Request

PHP Warning:  Attempt to read property "id" on false in /var/www/html/libraries/src/MVC/View/JsonApiView.php on line 218

### Expected result AFTER applying this Pull Request

no more warning

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
