### PR TITLE
Update TUF client to fix PHP 8.4 compat issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,10 @@
       "php": "8.1.0"
     },
     "vendor-dir": "libraries/vendor",
-    "github-protocols": ["https"]
+    "github-protocols": ["https"],
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   },
   "support": {
     "issues": "https://issues.joomla.org/",
@@ -108,7 +111,7 @@
     "phpseclib/bcmath_compat": "^2.0.3",
     "jfcherng/php-diff": "^6.16.2",
     "voku/portable-utf8": "dev-joomla-5.3 as 6.0.13",
-    "php-tuf/php-tuf": "^1.0.2",
+    "php-tuf/php-tuf": "^1.0.3",
     "php-debugbar/php-debugbar": "^2.1.6"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,7 @@
       "php": "8.1.0"
     },
     "vendor-dir": "libraries/vendor",
-    "github-protocols": ["https"],
-    "allow-plugins": {
-      "dealerdirect/phpcodesniffer-composer-installer": true
-    }
+    "github-protocols": ["https"]
   },
   "support": {
     "issues": "https://issues.joomla.org/",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3586da55843649b84080b5897310f06f",
+    "content-hash": "aea460a15f0d9c656441f03d58683ed5",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -3098,16 +3098,16 @@
         },
         {
             "name": "php-tuf/php-tuf",
-            "version": "1.0.2",
+            "version": "1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-backports/php-tuf.git",
-                "reference": "051750c097eaa1c3954e5f1f480f708260de5d47"
+                "reference": "1fc585dc5a090a4af94823e21470779f31030733"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-backports/php-tuf/zipball/051750c097eaa1c3954e5f1f480f708260de5d47",
-                "reference": "051750c097eaa1c3954e5f1f480f708260de5d47",
+                "url": "https://api.github.com/repos/joomla-backports/php-tuf/zipball/1fc585dc5a090a4af94823e21470779f31030733",
+                "reference": "1fc585dc5a090a4af94823e21470779f31030733",
                 "shasum": ""
             },
             "require": {
@@ -3168,7 +3168,7 @@
                 "MIT"
             ],
             "description": "PHP implementation of The Update Framework (TUF)",
-            "time": "2025-02-03T07:10:33+00:00"
+            "time": "2025-03-19T20:05:51+00:00"
         },
         {
             "name": "phpmailer/phpmailer",
@@ -10175,9 +10175,9 @@
         "ext-gd": "*",
         "ext-dom": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.1.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
### Summary of Changes
This PR updates the TUF client to 1.0.3, fixing numerous PHP 8.4 compat issues, see https://github.com/joomla-backports/php-tuf/pull/6


### Testing Instructions
Code review


### Actual result BEFORE applying this Pull Request
1.0.2 used


### Expected result AFTER applying this Pull Request
1.0.3 used


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
