### PR TITLE
[5.3] php 8.4 compatibility

### DIFF
--- a/administrator/components/com_users/src/Model/CaptiveModel.php
+++ b/administrator/components/com_users/src/Model/CaptiveModel.php
@@ -426,7 +426,7 @@ class CaptiveModel extends BaseDatabaseModel
         $maxTries   = (int) $params->get('mfatrycount', 10);
         $blockHours = (int) $params->get('mfatrytime', 1);
 
-        $lastTryTime       = strtotime($method->last_try) ?: 0;
+        $lastTryTime       = $method->last_try !== null ? strtotime($method->last_try) : 0;
         $hoursSinceLastTry = (strtotime(Factory::getDate()->toSql()) - $lastTryTime) / 3600;
 
         if ($method->last_try !== null && $hoursSinceLastTry > $blockHours) {


### PR DESCRIPTION
### Summary of Changes
PHP Deprecated:  strtotime(): Passing null to parameter #1 ($datetime) of type string is deprecated 



### Testing Instructions
Code review or use the cypress integration tests for mfa **with php 8.4**
                 `npx cypress run --spec '.\tests\System\integration\administrator\components\com_users\Mfa.cy.js'`


### Actual result BEFORE applying this Pull Request
php deprecated message in the logs


### Expected result AFTER applying this Pull Request
no deprecated message in the logs


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
