### PR TITLE
[5.3] php warning in BackupcodesModel

### DIFF
--- a/administrator/components/com_users/src/Model/BackupcodesModel.php
+++ b/administrator/components/com_users/src/Model/BackupcodesModel.php
@@ -252,7 +252,7 @@ class BackupcodesModel extends BaseDatabaseModel
          */
         $otherResult = false;
 
-        $temp1 = '';
+        $temp1 = [];
 
         for ($i = 0; $i < 10; $i++) {
             $temp1[$i] = random_int(0, 99999999);


### PR DESCRIPTION
_this is an AI generated explanation_

The warning Only the first byte will be assigned to the string offset occurs because $temp1 is being treated as a string, and assigning a value to $temp1[$i] attempts to modify a specific character (byte) of the string. However, the value being assigned (random_int(0, 99999999)) is an integer, which is incompatible with this operation.

### Root Cause:
In PHP, when you use array-like syntax (e.g., $temp1[$i]) on a variable that has not been explicitly declared as an array, PHP may treat it as a string. In this case, $temp1 is being treated as a string, and $temp1[$i] is interpreted as modifying a specific character of the string. Since random_int(0, 99999999) generates an integer, PHP raises a warning because you cannot assign an integer to a specific byte of a string.

### Fix:
To resolve this issue, you need to explicitly declare $temp1 as an array before using it. This ensures that $temp1[$i] is treated as an array element rather than a string offset.

### Explanation of the Fix:
Explicit Declaration:

$temp1 = []; ensures that $temp1 is treated as an array from the start. This avoids PHP's automatic type juggling, which might treat $temp1 as a string if it is not explicitly declared. Assigning Values:

$temp1[$i] = random_int(0, 99999999); now correctly assigns the random integer to the $ith index of the $temp1 array.

### Summary:
This fix ensures that $temp1 is treated as an array, eliminating the warning and allowing the code to function as intended.


### Testing Instructions
Code review or use the cypress integration tests for mfa with php 8.4
npx cypress run --spec '.\tests\System\integration\administrator\components\com_users\Mfa.cy.js'


### Actual result BEFORE applying this Pull Request
php warning in the logs
`PHP Warning:  Only the first byte will be assigned to the string offset in D:\repos\j51\administrator\components\com_users\src\Model\BackupcodesModel.php on line 258`


### Expected result AFTER applying this Pull Request
no php wanring


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
