### PR TITLE
[5.2] TinyMCE loads correct preset per user group

### DIFF
--- a/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
+++ b/plugins/editors/tinymce/src/PluginTraits/DisplayTrait.php
@@ -152,6 +152,7 @@ trait DisplayTrait
                 if (isset($ugroups[$group])) {
                     $extraOptions  = $val;
                     $toolbarParams = (object) $toolbarParamsAll[$set];
+                    break 2;
                 }
             }
         }


### PR DESCRIPTION
Pull Request for Issue #45173.

### Summary of Changes

Fixed an issue where TinyMCE editor presets assigned to specific user groups were not being correctly applied when a user belonged to multiple groups in the hierarchy. The code now prioritizes presets based on group specificity, ensuring the most direct user group's preset takes precedence.


### Testing Instructions

1. Set the default editor to "TinyMCE"
2. Create a user assigned to Publisher group
3. Go to System > Plugins > Editor - TinyMCE
4. Assign "Set 2" to "Publisher" and save
5. Go to frontend and login as the Publisher user
6. Edit an article


### Actual result BEFORE applying this Pull Request

![Screenshot 2025-03-21 021138](https://github.com/user-attachments/assets/f52055de-dfb7-4a55-93b8-75821c48c7b5)
TinyMCE loads "Set 0" (the largest set of tools) instead of the assigned "Set 2".


### Expected result AFTER applying this Pull Request

![Screenshot 2025-03-21 020221](https://github.com/user-attachments/assets/6ea4affc-1fb8-467a-862f-552684fc3fb1)
TinyMCE correctly loads "Set 2" (simple set of tools) as assigned to the Publisher group.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
