### PR TITLE
[5.2] change minor version to 5.3

### DIFF
--- a/.github/workflows/create-translation-pull-request-v5.yml
+++ b/.github/workflows/create-translation-pull-request-v5.yml
@@ -12,7 +12,7 @@ on:
 
 env:
   JOOMLA_MAJOR_VERSION: 5
-  JOOMLA_MINOR_VERSION: 5.2
+  JOOMLA_MINOR_VERSION: 5.3
 
 permissions:
   contents: read


### PR DESCRIPTION
### Summary of Changes

This PR changes the minor version from 5.2 to 5.3.
This ensures that the translation bot creates new PRs against the 5.3-dev branch.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
