### PR TITLE
[5.3] Author column

### DIFF
--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -321,7 +321,7 @@ $assoc = Associations::isEnabled();
                                     <?php echo $this->escape($item->access_level); ?>
                                 </td>
                                 <td class="small d-none d-md-table-cell">
-                                    <?php if ((int) $item->created_by != 0) : ?>
+                                    <?php if (!empty($item->author_name)) : ?>
                                         <a href="<?php echo Route::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>">
                                             <?php echo $this->escape($item->author_name); ?>
                                         </a>


### PR DESCRIPTION
### Summary of Changes
There is a check in the Author column to display the author name if the id is not 0 else to display the author as None

I believe this check to be incorrect. When a user is deleted from the users table the created_by in the content table is untouched so the condition in the query is never passed.

This PR changes the condition to check for the author_name and this way we can satisfy the condition and are able to display the author as None

_This PR does not fix the related problem in the authors filter where you can not filter by author None even though it is intended that you can._

_This changes in this PR if accepted will need to be applied to all other components with the same condition_

### Testing Instructions
Create two users
Create articles with each user
Delete one of the users


### Actual result BEFORE applying this Pull Request

![image](https://github.com/user-attachments/assets/82257368-c09a-4893-8c53-dc73c6a33284)


### Expected result AFTER applying this Pull Request

![image](https://github.com/user-attachments/assets/b544a5cb-6a94-4d68-91e1-c3bd83f9c40e)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
