### PR TITLE
[5.4] Featured Articles Author Column

### DIFF
--- a/administrator/components/com_content/tmpl/featured/default.php
+++ b/administrator/components/com_content/tmpl/featured/default.php
@@ -315,7 +315,7 @@ $assoc = Associations::isEnabled();
                                     <?php echo $this->escape($item->access_level); ?>
                                 </td>
                                 <td class="small d-none d-md-table-cell">
-                                    <?php if ((int) $item->created_by != 0) : ?>
+                                    <?php if (!empty($item->author_name)) : ?>
                                         <a href="<?php echo Route::_('index.php?option=com_users&task=user.edit&id=' . (int) $item->created_by); ?>">
                                             <?php echo $this->escape($item->author_name); ?>
                                         </a>


### PR DESCRIPTION
### Summary of Changes
There is a check in the Author column to display the author name if the id is not 0 else to display the author as None

I believe this check to be incorrect. When a user is deleted from the users table the created_by in the content table is untouched so the condition in the query is never passed.

This PR changes the condition to check for the author_name in the featured articles and this way we can satisfy the condition and are able to display the author as None

_This PR is the same as #45179 but for the featured articles view_

### Testing Instructions
Create two users
Create featured articles with each user
Delete one of the users

### Actual result BEFORE applying this Pull Request
![image](https://github.com/user-attachments/assets/8fc313f3-38da-4b5c-915a-81092cfee75b)



### Expected result AFTER applying this Pull Request
![image](https://github.com/user-attachments/assets/8dfeb0c1-d6da-46c4-bd11-82c19457ca94)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
