### PR TITLE
[6.0] Remove deprecated strings

### DIFF
--- a/administrator/language/en-GB/com_menus.ini
+++ b/administrator/language/en-GB/com_menus.ini
@@ -176,8 +176,6 @@ COM_MENUS_SELECT_A_MENUITEM="Select a Menu Item"
 COM_MENUS_SELECT_MENU="- Select Menu -"
 COM_MENUS_SELECT_MENU_FILTER="Select Menu"
 COM_MENUS_SELECT_MENU_FILTER_NOT_TRASHED="Filter the list by a state other than trashed or clear the filter."
-; Deprecated, will be removed with 6.0
-COM_MENUS_SELECT_MENU_FIRST="To use batch processing, please first select a Menu in the manager."
 COM_MENUS_SELECT_MENU_FIRST_EXPORT="To use export, please first select a valid Menu in the manager."
 COM_MENUS_SUBMENU_ITEMS="Menu Items"
 COM_MENUS_SUBMENU_MENUS="Menus"

--- a/administrator/language/en-GB/mod_stats_admin.sys.ini
+++ b/administrator/language/en-GB/mod_stats_admin.sys.ini
@@ -6,6 +6,3 @@
 MOD_STATS_ADMIN="Statistics"
 MOD_STATS_ADMIN_LAYOUT_DEFAULT="Default"
 MOD_STATS_XML_DESCRIPTION="The Statistics Module shows information about your server installation together with statistics on the website users and the number of Articles in your database."
-
-; Deprecated, will be removed with 6.0
-MOD_STATS_LAYOUT_DEFAULT="Default"

--- a/administrator/language/en-GB/plg_content_loadmodule.ini
+++ b/administrator/language/en-GB/plg_content_loadmodule.ini
@@ -9,6 +9,3 @@ PLG_LOADMODULE_FIELD_VALUE_DIVS="Wrapped by Divs"
 PLG_LOADMODULE_FIELD_VALUE_RAW="No wrapping (raw output)"
 PLG_LOADMODULE_FIELD_VALUE_TABLE="Wrapped by table (column)"
 PLG_LOADMODULE_XML_DESCRIPTION="Within content this plugin loads a Module by ID, Syntax: {loadmoduleid 1} or a Module by position, Syntax: {loadposition user1} or a Module by name, Syntax: {loadmodule mod_login}. Optionally can specify module style and for loadmodule a specific module by title, Syntax: {loadmodule mod_login,module title,style}."
-; Deprecated, will be removed with 6.0
-PLG_LOADMODULE_FIELD_VALUE_HORIZONTAL="Wrapped by table (horizontal)"
-PLG_LOADMODULE_FIELD_VALUE_MULTIPLEDIVS="Wrapped by Multiple Divs"


### PR DESCRIPTION
This PR removes several unused strings that had already been marked for removal in 6.0

Code review only


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
