### PR TITLE
[6.0] Fix frontend module editing

### DIFF
--- a/administrator/components/com_modules/src/Controller/ModuleController.php
+++ b/administrator/components/com_modules/src/Controller/ModuleController.php
@@ -232,7 +232,7 @@ class ModuleController extends FormController
             $model      = $this->getModel();
             $data       = $this->input->post->get('jform', [], 'array');
             $item       = $model->getItem($this->input->get('id'));
-            $properties = $item->getProperties();
+            $properties = get_object_vars($item);
 
             if (isset($data['params'])) {
                 unset($properties['params']);

--- a/components/com_config/src/View/Modules/HtmlView.php
+++ b/components/com_config/src/View/Modules/HtmlView.php
@@ -63,7 +63,7 @@ class HtmlView extends BaseHtmlView
         // @todo Move and clean up
         $module = (new \Joomla\Component\Modules\Administrator\Model\ModuleModel())->getItem(Factory::getApplication()->getInput()->getInt('id'));
 
-        $moduleData = $module->getProperties();
+        $moduleData = get_object_vars($module);
         unset($moduleData['xml']);
 
         /** @var \Joomla\Component\Config\Site\Model\ModulesModel $model */


### PR DESCRIPTION
Pull Request for Issue #45190.

### Summary of Changes
Currently, when you try to edit any module from frontend, there will be fatal error. This PR fixes that error

### Testing Instructions
- Use Joomla 6.0 nightly build
- Login to frontend of your site using super user account. Click on edit icon next to any module to edit the module

### Actual result BEFORE applying this Pull Request
- You get fatal error

### Expected result AFTER applying this Pull Request
- No error. You can see module edit form and can save the change


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed