### PR TITLE
[6.0] Fix fatal error on templates management

### DIFF
--- a/administrator/components/com_templates/tmpl/template/default_description.php
+++ b/administrator/components/com_templates/tmpl/template/default_description.php
@@ -27,5 +27,5 @@ use Joomla\Component\Templates\Administrator\Helper\TemplatesHelper;
     <h2><?php echo ucfirst($this->template->element); ?></h2>
     <?php $client = ApplicationHelper::getClientInfo($this->template->client_id); ?>
     <p><?php $this->template->xmldata = TemplatesHelper::parseXMLTemplateFile($client->path, $this->template->element); ?></p>
-    <p><?php echo Text::_($this->template->xmldata->get('description')); ?></p>
+    <p><?php echo Text::_($this->template->xmldata->description); ?></p>
 </div>

--- a/administrator/components/com_templates/tmpl/templates/default.php
+++ b/administrator/components/com_templates/tmpl/templates/default.php
@@ -98,21 +98,21 @@ $listDirn  = $this->escape($this->state->get('list.direction'));
                                     <?php endif; ?>
                                 </th>
                                 <td class="small d-none d-md-table-cell text-center">
-                                    <?php echo $this->escape($item->xmldata->get('version')); ?>
+                                    <?php echo $this->escape($item->xmldata->version); ?>
                                 </td>
                                 <td class="small d-none d-md-table-cell text-center">
-                                    <?php echo $this->escape($item->xmldata->get('creationDate')); ?>
+                                    <?php echo $this->escape($item->xmldata->creationDate); ?>
                                 </td>
                                 <td class="d-none d-md-table-cell text-center">
-                                    <?php if ($author = $item->xmldata->get('author')) : ?>
+                                    <?php if ($author = $item->xmldata->author) : ?>
                                         <div><?php echo $this->escape($author); ?></div>
                                     <?php else : ?>
                                         &mdash;
                                     <?php endif; ?>
-                                    <?php if ($email = $item->xmldata->get('authorEmail')) : ?>
+                                    <?php if ($email = $item->xmldata->authorEmail) : ?>
                                         <div><?php echo $this->escape($email); ?></div>
                                     <?php endif; ?>
-                                    <?php if ($url = $item->xmldata->get('authorUrl')) : ?>
+                                    <?php if ($url = $item->xmldata->authorUrl) : ?>
                                         <div><a href="<?php echo $this->escape($url); ?>"><?php echo $this->escape($url); ?></a></div>
                                     <?php endif; ?>
                                 </td>


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
Currently, on Joomla 6.0-dev, if you access to System -> Site Templates you will get fatal error. This PR fixes that error


### Testing Instructions
- Use Joomla 6.0 nightly build
- Login to administrator area of your site
- Access to System -> Site Templates


### Actual result BEFORE applying this Pull Request
- You got fatal error
- You cannot access to template detail, also fatal error


### Expected result AFTER applying this Pull Request
- No fatal error when access to Site Templates
- No fatal error when access to a template details


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
