### PR TITLE
[6.0] Fix frontend save template options error

### DIFF
--- a/administrator/components/com_templates/src/Controller/StyleController.php
+++ b/administrator/components/com_templates/src/Controller/StyleController.php
@@ -58,9 +58,9 @@ class StyleController extends FormController
             $item = $model->getItem($this->app->getTemplate(true)->id);
 
             // Setting received params
-            $item->set('params', $data);
+            $item->params = $data;
 
-            $data = $item->getProperties();
+            $data = get_object_vars($item);
             unset($data['xml']);
 
             $key = $table->getKeyName();


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This PR fixes fatal error when saving template options from frontend.


### Testing Instructions
- Use Joomla 6.0 nightly build
- Create a menu item to link to Configuration -> Display Template Options menu item type
- Login to frontend of your site using super user accountt
- Access to the above menu item and try to change template options, save it

### Actual result BEFORE applying this Pull Request
You got fatal error


### Expected result AFTER applying this Pull Request
No error, template options saved properly

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
