### PR TITLE
[6.0] Fix fatal error private message

### DIFF
--- a/administrator/components/com_messages/src/Model/MessageModel.php
+++ b/administrator/components/com_messages/src/Model/MessageModel.php
@@ -163,11 +163,11 @@ class MessageModel extends AdminModel implements UserFactoryAwareInterface
                             return false;
                         }
 
-                        $this->item->set('user_id_to', $message->user_id_from);
+                        $this->item->user_id_to = $message->user_id_from;
                         $re = Text::_('COM_MESSAGES_RE');
 
                         if (stripos($message->subject, $re) !== 0) {
-                            $this->item->set('subject', $re . ' ' . $message->subject);
+                            $this->item->subject = $re . ' ' . $message->subject;
                         }
                     }
                 } elseif ($this->item->user_id_to != $this->getCurrentUser()->id) {
@@ -188,7 +188,7 @@ class MessageModel extends AdminModel implements UserFactoryAwareInterface
 
             // Get the user name for an existing message.
             if ($this->item->user_id_from && $fromUser = new User($this->item->user_id_from)) {
-                $this->item->set('from_user_name', $fromUser->name);
+                $this->item->from_user_name = $fromUser->name;
             }
         }
 

--- a/administrator/components/com_messages/src/Model/MessageModel.php
+++ b/administrator/components/com_messages/src/Model/MessageModel.php
@@ -164,6 +164,7 @@ class MessageModel extends AdminModel implements UserFactoryAwareInterface
                         }
 
                         $this->item->user_id_to = $message->user_id_from;
+
                         $re = Text::_('COM_MESSAGES_RE');
 
                         if (stripos($message->subject, $re) !== 0) {

--- a/administrator/components/com_messages/tmpl/message/default.php
+++ b/administrator/components/com_messages/tmpl/message/default.php
@@ -33,7 +33,7 @@ $wa->useScript('core');
     <div class="card-body">
         <dl class="mb-0">
             <dt><?php echo Text::_('COM_MESSAGES_FIELD_USER_ID_FROM_LABEL'); ?></dt>
-            <dd><?php echo $this->item->get('from_user_name'); ?></dd>
+            <dd><?php echo $this->item->from_user_name; ?></dd>
 
             <dt><?php echo Text::_('COM_MESSAGES_FIELD_DATE_TIME_LABEL'); ?></dt>
             <dd><?php echo HTMLHelper::_('date', $this->item->date_time, Text::_('DATE_FORMAT_LC2')); ?></dd>


### PR DESCRIPTION
Pull Request for Issue #45212.

### Summary of Changes
This PR fixes fatal error described in the issue https://github.com/joomla/joomla-cms/issues/45212


### Testing Instructions
- Use Joomla 6.0
- Create a menu item to link to **Create Request** menu item type of **Privacy** component
- Login using to frontend use your account
- Access to that menu item, submit a Export request. The earlier step and this one is to make sure there is a private message sent to your super user account. If you already have private message, you can ignore these steps.
- Login to administrator area using super user account, access to Users -> Messaging -> Private Messages. You should see a private message. Click on the message to see the details

### Actual result BEFORE applying this Pull Request
You get fatal error as described in the issue https://github.com/joomla/joomla-cms/issues/45212

### Expected result AFTER applying this Pull Request
No fatal error anymore.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
