### PR TITLE
[6.0] Update Site ID fatal error

### DIFF
--- a/administrator/components/com_installer/src/View/Updatesite/HtmlView.php
+++ b/administrator/components/com_installer/src/View/Updatesite/HtmlView.php
@@ -70,7 +70,7 @@ class HtmlView extends InstallerViewDefault
 
         // Remove the extra_query field if it's a free download extension
         $dlidSupportingSites = InstallerHelper::getDownloadKeySupportedSites(false);
-        $update_site_id      = $this->item->get('update_site_id');
+        $update_site_id      = $this->item->update_site_id;
 
         if (!\in_array($update_site_id, $dlidSupportingSites)) {
             $this->form->removeField('extra_query');


### PR DESCRIPTION

### Summary of Changes
Another fix as a result of "return a stdClass instead of CMSObject" #42961



### Testing Instructions
Go to System=> Update sites and open any of the items there such as "Accredited Joomla! Translations"


### Actual result BEFORE applying this Pull Request
Fatal Error


### Expected result AFTER applying this Pull Request
Item opens as expected without error


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
