### PR TITLE
[6.0] Define a compat flag for better backwards compatibility

### DIFF
--- a/libraries/src/MVC/Model/AdminModel.php
+++ b/libraries/src/MVC/Model/AdminModel.php
@@ -18,6 +18,7 @@ use Joomla\CMS\Language\LanguageHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\Log\Log;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\CMS\Object\CMSObject;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\CMS\Router\Route;
 use Joomla\CMS\Table\Category;
@@ -1031,7 +1032,7 @@ abstract class AdminModel extends FormModel
 
         // Convert to \stdClass before adding other data
         $properties = get_object_vars($table);
-        $item       = ArrayHelper::toObject($properties);
+        $item       = ArrayHelper::toObject($properties, !\defined('JCOMPAT_ENABLED') ? \stdClass::class : CMSObject::class);
 
         if (property_exists($item, 'params')) {
             $registry     = new Registry($item->params);

--- a/plugins/behaviour/compat/src/Extension/Compat.php
+++ b/plugins/behaviour/compat/src/Extension/Compat.php
@@ -87,6 +87,11 @@ final class Compat extends CMSPlugin implements SubscriberInterface
          * @deprecated 4.4.0 will be removed in 7.0
          */
         \defined('JPATH_PLATFORM') or \define('JPATH_PLATFORM', __DIR__);
+
+        /**
+         * Enable compatibility flag.
+         */
+        \define('JCOMPAT_ENABLED', true);
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #45190.

### Summary of Changes
This pr eases the transition from CMSObject to stdClass when calling the getItem function. If the compatibility plugin is enabled it sets not the constant `JCOMPAT_ENABLED`. If this flag is set, then does the getItem function return a CMSObject instead of stdClass.

### Testing Instructions
Perform testing instructions from #45190 with the BC plugin enabled.

### Actual result BEFORE applying this Pull Request
Crashes.

### Expected result AFTER applying this Pull Request
No crash.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
