### PR TITLE
[5.3] Clean Up File::upload method arguments

### DIFF
--- a/administrator/components/com_installer/src/Model/InstallModel.php
+++ b/administrator/components/com_installer/src/Model/InstallModel.php
@@ -329,7 +329,7 @@ class InstallModel extends BaseDatabaseModel
 
         // Move uploaded file.
         try {
-            File::upload($tmp_src, $tmp_dest, false, true);
+            File::upload($tmp_src, $tmp_dest);
         } catch (FilesystemException) {
             Factory::getApplication()->enqueueMessage(Text::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR'), 'error');
 

--- a/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
+++ b/administrator/components/com_joomlaupdate/src/Model/UpdateModel.php
@@ -994,7 +994,7 @@ ENDDATA;
 
         // Move uploaded file.
         try {
-            File::upload($tmp_src, $tmp_dest, false);
+            File::upload($tmp_src, $tmp_dest);
         } catch (FilesystemException $exception) {
             throw new \RuntimeException(Text::_('COM_INSTALLER_MSG_INSTALL_WARNINSTALLUPLOADERROR'), 500, $exception);
         }


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
A minor bug fix/ clean up to File::upload() method arguments after we migrated from CMS FileSystem to Framework Filesystem package. Basically, unlike the CMS FileSystem package, the File::upload() method in Framework Filesystem package only has 3 parameters, see https://github.com/joomla-framework/filesystem/blob/3.x-dev/src/File.php#L285

So passing the fourth argument in File::upload call is not correct (PHP currently ignores the extra parameter, but it should be fixed anyway). Also, the third argument has same value with default value in method definition, so it could be omitted to make it consistent with other File::upload calls in our code.


### Testing Instructions
- Use Joomla 5.3 nightly build
- Apply patch
- Try to install an extension

Or code review should be enough, too.


### Actual result BEFORE applying this Pull Request
Works


### Expected result AFTER applying this Pull Request
Works


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
