### PR TITLE
[5.3] Revert update of typo3/phar-stream-wrapper and deprecate it

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
     "symfony/polyfill-mbstring": "^1.31.0",
     "symfony/web-link": "^6.4.13",
     "symfony/yaml": "^6.4.18",
-    "typo3/phar-stream-wrapper": "^v3.1.8",
+    "typo3/phar-stream-wrapper": "^3.1.8",
     "wamania/php-stemmer": "^4.0.0",
     "tobscure/json-api": "dev-joomla-backports",
     "willdurand/negotiation": "^3.1.0",

--- a/composer.json
+++ b/composer.json
@@ -90,7 +90,7 @@
     "symfony/polyfill-mbstring": "^1.31.0",
     "symfony/web-link": "^6.4.13",
     "symfony/yaml": "^6.4.18",
-    "typo3/phar-stream-wrapper": "^4.0.0",
+    "typo3/phar-stream-wrapper": "^v3.1.8",
     "wamania/php-stemmer": "^4.0.0",
     "tobscure/json-api": "dev-joomla-backports",
     "willdurand/negotiation": "^3.1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a109139d9162d43a56b14f779ccf46f2",
+    "content-hash": "657b69e9e12fd96012fbd526136246c7",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "657b69e9e12fd96012fbd526136246c7",
+    "content-hash": "ed802cce5f2f7e0177e819917eb0fba3",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aea460a15f0d9c656441f03d58683ed5",
+    "content-hash": "a109139d9162d43a56b14f779ccf46f2",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -5936,25 +5936,26 @@
         },
         {
             "name": "typo3/phar-stream-wrapper",
-            "version": "v4.0.0",
+            "version": "v3.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TYPO3/phar-stream-wrapper.git",
-                "reference": "ce4b6e9873d4dd7dce2a397511713bf14977fdf2"
+                "reference": "a931b28f422a60052db85c0a84a05a366453b2c0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/ce4b6e9873d4dd7dce2a397511713bf14977fdf2",
-                "reference": "ce4b6e9873d4dd7dce2a397511713bf14977fdf2",
+                "url": "https://api.github.com/repos/TYPO3/phar-stream-wrapper/zipball/a931b28f422a60052db85c0a84a05a366453b2c0",
+                "reference": "a931b28f422a60052db85c0a84a05a366453b2c0",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "php": "^7.1 || ^8.0"
+                "php": "^7.0 || ~8.0 || ~8.1 || ~8.2 || ~8.3"
             },
             "require-dev": {
                 "ext-xdebug": "*",
-                "phpunit/phpunit": "^7 || ^8 || ^9"
+                "phpspec/prophecy": "^1.10",
+                "symfony/phpunit-bridge": "^5.1"
             },
             "suggest": {
                 "ext-fileinfo": "For PHP builtin file type guessing, otherwise uses internal processing"
@@ -5962,7 +5963,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-master": "v3.x-dev"
                 }
             },
             "autoload": {
@@ -5984,9 +5985,9 @@
             ],
             "support": {
                 "issues": "https://github.com/TYPO3/phar-stream-wrapper/issues",
-                "source": "https://github.com/TYPO3/phar-stream-wrapper/tree/v4.0.0"
+                "source": "https://github.com/TYPO3/phar-stream-wrapper/tree/v3.1.8"
             },
-            "time": "2024-12-10T00:00:25+00:00"
+            "time": "2024-12-09T23:06:33+00:00"
         },
         {
             "name": "voku/portable-ascii",
@@ -10175,7 +10176,7 @@
         "ext-gd": "*",
         "ext-dom": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "platform-overrides": {
         "php": "8.1.0"
     },

--- a/libraries/bootstrap.php
+++ b/libraries/bootstrap.php
@@ -62,17 +62,6 @@ if (error_reporting() & E_USER_DEPRECATED) {
     set_error_handler(['Joomla\CMS\Exception\ExceptionHandler', 'handleUserDeprecatedErrors'], E_USER_DEPRECATED);
 }
 
-// Suppress phar stream wrapper for non .phar files
-$behavior = new \TYPO3\PharStreamWrapper\Behavior();
-\TYPO3\PharStreamWrapper\Manager::initialize(
-    $behavior->withAssertion(new \TYPO3\PharStreamWrapper\Interceptor\PharExtensionInterceptor())
-);
-
-if (in_array('phar', stream_get_wrappers())) {
-    stream_wrapper_unregister('phar');
-    stream_wrapper_register('phar', 'TYPO3\\PharStreamWrapper\\PharStreamWrapper');
-}
-
 // Define the Joomla version if not already defined.
 defined('JVERSION') or define('JVERSION', (new \Joomla\CMS\Version())->getShortVersion());
 

--- a/libraries/cms.php
+++ b/libraries/cms.php
@@ -49,17 +49,6 @@ $loader->unregister();
 // Decorate Composer autoloader
 spl_autoload_register([new \Joomla\CMS\Autoload\ClassLoader($loader), 'loadClass'], true, true);
 
-// Suppress phar stream wrapper for non .phar files
-$behavior = new \TYPO3\PharStreamWrapper\Behavior();
-\TYPO3\PharStreamWrapper\Manager::initialize(
-    $behavior->withAssertion(new \TYPO3\PharStreamWrapper\Interceptor\PharExtensionInterceptor())
-);
-
-if (in_array('phar', stream_get_wrappers())) {
-    stream_wrapper_unregister('phar');
-    stream_wrapper_register('phar', 'TYPO3\\PharStreamWrapper\\PharStreamWrapper');
-}
-
 // Define the Joomla version if not already defined
 if (!defined('JVERSION')) {
     define('JVERSION', (new \Joomla\CMS\Version())->getShortVersion());


### PR DESCRIPTION
### Summary of Changes
#44808 updated our dependency on the typo3/phar-stream-wrapper to the next major version, being under the impression, that the package is needed and that the updates would be backwards compatible. This actually seems to not be correct and (as unlikely as it is) when other code extends this, it would throw errors. It also turns out, that the whole package is not needed anymore, since the underlying issue has been solved in PHP 8.0 already. So this package isn't needed anymore. The plan is to deprecate it now and then to remove it in 6.0.


### Testing Instructions
Before and after applying the PR, there shouldn't be any changes.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [X] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/436
- [ ] No documentation changes for manual.joomla.org needed
