### PR TITLE
Revert idna to version 3 with the PHP 8.4 patch

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,7 +74,7 @@
     "joomla/string": "^3.0.1",
     "joomla/uri": "~3.0",
     "joomla/utilities": "~3.0",
-    "algo26-matthias/idna-convert": "feature/backport-4.2-dev",
+    "algo26-matthias/idna-convert": "^3.2.0",
     "defuse/php-encryption": "^2.4.0",
     "doctrine/inflector": "^1.4.4",
     "fig/link-util": "^1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -37,10 +37,6 @@
       "type": "vcs",
       "url": "https://github.com/joomla-backports/portable-utf8.git",
       "no-api": true
-    },
-    {
-      "type": "vcs",
-      "url": "https://github.com/laoneo/idna-convert.git"
     }
   ],
   "autoload": {
@@ -78,7 +74,7 @@
     "joomla/string": "^3.0.1",
     "joomla/uri": "~3.0",
     "joomla/utilities": "~3.0",
-    "algo26-matthias/idna-convert": "^3.x-dev",
+    "algo26-matthias/idna-convert": "feature/backport-4.2-dev",
     "defuse/php-encryption": "^2.4.0",
     "doctrine/inflector": "^1.4.4",
     "fig/link-util": "^1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,10 @@
       "type": "vcs",
       "url": "https://github.com/joomla-backports/portable-utf8.git",
       "no-api": true
+    },
+    {
+      "type": "vcs",
+      "url": "https://github.com/laoneo/idna-convert.git"
     }
   ],
   "autoload": {
@@ -74,7 +78,7 @@
     "joomla/string": "^3.0.1",
     "joomla/uri": "~3.0",
     "joomla/utilities": "~3.0",
-    "algo26-matthias/idna-convert": "^4.0.4",
+    "algo26-matthias/idna-convert": "^3.x-dev",
     "defuse/php-encryption": "^2.4.0",
     "doctrine/inflector": "^1.4.4",
     "fig/link-util": "^1.2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64c28182351516c1b66e68aa5a4c8902",
+    "content-hash": "79b78f23e0837f6afa0dd4c2782684b3",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
-            "version": "dev-feature/backport-4.2",
+            "version": "v3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/algo26-matthias/idna-convert.git",
-                "reference": "b57b15cb7eea4affb6b805a796ae26d70f44d845"
+                "reference": "0cea987c75b981797cf3bc28b182c5da05c41252"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/b57b15cb7eea4affb6b805a796ae26d70f44d845",
-                "reference": "b57b15cb7eea4affb6b805a796ae26d70f44d845",
+                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/0cea987c75b981797cf3bc28b182c5da05c41252",
+                "reference": "0cea987c75b981797cf3bc28b182c5da05c41252",
                 "shasum": ""
             },
             "require": {
@@ -58,9 +58,9 @@
             ],
             "support": {
                 "issues": "https://github.com/algo26-matthias/idna-convert/issues",
-                "source": "https://github.com/algo26-matthias/idna-convert/tree/feature/backport-4.2"
+                "source": "https://github.com/algo26-matthias/idna-convert/tree/v3.2.0"
             },
-            "time": "2025-04-01T11:01:13+00:00"
+            "time": "2025-04-01T11:22:26+00:00"
         },
         {
             "name": "brick/math",
@@ -10162,7 +10162,6 @@
     ],
     "minimum-stability": "stable",
     "stability-flags": {
-        "algo26-matthias/idna-convert": 20,
         "tobscure/json-api": 20,
         "voku/portable-utf8": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,33 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aea460a15f0d9c656441f03d58683ed5",
+    "content-hash": "972b77446a362a3bc4d0b4be9b88ee92",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
-            "version": "v4.0.4",
+            "version": "v3.x-dev",
             "source": {
                 "type": "git",
-                "url": "https://github.com/algo26-matthias/idna-convert.git",
-                "reference": "87fcd0252e86bf8f881b83ebbacd26fede361356"
+                "url": "https://github.com/laoneo/idna-convert.git",
+                "reference": "ccb422c22fd16d0d1a311d957808af5e28c4077d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/87fcd0252e86bf8f881b83ebbacd26fede361356",
-                "reference": "87fcd0252e86bf8f881b83ebbacd26fede361356",
+                "url": "https://api.github.com/repos/laoneo/idna-convert/zipball/ccb422c22fd16d0d1a311d957808af5e28c4077d",
+                "reference": "ccb422c22fd16d0d1a311d957808af5e28c4077d",
                 "shasum": ""
             },
             "require": {
                 "ext-pcre": "*",
                 "jakeasmith/http_build_url": "^1",
-                "php": ">=8.1"
+                "php": ">=7.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9 || ^10"
+                "phpunit/phpunit": "8.0"
             },
             "suggest": {
                 "ext-iconv": "Install ext/iconv for using input / output other than UTF-8 or ISO-8859-1",
-                "ext-intl": "Install ext/intl for better case folding",
                 "ext-mbstring": "Install ext/mbstring for using input / output other than UTF-8 or ISO-8859-1"
             },
             "type": "library",
@@ -39,7 +38,11 @@
                     "Algo26\\IdnaConvert\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Algo26\\IdnaConvert\\Test\\": "tests/"
+                }
+            },
             "license": [
                 "LGPL-2.1+"
             ],
@@ -53,15 +56,14 @@
             "description": "A library for encoding and decoding internationalized domain names",
             "homepage": "http://idnaconv.net/",
             "keywords": [
-                "idn",
-                "idna",
-                "php"
+                "IDN",
+                "IDNA",
+                "PHP"
             ],
             "support": {
-                "issues": "https://github.com/algo26-matthias/idna-convert/issues",
-                "source": "https://github.com/algo26-matthias/idna-convert/tree/v4.0.4"
+                "source": "https://github.com/laoneo/idna-convert/tree/v3.x"
             },
-            "time": "2025-03-16T10:00:35+00:00"
+            "time": "2025-03-31T09:25:30+00:00"
         },
         {
             "name": "brick/math",
@@ -10163,6 +10165,7 @@
     ],
     "minimum-stability": "stable",
     "stability-flags": {
+        "algo26-matthias/idna-convert": 20,
         "tobscure/json-api": 20,
         "voku/portable-utf8": 20
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "972b77446a362a3bc4d0b4be9b88ee92",
+    "content-hash": "64c28182351516c1b66e68aa5a4c8902",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
-            "version": "v3.x-dev",
+            "version": "dev-feature/backport-4.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/laoneo/idna-convert.git",
-                "reference": "ccb422c22fd16d0d1a311d957808af5e28c4077d"
+                "url": "https://github.com/algo26-matthias/idna-convert.git",
+                "reference": "b57b15cb7eea4affb6b805a796ae26d70f44d845"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laoneo/idna-convert/zipball/ccb422c22fd16d0d1a311d957808af5e28c4077d",
-                "reference": "ccb422c22fd16d0d1a311d957808af5e28c4077d",
+                "url": "https://api.github.com/repos/algo26-matthias/idna-convert/zipball/b57b15cb7eea4affb6b805a796ae26d70f44d845",
+                "reference": "b57b15cb7eea4affb6b805a796ae26d70f44d845",
                 "shasum": ""
             },
             "require": {
@@ -38,11 +38,7 @@
                     "Algo26\\IdnaConvert\\": "src/"
                 }
             },
-            "autoload-dev": {
-                "psr-4": {
-                    "Algo26\\IdnaConvert\\Test\\": "tests/"
-                }
-            },
+            "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "LGPL-2.1+"
             ],
@@ -56,14 +52,15 @@
             "description": "A library for encoding and decoding internationalized domain names",
             "homepage": "http://idnaconv.net/",
             "keywords": [
-                "IDN",
-                "IDNA",
-                "PHP"
+                "idn",
+                "idna",
+                "php"
             ],
             "support": {
-                "source": "https://github.com/laoneo/idna-convert/tree/v3.x"
+                "issues": "https://github.com/algo26-matthias/idna-convert/issues",
+                "source": "https://github.com/algo26-matthias/idna-convert/tree/feature/backport-4.2"
             },
-            "time": "2025-03-31T09:25:30+00:00"
+            "time": "2025-04-01T11:01:13+00:00"
         },
         {
             "name": "brick/math",


### PR DESCRIPTION
~Reverts the idna converter back to version 3 with the 8.4 compatibility patch from https://github.com/algo26-matthias/idna-convert/pull/48 but without https://github.com/algo26-matthias/idna-convert/commit/f193ac5eac8161cfbe0dc8b44d2e3a3cd37e5f5a. Because this commit contains the backwards compatibility break that the intl extension becomes a requirement which Joomla hasn't. When https://github.com/algo26-matthias/idna-convert/pull/56 is merged and a new release is done, then we can change the repository back to the original one in the composer file.~

Reverts the idna converter back to version 3 with the 8.4 compatibility patch from https://github.com/algo26-matthias/idna-convert/pull/57.