### PR TITLE
[5.3] Language switcher php deprecated notices

### DIFF
--- a/libraries/src/Extension/ExtensionManagerTrait.php
+++ b/libraries/src/Extension/ExtensionManagerTrait.php
@@ -42,7 +42,7 @@ trait ExtensionManagerTrait
     public function bootComponent($component): ComponentInterface
     {
         // Normalize the component name
-        $component = strtolower($component);
+        $component = strtolower((string) $component);
         $component = str_starts_with($component, 'com_') ? substr($component, 4) : $component;
 
         // Path to look for services

--- a/modules/mod_languages/src/Helper/LanguagesHelper.php
+++ b/modules/mod_languages/src/Helper/LanguagesHelper.php
@@ -76,7 +76,7 @@ class LanguagesHelper
                 $cassociations = $component->getAssociationsExtension()->getAssociationsForItem();
             } else {
                 // Load component associations
-                $class = str_replace('com_', '', $option) . 'HelperAssociation';
+                $class = str_replace('com_', '', $option ?? '') . 'HelperAssociation';
                 \JLoader::register($class, JPATH_SITE . '/components/' . $option . '/helpers/association.php');
 
                 if (class_exists($class) && \is_callable([$class, 'getAssociations'])) {


### PR DESCRIPTION
Pull Request for Issue #43293 .

### Summary of Changes
Fixes
- Deprecated: strtolower():  Passing null to parameter  #1 ($string) of type string is deprecated in libraries/src/Extension/ExtensionManagerTrait.php on line 45
- Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated in modules/mod_languages/src/Helper/LanguagesHelper.php on line 79


### Testing Instructions
Make sure you are using php 8.1 or higher
Create a bilingual site
Create an instance of mod_languages in a position that exists also on an error page
In global configuration, set error reporting to maximum
Navigate to a url that will produce an error


### Actual result BEFORE applying this Pull Request
two deprecated messages displayed


### Expected result AFTER applying this Pull Request
No errors displayed


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
