### PR TITLE
[5.3] Add method to allow get router object for CMSApplication

### DIFF
--- a/components/com_contact/src/Service/Router.php
+++ b/components/com_contact/src/Service/Router.php
@@ -207,7 +207,7 @@ class Router extends RouterView
                     // We haven't found a matching category, but maybe we turned off IDs?
                     foreach ($category->getChildren() as $child) {
                         if ($child->id == (int) $segment) {
-                            $this->app->getRouter()->setTainted();
+                            $this->app->getAppRouter()->setTainted();
 
                             return $child->id;
                         }
@@ -216,7 +216,7 @@ class Router extends RouterView
                     foreach ($category->getChildren() as $child) {
                         if ($child->id == (int) $segment) {
                             if ($child->id . '-' . $child->alias != $segment) {
-                                $this->app->getRouter()->setTainted();
+                                $this->app->getAppRouter()->setTainted();
                             }
 
                             return $child->id;
@@ -273,7 +273,7 @@ class Router extends RouterView
                 return $id;
             }
 
-            $this->app->getRouter()->setTainted();
+            $this->app->getAppRouter()->setTainted();
         }
 
         $id = (int) $segment;
@@ -288,7 +288,7 @@ class Router extends RouterView
             $alias = $this->db->loadResult();
 
             if ($alias && $id . '-' . $alias != $segment) {
-                $this->app->getRouter()->setTainted();
+                $this->app->getAppRouter()->setTainted();
             }
         }
 

--- a/components/com_content/src/Service/Router.php
+++ b/components/com_content/src/Service/Router.php
@@ -208,7 +208,7 @@ class Router extends RouterView
                     // We haven't found a matching category, but maybe we turned off IDs?
                     foreach ($category->getChildren() as $child) {
                         if ($child->id == (int) $segment) {
-                            $this->app->getRouter()->setTainted();
+                            $this->app->getAppRouter()->setTainted();
 
                             return $child->id;
                         }
@@ -217,7 +217,7 @@ class Router extends RouterView
                     foreach ($category->getChildren() as $child) {
                         if ($child->id == (int) $segment) {
                             if ($child->id . '-' . $child->alias != $segment) {
-                                $this->app->getRouter()->setTainted();
+                                $this->app->getAppRouter()->setTainted();
                             }
 
                             return $child->id;
@@ -274,7 +274,7 @@ class Router extends RouterView
                 return $id;
             }
 
-            $this->app->getRouter()->setTainted();
+            $this->app->getAppRouter()->setTainted();
         }
 
         $id = (int) $segment;
@@ -289,7 +289,7 @@ class Router extends RouterView
             $alias = $this->db->loadResult();
 
             if ($alias && $id . '-' . $alias != $segment) {
-                $this->app->getRouter()->setTainted();
+                $this->app->getAppRouter()->setTainted();
             }
         }
 

--- a/components/com_newsfeeds/src/Service/Router.php
+++ b/components/com_newsfeeds/src/Service/Router.php
@@ -188,7 +188,7 @@ class Router extends RouterView
                     // We haven't found a matching category, but maybe we turned off IDs?
                     foreach ($category->getChildren() as $child) {
                         if ($child->id == (int) $segment) {
-                            $this->app->getRouter()->setTainted();
+                            $this->app->getAppRouter()->setTainted();
 
                             return $child->id;
                         }
@@ -197,7 +197,7 @@ class Router extends RouterView
                     foreach ($category->getChildren() as $child) {
                         if ($child->id == (int) $segment) {
                             if ($child->id . '-' . $child->alias != $segment) {
-                                $this->app->getRouter()->setTainted();
+                                $this->app->getAppRouter()->setTainted();
                             }
 
                             return $child->id;
@@ -254,7 +254,7 @@ class Router extends RouterView
                 return $id;
             }
 
-            $this->app->getRouter()->setTainted();
+            $this->app->getAppRouter()->setTainted();
         }
 
         $id = (int) $segment;
@@ -269,7 +269,7 @@ class Router extends RouterView
             $alias = $this->db->loadResult();
 
             if ($alias && $id . '-' . $alias != $segment) {
-                $this->app->getRouter()->setTainted();
+                $this->app->getAppRouter()->setTainted();
             }
         }
 

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -659,7 +659,7 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
 
             if (!$this->getContainer()->has($resourceName)) {
                 throw new \RuntimeException(
-                    Text::sprintf('JLIB_APPLICATION_ERROR_PATHWAY_LOAD', $this->getName()),
+                    Text::sprintf('JLIB_APPLICATION_ERROR_ROUTER_LOAD', $this->getName()),
                     500
                 );
             }

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -132,6 +132,14 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
     protected $template = null;
 
     /**
+     * The router object
+     *
+     * @var    Router
+     * @since  __DEPLOY_VERSION__
+     */
+    protected $router = null;
+
+    /**
      * The pathway object
      *
      * @var    Pathway
@@ -635,6 +643,31 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * Returns the application router object.
+     *
+     * @return  Router
+     *
+     * @since   __DEPLOY_VERSION__
+     */
+    public function getAppRouter()
+    {
+        if ($this->router === null) {
+            $resourceName = ucfirst($this->getName()) . 'Router';
+
+            if (!$this->getContainer()->has($resourceName)) {
+                throw new \RuntimeException(
+                    Text::sprintf('JLIB_APPLICATION_ERROR_PATHWAY_LOAD', $this->getName()),
+                    500
+                );
+            }
+
+            $this->router = $this->getContainer()->get($resourceName);
+        }
+
+        return $this->router;
     }
 
     /**


### PR DESCRIPTION
Pull Request for Issue #44990, #45260.

### Summary of Changes
Currently, the Router Service of our components is calling deprecated method [getRouter](https://github.com/joomla/joomla-cms/blob/5.3-dev/libraries/src/Application/CMSApplication.php#L679) to get router object. As the method was deprecated and will be removed in future Joomla releases, we should not use it's in new code introduced in Joomla 5.3.

The PR address that issue by adding adding new method `getAppRouter()` to get router object directly from application's container (instead of from global container like the deprecated method)

### Testing Instructions
- Use Joomla 5.3 nightly build
- Follow the instructions at https://github.com/joomla/joomla-cms/issues/44990, confirm the issue.

### Actual result BEFORE applying this Pull Request
- Fatal error while access to a page that does not exist.

### Expected result AFTER applying this Pull Request
- No fatal error, 404 not found is throw as expected.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
