### PR TITLE
[5.2] [Security] Update joomla/database from 3.2.1 to 3.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
     "joomla/console": "^3.0.1",
     "joomla/crypt": "^3.0.1",
     "joomla/data": "^3.0.1",
-    "joomla/database": "^3.2",
+    "joomla/database": "^3.4",
     "joomla/di": "^3.0.1",
     "joomla/event": "^3.0.1",
     "joomla/filter": "^3.0.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1c0c2e8997137370931be7b027104d50",
+    "content-hash": "e74751bc61b9f174f3b78ceeb7fa466b",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -1494,16 +1494,16 @@
         },
         {
             "name": "joomla/database",
-            "version": "3.2.1",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/database.git",
-                "reference": "3927dea8a08927d7d1dd4254bee6c6d66994a202"
+                "reference": "10745e7b8a3632551861f4da9c6a80a04031a3a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/database/zipball/3927dea8a08927d7d1dd4254bee6c6d66994a202",
-                "reference": "3927dea8a08927d7d1dd4254bee6c6d66994a202",
+                "url": "https://api.github.com/repos/joomla-framework/database/zipball/10745e7b8a3632551861f4da9c6a80a04031a3a3",
+                "reference": "10745e7b8a3632551861f4da9c6a80a04031a3a3",
                 "shasum": ""
             },
             "require": {
@@ -1561,7 +1561,7 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/database/issues",
-                "source": "https://github.com/joomla-framework/database/tree/3.2.1"
+                "source": "https://github.com/joomla-framework/database/tree/3.4.0"
             },
             "funding": [
                 {
@@ -1573,7 +1573,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-19T13:09:59+00:00"
+            "time": "2025-03-30T14:43:37+00:00"
         },
         {
             "name": "joomla/di",


### PR DESCRIPTION
Pull Request for Issues #44545 , #45236 and #45112 .

### Summary of Changes

This pull request (PR) updates the composer dependency "joomla/database" from version 3.2.1 to version 3.4.0.

Changes see here: https://github.com/joomla-framework/database/releases/tag/3.4.0

Because of https://github.com/joomla-framework/database/pull/329 this is regarded as a security fix which will be released with the next 5.2.6 security release.

### Testing Instructions

This PR cannot be applied with the patchtester. You have to use the packages created by Drone.

Check that the database drivers work as well as before.

Check that the change from https://github.com/joomla-framework/database/pull/329 has been properly applied.

Check that #45236 and #44545 are resolved for MariaDB versions >= 10.2.0 and < 11.

Check that these 2 issues don't happen with MariaDB >= 11 or MySQL >= 8.

Check that issue #45112 is fixed.

### Actual result BEFORE applying this Pull Request

Database framework is not up to date, change from https://github.com/joomla-framework/database/pull/328 is not included.

### Expected result AFTER applying this Pull Request

Database framework is up to date, change from https://github.com/joomla-framework/database/pull/328 is applied, issues #44545 , #45236 and #45112 are fixed.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
