### PR TITLE
 [5.2] - Fixed wrong autoload fields path for redefined administrator

### DIFF
--- a/administrator/components/com_fields/src/Helper/FieldsHelper.php
+++ b/administrator/components/com_fields/src/Helper/FieldsHelper.php
@@ -428,9 +428,8 @@ class FieldsHelper
             /** @var \DOMElement $fieldset */
             $fieldset = $fieldsNode->appendChild(new \DOMElement('fieldset'));
             $fieldset->setAttribute('name', 'fields-' . $group->id);
-            $fieldset->setAttribute('addfieldpath', '/administrator/components/' . $component . '/models/fields');
-            $fieldset->setAttribute('addrulepath', '/administrator/components/' . $component . '/models/rules');
-
+            $fieldset->setAttribute('addfieldpath', str_replace(JPATH_ROOT, '', JPATH_ADMINISTRATOR) . '/components/' . $component . '/models/fields');
+            $fieldset->setAttribute('addrulepath', str_replace(JPATH_ROOT, '', JPATH_ADMINISTRATOR) . '/components/' . $component . '/models/rules');
             $label       = $group->title;
             $description = $group->description;
 

--- a/administrator/components/com_languages/src/Controller/InstalledController.php
+++ b/administrator/components/com_languages/src/Controller/InstalledController.php
@@ -46,8 +46,9 @@ class InstalledController extends BaseController
             if ($model->getState('client_id') == 1) {
                 $language          = Factory::getLanguage();
                 $newLang           = Language::getInstance($cid);
-                Factory::$language = $newLang;
-                $this->app->loadLanguage($language = $newLang);
+               // Factory::$language = $newLang;
+               //Deprecated line removed; language is now mangaged via DI or application
+                $this->app->loadLanguage($newLang);
                 $newLang->load('com_languages', JPATH_ADMINISTRATOR);
             }
 
@@ -92,10 +93,10 @@ class InstalledController extends BaseController
         if ($model->switchAdminLanguage($cid)) {
             // Switching to the new language for the message
             $languageName      = $info['nativeName'];
-            $language          = Factory::getLanguage();
+            //$language          = Factory::getLanguage();
             $newLang           = Language::getInstance($cid);
-            Factory::$language = $newLang;
-            $this->app->loadLanguage($language = $newLang);
+            //Factory::$language = $newLang;
+            $this->app->loadLanguage($newLang);
             $newLang->load('com_languages', JPATH_ADMINISTRATOR);
 
             $msg  = Text::sprintf('COM_LANGUAGES_MSG_SWITCH_ADMIN_LANGUAGE_SUCCESS', $languageName);

--- a/installation/src/Application/CliInstallationApplication.php
+++ b/installation/src/Application/CliInstallationApplication.php
@@ -127,7 +127,9 @@ final class CliInstallationApplication extends Application implements CMSApplica
 
         // Register the config to Factory.
         Factory::$config   = $this->config;
-        Factory::$language = $language;
+        //Factory::$language = $language;
+        $this->getContainer()->set(LanguageInterface::class, $language);
+
     }
 
     /**

--- a/installation/src/Application/InstallationApplication.php
+++ b/installation/src/Application/InstallationApplication.php
@@ -461,7 +461,9 @@ final class InstallationApplication extends CMSApplication
         $this->loadLanguage($lang);
 
         // Register the language object with Factory
-        Factory::$language = $this->getLanguage();
+        //Factory::$language = $this->getLanguage();
+        $this->getContainer()->set(LanguageInterface::class, $this->getLanguage());
+
     }
 
     /**

--- a/installation/src/Controller/LanguageController.php
+++ b/installation/src/Controller/LanguageController.php
@@ -67,8 +67,10 @@ class LanguageController extends JSONController
         $model->storeOptions($return);
 
         // Setup language
-        Factory::$language = Language::getInstance($return['language']);
-
+        //Factory::$language = Language::getInstance($return['language']);
+        $language = Language::getInstance($return['language']);
+        $this->getContainer()->set(LanguageInterface::class, $language);
+        
         // Redirect to the page.
         $r->view = $this->input->getWord('view', 'setup');
 

--- a/libraries/src/Application/CMSApplication.php
+++ b/libraries/src/Application/CMSApplication.php
@@ -788,7 +788,9 @@ abstract class CMSApplication extends WebApplication implements ContainerAwareIn
         $this->loadLanguage($lang);
 
         // Register the language object with Factory
-        Factory::$language = $this->getLanguage();
+        //Factory::$language = $this->getLanguage();
+        $this->getContainer()->set(LanguageInterface::class, $this->getLanguage());
+
 
         // Load the library language files
         $this->loadLibraryLanguage();

--- a/libraries/src/Error/AbstractRenderer.php
+++ b/libraries/src/Error/AbstractRenderer.php
@@ -104,7 +104,8 @@ abstract class AbstractRenderer implements RendererInterface
         ];
 
         // If there is a Language instance in Factory then let's pull the language and direction from its metadata
-        if (Factory::$language) {
+        //if (Factory::$language) {
+            if (Factory::getApplication()->getLanguage()) {
             $attributes['language']  = Factory::getLanguage()->getTag();
             $attributes['direction'] = Factory::getLanguage()->isRtl() ? 'rtl' : 'ltr';
         }


### PR DESCRIPTION
Pull Request for Issue #45151

Summary of Changes
This PR fixes the wrong autoload path for fields when the "administrator" folder has been redefined. The current setup assumes the folder is in the default location, and makes sure Joomla will always find the right location for "administrator" folder, no matter where it's placed.


### Testing Instructions
1. Set up a custom "administrator" folder 
Move or rename "administrator " folder in your Joomla installation to simulate custom folder.

2. Check the issue before applying the fix
Access a page in Joomla admin panel  that requires autoload fields. It should fail to load the fields correctly due to the custom folder location.

3.Apply the PR
Merge the PR into Joomla installation

4. Check the fix after applying the PR
Reload the same page. The fields should now load correctly, even with the custom folder location.


Actual result BEFORE applying this Pull Request
Joomla cannot find the autoload path for the fields, even when the "administrator" folder is relocated or renamed, and the fields will be loaded with errors.


Expected result AFTER applying this Pull Request
Joomla will correctly find the autoload path for the fields, even when the "administrator" folder is relocted or renamed and the fields will be loaded without any errors.
