### PR TITLE
[4.4] Composer update joomla/database to 2.2.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
     "joomla/console": "^2.0.1",
     "joomla/crypt": "^2.0.1",
     "joomla/data": "^2.0.1",
-    "joomla/database": "^2.2.0",
+    "joomla/database": "^2.2.1",
     "joomla/di": "^2.0.1",
     "joomla/event": "^2.0.2",
     "joomla/filter": "^2.0.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5e7aa72f51928d53f3e4ceb930add12",
+    "content-hash": "d5fc33c2c38765d59f0d259bf9e23eff",
     "packages": [
         {
             "name": "algo26-matthias/idna-convert",
@@ -1475,16 +1475,16 @@
         },
         {
             "name": "joomla/database",
-            "version": "2.2.0",
+            "version": "2.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/database.git",
-                "reference": "4886a900949f9422c3f441fa3434d1ba4beaff83"
+                "reference": "07f2127cb306ab9cc45d3e1719e1e64596529106"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/database/zipball/4886a900949f9422c3f441fa3434d1ba4beaff83",
-                "reference": "4886a900949f9422c3f441fa3434d1ba4beaff83",
+                "url": "https://api.github.com/repos/joomla-framework/database/zipball/07f2127cb306ab9cc45d3e1719e1e64596529106",
+                "reference": "07f2127cb306ab9cc45d3e1719e1e64596529106",
                 "shasum": ""
             },
             "require": {
@@ -1539,7 +1539,7 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/database/issues",
-                "source": "https://github.com/joomla-framework/database/tree/2.2.0"
+                "source": "https://github.com/joomla-framework/database/tree/2.2.1"
             },
             "funding": [
                 {
@@ -1551,7 +1551,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-30T18:57:24+00:00"
+            "time": "2025-04-06T13:54:39+00:00"
         },
         {
             "name": "joomla/di",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) updates the composer dependency "joomla/database" from version 2.2.0 to version 2.2.1.

Changes see here: https://github.com/joomla-framework/database/releases/tag/2.2.1

The only change is the one from https://github.com/joomla-framework/database/pull/339 .

The code fixed by this PR is not used by the core but might be used by 3rd party dependencies.

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

Composer dependency "joomla/database" has version 2.2.0.

### Expected result AFTER applying this Pull Request

Composer dependency "joomla/database" has version 2.2.1, which includes the fix from https://github.com/joomla-framework/database/pull/339 .

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
