### PR TITLE
[5.2] Composer update joomla/database to 3.4.1

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1494,16 +1494,16 @@
         },
         {
             "name": "joomla/database",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/database.git",
-                "reference": "10745e7b8a3632551861f4da9c6a80a04031a3a3"
+                "reference": "e283eb17a68b96c340cae397cb77e723b2ea50a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/database/zipball/10745e7b8a3632551861f4da9c6a80a04031a3a3",
-                "reference": "10745e7b8a3632551861f4da9c6a80a04031a3a3",
+                "url": "https://api.github.com/repos/joomla-framework/database/zipball/e283eb17a68b96c340cae397cb77e723b2ea50a6",
+                "reference": "e283eb17a68b96c340cae397cb77e723b2ea50a6",
                 "shasum": ""
             },
             "require": {
@@ -1561,7 +1561,7 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/database/issues",
-                "source": "https://github.com/joomla-framework/database/tree/3.4.0"
+                "source": "https://github.com/joomla-framework/database/tree/3.4.1"
             },
             "funding": [
                 {
@@ -1573,7 +1573,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-30T14:43:37+00:00"
+            "time": "2025-04-06T13:57:03+00:00"
         },
         {
             "name": "joomla/di",


### PR DESCRIPTION
Pull Request for Issue #45286 .

### Summary of Changes

This pull request (PR) updates the composer dependency "joomla/database" from version 3.4.0 to version 3.4.1.

Changes see here: https://github.com/joomla-framework/database/releases/tag/3.4.1

There are changes from 2 PRs:
- https://github.com/joomla-framework/database/pull/337 fixes issue #45286 .
- https://github.com/joomla-framework/database/pull/338 see https://github.com/joomla/joomla-cms/pull/45287 .

### Testing Instructions

Code review.

### Actual result BEFORE applying this Pull Request

Composer dependency "joomla/database" has version 3.4.0.

### Expected result AFTER applying this Pull Request

omposer dependency "joomla/database" has version 3.4.1, which includes the fixes from https://github.com/joomla-framework/database/pull/337 and https://github.com/joomla-framework/database/pull/338 .

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
