### PR TITLE
[5.4] Upmerge changes from 5.3-dev 2025-04-06 (2)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1494,16 +1494,16 @@
         },
         {
             "name": "joomla/database",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/joomla-framework/database.git",
-                "reference": "10745e7b8a3632551861f4da9c6a80a04031a3a3"
+                "reference": "e283eb17a68b96c340cae397cb77e723b2ea50a6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/joomla-framework/database/zipball/10745e7b8a3632551861f4da9c6a80a04031a3a3",
-                "reference": "10745e7b8a3632551861f4da9c6a80a04031a3a3",
+                "url": "https://api.github.com/repos/joomla-framework/database/zipball/e283eb17a68b96c340cae397cb77e723b2ea50a6",
+                "reference": "e283eb17a68b96c340cae397cb77e723b2ea50a6",
                 "shasum": ""
             },
             "require": {
@@ -1561,7 +1561,7 @@
             ],
             "support": {
                 "issues": "https://github.com/joomla-framework/database/issues",
-                "source": "https://github.com/joomla-framework/database/tree/3.4.0"
+                "source": "https://github.com/joomla-framework/database/tree/3.4.1"
             },
             "funding": [
                 {
@@ -1573,7 +1573,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-03-30T14:43:37+00:00"
+            "time": "2025-04-06T13:57:03+00:00"
         },
         {
             "name": "joomla/di",


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes

This pull request (PR) merges the changes from 5.3-dev up into 5.4-dev which have been made since the last upmerge PR #45285 .

There are only changes from PR #45288 , which were merged up from 5.2-dev into 5.3-dev with PR #45290 .

### Important hint for maintainers

This PR has to be merged with a merge commit, not a squash commit.

### Testing Instructions

Review. Check the commits of this PR and those in the 5.3-dev branch.

### Actual result BEFORE applying this Pull Request

5.4-dev branch is not up to date with 5.3-dev.

### Expected result AFTER applying this Pull Request

5.4-dev branch is up to date with 5.3-dev.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
