### PR TITLE
[4.x] - Respect individual width/height constraints in Media Action - Resize plugin

### DIFF
--- a/plugins/media-action/resize/src/Extension/Resize.php
+++ b/plugins/media-action/resize/src/Extension/Resize.php
@@ -52,7 +52,20 @@ final class Resize extends MediaActionPlugin
 
         $imgObject = new Image(imagecreatefromstring($item->data));
 
-        if ($imgObject->getWidth() < $this->params->get('batch_width', 0) && $imgObject->getHeight() < $this->params->get('batch_height', 0)) {
+        $maxWidth  = (int) $this->params->get('batch_width', 0);
+        $maxHeight = (int) $this->params->get('batch_height', 0);
+
+        $shouldResize = false;
+
+        if ($maxWidth > 0 && $imgObject->getWidth() > $maxWidth) {
+            $shouldResize = true;
+        }
+
+        if ($maxHeight > 0 && $imgObject->getHeight() > $maxHeight) {
+            $shouldResize = true;
+        }
+
+        if (!$shouldResize) {
             return;
         }
 


### PR DESCRIPTION
Pull Request for Issue #44862 

### Summary of Changes

This pull request resolves a bug in the Media Action - Resize plugin where images are resized unnecessarily when only one dimension (width or height) is set.

Previously, if a user defined only a max width (e.g., 1920px) and left height unset, the plugin would still resize small images (e.g., 200px wide). This occurred because the height check defaulted to 0, incorrectly failing the comparison logic.

The logic has been updated to evaluate width and height independently. The plugin now only resizes if the image exceeds a defined constraint.

### Testing Instructions

1. Enable the plugin Media Action - Resize.
2. Set Maximum Width to 1920. Leave Maximum Height empty.
3. Upload a small image via Media Manager (e.g., 200x300px).
4. Observe that before the patch, the image was resized unnecessarily.
5. Observe that after the patch, the image is not resized if not necessary.
6. Optionally test with only height set and both width and height set.

### Actual result BEFORE applying this Pull Request

Images smaller than the defined max width or height are still resized if one constraint is not set.


### Expected result AFTER applying this Pull Request

Images are only resized if they exceed a defined max width or height. Unset dimensions are ignored in the check, preventing unnecessary resizing.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org:
- [x] No documentation changes for docs.joomla.org needed
- [ ] Pull Request link for manual.joomla.org:
- [x] No documentation changes for manual.joomla.org needed
