### PR TITLE
[5.3] Update to TinyMCE Danish translation (Fixed typo)

### DIFF
--- a/build/media_source/vendor/tinymce/langs/da.es5.js
+++ b/build/media_source/vendor/tinymce/langs/da.es5.js
@@ -120,7 +120,7 @@ tinymce.addI18n('da',{
 "Source": "Kilde",
 "Dimensions": "Dimensioner",
 "Constrain proportions": "Behold propertioner",
-"General": "Generet",
+"General": "Generelt",
 "Advanced": "Avanceret",
 "Style": "Stil",
 "Vertical space": "Lodret afstand",


### PR DESCRIPTION
Fixed misspelled language string in Danish translation

Pull Request for Issue # .

### Summary of Changes

Fixed language string, line 123
"General": "Generelt",

### Testing Instructions

Create a table in the editor, then select table properties. 
Then select table properties and you see the language string in the popup

<img width="1297" alt="Skærmbillede 2025-04-11 kl  15 02 27" src="https://github.com/user-attachments/assets/c1aca4f4-556a-4e9b-a5b0-0d1b2acc7eba" />

### Actual result BEFORE applying this Pull Request

Generel was translated to Generet

### Expected result AFTER applying this Pull Request

Correct translation of General to Generelt

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
