### PR TITLE
[5.3] Media Manager Empty information

### DIFF
--- a/administrator/components/com_media/resources/scripts/components/browser/browser.vue
+++ b/administrator/components/com_media/resources/scripts/components/browser/browser.vue
@@ -30,7 +30,7 @@
     <div
       v-if="isEmpty"
       class="text-center"
-      style="display: grid; justify-content: center; align-content: center; margin-top: -1rem; color: var(--gray-200); height: 100%;"
+      style="display: grid; justify-content: center; align-content: center; color: var(--gray-200); height: 100%;"
     >
       <span
         class="fa-8x icon-cloud-upload upload-icon"


### PR DESCRIPTION
Pull Request for Issue #44955 .

### Summary of Changes
When a folder is empty and you have the information bar open then the text of the infobar is partially hidden



### Testing Instructions
This will require either a -prebuilt image or `run npm i`

Create an empty folder and display the infobar


### Actual result BEFORE applying this Pull Request
![image](https://github.com/user-attachments/assets/2cdbee0a-1617-47ef-a4a5-0cf5c364a5c7)



### Expected result AFTER applying this Pull Request
![image](https://github.com/user-attachments/assets/ca5a06ee-4340-495b-b052-c7995c90c9ae)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
