### PR TITLE
[5.3] Fix description positioning in search bar

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_form.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_form.scss
@@ -164,7 +164,8 @@ label.valid {
 }
 
 .filter-search-bar__description {
-  bottom: 100%;
+  top: 100%;
+  bottom: auto;
 }
 
 .container-popup .filter-search-bar__description {


### PR DESCRIPTION
Pull Request for Issue #44086.

### Summary of Changes

- Fixed an issue where the search bar description was partially visible

- Changed bottom: 100% to top: 100%; bottom: auto;, ensuring the description appears completely without obstructing the search input.

### Testing Instructions

- Go to the media manager or any relevant page with a search bar.
- Hover over the search bar to view the description tooltip.
- Ensure the description appears below the search bar and does not overlap.


### Actual result BEFORE applying this Pull Request
![image](https://github.com/user-attachments/assets/44eee75b-db01-48bd-b91e-208b74902f55)
The description was partially visible.


### Expected result AFTER applying this Pull Request
![image](https://github.com/user-attachments/assets/96e0389d-8080-4835-b40a-3222cb1caa74)
The description appears fully below the search bar.


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
