### PR TITLE
[5.3] Fix issue where unpublished admin module "Title" hides "Column select"

### DIFF
--- a/administrator/components/com_modules/tmpl/modules/default.php
+++ b/administrator/components/com_modules/tmpl/modules/default.php
@@ -40,7 +40,7 @@ if ($saveOrder && !empty($this->items)) {
     <div id="j-main-container" class="j-main-container">
         <?php echo LayoutHelper::render('joomla.searchtools.default', ['view' => $this]); ?>
         <?php if ($this->total > 0) : ?>
-            <table class="table" id="moduleList">
+            <table class="table" id="moduleList" data-name="admin-modules-table">
                 <caption class="visually-hidden">
                     <?php echo Text::_('COM_MODULES_TABLE_CAPTION'); ?>,
                             <span id="orderedBy"><?php echo Text::_('JGLOBAL_SORTED_BY'); ?> </span>,


### PR DESCRIPTION
Pull Request for Issue #45306 .

### Summary of Changes

- Fixed the issue where the unpublished admin module "Title" hides the "Column select" option.


### Testing Instructions

- Go to the Joomla admin panel.

- Unpublish the "Title" module.

- Verify that the "Column select" option is still visible and accessible.


### Actual result BEFORE applying this Pull Request

![Screenshot 2025-04-15 235851](https://github.com/user-attachments/assets/69433595-8f07-45be-939d-daebb9f2fd67)
When the "Title" admin module is unpublished, the "Column select" option is hidden.

### Expected result AFTER applying this Pull Request

![Screenshot 2025-04-15 235955](https://github.com/user-attachments/assets/4fc99199-d159-4286-916a-b710dc0f9a2d)
The "Column select" option remains visible and functional even when the "Title" admin module is unpublished.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
