### PR TITLE
README.md - add link to the manual for new contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Do you want to improve Joomla?
 --------------------
 * Where to [request a feature](https://issues.joomla.org)?
 * How do you [report a bug](https://docs.joomla.org/Special:MyLanguage/Filing_bugs_and_issues) on the [Issue Tracker](https://issues.joomla.org)?
-* How to [submit code](https://manual.joomla.org/docs/next/get-started/git/github-joomla-cms/) to the Joomla CMS using a Pull Request?
+* How to [submit code](https://manual.joomla.org/docs/next/get-started/git/) to the Joomla CMS using a Pull Request?
 * Get Involved: Joomla! is community developed software. [Join the community](https://volunteers.joomla.org).
 * Documentation for [Developers](https://manual.joomla.org/).
 * Documentation for [Web designers](https://docs.joomla.org/Special:MyLanguage/Web_designers).

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Do you want to improve Joomla?
 --------------------
 * Where to [request a feature](https://issues.joomla.org)?
 * How do you [report a bug](https://docs.joomla.org/Special:MyLanguage/Filing_bugs_and_issues) on the [Issue Tracker](https://issues.joomla.org)?
+* How to [submit code](https://manual.joomla.org/docs/next/get-started/git/github-joomla-cms/) to the Joomla CMS using a Pull Request??
 * Get Involved: Joomla! is community developed software. [Join the community](https://volunteers.joomla.org).
 * Documentation for [Developers](https://manual.joomla.org/).
 * Documentation for [Web designers](https://docs.joomla.org/Special:MyLanguage/Web_designers).

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Do you want to improve Joomla?
 --------------------
 * Where to [request a feature](https://issues.joomla.org)?
 * How do you [report a bug](https://docs.joomla.org/Special:MyLanguage/Filing_bugs_and_issues) on the [Issue Tracker](https://issues.joomla.org)?
-* How to [submit code](https://manual.joomla.org/docs/next/get-started/git/github-joomla-cms/) to the Joomla CMS using a Pull Request??
+* How to [submit code](https://manual.joomla.org/docs/next/get-started/git/github-joomla-cms/) to the Joomla CMS using a Pull Request?
 * Get Involved: Joomla! is community developed software. [Join the community](https://volunteers.joomla.org).
 * Documentation for [Developers](https://manual.joomla.org/).
 * Documentation for [Web designers](https://docs.joomla.org/Special:MyLanguage/Web_designers).


### PR DESCRIPTION
For new contributors who are starting with GitHub, it is maybe not clear they must first make a fork before they can send a Pull Request. I changed the README.md to add a link to the git section in the manual.

### Testing Instructions

Text review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
