### PR TITLE
[6.0] Simplyfy class generation in backend menu module

### DIFF
--- a/administrator/modules/mod_menu/tmpl/default_submenu.php
+++ b/administrator/modules/mod_menu/tmpl/default_submenu.php
@@ -34,13 +34,7 @@ if (!$this->enabled) {
     $class .= ' parent';
 }
 
-if ($current->level == 1) {
-    $class .= ' item-level-1';
-} elseif ($current->level == 2) {
-    $class .= ' item-level-2';
-} elseif ($current->level == 3) {
-    $class .= ' item-level-3';
-}
+$class .= ' item-level-' . (int) $current->level;
 
 // Set the correct aria role and print the item
 if ($current->type == 'separator') {


### PR DESCRIPTION
### Summary of Changes
Just a simplyfication of menu class generation to support deeper level marking


### Testing Instructions
Go to the backend and check the classes in the menu on the left side


### Actual result BEFORE applying this Pull Request
```item-level-1, item-level-2, item-level-3``` are there


### Expected result AFTER applying this Pull Request
```item-level-1, item-level-2, item-level-3``` are still there

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
