### PR TITLE
[5.3] Show correct custom fields when creating article after filtering by multiple categories

### DIFF
--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -590,9 +590,9 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
 
                 // Fix: If multiple categories are filtered, pick the first one to avoid loading all fields
                 $filteredCategories = $filters['category_id'] ?? null;
-                $selectedCatId = null;
+                $selectedCatId      = null;
 
-                if (is_array($filteredCategories)) {
+                if (\is_array($filteredCategories)) {
                     $selectedCatId = (int) reset($filteredCategories);
                 } elseif (!empty($filteredCategories)) {
                     $selectedCatId = (int) $filteredCategories;

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -587,7 +587,18 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
                         ((isset($filters['published']) && $filters['published'] !== '') ? $filters['published'] : null)
                     )
                 );
-                $data->set('catid', $app->getInput()->getInt('catid', (!empty($filters['category_id']) ? $filters['category_id'] : null)));
+
+                // Fix: If multiple categories are filtered, pick the first one to avoid loading all fields
+                $filteredCategories = $filters['category_id'] ?? null;
+                $selectedCatId = null;
+
+                if (is_array($filteredCategories)) {
+                    $selectedCatId = (int) reset($filteredCategories);
+                } elseif (!empty($filteredCategories)) {
+                    $selectedCatId = (int) $filteredCategories;
+                }
+
+                $data->set('catid', $app->getInput()->getInt('catid', $selectedCatId));
 
                 if ($app->isClient('administrator')) {
                     $data->set('language', $app->getInput()->getString('language', (!empty($filters['language']) ? $filters['language'] : null)));

--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -588,7 +588,7 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
                     )
                 );
 
-                // Fix: If multiple categories are filtered, pick the first one to avoid loading all fields
+                // If multiple categories are filtered, pick the first one to avoid loading all fields
                 $filteredCategories = $filters['category_id'] ?? null;
                 $selectedCatId      = null;
 


### PR DESCRIPTION
## Pull Request for Issue #45303

### Summary of Changes

This PR fixes a bug where creating a new article after filtering by **multiple categories** (e.g. "News" and "Events") incorrectly displays **all custom fields** from all those categories on the "Fields" tab.

Joomla previously used the `catid` filter directly from user state or input, which led to ambiguous behavior when multiple categories were selected. This fix:

- Detects when `category_id` filter is an array
- Selects the **first selected category** from the filtered list
- Ensures only relevant custom fields are loaded for the selected category
- Supports fallback logic for single-category filter or default category

This resolves #45303 and improves clarity and correctness of the custom field rendering in the admin UI.

---

### Testing Instructions

1. Create two categories: **Events** and **News**
2. Create two custom fields:
   - `events_title` → assigned to **Events**
   - `news_title` → assigned to **News**
3. Go to **Content > Articles**
4. Apply **category filter** for both "Events" and "News"
5. Click **New Article**
   - ✅ Only one custom field (`events_title` or `news_title`) should appear on the "Fields" tab
6. Change category using dropdown
   - ✅ Custom fields update correctly

---

### Actual result BEFORE applying this Pull Request

![Screenshot (37)](https://github.com/user-attachments/assets/81c2e459-a950-44f5-8734-fe4f78b862f8)
- When filtered by multiple categories and clicking "New", **all fields** from all selected categories are loaded.
- Changing category does **not reload** the field list properly.

---

### Expected result AFTER applying this Pull Request

![Screenshot (36)](https://github.com/user-attachments/assets/0912711b-7e3a-4fc7-87bc-214fddf91b5c)
- Only the **first selected category’s** custom fields are loaded initially
- Changing category in the form **correctly reloads** the associated custom fields dynamically
- Prevents confusion and clutter in the custom fields UI

---

### Link to documentation

Please select:
- [ ] Documentation link for docs.joomla.org:
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org:
- [x] No documentation changes for manual.joomla.org needed
