### PR TITLE
[5.3] Fancy-select filter missing values

### DIFF
--- a/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
+++ b/build/media_source/system/js/fields/joomla-field-fancy-select.w-c.es6.js
@@ -129,6 +129,7 @@ window.customElements.define('joomla-field-fancy-select', class extends HTMLElem
       searchFloor: this.minTermLength,
       searchResultLimit: parseInt(this.select.dataset.maxResults, 10) || 10,
       renderChoiceLimit: parseInt(this.select.dataset.maxRender, 10) || -1,
+      renderSelectedChoices: 'always',
       shouldSort: false,
       fuseOptions: {
         threshold: 0.3, // Strict search


### PR DESCRIPTION
Pull request for #45362

### Summary of Changes
In a fancy-select filter such as the list of categories in the article manager the dropdown excludes the currently selected category. 

This causes problems if that category has any subcategories as they now appear to be the children of a completely different category

This is caused by the choices.js script which by default removes selected items from the list which is fine for a flat list but causes the described problem on a nested list.

The solution is documented here https://github.com/Choices-js/Choices?tab=readme-ov-file#renderselectedchoices

> Usage: Whether selected choices should be removed from the list. By default choices are removed when they are selected in multiple select box. To always render choices pass always.

This PR changes the setting from auto to always

### Testing Instructions
Create two categories
Create subcategories for both of the above
Using the category filter select one of the parent categories
Now try to select one of the child categories

As this is a JS change you will need to test either a prebuilt package or `npm run build:js`

### Actual result BEFORE applying this Pull Request
The previously selected category is removed from the list

#### No category selected

![Image](https://github.com/user-attachments/assets/546b230b-2076-4d20-8618-eb4777f704fa)

#### Category selected

![Image](https://github.com/user-attachments/assets/734052b4-de0d-4b16-8eec-80fea2288fa3)

### Expected result AFTER applying this Pull Request
The categories in the list never changes

#### No category selected

![image](https://github.com/user-attachments/assets/b1b3a249-434f-448b-aa41-6060a974ec95)

#### Category selected

![image](https://github.com/user-attachments/assets/e5e30e0c-a027-49ab-be33-559e389e8218)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed

cc @laoneo 