### PR TITLE
[6.0] Remove not used query helper function

### DIFF
--- a/components/com_content/src/Helper/QueryHelper.php
+++ b/components/com_content/src/Helper/QueryHelper.php
@@ -10,7 +10,6 @@
 
 namespace Joomla\Component\Content\Site\Helper;
 
-use Joomla\CMS\Component\ComponentHelper;
 use Joomla\CMS\Factory;
 use Joomla\CMS\Plugin\PluginHelper;
 use Joomla\Database\DatabaseInterface;
@@ -192,37 +191,5 @@ class QueryHelper
         }
 
         return $queryDate;
-    }
-
-    /**
-     * Get join information for the voting query.
-     *
-     * @param   \Joomla\Registry\Registry  $params  An options object for the article.
-     *
-     * @return  array  A named array with "select" and "join" keys.
-     *
-     * @since   1.5
-     *
-     * @deprecated  4.3 will be removed in 6.0
-     *              Will be removed without replacement
-     */
-    public static function buildVotingQuery($params = null)
-    {
-        if (!$params) {
-            $params = ComponentHelper::getParams('com_content');
-        }
-
-        $voting = $params->get('show_vote');
-
-        if ($voting) {
-            // Calculate voting count
-            $select = ' , ROUND(v.rating_sum / v.rating_count) AS rating, v.rating_count';
-            $join   = ' LEFT JOIN #__content_rating AS v ON a.id = v.content_id';
-        } else {
-            $select = '';
-            $join   = '';
-        }
-
-        return ['select' => $select, 'join' => $join];
     }
 }


### PR DESCRIPTION
### Summary of Changes
Removes the not used `buildVotingQuery` function in the `QueryHelper` class.

Code review as the function is not used since ages as you can see from #27722.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/447
- [ ] No documentation changes for manual.joomla.org needed
