### PR TITLE
[6.0] Remove tfa property from login view

### DIFF
--- a/components/com_users/src/View/Login/HtmlView.php
+++ b/components/com_users/src/View/Login/HtmlView.php
@@ -66,17 +66,6 @@ class HtmlView extends BaseHtmlView
     protected $pageclass_sfx = '';
 
     /**
-     * No longer used
-     *
-     * @var    boolean
-     * @since  4.0.0
-     *
-     * @deprecated  4.3 will be removed in 6.0
-     *              Will be removed without replacement
-     */
-    protected $tfa = false;
-
-    /**
      * Additional buttons to show on the login page
      *
      * @var    array


### PR DESCRIPTION
### Summary of Changes
Removes the deprecated tfa property from the login view as it is not used anymore.

code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/451
- [ ] No documentation changes for manual.joomla.org needed
