### PR TITLE
[6.0] Remove BufferStreamHandler::stream_register in class

### DIFF
--- a/libraries/src/Utility/BufferStreamHandler.php
+++ b/libraries/src/Utility/BufferStreamHandler.php
@@ -6,20 +6,12 @@
  * @copyright  (C) 2007 Open Source Matters, Inc. <https://www.joomla.org>
  * @license    GNU General Public License version 2 or later; see LICENSE.txt
  *
- * Remove phpcs exception with deprecated autoloading BufferStreamHandler::stream_register();
  * @phpcs:disable PSR1.Files.SideEffects
  */
 
 namespace Joomla\CMS\Utility;
 
 \defined('_JEXEC') or die;
-
-/**
- * @deprecated  3.8 will be removed in 5.0
- *              Workaround for B/C. (removal missed in 4.0, also remove phpcs exception).
- *              If BufferStreamHandler is needed directly call BufferStreamHandler::stream_register();
- */
-BufferStreamHandler::stream_register();
 
 /**
  * Generic Buffer stream handler


### PR DESCRIPTION
### Summary of Changes
Does remove the call to `stream_register` in the `BufferStreamHandler` class outside of the class definition. If your extension relies on this, then call it before the logic.

Code review as this is only used in FTP client which is not used in core.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/452
- [ ] No documentation changes for manual.joomla.org needed
