### PR TITLE
[5.3] Does check the server error logs in system tests

### DIFF
--- a/cypress.config.dist.mjs
+++ b/cypress.config.dist.mjs
@@ -42,5 +42,6 @@ export default defineConfig({
     smtp_host: 'localhost',
     smtp_port: '1025',
     cmsPath: '.',
+    logFile: '',
   },
 });

--- a/tests/System/README.md
+++ b/tests/System/README.md
@@ -178,6 +178,8 @@ The Joomla System Tests come with some convenient [Cypress Tasks](https://docs.c
 - **writeRelativeFile** – Writes a file relative to the CMS root folder
 - **deleteRelativePath** – Deletes a file or folder relative to the CMS root folder
 - **copyRelativeFile** – Copies a file relative to the CMS root folder
+- **checkForLogs** – Checks the log file from the configuration for errors
+- **clearLogs** – Clears the logs in the log file from the configuration
 - **startMailServer** – Starts the smtp-tester SMTP server
 - **getMails** – Get received mails from smtp-tester
 - **clearEmails** – Clear all smtp-tester received mails

--- a/tests/System/README.md
+++ b/tests/System/README.md
@@ -178,7 +178,7 @@ The Joomla System Tests come with some convenient [Cypress Tasks](https://docs.c
 - **writeRelativeFile** – Writes a file relative to the CMS root folder
 - **deleteRelativePath** – Deletes a file or folder relative to the CMS root folder
 - **copyRelativeFile** – Copies a file relative to the CMS root folder
-- **checkForLogs** – Checks the log file from the configuration for errors
+- **checkForLogs** – Checks the log file (path defined in configuration) for errors
 - **clearLogs** – Clears the logs in the log file from the configuration
 - **startMailServer** – Starts the smtp-tester SMTP server
 - **getMails** – Get received mails from smtp-tester

--- a/tests/System/entrypoint.sh
+++ b/tests/System/entrypoint.sh
@@ -39,4 +39,4 @@ if [ -z "$( ls -A '/root/.cache/Cypress' )" ]; then
   npx cypress verify
 fi
 
-npx cypress run --browser=firefox --e2e --env cmsPath=/tests/www/$TEST_GROUP,db_type=$DB_ENGINE,db_host=$DB_HOST,db_password=joomla_ut,db_prefix="${TEST_GROUP}_" --config baseUrl=https://localhost/$TEST_GROUP,screenshotsFolder=$JOOMLA_BASE/tests/System/output/screenshots
+npx cypress run --browser=firefox --e2e --env cmsPath=/tests/www/$TEST_GROUP,db_type=$DB_ENGINE,db_host=$DB_HOST,db_password=joomla_ut,db_prefix="${TEST_GROUP}_",logFile=/var/log/apache2/error.log --config baseUrl=https://localhost/$TEST_GROUP,screenshotsFolder=$JOOMLA_BASE/tests/System/output/screenshots

--- a/tests/System/plugins/index.mjs
+++ b/tests/System/plugins/index.mjs
@@ -1,6 +1,7 @@
 import { getMails, clearEmails, startMailServer } from './mail.mjs';
 import { writeRelativeFile, deleteRelativePath, copyRelativeFile } from './fs.mjs';
 import { queryTestDB, deleteInsertedItems } from './db.mjs';
+import { checkForLogs, clearLogs } from './logs.mjs';
 
 /**
  * Does the setup of the plugins.
@@ -17,6 +18,8 @@ export default function setupPlugins(on, config) {
     writeRelativeFile: ({ path, content, mode }) => writeRelativeFile(path, content, config, mode),
     deleteRelativePath: (path) => deleteRelativePath(path, config),
     copyRelativeFile: ({ source, destination }) => copyRelativeFile(source, destination, config),
+    checkForLogs: () => checkForLogs(config),
+    clearLogs: () => clearLogs(config),
     getMails: () => getMails(),
     clearEmails: () => clearEmails(),
     startMailServer: () => startMailServer(config),

--- a/tests/System/plugins/logs.mjs
+++ b/tests/System/plugins/logs.mjs
@@ -1,0 +1,42 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+
+/**
+ * Checks if there are entries written to the logs file.
+ *
+ * @param {object} config - The Cypress configuration object
+ *
+ * @returns null
+ */
+function checkForLogs(config) {
+  const { logFile } = config.env;
+  if (!existsSync(logFile)) {
+    return null;
+  }
+
+  const log = readFileSync(logFile, 'utf8');
+  if (!log) {
+    return null;
+  }
+
+  throw new Error(log);
+}
+
+/**
+ * Clears the log file.
+ *
+ * @param {object} config - The Cypress configuration object
+ *
+ * @returns null
+ */
+function clearLogs(config) {
+  const { logFile } = config.env;
+  if (!existsSync(logFile)) {
+    return null;
+  }
+
+  writeFileSync(logFile, '');
+
+  return null;
+}
+
+export { checkForLogs, clearLogs };

--- a/tests/System/support/index.js
+++ b/tests/System/support/index.js
@@ -8,6 +8,6 @@ before(() => {
 
 afterEach(() => {
   cy.checkForPhpNoticesOrWarnings();
-  cy.task('cleanupDB');
   cy.task('checkForLogs');
+  cy.task('cleanupDB');
 });

--- a/tests/System/support/index.js
+++ b/tests/System/support/index.js
@@ -3,9 +3,11 @@ import('joomla-cypress');
 
 before(() => {
   cy.task('startMailServer');
+  cy.task('clearLogs');
 });
 
 afterEach(() => {
   cy.checkForPhpNoticesOrWarnings();
   cy.task('cleanupDB');
+  cy.task('checkForLogs');
 });


### PR DESCRIPTION
### Summary of Changes
Checks the error log file after each test if there is an entry written to it.

### Testing Instructions
Place somewhere in the CMS code the following code snippet ( I added it for testing to administrator/components/com_actionlogs/src/Model/ActionlogsModel.php into the delete function)

`error_log('test');`

Run the system test ( was running tests/System/integration/administrator/components/com_actionlogs/Actionlogs.cy.js).

### Actual result BEFORE applying this Pull Request
The test was running through.

### Expected result AFTER applying this Pull Request
The test failed.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
