### PR TITLE
[6.0] Remove the item association property in the web application

### DIFF
--- a/libraries/src/Application/WebApplication.php
+++ b/libraries/src/Application/WebApplication.php
@@ -57,16 +57,6 @@ abstract class WebApplication extends AbstractWebApplication
     public $JComponentTitle;
 
     /**
-     * The item associations
-     *
-     * @var    integer
-     * @since  4.3.0
-     *
-     * @deprecated 4.4.0 will be removed in 6.0 as this property is not used anymore
-     */
-    public $item_associations;
-
-    /**
      * The application document object.
      *
      * @var    Document


### PR DESCRIPTION
### Summary of Changes
Removes the `$item_associations` property in the `WebApplication` class as it is not used at all and was only there for PHP 8.2 compatibility in #39630.

code review

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [x] Pull Request link for manual.joomla.org: https://github.com/joomla/Manual/pull/456
- [ ] No documentation changes for manual.joomla.org needed
