### PR TITLE
Fix deprecation text and add Registry to StateBehaviorTrait

### DIFF
--- a/libraries/src/MVC/Model/State.php
+++ b/libraries/src/MVC/Model/State.php
@@ -21,7 +21,7 @@ use Joomla\Registry\Registry;
  *
  * @since  5.0.0
  *
- * @deprecated  7.0 Use the Registry directly
+ * @deprecated  5.0.0 will be removed in 7.0, use the Registry directly
  */
 class State extends Registry
 {
@@ -70,7 +70,7 @@ class State extends Registry
       *
       * @since   5.0.0
       *
-      * @deprecated  7.0 Use toArray instead
+      * @deprecated  5.0.0 will be removed in 7.0, use toArray instead
       */
     public function getProperties()
     {

--- a/libraries/src/MVC/Model/StateBehaviorTrait.php
+++ b/libraries/src/MVC/Model/StateBehaviorTrait.php
@@ -31,8 +31,10 @@ trait StateBehaviorTrait
     /**
      * A state object
      *
-     * @var    State
+     * @var    State|\Joomla\Registry\Registry
      * @since  4.0.0
+     *
+     * @todo   Remove the State type hint in Joomla 7.0 since it will be removed see State class
      */
     protected $state = null;
 


### PR DESCRIPTION
Add missing type hint and correct deprecation text.

### Summary of Changes

The `$state` property defined in the StateBehaviorTrait has as type hint the `State` class which is deprecated. The goal is to replace the `State` object with a `Registry` object. This can be done in 5.0+ by initialising the `$state` in the constructor with a `Registry` object. The Trait will use this `Registry` object. If the `$state` property is not type hinted with the Registry object, phpstan will complain about incorrect use of the `$state`.

This PR allows to use the correct type (Registry) and solves warnings from the static code analyser.


### Testing Instructions
Code Review.

if you use phpstan you should no longer get the following messages:

Initialization of `$state` with `\Joomla\Registry\Registry` in the constructor

```php
class YourModel extends ListModel
{
    public function __construct($config = [], ?MVCFactoryInterface $factory = null)
    {
        $this->state = new Registry();
    }
}
```

```
Property Joomla\CMS\MVC\Model\BaseModel::$state (Joomla\CMS\MVC\Model\State) does not accept Joomla\Registry\Registry.  
         🪪  assign.propertyType                                                                                                 
```

Get variable from the `$state` property when it's a `State` object

```php
class YourModel extends ListModel
{
    public function getItems()
    {
        return $this->state->get('dummy);
    }
    public function getItems2()
    {
        return $this->getState('dummy);
    }
}
```

```
Call to method get() of deprecated class Joomla\CMS\MVC\Model\State:                                                    
         7.0 Use the Registry directly                                                                                           
         🪪  method.deprecatedClass                                                                                              
```

Also if you run this code against the `State` object you get a runtime E_USER_DEPRECATED warning.

### Actual result BEFORE applying this Pull Request

With phpstan warnings and E_USER_DEPRECATED for the get function is triggered.

### Expected result AFTER applying this Pull Request

Without phpstan warnings and no E_USER_DEPRECATED for the get function is triggered.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
