### PR TITLE
[5.3] Allow update server administrator to return a message to the Joomla admin.

### DIFF
--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -359,8 +359,7 @@ class UpdateModel extends ListModel
                 } else {
                     $app->enqueueMessage($preupdatemessage, $update->preupdatemessage->type);
                     if ($update->preupdatemessage->type === 'error') {
-                        if (empty($preupdatemessage))
-                        {
+                        if (empty($preupdatemessage)) {
                             $preupdatemessage = strip_tags(Text::sprintf('COM_INSTALLER_UPDATE_ERROR', $instance->name, '', ''));
                             $app->enqueueMessage($preupdatemessage, 'error');
                         }

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -353,10 +353,9 @@ class UpdateModel extends ListModel
 
             // Handle optional message from update server administrator
             if (!empty($update->preupdatemessage->_data)) {
-                if(empty($update->preupdatemessage->type)) {
+                if (empty($update->preupdatemessage->type)) {
                     $app->enqueueMessage($update->preupdatemessage->_data);
-                }
-                else {
+                } else {
                     $app->enqueueMessage($update->preupdatemessage->_data, $update->preupdatemessage->type);
                     if ($update->preupdatemessage->type == 'error') {
                         return;

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -357,7 +357,7 @@ class UpdateModel extends ListModel
                     $app->enqueueMessage($update->preupdatemessage->_data);
                 } else {
                     $app->enqueueMessage($update->preupdatemessage->_data, $update->preupdatemessage->type);
-                    if ($update->preupdatemessage->type == 'error') {
+                    if ($update->preupdatemessage->type === 'error') {
                         return;
                     }
                 }

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -351,6 +351,19 @@ class UpdateModel extends ListModel
 
             $update->loadFromXml($instance->detailsurl, $minimumStability);
 
+            // Handle optional message from update server administrator
+            if (!empty($update->preupdatemessage->_data)) {
+                if(empty($update->preupdatemessage->type)) {
+                    $app->enqueueMessage($update->preupdatemessage->_data);
+                }
+                else {
+                    $app->enqueueMessage($update->preupdatemessage->_data, $update->preupdatemessage->type);
+                    if ($update->preupdatemessage->type == 'error') {
+                        return;
+                    }
+				}
+            }
+
             // Find and use extra_query from update_site if available
             $updateSiteInstance = new \Joomla\CMS\Table\UpdateSite($this->getDatabase());
             $updateSiteInstance->load($instance->update_site_id);

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -353,11 +353,17 @@ class UpdateModel extends ListModel
 
             // Handle optional message from update server administrator
             if (!empty($update->preupdatemessage->_data)) {
+                $preupdatemessage = strip_tags($update->preupdatemessage->_data);
                 if (empty($update->preupdatemessage->type)) {
-                    $app->enqueueMessage($update->preupdatemessage->_data);
+                    $app->enqueueMessage($preupdatemessage);
                 } else {
-                    $app->enqueueMessage($update->preupdatemessage->_data, $update->preupdatemessage->type);
+                    $app->enqueueMessage($preupdatemessage, $update->preupdatemessage->type);
                     if ($update->preupdatemessage->type === 'error') {
+                        if (empty($preupdatemessage))
+                        {
+                            $preupdatemessage = strip_tags(Text::sprintf('COM_INSTALLER_UPDATE_ERROR', $instance->name, '', ''));
+                            $app->enqueueMessage($preupdatemessage, 'error');
+                        }
                         return;
                     }
                 }

--- a/administrator/components/com_installer/src/Model/UpdateModel.php
+++ b/administrator/components/com_installer/src/Model/UpdateModel.php
@@ -361,7 +361,7 @@ class UpdateModel extends ListModel
                     if ($update->preupdatemessage->type == 'error') {
                         return;
                     }
-				}
+                }
             }
 
             // Find and use extra_query from update_site if available


### PR DESCRIPTION
Allow update server administrator to return a message to the Joomla admin.

Pull Request for Issue # .

### Summary of Changes

Add a preupdatemessage field to the XML returned by the update server.


### Testing Instructions

Install test plugin:
https://www.brainforge.co.uk/media/extra_downloads/test/test.zip

Check for updates and the test plugin will appear.
Tick the box and run update.
In this example a simple error message will appear and the update aborted.
... a warning / information message could been used instead.

### Actual result BEFORE applying this Pull Request

Update works as expected - although the version number is unchanged!
So it only temporarily disappears from the available update list.

### Expected result AFTER applying this Pull Request

Error message displayed and the update does not happen.

The benefit of this is that an update server manager can send a message to the Joomla administrator.
e.g. 'Please contact us.'

The following documentation requires updating:
https://manual.joomla.org/docs/building-extensions/install-update/update-server/
See file: https://www.brainforge.co.uk/media/extra_downloads/test/updatetest.xml

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
