### PR TITLE
[6.2] Add intro image to RSS feed item description in com_tags

### DIFF
--- a/components/com_tags/src/View/Tag/FeedView.php
+++ b/components/com_tags/src/View/Tag/FeedView.php
@@ -85,7 +85,13 @@ class FeedView extends BaseHtmlView
                 $title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
 
                 // Strip HTML from feed item description text
-                $description = $item->core_body;
+                $description = '';
+                $obj         = json_decode($item->core_images);
+
+                if (!empty($obj->image_intro)) {
+                    $description = '<p>' . HTMLHelper::_('image', $obj->image_intro, $obj->image_intro_alt) . '</p>';
+                }
+                $description .= $item->core_body;
                 $author      = $item->core_created_by_alias ?: $item->author;
                 $date        = ($item->displayDate ? date('r', strtotime($item->displayDate)) : '');
 

--- a/components/com_tags/src/View/Tag/FeedView.php
+++ b/components/com_tags/src/View/Tag/FeedView.php
@@ -84,7 +84,7 @@ class FeedView extends BaseHtmlView
                 $title = $this->escape($item->core_title);
                 $title = html_entity_decode($title, ENT_COMPAT, 'UTF-8');
 
-                // Strip HTML from feed item description text
+                // Build HTML feed item description (image + body)
                 $description = '';
                 $obj         = json_decode($item->core_images);
 

--- a/components/com_tags/src/View/Tag/FeedView.php
+++ b/components/com_tags/src/View/Tag/FeedView.php
@@ -16,6 +16,7 @@ use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Tags\Site\Model\TagModel;
+use Joomla\CMS\HTML\HTMLHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;

--- a/components/com_tags/src/View/Tag/FeedView.php
+++ b/components/com_tags/src/View/Tag/FeedView.php
@@ -12,11 +12,11 @@ namespace Joomla\Component\Tags\Site\View\Tag;
 
 use Joomla\CMS\Document\Feed\FeedItem;
 use Joomla\CMS\Factory;
+use Joomla\CMS\HTML\HTMLHelper;
 use Joomla\CMS\Language\Text;
 use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
 use Joomla\CMS\Router\Route;
 use Joomla\Component\Tags\Site\Model\TagModel;
-use Joomla\CMS\HTML\HTMLHelper;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;


### PR DESCRIPTION
Pull Request for Issue #44693

### Summary of Changes
When generating a feed from com_tags, this change prepends the intro image (if available) to the feed item's description using an <img> tag.

### Testing Instructions
Create a tagged article that has an intro image.
Open the tag feed
Check that the feed item description starts with the intro image as an <img> HTML element.

### Actual result BEFORE applying this Pull Request
The feed item description contains only the article body text.


### Expected result AFTER applying this Pull Request
If the article has an intro image, it is included before the description text in the feed.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
