### PR TITLE
[5.4] Remove sidebar border in dark mode

### DIFF
--- a/build/media_source/templates/administrator/atum/scss/blocks/_sidebar.scss
+++ b/build/media_source/templates/administrator/atum/scss/blocks/_sidebar.scss
@@ -291,7 +291,6 @@
 @if $enable-dark-mode {
   @include color-mode(dark) {
     .sidebar-wrapper {
-      border: 1px solid rgba(255, 255, 255, .05);
       box-shadow: none;
       .main-nav {
         .badge {


### PR DESCRIPTION
### Summary of Changes

When switching between light and dark mode in the backend template, you'll notice the sidebar contents moves by about 2px.
This is because a border is being applied only in dark mode.

This PR removes the border in dark mode as it's barely visible anyway.

### Testing Instructions

1. Run `npm run build:css`.
2. Toggle between light/dark mode in the backend template.

### Actual result BEFORE applying this Pull Request

Sidebar content layout shift

### Expected result AFTER applying this Pull Request

No layout shift