### PR TITLE
[5.3] Use time safe compare method in phpass library

### DIFF
--- a/administrator/manifests/libraries/phpass.xml
+++ b/administrator/manifests/libraries/phpass.xml
@@ -8,7 +8,7 @@
 	<authorEmail>solar@openwall.com</authorEmail>
 	<authorUrl>https://www.openwall.com/phpass/</authorUrl>
 	<license>PD / GWC</license>
-	<version>0.3</version>
+	<version>0.5.1</version>
 	<packagerurl>https://www.openwall.com/phpass/</packagerurl>
 
 	<files folder="phpass">

--- a/libraries/phpass/PasswordHash.php
+++ b/libraries/phpass/PasswordHash.php
@@ -2,7 +2,7 @@
 #
 # Portable PHP password hashing framework.
 #
-# Version 0.5 / genuine.
+# Version 0.5.1 / Joomla Project.
 #
 # Written by Solar Designer <solar at openwall.com> in 2004-2006 and placed in
 # the public domain.  Revised in subsequent years, still public domain.

--- a/libraries/phpass/PasswordHash.php
+++ b/libraries/phpass/PasswordHash.php
@@ -216,11 +216,7 @@ class PasswordHash {
 		if ($hash[0] === '*')
 			$hash = crypt($password, $stored_hash);
 
-		# This is not constant-time.  In order to keep the code simple,
-		# for timing safety we currently rely on the salts being
-		# unpredictable, which they are at least in the non-fallback
-		# cases (that is, when we use /dev/urandom and bcrypt).
-		return $hash === $stored_hash;
+		return hash_equals($hash, $stored_hash);
 	}
 }
 


### PR DESCRIPTION
### Summary of Changes
The phppass library shipped in core does not use a time-safe comparsion method for the hashes. It's not used in core and timing attacks in web apps are generally very difficult to perform, nevertheless a fix is straightforward.


### Testing Instructions
Core Review


### Actual result BEFORE applying this Pull Request
Non-Timesafe-Compare


### Expected result AFTER applying this Pull Request
Timesafe-Compare


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
