### PR TITLE
Add missing visually-hidden menu title in image menu

### DIFF
--- a/modules/mod_menu/tmpl/default_heading.php
+++ b/modules/mod_menu/tmpl/default_heading.php
@@ -35,9 +35,7 @@ if ($item->menu_icon) {
 
     $linktype = HTMLHelper::_('image', $item->menu_image, '', $image_attributes);
 
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
+    $linktype .= '<span class="image-title' . ($itemParams->get('menu_text', 1) ? '' : ' visually-hidden') . '">' . $item->title . '</span>';
 }
 
 ?>

--- a/modules/mod_menu/tmpl/default_separator.php
+++ b/modules/mod_menu/tmpl/default_separator.php
@@ -35,9 +35,7 @@ if ($item->menu_icon) {
 
     $linktype = HTMLHelper::_('image', $item->menu_image, '', $image_attributes);
 
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
+    $linktype .= '<span class="image-title' . ($itemParams->get('menu_text', 1) ? '' : ' visually-hidden') . '">' . $item->title . '</span>';
 }
 
 ?>

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_heading.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_heading.php
@@ -43,9 +43,7 @@ if ($item->menu_icon) {
 
     $linktype = HTMLHelper::_('image', $item->menu_image, '', $image_attributes);
 
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
+    $linktype .= '<span class="image-title' . ($itemParams->get('menu_text', 1) ? '' : ' visually-hidden') . '">' . $item->title . '</span>';
 }
 
 if ($showAll && $item->deeper) {

--- a/templates/cassiopeia/html/mod_menu/dropdown-metismenu_separator.php
+++ b/templates/cassiopeia/html/mod_menu/dropdown-metismenu_separator.php
@@ -43,9 +43,7 @@ if ($item->menu_icon) {
 
     $linktype = HTMLHelper::_('image', $item->menu_image, '', $image_attributes);
 
-    if ($itemParams->get('menu_text', 1)) {
-        $linktype .= '<span class="image-title">' . $item->title . '</span>';
-    }
+    $linktype .= '<span class="image-title' . ($itemParams->get('menu_text', 1) ? '' : ' visually-hidden') . '">' . $item->title . '</span>';
 }
 
 if ($showAll && $item->deeper) {


### PR DESCRIPTION
### Summary of Changes
Add missing visually-hidden menu title in menu items of type "heading" and "separator" when using an image without text

The changes are done for the standard menu and for the Metismenu in Cassiopeia.

### Testing Instructions
- Create a menu item of type "single article", select an image for the menu and set "Display Menu Item Title" to no
- Create a menu item of type "heading" and / or "separator"with the same configuration

### Actual result BEFORE applying this Pull Request
The menu item of type "single article" display the image and the title of the menu as a span element visually hidden
The menu item of type "heading" and / or "separator" show the image, but the title is missing

![grafik](https://github.com/user-attachments/assets/6a0cd224-6d76-47f4-ab74-244afd93a77c)

### Expected result AFTER applying this Pull Request

The menu items of type "heading" and "separator" have also a visually-hidden title.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
