### PR TITLE
[5.3] Remove spaces before and after Article title

### DIFF
--- a/administrator/components/com_content/src/Model/ArticleModel.php
+++ b/administrator/components/com_content/src/Model/ArticleModel.php
@@ -660,6 +660,9 @@ class ArticleModel extends AdminModel implements WorkflowModelInterface
         $input  = $app->getInput();
         $filter = InputFilter::getInstance();
 
+        // Remove spaces before and after title
+        $data['title'] = trim($data['title']);
+
         if (isset($data['metadata']['author'])) {
             $data['metadata']['author'] = $filter->clean($data['metadata']['author'], 'TRIM');
         }


### PR DESCRIPTION
When you save an article with spaces, before or after the title, the spaces are saved in the database.
Ordering the articles by Title give confusing results.

### Summary of Changes
This PR removes the spaces before and after the Article Title when saving the Article.

### Testing Instructions

- create some Articles with Titles
- add spaces before one of the Titles
- click on the Order Title
- notice that the ordering seems wrong (the Titles with spaces in front of them are listed first)

### Actual result BEFORE applying this Pull Request

If you add spaces before or after the Article Title, those are saved in the database

![article-title-before-pr](https://github.com/user-attachments/assets/657a4b5b-1734-44d9-9387-20f8c98b6f11)

The "Some titels start with a space or more spaces" is listed first because it starts with spaces.
However the back-end list does not show those spaces:

![before-pr](https://github.com/user-attachments/assets/bc877177-05dd-4b13-98da-ccf7486ac93e)

### Expected result AFTER applying this Pull Request

After save the spaces are removed before and after the Article Title

![article-title-after-pr](https://github.com/user-attachments/assets/2a23a306-7493-48b2-960d-855236284df2)

Now the order is correct

![after-pr](https://github.com/user-attachments/assets/aaeb4085-dfd0-44ea-ac0b-311469bee88f)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
