### PR TITLE
[5.3] Article Titles - Remove spaces before and after title

### DIFF
--- a/administrator/components/com_content/forms/article.xml
+++ b/administrator/components/com_content/forms/article.xml
@@ -25,6 +25,7 @@
 			label="JGLOBAL_TITLE"
 			required="true"
 			maxlength="255"
+			filter="trim"
 		/>
 
 		<field

--- a/components/com_content/forms/article.xml
+++ b/components/com_content/forms/article.xml
@@ -29,6 +29,7 @@
 			label="JGLOBAL_TITLE"
 			size="30"
 			required="true"
+			filter="trim"
 		/>
 
 		<field


### PR DESCRIPTION
When you save an article with spaces, before or after the title, the spaces are saved in the database.
Ordering the Articles by Titles which start with spaces, give confusing results.

### Summary of Changes
This PR removes the spaces before and after the Article Title when saving the Article.

### Testing Instructions

In the back-end under Content > Articles:
- create some Articles with Titles
- add spaces before one of the Titles and save
- click on the Order Title
- notice that the ordering seems wrong (the Titles with spaces in front of them are listed first)

In the front-end:
- edit an existing article
- add spaces before and after one of the Titles and save
- see that the spaces are saved in front and after the title

### Actual result BEFORE applying this Pull Request

In the back-end, if you add spaces before or after the Article Title, those are saved in the database

![article-title-before-pr](https://github.com/user-attachments/assets/657a4b5b-1734-44d9-9387-20f8c98b6f11)

In the front-end, if you add spaces before or after the Article Title, those are saved in the database

![front-end-article-before-pr](https://github.com/user-attachments/assets/c5882a61-bcac-4baf-9a3c-b375d7698043)

In the back-end, the "Some titels start with a space or more spaces" is listed first because it starts with spaces.
However the back-end list does not show those spaces:

![before-pr](https://github.com/user-attachments/assets/bc877177-05dd-4b13-98da-ccf7486ac93e)

### Expected result AFTER applying this Pull Request

In the back-end, after save the spaces are removed before and after the Article Title

![article-title-after-pr](https://github.com/user-attachments/assets/2a23a306-7493-48b2-960d-855236284df2)

In the front-end, after save the spaces are removed before and after the Article Title

![front-end-after-pr](https://github.com/user-attachments/assets/0a5481f0-26b9-4951-be20-299ca9a1f6c2)

In the back-end the order is now correct:

![after-pr](https://github.com/user-attachments/assets/aaeb4085-dfd0-44ea-ac0b-311469bee88f)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
