### PR TITLE
[5.3] Category Titles - Remove spaces before and after title

### DIFF
--- a/administrator/components/com_categories/forms/category.xml
+++ b/administrator/components/com_categories/forms/category.xml
@@ -68,6 +68,7 @@
 		type="text"
 		label="JGLOBAL_TITLE"
 		required="true"
+		filter="trim"
 	/>
 
 	<field


### PR DESCRIPTION
Same issue as #45501 but with Category Titles.
When you save a category with spaces, before or after the title, the spaces are saved in the database.
Ordering the Categories on Title, give confusing results with Titles that start with spaces.

### Summary of Changes
This PR removes the spaces before and after the Category Title when saving the Category.

### Testing Instructions
In the back-end under Content > Categories:
- create a few categories that start with different letters
- add some spaces before one of the category titles
- order the Categories on Title
- see the weird result (the title with spaces is on top)

### Actual result BEFORE applying this Pull Request

(Accidental) spaces before (and after) the Category Title are saved:

![category-title-before](https://github.com/user-attachments/assets/e66dec4d-5733-4dcd-8f5d-a9a0f41e7f3f)

The "Some categories have spaces before and after the title" starts with spaces, 
which are not visible in the list of categories,
which makes it confusing that this item is listed on top.
Instead you would expect it to be listed between "All categories have titles" and "Uncategorized"

![categories-before](https://github.com/user-attachments/assets/d257661d-4069-4fe6-a193-f5c85ff66b70)

### Expected result AFTER applying this Pull Request

Saving works well, the spaces before and after the title are trimmed (removed from the title) :

![category-title-after-pr](https://github.com/user-attachments/assets/b9a0e8fc-e9f9-4b3d-b973-caa927127e8c)

Ordering looks good:

![categories-after](https://github.com/user-attachments/assets/a474949d-826c-4d5d-8437-d9bbd31f483e)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
