### PR TITLE
[5.3] Module Titles - Remove spaces before and after title

### DIFF
--- a/administrator/components/com_modules/forms/module.xml
+++ b/administrator/components/com_modules/forms/module.xml
@@ -18,6 +18,7 @@
 			label="JGLOBAL_TITLE"
 			maxlength="100"
 			required="true"
+			filter="trim"
 		/>
 
 		<field

--- a/administrator/components/com_modules/forms/moduleadmin.xml
+++ b/administrator/components/com_modules/forms/moduleadmin.xml
@@ -18,6 +18,7 @@
 			label="JGLOBAL_TITLE"
 			maxlength="100"
 			required="true"
+			filter="trim"
 		/>
 
 		<field


### PR DESCRIPTION
Same issue as #45501 and #45502 but with Site and Admin Modules

### Summary of Changes

This PR trims the spaces before and after the titles of Site and Admin Modules.

### Testing Instructions
In the back-end open a Site Module, add a lot of spaces before the title, and save.
In the back-end open an Admin Module, add a lot of spaces before the title, and save.

### Actual result BEFORE applying this Pull Request

Site Module with a lot of spaces after save:

![site-module-before-pr](https://github.com/user-attachments/assets/d493222b-1c68-4742-a8be-61658884df93)

Admin Module with a lot of spaces after save:

![admin-module-before-pr](https://github.com/user-attachments/assets/d81af47c-34eb-4de7-a190-f53aab5a0bbd)

### Expected result AFTER applying this Pull Request

Site Module with a lot of spaces after save. The spaces before and after the title are removed:

![module-site-after-pr](https://github.com/user-attachments/assets/59c11472-ce0d-418c-bc3f-b75e2f707043)

Admin Module with a lot of spaces after save. The spaces before and after the title are removed:

![module-admin-after-pr](https://github.com/user-attachments/assets/00010d54-d172-4f47-ba81-bede3e340372)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
