### PR TITLE
[5.3] Menu Title + Menu Item Title - Remove spaces from title

### DIFF
--- a/administrator/components/com_menus/forms/item.xml
+++ b/administrator/components/com_menus/forms/item.xml
@@ -16,6 +16,7 @@
 			type="text"
 			label="COM_MENUS_ITEM_FIELD_TITLE_LABEL"
 			required="true"
+			filter="trim"
 		/>
 
 		<field

--- a/administrator/components/com_menus/forms/menu.xml
+++ b/administrator/components/com_menus/forms/menu.xml
@@ -26,7 +26,7 @@
 			label="JGLOBAL_TITLE"
 			maxlength="48"
 			required="true"
-			filter="trim"git s
+			filter="trim"
 		/>
 		<field
 			name="description"

--- a/administrator/components/com_menus/forms/menu.xml
+++ b/administrator/components/com_menus/forms/menu.xml
@@ -26,6 +26,7 @@
 			label="JGLOBAL_TITLE"
 			maxlength="48"
 			required="true"
+			filter="trim"git s
 		/>
 		<field
 			name="description"


### PR DESCRIPTION
Same issue as https://github.com/joomla/joomla-cms/pull/45501, https://github.com/joomla/joomla-cms/pull/45502 and https://github.com/joomla/joomla-cms/pull/45503 but with Menu Titles and Menu Item Titles

### Summary of Changes
This PR removes the spaces before and after the Menu Titles and Menu Item Titles.

### Testing Instructions
In back-end: Menus > Manage > edit Main Menu, add spaces and save 

In back-end: Menus > Main Menu > edit menu item, e.g. Home, add a lot of spaces and save 

### Actual result BEFORE applying this Pull Request

Menu edit
![menu-edit-before-pr](https://github.com/user-attachments/assets/83872d39-34c5-4910-8749-37847f11bc91)

Menu Item edit
![menu-title-before-pr](https://github.com/user-attachments/assets/8dd1807f-e0de-4923-b7ab-8d9958ecd646)

### Expected result AFTER applying this Pull Request

Menu edit
![menu-after-pr](https://github.com/user-attachments/assets/bb2038f4-60cd-42eb-a080-627f80ef0ba9)

Menu Item edit
![menu-title-after-pr](https://github.com/user-attachments/assets/8213d8aa-5e07-4a55-bd87-4d68afc34b50)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
