### PR TITLE
[5.3] Users - Remove spaces before and after title

### DIFF
--- a/administrator/components/com_users/forms/group.xml
+++ b/administrator/components/com_users/forms/group.xml
@@ -13,6 +13,7 @@
 			type="text"
 			label="COM_USERS_GROUP_FIELD_TITLE_LABEL"
 			required="true"
+			filter="trim"
 		/>
 
 		<field

--- a/administrator/components/com_users/forms/note.xml
+++ b/administrator/components/com_users/forms/note.xml
@@ -34,6 +34,7 @@
 			name="subject"
 			type="text"
 			label="COM_USERS_FIELD_SUBJECT_LABEL"
+			filter="trim"
 		/>
 
 		<field

--- a/administrator/components/com_users/forms/user.xml
+++ b/administrator/components/com_users/forms/user.xml
@@ -6,6 +6,7 @@
 			type="text"
 			label="COM_USERS_USER_FIELD_NAME_LABEL"
 			required="true"
+			filter="trim"
 		/>
 
 		<field


### PR DESCRIPTION
Same issue as https://github.com/joomla/joomla-cms/pull/45501, https://github.com/joomla/joomla-cms/pull/45502, https://github.com/joomla/joomla-cms/pull/45503 and #45504 but with Users, Groups, User Notes.
Access Levels does not have this issue: spaces before or after the Access level title are removed during saving.

### Summary of Changes
This PR removes any space before or after the Users Name, Group name, User Note Subject.

### Testing Instructions
In the back-end: 
- Users > Manage > edit a person and add spaces before the Name
- Users > Groups > edit a group and add spaces before the Group Title
- Users > User Notes > create a new note and add spaces before the Subject

### Actual result BEFORE applying this Pull Request

Users > Manage > edit a person and add spaces before the Name
![User-before](https://github.com/user-attachments/assets/800b14b6-3f8f-4208-8fc7-c975796f8547)

Users > Groups > edit a group and add spaces before the Group Title
![Group-before](https://github.com/user-attachments/assets/ad0b431a-ebc2-497b-a9ee-fc2514ee6b79)

Users > User Notes > create a new note and add spaces before the Subject
![user-notes](https://github.com/user-attachments/assets/55856639-e789-4342-82e1-f55e179d707b)

### Expected result AFTER applying this Pull Request

Users > Manage > edit a person and add spaces before the Name
![user-after](https://github.com/user-attachments/assets/476ea8d4-4f09-4ce8-b444-f9ed35c6a312)

Users > Groups > edit a group and add spaces before the Group Title
![group-after](https://github.com/user-attachments/assets/50a1dc69-6c1a-4631-b5fc-acd5e92159d0)

Users > User Notes > create a new note and add spaces before the Subject
![user-note-after](https://github.com/user-attachments/assets/b2a2fcb3-adc3-456f-87ce-47ec556c999d)


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
