### PR TITLE
[5.3] Tags - Remove spaces before and after title

### DIFF
--- a/administrator/components/com_tags/forms/tag.xml
+++ b/administrator/components/com_tags/forms/tag.xml
@@ -64,6 +64,7 @@
 		type="text"
 		label="JGLOBAL_TITLE"
 		required="true"
+		filter="trim"
 	/>
 
 	<field


### PR DESCRIPTION
Same issue as https://github.com/joomla/joomla-cms/pull/45501, https://github.com/joomla/joomla-cms/pull/45502, https://github.com/joomla/joomla-cms/pull/45503, https://github.com/joomla/joomla-cms/pull/45504 and #45505 but with Tags

### Summary of Changes
This PR removes any space before or after the Tag Title.

### Testing Instructions
in back-end: Components > Tags
- create some tags that start with different letters (to see what happens with ordering)
- add spaces to one of the Tag Titles and save
- order the Tags on Title

In back-end: Content > Article
- open an article
- click on the Tag field
- observe the order of the Tags 

### Actual result BEFORE applying this Pull Request

Tag is saved with spaces before and after the title:
![tag-before](https://github.com/user-attachments/assets/33eb4d21-21bc-488a-9eab-34ef972849a2)

Ordering the Tags on Title, the one that starts with a space is on top (and spaces are not visible) :
![tags-before](https://github.com/user-attachments/assets/89627891-984d-4d3f-acd9-6adb9fa481ce)

In an article, under Tags the order is the same: the Tag with spaces is listed first:
![tags-in-article](https://github.com/user-attachments/assets/b8a225ab-0612-476f-917b-e3fa97e0ffa7)


### Expected result AFTER applying this Pull Request

Tag is saved without spaces before and after the title
![tag-after](https://github.com/user-attachments/assets/71af4e29-aa0b-476b-b3a6-923b14ca4492)

Ordering looks better:
![tags-after](https://github.com/user-attachments/assets/45ca9c94-fc1d-4424-9a6d-8afbd50a5a02)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
