### PR TITLE
[5.3] Scheduler - Remove spaces before and after title

### DIFF
--- a/administrator/components/com_scheduler/forms/task.xml
+++ b/administrator/components/com_scheduler/forms/task.xml
@@ -11,6 +11,7 @@
 			size="40"
 			maxlength="100"
 			required="true"
+			filter="trim"
 		/>
 
 		<fieldset name="aside">


### PR DESCRIPTION
Same issue as #45501 but with Scheduler: When you save a task with spaces, before or after the title, the spaces are saved in the database.

### Summary of Changes
This PR trims the title of a task


### Testing Instructions

in back-end: System >  Scheduled Tasks > edit a Task, add spaces before the title and save

### Actual result BEFORE applying this Pull Request

![task-before](https://github.com/user-attachments/assets/6e336c32-2ba0-45f7-9272-06dfaf52ac3e)

### Expected result AFTER applying this Pull Request

![task-after](https://github.com/user-attachments/assets/633baf3e-4066-4954-9298-8c1e67bd9bee)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
