### PR TITLE
[5.3] Multiple components - Remove spaces before+after title

### DIFF
--- a/administrator/components/com_banners/forms/banner.xml
+++ b/administrator/components/com_banners/forms/banner.xml
@@ -16,6 +16,7 @@
 			type="text"
 			label="COM_BANNERS_FIELD_NAME_LABEL"
 			required="true"
+			filter="trim"
 		/>
 
 		<field

--- a/administrator/components/com_banners/forms/client.xml
+++ b/administrator/components/com_banners/forms/client.xml
@@ -15,6 +15,7 @@
 			type="text"
 			label="COM_BANNERS_FIELD_NAME_LABEL"
 			required="true"
+			filter="trim"
 		/>
 
 		<field
@@ -22,6 +23,7 @@
 			type="text"
 			label="COM_BANNERS_FIELD_CONTACT_LABEL"
 			required="true"
+			filter="trim"
 		/>
 
 		<field

--- a/administrator/components/com_contact/forms/contact.xml
+++ b/administrator/components/com_contact/forms/contact.xml
@@ -15,6 +15,7 @@
 			type="text"
 			label="COM_CONTACT_FIELD_NAME_LABEL"
 			required="true"
+			filter="trim"
 		/>
 
 		<field

--- a/administrator/components/com_languages/forms/language.xml
+++ b/administrator/components/com_languages/forms/language.xml
@@ -25,6 +25,7 @@
 			label="JGLOBAL_TITLE"
 			maxlength="50"
 			required="true"
+			filter="trim"
 		/>
 
 		<field
@@ -33,6 +34,7 @@
 			label="COM_LANGUAGES_FIELD_TITLE_NATIVE_LABEL"
 			maxlength="50"
 			required="true"
+			filter="trim"
 		/>
 
 		<field

--- a/administrator/components/com_newsfeeds/forms/newsfeed.xml
+++ b/administrator/components/com_newsfeeds/forms/newsfeed.xml
@@ -17,6 +17,7 @@
 			type="text"
 			label="JGLOBAL_TITLE"
 			required="true"
+			filter="trim"
 		/>
 
 		<field

--- a/administrator/components/com_templates/forms/style.xml
+++ b/administrator/components/com_templates/forms/style.xml
@@ -32,6 +32,7 @@
 			type="text"
 			label="COM_TEMPLATES_FIELD_TITLE_LABEL"
 			required="true"
+			filter="trim"
 		/>
 
 		<field


### PR DESCRIPTION
Same issue as https://github.com/joomla/joomla-cms/pull/45501 with multiple components: When you save a task with spaces, before or after the title, the spaces are saved in the database.

### Summary of Changes
This PR trims (removes spaces before and after) the title for:
- com_banners: banners
- com_banners: banner clients
- com_contacts: contacts
- com_languages: content languages
- com_newsfeeds: Newsfeeds
- com_templates: Template Style

### Testing Instructions
In backend go to the components, edit title, add a lot of spaces in front of the title, and save.

### Actual result BEFORE applying this Pull Request

Components > Banners > Banners
![banner-before](https://github.com/user-attachments/assets/3bd20424-92dc-427a-a1d9-404722e2040c)

Components > Banners > Clients
![banner-client-before](https://github.com/user-attachments/assets/cb1070f4-f8f4-4e6e-ae8e-815f59ee3775)

Components > Contacts > Contacts
![contact-before](https://github.com/user-attachments/assets/e4ecbd0b-3e7e-417d-8dea-1ac3dd4f2173)

System > Content Languages 
![language-content-before](https://github.com/user-attachments/assets/0ecb0c0d-38e2-4e6f-9c5e-fb5626b37c0e)

Components > Newsfeeds > Feeds
![newsfeed-before](https://github.com/user-attachments/assets/52411ff3-21d3-4df0-8281-426533fff485)

System > Site Template Styles or Admin Templates
![template-style-before](https://github.com/user-attachments/assets/5741b743-de5a-44e8-9962-f0b7c733cf97)

### Expected result AFTER applying this Pull Request

Components > Banners > Banners
![banner-after](https://github.com/user-attachments/assets/6926fea9-162b-4e57-82e5-8897276ada53)

Components > Banners > Clients
![banner-client-after](https://github.com/user-attachments/assets/d3ffcef6-e751-4a8d-9e51-de3dd88848a5)

Components > Contacts > Contacts
![contact-after](https://github.com/user-attachments/assets/e958cd4f-ed8e-439e-a989-169bdc323b27)

System > Content Languages 
![language-content-after](https://github.com/user-attachments/assets/51d222b5-7f69-4329-9db7-74bfd87eebeb)

Components > Newsfeeds > Feeds
![newsfeed-after](https://github.com/user-attachments/assets/9f45ca04-251e-448f-bd91-43e79f95b135)

System > Site Template Styles or Admin Templates
![template-style-after](https://github.com/user-attachments/assets/90be4e49-e492-491a-9a59-444570be5ca7)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
