### PR TITLE
[5.3] More components - Remove spaces before+after title

### DIFF
--- a/administrator/components/com_finder/forms/filter.xml
+++ b/administrator/components/com_finder/forms/filter.xml
@@ -15,6 +15,7 @@
 			type="text"
 			label="JGLOBAL_TITLE"
 			required="true"
+			filter="trim"
 		/>
 
 		<field

--- a/administrator/components/com_guidedtours/forms/step.xml
+++ b/administrator/components/com_guidedtours/forms/step.xml
@@ -46,6 +46,7 @@
 		type="text"
 		label="COM_GUIDEDTOURS_STEP_TITLE"
 		required="true"
+		filter="trim"
 	/>
 
 	<field
@@ -196,10 +197,10 @@
 		<fieldset name="options">
 
 			<fieldset name="targetvalues" label="COM_GUIDEDTOURS_STEP_TARGETVALUES_HEADING">
-				<field 
-					name="notetarget" 
-					type="note" 
-					class="alert alert-info" 
+				<field
+					name="notetarget"
+					type="note"
+					class="alert alert-info"
 					description="COM_GUIDEDTOURS_STEP_TARGETNOTE_MESSAGE"
 					showon=".type!:2[OR].interactive_type!:2,5,6" />
 

--- a/administrator/components/com_guidedtours/forms/tour.xml
+++ b/administrator/components/com_guidedtours/forms/tour.xml
@@ -17,6 +17,7 @@
 		type="text"
 		label="COM_GUIDEDTOURS_TITLE"
 		required="true"
+		filter="trim"
 	/>
 
 	<field

--- a/administrator/components/com_mails/forms/template.xml
+++ b/administrator/components/com_mails/forms/template.xml
@@ -13,6 +13,7 @@
 			name="subject"
 			type="text"
 			label="COM_MAILS_FIELD_SUBJECT_LABEL"
+			filter="trim"
 		/>
 		<field
 			name="body"


### PR DESCRIPTION
Same issue as https://github.com/joomla/joomla-cms/pull/45501 with some more components: When you save a task with spaces, before or after the title, the spaces are saved in the database.

### Summary of Changes
This PR trims (removes spaces before and after) the title for:
- com_finder: Filters
- com_guidedtours: Tour
- com_guidedtours: Tour > Step
- com_mails: Mail Templates 

### Testing Instructions
In backend go to the components, edit title, add a lot of spaces in front of the title, and save.

### Actual result BEFORE applying this Pull Request

Components > Smart Search > Filters
![smart-search-filter-before](https://github.com/user-attachments/assets/61bad5f7-3570-4259-8fef-c94b92a01863)

System > Guided Tours > edit Title
![guided-tours-before](https://github.com/user-attachments/assets/1760b1b7-b7d0-4d2b-b10e-3aab96bd9dd0)

System > Guided Tours > edit Steps (click on the Steps number and open + edit a Step)
![guided-tours-step-before](https://github.com/user-attachments/assets/c39f9890-f64e-4061-81d3-75437f742fa3)

System > Mail Templates
![mail-template-before](https://github.com/user-attachments/assets/94063fb3-896d-42a4-947d-e66cd3b6ecbd)

### Expected result AFTER applying this Pull Request

Components > Smart Search > Filters
![smart-search-filter-after](https://github.com/user-attachments/assets/406649d8-b55c-4280-a8a4-f5761a91ecbf)

System > Guided Tours > edit Title
![guided-tour-after](https://github.com/user-attachments/assets/2ed457dd-c8a8-4f97-b043-78974fe3c02f)

System > Guided Tours > edit Steps (click on the Steps number and open + edit a Step)
![guided-tours-step-after](https://github.com/user-attachments/assets/9207d843-cac1-4db2-9895-31d17faf1ee7)

System > Mail Templates
![mail-template-after](https://github.com/user-attachments/assets/adc13d28-2f4f-41f4-b610-969b853a5145)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
