### PR TITLE
[5.3] Spacer Field Double Translation

### DIFF
--- a/libraries/src/Form/Field/SpacerField.php
+++ b/libraries/src/Form/Field/SpacerField.php
@@ -71,7 +71,6 @@ class SpacerField extends FormField
 
             // Get the label text from the XML element, defaulting to the element name.
             $text = $this->element['label'] ? (string) $this->element['label'] : (string) $this->element['name'];
-            $text = $this->translateLabel ? Text::_($text) : $text;
 
             // Build the class for the label.
             $class = !empty($this->description) ? 'hasPopover' : '';


### PR DESCRIPTION
### Summary of Changes
Prevent the double translation on spacer fields


### Testing Instructions
Enable language debug
Enable workflows
Open an existing article
See the highlighted indicators **??


### Actual result BEFORE applying this Pull Request
![image](https://github.com/user-attachments/assets/de9e7a2f-bc91-4bbe-970c-fff5f106a502)



### Expected result AFTER applying this Pull Request
![image](https://github.com/user-attachments/assets/753111df-3b9a-45ca-ac84-6af4fa17b89f)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
