### PR TITLE
[5.4] Automated Updates information

### DIFF
--- a/administrator/components/com_joomlaupdate/config.xml
+++ b/administrator/components/com_joomlaupdate/config.xml
@@ -75,7 +75,8 @@
 	<fieldset
 		name="automated-updates"
 		label="COM_JOOMLAUPDATE_CONFIG_AUTOMATED_UPDATES_LABEL"
-	>
+		description="COM_JOOMLAUPDATE_CONFIG_AUTOMATED_UPDATES_DESC"
+		>
 		<field
 			name="autoupdate"
 			type="radio"

--- a/administrator/language/en-GB/com_joomlaupdate.ini
+++ b/administrator/language/en-GB/com_joomlaupdate.ini
@@ -10,6 +10,7 @@ COM_JOOMLAUPDATE_AUTOUPDATE_UNREGISTER_SUCCESS="Unregistered from automated upda
 COM_JOOMLAUPDATE_CAPTIVE_HEADLINE="Confirm your credentials"
 COM_JOOMLAUPDATE_CHECKED_UPDATES="Checked for updates."
 COM_JOOMLAUPDATE_CONFIG_AUTOMATED_UPDATES_DISABLED_LABEL="<span class=\"fa-fw me-2 fa fa-info-circle\"></span>Automated updates are only supported for the \"default\" channel and \"Minimum Stability\" \"Stable\"."
+COM_JOOMLAUPDATE_CONFIG_AUTOMATED_UPDATES_DESC="Automated updates are only available for sites that are publicly accessible on the internet. If your site is behind a firewall or not publicly accessible, such as a local test environment, you will need to update manually."
 COM_JOOMLAUPDATE_CONFIG_AUTOMATED_UPDATES_LABEL="Automated Updates"
 COM_JOOMLAUPDATE_CONFIG_AUTOUPDATE_DESC="Automatically update Joomla to the latest version when it is available."
 COM_JOOMLAUPDATE_CONFIG_AUTOUPDATE_LABEL="Automated Update"


### PR DESCRIPTION
When using a local dev environment or site that is not publicly accessible such as an intranet the quickicon will display "automated updates connection broken"

![image](https://github.com/user-attachments/assets/482a931e-d7ae-41d7-af1d-656c2cb1e9c4)


If you then click on the quickicon you will still not see why it is broken

![image](https://github.com/user-attachments/assets/ebcb4f6f-1afc-417f-9dc2-eb0305d38ed3)

If you then try and save the options only then do you get the technical reason danger
Error while registering to automated update service: cURL error 6: Could not resolve host: j51.test (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) for https://j51.test/api/index.php/v1/joomlaupdate/healthcheck (500).

![image](https://github.com/user-attachments/assets/19b84128-e011-4051-b89b-4acacb60fe8e)

This PR adds a fieldset description (displayed as information) which is always displayed

![image](https://github.com/user-attachments/assets/ba052b35-4af6-4c98-9288-aa7715e962bf)

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
