### PR TITLE
[5.3] Installation missing string

### DIFF
--- a/installation/language/en-GB/joomla.ini
+++ b/installation/language/en-GB/joomla.ini
@@ -222,6 +222,7 @@ INSTL_ZIP_SUPPORT_AVAILABLE="Native ZIP support"
 
 ; Global strings
 JADMINISTRATOR="Administrator"
+JCLOSE="Close"
 JEMAIL="Email"
 JERROR="Error"
 JERROR_LAYOUT_ERROR_HAS_OCCURRED_WHILE_PROCESSING_YOUR_REQUEST="An error has occurred while processing your request."


### PR DESCRIPTION
@chmst identified in [#45429 ](https://github.com/joomla/joomla-cms/issues/45429#issuecomment-2850743080) that the close button in the dialog was not being translated. This was because the language string JCLOSE was not present in the installation language files.

Technically core does not need this string to be added until j6 where it is used in the installation dialog but I dont see any harm in adding it now as it is possible that someone adds a dialog in upcoming 5.x releases

Testing either by code review or by following the original text instructions for the dialog element in #40150 making sure you are editing an installation template file


### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
