### PR TITLE
[5.3] Debug duplicate queries dark mode

### DIFF
--- a/build/media_source/plg_system_debug/widgets/sqlqueries/widget.css
+++ b/build/media_source/plg_system_debug/widgets/sqlqueries/widget.css
@@ -191,6 +191,6 @@ div.phpdebugbar-widgets-sqlqueries div.phpdebugbar-widgets-toolbar a.phpdebugbar
   background: #eee;
 }
 
-div.phpdebugbar[data-theme='dark'] div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-widgets-sql-duplicate {
-    background-color: #473e00;
+div.phpdebugbar[data-theme="dark"] div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-widgets-sql-duplicate {
+  background-color: #473e00;
 }

--- a/build/media_source/plg_system_debug/widgets/sqlqueries/widget.css
+++ b/build/media_source/plg_system_debug/widgets/sqlqueries/widget.css
@@ -190,3 +190,7 @@ div.phpdebugbar-widgets-sqlqueries div.phpdebugbar-widgets-toolbar a.phpdebugbar
   color: #888;
   background: #eee;
 }
+
+div.phpdebugbar[data-theme='dark'] div.phpdebugbar-widgets-sqlqueries li.phpdebugbar-widgets-list-item.phpdebugbar-widgets-sql-duplicate {
+    background-color: #473e00;
+}


### PR DESCRIPTION
Pull Request for Issue #45084

### Summary of Changes
Adds css for the display of duplicate queries in dark mode. 
_(the line of css added is directly from upstream although for some reason I am not aware of or have time to look into we are not using directly)


### Testing Instructions
enable debug and set your OS to dark mode (debugbar requires real dark mode not joomla's data-bs-theme=dark )
Visit any page with duplicate query eg site modules
Open debugbar and choose queries tab

as this is a css change you will need to test with either a prebuilt package or rebuild the css after applying the pr `npm run build:css`

### Actual result BEFORE applying this Pull Request
![image](https://github.com/user-attachments/assets/9dda31e5-8966-43b0-abdc-77ed5868a3c2)



### Expected result AFTER applying this Pull Request
![image](https://github.com/user-attachments/assets/e3c127dd-2027-4c7f-9536-9fa5b659146b)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
