### PR TITLE
[5.3] Fix build.php to create zstd packages on macOS

### DIFF
--- a/build/build.php
+++ b/build/build.php
@@ -211,6 +211,39 @@ function clean_composer(string $dir)
     chdir($cwd);
 }
 
+/**
+ * Executes a system command to build a package file.
+ * Shows a start and a finish message and terminates if an error occurs.
+ * Captures all outputs (stdout+stderr) and only displays them if an error has occurred.
+ *
+ * @param string $packageName Name of the package file to be created.
+ * @param string $command The full system command to execute.
+ *
+ * @return void
+ */
+function build_and_check(string $packageName, string $command): void
+{
+    echo "Building {$packageName} ... ";
+
+    // Redirect stderr to stdout
+    $fullCommand = $command . ' 2>&1';
+    $output = [];
+    $exitCode = 0;
+
+    exec($fullCommand, $output, $exitCode);
+
+    if ($exitCode !== 0) {
+        echo "failed.\n";
+        fwrite(STDERR, "ERROR: Command failed ($exitCode): $command\n");
+        if (!empty($output)) {
+            fwrite(STDERR, "Output:\n" . implode("\n", $output) . "\n");
+        }
+        exit($exitCode);
+    }
+
+    echo "done.\n";
+}
+
 $time = time();
 
 // Set path to git binary (e.g., /usr/local/git/bin/git or /usr/bin/git)
@@ -563,34 +596,29 @@ for ($num = $release - 1; $num >= 0; $num--) {
     if (!$excludeZip) {
         $packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.zip';
         echo "Building " . $packageName . "... ";
-        chdir($time);
-        system('zip ../packages/' . $packageName . ' -@ < ../diffconvert/' . $version . '.' . $num . '> /dev/null');
-        chdir('..');
-        echo "done.\n";
+        $command = "cd {$time} && zip ../packages/{$packageName} -@ < ../diffconvert/{$version}.{$num}";
+        build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 
     if (!$excludeGzip) {
         $packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.gz';
-        echo "Building " . $packageName . "... ";
-        system('tar --create --gzip  --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
-        echo "done.\n";
+        $command = "tar --create --gzip --no-recursion --directory {$time} --file packages/{$packageName} --files-from diffconvert/{$version}.{$num}";
+        build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 
     if (!$excludeBzip2) {
         $packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.bz2';
-        echo "Building " . $packageName . "... ";
-        system('tar --create --bzip2 --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
-        echo "done.\n";
+        $command = "tar --create --bzip2 --no-recursion --directory {$time} --file packages/{$packageName} --files-from diffconvert/{$version}.{$num}";
+        build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 
     if (!$excludeZstd) {
         $packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.zst';
-        echo "Building " . $packageName . "... ";
-        system('tar "-I zstd --ultra -22" --create --no-recursion --directory ' . $time . ' --file packages/' . $packageName . ' --files-from diffconvert/' . $version . '.' . $num . '> /dev/null');
-        echo "done.\n";
+        $command = "tar --create --no-recursion --directory {$time} --files-from diffconvert/{$version}.{$num} | zstd --ultra -22 -o packages/{$packageName}";
+        build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 }
@@ -601,33 +629,29 @@ chdir($time);
 // Create full archive packages.
 if (!$excludeZip) {
     $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.zip';
-    echo "Building " . $packageName . "... ";
-    system('zip -r ../packages/' . $packageName . ' * > /dev/null');
-    echo "done.\n";
+    $command = "zip -r ../packages/{$packageName} *";
+    build_and_check($packageName, $command);
     $checksums[$packageName] = [];
 }
 
 if (!$excludeGzip) {
     $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.gz';
-    echo "Building " . $packageName . "... ";
-    system('tar --create --gzip --file ../packages/' . $packageName . ' * > /dev/null');
-    echo "done.\n";
+    $command = "tar --create --gzip --file ../packages/{$packageName} *";
+    build_and_check($packageName, $command);
     $checksums[$packageName] = [];
 }
 
 if (!$excludeBzip2) {
     $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.bz2';
-    echo "Building " . $packageName . "... ";
-    system('tar --create --bzip2 --file ../packages/' . $packageName . ' * > /dev/null');
-    echo "done.\n";
+    $command = "tar --create --bzip2 --file ../packages/{$packageName} *";
+    build_and_check($packageName, $command);
     $checksums[$packageName] = [];
 }
 
 if (!$excludeZstd) {
     $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.zst';
-    echo "Building " . $packageName . "... ";
-    system('tar "-I zstd --ultra -22" --create --file ../packages/' . $packageName . ' * > /dev/null');
-    echo "done.\n";
+    $command = "tar --create * | zstd --ultra -22 -o ../packages/{$packageName}";
+    build_and_check($packageName, $command);
     $checksums[$packageName] = [];
 }
 
@@ -644,33 +668,29 @@ if (!$debugBuild) {
 
     if (!$excludeZip) {
         $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.zip';
-        echo "Building " . $packageName . "... ";
-        system('zip -r ../packages/' . $packageName . ' * > /dev/null');
-        echo "done.\n";
+        $command = "zip -r ../packages/{$packageName} *";
+        build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 
     if (!$excludeGzip) {
         $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.gz';
-        echo "Building " . $packageName . "... ";
-        system('tar --create --gzip --file ../packages/' . $packageName . ' * > /dev/null');
-        echo "done.\n";
+        $command = "tar --create --gzip --file ../packages/{$packageName} *";
+        build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 
     if (!$excludeBzip2) {
         $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.bz2';
-        echo "Building " . $packageName . "... ";
-        system('tar --create --bzip2 --file ../packages/' . $packageName . ' * > /dev/null');
-        echo "done.\n";
+        $command = "tar --create --bzip2 --file ../packages/{$packageName} *";
+        build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 
     if (!$excludeZstd) {
         $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.zst';
-        echo "Building " . $packageName . "... ";
-        system('tar "-I zstd --ultra -22" --create --file ../packages/' . $packageName . ' * > /dev/null');
-        echo "done.\n";
+        $command = "tar --create * | zstd --ultra -22 -o ../packages/{$packageName}";
+        build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 }

--- a/build/build.php
+++ b/build/build.php
@@ -227,8 +227,8 @@ function build_and_check(string $packageName, string $command): void
 
     // Redirect stderr to stdout
     $fullCommand = $command . ' 2>&1';
-    $output = [];
-    $exitCode = 0;
+    $output      = [];
+    $exitCode    = 0;
 
     exec($fullCommand, $output, $exitCode);
 
@@ -603,21 +603,21 @@ for ($num = $release - 1; $num >= 0; $num--) {
 
     if (!$excludeGzip) {
         $packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.gz';
-        $command = "tar --create --gzip --no-recursion --directory {$time} --file packages/{$packageName} --files-from diffconvert/{$version}.{$num}";
+        $command     = "tar --create --gzip --no-recursion --directory {$time} --file packages/{$packageName} --files-from diffconvert/{$version}.{$num}";
         build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 
     if (!$excludeBzip2) {
         $packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.bz2';
-        $command = "tar --create --bzip2 --no-recursion --directory {$time} --file packages/{$packageName} --files-from diffconvert/{$version}.{$num}";
+        $command     = "tar --create --bzip2 --no-recursion --directory {$time} --file packages/{$packageName} --files-from diffconvert/{$version}.{$num}";
         build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 
     if (!$excludeZstd) {
         $packageName = 'Joomla_' . $version . '.' . $fromName . '_to_' . $fullVersion . '-' . $packageStability . '-Patch_Package.tar.zst';
-        $command = "tar --create --no-recursion --directory {$time} --files-from diffconvert/{$version}.{$num} | zstd --ultra -22 -o packages/{$packageName}";
+        $command     = "tar --create --no-recursion --directory {$time} --files-from diffconvert/{$version}.{$num} | zstd --ultra -22 -o packages/{$packageName}";
         build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
@@ -629,28 +629,28 @@ chdir($time);
 // Create full archive packages.
 if (!$excludeZip) {
     $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.zip';
-    $command = "zip -r ../packages/{$packageName} *";
+    $command     = "zip -r ../packages/{$packageName} *";
     build_and_check($packageName, $command);
     $checksums[$packageName] = [];
 }
 
 if (!$excludeGzip) {
     $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.gz';
-    $command = "tar --create --gzip --file ../packages/{$packageName} *";
+    $command     = "tar --create --gzip --file ../packages/{$packageName} *";
     build_and_check($packageName, $command);
     $checksums[$packageName] = [];
 }
 
 if (!$excludeBzip2) {
     $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.bz2';
-    $command = "tar --create --bzip2 --file ../packages/{$packageName} *";
+    $command     = "tar --create --bzip2 --file ../packages/{$packageName} *";
     build_and_check($packageName, $command);
     $checksums[$packageName] = [];
 }
 
 if (!$excludeZstd) {
     $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Full_Package.tar.zst';
-    $command = "tar --create * | zstd --ultra -22 -o ../packages/{$packageName}";
+    $command     = "tar --create * | zstd --ultra -22 -o ../packages/{$packageName}";
     build_and_check($packageName, $command);
     $checksums[$packageName] = [];
 }
@@ -668,28 +668,28 @@ if (!$debugBuild) {
 
     if (!$excludeZip) {
         $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.zip';
-        $command = "zip -r ../packages/{$packageName} *";
+        $command     = "zip -r ../packages/{$packageName} *";
         build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 
     if (!$excludeGzip) {
         $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.gz';
-        $command = "tar --create --gzip --file ../packages/{$packageName} *";
+        $command     = "tar --create --gzip --file ../packages/{$packageName} *";
         build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 
     if (!$excludeBzip2) {
         $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.bz2';
-        $command = "tar --create --bzip2 --file ../packages/{$packageName} *";
+        $command     = "tar --create --bzip2 --file ../packages/{$packageName} *";
         build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }
 
     if (!$excludeZstd) {
         $packageName = 'Joomla_' . $fullVersion . '-' . $packageStability . '-Update_Package.tar.zst';
-        $command = "tar --create * | zstd --ultra -22 -o ../packages/{$packageName}";
+        $command     = "tar --create * | zstd --ultra -22 -o ../packages/{$packageName}";
         build_and_check($packageName, $command);
         $checksums[$packageName] = [];
     }


### PR DESCRIPTION
### Summary of Changes

**build.php** does not create zstd packages on macOS with default BSD tar:


In addition, the script does not stop in any environment if an error occurs, e.g. if zstd or the zip application is missing:
```
Building Joomla_5.3.1-Stable-Update_Package.zip... sh: 1: zip: not found
```

---

* Used is now separate piped `tar` and `zstd` calls, working in all environments, including macOS BSD-tar.
* Tested with (Intel-based):
  * macOS 15.5
  * Windows 11 WSL 2 Ubuntu 22.04
* For better readability, the shell commands are written without concatenations as one string.
* From my point of view every `system()` command should be check for error status and the script fail
  if a system commands fail. I can implement this in a follow-up PR. For example currently there is an
  to-be-ignored error:
  ``` 
  cp: build/fido.jwt: No such file or directory
  ```

### Testing Instructions

#### 1. If you have a Mac test the error before:
```
php build/build.php --remote=5.3.1
```

### Actual result BEFORE applying this Pull Request

```
Building Joomla_5.3.1-Stable-Full_Package.tar.zst... tar: Couldn't open  zstd --ultra -22: No such file or directory
```

### Expected result AFTER applying this Pull Request

#### 2. After applying this PR full testing (including bz2) on macOS, Windows WSL 2 or Ubuntu native, 8 respective 4 archive files are created between 150 and 350 MB:
```
php build/build.php --remote=5.3.1 --include-bzip2
ls -l build/tmp/packages
php build/build.php --remote=5.3.1 --include-bzip2 --debug-build
ls -l build/tmp/packages
```
#### 3. You can check that the script stops with hacking an error in
#### 3.a Change `zstd` with `zstdXXX` in line 653:
```
php build/build.php --remote=5.3.1
```

You have to get something like:
```
Building Joomla_5.3.1-Stable-Full_Package.tar.zst... tar: Write error
failed.
ERROR: Command failed (127): tar --create * | zstdXXX --ultra -22 -o ../packages/Joomla_5.3.1-Stable-Full_Package.tar.zst
Output:
sh: zstdXXX: command not found
```

#### 3.b Set packages directory file mode 0, inserting the `chmod` line after line 392 `mkdir packages`: 
```
system('chmod 0 packages');
```

You have to get something like:
```
Building Joomla_5.3.1-Stable-Full_Package.zip ... failed.
ERROR: Command failed (15): zip -r ../packages/Joomla_5.3.1-Stable-Full_Package.zip *
Output:
zip I/O error: Permission denied
zip error: Could not create output file (../packages/Joomla_5.3.1-Stable-Full_Package.zip)
```

#### 4. Unpack one package file and compare with previous build. Same number of files? Same file permissions?

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
