### PR TITLE
Set by default sef_ids to 1 in config.xml

### DIFF
--- a/administrator/components/com_contact/config.xml
+++ b/administrator/components/com_contact/config.xml
@@ -1026,7 +1026,7 @@
 				name="sef_ids"
 				type="radio"
 				layout="joomla.form.field.radio.switcher"
-				default="0"
+				default="1"
 				label="JGLOBAL_SEF_NOIDS_LABEL"
 				filter="integer">
 				<option value="0">JNO</option>

--- a/administrator/components/com_content/config.xml
+++ b/administrator/components/com_content/config.xml
@@ -1084,7 +1084,7 @@
 				name="sef_ids"
 				type="radio"
 				layout="joomla.form.field.radio.switcher"
-				default="0"
+				default="1"
 				label="JGLOBAL_SEF_NOIDS_LABEL"
 				filter="integer"
 				>

--- a/administrator/components/com_newsfeeds/config.xml
+++ b/administrator/components/com_newsfeeds/config.xml
@@ -403,7 +403,7 @@
 				name="sef_ids"
 				type="radio"
 				layout="joomla.form.field.radio.switcher"
-				default="0"
+				default="1"
 				label="JGLOBAL_SEF_NOIDS_LABEL"
 				filter="integer">
 				<option value="0">JNO</option>


### PR DESCRIPTION

### Summary of Changes

On install, when dumping data for table `#__extensions`, the param `sef_ids` is set to `1`.
For consistency, this PR also sets the default value of fields to 1 in config.xml for com_contact, com_content and com_newsfeeds.

### Testing Instructions

Should not change anything on install nor update.

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
