### PR TITLE
Use QueryMonitorInterface instead of hard-coded DebugMonitor class

### DIFF
--- a/plugins/system/debug/src/DataCollector/QueryCollector.php
+++ b/plugins/system/debug/src/DataCollector/QueryCollector.php
@@ -12,7 +12,8 @@ namespace Joomla\Plugin\System\Debug\DataCollector;
 
 use DebugBar\DataCollector\AssetProvider;
 use Joomla\CMS\Uri\Uri;
-use Joomla\Database\Monitor\DebugMonitor;
+use Joomla\Database\DatabaseDriver;
+use Joomla\Database\QueryMonitorInterface;
 use Joomla\Plugin\System\Debug\AbstractDataCollector;
 use Joomla\Registry\Registry;
 
@@ -38,7 +39,7 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
     /**
      * The query monitor.
      *
-     * @var    DebugMonitor
+     * @var    QueryMonitorInterface
      * @since  4.0.0
      */
     private $queryMonitor;
@@ -62,7 +63,7 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
     /**
      * Accumulated Duration.
      *
-     * @var   integer
+     * @var   int
      * @since 4.0.0
      */
     private $accumulatedDuration = 0;
@@ -70,7 +71,7 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
     /**
      * Accumulated Memory.
      *
-     * @var   integer
+     * @var   int
      * @since 4.0.0
      */
     private $accumulatedMemory = 0;
@@ -78,14 +79,14 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
     /**
      * Constructor.
      *
-     * @param   Registry      $params        Parameters.
-     * @param   DebugMonitor  $queryMonitor  Query monitor.
-     * @param   array         $profiles      Profile data.
-     * @param   array         $explains      Explain data
+     * @param   Registry               $params        Parameters.
+     * @param   QueryMonitorInterface  $queryMonitor  Query monitor.
+     * @param   array                  $profiles      Profile data.
+     * @param   array                  $explains      Explain data
      *
      * @since 4.0.0
      */
-    public function __construct(Registry $params, DebugMonitor $queryMonitor, array $profiles, array $explains)
+    public function __construct(Registry $params, QueryMonitorInterface $queryMonitor, array $profiles, array $explains)
     {
         $this->queryMonitor = $queryMonitor;
 
@@ -209,7 +210,7 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
             if (isset($stacks[$id])) {
                 $cnt = 0;
 
-                foreach ($stacks[$id] as $i => $stack) {
+                foreach ($stacks[$id] as $stack) {
                     $class = $stack['class'] ?? '';
                     $file  = $stack['file'] ?? '';
                     $line  = $stack['line'] ?? '';
@@ -219,7 +220,7 @@ class QueryCollector extends AbstractDataCollector implements AssetProvider
 
                     $isCaller = 0;
 
-                    if (\Joomla\Database\DatabaseDriver::class === $class && !str_contains($file, 'DatabaseDriver.php')) {
+                    if (DatabaseDriver::class === $class && !str_contains($file, 'DatabaseDriver.php')) {
                         $callerLocation = $location;
                         $isCaller       = 1;
                     }


### PR DESCRIPTION
### Summary of Changes

Allow debug plugin to use instance of `QueryMonitorInterface` in query collector.

Currently, it's hard-coded to instance of `DebugMonitor` (which is a final class for some reason). Hence, we can't use custom monitors with debug plugin enabled.

### Testing Instructions

Apply patch. Enable debug in global configuration and debug plugin.

### Actual result BEFORE applying this Pull Request

See debug.

### Expected result AFTER applying this Pull Request

See same debug, nothing is changed.

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
