### PR TITLE
[5.3] php notice stats plugin

### DIFF
--- a/build/media_source/plg_system_stats/js/stats-message.es6.js
+++ b/build/media_source/plg_system_stats/js/stats-message.es6.js
@@ -77,7 +77,7 @@ Joomla = window.Joomla || {};
             initStatsEvents(getJson);
           }
         } catch (e) {
-          throw new Error(e);
+          throw new Error(response);
         }
       },
       onError: (xhr) => {

--- a/cypress.config.dist.mjs
+++ b/cypress.config.dist.mjs
@@ -14,11 +14,6 @@ export default defineConfig({
     baseUrl: 'https://localhost/',
     specPattern: [
       'tests/System/integration/install/**/*.cy.{js,jsx,ts,tsx}',
-      'tests/System/integration/administrator/**/*.cy.{js,jsx,ts,tsx}',
-      'tests/System/integration/site/**/*.cy.{js,jsx,ts,tsx}',
-      'tests/System/integration/api/**/*.cy.{js,jsx,ts,tsx}',
-      'tests/System/integration/plugins/**/*.cy.{js,jsx,ts,tsx}',
-      'tests/System/integration/cli/**/*.cy.{js,jsx,ts,tsx}',
     ],
     supportFile: 'tests/System/support/index.js',
     scrollBehavior: 'center',

--- a/plugins/system/stats/src/Extension/Stats.php
+++ b/plugins/system/stats/src/Extension/Stats.php
@@ -537,7 +537,7 @@ final class Stats extends CMSPlugin implements SubscriberInterface
             } elseif ($response->code !== 200) {
                 $data = json_decode($response->body);
 
-                $error = 'Could not send site statistics to remote server: ' . $data->message;
+                $error = 'Could not send site statistics to remote server: ' . ($data->message ?? $response->body);
             }
         } catch (\UnexpectedValueException $e) {
             // There was an error sending stats. Should we do anything?

--- a/plugins/system/stats/src/Extension/Stats.php
+++ b/plugins/system/stats/src/Extension/Stats.php
@@ -537,7 +537,7 @@ final class Stats extends CMSPlugin implements SubscriberInterface
             } elseif ($response->code !== 200) {
                 $data = json_decode($response->body);
 
-                $error = 'Could not send site statistics to remote server: ' . ($data->message ?? $response->body);
+                $error = 'Could not send site statistics to remote server: ' . $data->message;
             }
         } catch (\UnexpectedValueException $e) {
             // There was an error sending stats. Should we do anything?

--- a/tests/System/integration/install/Installation.cy.js
+++ b/tests/System/integration/install/Installation.cy.js
@@ -24,8 +24,8 @@ describe('Install Joomla', () => {
 
     cy.doAdministratorLogin(config.username, config.password, false);
     cy.cancelTour();
-    cy.disableStatistics();
     cy.setErrorReportingToDevelopment();
+    cy.disableStatistics();
     cy.doAdministratorLogout();
 
     // Update to the correct secret for the API tests because of the bearer token

--- a/tests/System/integration/install/Installation.cy.js
+++ b/tests/System/integration/install/Installation.cy.js
@@ -24,7 +24,6 @@ describe('Install Joomla', () => {
 
     cy.doAdministratorLogin(config.username, config.password, false);
     cy.cancelTour();
-    cy.on('uncaught:exception', () => false);
     cy.disableStatistics();
     cy.setErrorReportingToDevelopment();
     cy.doAdministratorLogout();

--- a/tests/System/integration/install/Installation.cy.js
+++ b/tests/System/integration/install/Installation.cy.js
@@ -24,6 +24,7 @@ describe('Install Joomla', () => {
 
     cy.doAdministratorLogin(config.username, config.password, false);
     cy.cancelTour();
+    cy.on('uncaught:exception', () => false);
     cy.disableStatistics();
     cy.setErrorReportingToDevelopment();
     cy.doAdministratorLogout();


### PR DESCRIPTION
### Summary of Changes

System test falling often during installation step

```
  > SyntaxError: JSON.parse: unexpected end of data at line 1 column 1 of the JSON data
  at onSuccess (https://localhost/cpostgresmax/media/plg_system_stats/js/stats-message.min.js?44d5ad:5:1179)
  at Joomla.request/o/n.onreadystatechange (https://localhost/cpostgresmax/media/system/js/core.min.js?44d5ad:4:5125)
```

maybe due `Warning: Attempt to read property "message" on null in /plugins/system/stats/src/Extension/Stats.php on line 540`

![image](https://github.com/user-attachments/assets/cf950ac1-70da-448d-ae28-9785c2b32e1d)

- https://ci.joomla.org/joomla/joomla-cms/85363/1/26
- https://ci.joomla.org/joomla/joomla-cms/85364/1/26
- https://ci.joomla.org/joomla/joomla-cms/85394/1/26
- https://ci.joomla.org/joomla/joomla-cms/85400/1/26
- https://ci.joomla.org/joomla/joomla-cms/85405/1/27
- https://ci.joomla.org/joomla/joomla-cms/85406/1/27
- https://ci.joomla.org/joomla/joomla-cms/85407/1/26
- https://ci.joomla.org/joomla/joomla-cms/85409/1/26
- https://ci.joomla.org/joomla/joomla-cms/85423/1/27
- https://ci.joomla.org/joomla/joomla-cms/85430/1/26
- https://ci.joomla.org/joomla/joomla-cms/85431/1/26
- https://ci.joomla.org/joomla/joomla-cms/85432/1/26
- https://ci.joomla.org/joomla/joomla-cms/85435/1/27
- https://ci.joomla.org/joomla/joomla-cms/85436/1/28

### Testing Instructions

faulty response from stats server??

### Actual result BEFORE applying this Pull Request

php warning > invalid json response > js error

### Expected result AFTER applying this Pull Request

should not cause php warning (> invalid json response > js error)

### Link to documentations
Please select:
- [x] No documentation changes for docs.joomla.org needed
- [x] No documentation changes for manual.joomla.org needed
