### PR TITLE
[5.3] Login Module show password

### DIFF
--- a/modules/mod_login/tmpl/default.php
+++ b/modules/mod_login/tmpl/default.php
@@ -60,7 +60,13 @@ Text::script('JHIDEPASSWORD');
                 </div>
             <?php else : ?>
                 <label for="modlgn-passwd-<?php echo $module->id; ?>"><?php echo Text::_('JGLOBAL_PASSWORD'); ?></label>
-                <input id="modlgn-passwd-<?php echo $module->id; ?>" type="password" name="password" autocomplete="current-password" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>">
+                <div class="input-group">
+                    <input id="modlgn-passwd-<?php echo $module->id; ?>" type="password" name="password" autocomplete="current-password" class="form-control" placeholder="<?php echo Text::_('JGLOBAL_PASSWORD'); ?>">
+                    <button type="button" class="btn btn-secondary input-password-toggle">
+                        <span class="icon-eye icon-fw" aria-hidden="true"></span>
+                        <span class="visually-hidden"><?php echo Text::_('JSHOWPASSWORD'); ?></span>
+                    </button>
+                </div>
             <?php endif; ?>
         </div>
 


### PR DESCRIPTION
### Summary of Changes
The login module password field has a button to reveal the password (change from *) however this button is not present if you have set the module to display labels. This PR fixes that.



### Testing Instructions
Create a login module for the site and set the option Display Labels to Text

![image](https://github.com/user-attachments/assets/ac0d486c-55c5-4ac4-b6fd-5efa91154a22)



### Actual result BEFORE applying this Pull Request

![image](https://github.com/user-attachments/assets/b04d7058-5400-4a6f-aef3-6dd1344c6706)



### Expected result AFTER applying this Pull Request
![image](https://github.com/user-attachments/assets/160807ca-f76a-40f6-8f2d-b0b12c0cc3ca)



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [x] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
