### PR TITLE
Github Actions: Fix mysql matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,9 +210,9 @@ jobs:
             db_engine: mysqli
             db_host: mysql
           - php_version: '8.1'
-            test_group: cpostgres
-            db_engine: pgsql
-            db_host: postgres
+            test_group: cmysql
+            db_engine: mysqli
+            db_host: mysql
           - php_version: '8.1'
             test_group: cpostgres
             db_engine: pgsql


### PR DESCRIPTION
Pull Request for Issue # .

### Summary of Changes
This fixes the Github Actions system test matrix to use mysql/mariaDB instead of 3 times postgres.


### Testing Instructions



### Actual result BEFORE applying this Pull Request



### Expected result AFTER applying this Pull Request



### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [ ] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [ ] No documentation changes for manual.joomla.org needed
