### PR TITLE
[5.3] Fix type for custom form validators

### DIFF
--- a/build/media_source/system/js/fields/validate.es6.js
+++ b/build/media_source/system/js/fields/validate.es6.js
@@ -256,7 +256,7 @@ class JFormValidator {
 
     // Run custom form validators if present
     if (Object.keys(this.customValidators).length) {
-      Object.keys(this.customValidators).foreach((key) => {
+      Object.keys(this.customValidators).forEach((key) => {
         if (this.customValidators[key].exec() !== true) {
           valid = false;
         }


### PR DESCRIPTION
### Summary of Changes
Use the correct javascript method name.


### Testing Instructions
This is not used in Joomla Core.

Simple test:
1. Open a form like article and save it. Should work.
2. Open a form like article and remove a required argument and save it. Should fail.

Custom Code:

Add a custom validator in the article override form or any other override like the login module in frontend.

Something like this:

This validator will fail:
```javascript
            document.formvalidator.customValidators['validatorname'] = {
                exec: function() {
                    return false;
                }
            };
```

This validator will succeed:
```javascript
            document.formvalidator.customValidators['validatorname'] = {
                exec: function() {
                    return true;
                }
            };
```

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
