### PR TITLE
[6.2] [WiP] Improve articles lists in backend for display of and filtering by missing workflow associations + better performance

### DIFF
--- a/administrator/components/com_content/forms/filter_articles.xml
+++ b/administrator/components/com_content/forms/filter_articles.xml
@@ -30,8 +30,10 @@
 			class="js-select-submit-on-change"
 			activeonly="true"
 			extension="com_content.article"
+			default=""
 			>
 			<option value="">JOPTION_SELECT_STAGE</option>
+			<option value="0">JNONE_FILTER</option>
 		</field>
 
 		<field

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -357,7 +357,7 @@ class ArticlesModel extends ListModel
         } else {
             $query->where(
                 '(' . $db->quoteName('wa.extension') . ' = ' . $db->quote('com_content.article')
-                . ' OR ' . $db->quoteName('wa.extension') . ' IS NULL)'
+                . ' OR ' . $db->quoteName('wa.item_id') . ' IS NULL)'
             );
         }
 

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -209,12 +209,6 @@ class ArticlesModel extends ListModel
 
         $params = ComponentHelper::getParams('com_content');
 
-        // Subquery for workflows
-        $workflowQuery = $db->getQuery(true)
-            ->select([$db->quoteName('wa1.stage_id'), $db->quoteName('wa1.item_id')])
-            ->from($db->quoteName('#__workflow_associations', 'wa1'))
-            ->where($db->quoteName('wa1.extension') . ' = ' . $db->quote('com_content.article'));
-
         // Select the required fields from the table.
         $query->select(
             $this->getState(
@@ -281,7 +275,7 @@ class ArticlesModel extends ListModel
             ->join('LEFT', $db->quoteName('#__categories', 'c'), $db->quoteName('c.id') . ' = ' . $db->quoteName('a.catid'))
             ->join('LEFT', $db->quoteName('#__categories', 'parent'), $db->quoteName('parent.id') . ' = ' . $db->quoteName('c.parent_id'))
             ->join('LEFT', $db->quoteName('#__users', 'ua'), $db->quoteName('ua.id') . ' = ' . $db->quoteName('a.created_by'))
-            ->join('LEFT', '(' . $workflowQuery . ') AS ' . $db->quoteName('wa'), $db->quoteName('wa.item_id') . ' = ' . $db->quoteName('a.id'))
+            ->join('LEFT', $db->quoteName('#__workflow_associations', 'wa'), $db->quoteName('wa.item_id') . ' = ' . $db->quoteName('a.id'))
             ->join('LEFT', $db->quoteName('#__workflow_stages', 'ws'), $db->quoteName('ws.id') . ' = ' . $db->quoteName('wa.stage_id'))
             ->join('LEFT', $db->quoteName('#__workflows', 'w'), $db->quoteName('w.id') . ' = ' . $db->quoteName('ws.workflow_id'));
 
@@ -356,9 +350,12 @@ class ArticlesModel extends ListModel
             if ($workflowStage === 0) {
                 $query->where($db->quoteName('wa.stage_id') . ' IS NULL');
             } else {
+                $query->where($db->quoteName('wa.extension') . ' = ' . $db->quote('com_content.article'));
                 $query->where($db->quoteName('wa.stage_id') . ' = :stage')
                     ->bind(':stage', $workflowStage, ParameterType::INTEGER);
             }
+        } else {
+            $query->where($db->quoteName('wa.extension') . ' = ' . $db->quote('com_content.article'));
         }
 
         $published = (string) $this->getState('filter.published');

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -355,7 +355,10 @@ class ArticlesModel extends ListModel
                     ->bind(':stage', $workflowStage, ParameterType::INTEGER);
             }
         } else {
-            $query->where($db->quoteName('wa.extension') . ' = ' . $db->quote('com_content.article'));
+            $query->where(
+                $db->quoteName('wa.extension') . ' = ' . $db->quote('com_content.article')
+                . ' OR ' . $db->quoteName('wa.extension') . ' IS NULL'
+            );
         }
 
         $published = (string) $this->getState('filter.published');

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -356,8 +356,8 @@ class ArticlesModel extends ListModel
             }
         } else {
             $query->where(
-                $db->quoteName('wa.extension') . ' = ' . $db->quote('com_content.article')
-                . ' OR ' . $db->quoteName('wa.extension') . ' IS NULL'
+                '(' . $db->quoteName('wa.extension') . ' = ' . $db->quote('com_content.article')
+                . ' OR ' . $db->quoteName('wa.extension') . ' IS NULL)'
             );
         }
 

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -209,6 +209,12 @@ class ArticlesModel extends ListModel
 
         $params = ComponentHelper::getParams('com_content');
 
+        // Subquery for workflows
+        $workflowQuery = $db->getQuery(true)
+            ->select([$db->quoteName('wa1.stage_id'), $db->quoteName('wa1.item_id')])
+            ->from($db->quoteName('#__workflow_associations', 'wa1'))
+            ->where($db->quoteName('wa1.extension') . ' = ' . $db->quote('com_content.article'));
+
         // Select the required fields from the table.
         $query->select(
             $this->getState(
@@ -268,7 +274,6 @@ class ArticlesModel extends ListModel
                 ]
             )
             ->from($db->quoteName('#__content', 'a'))
-            ->where($db->quoteName('wa.extension') . ' = ' . $db->quote('com_content.article'))
             ->join('LEFT', $db->quoteName('#__languages', 'l'), $db->quoteName('l.lang_code') . ' = ' . $db->quoteName('a.language'))
             ->join('LEFT', $db->quoteName('#__content_frontpage', 'fp'), $db->quoteName('fp.content_id') . ' = ' . $db->quoteName('a.id'))
             ->join('LEFT', $db->quoteName('#__users', 'uc'), $db->quoteName('uc.id') . ' = ' . $db->quoteName('a.checked_out'))
@@ -276,9 +281,9 @@ class ArticlesModel extends ListModel
             ->join('LEFT', $db->quoteName('#__categories', 'c'), $db->quoteName('c.id') . ' = ' . $db->quoteName('a.catid'))
             ->join('LEFT', $db->quoteName('#__categories', 'parent'), $db->quoteName('parent.id') . ' = ' . $db->quoteName('c.parent_id'))
             ->join('LEFT', $db->quoteName('#__users', 'ua'), $db->quoteName('ua.id') . ' = ' . $db->quoteName('a.created_by'))
-            ->join('INNER', $db->quoteName('#__workflow_associations', 'wa'), $db->quoteName('wa.item_id') . ' = ' . $db->quoteName('a.id'))
-            ->join('INNER', $db->quoteName('#__workflow_stages', 'ws'), $db->quoteName('ws.id') . ' = ' . $db->quoteName('wa.stage_id'))
-            ->join('INNER', $db->quoteName('#__workflows', 'w'), $db->quoteName('w.id') . ' = ' . $db->quoteName('ws.workflow_id'));
+            ->join('LEFT', '(' . $workflowQuery . ') AS ' . $db->quoteName('wa'), $db->quoteName('wa.item_id') . ' = ' . $db->quoteName('a.id'))
+            ->join('LEFT', $db->quoteName('#__workflow_stages', 'ws'), $db->quoteName('ws.id') . ' = ' . $db->quoteName('wa.stage_id'))
+            ->join('LEFT', $db->quoteName('#__workflows', 'w'), $db->quoteName('w.id') . ' = ' . $db->quoteName('ws.workflow_id'));
 
         if (PluginHelper::isEnabled('content', 'vote')) {
             $query->select(

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -357,7 +357,7 @@ class ArticlesModel extends ListModel
         } else {
             $query->where(
                 '(' . $db->quoteName('wa.extension') . ' = ' . $db->quote('com_content.article')
-                . ' OR ' . $db->quoteName('wa.item_id') . ' IS NULL)'
+                . ' OR ' . $db->quoteName('wa.extension') . ' IS NULL)'
             );
         }
 

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -352,8 +352,13 @@ class ArticlesModel extends ListModel
 
         if ($params->get('workflow_enabled') && is_numeric($workflowStage)) {
             $workflowStage = (int) $workflowStage;
-            $query->where($db->quoteName('wa.stage_id') . ' = :stage')
-                ->bind(':stage', $workflowStage, ParameterType::INTEGER);
+
+            if ($workflowStage === 0) {
+                $query->where($db->quoteName('wa.stage_id') . 'IS NULL');
+            } else {
+                $query->where($db->quoteName('wa.stage_id') . ' = :stage')
+                    ->bind(':stage', $workflowStage, ParameterType::INTEGER);
+            }
         }
 
         $published = (string) $this->getState('filter.published');

--- a/administrator/components/com_content/src/Model/ArticlesModel.php
+++ b/administrator/components/com_content/src/Model/ArticlesModel.php
@@ -354,7 +354,7 @@ class ArticlesModel extends ListModel
             $workflowStage = (int) $workflowStage;
 
             if ($workflowStage === 0) {
-                $query->where($db->quoteName('wa.stage_id') . 'IS NULL');
+                $query->where($db->quoteName('wa.stage_id') . ' IS NULL');
             } else {
                 $query->where($db->quoteName('wa.stage_id') . ' = :stage')
                     ->bind(':stage', $workflowStage, ParameterType::INTEGER);

--- a/administrator/components/com_content/tmpl/articles/default.php
+++ b/administrator/components/com_content/tmpl/articles/default.php
@@ -217,13 +217,17 @@ $assoc = Associations::isEnabled();
                                 </td>
                                 <?php if ($workflow_enabled) : ?>
                                 <td class="article-stage text-center">
-                                    <?php
-                                    echo (new TransitionButton($options))
-                                    ->render(0, $i);
-                                    ?>
-                                    <div class="small">
-                                        <?php echo Text::_($item->stage_title); ?>
-                                    </div>
+                                    <?php if ($item->stage_id) : ?>
+                                        <?php
+                                        echo (new TransitionButton($options))
+                                        ->render(0, $i);
+                                        ?>
+                                        <div class="small">
+                                            <?php echo Text::_($item->stage_title); ?>
+                                        </div>
+                                    <?php else : ?>
+                                        [ <?php echo Text::_('JNONE'); ?> ]
+                                    <?php endif; ?>
                                 </td>
                                 <?php endif; ?>
                                 <td class="text-center d-none d-md-table-cell">


### PR DESCRIPTION
Pull Request for Issue #43701 (at least partly) and possibly others (will check) .

Alternative to PR #40176 and PR #45542 .

### Summary of Changes

This pull request (PR) changes the list query of the articles model in backend so that articles where the workflow association is missing are not hidden but still shown in the list.

Therefore the list query is changed from inner to left joins for the workflow related data, and the condition in the where clause is adapted to accept NULL values (if not explicitly filtered for a particular workflow stage).

This seems to result in a huge performance improvement.

In addition, this PR changes the articles and featured lists in backend so that "[ None ]" is shown instead of the transitions button for such articles, similar to other PRs for showing missing references which have been merged into 5.4-dev.

Finally, this PR adds the option to filter for such articles in the lists, also similar to other merged PRs in 5.4-dev.

### Testing Instructions

Have some 5.4-dev or alpha site with some articles which have and some others which don't have workflow associations, for both featured and unfeatured articles.

You can get this e.g. by enabling workflows in the integration options of com_content and installing Blog Sample Data and then delete the workflow associations of some (but not all) featured article(s) and some (but not all) unfeatured articles.

Then check in the articles list and the featured list if the articles with missing workflow associations are shown or not.

Then check if there is an option in the Stage filter to filter for articles without a workflow stage.

When testing with this PR applied, check that filtering by workflow stages works as well as before in the articles list and the featured list and that filtering by "_ None -" works, too.

Then disable workflows in the integration options of com_content and check again in the articles list and the featured list if the articles with missing workflow associations are shown or not.

Finally, make sure that nothing else related to articles in the administrator (backend) is broken, e.g. the administrator modules "Articles Latest" and "Popular Articles" are still working.

### Actual result BEFORE applying this Pull Request

Regardless if workflows are enabled or not, the articles list and the featured articles list do not show articles where the workflow association is missing.

There is no way to find such articles in these lists.

### Expected result AFTER applying this Pull Request

When workflows are enabled in the options of com_content, "[ None ]" is shown for the workflow stage in the articles lists in backend instead of a transition button for articles which have no workflow association, and there is a new option to filter for such articles.
![pr-45660_with-pr_articles-list_1](https://github.com/user-attachments/assets/c901b3de-a79f-4d7e-933c-af26cbef9741)

When workflows are disabled, the list shows all articles, also such where the workflow association is missing.
![pr-45660_with-pr_articles-list_2](https://github.com/user-attachments/assets/7f9c1bd4-e85f-487f-bb0f-5c4a77a3980a)

The same applies to the featured articles list in backend.
![pr-45660_with-pr_featured-list_1](https://github.com/user-attachments/assets/9a971d72-1db6-45e9-9ce4-6e8a64118422)

![pr-45660_with-pr_featured-list_2](https://github.com/user-attachments/assets/61ae6a25-d557-471f-a77c-fc66eee06828)

Anything else related to articles in backend works as well as without this PR, e.g. the administrator modules "Articles Latest" and "Popular Articles".

### Link to documentations
Please select:
- [ ] Documentation link for docs.joomla.org: <link>
- [X] No documentation changes for docs.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [X] No documentation changes for manual.joomla.org needed
